### PR TITLE
Block Editor: Avoid double-wrapping selectors when transforming the styles

### DIFF
--- a/packages/block-editor/src/utils/transform-styles/transforms/test/__snapshots__/wrap.js.snap
+++ b/packages/block-editor/src/utils/transform-styles/transforms/test/__snapshots__/wrap.js.snap
@@ -22,6 +22,19 @@ color: red;
 }"
 `;
 
+exports[`CSS selector wrap should not double wrap selectors 1`] = `
+".my-namespace h1,
+.my-namespace .red {
+color: red;
+}"
+`;
+
+exports[`CSS selector wrap should replace :root selectors 1`] = `
+".my-namespace {
+--my-color: #ff0000;
+}"
+`;
+
 exports[`CSS selector wrap should replace root tags 1`] = `
 ".my-namespace,
 .my-namespace h1 {
@@ -47,11 +60,5 @@ exports[`CSS selector wrap should wrap selectors inside container queries 1`] = 
 .my-namespace h1 {
 color: red;
 }
-}"
-`;
-
-exports[`CSS selector wrap should replace :root selectors 1`] = `
-".my-namespace {
---my-color: #ff0000;
 }"
 `;

--- a/packages/block-editor/src/utils/transform-styles/transforms/test/wrap.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/test/wrap.js
@@ -83,4 +83,13 @@ describe( 'CSS selector wrap', () => {
 
 		expect( output ).toMatchSnapshot();
 	} );
+
+	it( 'should not double wrap selectors', () => {
+		const callback = wrap( '.my-namespace' );
+		const input = ` .my-namespace h1, .red { color: red; }`;
+
+		const output = traverse( input, callback );
+
+		expect( output ).toMatchSnapshot();
+	} );
 } );

--- a/packages/block-editor/src/utils/transform-styles/transforms/wrap.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/wrap.js
@@ -27,6 +27,10 @@ const wrap =
 				return selector;
 			}
 
+			if ( selector.trim().startsWith( namespace ) ) {
+				return selector;
+			}
+
 			// Anything other than a root tag is always prefixed.
 			{
 				if ( ! selector.match( IS_ROOT_TAG ) ) {

--- a/packages/block-editor/src/utils/transform-styles/transforms/wrap.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/wrap.js
@@ -27,7 +27,8 @@ const wrap =
 				return selector;
 			}
 
-			if ( selector.trim().startsWith( namespace ) ) {
+			// Skip the update when a selector already has a namespace + space (" ").
+			if ( selector.trim().startsWith( `${ namespace } ` ) ) {
 				return selector;
 			}
 


### PR DESCRIPTION
## What?
Resolves #54943.

PR updates style transformation's `wrap` helper to avoid double-wrapping the selectors.

P.S. Ideally, the editor-generated styles shouldn't include [scope namespaces](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/layouts/utils.js#L11-L35).

## Why?
When the selector already has `namespace`, it is unnecessary to append it again.

## How?
The method checks if the selector already starts with the namespaces and skips it.

## Testing Instructions
CI checks should pass.

1. Open a post.
2. Add the testing block. See below.
3. Confirm paragraphs are rendered with space between.
4. Enable custom fields.
5. Confirm paragraphs are rendered as before.

### Snippet

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-10-02 at 21 38 11](https://github.com/WordPress/gutenberg/assets/240569/2759df6d-a339-41fc-ad03-da77fac16559)
