### PR TITLE
Add new ariakit-based `DropdownMenu` component

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -828,6 +828,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "DropdownMenuV2Ariakit",
+		"slug": "dropdown-menu-v2-ariakit",
+		"markdown_source": "../packages/components/src/dropdown-menu-v2-ariakit/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "DropdownMenu",
 		"slug": "dropdown-menu",
 		"markdown_source": "../packages/components/src/dropdown-menu/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,6 +361,27 @@
 				"react-dom": "^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/@ariakit/test": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.3.0.tgz",
+			"integrity": "sha512-fngAzkzCl9zM4O/tzVaUf7ixWUAk779hjTegr/zcegoxaMS5SmaLhNQ7RU0AGx06LrhJse6GYGy8ZtK58HP/EQ==",
+			"dependencies": {
+				"@ariakit/core": "0.3.3",
+				"@testing-library/dom": "^8.0.0 || ^9.0.0"
+			},
+			"peerDependencies": {
+				"@testing-library/react": "^12.0.0 || ^13.0.0 || ^14.0.0",
+				"react": "^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@testing-library/react": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@aw-web-design/x-default-browser": {
 			"version": "1.4.126",
 			"resolved": "https://registry.npmjs.org/@aw-web-design/x-default-browser/-/x-default-browser-1.4.126.tgz",
@@ -13922,7 +13943,6 @@
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
 			"integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
-			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -13941,7 +13961,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -13953,7 +13972,6 @@
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
 			"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-			"dev": true,
 			"dependencies": {
 				"deep-equal": "^2.0.5"
 			}
@@ -13962,7 +13980,6 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
 			"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
-			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.0",
 				"call-bind": "^1.0.2",
@@ -13990,14 +14007,12 @@
 		"node_modules/@testing-library/dom/node_modules/isarray": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
 		},
 		"node_modules/@testing-library/dom/node_modules/pretty-format": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -14010,8 +14025,7 @@
 		"node_modules/@testing-library/dom/node_modules/react-is": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
 		},
 		"node_modules/@testing-library/jest-dom": {
 			"version": "5.16.5",
@@ -14193,8 +14207,7 @@
 		"node_modules/@types/aria-query": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-			"dev": true
+			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.0",
@@ -23128,7 +23141,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
 			"integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"is-array-buffer": "^3.0.1"
@@ -23464,7 +23476,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
 			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -24869,7 +24880,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -28285,7 +28295,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
 			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
-			"dev": true,
 			"dependencies": {
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
@@ -28856,8 +28865,7 @@
 		"node_modules/dom-accessibility-api": {
 			"version": "0.5.14",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
-			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
-			"dev": true
+			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg=="
 		},
 		"node_modules/dom-converter": {
 			"version": "0.2.0",
@@ -29357,7 +29365,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
 			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.3",
@@ -29376,8 +29383,7 @@
 		"node_modules/es-get-iterator/node_modules/isarray": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
 		},
 		"node_modules/es-module-lexer": {
 			"version": "1.3.1",
@@ -31723,7 +31729,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
 			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.1.3"
 			}
@@ -32003,7 +32008,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
 			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -32081,7 +32085,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
 			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -32574,7 +32577,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
 			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.1.3"
 			},
@@ -32769,7 +32771,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
 			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -32786,7 +32787,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
 			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.1.1"
 			},
@@ -32798,7 +32798,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
 			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -32810,7 +32809,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -32822,7 +32820,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
 			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-			"dev": true,
 			"dependencies": {
 				"has-symbols": "^1.0.2"
 			},
@@ -33995,7 +33992,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
 			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
-			"dev": true,
 			"dependencies": {
 				"get-intrinsic": "^1.2.0",
 				"has": "^1.0.3",
@@ -34125,7 +34121,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
 			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -34141,7 +34136,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
 			"integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.2.0",
@@ -34160,7 +34154,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
 			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-			"dev": true,
 			"dependencies": {
 				"has-bigints": "^1.0.1"
 			},
@@ -34184,7 +34177,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
 			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -34220,7 +34212,6 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -34283,7 +34274,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
 			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-			"dev": true,
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -34477,7 +34467,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
 			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -34525,7 +34514,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
 			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-			"dev": true,
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -34636,7 +34624,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
 			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -34661,7 +34648,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
 			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -34670,7 +34656,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
 			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2"
 			},
@@ -34699,7 +34684,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
 			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-			"dev": true,
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -34714,7 +34698,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
 			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-			"dev": true,
 			"dependencies": {
 				"has-symbols": "^1.0.2"
 			},
@@ -34741,7 +34724,6 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
 			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-			"dev": true,
 			"dependencies": {
 				"which-typed-array": "^1.1.11"
 			},
@@ -34773,7 +34755,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
 			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -34794,7 +34775,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
 			"integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
@@ -39365,7 +39345,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-			"dev": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -44135,7 +44114,6 @@
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
 			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -44144,7 +44122,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
 			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
@@ -44160,7 +44137,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -44180,7 +44156,6 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
 			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
@@ -48746,7 +48721,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
 			"integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -50446,7 +50420,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -51252,7 +51225,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
 			"integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-			"dev": true,
 			"dependencies": {
 				"internal-slot": "^1.0.4"
 			},
@@ -55236,7 +55208,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
 			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-			"dev": true,
 			"dependencies": {
 				"is-bigint": "^1.0.1",
 				"is-boolean-object": "^1.1.0",
@@ -55252,7 +55223,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
 			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-			"dev": true,
 			"dependencies": {
 				"is-map": "^2.0.1",
 				"is-set": "^2.0.1",
@@ -55272,7 +55242,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
 			"integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
-			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
@@ -56310,6 +56279,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.3.5",
+				"@ariakit/test": "^0.3.0",
 				"@babel/runtime": "^7.16.0",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
@@ -58291,6 +58261,15 @@
 				"@ariakit/core": "0.3.4",
 				"@floating-ui/dom": "^1.0.0",
 				"use-sync-external-store": "^1.2.0"
+			}
+		},
+		"@ariakit/test": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.3.0.tgz",
+			"integrity": "sha512-fngAzkzCl9zM4O/tzVaUf7ixWUAk779hjTegr/zcegoxaMS5SmaLhNQ7RU0AGx06LrhJse6GYGy8ZtK58HP/EQ==",
+			"requires": {
+				"@ariakit/core": "0.3.3",
+				"@testing-library/dom": "^8.0.0 || ^9.0.0"
 			}
 		},
 		"@aw-web-design/x-default-browser": {
@@ -67936,7 +67915,6 @@
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
 			"integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -67951,14 +67929,12 @@
 				"ansi-styles": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-					"dev": true
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
 				},
 				"aria-query": {
 					"version": "5.1.3",
 					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
 					"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-					"dev": true,
 					"requires": {
 						"deep-equal": "^2.0.5"
 					}
@@ -67967,7 +67943,6 @@
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
 					"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
-					"dev": true,
 					"requires": {
 						"array-buffer-byte-length": "^1.0.0",
 						"call-bind": "^1.0.2",
@@ -67992,14 +67967,12 @@
 				"isarray": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-					"dev": true
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
 				},
 				"pretty-format": {
 					"version": "27.5.1",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
 					"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.1",
 						"ansi-styles": "^5.0.0",
@@ -68009,8 +67982,7 @@
 				"react-is": {
 					"version": "17.0.2",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-					"dev": true
+					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
 				}
 			}
 		},
@@ -68144,8 +68116,7 @@
 		"@types/aria-query": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-			"dev": true
+			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
 		},
 		"@types/babel__core": {
 			"version": "7.20.0",
@@ -69686,6 +69657,7 @@
 			"version": "file:packages/components",
 			"requires": {
 				"@ariakit/react": "^0.3.5",
+				"@ariakit/test": "^0.3.0",
 				"@babel/runtime": "^7.16.0",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
@@ -77933,7 +77905,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
 			"integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"is-array-buffer": "^3.0.1"
@@ -78195,8 +78166,7 @@
 		"available-typed-arrays": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true
+			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -79305,7 +79275,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -81885,7 +81854,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
 			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
-			"dev": true,
 			"requires": {
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
@@ -82324,8 +82292,7 @@
 		"dom-accessibility-api": {
 			"version": "0.5.14",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
-			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
-			"dev": true
+			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg=="
 		},
 		"dom-converter": {
 			"version": "0.2.0",
@@ -82749,7 +82716,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
 			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.3",
@@ -82765,8 +82731,7 @@
 				"isarray": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-					"dev": true
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
 				}
 			}
 		},
@@ -84570,7 +84535,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
 			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.3"
 			}
@@ -84780,8 +84744,7 @@
 		"functions-have-names": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-			"dev": true
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
 		},
 		"gauge": {
 			"version": "4.0.4",
@@ -84843,7 +84806,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
 			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -85229,7 +85191,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
 			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dev": true,
 			"requires": {
 				"get-intrinsic": "^1.1.3"
 			}
@@ -85383,8 +85344,7 @@
 		"has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-			"dev": true
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -85395,7 +85355,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
 			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-			"dev": true,
 			"requires": {
 				"get-intrinsic": "^1.1.1"
 			}
@@ -85403,20 +85362,17 @@
 		"has-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-			"dev": true
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
 		},
 		"has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
 		},
 		"has-tostringtag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
 			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
 			}
@@ -86298,7 +86254,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
 			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
-			"dev": true,
 			"requires": {
 				"get-intrinsic": "^1.2.0",
 				"has": "^1.0.3",
@@ -86401,7 +86356,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
 			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -86411,7 +86365,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
 			"integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.2.0",
@@ -86427,7 +86380,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
 			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-			"dev": true,
 			"requires": {
 				"has-bigints": "^1.0.1"
 			}
@@ -86445,7 +86397,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
 			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -86468,8 +86419,7 @@
 		"is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -86518,7 +86468,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
 			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -86646,8 +86595,7 @@
 		"is-map": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-			"dev": true
+			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
 		},
 		"is-nan": {
 			"version": "1.3.2",
@@ -86687,7 +86635,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
 			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -86757,7 +86704,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
 			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -86772,14 +86718,12 @@
 		"is-set": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-			"dev": true
+			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
 		},
 		"is-shared-array-buffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
 			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2"
 			}
@@ -86802,7 +86746,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
 			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -86811,7 +86754,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
 			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
 			}
@@ -86829,7 +86771,6 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
 			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-			"dev": true,
 			"requires": {
 				"which-typed-array": "^1.1.11"
 			}
@@ -86848,8 +86789,7 @@
 		"is-weakmap": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-			"dev": true
+			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
 		},
 		"is-weakref": {
 			"version": "1.0.2",
@@ -86864,7 +86804,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
 			"integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
@@ -90360,8 +90299,7 @@
 		"lz-string": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-			"dev": true
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
 		},
 		"macos-release": {
 			"version": "2.2.0",
@@ -94097,14 +94035,12 @@
 		"object-inspect": {
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-			"dev": true
+			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
 		},
 		"object-is": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
 			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
@@ -94113,8 +94049,7 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -94128,7 +94063,6 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
 			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
@@ -97539,7 +97473,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
 			"integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -98860,7 +98793,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -99502,7 +99434,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
 			"integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-			"dev": true,
 			"requires": {
 				"internal-slot": "^1.0.4"
 			}
@@ -102509,7 +102440,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
 			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-			"dev": true,
 			"requires": {
 				"is-bigint": "^1.0.1",
 				"is-boolean-object": "^1.1.0",
@@ -102522,7 +102452,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
 			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-			"dev": true,
 			"requires": {
 				"is-map": "^2.0.1",
 				"is-set": "^2.0.1",
@@ -102539,7 +102468,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
 			"integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
-			"dev": true,
 			"requires": {
 				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Autocomplete`: Add `aria-live` announcements for Mac and IOS Voiceover to fix lack of support for `aria-owns` ([#54902](https://github.com/WordPress/gutenberg/pull/54902)).
 
+### Internal
+
+-   Introduce experimental new version of `DropdownMenu` based on `ariakit` ([#54939](https://github.com/WordPress/gutenberg/pull/54939))
+
 ## 25.10.0 (2023-10-18)
 
 ### Enhancements
@@ -27,7 +31,6 @@
 ### Internal
 
 -   Update `@ariakit/react` to version `0.3.5` ([#55365](https://github.com/WordPress/gutenberg/pull/55365))
--   Introduce experimental new version of `DropdownMenu` based on `ariakit` ([#54939](https://github.com/WordPress/gutenberg/pull/54939))
 -   `ConfirmDialog`: Migrate to TypeScript. ([#54954](https://github.com/WordPress/gutenberg/pull/54954)).
 
 ### New Features

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Internal
 
 -   Update `@ariakit/react` to version `0.3.5` ([#55365](https://github.com/WordPress/gutenberg/pull/55365))
+-   Introduce experimental new version of `DropdownMenu` based on `ariakit` ([#54939](https://github.com/WordPress/gutenberg/pull/54939))
 -   `ConfirmDialog`: Migrate to TypeScript. ([#54954](https://github.com/WordPress/gutenberg/pull/54954)).
 
 ### New Features

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,6 +31,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@ariakit/react": "^0.3.5",
+		"@ariakit/test": "^0.3.0",
 		"@babel/runtime": "^7.16.0",
 		"@emotion/cache": "^11.7.1",
 		"@emotion/css": "^11.7.1",

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -1,0 +1,8 @@
+# `DropdownMenu` (v2 ariakit)
+
+<div class="callout callout-alert">
+This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+
+`DropdownMenu` displays a menu to the user (such as a set of actions or functions) triggered by a button.
+

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -71,6 +71,7 @@ The contents of the dropdown
 The open state of the dropdown menu when it is initially rendered. Use when not wanting to control its open state.
 
 - Required: no
+- Default: `false`
 
 ##### `open`: `boolean`
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -112,12 +112,6 @@ The skidding of the popover along the anchor element. Can be set to negative val
 - Required: no
 - Default: `0` for root-level menus, `-8` for nested menus
 
-##### `defaultValues`: `Record<string, string | boolean | number | Array< string | number > >`
-
-The default values for the values state.
-
-- Required: no
-
 ##### `hideOnEscape`: `boolean | ( ( event: KeyboardEvent | React.KeyboardEvent< Element > ) => boolean )`
 
 Determines whether the menu popover will be hidden when the user presses the Escape key.

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -1,4 +1,4 @@
-# `DropdownMenu` (v2 ariakit)
+# `DropdownMenu` (v2)
 
 <div class="callout callout-alert">
 This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
@@ -6,3 +6,324 @@ This feature is still experimental. “Experimental” means this is an early im
 
 `DropdownMenu` displays a menu to the user (such as a set of actions or functions) triggered by a button.
 
+
+## Design guidelines
+
+### Usage
+
+#### When to use a DropdownMenu
+
+Use a DropdownMenu when you want users to:
+
+-   Choose an action or change a setting from a list, AND
+-   Only see the available choices contextually.
+
+`DropdownMenu` is a React component to render an expandable menu of buttons. It is similar in purpose to a `<select>` element, with the distinction that it does not maintain a value. Instead, each option behaves as an action button.
+
+If you need to display all the available options at all times, consider using a Toolbar instead. Use a `DropdownMenu` to display a list of actions after the user interacts with a button.
+
+**Do**
+Use a `DropdownMenu` to display a list of actions after the user interacts with an icon.
+
+**Don’t** use a `DropdownMenu` for important actions that should always be visible. Use a `Toolbar` instead.
+
+**Don’t**
+Don’t use a `DropdownMenu` for frequently used actions. Use a `Toolbar` instead.
+
+#### Behavior
+
+Generally, the parent button should indicate that interacting with it will show a `DropdownMenu`.
+
+The parent button should retain the same visual styling regardless of whether the `DropdownMenu` is displayed or not.
+
+#### Placement
+
+The `DropdownMenu` should typically appear directly below, or below and to the left of, the parent button. If there isn’t enough space below to display the full `DropdownMenu`, it can be displayed instead above the parent button.
+
+## Development guidelines
+
+This component is still highly experimental, and it's not normally accessible to consumers of the `@wordpress/components` package.
+
+The component exposes a set of components that are meant to be used in combination with each other in order to implement a `DropdownMenu` correctly.
+
+### `DropdownMenu`
+
+The root component, used to specify the menu's trigger and its contents.
+
+#### Props
+
+The component accepts the following props:
+
+##### `trigger`: `React.ReactNode`
+
+The trigger button
+
+- Required: yes
+
+##### `children`: `React.ReactNode`
+
+The contents of the dropdown
+
+- Required: yes
+
+##### `defaultOpen`: `boolean`
+
+The open state of the dropdown menu when it is initially rendered. Use when not wanting to control its open state.
+
+- Required: no
+
+##### `open`: `boolean`
+
+The controlled open state of the dropdown menu. Must be used in conjunction with `onOpenChange`.
+
+- Required: no
+
+##### `onOpenChange`: `(open: boolean) => void`
+
+Event handler called when the open state of the dropdown menu changes.
+
+- Required: no
+
+##### `modal`: `boolean`
+
+The modality of the dropdown menu. When set to true, interaction with outside elements will be disabled and only menu content will be visible to screen readers.
+
+- Required: no
+- Default: `true`
+
+##### `placement`: ``'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end'`
+
+The placement of the dropdown menu popover.
+
+- Required: no
+- Default: `'bottom-start'` for root-level menus, `'right-start'` for nested menus
+
+##### `gutter`: `number`
+
+The distance in pixels from the trigger.
+
+- Required: no
+- Default: `8` for root-level menus, `16` for nested menus
+
+##### `shift`: `number`
+
+The skidding of the popover along the anchor element. Can be set to negative values to make the popover shift to the opposite side.
+
+- Required: no
+- Default: `0` for root-level menus, `-8` for nested menus
+
+##### `defaultValues`: `Record<string, string | boolean | number | Array< string | number > >`
+
+The default values for the values state.
+
+- Required: no
+
+##### `hideOnEscape`: `boolean | ( ( event: KeyboardEvent | React.KeyboardEvent< Element > ) => boolean )`
+
+Determines whether the menu popover will be hidden when the user presses the Escape key.
+
+- Required: no
+- Default: `true`
+
+### `DropdownMenuItem`
+
+Used to render a menu item.
+
+#### Props
+
+The component accepts the following props:
+
+##### `children`: `React.ReactNode`
+
+The contents of the item
+
+- Required: yes
+
+##### `prefix`: `React.ReactNode`
+
+The contents of the item's prefix.
+
+- Required: no
+
+##### `suffix`: `React.ReactNode`
+
+The contents of the item's suffix.
+
+- Required: no
+
+##### `hideOnClick`: `boolean`
+
+Whether to hide the dropdown menu when the menu item is clicked.
+
+- Required: no
+- Default: `true`
+
+##### `disabled`: `boolean`
+
+Determines if the element is disabled.
+
+- Required: no
+- Default: `false`
+
+### `DropdownMenuCheckboxItem`
+
+Used to render a checkbox item.
+
+#### Props
+
+The component accepts the following props:
+
+##### `children`: `React.ReactNode`
+
+The contents of the item
+
+- Required: yes
+
+##### `suffix`: `React.ReactNode`
+
+The contents of the item's suffix.
+
+- Required: no
+
+##### `hideOnClick`: `boolean`
+
+Whether to hide the dropdown menu when the menu item is clicked.
+
+- Required: no
+- Default: `false`
+
+##### `disabled`: `boolean`
+
+Determines if the element is disabled.
+
+- Required: no
+- Default: `false`
+
+##### `name`: `string`
+
+The checkbox item's name.
+
+- Required: yes
+
+##### `value`: `string`
+
+The checkbox item's value, useful when using multiple checkbox items
+ associated to the same `name`.
+
+- Required: no
+
+##### `checked`: `boolean`
+
+The checkbox item's value, useful when using multiple checkbox items
+ associated to the same `name`.
+
+- Required: no
+
+##### `defaultChecked`: `boolean`
+
+The checked state of the checkbox menu item when it is initially rendered. Use when not wanting to control its checked state.
+
+- Required: no
+
+##### `onChange`: `( event: React.ChangeEvent< HTMLInputElement > ) => void;`
+
+Event handler called when the checked state of the checkbox menu item changes.
+
+- Required: no
+
+### `DropdownMenuRadioItem`
+
+Used to render a radio item.
+
+#### Props
+
+The component accepts the following props:
+
+##### `children`: `React.ReactNode`
+
+The contents of the item
+
+- Required: yes
+
+##### `suffix`: `React.ReactNode`
+
+The contents of the item's suffix.
+
+- Required: no
+
+##### `hideOnClick`: `boolean`
+
+Whether to hide the dropdown menu when the menu item is clicked.
+
+- Required: no
+- Default: `false`
+
+##### `disabled`: `boolean`
+
+Determines if the element is disabled.
+
+- Required: no
+- Default: `false`
+
+##### `name`: `string`
+
+The radio item's name.
+
+- Required: yes
+
+##### `value`: `string | number`
+
+The radio item's value.
+
+- Required: yes
+
+##### `checked`: `boolean`
+
+The checkbox item's value, useful when using multiple checkbox items
+ associated to the same `name`.
+
+- Required: no
+
+##### `defaultChecked`: `boolean`
+
+The checked state of the radio menu item when it is initially rendered. Use when not wanting to control its checked state.
+
+- Required: no
+
+##### `onChange`: `( event: React.ChangeEvent< HTMLInputElement > ) => void;`
+
+Event handler called when the checked radio menu item changes.
+
+- Required: no
+
+### `DropdownMenuGroup`
+
+Used to group menu items.
+
+#### Props
+
+The component accepts the following props:
+
+##### `children`: `React.ReactNode`
+
+The contents of the group.
+
+- Required: yes
+
+### `DropdownMenuGroupLabel`
+
+Used to render a group label.
+
+#### Props
+
+The component accepts the following props:
+
+##### `children`: `React.ReactNode`
+
+The contents of the group.
+
+- Required: yes
+
+### `DropdownMenuSeparatorProps`
+
+Used to render a visual separator.

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -25,6 +25,7 @@ import type {
 	DropdownMenuGroupLabelProps,
 	DropdownMenuItemProps,
 	DropdownMenuCheckboxItemProps,
+	DropdownMenuSeparatorProps,
 } from './types';
 import * as Styled from './styles';
 
@@ -162,3 +163,16 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 		);
 	}
 );
+export const DropdownMenuSeparator = forwardRef<
+	HTMLHRElement,
+	DropdownMenuSeparatorProps
+>( function DropdownMenuSeparator( props, ref ) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+	return (
+		<Styled.DropdownMenuSeparator
+			ref={ ref }
+			{ ...props }
+			store={ dropdownMenuContext?.store }
+		/>
+	);
+} );

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -209,7 +209,7 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 			[ dropdownMenuStore ]
 		);
 
-		// const shouldShowDropdownMenu = dropdownMenuStore.useState( 'open' );
+		const shouldShowDropdownMenu = dropdownMenuStore.useState( 'open' );
 
 		return (
 			<>
@@ -237,18 +237,20 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 				/>
 
 				{ /* Menu popover */ }
-				<Styled.DropdownMenu
-					{ ...props }
-					modal={ modal }
-					store={ dropdownMenuStore }
-					gutter={ dropdownMenuStore.parent ? 16 : gutter }
-					shift={ dropdownMenuStore.parent ? -9 : shift }
-					hideOnHoverOutside={ false }
-				>
-					<DropdownMenuContext.Provider value={ contextValue }>
-						{ children }
-					</DropdownMenuContext.Provider>
-				</Styled.DropdownMenu>
+				{ shouldShowDropdownMenu && (
+					<Styled.DropdownMenu
+						{ ...props }
+						modal={ modal }
+						store={ dropdownMenuStore }
+						gutter={ dropdownMenuStore.parent ? 16 : gutter }
+						shift={ dropdownMenuStore.parent ? -9 : shift }
+						hideOnHoverOutside={ false }
+					>
+						<DropdownMenuContext.Provider value={ contextValue }>
+							{ children }
+						</DropdownMenuContext.Provider>
+					</Styled.DropdownMenu>
+				) }
 			</>
 		);
 	}

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -44,9 +44,13 @@ export const DropdownMenuItem = forwardRef<
 			{ ...props }
 			store={ dropdownMenuContext?.store }
 		>
-			{ prefix }
+			{ prefix && (
+				<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
+			) }
 			{ children }
-			{ suffix }
+			{ suffix && (
+				<Styled.ItemSuffixWrapper>{ suffix }</Styled.ItemSuffixWrapper>
+			) }
 		</Styled.DropdownMenuItem>
 	);
 } );

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -107,6 +107,9 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 			open,
 			defaultOpen,
 			onOpenChange,
