### PR TITLE
Media & text block: Try to fix JavaScript warning

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -85,7 +85,8 @@
 			"type": "string"
 		},
 		"imageFill": {
-			"type": "boolean"
+			"type": "boolean",
+			"default": false
 		},
 		"focalPoint": {
 			"type": "object"

--- a/test/integration/fixtures/blocks/core__media-text.json
+++ b/test/integration/fixtures/blocks/core__media-text.json
@@ -9,7 +9,8 @@
 			"mediaUrl": "data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
 			"mediaType": "image",
 			"mediaWidth": 50,
-			"isStackedOnMobile": true
+			"isStackedOnMobile": true,
+			"imageFill": false
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__media-text__image-alt-no-align.json
+++ b/test/integration/fixtures/blocks/core__media-text__image-alt-no-align.json
@@ -9,7 +9,8 @@
 			"mediaUrl": "data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
 			"mediaType": "image",
 			"mediaWidth": 50,
-			"isStackedOnMobile": true
+			"isStackedOnMobile": true,
+			"imageFill": false
 		},
 		"innerBlocks": [
 			{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds `false` as the default value for the ImageFill block attribute in the Media & Text block.
Closes https://github.com/WordPress/gutenberg/issues/54963

## Why?
The imageFill block attribute is a boolean but has no default value.
In WP 6.4 beta this caused a JavaScript warning in the block editor when the setting "Crop image to fill entire column" was enabled. See the issue linked above.

## Testing Instructions

1. Create a new post or page.
2. Add a media & text block. Select or upload an image.
3. Enable the option "Crop image to fill entire column"
4. Confirm that there is no JavaScript warning about the value changing from undefined to a defined value, and that the crop setting continues to work.

5. Deactivate Gutenberg, add two media and text blocks, one with the crop option enabled, one without.  Activate Gutenberg again and confirm that there are no block validation errors.
