### PR TITLE
Edit Post: Use hooks instead of HoCs in 'PostStatus' components

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-status/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-status/style.scss
@@ -1,5 +1,0 @@
-.edit-post-post-status .edit-post-post-publish-dropdown__switch-to-draft {
-	margin-top: 15px;
-	width: 100%;
-	text-align: center;
-}

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -14,7 +14,6 @@
 @import "./components/sidebar/post-format/style.scss";
 @import "./components/sidebar/post-schedule/style.scss";
 @import "./components/sidebar/post-slug/style.scss";
-@import "./components/sidebar/post-status/style.scss";
 @import "./components/sidebar/post-template/style.scss";
 @import "./components/sidebar/post-url/style.scss";
 @import "./components/sidebar/post-visibility/style.scss";


### PR DESCRIPTION
## What?
This is similar to #54949.

PR refactors `PostStatus` components to use `useDispatch` and `useSelect` hooks instead of the HoCs. I've also removed unused styles from the component.

## Why?
A micro-optimization makes the rendered component tree smaller.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open a post or page.
2. Confirm the "Post Status" panel renders as before.
3. You can close and open the panel.
4. Remove the panel programmatically using the following snippet - `wp.data.dispatch( 'core/edit-post' ).removeEditorPanel( 'post-status' );`

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2023-09-30 at 14 07 49](https://github.com/WordPress/gutenberg/assets/240569/38c8754a-e691-458a-990b-79dca2569d79)

**After**
![CleanShot 2023-09-30 at 14 06 35](https://github.com/WordPress/gutenberg/assets/240569/b1a12c49-edb9-4266-a2d3-952a248a81bd)
