### PR TITLE
Image: Fix inclusion of alttext in lightbox button aria-label

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -124,6 +124,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 
 	$aria_label = __( 'Enlarge image' );
 
+	$processor->next_tag( 'img' );
 	$alt_attribute = $processor->get_attribute( 'alt' );
 
 	if ( null !== $alt_attribute ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The logic to include alttext in the lightbox button's aria-label was not working properly, and screen readers were not able process that information as a result. This fixes that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We want users who use screen readers to have a good experience when navigating pages that contain the lightbox.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It adds back a line of logic that had been accidentally removed that allows us to create the aria-label with the alttext.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add an image to a post
2. Add alt text to the image
3. In the image block's settings, make sure "Expand on Click" is enabled
4. Publish and view the post using a screen reader
5. Tab to the image and make sure the alt text is announced by the screen reader

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A (specified above)