### PR TITLE
Patterns: Add category selector to pattern creation modal

### DIFF
--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -58,8 +58,8 @@ export default function CategorySelector( {
 			onChange={ handleChange }
 			onInputChange={ debouncedSearch }
 			label={ __( 'Categories' ) }
-			tokenizeOnBlur={ true }
-			__experimentalExpandOnFocus={ true }
+			tokenizeOnBlur
+			__experimentalExpandOnFocus
 		/>
 	);
 }

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -60,6 +60,7 @@ export default function CategorySelector( {
 			label={ __( 'Categories' ) }
 			tokenizeOnBlur
 			__experimentalExpandOnFocus
+			__next40pxDefaultSize
 		/>
 	);
 }

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -16,13 +16,13 @@ export const CATEGORY_SLUG = 'wp_pattern_category';
 export default function CategorySelector( {
 	categoryTerms,
 	onChange,
-	categoryOptions,
+	categoryMap,
 } ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
 	const suggestions = useMemo( () => {
-		return ( categoryOptions ?? [] )
+		return ( Array.from( categoryMap.values() ) ?? [] )
 			.map( ( category ) => unescapeString( category.label ) )
 			.filter( ( category ) => {
 				if ( search !== '' ) {
@@ -31,8 +31,9 @@ export default function CategorySelector( {
 						.includes( search.toLowerCase() );
 				}
 				return true;
-			} );
-	}, [ search, categoryOptions ] );
+			} )
+			.sort( ( a, b ) => a.localeCompare( b ) );
+	}, [ search, categoryMap ] );
 
 	function handleChange( termNames ) {
 		const uniqueTerms = termNames.reduce( ( terms, newTerm ) => {

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -3,9 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
-import { FormTokenField } from '@wordpress/components';
+import { FormTokenField, SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -22,7 +23,12 @@ const DEFAULT_QUERY = {
 };
 export const CATEGORY_SLUG = 'wp_pattern_category';
 
-export default function CategorySelector( { values, onChange } ) {
+export default function CategorySelector( {
+	selectedCategoryValue,
+	newCategoryValues,
+	onChangeNewCategories,
+	onChangeSelectedCategory,
+} ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
@@ -42,13 +48,51 @@ export default function CategorySelector( { values, onChange } ) {
 		[ search ]
 	);
 
+	const { corePatternCategories, userPatternCategories } = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			const { getUserPatternCategories } = select( coreStore );
+
+			return {
+				corePatternCategories:
+					getSettings().__experimentalBlockPatternCategories,
+				userPatternCategories: getUserPatternCategories(),
+			};
+		}
+	);
+
+	const categoryOptions = userPatternCategories.map( ( category ) => ( {
+		label: category.label,
+		value: category.label,
+	} ) );
+
+	corePatternCategories.forEach( ( category ) => {
+		if (
+			! categoryOptions.find( ( cat ) => cat.label === category.label ) &&
+			category.name !== 'query'
+		) {
+			categoryOptions.push( {
+				label: category.label,
+				value: category.label,
+			} );
+		}
+	} );
+
+	categoryOptions.unshift( {
+		value: '',
+		label: __( 'Select a category' ),
+		disabled: true,
+	} );
+
+	categoryOptions.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+
 	const suggestions = useMemo( () => {
 		return ( searchResults ?? [] ).map( ( term ) =>
 			unescapeString( term.name )
 		);
 	}, [ searchResults ] );
 
-	function handleChange( termNames ) {
+	function handleChangeAdd( termNames ) {
 		const uniqueTerms = termNames.reduce( ( terms, newTerm ) => {
 			if (
 				! terms.some(
@@ -60,19 +104,31 @@ export default function CategorySelector( { values, onChange } ) {
 			return terms;
 		}, [] );
 
-		onChange( uniqueTerms );
+		onChangeNewCategories( uniqueTerms );
+	}
+
+	function handleOnChangeSelect( selectedCategory ) {
+		onChangeSelectedCategory( selectedCategory );
 	}
 
 	return (
 		<>
+			<SelectControl
+				label={ __( 'Category' ) }
+				onChange={ handleOnChangeSelect }
+				options={ categoryOptions }
+				size="__unstable-large"
+				value={ selectedCategoryValue }
+			/>
+
 			<FormTokenField
 				className="patterns-menu-items__convert-modal-categories"
-				value={ values }
+				value={ newCategoryValues }
 				suggestions={ suggestions }
-				onChange={ handleChange }
+				onChange={ handleChangeAdd }
 				onInputChange={ debouncedSearch }
 				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
-				label={ __( 'Categories' ) }
+				label={ __( 'Add a new category' ) }
 				tokenizeOnBlur={ true }
 			/>
 		</>

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -22,7 +22,7 @@ export default function CategorySelector( {
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
 	const suggestions = useMemo( () => {
-		return ( Array.from( categoryMap.values() ) ?? [] )
+		return Array.from( categoryMap.values() )
 			.map( ( category ) => unescapeString( category.label ) )
 			.filter( ( category ) => {
 				if ( search !== '' ) {

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -56,7 +56,7 @@ export default function CategorySelector( {
 			suggestions={ suggestions }
 			onChange={ handleChange }
 			onInputChange={ debouncedSearch }
-			label={ __( 'Category' ) }
+			label={ __( 'Categories' ) }
 			tokenizeOnBlur={ true }
 			__experimentalExpandOnFocus={ true }
 		/>

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -4,9 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { FormTokenField } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -16,41 +13,13 @@ const unescapeString = ( arg ) => {
 
 export const CATEGORY_SLUG = 'wp_pattern_category';
 
-export default function CategorySelector( { categoryTerms, onChange } ) {
+export default function CategorySelector( {
+	categoryTerms,
+	onChange,
+	categoryOptions,
+} ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
-
-	const { corePatternCategories, userPatternCategories } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			const { getUserPatternCategories } = select( coreStore );
-
-			return {
-				corePatternCategories:
-					getSettings().__experimentalBlockPatternCategories,
-				userPatternCategories: getUserPatternCategories(),
-			};
-		}
-	);
-
-	const categoryOptions = userPatternCategories.map( ( category ) => ( {
-		label: category.label,
-		value: category.label,
-	} ) );
-
-	corePatternCategories.forEach( ( category ) => {
-		if (
-			! categoryOptions.find( ( cat ) => cat.label === category.label ) &&
-			category.name !== 'query'
-		) {
-			categoryOptions.push( {
-				label: category.label,
-				value: category.label,
-			} );
-		}
-	} );
-
-	categoryOptions.sort( ( a, b ) => a.label.localeCompare( b.label ) );
 
 	const suggestions = useMemo( () => {
 		return ( categoryOptions ?? [] )

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -16,7 +16,7 @@ const unescapeString = ( arg ) => {
 
 export const CATEGORY_SLUG = 'wp_pattern_category';
 
-export default function CategorySelector( { categoryValues, onChange } ) {
+export default function CategorySelector( { categoryTerms, onChange } ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
@@ -83,7 +83,7 @@ export default function CategorySelector( { categoryValues, onChange } ) {
 	return (
 		<FormTokenField
 			className="patterns-menu-items__convert-modal-categories"
-			value={ categoryValues }
+			value={ categoryTerms }
 			suggestions={ suggestions }
 			onChange={ handleChange }
 			onInputChange={ debouncedSearch }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -126,7 +126,7 @@ export default function CreatePatternModal( {
 	async function findOrCreateTerm( term ) {
 		try {
 			// We need to match any existing term to the correct slug to prevent duplicates, eg.
-			// the core `Headers` category uses a the singular `header` as the slug.
+			// the core `Headers` category uses the singular `header` as the slug.
 			const existingTerm = categoryOptions.find(
 				( cat ) => cat.label === term
 			);

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -55,26 +55,28 @@ export default function CreatePatternModal( {
 	);
 
 	const categoryOptions = useMemo( () => {
-		// We need to store the name separately as this is used as the slug in the
-		// taxonomy and may vary from the label.
-		const categories = userPatternCategories.map( ( category ) => ( {
-			label: category.label,
-			value: category.label,
-			name: category.name,
-		} ) );
-
-		corePatternCategories.forEach( ( category ) => {
+		// Merge the user and core pattern categories and remove any duplicates.
+		const categories = [
+			...userPatternCategories,
+			...corePatternCategories,
+		].reduce( ( uniqueCategories, category ) => {
 			if (
-				! categories.find( ( cat ) => cat.label === category.label ) &&
+				! uniqueCategories.find(
+					( existingCategory ) =>
+						existingCategory.label === category.label
+				) &&
 				category.name !== 'query'
 			) {
-				categories.push( {
+				// We need to store the name separately as this is used as the slug in the
+				// taxonomy and may vary from the label.
+				uniqueCategories.push( {
 					label: category.label,
 					value: category.label,
 					name: category.name,
 				} );
 			}
-		} );
+			return uniqueCategories;
+		}, [] );
 
 		return categories.sort( ( a, b ) => a.label.localeCompare( b.label ) );
 	}, [ userPatternCategories, corePatternCategories ] );

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -14,7 +14,6 @@ import { useState, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -45,12 +44,11 @@ export default function CreatePatternModal( {
 
 	const { corePatternCategories, userPatternCategories } = useSelect(
 		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			const { getUserPatternCategories } = select( coreStore );
+			const { getUserPatternCategories, getBlockPatternCategories } =
+				select( coreStore );
 
 			return {
-				corePatternCategories:
-					getSettings().__experimentalBlockPatternCategories,
+				corePatternCategories: getBlockPatternCategories(),
 				userPatternCategories: getUserPatternCategories(),
 			};
 		}

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -56,28 +56,26 @@ export default function CreatePatternModal( {
 
 	const categoryMap = useMemo( () => {
 		// Merge the user and core pattern categories and remove any duplicates.
-		const categories = [
-			...userPatternCategories,
-			...corePatternCategories,
-		].reduce( ( uniqueCategories, category ) => {
-			if (
-				! uniqueCategories.has( category.label ) &&
-				// There are two core categories with `Post` label so explictily remove the one with
-				// the `query` slug to avoid any confusion.
-				category.name !== 'query'
-			) {
-				// We need to store the name separately as this is used as the slug in the
-				// taxonomy and may vary from the label.
-				uniqueCategories.set( category.label, {
-					label: category.label,
-					value: category.label,
-					name: category.name,
-				} );
+		const uniqueCategories = new Map();
+		[ ...userPatternCategories, ...corePatternCategories ].forEach(
+			( category ) => {
+				if (
+					! uniqueCategories.has( category.label ) &&
+					// There are two core categories with `Post` label so explictily remove the one with
+					// the `query` slug to avoid any confusion.
+					category.name !== 'query'
+				) {
+					// We need to store the name separately as this is used as the slug in the
+					// taxonomy and may vary from the label.
+					uniqueCategories.set( category.label, {
+						label: category.label,
+						value: category.label,
+						name: category.name,
+					} );
+				}
 			}
-			return uniqueCategories;
-		}, new Map() );
-
-		return categories;
+		);
+		return uniqueCategories;
 	}, [ userPatternCategories, corePatternCategories ] );
 
 	async function onCreate( patternTitle, sync ) {

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -61,7 +61,7 @@ export default function CreatePatternModal( {
 			( category ) => {
 				if (
 					! uniqueCategories.has( category.label ) &&
-					// There are two core categories with `Post` label so explictily remove the one with
+					// There are two core categories with `Post` label so explicitly remove the one with
 					// the `query` slug to avoid any confusion.
 					category.name !== 'query'
 				) {

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -36,6 +36,7 @@ export default function CreatePatternModal( {
 } ) {
 	const [ syncType, setSyncType ] = useState( PATTERN_SYNC_TYPES.full );
 	const [ categoryTerms, setCategoryTerms ] = useState( [] );
+	const [ selectedCategory, setSelectedCategory ] = useState( '' );
 	const [ title, setTitle ] = useState( '' );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { createPattern } = unlock( useDispatch( patternsStore ) );
@@ -50,7 +51,7 @@ export default function CreatePatternModal( {
 		try {
 			setIsSaving( true );
 			const categories = await Promise.all(
-				categoryTerms.map( ( termName ) =>
+				[ ...categoryTerms, selectedCategory ].map( ( termName ) =>
 					findOrCreateTerm( termName )
 				)
 			);
@@ -126,8 +127,10 @@ export default function CreatePatternModal( {
 						className="patterns-create-modal__name-input"
 					/>
 					<CategorySelector
-						values={ categoryTerms }
-						onChange={ setCategoryTerms }
+						newCategoryValues={ categoryTerms }
+						onChangeNewCategories={ setCategoryTerms }
+						onChangeSelectedCategory={ setSelectedCategory }
+						selectedCategoryValue={ selectedCategory }
 					/>
 					<ToggleControl
 						label={ __( 'Synced' ) }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -126,7 +126,7 @@ export default function CreatePatternModal( {
 						className="patterns-create-modal__name-input"
 					/>
 					<CategorySelector
-						categoryValues={ categoryTerms }
+						categoryTerms={ categoryTerms }
 						onChange={ setCategoryTerms }
 					/>
 					<ToggleControl

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -36,7 +36,6 @@ export default function CreatePatternModal( {
 } ) {
 	const [ syncType, setSyncType ] = useState( PATTERN_SYNC_TYPES.full );
 	const [ categoryTerms, setCategoryTerms ] = useState( [] );
-	const [ selectedCategory, setSelectedCategory ] = useState( '' );
 	const [ title, setTitle ] = useState( '' );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { createPattern } = unlock( useDispatch( patternsStore ) );
@@ -51,7 +50,7 @@ export default function CreatePatternModal( {
 		try {
 			setIsSaving( true );
 			const categories = await Promise.all(
-				[ ...categoryTerms, selectedCategory ].map( ( termName ) =>
+				categoryTerms.map( ( termName ) =>
 					findOrCreateTerm( termName )
 				)
 			);
@@ -127,10 +126,8 @@ export default function CreatePatternModal( {
 						className="patterns-create-modal__name-input"
 					/>
 					<CategorySelector
-						newCategoryValues={ categoryTerms }
-						onChangeNewCategories={ setCategoryTerms }
-						onChangeSelectedCategory={ setSelectedCategory }
-						selectedCategoryValue={ selectedCategory }
+						categoryValues={ categoryTerms }
+						onChange={ setCategoryTerms }
 					/>
 					<ToggleControl
 						label={ __( 'Synced' ) }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -61,7 +61,7 @@ export default function CreatePatternModal( {
 			...corePatternCategories,
 		].reduce( ( uniqueCategories, category ) => {
 			if (
-				! uniqueCategories.get( category.label ) &&
+				! uniqueCategories.has( category.label ) &&
 				// There are two core categories with `Post` label so explictily remove the one with
 				// the `query` slug to avoid any confusion.
 				category.name !== 'query'

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -54,33 +54,30 @@ export default function CreatePatternModal( {
 		}
 	);
 
-	const categoryOptions = useMemo( () => {
+	const categoryMap = useMemo( () => {
 		// Merge the user and core pattern categories and remove any duplicates.
 		const categories = [
 			...userPatternCategories,
 			...corePatternCategories,
 		].reduce( ( uniqueCategories, category ) => {
 			if (
-				! uniqueCategories.find(
-					( existingCategory ) =>
-						existingCategory.label === category.label
-				) &&
+				! uniqueCategories.get( category.label ) &&
 				// There are two core categories with `Post` label so explictily remove the one with
 				// the `query` slug to avoid any confusion.
 				category.name !== 'query'
 			) {
 				// We need to store the name separately as this is used as the slug in the
 				// taxonomy and may vary from the label.
-				uniqueCategories.push( {
+				uniqueCategories.set( category.label, {
 					label: category.label,
 					value: category.label,
 					name: category.name,
 				} );
 			}
 			return uniqueCategories;
-		}, [] );
+		}, new Map() );
 
-		return categories.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+		return categories;
 	}, [ userPatternCategories, corePatternCategories ] );
 
 	async function onCreate( patternTitle, sync ) {
@@ -127,9 +124,7 @@ export default function CreatePatternModal( {
 		try {
 			// We need to match any existing term to the correct slug to prevent duplicates, eg.
 			// the core `Headers` category uses the singular `header` as the slug.
-			const existingTerm = categoryOptions.find(
-				( cat ) => cat.label === term
-			);
+			const existingTerm = categoryMap.get( term );
 			const termData = existingTerm
 				? { name: existingTerm.label, slug: existingTerm.name }
 				: { name: term };
@@ -177,7 +172,7 @@ export default function CreatePatternModal( {
 					<CategorySelector
 						categoryTerms={ categoryTerms }
 						onChange={ setCategoryTerms }
-						categoryOptions={ categoryOptions }
+						categoryMap={ categoryMap }
 					/>
 					<ToggleControl
 						label={ __( 'Synced' ) }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -65,6 +65,8 @@ export default function CreatePatternModal( {
 					( existingCategory ) =>
 						existingCategory.label === category.label
 				) &&
+				// There are two core categories with `Post` label so explictily remove the one with
+				// the `query` slug to avoid any confusion.
 				category.name !== 'query'
 			) {
 				// We need to store the name separately as this is used as the slug in the

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -1,5 +1,11 @@
 .patterns-menu-items__convert-modal {
 	z-index: z-index(".patterns-menu-items__convert-modal");
+
+	// Fix the modal width to prevent added categories from stretching the modal.
+	[role="dialog"] > [role="document"] {
+		width: 350px;
+	}
+
 	.patterns-menu-items__convert-modal-categories {
 		max-width: 300px;
 	}
@@ -14,5 +20,8 @@
 }
 
 .patterns-create-modal__name-input input[type="text"] {
-	min-height: 34px;
+	// Match the minimal height of the category selector.
+	min-height: 40px;
+	// Override the default 1px margin-x.
+	margin: 0;
 }

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -7,15 +7,24 @@
 	}
 
 	.patterns-menu-items__convert-modal-categories {
-		max-width: 300px;
+		width: 100%;
+		position: relative;
+		min-height: 40px;
 	}
 	.components-form-token-field__suggestions-list {
 		position: absolute;
+		box-sizing: border-box;
 		z-index: 1;
 		background-color: $white;
-		width: 295px;
+		// Account for the border width of the token field.
+		width: calc(100% + 2px);
+		left: -1px;
 		min-width: initial;
-		border: 1px solid $gray-600;
+		border: 1px solid var(--wp-admin-theme-color);
+		border-top: none;
+		box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
+		border-bottom-left-radius: 2px;
+		border-bottom-right-radius: 2px;
 	}
 }
 

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -3,6 +3,14 @@
 	.patterns-menu-items__convert-modal-categories {
 		max-width: 300px;
 	}
+	.components-form-token-field__suggestions-list {
+		position: absolute;
+		z-index: 1;
+		background-color: $white;
+		width: 295px;
+		min-width: initial;
+		border: 1px solid $gray-600;
+	}
 }
 
 .patterns-create-modal__name-input input[type="text"] {


### PR DESCRIPTION
## What?
Adds a list of available categories to select from to the pattern creation modal category selection field.

## Why?
It was [noted in 6.4 beta testing](https://github.com/WordPress/gutenberg/issues/54885) that the simple tag input box is confusing to users and potentially difficult for them to use, potentially causing a lot of additional categories being added, etc.

## How?
Uses the `FormTokenFields` `__experimentalExpandOnFocus` and `suggestions` props to show a select list of existing categories when the category field is focused

## Testing Instructions
- Delete any existing categories from `/wp-admin/edit-tags.php?taxonomy=wp_pattern_category`
- Add a block in post editor and using block overflow menu chose the `Create pattern` option
- Enter a name and click the category field and make sure list of default core pattern categories displays
- Select the `Headers` option and save the pattern
- Go to `/wp-admin/edit-tags.php?taxonomy=wp_pattern_category` and make sure category was added with name of `Headers` but slug of `header`
- Repeat the process but add a new category instead of selecting an existing one and make sure it works as expected
- Also try adding patterns from site editor and make sure categories work as expected

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/6b7dac8b-844f-4147-83a2-602d7c2b0d9b