+			placement,
+			gutter = 8,
+			shift = 0,
 			...props
 		},
 		// Menu ref
@@ -118,6 +121,7 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 			parent: parentContext?.store,
 			open,
 			defaultOpen,
+			placement,
 			setOpen( willBeOpen ) {
 				onOpenChange?.( willBeOpen );
 			},
@@ -151,8 +155,8 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 				<Styled.DropdownMenu
 					{ ...props }
 					store={ dropdownMenuStore }
-					gutter={ dropdownMenuStore.parent ? 16 : 8 }
-					shift={ dropdownMenuStore.parent ? -9 : 0 }
+					gutter={ dropdownMenuStore.parent ? 16 : gutter }
+					shift={ dropdownMenuStore.parent ? -9 : shift }
 					hideOnHoverOutside={ false }
 				>
 					<DropdownMenuContext.Provider value={ contextValue }>
@@ -163,6 +167,7 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 		);
 	}
 );
+
 export const DropdownMenuSeparator = forwardRef<
 	HTMLHRElement,
 	DropdownMenuSeparatorProps

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -24,6 +24,7 @@ import type {
 	DropdownMenuGroupProps,
 	DropdownMenuGroupLabelProps,
 	DropdownMenuItemProps,
+	DropdownMenuCheckboxItemProps,
 } from './types';
 import * as Styled from './styles';
 
@@ -46,6 +47,24 @@ export const DropdownMenuItem = forwardRef<
 			{ children }
 			{ suffix }
 		</Styled.DropdownMenuItem>
+	);
+} );
+
+export const DropdownMenuCheckboxItem = forwardRef<
+	HTMLDivElement,
+	DropdownMenuCheckboxItemProps
+>( function DropdownMenuCheckboxItem( { suffix, children, ...props }, ref ) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+	return (
+		<Styled.DropdownMenuCheckboxItem
+			ref={ ref }
+			{ ...props }
+			store={ dropdownMenuContext?.store }
+		>
+			<Ariakit.MenuItemCheck store={ dropdownMenuContext?.store } />
+			{ children }
+			{ suffix }
+		</Styled.DropdownMenuCheckboxItem>
 	);
 } );
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import * as Ariakit from '@ariakit/react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	forwardRef,
+	createContext,
+	useContext,
+	useMemo,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	StyledAriakitMenu,
+	StyledAriakitMenuItem,
+	toggleButton,
+} from './styles';
+import { useCx } from '../utils';
+
+export const DropdownMenuContext = createContext<
+	{ store: Ariakit.MenuStore } | undefined
+>( undefined );
+
+export interface DropdownMenuItemProps
+	extends Omit< Ariakit.MenuItemProps, 'store' > {}
+
+export const DropdownMenuItem = forwardRef<
+	HTMLDivElement,
+	DropdownMenuItemProps
+>( function DropdownMenuItem( props, ref ) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+	return (
+		<StyledAriakitMenuItem
+			ref={ ref }
+			{ ...props }
+			store={ dropdownMenuContext?.store }
+		/>
+	);
+} );
+
+export interface DropdownMenuProps extends Ariakit.MenuButtonProps {
+	trigger: React.ReactNode;
+	children?: React.ReactNode;
+}
+
+export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
+	function DropdownMenu( { trigger, children, className, ...props }, ref ) {
+		const parentContext = useContext( DropdownMenuContext );
+
+		const dropdownMenuStore = Ariakit.useMenuStore( {
+			parent: parentContext?.store,
+		} );
+
+		const cx = useCx();
+		const menuButtonClassName = useMemo(
+			() => cx( ! dropdownMenuStore.parent && toggleButton, className ),
+			[ cx, dropdownMenuStore.parent, className ]
+		);
+
+		const contextValue = useMemo(
+			() => ( { store: dropdownMenuStore } ),
+			[ dropdownMenuStore ]
+		);
+
+		return (
+			<>
+				{ /* Menu trigger */ }
+				<Ariakit.MenuButton
+					ref={ ref }
+					{ ...props }
+					store={ dropdownMenuStore }
+					className={ menuButtonClassName }
+					render={
+						dropdownMenuStore.parent ? (
+							<DropdownMenuItem render={ props.render } />
+						) : undefined
+					}
+				>
+					{ trigger }
+					<Ariakit.MenuButtonArrow />
+				</Ariakit.MenuButton>
+
+				{ /* Menu popover */ }
+				<StyledAriakitMenu
+					store={ dropdownMenuStore }
+					gutter={ dropdownMenuStore.parent ? 16 : 8 }
+					shift={ dropdownMenuStore.parent ? -9 : 0 }
+					hideOnHoverOutside={ false }
+					modal
+				>
+					<DropdownMenuContext.Provider value={ contextValue }>
+						{ children }
+					</DropdownMenuContext.Provider>
+				</StyledAriakitMenu>
+			</>
+		);
+	}
+);

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -216,6 +216,11 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 
 		const shouldShowDropdownMenu = dropdownMenuStore.useState( 'open' );
 
