### PR TITLE
Try: Fix overlay blur flickering.

### DIFF
--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -1,6 +1,11 @@
 // Provide special styling for the placeholder.
 // @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-post-featured-image {
+	.block-editor-media-placeholder {
+		z-index: 1; // Need to put it above the overlay so the upload button works.
+		//backdrop-filter: none; // Removes background blur so the overlay's actual color is visible.
+	}
+
 	// Style the placeholder.
 	.wp-block-post-featured-image__placeholder,
 	.components-placeholder {

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -1,11 +1,6 @@
 // Provide special styling for the placeholder.
 // @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-post-featured-image {
-	.block-editor-media-placeholder {
-		z-index: 1; // Need to put it above the overlay so the upload button works.
-		backdrop-filter: none; // Removes background blur so the overlay's actual color is visible.
-	}
-
 	// Style the placeholder.
 	.wp-block-post-featured-image__placeholder,
 	.components-placeholder {

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -165,17 +165,12 @@
 // This is mainly an issue in terms of Site Logo which has a brief flash of the square placeholder.
 .components-placeholder.has-illustration {
 	color: inherit;
-	display: flex;
 	box-shadow: none;
 
 	// Blur the background so layered dashed placeholders are still visually separate.
 	// Make the background transparent to not interfere with the background overlay in placeholder-style() pseudo element
 	backdrop-filter: blur(100px);
 	background-color: transparent;
-
-	// Fix a flickering that happens in the blur when transforms are applied.
-	margin: 1px;
-	width: auto;
 
 	// This appears to fix an occasional Chrome bug where the blurred background would have an incorrect color.
 	backface-visibility: hidden;
@@ -186,7 +181,11 @@
 	}
 
 	.components-placeholder__fieldset {
-		width: auto;
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		display: flex;
+		justify-content: center;
 
 		// Unset intrinsic margins.
 		margin-left: 0;
@@ -216,6 +215,16 @@
 	// By painting the borders here, we enable them to be replaced by the Border control.
 	@include placeholder-style();
 	overflow: auto;
+
+	// Fix a flickering that happens in the blur when transforms are applied.
+	// This hack would be good to remove in case https://bugs.chromium.org/p/chromium/issues/detail?id=986206 gets fixed.
+	&.has-illustration {
+		display: inline-block;
+		width: calc(100% - 3px);
+		height: auto;
+		margin: 1.5px;
+		vertical-align: bottom;
+	}
 }
 
 // Position the spinner.

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -173,6 +173,10 @@
 	backdrop-filter: blur(100px);
 	background-color: transparent;
 
+	// Fix a flickering that happens in the blur when transforms are applied.
+	margin: 1px;
+	width: auto;
+
 	// This appears to fix an occasional Chrome bug where the blurred background would have an incorrect color.
 	backface-visibility: hidden;
 


### PR DESCRIPTION
## What?

Attempts to fix #52313.

As explained in https://github.com/WordPress/gutenberg/issues/52313#issuecomment-1746239872, blur is complicated, and surroundings affect the blur inside. This can cause flickering.

This PR fixes it by applying a 1px margin around the entire blurred placeholder, so that it should be "spared" from those surroundings bleeding in. 

Before:

![before](https://github.com/WordPress/gutenberg/assets/1204802/26585255-3b0f-4403-91a0-b3cc3fcd793e)

After:

![after](https://github.com/WordPress/gutenberg/assets/1204802/eb536ab2-e73d-437a-8d34-c417046285e6)

Note, however, that this also tweaks CSS from #43838 which, according to comments in the code, disabled the backdrop filter for just the _featured image placeholder_ in order for the overlay to work. There were also visual glitches due to how the overlay borders affected this in the site editor:

![huh](https://github.com/WordPress/gutenberg/assets/1204802/6d93dede-6a73-44e9-9459-7e66fd483103)

I missed this aspect initially and it's really not ideal to have the backdrop filter just for some placeholders, not for others, so I took a very hacky approach to get that working here. To that end, please review the CSS and follow the test instructions clearly. That said, the hack works for me and ensures that:

* there's no flickering
* the upload button on the featured image block still works
* the overlay on the featured image works even in the placeholders state
* there are no weird flickering issues in the site editor

![button](https://github.com/WordPress/gutenberg/assets/1204802/bddac9fe-f35c-4a06-a511-1514a390277d)


## Testing Instructions

* Please test a full-wide _Image_ and _Featured Image_ in their placeholder states, in the site view, and hover the frame to see whether they flicker.
* Please test both image and featured images in the site editor edit view, and see that their hover states work.
* Please test featured image in its placeholder state, and test that the overlay and upload buttons still work.
* Please test ideally existing layouts that use the featured image block, both in filled in and empty states, and note no layout changes.

