### PR TITLE
Wrapped `TextareaControl` in a `forwardRef` call

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `Modal`: Accessibly hide/show outer modal when nested ([#54743](https://github.com/WordPress/gutenberg/pull/54743)).
 -   `InputControl`, `NumberControl`, `UnitControl`, `SelectControl`, `CustomSelectControl`, `TreeSelect`: Add opt-in prop for next 40px default size, superseding the `__next36pxDefaultSize` prop ([#53819](https://github.com/WordPress/gutenberg/pull/53819)).
 -   `Modal`: add a new `size` prop to support preset widths, including a `fill` option to eventually replace the `isFullScreen` prop ([#54471](https://github.com/WordPress/gutenberg/pull/54471)).
+-   Wrapped `TextareaControl` in a `forwardRef` call ([#54975](https://github.com/WordPress/gutenberg/pull/54975)).
 
 ### Bug Fix
 

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import type { ChangeEvent } from 'react';
+import type { ChangeEvent, ForwardedRef } from 'react';
 
 /**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -39,8 +40,9 @@ import type { WordPressComponentProps } from '../context';
  * };
  * ```
  */
-export function TextareaControl(
-	props: WordPressComponentProps< TextareaControlProps, 'textarea', false >
+function UnforwardedTextareaControl(
+	props: WordPressComponentProps< TextareaControlProps, 'textarea', false >,
+	ref: ForwardedRef< HTMLTextAreaElement >
 ) {
 	const {
 		__nextHasNoMarginBottom,
@@ -74,10 +76,13 @@ export function TextareaControl(
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				value={ value }
+				ref={ ref }
 				{ ...additionalProps }
 			/>
 		</BaseControl>
 	);
 }
+
+export const TextareaControl = forwardRef( UnforwardedTextareaControl );
 
 export default TextareaControl;

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -12,29 +12,6 @@ import { StyledTextarea } from './styles/textarea-control-styles';
 import type { TextareaControlProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
-/**
- * TextareaControls are TextControls that allow for multiple lines of text, and
- * wrap overflow text onto a new line. They are a fixed height and scroll
- * vertically when the cursor reaches the bottom of the field.
- *
- * ```jsx
- * import { TextareaControl } from '@wordpress/components';
- * import { useState } from '@wordpress/element';
- *
- * const MyTextareaControl = () => {
- *   const [ text, setText ] = useState( '' );
- *
- *   return (
- *     <TextareaControl
- *       label="Text"
- *       help="Enter some text"
- *       value={ text }
- *       onChange={ ( value ) => setText( value ) }
- *     />
- *   );
- * };
- * ```
- */
 function UnforwardedTextareaControl(
 	props: WordPressComponentProps< TextareaControlProps, 'textarea', false >,
 	ref: React.ForwardedRef< HTMLTextAreaElement >
@@ -78,6 +55,29 @@ function UnforwardedTextareaControl(
 	);
 }
 
+/**
+ * TextareaControls are TextControls that allow for multiple lines of text, and
+ * wrap overflow text onto a new line. They are a fixed height and scroll
+ * vertically when the cursor reaches the bottom of the field.
+ *
+ * ```jsx
+ * import { TextareaControl } from '@wordpress/components';
+ * import { useState } from '@wordpress/element';
+ *
+ * const MyTextareaControl = () => {
+ *   const [ text, setText ] = useState( '' );
+ *
+ *   return (
+ *     <TextareaControl
+ *       label="Text"
+ *       help="Enter some text"
+ *       value={ text }
+ *       onChange={ ( value ) => setText( value ) }
+ *     />
+ *   );
+ * };
+ * ```
+ */
 export const TextareaControl = forwardRef( UnforwardedTextareaControl );
 
 export default TextareaControl;

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import type { ChangeEvent, ForwardedRef } from 'react';
-
-/**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
@@ -42,7 +37,7 @@ import type { WordPressComponentProps } from '../context';
  */
 function UnforwardedTextareaControl(
 	props: WordPressComponentProps< TextareaControlProps, 'textarea', false >,
-	ref: ForwardedRef< HTMLTextAreaElement >
+	ref: React.ForwardedRef< HTMLTextAreaElement >
 ) {
 	const {
 		__nextHasNoMarginBottom,
@@ -57,7 +52,7 @@ function UnforwardedTextareaControl(
 	} = props;
 	const instanceId = useInstanceId( TextareaControl );
 	const id = `inspector-textarea-control-${ instanceId }`;
-	const onChangeValue = ( event: ChangeEvent< HTMLTextAreaElement > ) =>
+	const onChangeValue = ( event: React.ChangeEvent< HTMLTextAreaElement > ) =>
 		onChange( event.target.value );
 
 	return (


### PR DESCRIPTION
Closes: #54723

## What?

This PR wraps the `TextAreaControl` component in a `forwardRef` call.

## Why?

Many components, not just form elements, are wrapped in `forwardRef` calls. This component is also a form element, and exposing the ref may also be useful to third-party developers.

## Testing Instructions

I wrote a simple code to test the `ref` prop. Update the code block's Edit component (`packages/block-library/src/code/edit.js`) with this code.

```javascript
/**
 * WordPress dependencies
 */
import { useBlockProps } from '@wordpress/block-editor';
import { TextareaControl } from '@wordpress/components';
import { useRef } from '@wordpress/element';

export default function CodeEdit() {
	const ref = useRef();
	const blockProps = useBlockProps();

	return (
		<div { ...blockProps }>
			<TextareaControl ref={ ref } />
			<button
				onClick={ () => {
					ref.current.focus();
					ref.current.value = 'Focued!';
				} }
			>
				Focus on textarea!
			</button>
		</div>
	);
}
```

- Insert a Code block in the block editor and click the button.
- The textarea should now have focus and be filled with a value.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/1f0acd17-ad4c-40c4-a733-c724561c6db2

