### PR TITLE
Block Styles: Display default style label correctly in the block sidebar

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -14,7 +14,6 @@ import {
 	Popover,
 } from '@wordpress/components';
 import deprecated from '@wordpress/deprecated';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -65,9 +64,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 		<div className="block-editor-block-styles">
 			<div className="block-editor-block-styles__variants">
 				{ stylesToRender.map( ( style ) => {
-					const buttonText = style.isDefault
-						? __( 'Default' )
-						: style.label || style.name;
+					const buttonText = style.label || style.name;
 
 					return (
 						<Button


### PR DESCRIPTION
Fixes #54987

## What?

This PR fixes an issue where the block style button in the block sidebar displays "Default" instead of the label when the style variation is the default.

Below is an example of a button block whose default style label is "Fill".

### Before

![before](https://github.com/WordPress/gutenberg/assets/54422211/6a63f196-3802-4a0c-b43d-1ecfa966db5c)

### After

![after](https://github.com/WordPress/gutenberg/assets/54422211/3b9c4cd7-0c20-4e3e-a892-3f26b6770457)

## Why?

You can specify a label whether the block variation is the default or not. However, in the block sidebar, if the variation is the default, the text will always be "Default".

As a result, the text in the block sidebar and block toolbar is different when a label is specified in the default style.

## How?

Like [the block toolbar](https://github.com/WordPress/gutenberg/blob/140d04e56a67c501bc058f1c7fbc84ab31285162/packages/block-editor/src/components/block-styles/menu-items.js#L26) and [preview panel](https://github.com/WordPress/gutenberg/blob/140d04e56a67c501bc058f1c7fbc84ab31285162/packages/block-editor/src/components/block-styles/preview-panel.js#L24), it no longer takes into account whether it is the default style or not.

As a result, the button text in the block sidebar changes from `Default` to `Fill` in the Button block, which is the only core block that defines a label other than "Default" in its default style. But I believe this is the originally expected behavior.

## Testing Instructions

- Insert a button block.
- Make sure that the transform menu on the block toolbar, the button text on the block sidebar, and the title on the block style preview all match.