+		// Extract the side part from the placement (ie. top/bottom/left/start)
+		// It is useful to animate the opening of the menu in the right direction.
+		const computedPlacement = dropdownMenuStore.useState( 'placement' );
+		const side = computedPlacement.split( '-' )[ 0 ];
+
 		return (
 			<>
 				{ /* Menu trigger */ }
@@ -249,6 +254,7 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 						gutter={ dropdownMenuStore.parent ? 16 : gutter }
 						shift={ dropdownMenuStore.parent ? -8 : shift }
 						hideOnHoverOutside={ false }
+						data-side={ side }
 					>
 						<DropdownMenuContext.Provider value={ contextValue }>
 							{ children }

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -127,7 +127,10 @@ export const DropdownMenuRadioItem = forwardRef<
 			onChange={ onChangeWithTargetValue }
 			store={ dropdownMenuContext?.store }
 		>
-			<Ariakit.MenuItemCheck store={ dropdownMenuContext?.store }>
+			<Ariakit.MenuItemCheck
+				store={ dropdownMenuContext?.store }
+				render={ <Styled.ItemPrefixWrapper /> }
+			>
 				<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 					<Circle
 						cx={ 12 }
@@ -198,7 +201,9 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 			open,
 			defaultOpen,
 			placement,
+			// TODO: can we remove this prop?
 			defaultValues,
+			focusLoop: true,
 			setOpen( willBeOpen ) {
 				onOpenChange?.( willBeOpen );
 			},
@@ -224,12 +229,11 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 							  cloneElement( trigger, {
 									// TODO: add prefix
 									suffix: trigger.props.suffix ?? (
-										<Ariakit.MenuButtonArrow>
-											<Icon
-												icon={ chevronRightSmall }
-												size={ 24 }
-											/>{ ' ' }
-										</Ariakit.MenuButtonArrow>
+										<Styled.SubmenuRtlChevronIcon
+											aria-hidden="true"
+											icon={ chevronRightSmall }
+											size={ 24 }
+										/>
 									),
 							  } )
 							: trigger
@@ -243,7 +247,7 @@ export const DropdownMenu = forwardRef< HTMLDivElement, DropdownMenuProps >(
 						modal={ modal }
 						store={ dropdownMenuStore }
 						gutter={ dropdownMenuStore.parent ? 16 : gutter }
-						shift={ dropdownMenuStore.parent ? -9 : shift }
+						shift={ dropdownMenuStore.parent ? -8 : shift }
 						hideOnHoverOutside={ false }
 					>
 						<DropdownMenuContext.Provider value={ contextValue }>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -168,7 +168,7 @@ const UnconnectedDropdownMenu = (
 	const {
 		// Store props
 		open,
-		defaultOpen,
+		defaultOpen = false,
 		onOpenChange,
 		placement,
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -201,9 +201,9 @@ const UnconnectedDropdownMenu = (
 		trigger,
 
 		// Menu props
-		gutter = 8,
+		gutter,
 		children,
-		shift = 0,
+		shift,
 		modal = true,
 		hideOnEscape = true,
 
@@ -301,7 +301,7 @@ const UnconnectedDropdownMenu = (
 				{ ...otherProps }
 				modal={ modal }
 				store={ dropdownMenuStore }
-				gutter={ gutter ?? ( dropdownMenuStore.parent ? 16 : 0 ) }
+				gutter={ gutter ?? ( dropdownMenuStore.parent ? 16 : 8 ) }
 				shift={ shift ?? ( dropdownMenuStore.parent ? -8 : 0 ) }
 				hideOnHoverOutside={ false }
 				data-side={ appliedPlacementSide }

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -49,6 +49,7 @@ export const DropdownMenuItem = forwardRef<
 	ref
 ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
+
 	return (
 		<Styled.DropdownMenuItem
 			ref={ ref }

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -13,6 +13,7 @@ import {
 	useContext,
 	useMemo,
 	cloneElement,
+	isValidElement,
 } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 import { check, chevronRightSmall } from '@wordpress/icons';
@@ -258,6 +259,16 @@ const UnconnectedDropdownMenu = (
 		.useState( 'placement' )
 		.split( '-' )[ 0 ];
 
+	if (
+		dropdownMenuStore.parent &&
+		! ( isValidElement( trigger ) && DropdownMenuItem === trigger.type )
+	) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'For nested DropdownMenus, the `trigger` should always be a `DropdownMenuItem`.'
+		);
+	}
+
 	return (
 		<>
 			{ /* Menu trigger */ }
@@ -265,11 +276,9 @@ const UnconnectedDropdownMenu = (
 				ref={ ref }
 				store={ dropdownMenuStore }
 				render={
-					// Add arrow for submenus
 					dropdownMenuStore.parent
-						? // TODO: check that `trigger` renders a `DropdownMenuItem`?
-						  cloneElement( trigger, {
-								// TODO: add prefix
+						? cloneElement( trigger, {
+								// Add submenu arrow, unless a `suffix` is explicitly specified
 								suffix: trigger.props.suffix ?? (
 									<Styled.SubmenuChevronIcon
 										aria-hidden="true"

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -250,6 +250,7 @@ const UnconnectedDropdownMenu = (
 		[ dropdownMenuStore, variant ]
 	);
 
+	// TODO: could be done via the `unmountOnHide` prop when updating to a newer version
 	const shouldShowDropdownMenu = dropdownMenuStore.useState( 'open' );
 
 	// Extract the side from the applied placement — useful for animations.

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -199,6 +199,7 @@ const UnconnectedDropdownMenu = (
 		children,
 		shift = 0,
 		modal = true,
+		hideOnEscape = true,
 
 		// From internal components context
 		variant,
@@ -300,6 +301,7 @@ const UnconnectedDropdownMenu = (
 				data-side={ appliedPlacementSide }
 				variant={ variant }
 				dir={ computedDirection }
+				hideOnEscape={ hideOnEscape }
 				unmountOnHide
 			>
 				<DropdownMenuContext.Provider value={ contextValue }>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -252,9 +252,6 @@ const UnconnectedDropdownMenu = (
 		[ dropdownMenuStore, variant ]
 	);
 
-	// TODO: could be done via the `unmountOnHide` prop when updating to a newer version
-	const shouldShowDropdownMenu = dropdownMenuStore.useState( 'open' );
-
 	// Extract the side from the applied placement — useful for animations.
 	const appliedPlacementSide = dropdownMenuStore
 		.useState( 'placement' )
@@ -293,23 +290,22 @@ const UnconnectedDropdownMenu = (
 			/>
 
 			{ /* Menu popover */ }
-			{ shouldShowDropdownMenu && (
-				<Styled.DropdownMenu
-					{ ...otherProps }
-					modal={ modal }
-					store={ dropdownMenuStore }
-					gutter={ gutter ?? ( dropdownMenuStore.parent ? 16 : 0 ) }
-					shift={ shift ?? ( dropdownMenuStore.parent ? -8 : 0 ) }
-					hideOnHoverOutside={ false }
-					data-side={ appliedPlacementSide }
-					variant={ variant }
-					dir={ computedDirection }
-				>
-					<DropdownMenuContext.Provider value={ contextValue }>
-						{ children }
-					</DropdownMenuContext.Provider>
-				</Styled.DropdownMenu>
-			) }
+			<Styled.DropdownMenu
+				{ ...otherProps }
+				modal={ modal }
+				store={ dropdownMenuStore }
+				gutter={ gutter ?? ( dropdownMenuStore.parent ? 16 : 0 ) }
+				shift={ shift ?? ( dropdownMenuStore.parent ? -8 : 0 ) }
+				hideOnHoverOutside={ false }
+				data-side={ appliedPlacementSide }
+				variant={ variant }
+				dir={ computedDirection }
+				unmountOnHide
+			>
+				<DropdownMenuContext.Provider value={ contextValue }>
+					{ children }
+				</DropdownMenuContext.Provider>
+			</Styled.DropdownMenu>
 		</>
 	);
 };

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -300,7 +300,12 @@ const UnconnectedDropdownMenu = (
 				hideOnHoverOutside={ false }
 				data-side={ appliedPlacementSide }
 				variant={ variant }
-				dir={ computedDirection }
+				wrapperProps={ {
+					dir: computedDirection,
+					style: {
+						direction: computedDirection,
+					},
+				} }
 				hideOnEscape={ hideOnEscape }
 				unmountOnHide
 			>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -23,6 +23,7 @@ import { SVG, Circle } from '@wordpress/primitives';
  * Internal dependencies
  */
 import { useContextSystem, contextConnect } from '../context';
+import type { WordPressComponentProps } from '../context';
 import Icon from '../icon';
 import type {
 	DropdownMenuContext as DropdownMenuContextType,
@@ -41,7 +42,7 @@ export const DropdownMenuContext = createContext<
 
 export const DropdownMenuItem = forwardRef<
 	HTMLDivElement,
-	DropdownMenuItemProps
+	WordPressComponentProps< DropdownMenuItemProps, 'div', false >
 >( function DropdownMenuItem( { prefix, suffix, children, ...props }, ref ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 	return (
@@ -63,7 +64,7 @@ export const DropdownMenuItem = forwardRef<
 
 export const DropdownMenuCheckboxItem = forwardRef<
 	HTMLDivElement,
-	DropdownMenuCheckboxItemProps
+	WordPressComponentProps< DropdownMenuCheckboxItemProps, 'div', false >
 >( function DropdownMenuCheckboxItem( { suffix, children, ...props }, ref ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 
@@ -113,7 +114,7 @@ export const DropdownMenuCheckboxItem = forwardRef<
 
 export const DropdownMenuRadioItem = forwardRef<
 	HTMLDivElement,
-	DropdownMenuCheckboxItemProps
+	WordPressComponentProps< DropdownMenuCheckboxItemProps, 'div', false >
 >( function DropdownMenuRadioItem( { suffix, children, ...props }, ref ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 	const onChangeWithTargetValue: typeof props.onChange = ( e ) => {
@@ -151,7 +152,7 @@ export const DropdownMenuRadioItem = forwardRef<
 
 export const DropdownMenuGroup = forwardRef<
 	HTMLDivElement,
-	DropdownMenuGroupProps
+	WordPressComponentProps< DropdownMenuGroupProps, 'div', false >
 >( function DropdownMenuGroup( props, ref ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 	return (
@@ -165,7 +166,7 @@ export const DropdownMenuGroup = forwardRef<
 
 export const DropdownMenuGroupLabel = forwardRef<
 	HTMLDivElement,
-	DropdownMenuGroupLabelProps
+	WordPressComponentProps< DropdownMenuGroupLabelProps, 'div', false >
 >( function DropdownMenuGroupLabel( props, ref ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 	return (
@@ -178,7 +179,7 @@ export const DropdownMenuGroupLabel = forwardRef<
 } );
 
 const UnconnectedDropdownMenu = (
-	props: DropdownMenuProps,
+	props: WordPressComponentProps< DropdownMenuProps, 'div', false >,
 	ref: React.ForwardedRef< HTMLDivElement >
 ) => {
 	const {
@@ -205,7 +206,7 @@ const UnconnectedDropdownMenu = (
 		// Rest
 		...otherProps
 	} = useContextSystem<
-		DropdownMenuProps & Pick< DropdownMenuContextType, 'variant' >
+		typeof props & Pick< DropdownMenuContextType, 'variant' >
 	>( props, 'DropdownMenu' );
 
 	const parentContext = useContext( DropdownMenuContext );
@@ -319,7 +320,7 @@ export const DropdownMenu = contextConnect(
 
 export const DropdownMenuSeparator = forwardRef<
 	HTMLHRElement,
-	DropdownMenuSeparatorProps
+	WordPressComponentProps< DropdownMenuSeparatorProps, 'hr', false >
 >( function DropdownMenuSeparator( props, ref ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 	return (

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -71,7 +71,10 @@ export const DropdownMenuCheckboxItem = forwardRef<
 	const onChangeWithTargetValue: typeof props.onChange = ( e ) => {
 		props.onChange?.( {
 			...e,
-			target: Object.assign( e.target, { value: props.value } ),
+			target: Object.assign( e.target, {
+				value: props.value,
+				name: props.name,
+			} ),
 		} );
 	};
 
@@ -120,7 +123,10 @@ export const DropdownMenuRadioItem = forwardRef<
 	const onChangeWithTargetValue: typeof props.onChange = ( e ) => {
 		props.onChange?.( {
 			...e,
-			target: Object.assign( e.target, { value: props.value } ),
+			target: Object.assign( e.target, {
+				value: props.value,
+				name: props.name,
+			} ),
 		} );
 	};
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -76,33 +76,11 @@ export const DropdownMenuCheckboxItem = forwardRef<
 ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 
-	const onChangeWithTargetValue: typeof props.onChange = ( e ) => {
-		props.onChange?.( {
-			...e,
-			target: Object.assign( e.target, {
-				value: props.value,
-				name: props.name,
-			} ),
-		} );
-	};
-
-	// This can't be currently done because of
-	// https://github.com/ariakit/ariakit/blob/main/packages/ariakit-react-core/src/menu/menu-item-check.ts
-	// But using `Ariakit.MenuItemCheck` works as expected.
-	// const isChecked = dropdownMenuContext?.store.useState( ( state ) => {
-	// 	// state.values doesn't have a property with key [props.name] when empty
-	// 	const checkedOrValues = state.values[ props.name ];
-	// 	return Array.isArray( checkedOrValues )
-	// 		? checkedOrValues.includes( props.value )
-	// 		: checkedOrValues;
-	// } );
-
 	return (
 		<Styled.DropdownMenuCheckboxItem
 			ref={ ref }
 			{ ...props }
 			hideOnClick={ hideOnClick }
-			onChange={ onChangeWithTargetValue }
 			store={ dropdownMenuContext?.store }
 		>
 			<Ariakit.MenuItemCheck
@@ -111,10 +89,6 @@ export const DropdownMenuCheckboxItem = forwardRef<
 			>
 				<Icon icon={ check } size={ 24 } />
 			</Ariakit.MenuItemCheck>
-
-			{ /* <Styled.ItemPrefixWrapper>
-				{ isChecked ? <Icon icon={ check } size={ 24 } /> : null }
-			</Styled.ItemPrefixWrapper> */ }
 
 			{ children }
 			{ suffix && (
@@ -132,22 +106,12 @@ export const DropdownMenuRadioItem = forwardRef<
 	ref
 ) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
-	const onChangeWithTargetValue: typeof props.onChange = ( e ) => {
-		props.onChange?.( {
-			...e,
-			target: Object.assign( e.target, {
-				value: props.value,
-				name: props.name,
-			} ),
-		} );
-	};
 
 	return (
 		<Styled.DropdownMenuRadioItem
 			ref={ ref }
 			{ ...props }
 			hideOnClick={ hideOnClick }
-			onChange={ onChangeWithTargetValue }
 			store={ dropdownMenuContext?.store }
 		>
 			<Ariakit.MenuItemCheck
@@ -207,8 +171,6 @@ const UnconnectedDropdownMenu = (
 		defaultOpen,
 		onOpenChange,
 		placement,
-		// TODO: can we remove this prop?
-		defaultValues,
 
 		// Menu trigger props
 		trigger,
@@ -259,7 +221,6 @@ const UnconnectedDropdownMenu = (
 		open,
 		defaultOpen,
 		placement: computedPlacement,
-		defaultValues,
 		focusLoop: true,
 		setOpen( willBeOpen ) {
 			onOpenChange?.( willBeOpen );

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -32,6 +32,7 @@ import type {
 	DropdownMenuGroupLabelProps,
 	DropdownMenuItemProps,
 	DropdownMenuCheckboxItemProps,
+	DropdownMenuRadioItemProps,
 	DropdownMenuSeparatorProps,
 } from './types';
 import * as Styled from './styles';
@@ -43,12 +44,16 @@ export const DropdownMenuContext = createContext<
 export const DropdownMenuItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< DropdownMenuItemProps, 'div', false >
->( function DropdownMenuItem( { prefix, suffix, children, ...props }, ref ) {
+>( function DropdownMenuItem(
+	{ prefix, suffix, children, hideOnClick = true, ...props },
+	ref
+) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 	return (
 		<Styled.DropdownMenuItem
 			ref={ ref }
 			{ ...props }
+			hideOnClick={ hideOnClick }
 			store={ dropdownMenuContext?.store }
 		>
 			{ prefix && (
@@ -65,7 +70,10 @@ export const DropdownMenuItem = forwardRef<
 export const DropdownMenuCheckboxItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< DropdownMenuCheckboxItemProps, 'div', false >
->( function DropdownMenuCheckboxItem( { suffix, children, ...props }, ref ) {
+>( function DropdownMenuCheckboxItem(
+	{ suffix, children, hideOnClick = false, ...props },
+	ref
+) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 
 	const onChangeWithTargetValue: typeof props.onChange = ( e ) => {
@@ -93,6 +101,7 @@ export const DropdownMenuCheckboxItem = forwardRef<
 		<Styled.DropdownMenuCheckboxItem
 			ref={ ref }
 			{ ...props }
+			hideOnClick={ hideOnClick }
 			onChange={ onChangeWithTargetValue }
 			store={ dropdownMenuContext?.store }
 		>
@@ -117,8 +126,11 @@ export const DropdownMenuCheckboxItem = forwardRef<
 
 export const DropdownMenuRadioItem = forwardRef<
 	HTMLDivElement,
-	WordPressComponentProps< DropdownMenuCheckboxItemProps, 'div', false >
->( function DropdownMenuRadioItem( { suffix, children, ...props }, ref ) {
+	WordPressComponentProps< DropdownMenuRadioItemProps, 'div', false >
+>( function DropdownMenuRadioItem(
+	{ suffix, children, hideOnClick = false, ...props },
+	ref
+) {
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 	const onChangeWithTargetValue: typeof props.onChange = ( e ) => {
 		props.onChange?.( {
@@ -134,6 +146,7 @@ export const DropdownMenuRadioItem = forwardRef<
 		<Styled.DropdownMenuRadioItem
 			ref={ ref }
 			{ ...props }
+			hideOnClick={ hideOnClick }
 			onChange={ onChangeWithTargetValue }
 			store={ dropdownMenuContext?.store }
 		>

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -20,6 +20,7 @@ import {
 	DropdownMenuGroupLabel,
 	DropdownMenuSeparator,
 	DropdownMenuContext,
+	DropdownMenuRadioItem,
 } from '..';
 import Button from '../../button';
 import Modal from '../../modal';
@@ -58,97 +59,254 @@ const meta: Meta< typeof DropdownMenu > = {
 };
 export default meta;
 
-const Template: StoryFn< typeof DropdownMenu > = ( props ) => (
-	<DropdownMenu { ...props } />
+export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
+	<DropdownMenu { ...props }>
+		<DropdownMenuItem>Item</DropdownMenuItem>
+		<DropdownMenuItem hideOnClick={ false }>
+			Item (does not close the menu when clicked)
+		</DropdownMenuItem>
+		<DropdownMenuItem
+			disabled
+			prefix={ <span>Pre</span> }
+			suffix={ <span>Suf</span> }
+		>
+			Disabled item
+		</DropdownMenuItem>
+		<DropdownMenuSeparator />
+		<DropdownMenuGroup>
+			<DropdownMenuGroupLabel>Group Label</DropdownMenuGroupLabel>
+			<DropdownMenuItem prefix={ <span>Pre</span> }>
+				Item with prefix
+			</DropdownMenuItem>
+			<DropdownMenuItem suffix={ <span>Suf</span> }>
+				Item with suffix
+			</DropdownMenuItem>
+		</DropdownMenuGroup>
+	</DropdownMenu>
 );
-export const Default = Template.bind( {} );
 Default.args = {
 	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
-	children: (
-		<>
-			<DropdownMenuItem>Single item</DropdownMenuItem>
-			<DropdownMenuSeparator />
+};
+
+export const WithSubmenu: StoryFn< typeof DropdownMenu > = ( props ) => (
+	<DropdownMenu { ...props }>
+		<DropdownMenuItem>Level 1 item</DropdownMenuItem>
+		<DropdownMenu
+			trigger={ <DropdownMenuItem>Submenu trigger</DropdownMenuItem> }
+		>
+			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
+			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
+			<DropdownMenu
+				trigger={ <DropdownMenuItem>Submenu trigger</DropdownMenuItem> }
+			>
+				<DropdownMenuItem>Level 3 item</DropdownMenuItem>
+				<DropdownMenuItem>Level 3 item</DropdownMenuItem>
+			</DropdownMenu>
+		</DropdownMenu>
+	</DropdownMenu>
+);
+WithSubmenu.args = {
+	...Default.args,
+};
+
+export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
+	const [ isAChecked, setAChecked ] = useState( false );
+	const [ isBChecked, setBChecked ] = useState( true );
+	const [ multipleCheckboxesValue, setMultipleCheckboxesValue ] = useState<
+		string[]
+	>( [ 'b' ] );
+
+	const onMultipleCheckboxesCheckedChange: React.ComponentProps<
+		typeof DropdownMenuCheckboxItem
+	>[ 'onChange' ] = ( e ) => {
+		setMultipleCheckboxesValue( ( prevValues ) => {
+			if ( prevValues.includes( e.target.value ) ) {
+				return prevValues.filter( ( val ) => val !== e.target.value );
+			}
+			return [ ...prevValues, e.target.value ];
+		} );
+	};
+
+	return (
+		<DropdownMenu { ...props }>
 			<DropdownMenuGroup>
-				<DropdownMenuGroupLabel>Group</DropdownMenuGroupLabel>
-				<DropdownMenuItem>One</DropdownMenuItem>
-				<DropdownMenuItem>Two</DropdownMenuItem>
-				<DropdownMenuItem>Three</DropdownMenuItem>
+				<DropdownMenuGroupLabel>
+					Individual, uncontrolled checkboxes
+				</DropdownMenuGroupLabel>
+				<DropdownMenuCheckboxItem
+					name="checkbox-individual-uncontrolled-a"
+					value="a"
+				>
+					Checkbox item A (initially unchecked)
+				</DropdownMenuCheckboxItem>
+				<DropdownMenuCheckboxItem
+					name="checkbox-individual-uncontrolled-b"
+					value="b"
+					defaultChecked
+				>
+					{ /*
+					 * TODO: default checked doesn't work yet
+					 * https://github.com/ariakit/ariakit/issues/2913
+					 */ }
+					Checkbox item B (initially checked)
+				</DropdownMenuCheckboxItem>
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
 			<DropdownMenuGroup>
 				<DropdownMenuGroupLabel>
-					Checks (separate)
+					Individual, controlled checkboxes
 				</DropdownMenuGroupLabel>
-				<DropdownMenuCheckboxItem name="checkbox-a" value="a">
+				<DropdownMenuCheckboxItem
+					name="checkbox-individual-controlled-a"
+					value="a"
+					checked={ isAChecked }
+					onChange={ ( e ) => setAChecked( e.target.checked ) }
+				>
 					Checkbox item A
 				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem name="checkbox-b" value="b">
-					Checkbox item B
+				<DropdownMenuCheckboxItem
+					name="checkbox-individual-controlled-b"
+					value="b"
+					checked={ isBChecked }
+					onChange={ ( e ) => setBChecked( e.target.checked ) }
+				>
+					Checkbox item B (initially checked)
 				</DropdownMenuCheckboxItem>
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
-			<DropdownMenu
-				trigger={ <DropdownMenuItem>Open submenu</DropdownMenuItem> }
-			>
-				<DropdownMenuItem>Start Speaking</DropdownMenuItem>
-				<DropdownMenuItem disabled>Stop Speaking</DropdownMenuItem>
-			</DropdownMenu>
-		</>
-	),
-};
-
-export const WithControlledCheckboxes: StoryFn< typeof DropdownMenu > = (
-	props
-) => {
-	const [ isAChecked, setAChecked ] = useState( false );
-	const [ isBChecked, setBChecked ] = useState( true );
-	return (
-		<DropdownMenu { ...props }>
-			<DropdownMenuCheckboxItem
-				name="checkbox-a"
-				value="a"
-				checked={ isAChecked }
-				onChange={ ( e ) => setAChecked( e.target.checked ) }
-			>
-				Checkbox item A (controlled)
-			</DropdownMenuCheckboxItem>
-			<DropdownMenuCheckboxItem
-				name="checkbox-b"
-				value="b"
-				checked={ isBChecked }
-				onChange={ ( e ) => setBChecked( e.target.checked ) }
-			>
-				Checkbox item B (controlled, checked by default)
-			</DropdownMenuCheckboxItem>
-			<DropdownMenuCheckboxItem
-				name="checkbox-c"
-				value="c"
-				defaultChecked
-			>
-				Checkbox item C (uncontrolled, checked by default)
-			</DropdownMenuCheckboxItem>
+			<DropdownMenuGroup>
+				<DropdownMenuGroupLabel>
+					{ /* TODO: can this be done using `defaultChecked` on the single item,
+					 * instead of using `defaultValues` on the menu component? */ }
+					Multiple, uncontrolled checkboxes
+				</DropdownMenuGroupLabel>
+				<DropdownMenuCheckboxItem
+					name="checkbox-multiple-uncontrolled"
+					value="a"
+				>
+					Checkbox item A (initially unchecked)
+				</DropdownMenuCheckboxItem>
+				<DropdownMenuCheckboxItem
+					name="checkbox-multiple-uncontrolled"
+					value="b"
+				>
+					Checkbox item B (initially checked)
+				</DropdownMenuCheckboxItem>
+			</DropdownMenuGroup>
+			<DropdownMenuSeparator />
+			<DropdownMenuGroup>
+				<DropdownMenuGroupLabel>
+					Multiple, controlled checkboxes
+				</DropdownMenuGroupLabel>
+				<DropdownMenuCheckboxItem
+					name="checkbox-multiple-controlled"
+					value="a"
+					checked={ multipleCheckboxesValue.includes( 'a' ) }
+					onChange={ onMultipleCheckboxesCheckedChange }
+				>
+					Checkbox item A (initially unchecked)
+				</DropdownMenuCheckboxItem>
+				<DropdownMenuCheckboxItem
+					name="checkbox-multiple-controlled"
+					value="b"
+					checked={ multipleCheckboxesValue.includes( 'b' ) }
+					onChange={ onMultipleCheckboxesCheckedChange }
+				>
+					Checkbox item B (initially checked)
+				</DropdownMenuCheckboxItem>
+			</DropdownMenuGroup>
 		</DropdownMenu>
 	);
 };
-WithControlledCheckboxes.args = {
-	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
+WithCheckboxes.args = {
+	...Default.args,
+	defaultValues: { 'checkbox-multiple-uncontrolled': [ 'b' ] },
 };
 
-export const WithModalAsSiblingOfMenu: StoryFn< typeof DropdownMenu > = (
-	props
-) => {
-	const [ isModalOpen, setModalOpen ] = useState( false );
+export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
+	const [ radioValue, setRadioValue ] = useState( 'two' );
+	const onRadioChange: React.ComponentProps<
+		typeof DropdownMenuRadioItem
+	>[ 'onChange' ] = ( e ) => setRadioValue( e.target.value );
+
+	return (
+		<DropdownMenu { ...props }>
+			<DropdownMenuGroup>
+				<DropdownMenuGroupLabel>
+					Uncontrolled radios
+				</DropdownMenuGroupLabel>
+				<DropdownMenuRadioItem name="radio-uncontrolled" value="one">
+					Radio item 1
+				</DropdownMenuRadioItem>
+				<DropdownMenuRadioItem
+					name="radio-uncontrolled"
+					value="two"
+					defaultChecked
+				>
+					Radio item 2 (initially checked)
+				</DropdownMenuRadioItem>
+			</DropdownMenuGroup>
+			<DropdownMenuSeparator />
+			<DropdownMenuGroup>
+				<DropdownMenuGroupLabel>
+					Controlled radios
+				</DropdownMenuGroupLabel>
+				<DropdownMenuRadioItem
+					name="radio-controlled"
+					value="one"
+					checked={ radioValue === 'one' }
+					onChange={ onRadioChange }
+				>
+					Radio item 1
+				</DropdownMenuRadioItem>
+				<DropdownMenuRadioItem
+					name="radio-controlled"
+					value="two"
+					checked={ radioValue === 'two' }
+					onChange={ onRadioChange }
+				>
+					Radio item 2 (initially checked)
+				</DropdownMenuRadioItem>
+			</DropdownMenuGroup>
+		</DropdownMenu>
+	);
+};
+WithRadios.args = {
+	...Default.args,
+};
+
+// For more examples with `Modal`, check https://ariakit.org/examples/menu-wordpress-modal
+export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
+	const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
+	const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
 	return (
 		<>
 			<DropdownMenu { ...props }>
-				<DropdownMenuItem onClick={ () => setModalOpen( true ) }>
-					Open modal
+				<DropdownMenuItem
+					onClick={ () => setOuterModalOpen( true ) }
+					hideOnClick={ false }
+				>
+					Open outer modal
 				</DropdownMenuItem>
+				<DropdownMenuItem
+					onClick={ () => setInnerModalOpen( true ) }
+					hideOnClick={ false }
+				>
+					Open inner modal
+				</DropdownMenuItem>
+				{ isInnerModalOpen && (
+					<Modal onRequestClose={ () => setInnerModalOpen( false ) }>
+						Modal&apos;s contents
+						<button onClick={ () => setInnerModalOpen( false ) }>
+							Close
+						</button>
+					</Modal>
+				) }
 			</DropdownMenu>
-			{ isModalOpen && (
-				<Modal onRequestClose={ () => setModalOpen( false ) }>
+			{ isOuterModalOpen && (
+				<Modal onRequestClose={ () => setOuterModalOpen( false ) }>
 					Modal&apos;s contents
-					<button onClick={ () => setModalOpen( false ) }>
+					<button onClick={ () => setOuterModalOpen( false ) }>
 						Close
 					</button>
 				</Modal>
@@ -156,34 +314,7 @@ export const WithModalAsSiblingOfMenu: StoryFn< typeof DropdownMenu > = (
 		</>
 	);
 };
-WithModalAsSiblingOfMenu.args = {
-	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
-};
-
-export const WithModalAsSiblingOfMenuItem: StoryFn< typeof DropdownMenu > = (
-	props
-) => {
-	const [ isModalOpen, setModalOpen ] = useState( false );
-	return (
-		<DropdownMenu { ...props }>
-			<DropdownMenuItem
-				hideOnClick={ false }
-				onClick={ () => setModalOpen( true ) }
-			>
-				Open modal
-			</DropdownMenuItem>
-			{ isModalOpen && (
-				<Modal onRequestClose={ () => setModalOpen( false ) }>
-					Yo!
-					<button onClick={ () => setModalOpen( false ) }>
-						Modal&apos;s contents
-					</button>
-				</Modal>
-			) }
-		</DropdownMenu>
-	);
-};
-WithModalAsSiblingOfMenuItem.args = {
+WithModals.args = {
 	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
 };
 
@@ -232,9 +363,7 @@ const Fill = ( { children }: { children: React.ReactNode } ) => {
 	);
 };
 
-export const AddItemsViaSlotFill: StoryFn< typeof DropdownMenu > = (
-	props
-) => {
+export const WithSlotFill: StoryFn< typeof DropdownMenu > = ( props ) => {
 	return (
 		<SlotFillProvider>
 			<DropdownMenu { ...props }>
@@ -263,6 +392,6 @@ export const AddItemsViaSlotFill: StoryFn< typeof DropdownMenu > = (
 		</SlotFillProvider>
 	);
 };
-AddItemsViaSlotFill.args = {
-	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
+WithSlotFill.args = {
+	...Default.args,
 };

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 /**
  * WordPress dependencies
  */
-import { menu } from '@wordpress/icons';
+import { wordpress } from '@wordpress/icons';
 import { useState, useMemo, useContext } from '@wordpress/element';
 
 /**
@@ -22,6 +22,7 @@ import {
 	DropdownMenuContext,
 	DropdownMenuRadioItem,
 } from '..';
+import Icon from '../../icon';
 import Button from '../../button';
 import Modal from '../../modal';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
@@ -61,31 +62,39 @@ export default meta;
 
 export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 	<DropdownMenu { ...props }>
-		<DropdownMenuItem>Item</DropdownMenuItem>
+		<DropdownMenuItem>Default item</DropdownMenuItem>
 		<DropdownMenuItem hideOnClick={ false }>
-			Item (does not close the menu when clicked)
+			{ /* TODO: move this to description text */ }
+			Keep menu open on click
 		</DropdownMenuItem>
-		<DropdownMenuItem
-			disabled
-			prefix={ <span>Pre</span> }
-			suffix={ <span>Suf</span> }
-		>
-			Disabled item
-		</DropdownMenuItem>
+		<DropdownMenuItem disabled>Disabled</DropdownMenuItem>
 		<DropdownMenuSeparator />
 		<DropdownMenuGroup>
-			<DropdownMenuGroupLabel>Group Label</DropdownMenuGroupLabel>
-			<DropdownMenuItem prefix={ <span>Pre</span> }>
-				Item with prefix
+			<DropdownMenuGroupLabel>Prefix and suffix</DropdownMenuGroupLabel>
+			<DropdownMenuItem
+				prefix={ <Icon icon={ wordpress } size={ 24 } /> }
+			>
+				With prefix
 			</DropdownMenuItem>
 			<DropdownMenuItem suffix={ <span>Suf</span> }>
-				Item with suffix
+				With suffix
+			</DropdownMenuItem>
+			<DropdownMenuItem
+				disabled
+				prefix={ <span>Pre</span> }
+				suffix={ <span>Suf</span> }
+			>
+				Disabled with both
 			</DropdownMenuItem>
 		</DropdownMenuGroup>
 	</DropdownMenu>
 );
 Default.args = {
-	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
+	trigger: (
+		<Button __next40pxDefaultSize variant="secondary">
+			Open menu
+		</Button>
+	),
 };
 
 export const WithSubmenu: StoryFn< typeof DropdownMenu > = ( props ) => (
@@ -315,7 +324,7 @@ export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
 	);
 };
 WithModals.args = {
-	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
+	...Default.args,
 };
 
 const ExampleSlotFill = createSlotFill( 'Example' );

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -18,6 +18,7 @@ import {
 	DropdownMenuCheckboxItem,
 	DropdownMenuGroup,
 	DropdownMenuGroupLabel,
+	DropdownMenuSeparator,
 	DropdownMenuContext,
 } from '..';
 import Button from '../../button';
@@ -66,24 +67,26 @@ Default.args = {
 	children: (
 		<>
 			<DropdownMenuItem>Single item</DropdownMenuItem>
+			<DropdownMenuSeparator />
 			<DropdownMenuGroup>
 				<DropdownMenuGroupLabel>Group</DropdownMenuGroupLabel>
 				<DropdownMenuItem>One</DropdownMenuItem>
 				<DropdownMenuItem>Two</DropdownMenuItem>
 				<DropdownMenuItem>Three</DropdownMenuItem>
 			</DropdownMenuGroup>
+			<DropdownMenuSeparator />
 			<DropdownMenuGroup>
-				<DropdownMenuGroupLabel>Checks</DropdownMenuGroupLabel>
-				<DropdownMenuCheckboxItem name="test-check" value="a">
-					A
+				<DropdownMenuGroupLabel>
+					Checks (separate)
+				</DropdownMenuGroupLabel>
+				<DropdownMenuCheckboxItem name="checkbox-a" value="a">
+					Checkbox item A
 				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem name="test-check" value="b">
-					B
-				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem name="test-check" value="c">
-					C
+				<DropdownMenuCheckboxItem name="checkbox-b" value="b">
+					Checkbox item B
 				</DropdownMenuCheckboxItem>
 			</DropdownMenuGroup>
+			<DropdownMenuSeparator />
 			<DropdownMenu
 				trigger={ <DropdownMenuItem>Open submenu</DropdownMenuItem> }
 			>

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -12,8 +12,14 @@ import { useState, useMemo, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { DropdownMenu, DropdownMenuItem, DropdownMenuContext } from '..';
-import Icon from '../../icon';
+import {
+	DropdownMenu,
+	DropdownMenuItem,
+	DropdownMenuGroup,
+	DropdownMenuGroupLabel,
+	DropdownMenuContext,
+} from '..';
+import Button from '../../button';
 import Modal from '../../modal';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 
@@ -55,18 +61,19 @@ const Template: StoryFn< typeof DropdownMenu > = ( props ) => (
 );
 export const Default = Template.bind( {} );
 Default.args = {
-	trigger: <Icon icon={ menu } size={ 24 } />,
+	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
 	children: (
 		<>
-			<DropdownMenuItem>Undo</DropdownMenuItem>
-			<DropdownMenuItem>Redo</DropdownMenuItem>
-			<DropdownMenu trigger="Find">
-				<DropdownMenuItem>Search the Web...</DropdownMenuItem>
-				<DropdownMenuItem>Find...</DropdownMenuItem>
-				<DropdownMenuItem>Find Next</DropdownMenuItem>
-				<DropdownMenuItem>Find Previous</DropdownMenuItem>
-			</DropdownMenu>
-			<DropdownMenu trigger="Speech">
+			<DropdownMenuItem>Single item</DropdownMenuItem>
+			<DropdownMenuGroup>
+				<DropdownMenuGroupLabel>Group</DropdownMenuGroupLabel>
+				<DropdownMenuItem>One</DropdownMenuItem>
+				<DropdownMenuItem>Two</DropdownMenuItem>
+				<DropdownMenuItem>Three</DropdownMenuItem>
+			</DropdownMenuGroup>
+			<DropdownMenu
+				trigger={ <DropdownMenuItem>Open submenu</DropdownMenuItem> }
+			>
 				<DropdownMenuItem>Start Speaking</DropdownMenuItem>
 				<DropdownMenuItem disabled>Stop Speaking</DropdownMenuItem>
 			</DropdownMenu>
@@ -97,7 +104,7 @@ export const WithModalAsSiblingOfMenu: StoryFn< typeof DropdownMenu > = (
 	);
 };
 WithModalAsSiblingOfMenu.args = {
-	trigger: <Icon icon={ menu } size={ 24 } />,
+	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
 };
 
 export const WithModalAsSiblingOfMenuItem: StoryFn< typeof DropdownMenu > = (
@@ -124,7 +131,7 @@ export const WithModalAsSiblingOfMenuItem: StoryFn< typeof DropdownMenu > = (
 	);
 };
 WithModalAsSiblingOfMenuItem.args = {
-	trigger: <Icon icon={ menu } size={ 24 } />,
+	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
 };
 
 const ExampleSlotFill = createSlotFill( 'Example' );
@@ -179,7 +186,9 @@ export const AddItemsViaSlotFill: StoryFn< typeof DropdownMenu > = (
 		<SlotFillProvider>
 			<DropdownMenu { ...props }>
 				<DropdownMenuItem>Item</DropdownMenuItem>
-				<DropdownMenu trigger="Nested">
+				<DropdownMenu
+					trigger={ <DropdownMenuItem>Nested</DropdownMenuItem> }
+				>
 					<Slot />
 				</DropdownMenu>
 			</DropdownMenu>
@@ -188,7 +197,11 @@ export const AddItemsViaSlotFill: StoryFn< typeof DropdownMenu > = (
 				<DropdownMenuItem hideOnClick={ false }>
 					Item from fill
 				</DropdownMenuItem>
-				<DropdownMenu trigger="Nested in fill">
+				<DropdownMenu
+					trigger={
+						<DropdownMenuItem>Nested in fill</DropdownMenuItem>
+					}
+				>
 					<DropdownMenuItem hideOnClick={ false }>
 						Test
 					</DropdownMenuItem>
@@ -198,5 +211,5 @@ export const AddItemsViaSlotFill: StoryFn< typeof DropdownMenu > = (
 	);
 };
 AddItemsViaSlotFill.args = {
-	trigger: <Icon icon={ menu } size={ 24 } />,
+	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
 };

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -1,0 +1,202 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryFn } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+import { menu } from '@wordpress/icons';
+import { useState, useMemo, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { DropdownMenu, DropdownMenuItem, DropdownMenuContext } from '..';
+import Icon from '../../icon';
+import Modal from '../../modal';
+import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
+
+const meta: Meta< typeof DropdownMenu > = {
+	title: 'Components (Experimental)/DropdownMenu v2 ariakit',
+	component: DropdownMenu,
+	subcomponents: {
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuItem,
+	},
+	argTypes: {
+		children: { control: { type: null } },
+	},
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+		controls: { expanded: true },
+		docs: {
+			canvas: { sourceState: 'shown' },
+			source: { excludeDecorators: true },
+		},
+	},
+	decorators: [
+		// Layout wrapper
+		( Story ) => (
+			<div
+				style={ {
+					minHeight: '300px',
+				} }
+			>
+				<Story />
+			</div>
+		),
+	],
+};
+export default meta;
+
+const Template: StoryFn< typeof DropdownMenu > = ( props ) => (
+	<DropdownMenu { ...props } />
+);
+export const Default = Template.bind( {} );
+Default.args = {
+	trigger: <Icon icon={ menu } size={ 24 } />,
+	children: (
+		<>
+			<DropdownMenuItem>Undo</DropdownMenuItem>
+			<DropdownMenuItem>Redo</DropdownMenuItem>
+			<DropdownMenu trigger="Find">
+				<DropdownMenuItem>Search the Web...</DropdownMenuItem>
+				<DropdownMenuItem>Find...</DropdownMenuItem>
+				<DropdownMenuItem>Find Next</DropdownMenuItem>
+				<DropdownMenuItem>Find Previous</DropdownMenuItem>
+			</DropdownMenu>
+			<DropdownMenu trigger="Speech">
+				<DropdownMenuItem>Start Speaking</DropdownMenuItem>
+				<DropdownMenuItem disabled>Stop Speaking</DropdownMenuItem>
+			</DropdownMenu>
+		</>
+	),
+};
+
+export const WithModalAsSiblingOfMenu: StoryFn< typeof DropdownMenu > = (
+	props
+) => {
+	const [ isModalOpen, setModalOpen ] = useState( false );
+	return (
+		<>
+			<DropdownMenu { ...props }>
+				<DropdownMenuItem onClick={ () => setModalOpen( true ) }>
+					Open modal
+				</DropdownMenuItem>
+			</DropdownMenu>
+			{ isModalOpen && (
+				<Modal onRequestClose={ () => setModalOpen( false ) }>
+					Modal&apos;s contents
+					<button onClick={ () => setModalOpen( false ) }>
+						Close
+					</button>
+				</Modal>
+			) }
+		</>
+	);
+};
+WithModalAsSiblingOfMenu.args = {
+	trigger: <Icon icon={ menu } size={ 24 } />,
+};
+
+export const WithModalAsSiblingOfMenuItem: StoryFn< typeof DropdownMenu > = (
+	props
+) => {
+	const [ isModalOpen, setModalOpen ] = useState( false );
+	return (
+		<DropdownMenu { ...props }>
+			<DropdownMenuItem
+				hideOnClick={ false }
+				onClick={ () => setModalOpen( true ) }
+			>
+				Open modal
+			</DropdownMenuItem>
+			{ isModalOpen && (
+				<Modal onRequestClose={ () => setModalOpen( false ) }>
+					Yo!
+					<button onClick={ () => setModalOpen( false ) }>
+						Modal&apos;s contents
+					</button>
+				</Modal>
+			) }
+		</DropdownMenu>
+	);
+};
+WithModalAsSiblingOfMenuItem.args = {
+	trigger: <Icon icon={ menu } size={ 24 } />,
+};
+
+const ExampleSlotFill = createSlotFill( 'Example' );
+
+const Slot = () => {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+
+	// Forwarding the content of the slot so that it can be used by the fill
+	const fillProps = useMemo(
+		() => ( {
+			forwardedContext: [
+				[
+					DropdownMenuContext.Provider,
+					{ value: dropdownMenuContext },
+				],
+			],
+		} ),
+		[ dropdownMenuContext ]
+	);
+
+	return <ExampleSlotFill.Slot fillProps={ fillProps } bubblesVirtually />;
+};
+
+type ForwardedContextTuple< P = {} > = [
+	React.ComponentType< React.PropsWithChildren< P > >,
+	P,
+];
+
+const Fill = ( { children }: { children: React.ReactNode } ) => {
+	const innerMarkup = <>{ children }</>;
+
+	return (
+		<ExampleSlotFill.Fill>
+			{ ( fillProps: { forwardedContext?: ForwardedContextTuple[] } ) => {
+				const { forwardedContext = [] } = fillProps;
+
+				return forwardedContext.reduce(
+					( inner: JSX.Element, [ Provider, props ] ) => (
+						<Provider { ...props }>{ inner }</Provider>
+					),
+					innerMarkup
+				);
+			} }
+		</ExampleSlotFill.Fill>
+	);
+};
+
+export const AddItemsViaSlotFill: StoryFn< typeof DropdownMenu > = (
+	props
+) => {
+	return (
+		<SlotFillProvider>
+			<DropdownMenu { ...props }>
+				<DropdownMenuItem>Item</DropdownMenuItem>
+				<DropdownMenu trigger="Nested">
+					<Slot />
+				</DropdownMenu>
+			</DropdownMenu>
+
+			<Fill>
+				<DropdownMenuItem hideOnClick={ false }>
+					Item from fill
+				</DropdownMenuItem>
+				<DropdownMenu trigger="Nested in fill">
+					<DropdownMenuItem hideOnClick={ false }>
+						Test
+					</DropdownMenuItem>
+				</DropdownMenu>
+			</Fill>
+		</SlotFillProvider>
+	);
+};
+AddItemsViaSlotFill.args = {
+	trigger: <Icon icon={ menu } size={ 24 } />,
+};

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -15,6 +15,7 @@ import { useState, useMemo, useContext } from '@wordpress/element';
 import {
 	DropdownMenu,
 	DropdownMenuItem,
+	DropdownMenuCheckboxItem,
 	DropdownMenuGroup,
 	DropdownMenuGroupLabel,
 	DropdownMenuContext,
@@ -71,6 +72,18 @@ Default.args = {
 				<DropdownMenuItem>Two</DropdownMenuItem>
 				<DropdownMenuItem>Three</DropdownMenuItem>
 			</DropdownMenuGroup>
+			<DropdownMenuGroup>
+				<DropdownMenuGroupLabel>Checks</DropdownMenuGroupLabel>
+				<DropdownMenuCheckboxItem name="test-check" value="a">
+					A
+				</DropdownMenuCheckboxItem>
+				<DropdownMenuCheckboxItem name="test-check" value="b">
+					B
+				</DropdownMenuCheckboxItem>
+				<DropdownMenuCheckboxItem name="test-check" value="c">
+					C
+				</DropdownMenuCheckboxItem>
+			</DropdownMenuGroup>
 			<DropdownMenu
 				trigger={ <DropdownMenuItem>Open submenu</DropdownMenuItem> }
 			>
@@ -79,6 +92,43 @@ Default.args = {
 			</DropdownMenu>
 		</>
 	),
+};
+
+export const WithControlledCheckboxes: StoryFn< typeof DropdownMenu > = (
+	props
+) => {
+	const [ isAChecked, setAChecked ] = useState( false );
+	const [ isBChecked, setBChecked ] = useState( true );
+	return (
+		<DropdownMenu { ...props }>
+			<DropdownMenuCheckboxItem
+				name="checkbox-a"
+				value="a"
+				checked={ isAChecked }
+				onChange={ ( e ) => setAChecked( e.target.checked ) }
+			>
+				Checkbox item A (controlled)
+			</DropdownMenuCheckboxItem>
+			<DropdownMenuCheckboxItem
+				name="checkbox-b"
+				value="b"
+				checked={ isBChecked }
+				onChange={ ( e ) => setBChecked( e.target.checked ) }
+			>
+				Checkbox item B (controlled, checked by default)
+			</DropdownMenuCheckboxItem>
+			<DropdownMenuCheckboxItem
+				name="checkbox-c"
+				value="c"
+				defaultChecked
+			>
+				Checkbox item C (uncontrolled, checked by default)
+			</DropdownMenuCheckboxItem>
+		</DropdownMenu>
+	);
+};
+WithControlledCheckboxes.args = {
+	trigger: <Button __next40pxDefaultSize label="Open menu" icon={ menu } />,
 };
 
 export const WithModalAsSiblingOfMenu: StoryFn< typeof DropdownMenu > = (

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -26,6 +26,7 @@ import Icon from '../../icon';
 import Button from '../../button';
 import Modal from '../../modal';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
+import { ContextSystemProvider } from '../../context';
 
 const meta: Meta< typeof DropdownMenu > = {
 	title: 'Components (Experimental)/DropdownMenu v2 ariakit',
@@ -402,5 +403,28 @@ export const WithSlotFill: StoryFn< typeof DropdownMenu > = ( props ) => {
 	);
 };
 WithSlotFill.args = {
+	...Default.args,
+};
+
+const toolbarVariantContextValue = {
+	DropdownMenu: {
+		variant: 'toolbar',
+	},
+};
+export const ToolbarVariant: StoryFn< typeof DropdownMenu > = ( props ) => (
+	<ContextSystemProvider value={ toolbarVariantContextValue }>
+		<DropdownMenu { ...props }>
+			<DropdownMenuItem>Level 1 item</DropdownMenuItem>
+			<DropdownMenuItem>Level 1 item</DropdownMenuItem>
+			<DropdownMenuSeparator />
+			<DropdownMenu
+				trigger={ <DropdownMenuItem>Submenu trigger</DropdownMenuItem> }
+			>
+				<DropdownMenuItem>Level 2 item</DropdownMenuItem>
+			</DropdownMenu>
+		</DropdownMenu>
+	</ContextSystemProvider>
+);
+ToolbarVariant.args = {
 	...Default.args,
 };

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -469,7 +469,13 @@ export const InsideModal: StoryFn< typeof DropdownMenu > = ( props ) => {
 	const [ isModalOpen, setModalOpen ] = useState( false );
 	return (
 		<>
-			<Button onClick={ () => setModalOpen( true ) }>Open modal</Button>
+			<Button
+				onClick={ () => setModalOpen( true ) }
+				__next40pxDefaultSize
+				variant="secondary"
+			>
+				Open modal
+			</Button>
 			{ isModalOpen && (
 				<Modal onRequestClose={ () => setModalOpen( false ) }>
 					<DropdownMenu { ...props }>

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -507,3 +507,8 @@ InsideModal.args = {
 		return true;
 	},
 };
+InsideModal.parameters = {
+	docs: {
+		source: { type: 'code' },
+	},
+};

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -3,6 +3,7 @@
  */
 import type { Meta, StoryFn } from '@storybook/react';
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 /**
  * WordPress dependencies
@@ -13,7 +14,7 @@ import { useState, useMemo, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { COLORS } from '../../utils';
+import { COLORS, useCx } from '../../utils';
 import {
 	DropdownMenu,
 	DropdownMenuItem,
@@ -310,10 +311,20 @@ WithRadios.args = {
 	...Default.args,
 };
 
+const modalOnTopOfDropdown = css`
+	&& {
+		z-index: 1000000;
+	}
+`;
+
 // For more examples with `Modal`, check https://ariakit.org/examples/menu-wordpress-modal
 export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
 	const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
 	const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
+
+	const cx = useCx();
+	const modalOverlayClassName = cx( modalOnTopOfDropdown );
+
 	return (
 		<>
 			<DropdownMenu { ...props }>
@@ -330,7 +341,10 @@ export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
 					Open inner modal
 				</DropdownMenuItem>
 				{ isInnerModalOpen && (
-					<Modal onRequestClose={ () => setInnerModalOpen( false ) }>
+					<Modal
+						onRequestClose={ () => setInnerModalOpen( false ) }
+						overlayClassName={ modalOverlayClassName }
+					>
 						Modal&apos;s contents
 						<button onClick={ () => setInnerModalOpen( false ) }>
 							Close
@@ -339,7 +353,10 @@ export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
 				) }
 			</DropdownMenu>
 			{ isOuterModalOpen && (
-				<Modal onRequestClose={ () => setOuterModalOpen( false ) }>
+				<Modal
+					onRequestClose={ () => setOuterModalOpen( false ) }
+					overlayClassName={ modalOverlayClassName }
+				>
 					Modal&apos;s contents
 					<button onClick={ () => setOuterModalOpen( false ) }>
 						Close

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -180,10 +180,6 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					value="b"
 					defaultChecked
 				>
-					{ /*
-					 * TODO: default checked doesn't work yet
-					 * https://github.com/ariakit/ariakit/issues/2913
-					 */ }
 					Checkbox item B (initially checked)
 				</DropdownMenuCheckboxItem>
 			</DropdownMenuGroup>
@@ -212,8 +208,6 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 			<DropdownMenuSeparator />
 			<DropdownMenuGroup>
 				<DropdownMenuGroupLabel>
-					{ /* TODO: can this be done using `defaultChecked` on the single item,
-					 * instead of using `defaultValues` on the menu component? */ }
 					Multiple, uncontrolled checkboxes
 				</DropdownMenuGroupLabel>
 				<DropdownMenuCheckboxItem
@@ -225,6 +219,7 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 				<DropdownMenuCheckboxItem
 					name="checkbox-multiple-uncontrolled"
 					value="b"
+					defaultChecked
 				>
 					Checkbox item B (initially checked)
 				</DropdownMenuCheckboxItem>
@@ -256,7 +251,6 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 };
 WithCheckboxes.args = {
 	...Default.args,
-	defaultValues: { 'checkbox-multiple-uncontrolled': [ 'b' ] },
 };
 
 export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -428,3 +428,40 @@ export const ToolbarVariant: StoryFn< typeof DropdownMenu > = ( props ) => (
 ToolbarVariant.args = {
 	...Default.args,
 };
+
+export const InsideModal: StoryFn< typeof DropdownMenu > = ( props ) => {
+	const [ isModalOpen, setModalOpen ] = useState( false );
+	return (
+		<>
+			<Button onClick={ () => setModalOpen( true ) }>Open modal</Button>
+			{ isModalOpen && (
+				<Modal onRequestClose={ () => setModalOpen( false ) }>
+					<DropdownMenu { ...props }>
+						<DropdownMenuItem>Level 1 item</DropdownMenuItem>
+						<DropdownMenuItem>Level 1 item</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenu
+							trigger={
+								<DropdownMenuItem>
+									Submenu trigger
+								</DropdownMenuItem>
+							}
+						>
+							<DropdownMenuItem>Level 2 item</DropdownMenuItem>
+						</DropdownMenu>
+					</DropdownMenu>
+					<Button onClick={ () => setModalOpen( false ) }>
+						Close modal
+					</Button>
+				</Modal>
+			) }
+		</>
+	);
+};
+InsideModal.args = {
+	...Default.args,
+	hideOnEscape: ( e ) => {
+		e.stopPropagation();
+		return true;
+	},
+};

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -414,25 +414,17 @@ export const WithSlotFill: StoryFn< typeof DropdownMenu > = ( props ) => {
 		<SlotFillProvider>
 			<DropdownMenu { ...props }>
 				<DropdownMenuItem>Item</DropdownMenuItem>
-				<DropdownMenu
-					trigger={ <DropdownMenuItem>Nested</DropdownMenuItem> }
-				>
-					<Slot />
-				</DropdownMenu>
+				<Slot />
 			</DropdownMenu>
 
 			<Fill>
-				<DropdownMenuItem hideOnClick={ false }>
-					Item from fill
-				</DropdownMenuItem>
+				<DropdownMenuItem>Item from fill</DropdownMenuItem>
 				<DropdownMenu
 					trigger={
-						<DropdownMenuItem>Nested in fill</DropdownMenuItem>
+						<DropdownMenuItem>Submenu from fill</DropdownMenuItem>
 					}
 				>
-					<DropdownMenuItem hideOnClick={ false }>
-						Test
-					</DropdownMenuItem>
+					<DropdownMenuItem>Submenu item from fill</DropdownMenuItem>
 				</DropdownMenu>
 			</Fill>
 		</SlotFillProvider>

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import styled from '@emotion/styled';
 
 /**
  * WordPress dependencies
@@ -12,6 +13,7 @@ import { useState, useMemo, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { COLORS } from '../../utils';
 import {
 	DropdownMenu,
 	DropdownMenuItem,
@@ -61,14 +63,37 @@ const meta: Meta< typeof DropdownMenu > = {
 };
 export default meta;
 
+const ItemHelpText = styled.span`
+	font-size: 12px;
+	color: ${ COLORS.gray[ '700' ] };
+
+	/* when the immediate parent item is hovered / focused */
+	[data-active-item] > * > &,
+	/* when the parent item is a submenu trigger and the submenu is open */
+	[aria-expanded='true'] > &,
+	/* when the parent item is disabled */
+	[aria-disabled='true'] > & {
+		color: inherit;
+	}
+`;
+
 export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 	<DropdownMenu { ...props }>
 		<DropdownMenuItem>Default item</DropdownMenuItem>
 		<DropdownMenuItem hideOnClick={ false }>
-			{ /* TODO: move this to description text */ }
-			Keep menu open on click
+			<div
+				style={ {
+					display: 'inline-flex',
+					flexDirection: 'column',
+				} }
+			>
+				Other item
+				<ItemHelpText>
+					Won&apos;t close the menu when clicked
+				</ItemHelpText>
+			</div>
 		</DropdownMenuItem>
-		<DropdownMenuItem disabled>Disabled</DropdownMenuItem>
+		<DropdownMenuItem disabled>Disabled item</DropdownMenuItem>
 		<DropdownMenuSeparator />
 		<DropdownMenuGroup>
 			<DropdownMenuGroupLabel>Prefix and suffix</DropdownMenuGroupLabel>
@@ -77,15 +102,15 @@ export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 			>
 				With prefix
 			</DropdownMenuItem>
-			<DropdownMenuItem suffix={ <span>Suf</span> }>
+			<DropdownMenuItem suffix={ <span>⌘S</span> }>
 				With suffix
 			</DropdownMenuItem>
 			<DropdownMenuItem
 				disabled
-				prefix={ <span>Pre</span> }
-				suffix={ <span>Suf</span> }
+				prefix={ <Icon icon={ wordpress } size={ 24 } /> }
+				suffix={ <span>⌥⌘T</span> }
 			>
-				Disabled with both
+				Disabled with prefix and suffix
 			</DropdownMenuItem>
 		</DropdownMenuGroup>
 	</DropdownMenu>

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -1,0 +1,151 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import * as Ariakit from '@ariakit/react';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+export const toggleButton = css`
+	display: flex;
+	height: 2.5rem;
+	touch-action: none;
+	user-select: none;
+	align-items: center;
+	justify-content: center;
+	gap: 0.25rem;
+	white-space: nowrap;
+	border-radius: 0.5rem;
+	border-style: none;
+	background-color: hsl( 204 20% 100% );
+	padding-left: 1rem;
+	padding-right: 1rem;
+	font-size: 1rem;
+	line-height: 1.5rem;
+	color: hsl( 204 10% 10% );
+	text-decoration-line: none;
+	outline-width: 2px;
+	outline-offset: 2px;
+	outline-color: hsl( 204 100% 40% );
+	box-shadow:
+		inset 0 0 0 1px rgba( 0, 0, 0, 0.1 ),
+		inset 0 -1px 0 rgba( 0, 0, 0, 0.1 ),
+		0 1px 1px rgba( 0, 0, 0, 0.1 );
+	font-weight: 500;
+
+	&:hover {
+		background-color: hsl( 204 20% 96% );
+	}
+
+	&[aria-disabled='true'] {
+		opacity: 0.5;
+	}
+
+	&[aria-expanded='true'] {
+		background-color: hsl( 204 20% 96% );
+	}
+
+	&[data-focus-visible] {
+		outline-style: solid;
+	}
+
+	&:active,
+	&[data-active] {
+		transform: scale( 0.98 );
+	}
+
+	&:active[aria-expanded='true'],
+	&[data-active][aria-expanded='true'] {
+		transform: scale( 1 );
+	}
+
+	@media ( min-width: 640px ) {
+		gap: 0.5rem;
+	}
+`;
+
+// :is(.dark .button) {
+//   background-color: hsl(204 20% 100% / 0.05);
+//   color: hsl(204 20% 100%);
+//   box-shadow:
+//     inset 0 0 0 1px rgba(255, 255, 255, 0.1),
+//     inset 0 -1px 0 1px rgba(0, 0, 0, 0.2),
+//     inset 0 1px 0 rgba(255, 255, 255, 0.05);
+// }
+
+// :is(.dark .button:hover) {
+//   background-color: hsl(204 20% 100% / 0.1);
+// }
+
+// :is(.dark .button)[aria-expanded="true"] {
+//   background-color: hsl(204 20% 100% / 0.1);
+// }
+
+export const StyledAriakitMenu = styled( Ariakit.Menu )`
+	position: relative;
+	z-index: 50;
+	display: flex;
+	max-height: var( --popover-available-height );
+	min-width: 180px;
+	flex-direction: column;
+	overscroll-behavior: contain;
+	border-radius: 0.5rem;
+	border-width: 1px;
+	border-style: solid;
+	border-color: hsl( 204 20% 88% );
+	background-color: hsl( 204 20% 100% );
+	padding: 0.5rem;
+	color: hsl( 204 10% 10% );
+	box-shadow:
+		0 10px 15px -3px rgb( 0 0 0 / 0.1 ),
+		0 4px 6px -4px rgb( 0 0 0 / 0.1 );
+	outline: none !important;
+	overflow: visible;
+`;
+
+// :is(.dark .menu) {
+//   border-color: hsl(204 3% 26%);
+//   background-color: hsl(204 3% 18%);
+//   color: hsl(204 20% 100%);
+//   box-shadow:
+//     0 10px 15px -3px rgb(0 0 0 / 0.25),
+//     0 4px 6px -4px rgb(0 0 0 / 0.1);
+// }
+
+export const StyledAriakitMenuItem = styled( Ariakit.MenuItem )`
+	display: flex;
+	cursor: default;
+	scroll-margin: 0.5rem;
+	align-items: center;
+	gap: 0.5rem;
+	border-radius: 0.25rem;
+	padding: 0.5rem;
+	outline: none !important;
+
+	&[aria-disabled='true'] {
+		opacity: 0.25;
+	}
+
+	&[data-active-item] {
+		background-color: hsl( 204 100% 40% );
+		color: hsl( 204 20% 100% );
+	}
+
+	&:active,
+	&[data-active] {
+		background-color: hsl( 204 100% 32% );
+	}
+
+	${ StyledAriakitMenu }:not(:focus) &:not(:focus)[aria-expanded="true"] {
+		background-color: hsl( 204 10% 10% / 0.1 );
+		color: currentColor;
+	}
+`;
+
+// :is(.dark .menu:not(:focus) .menu-item:not(:focus)[aria-expanded="true"]) {
+//   background-color: hsl(204 20% 100% / 0.1);
+// }
+
+export const StyledMenuButtonLabel = styled.span`
+	flex: 1 1 0%;
+`;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -4,84 +4,9 @@
 // eslint-disable-next-line no-restricted-imports
 import * as Ariakit from '@ariakit/react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 
-export const toggleButton = css`
-	display: flex;
-	height: 2.5rem;
-	touch-action: none;
-	user-select: none;
-	align-items: center;
-	justify-content: center;
-	gap: 0.25rem;
-	white-space: nowrap;
-	border-radius: 0.5rem;
-	border-style: none;
-	background-color: hsl( 204 20% 100% );
-	padding-left: 1rem;
-	padding-right: 1rem;
-	font-size: 1rem;
-	line-height: 1.5rem;
-	color: hsl( 204 10% 10% );
-	text-decoration-line: none;
-	outline-width: 2px;
-	outline-offset: 2px;
-	outline-color: hsl( 204 100% 40% );
-	box-shadow:
-		inset 0 0 0 1px rgba( 0, 0, 0, 0.1 ),
-		inset 0 -1px 0 rgba( 0, 0, 0, 0.1 ),
-		0 1px 1px rgba( 0, 0, 0, 0.1 );
-	font-weight: 500;
-
-	&:hover {
-		background-color: hsl( 204 20% 96% );
-	}
-
-	&[aria-disabled='true'] {
-		opacity: 0.5;
-	}
-
-	&[aria-expanded='true'] {
-		background-color: hsl( 204 20% 96% );
-	}
-
-	&[data-focus-visible] {
-		outline-style: solid;
-	}
-
-	&:active,
-	&[data-active] {
-		transform: scale( 0.98 );
-	}
-
-	&:active[aria-expanded='true'],
-	&[data-active][aria-expanded='true'] {
-		transform: scale( 1 );
-	}
-
-	@media ( min-width: 640px ) {
-		gap: 0.5rem;
-	}
-`;
-
-// :is(.dark .button) {
-//   background-color: hsl(204 20% 100% / 0.05);
-//   color: hsl(204 20% 100%);
-//   box-shadow:
-//     inset 0 0 0 1px rgba(255, 255, 255, 0.1),
-//     inset 0 -1px 0 1px rgba(0, 0, 0, 0.2),
-//     inset 0 1px 0 rgba(255, 255, 255, 0.05);
-// }
-
-// :is(.dark .button:hover) {
-//   background-color: hsl(204 20% 100% / 0.1);
-// }
-
-// :is(.dark .button)[aria-expanded="true"] {
-//   background-color: hsl(204 20% 100% / 0.1);
-// }
-
-export const StyledAriakitMenu = styled( Ariakit.Menu )`
+// TODO: z-index from global vars
+export const DropdownMenu = styled( Ariakit.Menu )`
 	position: relative;
 	z-index: 50;
 	display: flex;
@@ -102,17 +27,9 @@ export const StyledAriakitMenu = styled( Ariakit.Menu )`
 	outline: none !important;
 	overflow: visible;
 `;
-
-// :is(.dark .menu) {
-//   border-color: hsl(204 3% 26%);
-//   background-color: hsl(204 3% 18%);
-//   color: hsl(204 20% 100%);
-//   box-shadow:
-//     0 10px 15px -3px rgb(0 0 0 / 0.25),
-//     0 4px 6px -4px rgb(0 0 0 / 0.1);
-// }
-
-export const StyledAriakitMenuItem = styled( Ariakit.MenuItem )`
+export const DropdownMenuGroup = styled( Ariakit.MenuGroup )``;
+export const DropdownMenuGroupLabel = styled( Ariakit.MenuGroupLabel )``;
+export const DropdownMenuItem = styled( Ariakit.MenuItem )`
 	display: flex;
 	cursor: default;
 	scroll-margin: 0.5rem;
@@ -136,16 +53,11 @@ export const StyledAriakitMenuItem = styled( Ariakit.MenuItem )`
 		background-color: hsl( 204 100% 32% );
 	}
 
-	${ StyledAriakitMenu }:not(:focus) &:not(:focus)[aria-expanded="true"] {
+	${ DropdownMenu }:not(:focus) &:not(:focus)[aria-expanded="true"] {
 		background-color: hsl( 204 10% 10% / 0.1 );
 		color: currentColor;
 	}
 `;
-
-// :is(.dark .menu:not(:focus) .menu-item:not(:focus)[aria-expanded="true"]) {
-//   background-color: hsl(204 20% 100% / 0.1);
-// }
-
-export const StyledMenuButtonLabel = styled.span`
-	flex: 1 1 0%;
-`;
+export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox );
+export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio );
+export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator );

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -9,9 +9,9 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { COLORS, font, CONFIG } from '../utils';
+import { COLORS, font, rtl, CONFIG } from '../utils';
 import { space } from '../utils/space';
-// import Icon from '../icon';
+import Icon from '../icon';
 import type { DropdownMenuContext } from './types';
 
 const CONTENT_WRAPPER_PADDING = space( 2 );
@@ -48,11 +48,12 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 	overscroll-behavior: contain;
 	overflow: visible;
 `;
-export const DropdownMenuGroup = styled( Ariakit.MenuGroup )``;
-export const DropdownMenuGroupLabel = styled( Ariakit.MenuGroupLabel )``;
 
 const itemPrefix = css`
-	width: ${ ITEM_PREFIX_WIDTH };
+	/* !important is to override some inline styles set by Ariakit */
+	width: ${ ITEM_PREFIX_WIDTH } !important;
+	/* !important is to override some inline styles set by Ariakit */
+	height: auto !important;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -152,21 +153,23 @@ const baseItem = css`
 		outline: 2px solid transparent;
 	}
 
-	/* Active (ie. pressed) */
+	/* Active (ie. pressed, mouse down) */
 	&:active,
 	&[data-active] {
-		background-color: hsl( 204 100% 32% );
+		/* TODO: should there be a visual active state? */
 	}
 
-	/* When trigger or a submenu that is open */
+	/* When the item is the trigger of an open submenu */
 	${ DropdownMenu }:not(:focus) &:not(:focus)[aria-expanded="true"] {
-		background-color: hsl( 204 10% 10% / 0.1 );
-		color: currentColor;
-		outline: 1px solid red;
+		/* TODO: should we style submenu triggers any different? */
 	}
 
 	svg {
 		fill: currentColor;
+	}
+
+	&:not( :has( ${ ItemPrefixWrapper } ) ) {
+		padding-inline-start: ${ ITEM_PREFIX_WIDTH };
 	}
 `;
 // TODO: add styles to item for adding extra space when there's no prefix
@@ -177,10 +180,56 @@ const baseItem = css`
 export const DropdownMenuItem = styled( Ariakit.MenuItem )`
 	${ baseItem }
 `;
+
 export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox )`
 	${ baseItem }
 `;
+
 export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio )`
 	${ baseItem }
 `;
-export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )``;
+
+export const DropdownMenuGroup = styled( Ariakit.MenuGroup )``;
+
+export const DropdownMenuGroupLabel = styled( Ariakit.MenuGroupLabel )`
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	min-height: ${ space( 8 ) };
+
+	padding: ${ space( 2 ) } ${ ITEM_PADDING_INLINE_END } ${ space( 2 ) }
+		${ ITEM_PREFIX_WIDTH };
+	/* TODO: color doesn't match available UI variables */
+	color: ${ COLORS.gray[ 700 ] };
+
+	/* TODO: font size doesn't match available ones via "font" utils */
+	font-size: 11px;
+	line-height: 1.4;
+	font-weight: 500;
+	text-transform: uppercase;
+`;
+
+export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )<
+	Pick< DropdownMenuContext, 'variant' >
+>`
+	border: none;
+	height: ${ CONFIG.borderWidth };
+	/* TODO: doesn't match border color from variables */
+	background-color: ${ ( props ) =>
+		props.variant === 'toolbar'
+			? TOOLBAR_VARIANT_BORDER_COLOR
+			: DEFAULT_BORDER_COLOR };
+	/* Negative horizontal margin to make separator go from side to side */
+	margin: ${ space( 2 ) } calc( -1 * ${ CONTENT_WRAPPER_PADDING } );
+`;
+
+export const SubmenuRtlChevronIcon = styled( Icon )`
+	${ rtl(
+		{
+			transform: `scaleX(1) translateX(${ space( 2 ) })`,
+		},
+		{
+			transform: `scaleX(-1) translateX(${ space( 2 ) })`,
+		}
+	) }
+`;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -58,6 +58,6 @@ export const DropdownMenuItem = styled( Ariakit.MenuItem )`
 		color: currentColor;
 	}
 `;
-export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox );
-export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio );
-export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator );
+export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox )``;
+export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio )``;
+export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )``;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -3,61 +3,184 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import * as Ariakit from '@ariakit/react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+/**
+ * Internal dependencies
+ */
+import { COLORS, font, CONFIG } from '../utils';
+import { space } from '../utils/space';
+// import Icon from '../icon';
+import type { DropdownMenuContext } from './types';
+
+const CONTENT_WRAPPER_PADDING = space( 2 );
+const ITEM_PREFIX_WIDTH = space( 7 );
+const ITEM_PADDING_INLINE_START = space( 2 );
+const ITEM_PADDING_INLINE_END = space( 2.5 );
+
+// TODO: should bring this into the config, and make themeable
+const DEFAULT_BORDER_COLOR = COLORS.ui.borderDisabled;
+const TOOLBAR_VARIANT_BORDER_COLOR = COLORS.gray[ '900' ];
+const DEFAULT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ DEFAULT_BORDER_COLOR }, ${ CONFIG.popoverShadow }`;
+const TOOLBAR_VARIANT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ TOOLBAR_VARIANT_BORDER_COLOR }`;
+
 // TODO: z-index from global vars
-export const DropdownMenu = styled( Ariakit.Menu )`
+export const DropdownMenu = styled( Ariakit.Menu )<
+	Pick< DropdownMenuContext, 'variant' >
+>`
 	position: relative;
 	z-index: 50;
-	display: flex;
+
+	min-width: 220px;
 	max-height: var( --popover-available-height );
-	min-width: 180px;
-	flex-direction: column;
-	overscroll-behavior: contain;
-	border-radius: 0.5rem;
-	border-width: 1px;
-	border-style: solid;
-	border-color: hsl( 204 20% 88% );
-	background-color: hsl( 204 20% 100% );
-	padding: 0.5rem;
-	color: hsl( 204 10% 10% );
-	box-shadow:
-		0 10px 15px -3px rgb( 0 0 0 / 0.1 ),
-		0 4px 6px -4px rgb( 0 0 0 / 0.1 );
+	padding: ${ CONTENT_WRAPPER_PADDING };
+
+	background-color: ${ COLORS.ui.background };
+	border-radius: ${ CONFIG.radiusBlockUi };
+	${ ( props ) => css`
+		box-shadow: ${ props.variant === 'toolbar'
+			? TOOLBAR_VARIANT_BOX_SHADOW
+			: DEFAULT_BOX_SHADOW };
+	` }
 	outline: none !important;
+
+	overscroll-behavior: contain;
 	overflow: visible;
 `;
 export const DropdownMenuGroup = styled( Ariakit.MenuGroup )``;
 export const DropdownMenuGroupLabel = styled( Ariakit.MenuGroupLabel )``;
-export const DropdownMenuItem = styled( Ariakit.MenuItem )`
-	display: flex;
-	cursor: default;
-	scroll-margin: 0.5rem;
+
+const itemPrefix = css`
+	width: ${ ITEM_PREFIX_WIDTH };
+	display: inline-flex;
 	align-items: center;
-	gap: 0.5rem;
-	border-radius: 0.25rem;
-	padding: 0.5rem;
-	outline: none !important;
+	justify-content: center;
+	/* Prefixes don't get affected by the item's inline start padding */
+	margin-inline-start: calc( -1 * ${ ITEM_PADDING_INLINE_START } );
+	/*
+		Negative margin allows the suffix to be as tall as the whole item
+		(incl. padding) before increasing the items' height. This can be useful,
+		e.g., when using icons that are bigger than 20x20 px
+	*/
+	margin-top: ${ space( -2 ) };
+	margin-bottom: ${ space( -2 ) };
+`;
+
+const itemSuffix = css`
+	width: max-content;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	/* Push prefix to the inline-end of the item */
+	margin-inline-start: auto;
+	/* Minimum space between the item's content and suffix */
+	padding-inline-start: ${ space( 6 ) };
+	/*
+		Negative margin allows the suffix to be as tall as the whole item
+		(incl. padding) before increasing the items' height. This can be useful,
+		e.g., when using icons that are bigger than 20x20 px
+	*/
+	margin-top: ${ space( -2 ) };
+	margin-bottom: ${ space( -2 ) };
+
+	/*
+		Override color in normal conditions, but inherit the item's color
+	  for altered conditions.
+
+		TODO:
+		  - For now, used opacity like for disabled item, which makes it work
+			  regardless of the theme
+		  - how do we translate this for themes? Should we have a new variable
+		for "secondary" text?
+	*/
+	opacity: 0.6;
+
+	/* TODO: find equivalent of data-state="open" and data-disabled */
+	&[data-active-item] > &,
+	[data-state='open'] > &,
+	[data-disabled] > & {
+		opacity: 1;
+	}
+`;
+
+export const ItemPrefixWrapper = styled.span`
+	${ itemPrefix }
+`;
+
+export const ItemSuffixWrapper = styled.span`
+	${ itemSuffix }
+`;
+
+const baseItem = css`
+	all: unset;
+	font-size: ${ font( 'default.fontSize' ) };
+	font-family: inherit;
+	font-weight: normal;
+	line-height: 20px;
+	color: ${ COLORS.gray[ 900 ] };
+	border-radius: ${ CONFIG.radiusBlockUi };
+	display: flex;
+	align-items: center;
+	padding: ${ space( 2 ) } ${ ITEM_PADDING_INLINE_END } ${ space( 2 ) }
+		${ ITEM_PADDING_INLINE_START };
+	position: relative;
+	user-select: none;
+	outline: none;
 
 	&[aria-disabled='true'] {
-		opacity: 0.25;
+		/*
+		TODO:
+			- we need a disabled color in the Theme variables
+			- design specs use opacity instead of setting a new text color
+	*/
+		opacity: 0.5;
+		pointer-events: none;
 	}
 
+	/* Hover */
 	&[data-active-item] {
-		background-color: hsl( 204 100% 40% );
-		color: hsl( 204 20% 100% );
+		/* TODO: reconcile with global focus styles */
+		background-color: ${ COLORS.gray[ '100' ] };
 	}
 
+	/* Keyboard focus (focus-visible) */
+	&[data-focus-visible] {
+		/* TODO: should there be a visual indication of keyboard focus vs hover? */
+
+		/* Only visible in Windows High Contrast mode */
+		outline: 2px solid transparent;
+	}
+
+	/* Active (ie. pressed) */
 	&:active,
 	&[data-active] {
 		background-color: hsl( 204 100% 32% );
 	}
 
+	/* When trigger or a submenu that is open */
 	${ DropdownMenu }:not(:focus) &:not(:focus)[aria-expanded="true"] {
 		background-color: hsl( 204 10% 10% / 0.1 );
 		color: currentColor;
+		outline: 1px solid red;
+	}
+
+	svg {
+		fill: currentColor;
 	}
 `;
-export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox )``;
-export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio )``;
+// TODO: add styles to item for adding extra space when there's no prefix
+// &:not( :has( ${ ItemPrefixWrapper } ) ) {
+// 	padding-inline-start: ${ ITEM_PREFIX_WIDTH };
+// }
+
+export const DropdownMenuItem = styled( Ariakit.MenuItem )`
+	${ baseItem }
+`;
+export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox )`
+	${ baseItem }
+`;
+export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio )`
+	${ baseItem }
+`;
 export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )``;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -3,7 +3,7 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import * as Ariakit from '@ariakit/react';
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
 /**
@@ -13,6 +13,12 @@ import { COLORS, font, rtl, CONFIG } from '../utils';
 import { space } from '../utils/space';
 import Icon from '../icon';
 import type { DropdownMenuContext } from './types';
+
+const ANIMATION_PARAMS = {
+	SLIDE_AMOUNT: '2px',
+	DURATION: '400ms',
+	EASING: 'cubic-bezier( 0.16, 1, 0.3, 1 )',
+};
 
 const CONTENT_WRAPPER_PADDING = space( 2 );
 const ITEM_PREFIX_WIDTH = space( 7 );
@@ -24,6 +30,38 @@ const DEFAULT_BORDER_COLOR = COLORS.ui.borderDisabled;
 const TOOLBAR_VARIANT_BORDER_COLOR = COLORS.gray[ '900' ];
 const DEFAULT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ DEFAULT_BORDER_COLOR }, ${ CONFIG.popoverShadow }`;
 const TOOLBAR_VARIANT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ TOOLBAR_VARIANT_BORDER_COLOR }`;
+
+const slideUpAndFade = keyframes( {
+	'0%': {
+		opacity: 0,
+		transform: `translateY(${ ANIMATION_PARAMS.SLIDE_AMOUNT })`,
+	},
+	'100%': { opacity: 1, transform: 'translateY(0)' },
+} );
+
+const slideRightAndFade = keyframes( {
+	'0%': {
+		opacity: 0,
+		transform: `translateX(-${ ANIMATION_PARAMS.SLIDE_AMOUNT })`,
+	},
+	'100%': { opacity: 1, transform: 'translateX(0)' },
+} );
+
+const slideDownAndFade = keyframes( {
+	'0%': {
+		opacity: 0,
+		transform: `translateY(-${ ANIMATION_PARAMS.SLIDE_AMOUNT })`,
+	},
+	'100%': { opacity: 1, transform: 'translateY(0)' },
+} );
+
+const slideLeftAndFade = keyframes( {
+	'0%': {
+		opacity: 0,
+		transform: `translateX(${ ANIMATION_PARAMS.SLIDE_AMOUNT })`,
+	},
+	'100%': { opacity: 1, transform: 'translateX(0)' },
+} );
 
 // TODO: z-index from global vars
 export const DropdownMenu = styled( Ariakit.Menu )<
@@ -47,6 +85,26 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 
 	overscroll-behavior: contain;
 	overflow: visible;
+
+	/* Animation */
+	animation-duration: ${ ANIMATION_PARAMS.DURATION };
+	animation-timing-function: ${ ANIMATION_PARAMS.EASING };
+	will-change: transform, opacity;
+	/* Default animation.*/
+	animation-name: ${ slideDownAndFade };
+
+	&[data-side='right'] {
+		animation-name: ${ slideLeftAndFade };
+	}
+	&[data-side='bottom'] {
+		animation-name: ${ slideUpAndFade };
+	}
+	&[data-side='left'] {
+		animation-name: ${ slideRightAndFade };
+	}
+	@media ( prefers-reduced-motion ) {
+		animation-duration: 0s;
+	}
 `;
 
 const itemPrefix = css`

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -281,7 +281,7 @@ export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )<
 	margin: ${ space( 2 ) } calc( -1 * ${ CONTENT_WRAPPER_PADDING } );
 `;
 
-export const SubmenuRtlChevronIcon = styled( Icon )`
+export const SubmenuChevronIcon = styled( Icon )`
 	${ rtl(
 		{
 			transform: `scaleX(1) translateX(${ space( 2 ) })`,

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -63,12 +63,13 @@ const slideLeftAndFade = keyframes( {
 	'100%': { opacity: 1, transform: 'translateX(0)' },
 } );
 
-// TODO: z-index from global vars
 export const DropdownMenu = styled( Ariakit.Menu )<
 	Pick< DropdownMenuContext, 'variant' >
 >`
 	position: relative;
-	z-index: 50;
+	/* Same as popover component */
+	/* TODO: is there a way to read the sass variable? */
+	z-index: 1000000;
 
 	min-width: 220px;
 	max-height: var( --popover-available-height );

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -156,10 +156,12 @@ const itemSuffix = css`
 	*/
 	opacity: 0.6;
 
-	/* TODO: find equivalent of data-state="open" and data-disabled */
-	&[data-active-item] > &,
-	[data-state='open'] > &,
-	[data-disabled] > & {
+	/* when the parent item is hovered / focused */
+	[data-active-item] > &,
+	/* when the parent item is a submenu trigger and the submenu is open */
+	[aria-expanded='true'] > &,
+	/* when the parent item is disabled */
+	[aria-disabled='true'] > & {
 		opacity: 1;
 	}
 `;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -208,7 +208,7 @@ const baseItem = css`
 
 	/* Keyboard focus (focus-visible) */
 	&[data-focus-visible] {
-		/* TODO: should there be a visual indication of keyboard focus vs hover? */
+		box-shadow: 0 0 0 1.5px var( --wp-admin-theme-color );
 
 		/* Only visible in Windows High Contrast mode */
 		outline: 2px solid transparent;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -82,10 +82,12 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 			? TOOLBAR_VARIANT_BOX_SHADOW
 			: DEFAULT_BOX_SHADOW };
 	` }
-	outline: none !important;
 
 	overscroll-behavior: contain;
 	overflow: visible;
+
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent !important;
 
 	/* Animation */
 	animation-duration: ${ ANIMATION_PARAMS.DURATION };
@@ -278,6 +280,9 @@ export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )<
 			: DEFAULT_BORDER_COLOR };
 	/* Negative horizontal margin to make separator go from side to side */
 	margin: ${ space( 2 ) } calc( -1 * ${ CONTENT_WRAPPER_PADDING } );
+
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent;
 `;
 
 export const SubmenuChevronIcon = styled( Icon )`

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -230,10 +230,6 @@ const baseItem = css`
 		padding-inline-start: ${ ITEM_PREFIX_WIDTH };
 	}
 `;
-// TODO: add styles to item for adding extra space when there's no prefix
-// &:not( :has( ${ ItemPrefixWrapper } ) ) {
-// 	padding-inline-start: ${ ITEM_PREFIX_WIDTH };
-// }
 
 export const DropdownMenuItem = styled( Ariakit.MenuItem )`
 	${ baseItem }

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -84,7 +84,7 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 	` }
 
 	overscroll-behavior: contain;
-	overflow: visible;
+	overflow: auto;
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent !important;

--- a/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
@@ -1,816 +1,842 @@
-// /**
-//  * External dependencies
-//  */
-// import { render, screen, waitFor } from '@testing-library/react';
-// import {
-// 	default as userEvent,
-// 	PointerEventsCheckLevel,
-// } from '@testing-library/user-event';
-
-// /**
-//  * WordPress dependencies
-//  */
-// import { useState } from '@wordpress/element';
-
-// /**
-//  * Internal dependencies
-//  */
-// import {
-// 	DropdownMenu,
-// 	DropdownMenuCheckboxItem,
-// 	DropdownMenuItem,
-// 	DropdownMenuLabel,
-// 	DropdownMenuRadioGroup,
-// 	DropdownMenuRadioItem,
-// 	DropdownMenuSeparator,
-// 	DropdownSubMenu,
-// 	DropdownSubMenuTrigger,
-// } from '..';
-
-// const delay = ( delayInMs: number ) => {
-// 	return new Promise( ( resolve ) => setTimeout( resolve, delayInMs ) );
-// };
-
-// describe( 'DropdownMenu', () => {
-// 	// See https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/
-// 	it( 'should follow the WAI-ARIA spec', async () => {
-// 		// Radio and Checkbox items'
-// 		const user = userEvent.setup();
-
-// 		render(
-// 			<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 				<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-// 				<DropdownMenuSeparator />
-// 				<DropdownSubMenu
-// 					trigger={
-// 						<DropdownSubMenuTrigger>
-// 							Dropdown submenu
-// 						</DropdownSubMenuTrigger>
-// 					}
-// 				>
-// 					<DropdownMenuItem>Dropdown submenu item 1</DropdownMenuItem>
-// 					<DropdownMenuItem>Dropdown submenu item 2</DropdownMenuItem>
-// 				</DropdownSubMenu>
-// 			</DropdownMenu>
-// 		);
-
-// 		const toggleButton = screen.getByRole( 'button', {
-// 			name: 'Open dropdown',
-// 		} );
-
-// 		expect( toggleButton ).toHaveAttribute( 'aria-haspopup', 'menu' );
-// 		expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'false' );
-
-// 		await user.click( toggleButton );
-
-// 		expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'true' );
-
-// 		expect( screen.getByRole( 'menu' ) ).toHaveFocus();
-// 		expect( screen.getByRole( 'separator' ) ).toHaveAttribute(
-// 			'aria-orientation',
-// 			'horizontal'
-// 		);
-// 		expect( screen.getAllByRole( 'menuitem' ) ).toHaveLength( 2 );
-
-// 		const submenuTrigger = screen.getByRole( 'menuitem', {
-// 			name: 'Dropdown submenu',
-// 		} );
-// 		expect( submenuTrigger ).toHaveAttribute( 'aria-haspopup', 'menu' );
-// 		expect( submenuTrigger ).toHaveAttribute( 'aria-expanded', 'false' );
-
-// 		await user.hover( submenuTrigger );
-
-// 		// Wait for the open animation after hovering
-// 		await waitFor( () =>
-// 			expect( screen.getAllByRole( 'menu' ) ).toHaveLength( 2 )
-// 		);
-
-// 		expect( submenuTrigger ).toHaveAttribute( 'aria-expanded', 'true' );
-// 		expect( submenuTrigger ).toHaveAttribute(
-// 			'aria-controls',
-// 			screen.getAllByRole( 'menu' )[ 1 ].id
-// 		);
-// 	} );
-
-// 	describe( 'pointer and keyboard interactions', () => {
-// 		it( 'should open when clicking the trigger', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			const toggleButton = screen.getByRole( 'button', {
-// 				name: 'Open dropdown',
-// 			} );
-
-// 			// DropdownMenu closed, the content is not displayed
-// 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
-// 			expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
-
-// 			// Click to open the menu
-// 			await user.click( toggleButton );
-
-// 			// DropdownMenu open, the content is displayed
-// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
-// 			expect( screen.getByRole( 'menuitem' ) ).toBeInTheDocument();
-// 		} );
-
-// 		it( 'should open when pressing the arrow down key on the trigger', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			const toggleButton = screen.getByRole( 'button', {
-// 				name: 'Open dropdown',
-// 			} );
-
-// 			// Move focus on the toggle
-// 			await user.keyboard( '{Tab}' );
-
-// 			expect( toggleButton ).toHaveFocus();
-
-// 			// DropdownMenu closed, the content is not displayed
-// 			expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
-
-// 			await user.keyboard( '{ArrowDown}' );
-
-// 			// DropdownMenu open, the content is displayed
-// 			expect( screen.getByRole( 'menuitem' ) ).toBeInTheDocument();
-// 		} );
-
-// 		it( 'should close when pressing the escape key', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu
-// 					defaultOpen
-// 					trigger={ <button>Open dropdown</button> }
-// 				>
-// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			// The menu is focused automatically when `defaultOpen` is set.
-// 			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
-
-// 			// Pressing esc will close the menu and move focus to the toggle
-// 			await user.keyboard( '{Escape}' );
-
-// 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
-// 			expect(
-// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
-// 			).toHaveFocus();
-// 		} );
-
-// 		it( 'should close when clicking outside of the content', async () => {
-// 			const user = userEvent.setup( {
-// 				// Disabling this check otherwise testing-library would complain
-// 				// when clicking on document.body to close the dropdown menu.
-// 				pointerEventsCheck: PointerEventsCheckLevel.Never,
-// 			} );
-
-// 			render(
-// 				<DropdownMenu
-// 					defaultOpen
-// 					trigger={ <button>Open dropdown</button> }
-// 				>
-// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
-
-// 			// Click on the body (ie. outside of the dropdown menu)
-// 			await user.click( document.body );
-
-// 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
-// 		} );
-
-// 		it( 'should close when clicking on a menu item', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu
-// 					defaultOpen
-// 					trigger={ <button>Open dropdown</button> }
-// 				>
-// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
-
-// 			// Clicking a menu item will close the menu
-// 			await user.click( screen.getByRole( 'menuitem' ) );
-
-// 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
-// 		} );
-
-// 		it( 'should not close when clicking on a disabled menu item', async () => {
-// 			const user = userEvent.setup( {
-// 				// Disabling this check otherwise testing-library would complain
-// 				// when clicking on a disabled element with pointer-events: none
-// 				pointerEventsCheck: PointerEventsCheckLevel.Never,
-// 			} );
-
-// 			render(
-// 				<DropdownMenu
-// 					defaultOpen
-// 					trigger={ <button>Open dropdown</button> }
-// 				>
-// 					<DropdownMenuItem disabled>
-// 						Dropdown menu item
-// 					</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
-
-// 			// Clicking a disabled menu item won't close the menu
-// 			await user.click( screen.getByRole( 'menuitem' ) );
-
-// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
-// 		} );
-
-// 		it( 'should reveal submenu content when hovering over the submenu trigger', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu
-// 					defaultOpen
-// 					trigger={ <button>Open dropdown</button> }
-// 				>
-// 					<DropdownMenuItem>Dropdown menu item 1</DropdownMenuItem>
-// 					<DropdownMenuItem>Dropdown menu item 2</DropdownMenuItem>
-// 					<DropdownSubMenu
-// 						trigger={
-// 							<DropdownSubMenuTrigger>
-// 								Dropdown submenu
-// 							</DropdownSubMenuTrigger>
-// 						}
-// 					>
-// 						<DropdownMenuItem>
-// 							Dropdown submenu item 1
-// 						</DropdownMenuItem>
-// 						<DropdownMenuItem>
-// 							Dropdown submenu item 2
-// 						</DropdownMenuItem>
-// 					</DropdownSubMenu>
-// 					<DropdownMenuItem>Dropdown menu item 3</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			// Before hover, submenu items are not rendered
-// 			expect(
-// 				screen.queryByRole( 'menuitem', {
-// 					name: 'Dropdown submenu item 1',
-// 				} )
-// 			).not.toBeInTheDocument();
-
-// 			await user.hover(
-// 				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
-// 			);
-
-// 			// After hover, submenu items are rendered
-// 			// Reason for `findByRole`: due to the animation, we've got to wait
-// 			// a short amount of time for the submenu to appear
-// 			await screen.findByRole( 'menuitem', {
-// 				name: 'Dropdown submenu item 1',
-// 			} );
-// 		} );
-
-// 		it( 'should navigate menu items and subitems using the arrow, spacebar and enter keys', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu
-// 					defaultOpen
-// 					trigger={ <button>Open dropdown</button> }
-// 				>
-// 					<DropdownMenuItem>Dropdown menu item 1</DropdownMenuItem>
-// 					<DropdownMenuItem>Dropdown menu item 2</DropdownMenuItem>
-// 					<DropdownSubMenu
-// 						trigger={
-// 							<DropdownSubMenuTrigger>
-// 								Dropdown submenu
-// 							</DropdownSubMenuTrigger>
-// 						}
-// 					>
-// 						<DropdownMenuItem>
-// 							Dropdown submenu item 1
-// 						</DropdownMenuItem>
-// 						<DropdownMenuItem>
-// 							Dropdown submenu item 2
-// 						</DropdownMenuItem>
-// 					</DropdownSubMenu>
-// 					<DropdownMenuItem>Dropdown menu item 3</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			// The menu is focused automatically when `defaultOpen` is set.
-// 			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
-
-// 			// Arrow up/down selects menu items
-// 			// The selection wraps around from last to first and viceversa
-// 			await user.keyboard( '{ArrowDown}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 1' } )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowDown}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 2' } )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowDown}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowDown}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 3' } )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowDown}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 1' } )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowUp}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 3' } )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowUp}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
-// 			).toHaveFocus();
-
-// 			// Arrow right/left can be used to enter/leave submenus
-// 			await user.keyboard( '{ArrowRight}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Dropdown submenu item 1',
-// 				} )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowDown}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Dropdown submenu item 2',
-// 				} )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowLeft}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Dropdown submenu',
-// 				} )
-// 			).toHaveFocus();
-
-// 			// Spacebar or enter key can also be used to enter a submenu
-// 			await user.keyboard( '{Enter}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Dropdown submenu item 1',
-// 				} )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowLeft}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Dropdown submenu',
-// 				} )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{Spacebar}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Dropdown submenu item 1',
-// 				} )
-// 			).toHaveFocus();
-
-// 			await user.keyboard( '{ArrowLeft}' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Dropdown submenu',
-// 				} )
-// 			).toHaveFocus();
-// 		} );
-
-// 		it( 'should check menu radio items', async () => {
-// 			const user = userEvent.setup();
-
-// 			const onRadioValueChangeSpy = jest.fn();
-
-// 			const ControlledRadioGroup = () => {
-// 				const [ radioValue, setRadioValue ] = useState< string >();
-// 				return (
-// 					<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 						<DropdownMenuRadioGroup
-// 							value={ radioValue }
-// 							onValueChange={ ( value ) => {
-// 								onRadioValueChangeSpy( value );
-// 								setRadioValue( value );
-// 							} }
-// 						>
-// 							<DropdownMenuLabel>
-// 								Radio group label
-// 							</DropdownMenuLabel>
-// 							<DropdownMenuRadioItem value="radio-one">
-// 								Radio item one
-// 							</DropdownMenuRadioItem>
-// 							<DropdownMenuRadioItem value="radio-two">
-// 								Radio item two
-// 							</DropdownMenuRadioItem>
-// 						</DropdownMenuRadioGroup>
-// 					</DropdownMenu>
-// 				);
-// 			};
-
-// 			render( <ControlledRadioGroup /> );
-
-// 			// Open dropdown
-// 			await user.click(
-// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
-// 			);
-
-// 			// No radios should be checked at this point
-// 			expect( screen.getAllByRole( 'menuitemradio' ) ).toHaveLength( 2 );
-// 			expect(
-// 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
-// 			).not.toBeChecked();
-// 			expect(
-// 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-// 			).not.toBeChecked();
-
-// 			// Click first radio item, make sure that the callback fires
-// 			await user.click(
-// 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
-// 			);
-// 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
-// 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
-// 				'radio-one'
-// 			);
-
-// 			// Open dropdown
-// 			await user.click(
-// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
-// 			);
-
-// 			// Make sure that first radio is checked
-// 			expect(
-// 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
-// 			).toBeChecked();
-// 			expect(
-// 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-// 			).not.toBeChecked();
-
-// 			// Click second radio item, make sure that the callback fires
-// 			await user.click(
-// 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-// 			);
-// 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
-// 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
-// 				'radio-two'
-// 			);
-
-// 			// Open dropdown
-// 			await user.click(
-// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
-// 			);
-
-// 			// Make sure that second radio is selected
-// 			expect(
-// 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
-// 			).not.toBeChecked();
-// 			expect(
-// 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-// 			).toBeChecked();
-// 		} );
-
-// 		it( 'should check menu checkbox items', async () => {
-// 			const user = userEvent.setup();
-
-// 			const onCheckboxValueChangeSpy = jest.fn();
-
-// 			const ControlledRadioGroup = () => {
-// 				const [ itemOneChecked, setItemOneChecked ] =
-// 					useState< boolean >();
-// 				const [ itemTwoChecked, setItemTwoChecked ] =
-// 					useState< boolean >();
-// 				return (
-// 					<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 						<DropdownMenuLabel>
-// 							Checkbox group label
-// 						</DropdownMenuLabel>
-// 						<DropdownMenuCheckboxItem
-// 							checked={ itemOneChecked }
-// 							onCheckedChange={ ( checked ) => {
-// 								setItemOneChecked( checked );
-// 								onCheckboxValueChangeSpy( 'item-one', checked );
-// 							} }
-// 						>
-// 							Checkbox item one
-// 						</DropdownMenuCheckboxItem>
-
-// 						<DropdownMenuCheckboxItem
-// 							checked={ itemTwoChecked }
-// 							onCheckedChange={ ( checked ) => {
-// 								setItemTwoChecked( checked );
-// 								onCheckboxValueChangeSpy( 'item-two', checked );
-// 							} }
-// 						>
-// 							Checkbox item two
-// 						</DropdownMenuCheckboxItem>
-// 					</DropdownMenu>
-// 				);
-// 			};
-
-// 			render( <ControlledRadioGroup /> );
-
-// 			// Open dropdown
-// 			await user.click(
-// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
-// 			);
-
-// 			// No checkboxes should be checked at this point
-// 			expect( screen.getAllByRole( 'menuitemcheckbox' ) ).toHaveLength(
-// 				2
-// 			);
-// 			expect(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item one',
-// 				} )
-// 			).not.toBeChecked();
-// 			expect(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item two',
-// 				} )
-// 			).not.toBeChecked();
-
-// 			// Click first checkbox item, make sure that the callback fires
-// 			await user.click(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item one',
-// 				} )
-// 			);
-// 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
-// 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
-// 				'item-one',
-// 				true
-// 			);
-
-// 			// Open dropdown
-// 			await user.click(
-// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
-// 			);
-
-// 			// Make sure that first checkbox is checked
-// 			expect(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item one',
-// 				} )
-// 			).toBeChecked();
-
-// 			// Click second checkbox item, make sure that the callback fires
-// 			await user.click(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item two',
-// 				} )
-// 			);
-// 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
-// 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
-// 				'item-two',
-// 				true
-// 			);
-
-// 			// Open dropdown
-// 			await user.click(
-// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
-// 			);
-
-// 			// Make sure that second checkbox is selected
-// 			expect(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item two',
-// 				} )
-// 			).toBeChecked();
-
-// 			// Click second checkbox item, make sure that the callback fires
-// 			await user.click(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item two',
-// 				} )
-// 			);
-// 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
-// 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
-// 				'item-two',
-// 				false
-// 			);
-
-// 			// Open dropdown
-// 			await user.click(
-// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
-// 			);
-
-// 			// Make sure that second checkbox is unselected
-// 			expect(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item two',
-// 				} )
-// 			).not.toBeChecked();
-// 		} );
-// 	} );
-
-// 	describe( 'items prefix and suffix', () => {
-// 		it( 'should display a prefix on regular items', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 					<DropdownMenuItem prefix={ <>Item prefix</> }>
-// 						Dropdown menu item
-// 					</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			// Click to open the menu
-// 			await user.click(
-// 				screen.getByRole( 'button', {
-// 					name: 'Open dropdown',
-// 				} )
-// 			);
-
-// 			// The contents of the prefix are rendered before the item's children
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Item prefix Dropdown menu item',
-// 				} )
-// 			).toBeInTheDocument();
-// 		} );
-
-// 		it( 'should display a suffix on regular items', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 					<DropdownMenuItem suffix={ <>Item suffix</> }>
-// 						Dropdown menu item
-// 					</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			// Click to open the menu
-// 			await user.click(
-// 				screen.getByRole( 'button', {
-// 					name: 'Open dropdown',
-// 				} )
-// 			);
-
-// 			// The contents of the suffix are rendered after the item's children
-// 			expect(
-// 				screen.getByRole( 'menuitem', {
-// 					name: 'Dropdown menu item Item suffix',
-// 				} )
-// 			).toBeInTheDocument();
-// 		} );
-
-// 		it( 'should display a suffix on radio items', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 					<DropdownMenuRadioGroup>
-// 						<DropdownMenuRadioItem
-// 							value="radio-one"
-// 							suffix="Radio suffix"
-// 						>
-// 							Radio item one
-// 						</DropdownMenuRadioItem>
-// 					</DropdownMenuRadioGroup>
-// 				</DropdownMenu>
-// 			);
-
-// 			// Click to open the menu
-// 			await user.click(
-// 				screen.getByRole( 'button', {
-// 					name: 'Open dropdown',
-// 				} )
-// 			);
-
-// 			// The contents of the suffix are rendered after the item's children
-// 			expect(
-// 				screen.getByRole( 'menuitemradio', {
-// 					name: 'Radio item one Radio suffix',
-// 				} )
-// 			).toBeInTheDocument();
-// 		} );
-
-// 		it( 'should display a suffix on checkbox items', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 					<DropdownMenuCheckboxItem suffix={ 'Checkbox suffix' }>
-// 						Checkbox item one
-// 					</DropdownMenuCheckboxItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			// Click to open the menu
-// 			await user.click(
-// 				screen.getByRole( 'button', {
-// 					name: 'Open dropdown',
-// 				} )
-// 			);
-
-// 			// The contents of the suffix are rendered after the item's children
-// 			expect(
-// 				screen.getByRole( 'menuitemcheckbox', {
-// 					name: 'Checkbox item one Checkbox suffix',
-// 				} )
-// 			).toBeInTheDocument();
-// 		} );
-// 	} );
-
-// 	describe( 'typeahead', () => {
-// 		it( 'should highlight matching item', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 					<DropdownMenuItem>One</DropdownMenuItem>
-// 					<DropdownMenuItem>Two</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			// Click to open the menu
-// 			await user.click(
-// 				screen.getByRole( 'button', {
-// 					name: 'Open dropdown',
-// 				} )
-// 			);
-// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
-
-// 			// Type "tw", it should match and focus the item with content "Two"
-// 			await user.keyboard( 'tw' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Two' } )
-// 			).toHaveFocus();
-
-// 			// Wait for the typeahead timer to reset and interpret
-// 			// the next keystrokes as a new search
-// 			await delay( 1000 );
-
-// 			// Type "on", it should match and focus the item with content "One"
-// 			await user.keyboard( 'on' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'One' } )
-// 			).toHaveFocus();
-// 		} );
-
-// 		it( 'should use the textValue prop if specificied', async () => {
-// 			const user = userEvent.setup();
-
-// 			render(
-// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-// 					<DropdownMenuItem>One</DropdownMenuItem>
-// 					<DropdownMenuItem textValue="Four">Two</DropdownMenuItem>
-// 				</DropdownMenu>
-// 			);
-
-// 			// Click to open the menu
-// 			await user.click(
-// 				screen.getByRole( 'button', {
-// 					name: 'Open dropdown',
-// 				} )
-// 			);
-// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
-
-// 			// Type "tw", it should not match the item with content "Two" because it
-// 			// that item specifies the "textValue" prop. Therefore, the menu container
-// 			// retains focus.
-// 			await user.keyboard( 'tw' );
-// 			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
-
-// 			// Wait for the typeahead timer to reset and interpret
-// 			// the next keystrokes as a new search
-// 			await delay( 1000 );
-
-// 			// Type "fo", it should match and focus the item with textValue "Four"
-// 			await user.keyboard( 'fo' );
-// 			expect(
-// 				screen.getByRole( 'menuitem', { name: 'Two' } )
-// 			).toHaveFocus();
-// 		} );
-// 	} );
-// } );
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+	default as userEvent,
+	PointerEventsCheckLevel,
+} from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	DropdownMenu,
+	DropdownMenuCheckboxItem,
+	DropdownMenuItem,
+	DropdownMenuGroupLabel,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuGroup,
+} from '..';
+
+const delay = ( delayInMs: number ) => {
+	return new Promise( ( resolve ) => setTimeout( resolve, delayInMs ) );
+};
+
+describe( 'DropdownMenu', () => {
+	// See https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/
+	it( 'should follow the WAI-ARIA spec', async () => {
+		// Radio and Checkbox items'
+		const user = userEvent.setup();
+
+		render(
+			<DropdownMenu trigger={ <button>Open dropdown</button> }>
+				<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+				<DropdownMenuSeparator />
+				<DropdownMenu
+					trigger={
+						<DropdownMenuItem>Dropdown submenu</DropdownMenuItem>
+					}
+				>
+					<DropdownMenuItem>Dropdown submenu item 1</DropdownMenuItem>
+					<DropdownMenuItem>Dropdown submenu item 2</DropdownMenuItem>
+				</DropdownMenu>
+			</DropdownMenu>
+		);
+
+		const toggleButton = screen.getByRole( 'button', {
+			name: 'Open dropdown',
+		} );
+
+		expect( toggleButton ).toHaveAttribute( 'aria-haspopup', 'menu' );
+		expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		await user.click( toggleButton );
+
+		expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+		expect( screen.getByRole( 'separator' ) ).toHaveAttribute(
+			'aria-orientation',
+			'horizontal'
+		);
+		expect( screen.getAllByRole( 'menuitem' ) ).toHaveLength( 2 );
+
+		const submenuTrigger = screen.getByRole( 'menuitem', {
+			name: 'Dropdown submenu',
+		} );
+		expect( submenuTrigger ).toHaveAttribute( 'aria-haspopup', 'menu' );
+		expect( submenuTrigger ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		await user.hover( submenuTrigger );
+
+		// Wait for the open animation after hovering
+		await waitFor( () =>
+			expect( screen.getAllByRole( 'menu' ) ).toHaveLength( 2 )
+		);
+
+		expect( submenuTrigger ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( submenuTrigger ).toHaveAttribute(
+			'aria-controls',
+			screen.getAllByRole( 'menu' )[ 1 ].id
+		);
+	} );
+
+	describe( 'pointer and keyboard interactions', () => {
+		it( 'should open when clicking the trigger', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			const toggleButton = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+
+			// DropdownMenu closed, the content is not displayed
+			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
+
+			// Click to open the menu
+			await user.click( toggleButton );
+
+			// DropdownMenu open, the content is displayed
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'menuitem' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should open when pressing the arrow down key on the trigger', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			const toggleButton = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+
+			// Move focus on the toggle
+			await user.keyboard( '{Tab}' );
+
+			expect( toggleButton ).toHaveFocus();
+
+			// DropdownMenu closed, the content is not displayed
+			expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
+
+			await user.keyboard( '{ArrowDown}' );
+
+			// DropdownMenu open, the content is displayed
+			expect( screen.getByRole( 'menuitem' ) ).toBeInTheDocument();
+		} );
+
+		it.only( 'should close when pressing the escape key', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+
+			await user.click( trigger );
+
+			// The menu is focused automatically when `defaultOpen` is set.
+			await waitFor( () =>
+				expect( screen.getByRole( 'menuitem' ) ).toHaveFocus()
+			);
+
+			// Pressing esc will close the menu and move focus to the toggle
+			await user.keyboard( '{Escape}' );
+
+			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+			await waitFor(
+				() =>
+					expect(
+						screen.getByRole( 'button', { name: 'Open dropdown' } )
+					).toHaveFocus(),
+				{ timeout: 100000 }
+			);
+		} );
+
+		it( 'should close when clicking outside of the content', async () => {
+			const user = userEvent.setup( {
+				// Disabling this check otherwise testing-library would complain
+				// when clicking on document.body to close the dropdown menu.
+				pointerEventsCheck: PointerEventsCheckLevel.Never,
+			} );
+
+			render(
+				<DropdownMenu
+					defaultOpen
+					trigger={ <button>Open dropdown</button> }
+				>
+					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+			// Click on the body (ie. outside of the dropdown menu)
+			await user.click( document.body );
+
+			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should close when clicking on a menu item', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu
+					defaultOpen
+					trigger={ <button>Open dropdown</button> }
+				>
+					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+			// Clicking a menu item will close the menu
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should not close when clicking on a disabled menu item', async () => {
+			const user = userEvent.setup( {
+				// Disabling this check otherwise testing-library would complain
+				// when clicking on a disabled element with pointer-events: none
+				pointerEventsCheck: PointerEventsCheckLevel.Never,
+			} );
+
+			render(
+				<DropdownMenu
+					defaultOpen
+					trigger={ <button>Open dropdown</button> }
+				>
+					<DropdownMenuItem disabled>
+						Dropdown menu item
+					</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+			// Clicking a disabled menu item won't close the menu
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should reveal submenu content when hovering over the submenu trigger', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu
+					defaultOpen
+					trigger={ <button>Open dropdown</button> }
+				>
+					<DropdownMenuItem>Dropdown menu item 1</DropdownMenuItem>
+					<DropdownMenuItem>Dropdown menu item 2</DropdownMenuItem>
+					<DropdownMenu
+						trigger={
+							<DropdownMenuItem>
+								Dropdown submenu
+							</DropdownMenuItem>
+						}
+					>
+						<DropdownMenuItem>
+							Dropdown submenu item 1
+						</DropdownMenuItem>
+						<DropdownMenuItem>
+							Dropdown submenu item 2
+						</DropdownMenuItem>
+					</DropdownMenu>
+					<DropdownMenuItem>Dropdown menu item 3</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			// Before hover, submenu items are not rendered
+			expect(
+				screen.queryByRole( 'menuitem', {
+					name: 'Dropdown submenu item 1',
+				} )
+			).not.toBeInTheDocument();
+
+			await user.hover(
+				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
+			);
+
+			// After hover, submenu items are rendered
+			// Reason for `findByRole`: due to the animation, we've got to wait
+			// a short amount of time for the submenu to appear
+			await screen.findByRole( 'menuitem', {
+				name: 'Dropdown submenu item 1',
+			} );
+		} );
+
+		it( 'should navigate menu items and subitems using the arrow, spacebar and enter keys', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu
+					defaultOpen
+					trigger={ <button>Open dropdown</button> }
+				>
+					<DropdownMenuItem>Dropdown menu item 1</DropdownMenuItem>
+					<DropdownMenuItem>Dropdown menu item 2</DropdownMenuItem>
+					<DropdownMenu
+						trigger={
+							<DropdownMenuItem>
+								Dropdown submenu
+							</DropdownMenuItem>
+						}
+					>
+						<DropdownMenuItem>
+							Dropdown submenu item 1
+						</DropdownMenuItem>
+						<DropdownMenuItem>
+							Dropdown submenu item 2
+						</DropdownMenuItem>
+					</DropdownMenu>
+					<DropdownMenuItem>Dropdown menu item 3</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			// The menu is focused automatically when `defaultOpen` is set.
+			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+
+			// Arrow up/down selects menu items
+			// The selection wraps around from last to first and viceversa
+			await user.keyboard( '{ArrowDown}' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 1' } )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowDown}' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 2' } )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowDown}' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowDown}' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 3' } )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowDown}' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 1' } )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowUp}' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 3' } )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowUp}' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
+			).toHaveFocus();
+
+			// Arrow right/left can be used to enter/leave submenus
+			await user.keyboard( '{ArrowRight}' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Dropdown submenu item 1',
+				} )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowDown}' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Dropdown submenu item 2',
+				} )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowLeft}' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Dropdown submenu',
+				} )
+			).toHaveFocus();
+
+			// Spacebar or enter key can also be used to enter a submenu
+			await user.keyboard( '{Enter}' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Dropdown submenu item 1',
+				} )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowLeft}' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Dropdown submenu',
+				} )
+			).toHaveFocus();
+
+			await user.keyboard( '{Spacebar}' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Dropdown submenu item 1',
+				} )
+			).toHaveFocus();
+
+			await user.keyboard( '{ArrowLeft}' );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Dropdown submenu',
+				} )
+			).toHaveFocus();
+		} );
+
+		it( 'should check menu radio items', async () => {
+			const user = userEvent.setup();
+
+			const onRadioValueChangeSpy = jest.fn();
+
+			const ControlledRadioGroup = () => {
+				const [ radioValue, setRadioValue ] = useState( 'two' );
+				const onRadioChange: React.ComponentProps<
+					typeof DropdownMenuRadioItem
+				>[ 'onChange' ] = ( e ) => {
+					onRadioValueChangeSpy( e.target.value );
+					setRadioValue( e.target.value );
+				};
+				return (
+					<DropdownMenu trigger={ <button>Open dropdown</button> }>
+						<DropdownMenuGroup>
+							<DropdownMenuGroupLabel>
+								Radio group label
+							</DropdownMenuGroupLabel>
+							<DropdownMenuRadioItem
+								name="radio-test"
+								value="radio-one"
+								checked={ radioValue === 'radio-one' }
+								onChange={ onRadioChange }
+							>
+								Radio item one
+							</DropdownMenuRadioItem>
+							<DropdownMenuRadioItem
+								name="radio-test"
+								value="radio-two"
+								checked={ radioValue === 'radio-two' }
+								onChange={ onRadioChange }
+							>
+								Radio item two
+							</DropdownMenuRadioItem>
+						</DropdownMenuGroup>
+					</DropdownMenu>
+				);
+			};
+
+			render( <ControlledRadioGroup /> );
+
+			// Open dropdown
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// No radios should be checked at this point
+			expect( screen.getAllByRole( 'menuitemradio' ) ).toHaveLength( 2 );
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).not.toBeChecked();
+
+			// Click first radio item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			);
+			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
+				'radio-one'
+			);
+
+			// Open dropdown
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// Make sure that first radio is checked
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).not.toBeChecked();
+
+			// Click second radio item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			);
+			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
+				'radio-two'
+			);
+
+			// Open dropdown
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// Make sure that second radio is selected
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).toBeChecked();
+		} );
+
+		it( 'should check menu checkbox items', async () => {
+			const user = userEvent.setup();
+
+			const onCheckboxValueChangeSpy = jest.fn();
+
+			const ControlledRadioGroup = () => {
+				const [ itemOneChecked, setItemOneChecked ] =
+					useState< boolean >();
+				const [ itemTwoChecked, setItemTwoChecked ] =
+					useState< boolean >();
+
+				return (
+					<DropdownMenu trigger={ <button>Open dropdown</button> }>
+						<DropdownMenuCheckboxItem
+							name="item-one"
+							value="item-one-value"
+							checked={ itemOneChecked }
+							onChange={ ( e ) => {
+								onCheckboxValueChangeSpy(
+									e.target.name,
+									e.target.checked
+								);
+								setItemOneChecked( e.target.checked );
+							} }
+						>
+							Checkbox item one
+						</DropdownMenuCheckboxItem>
+
+						<DropdownMenuCheckboxItem
+							name="item-two"
+							value="item-two-value"
+							checked={ itemTwoChecked }
+							onChange={ ( e ) => {
+								onCheckboxValueChangeSpy(
+									e.target.name,
+									e.target.checked
+								);
+								setItemTwoChecked( e.target.checked );
+							} }
+						>
+							Checkbox item two
+						</DropdownMenuCheckboxItem>
+					</DropdownMenu>
+				);
+			};
+
+			render( <ControlledRadioGroup /> );
+
+			// Open dropdown
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// No checkboxes should be checked at this point
+			expect( screen.getAllByRole( 'menuitemcheckbox' ) ).toHaveLength(
+				2
+			);
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).not.toBeChecked();
+
+			// Click first checkbox item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-one',
+				true
+			);
+
+			// Open dropdown
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// Make sure that first checkbox is checked
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			).toBeChecked();
+
+			// Click second checkbox item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-two',
+				true
+			);
+
+			// Open dropdown
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// Make sure that second checkbox is selected
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).toBeChecked();
+
+			// Click second checkbox item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-two',
+				false
+			);
+
+			// Open dropdown
+			await user.click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// Make sure that second checkbox is unselected
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).not.toBeChecked();
+		} );
+	} );
+
+	describe( 'items prefix and suffix', () => {
+		it( 'should display a prefix on regular items', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuItem prefix={ <>Item prefix</> }>
+						Dropdown menu item
+					</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			// Click to open the menu
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Open dropdown',
+				} )
+			);
+
+			// The contents of the prefix are rendered before the item's children
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Item prefix Dropdown menu item',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should display a suffix on regular items', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuItem suffix={ <>Item suffix</> }>
+						Dropdown menu item
+					</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			// Click to open the menu
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Open dropdown',
+				} )
+			);
+
+			// The contents of the suffix are rendered after the item's children
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: 'Dropdown menu item Item suffix',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should display a suffix on radio items', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuRadioItem
+						name="radio-test"
+						value="radio-one"
+						suffix="Radio suffix"
+					>
+						Radio item one
+					</DropdownMenuRadioItem>
+				</DropdownMenu>
+			);
+
+			// Click to open the menu
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Open dropdown',
+				} )
+			);
+
+			// The contents of the suffix are rendered after the item's children
+			expect(
+				screen.getByRole( 'menuitemradio', {
+					name: 'Radio item one Radio suffix',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should display a suffix on checkbox items', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuCheckboxItem
+						name="checkbox-test"
+						value="checkbox-one"
+						suffix={ 'Checkbox suffix' }
+					>
+						Checkbox item one
+					</DropdownMenuCheckboxItem>
+				</DropdownMenu>
+			);
+
+			// Click to open the menu
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Open dropdown',
+				} )
+			);
+
+			// The contents of the suffix are rendered after the item's children
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one Checkbox suffix',
+				} )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'typeahead', () => {
+		it( 'should highlight matching item', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuItem>One</DropdownMenuItem>
+					<DropdownMenuItem>Two</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			// Click to open the menu
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Open dropdown',
+				} )
+			);
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+			// Type "tw", it should match and focus the item with content "Two"
+			await user.keyboard( 'tw' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Two' } )
+			).toHaveFocus();
+
+			// Wait for the typeahead timer to reset and interpret
+			// the next keystrokes as a new search
+			await delay( 1000 );
+
+			// Type "on", it should match and focus the item with content "One"
+			await user.keyboard( 'on' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'One' } )
+			).toHaveFocus();
+		} );
+
+		it.skip( 'should use the textValue prop if specificied', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuItem>One</DropdownMenuItem>
+					<DropdownMenuItem>Two</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			// Click to open the menu
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Open dropdown',
+				} )
+			);
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+			// Type "tw", it should not match the item with content "Two" because it
+			// that item specifies the "textValue" prop. Therefore, the menu container
+			// retains focus.
+			await user.keyboard( 'tw' );
+			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+
+			// Wait for the typeahead timer to reset and interpret
+			// the next keystrokes as a new search
+			await delay( 1000 );
+
+			// Type "fo", it should match and focus the item with textValue "Four"
+			await user.keyboard( 'fo' );
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Two' } )
+			).toHaveFocus();
+		} );
+	} );
+} );

