### PR TITLE
Navigation: Add an experimental label

### DIFF
--- a/packages/block-library/src/navigation/build-navigation-label.js
+++ b/packages/block-library/src/navigation/build-navigation-label.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+
+function buildNavigationLabel( title, id, status ) {
+	if ( ! title ) {
+		/* translators: %s is the index of the menu in the list of menus. */
+		return sprintf( __( '(no title %s)' ), id );
+	}
+
+	if ( status === 'publish' ) {
+		return decodeEntities( title );
+	}
+
+	return sprintf(
+		// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
+		__( '%1$s (%2$s)' ),
+		decodeEntities( title ),
+		status
+	);
+}
+
+export default buildNavigationLabel;

--- a/packages/block-library/src/navigation/build-navigation-label.js
+++ b/packages/block-library/src/navigation/build-navigation-label.js
@@ -10,14 +10,16 @@ function buildNavigationLabel( title, id, status ) {
 		return sprintf( __( '(no title %s)' ), id );
 	}
 
+	const decodedTitle = decodeEntities( title );
+
 	if ( status === 'publish' ) {
-		return decodeEntities( title );
+		return decodedTitle;
 	}
 
 	return sprintf(
 		// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
 		__( '%1$s (%2$s)' ),
-		decodeEntities( title ),
+		decodedTitle,
 		status
 	);
 }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -18,24 +18,7 @@ import { useEntityProp } from '@wordpress/core-data';
  */
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
-
-function buildMenuLabel( title, id, status ) {
-	if ( ! title ) {
-		/* translators: %s is the index of the menu in the list of menus. */
-		return sprintf( __( '(no title %s)' ), id );
-	}
-
-	if ( status === 'publish' ) {
-		return decodeEntities( title );
-	}
-
-	return sprintf(
-		// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
-		__( '%1$s (%2$s)' ),
-		decodeEntities( title ),
-		status
-	);
-}
+import buildNavigationLabel from '../build-navigation-label';
 
 function NavigationMenuSelector( {
 	currentMenuId,
@@ -72,7 +55,7 @@ function NavigationMenuSelector( {
 	const menuChoices = useMemo( () => {
 		return (
 			navigationMenus?.map( ( { id, title, status }, index ) => {
-				const label = buildMenuLabel(
+				const label = buildNavigationLabel(
 					title?.rendered,
 					index + 1,
 					status

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -12,6 +12,8 @@ import metadata from './block.json';
 import edit from './edit';
 import save from './save';
 import deprecated from './deprecated';
+import useNavigationMenu from './use-navigation-menu';
+import buildNavigationLabel from './build-navigation-label';
 
 const { name } = metadata;
 
@@ -49,6 +51,14 @@ export const settings = {
 				},
 			},
 		],
+	},
+	__experimentalLabel( { ref } ) {
+		const { navigationMenu } = useNavigationMenu( ref );
+		return buildNavigationLabel(
+			navigationMenu.title,
+			1, // This has to be 1 because in this context there is only one Navigation shown.
+			navigationMenu.status
+		);
 	},
 	edit,
 	save,

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -55,7 +55,7 @@ export const settings = {
 	__experimentalLabel( { ref } ) {
 		const { navigationMenu } = useNavigationMenu( ref );
 		return buildNavigationLabel(
-			navigationMenu.title,
+			navigationMenu?.title,
 			1, // This has to be 1 because in this context there is only one Navigation shown.
 			navigationMenu.status
 		);

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -57,7 +57,7 @@ export const settings = {
 		return buildNavigationLabel(
 			navigationMenu?.title,
 			1, // This has to be 1 because in this context there is only one Navigation shown.
-			navigationMenu.status
+			navigationMenu?.status
 		);
 	},
 	edit,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/build-navigation-label.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/build-navigation-label.js
@@ -11,14 +11,16 @@ export default function buildNavigationLabel( title, id, status ) {
 		return sprintf( __( '(no title %s)' ), id );
 	}
 
+	const decodedTitle = decodeEntities( title?.rendered );
+
 	if ( status === 'publish' ) {
-		return decodeEntities( title?.rendered );
+		return decodedTitle;
 	}
 
 	return sprintf(
 		// translators: %1s: title of the menu; %2s: status of the menu (draft, pending, etc.).
 		__( '%1$s (%2$s)' ),
-		decodeEntities( title?.rendered ),
+		decodedTitle,
 		status
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR requires https://github.com/WordPress/gutenberg/pull/54426.

This adds a label to the list view is the name of the navigation in the database.

## Why?
This will make the connection between the block and the data within the block clearer.

## How?
Add an __experimentalLabel function to the Navigation block, and reuse the buildNavigationLabel function do display the name of the navigation in the list view.

## Testing Instructions
1. Add a navigation block to a post
2. Open the list view
3. Check that the name of the Navigation CPT appears in the List View

## Screenshots or screencast <!-- if applicable -->
<img width="1077" alt="Screenshot 2023-09-29 at 22 51 56" src="https://github.com/WordPress/gutenberg/assets/275961/f9674536-afa2-4dc3-85a5-c8683172ec8b">
