### PR TITLE
Site Editor: Avoid stale navigation block values when parsing entity record

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-content.js
@@ -10,6 +10,16 @@ import TemplatePartNavigationMenus from './template-part-navigation-menus';
 import useEditedEntityRecord from '../use-edited-entity-record';
 import { TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
+function getBlocksFromRecord( record ) {
+	if ( record?.blocks ) {
+		return record?.blocks;
+	}
+
+	return record?.content && typeof record.content !== 'function'
+		? parse( record.content )
+		: [];
+}
+
 /**
  * Retrieves a list of specific blocks from a given tree of blocks.
  *
@@ -60,11 +70,7 @@ export default function useNavigationMenuContent( postType, postId ) {
 		return;
 	}
 
-	const blocks =
-		record?.content && typeof record.content !== 'function'
-			? parse( record.content )
-			: [];
-
+	const blocks = getBlocksFromRecord( record );
 	const navigationBlocks = getBlocksOfTypeFromBlocks(
 		'core/navigation',
 		blocks


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/54993#issuecomment-1744241005. Props to @aaronrobertshaw for discovering the bug.

PR updates template parts navigation menus display component to handle rendering fallback menus.

## Why?
The navigation block sets fallback `ref` [during the render](https://github.com/WordPress/gutenberg/blob/2afdedf792b5a74ffaf109fcee5dbbcbbef361f4/packages/block-library/src/navigation/edit/index.js#L229-L244). Since this data isn't part of the content, it was never picked up by the `useNavigationMenuContent`.


## How?
Add a new helper method, `getBlocksFromRecord`, which returns edited blocks from the record when available and fallbacks to blocks from the content. This matches the logic for edited blocks in [`useEntityBlockEditor`](https://github.com/WordPress/gutenberg/blob/205f1e3ba8104365c16b856c2ef7a983b4416581/packages/core-data/src/entity-provider.js#L171-L179).

## Testing Instructions
1. Using TT3 theme.
2. Create all customizations from the Header template part.
3. Delete all navigation menus. You can use the `wp-admin/edit.php?post_type=wp_navigation` screen.
4. Open the Header template part.
5. Confirm fallback navigation is displayed in sidebar details.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-10-03 at 10 14 42](https://github.com/WordPress/gutenberg/assets/240569/9f20c4e7-3fb4-46b4-ab52-d753ac08945a)