--- a/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
@@ -1,0 +1,816 @@
+// /**
+//  * External dependencies
+//  */
+// import { render, screen, waitFor } from '@testing-library/react';
+// import {
+// 	default as userEvent,
+// 	PointerEventsCheckLevel,
+// } from '@testing-library/user-event';
+
+// /**
+//  * WordPress dependencies
+//  */
+// import { useState } from '@wordpress/element';
+
+// /**
+//  * Internal dependencies
+//  */
+// import {
+// 	DropdownMenu,
+// 	DropdownMenuCheckboxItem,
+// 	DropdownMenuItem,
+// 	DropdownMenuLabel,
+// 	DropdownMenuRadioGroup,
+// 	DropdownMenuRadioItem,
+// 	DropdownMenuSeparator,
+// 	DropdownSubMenu,
+// 	DropdownSubMenuTrigger,
+// } from '..';
+
+// const delay = ( delayInMs: number ) => {
+// 	return new Promise( ( resolve ) => setTimeout( resolve, delayInMs ) );
+// };
+
+// describe( 'DropdownMenu', () => {
+// 	// See https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/
+// 	it( 'should follow the WAI-ARIA spec', async () => {
+// 		// Radio and Checkbox items'
+// 		const user = userEvent.setup();
+
+// 		render(
+// 			<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 				<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+// 				<DropdownMenuSeparator />
+// 				<DropdownSubMenu
+// 					trigger={
+// 						<DropdownSubMenuTrigger>
+// 							Dropdown submenu
+// 						</DropdownSubMenuTrigger>
+// 					}
+// 				>
+// 					<DropdownMenuItem>Dropdown submenu item 1</DropdownMenuItem>
+// 					<DropdownMenuItem>Dropdown submenu item 2</DropdownMenuItem>
+// 				</DropdownSubMenu>
+// 			</DropdownMenu>
+// 		);
+
+// 		const toggleButton = screen.getByRole( 'button', {
+// 			name: 'Open dropdown',
+// 		} );
+
+// 		expect( toggleButton ).toHaveAttribute( 'aria-haspopup', 'menu' );
+// 		expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'false' );
+
+// 		await user.click( toggleButton );
+
+// 		expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'true' );
+
+// 		expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+// 		expect( screen.getByRole( 'separator' ) ).toHaveAttribute(
+// 			'aria-orientation',
+// 			'horizontal'
+// 		);
+// 		expect( screen.getAllByRole( 'menuitem' ) ).toHaveLength( 2 );
+
+// 		const submenuTrigger = screen.getByRole( 'menuitem', {
+// 			name: 'Dropdown submenu',
+// 		} );
+// 		expect( submenuTrigger ).toHaveAttribute( 'aria-haspopup', 'menu' );
+// 		expect( submenuTrigger ).toHaveAttribute( 'aria-expanded', 'false' );
+
+// 		await user.hover( submenuTrigger );
+
+// 		// Wait for the open animation after hovering
+// 		await waitFor( () =>
+// 			expect( screen.getAllByRole( 'menu' ) ).toHaveLength( 2 )
+// 		);
+
+// 		expect( submenuTrigger ).toHaveAttribute( 'aria-expanded', 'true' );
+// 		expect( submenuTrigger ).toHaveAttribute(
+// 			'aria-controls',
+// 			screen.getAllByRole( 'menu' )[ 1 ].id
+// 		);
+// 	} );
+
+// 	describe( 'pointer and keyboard interactions', () => {
+// 		it( 'should open when clicking the trigger', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			const toggleButton = screen.getByRole( 'button', {
+// 				name: 'Open dropdown',
+// 			} );
+
+// 			// DropdownMenu closed, the content is not displayed
+// 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+// 			expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
+
+// 			// Click to open the menu
+// 			await user.click( toggleButton );
+
+// 			// DropdownMenu open, the content is displayed
+// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+// 			expect( screen.getByRole( 'menuitem' ) ).toBeInTheDocument();
+// 		} );
+
+// 		it( 'should open when pressing the arrow down key on the trigger', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			const toggleButton = screen.getByRole( 'button', {
+// 				name: 'Open dropdown',
+// 			} );
+
+// 			// Move focus on the toggle
+// 			await user.keyboard( '{Tab}' );
+
+// 			expect( toggleButton ).toHaveFocus();
+
+// 			// DropdownMenu closed, the content is not displayed
+// 			expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
+
+// 			await user.keyboard( '{ArrowDown}' );
+
+// 			// DropdownMenu open, the content is displayed
+// 			expect( screen.getByRole( 'menuitem' ) ).toBeInTheDocument();
+// 		} );
+
+// 		it( 'should close when pressing the escape key', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu
+// 					defaultOpen
+// 					trigger={ <button>Open dropdown</button> }
+// 				>
+// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			// The menu is focused automatically when `defaultOpen` is set.
+// 			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+
+// 			// Pressing esc will close the menu and move focus to the toggle
+// 			await user.keyboard( '{Escape}' );
+
+// 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+// 			expect(
+// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
+// 			).toHaveFocus();
+// 		} );
+
+// 		it( 'should close when clicking outside of the content', async () => {
+// 			const user = userEvent.setup( {
+// 				// Disabling this check otherwise testing-library would complain
+// 				// when clicking on document.body to close the dropdown menu.
+// 				pointerEventsCheck: PointerEventsCheckLevel.Never,
+// 			} );
+
+// 			render(
+// 				<DropdownMenu
+// 					defaultOpen
+// 					trigger={ <button>Open dropdown</button> }
+// 				>
+// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+// 			// Click on the body (ie. outside of the dropdown menu)
+// 			await user.click( document.body );
+
+// 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+// 		} );
+
+// 		it( 'should close when clicking on a menu item', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu
+// 					defaultOpen
+// 					trigger={ <button>Open dropdown</button> }
+// 				>
+// 					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+// 			// Clicking a menu item will close the menu
+// 			await user.click( screen.getByRole( 'menuitem' ) );
+
+// 			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+// 		} );
+
+// 		it( 'should not close when clicking on a disabled menu item', async () => {
+// 			const user = userEvent.setup( {
+// 				// Disabling this check otherwise testing-library would complain
+// 				// when clicking on a disabled element with pointer-events: none
+// 				pointerEventsCheck: PointerEventsCheckLevel.Never,
+// 			} );
+
+// 			render(
+// 				<DropdownMenu
+// 					defaultOpen
+// 					trigger={ <button>Open dropdown</button> }
+// 				>
+// 					<DropdownMenuItem disabled>
+// 						Dropdown menu item
+// 					</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+// 			// Clicking a disabled menu item won't close the menu
+// 			await user.click( screen.getByRole( 'menuitem' ) );
+
+// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+// 		} );
+
+// 		it( 'should reveal submenu content when hovering over the submenu trigger', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu
+// 					defaultOpen
+// 					trigger={ <button>Open dropdown</button> }
+// 				>
+// 					<DropdownMenuItem>Dropdown menu item 1</DropdownMenuItem>
+// 					<DropdownMenuItem>Dropdown menu item 2</DropdownMenuItem>
+// 					<DropdownSubMenu
+// 						trigger={
+// 							<DropdownSubMenuTrigger>
+// 								Dropdown submenu
+// 							</DropdownSubMenuTrigger>
+// 						}
+// 					>
+// 						<DropdownMenuItem>
+// 							Dropdown submenu item 1
+// 						</DropdownMenuItem>
+// 						<DropdownMenuItem>
+// 							Dropdown submenu item 2
+// 						</DropdownMenuItem>
+// 					</DropdownSubMenu>
+// 					<DropdownMenuItem>Dropdown menu item 3</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			// Before hover, submenu items are not rendered
+// 			expect(
+// 				screen.queryByRole( 'menuitem', {
+// 					name: 'Dropdown submenu item 1',
+// 				} )
+// 			).not.toBeInTheDocument();
+
+// 			await user.hover(
+// 				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
+// 			);
+
+// 			// After hover, submenu items are rendered
+// 			// Reason for `findByRole`: due to the animation, we've got to wait
+// 			// a short amount of time for the submenu to appear
+// 			await screen.findByRole( 'menuitem', {
+// 				name: 'Dropdown submenu item 1',
+// 			} );
+// 		} );
+
+// 		it( 'should navigate menu items and subitems using the arrow, spacebar and enter keys', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu
+// 					defaultOpen
+// 					trigger={ <button>Open dropdown</button> }
+// 				>
+// 					<DropdownMenuItem>Dropdown menu item 1</DropdownMenuItem>
+// 					<DropdownMenuItem>Dropdown menu item 2</DropdownMenuItem>
+// 					<DropdownSubMenu
+// 						trigger={
+// 							<DropdownSubMenuTrigger>
+// 								Dropdown submenu
+// 							</DropdownSubMenuTrigger>
+// 						}
+// 					>
+// 						<DropdownMenuItem>
+// 							Dropdown submenu item 1
+// 						</DropdownMenuItem>
+// 						<DropdownMenuItem>
+// 							Dropdown submenu item 2
+// 						</DropdownMenuItem>
+// 					</DropdownSubMenu>
+// 					<DropdownMenuItem>Dropdown menu item 3</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			// The menu is focused automatically when `defaultOpen` is set.
+// 			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+
+// 			// Arrow up/down selects menu items
+// 			// The selection wraps around from last to first and viceversa
+// 			await user.keyboard( '{ArrowDown}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 1' } )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowDown}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 2' } )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowDown}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowDown}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 3' } )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowDown}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 1' } )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowUp}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Dropdown menu item 3' } )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowUp}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Dropdown submenu' } )
+// 			).toHaveFocus();
+
+// 			// Arrow right/left can be used to enter/leave submenus
+// 			await user.keyboard( '{ArrowRight}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Dropdown submenu item 1',
+// 				} )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowDown}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Dropdown submenu item 2',
+// 				} )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowLeft}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Dropdown submenu',
+// 				} )
+// 			).toHaveFocus();
+
+// 			// Spacebar or enter key can also be used to enter a submenu
+// 			await user.keyboard( '{Enter}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Dropdown submenu item 1',
+// 				} )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowLeft}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Dropdown submenu',
+// 				} )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{Spacebar}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Dropdown submenu item 1',
+// 				} )
+// 			).toHaveFocus();
+
+// 			await user.keyboard( '{ArrowLeft}' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Dropdown submenu',
+// 				} )
+// 			).toHaveFocus();
+// 		} );
+
+// 		it( 'should check menu radio items', async () => {
+// 			const user = userEvent.setup();
+
+// 			const onRadioValueChangeSpy = jest.fn();
+
+// 			const ControlledRadioGroup = () => {
+// 				const [ radioValue, setRadioValue ] = useState< string >();
+// 				return (
+// 					<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 						<DropdownMenuRadioGroup
+// 							value={ radioValue }
+// 							onValueChange={ ( value ) => {
+// 								onRadioValueChangeSpy( value );
+// 								setRadioValue( value );
+// 							} }
+// 						>
+// 							<DropdownMenuLabel>
+// 								Radio group label
+// 							</DropdownMenuLabel>
+// 							<DropdownMenuRadioItem value="radio-one">
+// 								Radio item one
+// 							</DropdownMenuRadioItem>
+// 							<DropdownMenuRadioItem value="radio-two">
+// 								Radio item two
+// 							</DropdownMenuRadioItem>
+// 						</DropdownMenuRadioGroup>
+// 					</DropdownMenu>
+// 				);
+// 			};
+
+// 			render( <ControlledRadioGroup /> );
+
+// 			// Open dropdown
+// 			await user.click(
+// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
+// 			);
+
+// 			// No radios should be checked at this point
+// 			expect( screen.getAllByRole( 'menuitemradio' ) ).toHaveLength( 2 );
+// 			expect(
+// 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+// 			).not.toBeChecked();
+// 			expect(
+// 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+// 			).not.toBeChecked();
+
+// 			// Click first radio item, make sure that the callback fires
+// 			await user.click(
+// 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+// 			);
+// 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+// 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
+// 				'radio-one'
+// 			);
+
+// 			// Open dropdown
+// 			await user.click(
+// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
+// 			);
+
+// 			// Make sure that first radio is checked
+// 			expect(
+// 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+// 			).toBeChecked();
+// 			expect(
+// 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+// 			).not.toBeChecked();
+
+// 			// Click second radio item, make sure that the callback fires
+// 			await user.click(
+// 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+// 			);
+// 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+// 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
+// 				'radio-two'
+// 			);
+
+// 			// Open dropdown
+// 			await user.click(
+// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
+// 			);
+
+// 			// Make sure that second radio is selected
+// 			expect(
+// 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+// 			).not.toBeChecked();
+// 			expect(
+// 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+// 			).toBeChecked();
+// 		} );
+
+// 		it( 'should check menu checkbox items', async () => {
+// 			const user = userEvent.setup();
+
+// 			const onCheckboxValueChangeSpy = jest.fn();
+
+// 			const ControlledRadioGroup = () => {
+// 				const [ itemOneChecked, setItemOneChecked ] =
+// 					useState< boolean >();
+// 				const [ itemTwoChecked, setItemTwoChecked ] =
+// 					useState< boolean >();
+// 				return (
+// 					<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 						<DropdownMenuLabel>
+// 							Checkbox group label
+// 						</DropdownMenuLabel>
+// 						<DropdownMenuCheckboxItem
+// 							checked={ itemOneChecked }
+// 							onCheckedChange={ ( checked ) => {
+// 								setItemOneChecked( checked );
+// 								onCheckboxValueChangeSpy( 'item-one', checked );
+// 							} }
+// 						>
+// 							Checkbox item one
+// 						</DropdownMenuCheckboxItem>
+
+// 						<DropdownMenuCheckboxItem
+// 							checked={ itemTwoChecked }
+// 							onCheckedChange={ ( checked ) => {
+// 								setItemTwoChecked( checked );
+// 								onCheckboxValueChangeSpy( 'item-two', checked );
+// 							} }
+// 						>
+// 							Checkbox item two
+// 						</DropdownMenuCheckboxItem>
+// 					</DropdownMenu>
+// 				);
+// 			};
+
+// 			render( <ControlledRadioGroup /> );
+
+// 			// Open dropdown
+// 			await user.click(
+// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
+// 			);
+
+// 			// No checkboxes should be checked at this point
+// 			expect( screen.getAllByRole( 'menuitemcheckbox' ) ).toHaveLength(
+// 				2
+// 			);
+// 			expect(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item one',
+// 				} )
+// 			).not.toBeChecked();
+// 			expect(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item two',
+// 				} )
+// 			).not.toBeChecked();
+
+// 			// Click first checkbox item, make sure that the callback fires
+// 			await user.click(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item one',
+// 				} )
+// 			);
+// 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+// 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+// 				'item-one',
+// 				true
+// 			);
+
+// 			// Open dropdown
+// 			await user.click(
+// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
+// 			);
+
+// 			// Make sure that first checkbox is checked
+// 			expect(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item one',
+// 				} )
+// 			).toBeChecked();
+
+// 			// Click second checkbox item, make sure that the callback fires
+// 			await user.click(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item two',
+// 				} )
+// 			);
+// 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+// 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+// 				'item-two',
+// 				true
+// 			);
+
+// 			// Open dropdown
+// 			await user.click(
+// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
+// 			);
+
+// 			// Make sure that second checkbox is selected
+// 			expect(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item two',
+// 				} )
+// 			).toBeChecked();
+
+// 			// Click second checkbox item, make sure that the callback fires
+// 			await user.click(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item two',
+// 				} )
+// 			);
+// 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
+// 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+// 				'item-two',
+// 				false
+// 			);
+
+// 			// Open dropdown
+// 			await user.click(
+// 				screen.getByRole( 'button', { name: 'Open dropdown' } )
+// 			);
+
+// 			// Make sure that second checkbox is unselected
+// 			expect(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item two',
+// 				} )
+// 			).not.toBeChecked();
+// 		} );
+// 	} );
+
+// 	describe( 'items prefix and suffix', () => {
+// 		it( 'should display a prefix on regular items', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 					<DropdownMenuItem prefix={ <>Item prefix</> }>
+// 						Dropdown menu item
+// 					</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			// Click to open the menu
+// 			await user.click(
+// 				screen.getByRole( 'button', {
+// 					name: 'Open dropdown',
+// 				} )
+// 			);
+
+// 			// The contents of the prefix are rendered before the item's children
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Item prefix Dropdown menu item',
+// 				} )
+// 			).toBeInTheDocument();
+// 		} );
+
+// 		it( 'should display a suffix on regular items', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 					<DropdownMenuItem suffix={ <>Item suffix</> }>
+// 						Dropdown menu item
+// 					</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			// Click to open the menu
+// 			await user.click(
+// 				screen.getByRole( 'button', {
+// 					name: 'Open dropdown',
+// 				} )
+// 			);
+
+// 			// The contents of the suffix are rendered after the item's children
+// 			expect(
+// 				screen.getByRole( 'menuitem', {
+// 					name: 'Dropdown menu item Item suffix',
+// 				} )
+// 			).toBeInTheDocument();
+// 		} );
+
+// 		it( 'should display a suffix on radio items', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 					<DropdownMenuRadioGroup>
+// 						<DropdownMenuRadioItem
+// 							value="radio-one"
+// 							suffix="Radio suffix"
+// 						>
+// 							Radio item one
+// 						</DropdownMenuRadioItem>
+// 					</DropdownMenuRadioGroup>
+// 				</DropdownMenu>
+// 			);
+
+// 			// Click to open the menu
+// 			await user.click(
+// 				screen.getByRole( 'button', {
+// 					name: 'Open dropdown',
+// 				} )
+// 			);
+
+// 			// The contents of the suffix are rendered after the item's children
+// 			expect(
+// 				screen.getByRole( 'menuitemradio', {
+// 					name: 'Radio item one Radio suffix',
+// 				} )
+// 			).toBeInTheDocument();
+// 		} );
+
+// 		it( 'should display a suffix on checkbox items', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 					<DropdownMenuCheckboxItem suffix={ 'Checkbox suffix' }>
+// 						Checkbox item one
+// 					</DropdownMenuCheckboxItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			// Click to open the menu
+// 			await user.click(
+// 				screen.getByRole( 'button', {
+// 					name: 'Open dropdown',
+// 				} )
+// 			);
+
+// 			// The contents of the suffix are rendered after the item's children
+// 			expect(
+// 				screen.getByRole( 'menuitemcheckbox', {
+// 					name: 'Checkbox item one Checkbox suffix',
+// 				} )
+// 			).toBeInTheDocument();
+// 		} );
+// 	} );
+
+// 	describe( 'typeahead', () => {
+// 		it( 'should highlight matching item', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 					<DropdownMenuItem>One</DropdownMenuItem>
+// 					<DropdownMenuItem>Two</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			// Click to open the menu
+// 			await user.click(
+// 				screen.getByRole( 'button', {
+// 					name: 'Open dropdown',
+// 				} )
+// 			);
+// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+// 			// Type "tw", it should match and focus the item with content "Two"
+// 			await user.keyboard( 'tw' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Two' } )
+// 			).toHaveFocus();
+
+// 			// Wait for the typeahead timer to reset and interpret
+// 			// the next keystrokes as a new search
+// 			await delay( 1000 );
+
+// 			// Type "on", it should match and focus the item with content "One"
+// 			await user.keyboard( 'on' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'One' } )
+// 			).toHaveFocus();
+// 		} );
+
+// 		it( 'should use the textValue prop if specificied', async () => {
+// 			const user = userEvent.setup();
+
+// 			render(
+// 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+// 					<DropdownMenuItem>One</DropdownMenuItem>
+// 					<DropdownMenuItem textValue="Four">Two</DropdownMenuItem>
+// 				</DropdownMenu>
+// 			);
+
+// 			// Click to open the menu
+// 			await user.click(
+// 				screen.getByRole( 'button', {
+// 					name: 'Open dropdown',
+// 				} )
+// 			);
+// 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+// 			// Type "tw", it should not match the item with content "Two" because it
+// 			// that item specifies the "textValue" prop. Therefore, the menu container
+// 			// retains focus.
+// 			await user.keyboard( 'tw' );
+// 			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
+
+// 			// Wait for the typeahead timer to reset and interpret
+// 			// the next keystrokes as a new search
+// 			await delay( 1000 );
+
+// 			// Type "fo", it should match and focus the item with textValue "Four"
+// 			await user.keyboard( 'fo' );
+// 			expect(
+// 				screen.getByRole( 'menuitem', { name: 'Two' } )
+// 			).toHaveFocus();
+// 		} );
+// 	} );
+// } );

