### PR TITLE
Shortcode Block: fix layout margin override

### DIFF
--- a/packages/block-library/src/shortcode/edit.js
+++ b/packages/block-library/src/shortcode/edit.js
@@ -4,29 +4,25 @@
 import { __ } from '@wordpress/i18n';
 import { PlainText, useBlockProps } from '@wordpress/block-editor';
 import { useInstanceId } from '@wordpress/compose';
-import { Icon, shortcode } from '@wordpress/icons';
+import { Placeholder } from '@wordpress/components';
+import { shortcode } from '@wordpress/icons';
 
 export default function ShortcodeEdit( { attributes, setAttributes } ) {
 	const instanceId = useInstanceId( ShortcodeEdit );
 	const inputId = `blocks-shortcode-input-${ instanceId }`;
 
 	return (
-		<div { ...useBlockProps( { className: 'components-placeholder' } ) }>
-			<label
-				htmlFor={ inputId }
-				className="components-placeholder__label"
-			>
-				<Icon icon={ shortcode } />
-				{ __( 'Shortcode' ) }
-			</label>
-			<PlainText
-				className="blocks-shortcode__textarea"
-				id={ inputId }
-				value={ attributes.text }
-				aria-label={ __( 'Shortcode text' ) }
-				placeholder={ __( 'Write shortcode here…' ) }
-				onChange={ ( text ) => setAttributes( { text } ) }
-			/>
+		<div { ...useBlockProps() }>
+			<Placeholder icon={ shortcode } label={ __( 'Shortcode' ) }>
+				<PlainText
+					className="blocks-shortcode__textarea"
+					id={ inputId }
+					value={ attributes.text }
+					aria-label={ __( 'Shortcode text' ) }
+					placeholder={ __( 'Write shortcode here…' ) }
+					onChange={ ( text ) => setAttributes( { text } ) }
+				/>
+			</Placeholder>
 		</div>
 	);
 }

--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -1,9 +1,3 @@
-[data-type="core/shortcode"] {
-	&.components-placeholder {
-		min-height: 0;
-	}
-}
-
 // The editing view for the Shortcode block is equivalent to block UI.
 // Therefore we increase specificity to avoid theme styles bleeding in.
 .blocks-shortcode__textarea {


### PR DESCRIPTION
## What?

This PR fixes an issue where the shortcode block's `margin:0` is prioritized and layout margins are not applied.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/e2427f66-3840-4a90-8052-475367952c5b) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/c1585763-0188-49c7-aaa2-d3d4272b8d99) | 


## Why?

This Shortcode block has a wrapper div given the `component-placeholder` class, and this component has [zero margin](https://github.com/WordPress/gutenberg/blob/8f80a1186a67651385c0980effe10a1783614bd3/packages/components/src/placeholder/style.scss#L8).

This margin was previously probably overridden by layout margins. However, this problem came to light because #47858 lowered the level of detail of the selector.

## How?

~~I added a div element inside the block and gave it the `components-placeholder` class.~~

~~Ideally, it could be refactored using a `Placeholder` component, similar to RSS blocks, Embed blocks, etc. However, the label size changes significantly, so I've only fixed the margins for now. As a follow-up to this PR, weu may be able to replace it with a Placeholder component and adjust the style.~~

#59275 improved the `Placeholder` component and unified the label size to a smaller size. With this, I was able to completely replace it with the `Placeholder` component.

## Testing Instructions

Insert multiple shortcode blocks and make sure margins are applied between the blocks.