### PR TITLE
[RNMobile] Quote block: Ensure border is visible with block-based themes in dark mode

### DIFF
--- a/packages/primitives/src/block-quotation/index.native.js
+++ b/packages/primitives/src/block-quotation/index.native.js
@@ -20,6 +20,9 @@ export const BlockQuotation = forwardRef( ( { ...props }, ref ) => {
 			styles.wpBlockQuoteLight,
 			styles.wpBlockQuoteDark
 		),
+		style?.baseColors?.color?.text && {
+			borderLeftColor: style.baseColors.color.text,
+		},
 		style?.color && {
 			borderLeftColor: style.color,
 		},


### PR DESCRIPTION
* Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6268

## What?

Partial fix for https://github.com/WordPress/gutenberg/issues/50666, ensures that the Quote block's left border is always visible.

## Why?

There are certain scenarios where the Quote block's left border is currently invisible. This happens if a block-based theme has a light background (which the native editor displays) and the device has dark mode enabled, and vice versa.

## How?

If a block-based theme is active, the theme's text colour will be detected and used for the block's left border. 

## Testing Instructions

* Ensure dark mode is enabled on your device.
* Activate a theme with support for global styles. For example, [Byrne](https://byrnedemo.wordpress.com/).
* While in the site's /wp-admin area in a browser, navigate to the site editor (Appearance → Editor) and select a style with a white background.
* In the app, navigate to the editor for any of the site's posts or pages.
* Verify that the editor's background is white.
* Add a Quote block to the editor.
* Verify that the left border in the Quote block is visible.

### Testing Instructions for Keyboard

N/A, this is a visual change only.

## Screenshots or screencast

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/WordPress/gutenberg/assets/2998162/7636441d-90d9-4d62-b15b-2584d0a8801f" width="100%"> | <img src="https://github.com/WordPress/gutenberg/assets/2998162/7d16a7a6-3344-425c-81a8-36f82ed0b979" width="100%"> |
