### PR TITLE
Editor: Use hooks instead of HoCs in 'PostSticky' components

### DIFF
--- a/packages/editor/src/components/post-sticky/check.js
+++ b/packages/editor/src/components/post-sticky/check.js
@@ -1,28 +1,25 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-export function PostStickyCheck( { hasStickyAction, postType, children } ) {
+export default function PostStickyCheck( { children } ) {
+	const { hasStickyAction, postType } = useSelect( ( select ) => {
+		const post = select( editorStore ).getCurrentPost();
+		return {
+			hasStickyAction: post._links?.[ 'wp:action-sticky' ] ?? false,
+			postType: select( editorStore ).getCurrentPostType(),
+		};
+	}, [] );
+
 	if ( postType !== 'post' || ! hasStickyAction ) {
 		return null;
 	}
 
 	return children;
 }
-
-export default compose( [
-	withSelect( ( select ) => {
-		const post = select( editorStore ).getCurrentPost();
-		return {
-			hasStickyAction: post._links?.[ 'wp:action-sticky' ] ?? false,
-			postType: select( editorStore ).getCurrentPostType(),
-		};
-	} ),
-] )( PostStickyCheck );

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -3,8 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,31 +11,22 @@ import { compose } from '@wordpress/compose';
 import PostStickyCheck from './check';
 import { store as editorStore } from '../../store';
 
-export function PostSticky( { onUpdateSticky, postSticky = false } ) {
+export default function PostSticky() {
+	const postSticky = useSelect( ( select ) => {
+		return (
+			select( editorStore ).getEditedPostAttribute( 'sticky' ) ?? false
+		);
+	}, [] );
+	const { editPost } = useDispatch( editorStore );
+
 	return (
 		<PostStickyCheck>
 			<CheckboxControl
 				__nextHasNoMarginBottom
 				label={ __( 'Stick to the top of the blog' ) }
 				checked={ postSticky }
-				onChange={ () => onUpdateSticky( ! postSticky ) }
+				onChange={ () => editPost( { sticky: ! postSticky } ) }
 			/>
 		</PostStickyCheck>
 	);
 }
-
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			postSticky:
-				select( editorStore ).getEditedPostAttribute( 'sticky' ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		return {
-			onUpdateSticky( postSticky ) {
-				dispatch( editorStore ).editPost( { sticky: postSticky } );
-			},
-		};
-	} ),
-] )( PostSticky );

--- a/packages/editor/src/components/post-sticky/test/index.js
+++ b/packages/editor/src/components/post-sticky/test/index.js
@@ -4,39 +4,54 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { PostStickyCheck } from '../check';
+import PostStickyCheck from '../check';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test.
+	const mock = jest.fn();
+	return mock;
+} );
+
+function setupUseSelectMock( { hasStickyAction, postType } ) {
+	useSelect.mockImplementation( ( cb ) => {
+		return cb( () => ( {
+			getCurrentPostType: () => postType,
+			getCurrentPost: () => ( {
+				_links: {
+					'wp:action-sticky': hasStickyAction,
+				},
+			} ),
+		} ) );
+	} );
+}
 
 describe( 'PostSticky', () => {
 	it( 'should not render anything if the post type is not "post"', () => {
-		render(
-			<PostStickyCheck postType="page" hasStickyAction={ true }>
-				Can Toggle Sticky
-			</PostStickyCheck>
-		);
+		setupUseSelectMock( { hasStickyAction: true, postType: 'page' } );
+		render( <PostStickyCheck>Can Toggle Sticky</PostStickyCheck> );
 		expect(
 			screen.queryByText( 'Can Toggle Sticky' )
 		).not.toBeInTheDocument();
 	} );
 
 	it( "should not render anything if post doesn't support stickying", () => {
-		render(
-			<PostStickyCheck postType="post" hasStickyAction={ false }>
-				Can Toggle Sticky
-			</PostStickyCheck>
-		);
+		setupUseSelectMock( { hasStickyAction: false, postType: 'post' } );
+		render( <PostStickyCheck>Can Toggle Sticky</PostStickyCheck> );
 		expect(
 			screen.queryByText( 'Can Toggle Sticky' )
 		).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if the post supports stickying', () => {
-		render(
-			<PostStickyCheck postType="post" hasStickyAction={ true }>
-				Can Toggle Sticky
-			</PostStickyCheck>
-		);
+		setupUseSelectMock( { hasStickyAction: true, postType: 'post' } );
+		render( <PostStickyCheck>Can Toggle Sticky</PostStickyCheck> );
 		expect( screen.getByText( 'Can Toggle Sticky' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?
This is similar to #53389.

PR refactors `PostStickyCheck` and `PostSticky` components to use `useDispatch` and `useSelect` hooks instead of the HoCs.

## Why?
A micro-optimization makes the rendered component tree smaller.

## Testing Instructions
Confirm 

### Testing Instructions for Keyboard
The same "Stick to the top of the blog" action works as before.

* Is only displayed for posts.
* Can mark a post as "sticky".

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2023-09-25 at 18 47 36](https://github.com/WordPress/gutenberg/assets/240569/bcb24f86-b7cc-4902-a46b-522cd222abd9)

**After**
![CleanShot 2023-09-30 at 11 20 42](https://github.com/WordPress/gutenberg/assets/240569/ef3c56bc-f958-4118-b2a3-4a2c83b73b2c)
