### PR TITLE
Label enforcer workflow: make accessibility a focus instead of a type

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -12,7 +12,7 @@ jobs:
               with:
                   mode: exactly
                   count: 1
-                  labels: '[Type] Accessibility (a11y), [Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Regression, [Type] Security, [Type] WP Core Ticket, Backport from WordPress Core'
+                  labels: '[Type] Automated Testing, [Type] Breaking Change, [Type] Bug, [Type] Build Tooling, [Type] Code Quality, [Type] Copy, [Type] Developer Documentation, [Type] Enhancement, [Type] Experimental, [Type] Feature, [Type] New API, [Type] Task, [Type] Performance, [Type] Project Management, [Type] Regression, [Type] Security, [Type] WP Core Ticket, Backport from WordPress Core'
                   add_comment: true
                   message: "**Warning: Type of PR label error**\n\n To merge this PR, it requires {{ errorString }} {{ count }} label indicating the type of PR. Other labels are optional and not being checked here. \n- **Type-related labels to choose from**: {{ provided }}.\n- **Labels found**: {{ applied }}.\n\nRead more about [Type labels in Gutenberg](https://github.com/WordPress/gutenberg/labels?q=type)."
                   exit_type: failure


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the limitation of having the Accessibility label along with types of labels like Bug or Enhancement.

At the same time, if this change is approved, a PR will _need_ to have a type-of-task label associated with it. The reasoning behind this is multiple, as not having clear rules for labeling makes it more complicated to contribute and to report and do project management on the project.

## Why?
As mentioned by @afercia [here](https://github.com/WordPress/gutenberg/discussions/52727#discussioncomment-7102557).

> Regarding the accessibility label, quoting from https://github.com/WordPress/gutenberg/pull/54724#issuecomment-1733830085
>
>I think I already pointed out in some other discussion or issue that Accessibility is typically something that spans across different areas of a project. As such, we should be able to add the Accessibility label everywhere. WhethEr it's a Type or other, I don't have strong preferences.
>
>Accessibility in Core Trac used to be a component and was changed to Focus right for that reason. The re=organizazion of the Trac focuses dates early 2014. For more details and the reasoning about Accessibility as focus, see https://make.wordpress.org/core/2014/01/24/trac-focuses/

## How?
By removing the label from the list of type labels.

If this PR is approved, I will follow up with renaming the label to remove the `[Type]` prefix.
