### PR TITLE
Don't display the navigation section in template parts details when a menu is missing

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
@@ -24,7 +24,9 @@ export default function TemplatePartNavigationMenuListItem( { id } ) {
 		postType: NAVIGATION_POST_TYPE,
 	} );
 
-	if ( ! id ) return null;
+	if ( ! id || title === undefined ) {
+		return null;
+	}
 
 	return (
 		<SidebarNavigationItem withChevron { ...linkInfo }>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -19,7 +19,9 @@ export default function TemplatePartNavigationMenu( { id } ) {
 		id
 	);
 
-	if ( ! id ) return null;
+	if ( ! id || title === undefined ) {
+		return null;
+	}
 
 	return (
 		<>


### PR DESCRIPTION
## What?
Resolves #54822.

PR updates template part navigation menu components to render nothing when a menu is missing.

## Why?
There's no use in rendering menus that the user can't edit.

## How?
The component now checks if the `title` resolves to `undefined`. This happens when an entity is still resolving or missing.

## Testing Instructions
1. Open a Site Editor.
2. Open a template part with a navigation block.
3. Confirm navigation is displayed in sidebar details.
4. Change the navigation `ref` attribute to a non-existing ID via the code editor.
5. Confirm navigation is no longer displayed in sidebar details.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-10-03 at 08 44 41](https://github.com/WordPress/gutenberg/assets/240569/39565c7f-e2e8-4add-832f-875e26131ff0)
