### PR TITLE
Components: Add itemToString to custom-select-control props

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Allow using CSS level 4 viewport-relative units ([54415](https://github.com/WordPress/gutenberg/pull/54415))
 -   `ToolsPanel`: do not apply the `className` to prop to `ToolsPanelItem` components when rendered as placeholders ([#55207](https://github.com/WordPress/gutenberg/pull/55207)).
 -   `ColorPalette`/`ToggleGroupControl/ToggleGroupControlOptionBase`: add `type="button"` attribute to native `<button>`s ([#55125](https://github.com/WordPress/gutenberg/pull/55125)).
+-   `CustomSelectControl`: Add `itemToString` prop to allow passing custom react components instead of strings as dropdown options ([#55015](https://github.com/WordPress/gutenberg/pull/55015)).
 
 ### Bug Fix
 

--- a/packages/components/src/custom-select-control/README.md
+++ b/packages/components/src/custom-select-control/README.md
@@ -103,7 +103,7 @@ Pass in a description that will be shown to screen readers associated with the s
 
 The options that can be chosen from.
 
--   Type: `Array<{ key: String, name: String, style: ?{}, className: ?String, ...rest }>`
+-   Type: `Array<{ key: String, name: String | ReactNode, style: ?{}, className: ?String, ...rest }>`
 -   Required: Yes
 
 #### onChange
@@ -152,6 +152,13 @@ A handler for onFocus events.
 #### onBlur
 
 A handler for onBlur events.
+
+-   Type: `Function`
+-   Required: No
+
+#### itemToString
+
+Function called with a given dropdown option. The return value will be used by aria live to inform users of updated selections and for selection/highlight by character keys
 
 -   Type: `Function`
 -   Required: No

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -23,7 +23,7 @@ import { InputBaseWithBackCompatMinWidth } from './styles';
 import { StyledLabel } from '../base-control/styles/base-control-styles';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
 
-const itemToString = ( item ) => item?.name;
+const itemToStringDefault = ( item ) => item?.name;
 // This is needed so that in Windows, where
 // the menu does not necessarily open on
 // key up/down, you can still switch between
@@ -73,6 +73,7 @@ export default function CustomSelectControl( props ) {
 		hideLabelFromVision,
 		label,
 		describedBy,
+		itemToString = itemToStringDefault,
 		options: items,
 		onChange: onSelectedItemChange,
 		/** @type {import('../select-control/types').SelectControlProps.size} */
@@ -211,7 +212,7 @@ export default function CustomSelectControl( props ) {
 						describedBy: getDescribedBy(),
 					} ) }
 				>
-					{ itemToString( selectedItem ) }
+					{ selectedItem?.name }
 					{ __experimentalShowSelectedHint &&
 						selectedItem.__experimentalHint && (
 							<span className="components-custom-select-control__hint">

--- a/packages/components/src/custom-select-control/stories/index.story.js
+++ b/packages/components/src/custom-select-control/stories/index.story.js
@@ -47,6 +47,44 @@ Default.args = {
 	],
 };
 
+export const WithCustomOptions = CustomSelectControl.bind( {} );
+WithCustomOptions.args = {
+	...Default.args,
+	options: [
+		{
+			key: 'thumbnail',
+			name: (
+				<div>
+					<span className="title">Thumbnail </span>
+					<span clasName="size">50px </span>
+				</div>
+			),
+			selectionMessage: 'Thumbnail',
+		},
+		{
+			key: 'medium',
+			name: (
+				<div>
+					<span className="title">Medium </span>
+					<span clasName="size">100px</span>
+				</div>
+			),
+			selectionMessage: 'Medium',
+		},
+		{
+			key: 'large',
+			name: (
+				<div>
+					<span className="title">Large </span>
+					<span clasName="size">200px </span>
+				</div>
+			),
+			selectionMessage: 'Large',
+		},
+	],
+	itemToString: ( item ) => item.selectionMessage,
+};
+
 export const WithLongLabels = CustomSelectControl.bind( {} );
 WithLongLabels.args = {
 	...Default.args,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allow consumers of custom select control to pass in their own `itemToString` function. Use the existing default implementation if no `itemToString` function is given.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Dropdown options are represented as strings. It seems natural, however, to want to pass in custom react components in lieu of strings for more granular control of what is rendered and how it's styled.

For the most part, the existing logic in custom select control supports custom components except for the `itemToString` function [which is currently hard coded](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/custom-select-control/index.js#L26). Its return value is used to [read out aria-live selections](https://www.downshift-js.com/use-select/#materialui), but throws a runtime error when called ( if we pass custom react components to render )


```javascript
// example of traditional dropdown options data structure
const options = [
  { key: 'thumbnail-image', name: 'Thumbnail 50px' },
  { key: 'medium-image', name: 'Medium 50px' },
];

// example dropdown options data structure with custom react components we'd like to support
const options = [
  {
    key: 'thumbnail-image',
    name: (
      <div>
        <span>Thumbnail</span>
        <span>50px</span>
      </div>
    )
  },
  {
    key: 'medium-image',
    name: (
      <div>
        <span>Medium</span>
        <span>100px</span>
      </div>
    )
  },
];

// existing itemToString function expects the name property to be a string, so 
// it throws a runtime error when called with a react element instead like seen above
const itemToString = ( item ) => item?.name

// To support custom react components, we allow consumers of CustomSelectControl define their own itemToString method
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In these changes, we add `itemToString` to the custom select control API and default to the existing implementation if none is provided. In doing so, we can then allow consumers of custom select control to pass in their own custom react components to render as dropdown options.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Check out this branch
- Run `npm run storybook:dev`
- Under Components > CustomSelectControl, verify that the withCustomOptions story behaves as expected
- Note that under the `options` control, the `name` property is a react element instead of a simple string
- `itemToString` was generating runtime errors if CustomSelectControl was rendering custom react components for its dropdown options. `itemToString` was called when the control was focused and some character keys were pressed Ex. `a`, `f`, `o`, etc. Verify that the issue no longer occurs in the storybook story

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1271" alt="Screenshot 2023-10-03 at 11 55 38 AM" src="https://github.com/WordPress/gutenberg/assets/5414230/d38d5e95-8899-4ef7-8d3b-eef157bdd59f">

<img width="751" alt="Screenshot 2023-10-03 at 11 55 50 AM" src="https://github.com/WordPress/gutenberg/assets/5414230/df10909b-b00b-42b1-b10a-ea8f3f9e679d">