--- a/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
@@ -139,6 +139,35 @@ describe( 'DropdownMenu', () => {
 			).toHaveFocus();
 		} );
 
+		it( 'should open and focus the first item when pressing the space key on the trigger', async () => {
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuItem disabled>First item</DropdownMenuItem>
+					<DropdownMenuItem>Second item</DropdownMenuItem>
+					<DropdownMenuItem>Third item</DropdownMenuItem>
+				</DropdownMenu>
+			);
+
+			const toggleButton = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+
+			// Move focus on the toggle
+			await press.Tab();
+
+			expect( toggleButton ).toHaveFocus();
+
+			// DropdownMenu closed
+			expect( screen.queryByRole( 'menuitem' ) ).not.toBeInTheDocument();
+
+			await press.Space();
+
+			// DropdownMenu open, focus is on the first focusable item
+			expect(
+				screen.getByRole( 'menuitem', { name: 'Second item' } )
+			).toHaveFocus();
+		} );
+
 		it( 'should close when pressing the escape key', async () => {
 			render(
 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
@@ -435,7 +464,7 @@ describe( 'DropdownMenu', () => {
 			).toHaveFocus();
 		} );
 
-		it( 'should check radio items and keep the menu open when clicking', async () => {
+		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
 
 			const ControlledRadioGroup = () => {
@@ -524,7 +553,87 @@ describe( 'DropdownMenu', () => {
 			).toBeChecked();
 		} );
 
-		it( 'should check checkbox items and keep the menu open when clicking', async () => {
+		it( 'should check radio items and keep the menu open when clicking (uncontrolled)', async () => {
+			const onRadioValueChangeSpy = jest.fn();
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuGroup>
+						<DropdownMenuGroupLabel>
+							Radio group label
+						</DropdownMenuGroupLabel>
+						<DropdownMenuRadioItem
+							name="radio-test"
+							value="radio-one"
+							onChange={ ( e ) =>
+								onRadioValueChangeSpy( e.target.value )
+							}
+						>
+							Radio item one
+						</DropdownMenuRadioItem>
+						<DropdownMenuRadioItem
+							name="radio-test"
+							value="radio-two"
+							defaultChecked
+							onChange={ ( e ) =>
+								onRadioValueChangeSpy( e.target.value )
+							}
+						>
+							Radio item two
+						</DropdownMenuRadioItem>
+					</DropdownMenuGroup>
+				</DropdownMenu>
+			);
+
+			// Open dropdown
+			await click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// Radio item two should be checked (`defaultChecked` prop)
+			expect( screen.getAllByRole( 'menuitemradio' ) ).toHaveLength( 2 );
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).toBeChecked();
+
+			// Click first radio item, make sure that the callback fires
+			await click(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			);
+			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
+				'radio-one'
+			);
+
+			// Make sure that first radio is checked
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).not.toBeChecked();
+
+			// Click second radio item, make sure that the callback fires
+			await click(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			);
+			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
+				'radio-two'
+			);
+
+			// Make sure that second radio is selected
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).toBeChecked();
+		} );
+
+		it( 'should check checkbox items and keep the menu open when clicking (controlled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
 
 			const ControlledRadioGroup = () => {
@@ -651,6 +760,123 @@ describe( 'DropdownMenu', () => {
 					name: 'Checkbox item two',
 				} )
 			).not.toBeChecked();
+		} );
+
+		it( 'should check checkbox items and keep the menu open when clicking (uncontrolled)', async () => {
+			const onCheckboxValueChangeSpy = jest.fn();
+
+			render(
+				<DropdownMenu trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuCheckboxItem
+						name="item-one"
+						value="item-one-value"
+						onChange={ ( e ) => {
+							onCheckboxValueChangeSpy(
+								e.target.name,
+								e.target.value,
+								e.target.checked
+							);
+						} }
+					>
+						Checkbox item one
+					</DropdownMenuCheckboxItem>
+
+					<DropdownMenuCheckboxItem
+						name="item-two"
+						value="item-two-value"
+						defaultChecked
+						onChange={ ( e ) => {
+							onCheckboxValueChangeSpy(
+								e.target.name,
+								e.target.value,
+								e.target.checked
+							);
+						} }
+					>
+						Checkbox item two
+					</DropdownMenuCheckboxItem>
+				</DropdownMenu>
+			);
+
+			// Open dropdown
+			await click(
+				screen.getByRole( 'button', { name: 'Open dropdown' } )
+			);
+
+			// Checkbox item two should be checked (`defaultChecked`)
+			expect( screen.getAllByRole( 'menuitemcheckbox' ) ).toHaveLength(
+				2
+			);
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).toBeChecked();
+
+			// Click first checkbox item, make sure that the callback fires
+			await click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-one',
+				'item-one-value',
+				true
+			);
+
+			// Make sure that first checkbox is checked
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			).toBeChecked();
+
+			// Click second checkbox item, make sure that the callback fires
+			await click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-two',
+				'item-two-value',
+				false
+			);
+
+			// Make sure that second checkbox is unchecked
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).not.toBeChecked();
+
+			// Click second checkbox item, make sure that the callback fires
+			await click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-two',
+				'item-two-value',
+				true
+			);
+
+			// Make sure that second checkbox is unselected
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).toBeChecked();
 		} );
 	} );
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -7,6 +7,7 @@ import type { Placement } from '@floating-ui/react-dom';
 
 export interface DropdownMenuContext {
 	store: Ariakit.MenuStore;
+	variant?: 'toolbar';
 }
 
 // TODO: add support for standard HTML props

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -46,3 +46,6 @@ export interface DropdownMenuCheckboxItemProps
 	defaultChecked?: boolean;
 	onChange?: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 }
