### PR TITLE
Fix Deleted Navigation Menu warning string

### DIFF
--- a/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
+++ b/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
@@ -4,14 +4,19 @@
 import { Warning } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 
 function DeletedNavigationWarning( { onCreateNew } ) {
 	return (
 		<Warning>
-			{ __( 'Navigation menu has been deleted or is unavailable.' ) }
-			<Button onClick={ onCreateNew } variant="link">
-				{ __( 'Create a new menu?' ) }
-			</Button>
+			{ createInterpolateElement(
+				__(
+					'Navigation menu has been deleted or is unavailable. <button>Create a new menu?</button>'
+				),
+				{
+					button: <Button onClick={ onCreateNew } variant="link" />,
+				}
+			) }
 		</Warning>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix creation of translatable string which was missing a space character.

Rectifies Issue discovered in https://github.com/WordPress/gutenberg/pull/54654#issuecomment-1746392718

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The string needs a space to make sense.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses `createInterpolateElement` to create the full string which avoids dealing with trailing whitespace and makes the entire string translatable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add Nav block to a Post and save the post.
2. Find out which Navigation Menu is assigned to the block.
3. In a new tab, go to Site Editor -> Site View (sidebar) -> Navigation. Find the Navigation Menu and delete it.
4. Return to wherever you added the Nav block originally.
5. See the warning about deleted menu.
6. Check that text now contains a space between end of sentence and the button.
7. Check that clicking the button works as on `trunk`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="599" alt="Screenshot 2023-10-04 at 09 54 04" src="https://github.com/WordPress/gutenberg/assets/444434/43b4b499-7923-433f-a76c-d6bdd9f510b8">
