### PR TITLE
Theme slug injection: Make the function recursive

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -37,13 +37,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 			)
 		) {
 			block.innerBlocks = block.innerBlocks.map( ( innerBlock ) => {
-				if (
-					innerBlock.name === 'core/template-part' &&
-					innerBlock.attributes.theme === undefined
-				) {
-					innerBlock.attributes.theme = currentThemeStylesheet;
-				}
-				return innerBlock;
+				return injectThemeAttributeInBlockTemplateContent( innerBlock );
 			} );
 		}
 

--- a/packages/edit-site/src/components/start-template-options/index.js
+++ b/packages/edit-site/src/components/start-template-options/index.js
@@ -63,13 +63,7 @@ function useStartPatterns( fallbackContent ) {
 			)
 		) {
 			block.innerBlocks = block.innerBlocks.map( ( innerBlock ) => {
-				if (
-					innerBlock.name === 'core/template-part' &&
-					innerBlock.attributes.theme === undefined
-				) {
-					innerBlock.attributes.theme = currentThemeStylesheet;
-				}
-				return innerBlock;
+				return injectThemeAttributeInBlockTemplateContent( innerBlock );
 			} );
 		}
 


### PR DESCRIPTION
## What?
The function `injectThemeAttributeInBlockTemplateContent` can be recursive, which makes it slightly smaller. It also ensures that nested template part blocks will continue to work as expected.

## Why?
Code quality.

## How?
Call `injectThemeAttributeInBlockTemplateContent` inside `injectThemeAttributeInBlockTemplateContent`.

## Testing Instructions
See the instructions on https://github.com/WordPress/gutenberg/pull/53423 and https://github.com/WordPress/gutenberg/pull/54595

