### PR TITLE
Components: Use `aria-pressed` attribute instead of the hard-coded `is-pressed` class

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -44,7 +44,7 @@ const FormatToolbar = () => {
 									toggleProps={ {
 										...toggleProps,
 										className: toggleProps.className,
-										isPressed: hasActive,
+										'aria-pressed': hasActive,
 										describedBy: __(
 											'Displays more block tools'
 										),

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -48,10 +43,8 @@ const FormatToolbar = () => {
 									label={ __( 'More' ) }
 									toggleProps={ {
 										...toggleProps,
-										className: classnames(
-											toggleProps.className,
-											{ 'is-pressed': hasActive }
-										),
+										className: toggleProps.className,
+										isPressed: hasActive,
 										describedBy: __(
 											'Displays more block tools'
 										),

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -379,7 +379,7 @@ export default function SearchEdit( {
 								showLabel: ! showLabel,
 							} );
 						} }
-						className={ showLabel ? 'is-pressed' : undefined }
+						isPressed={ showLabel }
 					/>
 					<ToolbarDropdownMenu
 						icon={ getButtonPositionIcon() }
@@ -395,9 +395,7 @@ export default function SearchEdit( {
 									buttonUseIcon: ! buttonUseIcon,
 								} );
 							} }
-							className={
-								buttonUseIcon ? 'is-pressed' : undefined
-							}
+							isPressed={ buttonUseIcon }
 						/>
 					) }
 				</ToolbarGroup>

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -379,7 +379,7 @@ export default function SearchEdit( {
 								showLabel: ! showLabel,
 							} );
 						} }
-						isPressed={ showLabel }
+						aria-pressed={ buttonUseIcon }
 					/>
 					<ToolbarDropdownMenu
 						icon={ getButtonPositionIcon() }
@@ -395,7 +395,7 @@ export default function SearchEdit( {
 									buttonUseIcon: ! buttonUseIcon,
 								} );
 							} }
-							isPressed={ buttonUseIcon }
+							aria-pressed={ buttonUseIcon }
 						/>
 					) }
 				</ToolbarGroup>


### PR DESCRIPTION
Fixes: #55002
Related to #54740

## What?

This PR uses the ~`isPressed` prop~ `aria-pressed` attribute instead in components that have manually assigned the `is-pressed` class.

This PR fixes two unintended pressed styles:

- Block toolbar buttons for the search block 
- "More" dropdown button for inline formatting ([#55002](https://github.com/WordPress/gutenberg/issues/55002))

| | Before | After |
|--------|--------|--------|
| Block toolbar buttons for the search block | ![search_before](https://github.com/WordPress/gutenberg/assets/54422211/a7195464-53a1-4e41-9769-7a4321e8cb8a) | ![search_after](https://github.com/WordPress/gutenberg/assets/54422211/3ecb3062-62db-4761-8f31-86155b119ca8) |
| "More" dropdown button for inline formatting | ![more_before](https://github.com/WordPress/gutenberg/assets/54422211/59627990-1195-4ca0-8891-0683f914f729) | ![more_after](https://github.com/WordPress/gutenberg/assets/54422211/34a79aca-672b-485d-8a68-4d0c0ed4c2d2) |



## Why?

In #54740, `isPressed` prop is now internally converted to the `aria-pressed` attribute. However, as fixed in this PR, `isPressed` prop or `aria-pressed` attribute may not be used and the `is-pressed` class is given directly.

In this case, the component will not be given the `aria-pressed` attribute; the selector for the `.is-pressed` class has been removed [here](https://github.com/WordPress/gutenberg/pull/54740/files#diff-0688ad494526b3b921c4444dc8bc6f63efc4ad74c7c1123b061490cfc57f293aL311), and the intended style will not be applied.

## How?

Simply replaced with ~~`isPressed` prop~~ `aria-pressed` attribute.

## Testing Instructions

- Insert a Search block.
- Activate "Toggle search label" and "Use button with icon" from the block toolbar.
- The pressed styles should be applied correctly.
- Apply one of the styles in the More dropdown menu to the text.
- The pressed styles should be applied correctly.

## Other concern

As in this case, there may be many consumers who directly grant the `is-pressed` class just to change its appearance. Reinstating the selector that was removed [here](https://github.com/WordPress/gutenberg/pull/54740/files#diff-0688ad494526b3b921c4444dc8bc6f63efc4ad74c7c1123b061490cfc57f293aL311) would solve that, but would instead break the backward compatibility mentioned in #54740.

> The only potential scope for issues is where a consumer has already set `aria-pressed` on a `Button`, but not `isPressed`, as this could affect the visual appearance due to the added `is-pressed` class.

I think we need to explore approaches to resolve these.