### PR TITLE
Update fullscreen icon

### DIFF
--- a/packages/icons/src/library/fullscreen.js
+++ b/packages/icons/src/library/fullscreen.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const fullscreen = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M4.2 9h1.5V5.8H9V4.2H4.2V9zm14 9.2H15v1.5h4.8V15h-1.5v3.2zM15 4.2v1.5h3.2V9h1.5V4.2H15zM5.8 15H4.2v4.8H9v-1.5H5.8V15z" />
+		<Path d="M6 4a2 2 0 0 0-2 2v3h1.5V6a.5.5 0 0 1 .5-.5h3V4H6Zm3 14.5H6a.5.5 0 0 1-.5-.5v-3H4v3a2 2 0 0 0 2 2h3v-1.5Zm6 1.5v-1.5h3a.5.5 0 0 0 .5-.5v-3H20v3a2 2 0 0 1-2 2h-3Zm3-16a2 2 0 0 1 2 2v3h-1.5V6a.5.5 0 0 0-.5-.5h-3V4h3Z" />
 	</SVG>
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small update to the `fullscreen` icon to use a 1.5px stroke width and rounded corners like the media (and related) icons. Surfaced up while exploring lightbox/expand on click UI in https://github.com/WordPress/gutenberg/issues/55020. 

## Visuals

Before > After: 
![CleanShot 2023-10-03 at 15 58 34](https://github.com/WordPress/gutenberg/assets/1813435/dabbfac5-91b1-47ee-87a4-2a4c46cb1ee0)

As seen in the cover block: 
![CleanShot 2023-10-03 at 16 01 36](https://github.com/WordPress/gutenberg/assets/1813435/18010975-c479-482f-a0bc-7d204c95c942)


As seen in https://github.com/WordPress/gutenberg/issues/55020 for lightbox: 
![CleanShot 2023-10-03 at 16 00 19](https://github.com/WordPress/gutenberg/assets/1813435/1f6a0368-f182-4085-b926-766274e7b4e8)

As seen in the freeform/classic editor block: 
![CleanShot 2023-10-03 at 15 55 04](https://github.com/WordPress/gutenberg/assets/1813435/2cae08da-1355-4c86-96af-a3fb6d2d5df3)