+
+export interface DropdownMenuSeparatorProps
+	extends Omit< Ariakit.MenuSeparatorProps, 'store' > {}

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -31,6 +31,18 @@ export interface DropdownMenuItemProps {
 	prefix?: React.ReactNode;
 	suffix?: React.ReactNode;
 	onClick?: React.MouseEventHandler;
+	// Default true
 	hideOnClick?: boolean;
 	disabled?: boolean;
+}
+
+export interface DropdownMenuCheckboxItemProps
+	extends Omit< DropdownMenuItemProps, 'prefix' | 'hideOnClick' > {
+	// Default false
+	hideOnClick?: boolean;
+	name: string;
+	value: string;
+	checked?: boolean;
+	defaultChecked?: boolean;
+	onChange?: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 }

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type * as Ariakit from '@ariakit/react';
+
+export interface DropdownMenuContext {
+	store: Ariakit.MenuStore;
+}
+
+// TODO: add support for standard HTML props
+export interface DropdownMenuProps {
+	// TODO: do we need to support render props too?
+	trigger: React.ReactElement;
+	children?: React.ReactNode;
+	modal?: boolean;
+	className?: string;
+	open?: boolean;
+	defaultOpen?: boolean;
+	onOpenChange?: ( open: boolean ) => void;
+}
+
+export interface DropdownMenuGroupProps
+	extends Omit< Ariakit.MenuGroupProps, 'store' > {}
+
+export interface DropdownMenuGroupLabelProps
+	extends Omit< Ariakit.MenuGroupLabelProps, 'store' > {}
+
+export interface DropdownMenuItemProps {
+	children: React.ReactNode;
+	prefix?: React.ReactNode;
+	suffix?: React.ReactNode;
+	onClick?: React.MouseEventHandler;
+	hideOnClick?: boolean;
+	disabled?: boolean;
+}

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -15,6 +15,9 @@ export interface DropdownMenuProps {
 	// TODO: do we need to support render props too?
 	trigger: React.ReactElement;
 	children?: React.ReactNode;
+	/**
+	 * @default true
+	 */
 	modal?: boolean;
 	className?: string;
 	open?: boolean;
@@ -23,6 +26,7 @@ export interface DropdownMenuProps {
 	placement?: Placement;
 	gutter?: number;
 	shift?: number;
+	defaultValues?: Ariakit.MenuStoreProps[ 'defaultValues' ];
 }
 
 export interface DropdownMenuGroupProps
@@ -42,6 +46,17 @@ export interface DropdownMenuItemProps {
 }
 
 export interface DropdownMenuCheckboxItemProps
+	extends Omit< DropdownMenuItemProps, 'prefix' | 'hideOnClick' > {
+	// Default false
+	hideOnClick?: boolean;
+	name: string;
+	value: string;
+	checked?: boolean;
+	defaultChecked?: boolean;
+	onChange?: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
+}
+
+export interface DropdownMenuRadioItemProps
 	extends Omit< DropdownMenuItemProps, 'prefix' | 'hideOnClick' > {
 	// Default false
 	hideOnClick?: boolean;

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -3,6 +3,7 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import type * as Ariakit from '@ariakit/react';
+import type { Placement } from '@floating-ui/react-dom';
 
 export interface DropdownMenuContext {
 	store: Ariakit.MenuStore;
@@ -18,6 +19,9 @@ export interface DropdownMenuProps {
 	open?: boolean;
 	defaultOpen?: boolean;
 	onOpenChange?: ( open: boolean ) => void;
+	placement?: Placement;
+	gutter?: number;
+	shift?: number;
 }
 
 export interface DropdownMenuGroupProps

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -23,6 +23,7 @@ export interface DropdownMenuProps {
 	open?: boolean;
 	defaultOpen?: boolean;
 	onOpenChange?: ( open: boolean ) => void;
+	// default depends on root level or nested menu
 	placement?: Placement;
 	gutter?: number;
 	shift?: number;

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -61,13 +61,6 @@ export interface DropdownMenuProps {
 	 */
 	shift?: number;
 	/**
-	 * The default values for the values state.
-	 */
-	defaultValues?: Record<
-		string,
-		string | boolean | number | Array< string | number >
-	>;
-	/**
 	 * Determines whether the menu popover will be hidden when the user presses
 	 * the Escape key.
 	 *

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -12,7 +12,6 @@ export interface DropdownMenuContext {
 
 // TODO: add support for standard HTML props
 export interface DropdownMenuProps {
-	// TODO: do we need to support render props too?
 	trigger: React.ReactElement;
 	children?: React.ReactNode;
 	/**

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -28,6 +28,8 @@ export interface DropdownMenuProps {
 	/**
 	 * The open state of the dropdown menu when it is initially rendered. Use when
 	 * not wanting to control its open state.
+	 *
+	 * @default false
 	 */
 	defaultOpen?: boolean;
 	/**

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -11,7 +11,7 @@ export interface DropdownMenuContext {
 	 */
 	store: Ariakit.MenuStore;
 	/**
-	 * The variant used by the underlying menu popover
+	 * The variant used by the underlying menu popover.
 	 */
 	variant?: 'toolbar';
 }
@@ -22,7 +22,7 @@ export interface DropdownMenuProps {
 	 */
 	trigger: React.ReactElement;
 	/**
-	 * The contents of the dropdown
+	 * The contents of the dropdown.
 	 */
 	children?: React.ReactNode;
 	/**
@@ -81,33 +81,33 @@ export interface DropdownMenuProps {
 
 export interface DropdownMenuGroupProps {
 	/**
-	 * The contents of the group
+	 * The contents of the dropdown menu group.
 	 */
 	children: React.ReactNode;
 }
 
 export interface DropdownMenuGroupLabelProps {
 	/**
-	 * The contents of the label
+	 * The contents of the dropdown menu group label.
 	 */
 	children: React.ReactNode;
 }
 
 export interface DropdownMenuItemProps {
 	/**
-	 * The contents of the label
+	 * The contents of the menu item.
 	 */
 	children: React.ReactNode;
 	/**
-	 * The contents of the item's prefix
+	 * The contents of the menu item's prefix.
 	 */
 	prefix?: React.ReactNode;
 	/**
-	 * The contents of the item's suffix
+	 * The contents of the menu item's suffix.
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * Whether to hide the dropdown menu when the menu item is clicked.
+	 * Whether to hide the parent menu when the item is clicked.
 	 *
 	 * @default true
 	 */
@@ -121,17 +121,17 @@ export interface DropdownMenuItemProps {
 export interface DropdownMenuCheckboxItemProps
 	extends Omit< DropdownMenuItemProps, 'prefix' | 'hideOnClick' > {
 	/**
-	 * Whether to hide the dropdown menu when the menu item is clicked.
+	 * Whether to hide the dropdown menu when the item is clicked.
 	 *
 	 * @default false
 	 */
 	hideOnClick?: boolean;
 	/**
-	 * The checkbox item's name.
+	 * The checkbox menu item's name.
 	 */
 	name: string;
 	/**
-	 * The checkbox item's value, useful when using multiple checkbox items
+	 * The checkbox item's value, useful when using multiple checkbox menu items
 	 * associated to the same `name`.
 	 */
 	value?: string;
@@ -153,7 +153,7 @@ export interface DropdownMenuCheckboxItemProps
 export interface DropdownMenuRadioItemProps
 	extends Omit< DropdownMenuItemProps, 'prefix' | 'hideOnClick' > {
 	/**
-	 * Whether to hide the dropdown menu when the menu item is clicked.
+	 * Whether to hide the dropdown menu when the item is clicked.
 	 *
 	 * @default false
 	 */

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -6,7 +6,13 @@ import type * as Ariakit from '@ariakit/react';
 import type { Placement } from '@floating-ui/react-dom';
 
 export interface DropdownMenuContext {
+	/**
+	 * The ariakit store shared across all DropdownMenu subcomponents.
+	 */
 	store: Ariakit.MenuStore;
+	/**
+	 * The variant used by the underlying menu popover
+	 */
 	variant?: 'toolbar';
 }
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -10,7 +10,6 @@ export interface DropdownMenuContext {
 	variant?: 'toolbar';
 }
 
-// TODO: add support for standard HTML props
 export interface DropdownMenuProps {
 	trigger: React.ReactElement;
 	children?: React.ReactNode;
@@ -18,7 +17,6 @@ export interface DropdownMenuProps {
 	 * @default true
 	 */
 	modal?: boolean;
-	className?: string;
 	open?: boolean;
 	defaultOpen?: boolean;
 	onOpenChange?: ( open: boolean ) => void;

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -11,60 +11,175 @@ export interface DropdownMenuContext {
 }
 
 export interface DropdownMenuProps {
+	/**
+	 * The trigger button.
+	 */
 	trigger: React.ReactElement;
+	/**
+	 * The contents of the dropdown
+	 */
 	children?: React.ReactNode;
 	/**
+	 * The modality of the dropdown menu. When set to true, interaction with
+	 * outside elements will be disabled and only menu content will be visible to
+	 * screen readers.
+	 *
 	 * @default true
 	 */
 	modal?: boolean;
+	/**
+	 * The controlled open state of the dropdown menu. Must be used in conjunction
+	 * with `onOpenChange`.
+	 */
 	open?: boolean;
+	/**
+	 * The open state of the dropdown menu when it is initially rendered. Use when
+	 * not wanting to control its open state.
+	 */
 	defaultOpen?: boolean;
+	/**
+	 * Event handler called when the open state of the dropdown menu changes.
+	 */
 	onOpenChange?: ( open: boolean ) => void;
-	// default depends on root level or nested menu
+	/**
+	 * The placement of the dropdown menu popover.
+	 *
+	 * @default 'bottom-start' for root-level menus, 'right-start' for nested menus
+	 */
 	placement?: Placement;
+	/**
+	 * The distance between the popover and the anchor element.
+	 *
+	 * @default 8 for root-level menus, 16 for nested menus
+	 */
 	gutter?: number;
+	/**
+	 * The skidding of the popover along the anchor element. Can be set to
+	 * negative values to make the popover shift to the opposite side.
+	 *
+	 * @default 0 for root-level menus, -8 for nested menus
+	 */
 	shift?: number;
-	defaultValues?: Ariakit.MenuStoreProps[ 'defaultValues' ];
-	hideOnEscape?: Ariakit.MenuProps[ 'hideOnEscape' ];
+	/**
+	 * The default values for the values state.
+	 */
+	defaultValues?: Record<
+		string,
+		string | boolean | number | Array< string | number >
+	>;
+	/**
+	 * Determines whether the menu popover will be hidden when the user presses
+	 * the Escape key.
+	 *
+	 * @default true
+	 */
+	hideOnEscape?:
+		| boolean
+		| ( (
+				event: KeyboardEvent | React.KeyboardEvent< Element >
+		  ) => boolean );
 }
 
-export interface DropdownMenuGroupProps
-	extends Omit< Ariakit.MenuGroupProps, 'store' > {}
+export interface DropdownMenuGroupProps {
+	/**
+	 * The contents of the group
+	 */
+	children: React.ReactNode;
+}
 
-export interface DropdownMenuGroupLabelProps
-	extends Omit< Ariakit.MenuGroupLabelProps, 'store' > {}
+export interface DropdownMenuGroupLabelProps {
+	/**
+	 * The contents of the label
+	 */
+	children: React.ReactNode;
+}
 
 export interface DropdownMenuItemProps {
+	/**
+	 * The contents of the label
+	 */
 	children: React.ReactNode;
+	/**
+	 * The contents of the item's prefix
+	 */
 	prefix?: React.ReactNode;
+	/**
+	 * The contents of the item's suffix
+	 */
 	suffix?: React.ReactNode;
-	onClick?: React.MouseEventHandler;
-	// Default true
+	/**
+	 * Whether to hide the dropdown menu when the menu item is clicked.
+	 *
+	 * @default true
+	 */
 	hideOnClick?: boolean;
+	/**
+	 * Determines if the element is disabled.
+	 */
 	disabled?: boolean;
 }
 
 export interface DropdownMenuCheckboxItemProps
 	extends Omit< DropdownMenuItemProps, 'prefix' | 'hideOnClick' > {
-	// Default false
+	/**
+	 * Whether to hide the dropdown menu when the menu item is clicked.
+	 *
+	 * @default false
+	 */
 	hideOnClick?: boolean;
+	/**
+	 * The checkbox item's name.
+	 */
 	name: string;
-	value: string;
+	/**
+	 * The checkbox item's value, useful when using multiple checkbox items
+	 * associated to the same `name`.
+	 */
+	value?: string;
+	/**
+	 * The controlled checked state of the checkbox menu item.
+	 */
 	checked?: boolean;
+	/**
+	 * The checked state of the checkbox menu item when it is initially rendered.
+	 * Use when not wanting to control its checked state.
+	 */
 	defaultChecked?: boolean;
+	/**
+	 * Event handler called when the checked state of the checkbox menu item changes.
+	 */
 	onChange?: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 }
 
 export interface DropdownMenuRadioItemProps
 	extends Omit< DropdownMenuItemProps, 'prefix' | 'hideOnClick' > {
-	// Default false
+	/**
+	 * Whether to hide the dropdown menu when the menu item is clicked.
+	 *
+	 * @default false
+	 */
 	hideOnClick?: boolean;
+	/**
+	 * The radio item's name.
+	 */
 	name: string;
-	value: string;
+	/**
+	 * The radio item's value.
+	 */
+	value: string | number;
+	/**
+	 * The controlled checked state of the radio menu item.
+	 */
 	checked?: boolean;
+	/**
+	 * The checked state of the radio menu item when it is initially rendered.
+	 * Use when not wanting to control its checked state.
+	 */
 	defaultChecked?: boolean;
+	/**
+	 * Event handler called when the checked radio menu item changes.
+	 */
 	onChange?: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 }
 
-export interface DropdownMenuSeparatorProps
-	extends Omit< Ariakit.MenuSeparatorProps, 'store' > {}
+export interface DropdownMenuSeparatorProps {}

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -25,6 +25,7 @@ export interface DropdownMenuProps {
 	gutter?: number;
 	shift?: number;
 	defaultValues?: Ariakit.MenuStoreProps[ 'defaultValues' ];
+	hideOnEscape?: Ariakit.MenuProps[ 'hideOnEscape' ];
 }
 
 export interface DropdownMenuGroupProps

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -20,6 +20,20 @@ export interface DropdownMenuProps {
 	 */
 	children?: React.ReactNode;
 	/**
+	 * The open state of the dropdown menu when it is initially rendered. Use when
+	 * not wanting to control its open state.
+	 */
+	defaultOpen?: boolean;
+	/**
+	 * The controlled open state of the dropdown menu. Must be used in conjunction
+	 * with `onOpenChange`.
+	 */
+	open?: boolean;
+	/**
+	 * Event handler called when the open state of the dropdown menu changes.
+	 */
+	onOpenChange?: ( open: boolean ) => void;
+	/**
 	 * The modality of the dropdown menu. When set to true, interaction with
 	 * outside elements will be disabled and only menu content will be visible to
 	 * screen readers.
@@ -27,20 +41,6 @@ export interface DropdownMenuProps {
 	 * @default true
 	 */
 	modal?: boolean;
-	/**
-	 * The controlled open state of the dropdown menu. Must be used in conjunction
-	 * with `onOpenChange`.
-	 */
-	open?: boolean;
-	/**
-	 * The open state of the dropdown menu when it is initially rendered. Use when
-	 * not wanting to control its open state.
-	 */
-	defaultOpen?: boolean;
-	/**
-	 * Event handler called when the open state of the dropdown menu changes.
-	 */
-	onOpenChange?: ( open: boolean ) => void;
 	/**
 	 * The placement of the dropdown menu popover.
 	 *

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -29,6 +29,15 @@ import {
 	DropdownSubMenu as DropdownSubMenuV2,
 	DropdownSubMenuTrigger as DropdownSubMenuTriggerV2,
 } from './dropdown-menu-v2';
+import {
+	DropdownMenu as DropdownMenuV2Ariakit,
+	DropdownMenuGroup as DropdownMenuGroupV2Ariakit,
+	DropdownMenuGroupLabel as DropdownMenuGroupLabelV2Ariakit,
+	DropdownMenuItem as DropdownMenuItemV2Ariakit,
+	DropdownMenuCheckboxItem as DropdownMenuCheckboxItemV2Ariakit,
+	DropdownMenuRadioItem as DropdownMenuRadioItemV2Ariakit,
+	DropdownMenuSeparator as DropdownMenuSeparatorV2Ariakit,
+} from './dropdown-menu-v2-ariakit';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import Tabs from './tabs';
@@ -63,4 +72,11 @@ lock( privateApis, {
 	ProgressBar,
 	Tabs,
 	Theme,
+	DropdownMenuV2Ariakit,
+	DropdownMenuGroupV2Ariakit,
+	DropdownMenuGroupLabelV2Ariakit,
+	DropdownMenuItemV2Ariakit,
+	DropdownMenuCheckboxItemV2Ariakit,
+	DropdownMenuRadioItemV2Ariakit,
+	DropdownMenuSeparatorV2Ariakit,
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Part of #50459
Requires #55365

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a new version of the `DropdownMenu` component based off the `ariakit` library.

**_Note: The component should still be considered a WIP and will be tweaked and refined either in this PR or via follow-up PRs as it receives feedback and as it gets used throughout the codebase_**

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We found a few blockers when working on the radix-ui based new version of `DropdownMenu`, and therefore we're trying a version based on `ariakit` instead

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- followed examples from ariakit's website
- requirements, styles, stories and unit tests were heavily inspired from the radix-ui version of the experimental component

#### Next steps:

 - Refine design and behaviour
 - Address any bugs
 - Start testing in the editor
 - Try to write a compat layer for legacy `DropdownMenu` and `MenuItem`
 
<details>

<summary>Progress tracker</summary>

- Prep basic version of components:
  - [x] `DropdownMenu`
    - [x] controlled mode
    - [x] modal
    - [x] trigger (use `DropdownMenuItem`)
    - [x] children
  - [x] `DropdownMenuGroup`
  - [x] `DropdownMenuGroupLabel` (or `DropdownMenuLabel`)
  - [x] `DropdownMenuItem`
      - [x] disabled
      - [x] onClick
      - [x] hideOnClick
      - [x] prefix and suffix
  - [x] `DropdownMenuCheckboxItem`
      - [x] controlled/uncontrolled (checked/onChange/defaultChecked..)
      - [x] multiple values
      - [x] same as menu item, but no prefix (taken by check icon)
  - [x] `DropdownMenuRadioItem`
      - [x] controlled/uncontrolled (checked/onChange/defaultChecked..)
      - [x] same as menu item, but no prefix (taken by radio icon)
  - [x] `DropdownMenuSeparator` 
- [x] Add back comprehensive Storybook examples
- [x] Tweak styles to meet design spec
- [x] Add animation (either via CSS or via framer motion)
- [x] Check reduced motion support
- [x] Check RTL support:
  - [x] it should flip left/right placements
  - [x] it should affect keyboard navigation
  - [x] set the `dir` attribute via HTML
- [x] Support toolbar variant via components context
- [x] edge case: dropdown opened inside a Modal, we should use `hideOnEscape={ ( e ) => { e.stopPropagation(); return true; } }`
- [x] Export via private APIs
- [x] Add back unit tests
- [x] Add types JSDocs
- [x] Add README
- [x] Check that all actionable TODOs in the code have been done, open follow-up issues for non-solvable items
</details>

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. `npm run distclean && npm ci && npm run storybook:dev`
2. Load the `DropdownMenuV2Ariakit` storybook examples
3. Interact with the example, and make sure that the dropdown:
    - uses semantically correct markup and attributes/roles
    - behaves as expected
    - looks as expected (including high contrast mode)
    - doesn't have any clear missing feature

## Screenshots or screencast <!-- if applicable -->

_**(ignore the fact that menu's popover is not aligned with the trigger when Storybook's sidebar is opened, as that's a `floating-ui` bug not related to this PR)**_

https://github.com/WordPress/gutenberg/assets/1083581/685beb1b-3107-422c-82d5-4f48eb0df7b3


