### PR TITLE
build: Support custom mobile Demo editor setup configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ test/storybook-playwright/specs/__snapshots__
 test/storybook-playwright/specs/*-snapshots/**
 test/gutenberg-test-themes/twentytwentyone
 test/gutenberg-test-themes/twentytwentythree
+packages/react-native-editor/src/setup-local.js

--- a/docs/contributors/code/react-native/getting-started-react-native.md
+++ b/docs/contributors/code/react-native/getting-started-react-native.md
@@ -71,6 +71,40 @@ npm run native ios -- -- --simulator="iPhone Xs Max"
 
 To see a list of all of your available iOS devices, use `xcrun simctl list devices`.
 
+### Customizing the Demo Editor
+
+By default, the Demo editor renders most of the supported core blocks. This is helpful to showcase the editor's capabilities, but can be distracting when focusing on a specific block or feature. One can customize the editor's intial state by leveraging the `native.block_editor_props` hook in a `packages/react-native-editor/src/setup-local.js` file.
+
+<details><summary>Example setup-local.js</summary>
+
+```js
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+export default () => {
+	addFilter(
+		'native.block_editor_props',
+		'core/react-native-editor',
+		( props ) => {
+			return {
+				...props,
+				initialHtml,
+			};
+		}
+	);
+};
+
+const initialHtml = `
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Just a Heading</h2>
+<!-- /wp:heading -->
+`;
+```
+
+</details>
+
 ### Troubleshooting
 
 If the Android emulator doesn't start correctly, or compiling fails with `Could not initialize class org.codehaus.groovy.runtime.InvokerHelper` or similar, it may help to double check the set up of your development environment against the latest requirements in [React Native's documentation](https://reactnative.dev/docs/environment-setup). With Android Studio, for example, you will need to configure the `ANDROID_HOME` environment variable and ensure that your version of JDK matches the latest requirements.

--- a/packages/react-native-editor/metro.config.js
+++ b/packages/react-native-editor/metro.config.js
@@ -27,6 +27,7 @@ module.exports = {
 				inlineRequires: false,
 			},
 		} ),
+		unstable_allowRequireContext: true, // Used for optional setup configuration.
 	},
 	server: {
 		enhanceMiddleware: ( middleware ) => ( req, res, next ) => {

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -52,8 +52,10 @@ const registerGutenberg = ( {
 			this.editorComponent = setup();
 
 			// Apply optional setup configuration, enabling modification via hooks.
-			const req = require.context( './', false, /setup-local\.js$/ );
-			req.keys().forEach( ( key ) => req( key ).default() );
+			if ( typeof require.context === 'function' ) {
+				const req = require.context( './', false, /setup-local\.js$/ );
+				req.keys().forEach( ( key ) => req( key ).default() );
+			}
 
 			// Dispatch pre-render hooks.
 			doAction( 'native.pre-render', parentProps );

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -51,6 +51,10 @@ const registerGutenberg = ( {
 			// Initialize editor
 			this.editorComponent = setup();
 
+			// Apply optional setup configuration, enabling modification via hooks.
+			const req = require.context( './', false, /setup-local\.js$/ );
+			req.keys().forEach( ( key ) => req( key ).default() );
+
 			// Dispatch pre-render hooks.
 			doAction( 'native.pre-render', parentProps );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Support custom mobile Demo editor setup configuration.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Applying optional setup configuration files allows developers to modify
the Demo editor environment via Hooks, e.g. to set custom `initialHtml`
for the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Rely upon the experimental `unstable_allowRequireContext` Metro configuration to
enable searching for the optional `setup-local.js` configuration file via
`require.context`.

This approach is a workaround as loading the optional configuration file fails
when using `allowOptionalDependencies`, as outlined in https://github.com/facebook/metro/issues/666#issuecomment-1742186952.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**Without custom configuration**
1. Clone this branch.
1. Start the server via `npm run native start:reset`.
1. Build the app via `npm run native ios` or `npm run native android`.
1. Verify the Demo editor runs loading the existing `initial-html`
    configuration, displaying the expected blocks.

**With custom configuration**

<details><summary>Example setup configuration</summary>

```
/**
 * WordPress dependencies
 */
import { addFilter } from '@wordpress/hooks';

export default () => {
	addFilter(
		'native.block_editor_props',
		'core/react-native-editor',
		( props ) => {
			return {
				...props,
				initialHtml,
			};
		}
	);
};

const initialHtml = `
<!-- wp:heading -->
<h2 class="wp-block-heading" id="this-is-an-anchor">Just a Heading</h2>
<!-- /wp:heading -->
`;
```

</details>

1. Clone this branch.
1. Create a new file: `packages/react-native-editor/src/setup-local.js`
1. Populate the file with the "Example setup configuration" above.
1. Start the server via `npm run native start:reset`.
1. Build the app via `npm run native ios` or `npm run native android`.
1. Verify the Demo editor runs loading the local configuration file, displaying
    the blocks within the custom configuration.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
