### PR TITLE
Remove duplicate template areas from the site view sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/home-template-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/home-template-details.js
@@ -116,14 +116,30 @@ export default function HomeTemplateDetails() {
 	 * which contains the template icon and fallback labels
 	 */
 	const templateAreas = useMemo( () => {
+		// Keep track of template part IDs that have already been added to the array.
+		const templatePartIds = [];
+		const filterOutDuplicateTemplateParts = ( currentTemplatePart ) => {
+			// If the template part has already been added to the array, skip it.
+			if (
+				templatePartIds.indexOf( currentTemplatePart.templatePart.id ) >
+				-1
+			) {
+				return;
+			}
+			// Add to the array of template part IDs.
+			templatePartIds.push( currentTemplatePart.templatePart.id );
+			return currentTemplatePart;
+		};
 		return currentTemplateParts.length && templatePartAreas
-			? currentTemplateParts.map( ( { templatePart, block } ) => ( {
-					...templatePartAreas?.find(
-						( { area } ) => area === templatePart?.area
-					),
-					...templatePart,
-					clientId: block.clientId,
-			  } ) )
+			? currentTemplateParts
+					.filter( filterOutDuplicateTemplateParts )
+					.map( ( { templatePart, block } ) => ( {
+						...templatePartAreas?.find(
+							( { area } ) => area === templatePart?.area
+						),
+						...templatePart,
+						clientId: block.clientId,
+					} ) )
 			: [];
 	}, [ currentTemplateParts, templatePartAreas ] );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-template/home-template-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-template/home-template-details.js
@@ -117,19 +117,17 @@ export default function HomeTemplateDetails() {
 	 */
 	const templateAreas = useMemo( () => {
 		// Keep track of template part IDs that have already been added to the array.
-		const templatePartIds = [];
+		const templatePartIds = new Set();
 		const filterOutDuplicateTemplateParts = ( currentTemplatePart ) => {
 			// If the template part has already been added to the array, skip it.
-			if (
-				templatePartIds.indexOf( currentTemplatePart.templatePart.id ) >
-				-1
-			) {
+			if ( templatePartIds.has( currentTemplatePart.templatePart.id ) ) {
 				return;
 			}
 			// Add to the array of template part IDs.
-			templatePartIds.push( currentTemplatePart.templatePart.id );
+			templatePartIds.add( currentTemplatePart.templatePart.id );
 			return currentTemplatePart;
 		};
+
 		return currentTemplateParts.length && templatePartAreas
 			? currentTemplateParts
 					.filter( filterOutDuplicateTemplateParts )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is another attempt at https://github.com/WordPress/gutenberg/pull/54861.

This PR removes duplicate template areas from the sidebar when in Site View.

The list of areas is based on the template parts used on the page, but we may use some template parts twice. 

## Why?
We only want to display these template areas and corresponding parts once in the sidebar even if they are used multiple times.

## How?
By updating `templateAreas` inside `packages/edit-site/src/components/sidebar-navigation-screen-template/home-template-details.js` to remove template parts with the same ID.

## Screenshot
<img width="436" alt="Screenshot 2023-09-28 at 15 56 20" src="https://github.com/WordPress/gutenberg/assets/275961/12fc1521-80a8-427e-8ed0-71a2143b713d">
