### PR TITLE
Font Library: use snake_case instead of camelCase on fontFamilies endpoint param

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
@@ -45,7 +45,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 					'callback'            => array( $this, 'install_fonts' ),
 					'permission_callback' => array( $this, 'update_font_library_permissions_check' ),
 					'args'                => array(
-						'fontFamilies' => array(
+						'font_families' => array(
 							'required'          => true,
 							'type'              => 'string',
 							'validate_callback' => array( $this, 'validate_install_font_families' ),
@@ -147,13 +147,13 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 		$error_messages = array();
 
 		if ( ! is_array( $font_families ) ) {
-			$error_messages[] = __( 'fontFamilies should be an array of font families.', 'gutenberg' );
+			$error_messages[] = __( 'font_families should be an array of font families.', 'gutenberg' );
 			return $error_messages;
 		}
 
 		// Checks if there is at least one font family.
 		if ( count( $font_families ) < 1 ) {
-			$error_messages[] = __( 'fontFamilies should have at least one font family definition.', 'gutenberg' );
+			$error_messages[] = __( 'font_families should have at least one font family definition.', 'gutenberg' );
 			return $error_messages;
 		}
 
@@ -260,7 +260,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	 */
 	public function uninstall_schema() {
 		return array(
-			'fontFamilies' => array(
+			'font_families' => array(
 				'type'        => 'array',
 				'description' => __( 'The font families to install.', 'gutenberg' ),
 				'required'    => true,
@@ -289,7 +289,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function uninstall_fonts( $request ) {
-		$fonts_to_uninstall = $request->get_param( 'fontFamilies' );
+		$fonts_to_uninstall = $request->get_param( 'font_families' );
 
 		$errors    = array();
 		$successes = array();
@@ -397,7 +397,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	 */
 	public function install_fonts( $request ) {
 		// Get new fonts to install.
-		$fonts_param = $request->get_param( 'fontFamilies' );
+		$fonts_param = $request->get_param( 'font_families' );
 
 		/*
 		 * As this is receiving form data, the font families are encoded as a string.

--- a/packages/edit-site/src/components/global-styles/font-library-modal/resolvers.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/resolvers.js
@@ -18,7 +18,7 @@ export async function fetchInstallFonts( data ) {
 
 export async function fetchUninstallFonts( fonts ) {
 	const data = {
-		fontFamilies: fonts,
+		font_families: fonts,
 	};
 	const config = {
 		path: '/wp/v2/fonts',

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -152,6 +152,6 @@ export function makeFormDataFromFontFamilies( fontFamilies ) {
 		}
 		return family;
 	} );
-	formData.append( 'fontFamilies', JSON.stringify( newFontFamilies ) );
+	formData.append( 'font_families', JSON.stringify( newFontFamilies ) );
 	return formData;
 }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/makeFormDataFromFontFamilies.spec.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/makeFormDataFromFontFamilies.spec.js
@@ -55,7 +55,7 @@ describe( 'makeFormDataFromFontFamilies', () => {
 				fontFamily: 'Bebas',
 			},
 		];
-		expect( JSON.parse( formData.get( 'fontFamilies' ) ) ).toEqual(
+		expect( JSON.parse( formData.get( 'font_families' ) ) ).toEqual(
 			expectedFontFamilies
 		);
 	} );

--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/installFonts.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/installFonts.php
@@ -24,7 +24,7 @@ class Tests_Fonts_WPRESTFontLibraryController_InstallFonts extends WP_REST_Font_
 	public function test_install_fonts( $font_families, $files, $expected_response ) {
 		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
 		$font_families_json = json_encode( $font_families );
-		$install_request->set_param( 'fontFamilies', $font_families_json );
+		$install_request->set_param( 'font_families', $font_families_json );
 		$install_request->set_file_params( $files );
 		$response = rest_get_server()->dispatch( $install_request );
 		$data     = $response->get_data();
@@ -309,7 +309,7 @@ class Tests_Fonts_WPRESTFontLibraryController_InstallFonts extends WP_REST_Font_
 	public function test_install_with_improper_inputs( $font_families, $files = array() ) {
 		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
 		$font_families_json = json_encode( $font_families );
-		$install_request->set_param( 'fontFamilies', $font_families_json );
+		$install_request->set_param( 'font_families', $font_families_json );
 		$install_request->set_file_params( $files );
 
 		$response = rest_get_server()->dispatch( $install_request );

--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/uninstallFonts.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/uninstallFonts.php
@@ -53,7 +53,7 @@ class Tests_Fonts_WPRESTFontLibraryController_UninstallFonts extends WP_REST_Fon
 
 		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
 		$font_families_json = json_encode( $mock_families );
-		$install_request->set_param( 'fontFamilies', $font_families_json );
+		$install_request->set_param( 'font_families', $font_families_json );
 		rest_get_server()->dispatch( $install_request );
 	}
 
@@ -68,7 +68,7 @@ class Tests_Fonts_WPRESTFontLibraryController_UninstallFonts extends WP_REST_Fon
 		);
 
 		$uninstall_request = new WP_REST_Request( 'DELETE', '/wp/v2/fonts' );
-		$uninstall_request->set_param( 'fontFamilies', $font_families_to_uninstall );
+		$uninstall_request->set_param( 'font_families', $font_families_to_uninstall );
 		$response = rest_get_server()->dispatch( $uninstall_request );
 		$this->assertSame( 200, $response->get_status(), 'The response status is not 200.' );
 	}
@@ -88,7 +88,7 @@ class Tests_Fonts_WPRESTFontLibraryController_UninstallFonts extends WP_REST_Fon
 			),
 		);
 
-		$uninstall_request->set_param( 'fontFamilies', $non_existing_font_data );
+		$uninstall_request->set_param( 'font_families', $non_existing_font_data );
 		$response = rest_get_server()->dispatch( $uninstall_request );
 		$data     = $response->get_data();
 		$this->assertCount( 2, $data['errors'], 'The response should have 2 errors, one for each font family uninstall failure.' );


### PR DESCRIPTION
## What?
Font Library: use snake_case instead of camelCase on fontFamilies endpoint param

## Why?
Endpoint parameters should use snake_case instead of camelCase as requested in this core pr review comment:
https://github.com/WordPress/wordpress-develop/pull/5285#discussion_r1342644332

## Testing Instructions
- Run unit tests
