### PR TITLE
Latest Posts: add screen reader title text to Read more links and use alternative to excerpt_more filter

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -483,18 +483,27 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								.split( ' ', excerptLength )
 								.join( ' ' ) }
 							{ createInterpolateElement(
-								/* translators: excerpt truncation character, default …  */
-								__( ' … <a>Read more</a>' ),
+								sprintf(
+									/* translators: accessibility text. %s: trimmed post title. */
+									__(
+										'… <a>Read more <span>of %s</span></a>'
+									),
+									titleTrimmed
+								),
 								{
 									a: (
 										// eslint-disable-next-line jsx-a11y/anchor-has-content
 										<a
+											className="wp-block-latest-posts__read-more"
 											href={ post.link }
 											rel="noopener noreferrer"
 											onClick={
 												showRedirectionPreventedNotice
 											}
 										/>
+									),
+									span: (
+										<span className="screen-reader-text" />
 									),
 								}
 							) }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -484,11 +484,10 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								.join( ' ' ) }
 							{ createInterpolateElement(
 								sprintf(
-									/* translators: accessibility text. %s: trimmed post title. */
-									__(
-										'… <a>Read more <span>of %s</span></a>'
-									),
-									titleTrimmed
+									/* translators: 1: The static string "Read more", 2: The post title only visible to screen readers. */
+									__( '… <a>%1$s<span>: %2$s</span></a>' ),
+									__( 'Read more' ),
+									titleTrimmed || __( '(no title)' )
 								),
 								{
 									a: (

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -48,14 +48,6 @@ function render_block_core_latest_posts( $attributes ) {
 	$block_core_latest_posts_excerpt_length = $attributes['excerptLength'];
 	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
-	$filter_latest_posts_excerpt_more = static function ( $more ) use ( $attributes ) {
-		$use_excerpt = 'excerpt' === $attributes['displayPostContentRadio'];
-		/* translators: %1$s is a URL to a post, excerpt truncation character, default … */
-		return $use_excerpt ? sprintf( __( ' … <a href="%1$s" rel="noopener noreferrer">Read more</a>' ), esc_url( get_permalink() ) ) : $more;
-	};
-
-	add_filter( 'excerpt_more', $filter_latest_posts_excerpt_more );
-
 	if ( ! empty( $attributes['categories'] ) ) {
 		$args['category__in'] = array_column( $attributes['categories'], 'id' );
 	}
@@ -150,6 +142,19 @@ function render_block_core_latest_posts( $attributes ) {
 			&& isset( $attributes['displayPostContentRadio'] ) && 'excerpt' === $attributes['displayPostContentRadio'] ) {
 
 			$trimmed_excerpt = get_the_excerpt( $post );
+
+			/*
+			 * Adds a "Read more" link with screen reader text.
+			 * [&hellip;] is the default excerpt ending from wp_trim_excerpt() in Core.
+			 */
+			if ( str_ends_with( $trimmed_excerpt, ' [&hellip;]' ) && 'excerpt' === $attributes['displayPostContentRadio'] ) {
+				$excerpt_length = (int) apply_filters( 'excerpt_length', $block_core_latest_posts_excerpt_length );
+				if ( $excerpt_length <= $block_core_latest_posts_excerpt_length ) {
+					$trimmed_excerpt = substr( $trimmed_excerpt, 0, -11 );
+					/* translators: %1$s is a URL to a post, excerpt truncation character, %2$s is the post title. Only visible to screen readers. */
+					$trimmed_excerpt .= sprintf( __( '… <a href="%1$s" rel="noopener noreferrer">Read more <span class="screen-reader-text"> of %2$s</span></a>' ), esc_url( $post_link ), esc_html( $title ) );
+				}
+			}
 
 			if ( post_password_required( $post ) ) {
 				$trimmed_excerpt = __( 'This content is password protected.' );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -147,12 +147,17 @@ function render_block_core_latest_posts( $attributes ) {
 			 * Adds a "Read more" link with screen reader text.
 			 * [&hellip;] is the default excerpt ending from wp_trim_excerpt() in Core.
 			 */
-			if ( str_ends_with( $trimmed_excerpt, ' [&hellip;]' ) && 'excerpt' === $attributes['displayPostContentRadio'] ) {
+			if ( str_ends_with( $trimmed_excerpt, ' [&hellip;]' ) ) {
 				$excerpt_length = (int) apply_filters( 'excerpt_length', $block_core_latest_posts_excerpt_length );
 				if ( $excerpt_length <= $block_core_latest_posts_excerpt_length ) {
-					$trimmed_excerpt = substr( $trimmed_excerpt, 0, -11 );
-					/* translators: %1$s is a URL to a post, excerpt truncation character, %2$s is the post title. Only visible to screen readers. */
-					$trimmed_excerpt .= sprintf( __( '… <a href="%1$s" rel="noopener noreferrer">Read more <span class="screen-reader-text"> of %2$s</span></a>' ), esc_url( $post_link ), esc_html( $title ) );
+					$trimmed_excerpt  = substr( $trimmed_excerpt, 0, -11 );
+					$trimmed_excerpt .= sprintf(
+						/* translators: 1: A URL to a post, 2: The static string "Read more", 3: The post title only visible to screen readers. */
+						__( '… <a href="%1$s" rel="noopener noreferrer">%2$s<span class="screen-reader-text">: %3$s</span></a>' ),
+						esc_url( $post_link ),
+						__( 'Read more' ),
+						esc_html( $title )
+					);
 				}
 			}
 


### PR DESCRIPTION
Maybe resolves https://github.com/WordPress/gutenberg/issues/55026


Follow up to https://github.com/WordPress/gutenberg/pull/51190

## What?

**In the editor**: adds a screen reader text span with the post title in the i18n interpolator

**In the frontend**: removes `excerpt_more` filter so we don't override themes and also replaces the default ellipsis with an accessible read more link. This is done only when the Latest Post attribute `displayPostContentRadio` is explicitly set to `excerpt`.

Also I notices that the frontend didn't match the editor in one respect: the "Read more" default text should only appear when the attribute `excerptLength` is less than the currently-set excerpt length (from any filters etc)

❗ It's important to note that themes, such as 2019, that specific a custom excerpt more text will not have that custom text and link reflected in the editor when the `displayPostContentRadio` is set to `excerpt` and the attribute `excerptLength` is less than the currently-set excerpt length. The editor's preferences take precedence here. . "Read more" will always show in this case.

## Why?
Use of the `excerpt_more` filter was overriding theme defaults, e.g., 2021, 2019

The repetition of "Read more" text in the frontend and editor did not provide any context to screen reader users. SeE: https://make.wordpress.org/themes/handbook/review/accessibility/required/#repetitive-link-text



## Testing Instructions

1. Create a few posts with text content.
2. Create another new post in a block theme and add a Latest Posts block
3. In the block setting sidebar, activate Post content > Excerpts radio button. Slide the "MAX NUMBER OF WORDS" so that the "Read more" link appears.
4. Save the post and preview in the frontend
5. Ensure the "Read more" link is consistent between editor and frontend - check that the screen reader text with the title appears in the source HTML
6. Check in other themes, especially 2021, 2019
7. Ensure that theme excerpt more copy takes precedence on the frontend. (2021 might show an extra ellipsis in the editor - it's inconsistent between themes, so I was aiming for the most general approach)
8. Play around with the "MAX NUMBER OF WORDS" attribute in various theme.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


#### Editor

<img width="937" alt="Screenshot 2023-10-04 at 5 35 25 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/cc402b6f-c2a1-4a25-91b0-2df70c2296c2">

#### Frontend
<img width="999" alt="Screenshot 2023-10-04 at 5 35 30 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/1a8479ae-075c-480b-86b2-f38b83bf226f">