### PR TITLE
Update changelog automation and test fixtures to match the last a11y label renaming

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -75,7 +75,7 @@ const LABEL_TYPE_MAPPING = {
 	'[Type] Automated Testing': 'Tools',
 	'[Package] Dependency Extraction Webpack Plugin': 'Tools',
 	'[Type] Code Quality': 'Code Quality',
-	'[Type] Accessibility (a11y)': 'Accessibility',
+	'[Focus] Accessibility (a11y)': 'Accessibility',
 	'[Type] Performance': 'Performance',
 	'[Type] Security': 'Security',
 	'[Feature] Navigation Screen': 'Experiments',

--- a/bin/plugin/commands/test/fixtures/pull-requests.json
+++ b/bin/plugin/commands/test/fixtures/pull-requests.json
@@ -5750,7 +5750,7 @@
 				"id": 546517042,
 				"node_id": "MDU6TGFiZWw1NDY1MTcwNDI=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/Accessibility%20(a11y)",
-				"name": "[Type] Accessibility (a11y)",
+				"name": "[Focus] Accessibility (a11y)",
 				"color": "655104",
 				"default": false,
 				"description": "Changes that impact accessibility and need corresponding review (e.g. markup changes)."
@@ -12552,7 +12552,7 @@
 				"id": 546517042,
 				"node_id": "MDU6TGFiZWw1NDY1MTcwNDI=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/Accessibility%20(a11y)",
-				"name": "[Type] Accessibility (a11y)",
+				"name": "[Focus] Accessibility (a11y)",
 				"color": "655104",
 				"default": false,
 				"description": "Changes that impact accessibility and need corresponding review (e.g. markup changes)."


### PR DESCRIPTION
## What?
Updates the changelog automation tests to work with the latest name of the a11y label.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
So that the changelog automation continues to create a top section for Accessibility-related PRs even if accessibility is treated as a focus instead of a type of task.


## How?
By using the latest accessibility label name.

## Testing Instructions
1. Clear your jest cache with `npx jest --clearCache`
2. Run the changelog automation tests with `test:unit bin/plugin/commands/test/changelog.js`
