### PR TITLE
Revert "Font Library: avoid rendering font library ui outisde gutenberg plugin"

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -64,12 +64,8 @@ function FontFamilies() {
 	);
 }
 
-const FontFamiliesComponent = ( { ...props } ) => (
+export default ( { ...props } ) => (
 	<FontLibraryProvider>
 		<FontFamilies { ...props } />
 	</FontLibraryProvider>
 );
-
-export default process.env.IS_GUTENBERG_PLUGIN
-	? FontFamiliesComponent
-	: undefined;

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -22,10 +22,9 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen-typography">
 				<VStack spacing={ 6 }>
-					{ FontFamilies &&
-						! window.__experimentalDisableFontLibrary && (
-							<FontFamilies />
-						) }
+					{ ! window.__experimentalDisableFontLibrary && (
+						<FontFamilies />
+					) }
 					<TypographyElements />
 				</VStack>
 			</div>


### PR DESCRIPTION
## What?
Reverts the conditional export of the font library UI components to make it available only in Gutenberg.

## Why?
To make the font library also available on core.


Reverts WordPress/gutenberg#54830