### PR TITLE
E2E Utils: Allow overriding username/password

### DIFF
--- a/packages/e2e-test-utils-playwright/src/config.ts
+++ b/packages/e2e-test-utils-playwright/src/config.ts
@@ -9,4 +9,4 @@ const {
 	WP_BASE_URL = 'http://localhost:8889',
 } = process.env;
 
-export { WP_ADMIN_USER, WP_USERNAME, WP_PASSWORD, WP_BASE_URL };
+export { WP_USERNAME, WP_PASSWORD, WP_BASE_URL };

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -9,7 +9,7 @@ import type { APIRequestContext, Cookie } from '@playwright/test';
 /**
  * Internal dependencies
  */
-import { WP_ADMIN_USER, WP_BASE_URL } from '../config';
+import { WP_USERNAME, WP_PASSWORD, WP_BASE_URL } from '../config';
 import type { User } from './login';
 import { login } from './login';
 import { listMedia, uploadMedia, deleteMedia, deleteAllMedia } from './media';
@@ -105,7 +105,7 @@ class RequestUtils {
 	constructor(
 		requestContext: APIRequestContext,
 		{
-			user = WP_ADMIN_USER,
+			user = { username: WP_USERNAME, password: WP_PASSWORD },
 			storageState,
 			storageStatePath,
 			baseURL = WP_BASE_URL,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This allows others to do things like `WP_BASE_URL=http://mycustomurl WP_USERNAME=username WP_PASSWORD=password npm run test:e2e`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the hardcoded `WP_ADMIN_USER` usage this currently isn't possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
