### PR TITLE
Patterns: Add rename/delete options for pattern categories in site editor

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -7,6 +7,7 @@ import { camelCase } from 'change-case';
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -659,7 +660,7 @@ export const getUserPatternCategories =
 		const mappedPatternCategories =
 			patternCategories?.map( ( userCategory ) => ( {
 				...userCategory,
-				label: userCategory.name,
+				label: decodeEntities( userCategory.name ),
 				name: userCategory.slug,
 			} ) ) || [];
 

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -30,10 +30,6 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 	const { deleteEntityRecord, invalidateResolution } =
 		useDispatch( coreStore );
 
-	if ( ! category?.id ) {
-		return null;
-	}
-
 	const onDelete = async () => {
 		try {
 			await deleteEntityRecord(

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -91,7 +91,9 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 			>
 				{ sprintf(
 					// translators: %s: The pattern category's name.
-					__( 'Are you sure you want to delete "%s"?' ),
+					__(
+						'Are you sure you want to delete the category "%s"? The patterns will not be deleted.'
+					),
 					decodeEntities( category.label )
 				) }
 			</ConfirmDialog>

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -72,7 +72,9 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
-					: __( 'An error occurred while deleting the pattern.' );
+					: __(
+							'An error occurred while deleting the pattern category.'
+					  );
 
 			createErrorNotice( errorMessage, {
 				type: 'snackbar',

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -88,6 +88,7 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 				isOpen={ isModalOpen }
 				onConfirm={ onDelete }
 				onCancel={ () => setIsModalOpen( false ) }
+				confirmButtonText={ __( 'Delete' ) }
 			>
 				{ sprintf(
 					// translators: %s: The pattern category's name.

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -89,6 +89,7 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 				onConfirm={ onDelete }
 				onCancel={ () => setIsModalOpen( false ) }
 				confirmButtonText={ __( 'Delete' ) }
+				className="edit-site-patterns__delete-modal"
 			>
 				{ sprintf(
 					// translators: %s: The pattern category's name.

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -44,7 +44,14 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 				{ throwOnError: true }
 			);
 
+			// Prevent the need to refresh the page to get up-to-date categories
+			// and pattern categorization.
 			invalidateResolution( 'getUserPatternCategories' );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				PATTERN_TYPES.user,
+				{ per_page: -1 },
+			] );
 
 			createSuccessNotice(
 				sprintf(

--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -18,6 +18,7 @@ import { moreVertical } from '@wordpress/icons';
  * Internal dependencies
  */
 import RenameCategoryMenuItem from './rename-category-menu-item';
+import DeleteCategoryMenuItem from './delete-category-menu-item';
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
 import { TEMPLATE_PART_POST_TYPE, PATTERN_TYPES } from '../../utils/constants';
 
@@ -73,6 +74,10 @@ export default function PatternsHeader( {
 						{ ( { onClose } ) => (
 							<MenuGroup>
 								<RenameCategoryMenuItem
+									category={ patternCategory }
+									onClose={ onClose }
+								/>
+								<DeleteCategoryMenuItem
 									category={ patternCategory }
 									onClose={ onClose }
 								/>

--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -2,16 +2,22 @@
  * WordPress dependencies
  */
 import {
-	__experimentalVStack as VStack,
+	DropdownMenu,
+	MenuGroup,
+	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import RenameCategoryMenuItem from './rename-category-menu-item';
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
 import { TEMPLATE_PART_POST_TYPE, PATTERN_TYPES } from '../../utils/constants';
 
@@ -28,7 +34,7 @@ export default function PatternsHeader( {
 		[]
 	);
 
-	let title, description;
+	let title, description, patternCategory;
 	if ( type === TEMPLATE_PART_POST_TYPE ) {
 		const templatePartArea = templatePartAreas.find(
 			( area ) => area.area === categoryId
@@ -36,7 +42,7 @@ export default function PatternsHeader( {
 		title = templatePartArea?.label;
 		description = templatePartArea?.description;
 	} else if ( type === PATTERN_TYPES.theme ) {
-		const patternCategory = patternCategories.find(
+		patternCategory = patternCategories.find(
 			( category ) => category.name === categoryId
 		);
 		title = patternCategory?.label;
@@ -47,9 +53,34 @@ export default function PatternsHeader( {
 
 	return (
 		<VStack className="edit-site-patterns__section-header">
-			<Heading as="h2" level={ 4 } id={ titleId }>
-				{ title }
-			</Heading>
+			<HStack justify="space-between">
+				<Heading as="h2" level={ 4 } id={ titleId }>
+					{ title }
+				</Heading>
+				{ !! patternCategory?.id && (
+					<DropdownMenu
+						icon={ moreVertical }
+						label={ __( 'Actions' ) }
+						toggleProps={ {
+							className: 'edit-site-patterns__button',
+							describedBy: sprintf(
+								/* translators: %s: pattern category name */
+								__( 'Action menu for %s pattern category' ),
+								title
+							),
+						} }
+					>
+						{ ( { onClose } ) => (
+							<MenuGroup>
+								<RenameCategoryMenuItem
+									category={ patternCategory }
+									onClose={ onClose }
+								/>
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+				) }
+			</HStack>
 			{ description ? (
 				<Text variant="muted" as="p" id={ descriptionId }>
 					{ description }

--- a/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
@@ -16,10 +16,6 @@ const { RenamePatternCategoryModal } = unlock( patternsPrivateApis );
 export default function RenameCategoryMenuItem( { category, onClose } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	if ( ! category?.id ) {
-		return null;
-	}
-
 	// User created pattern categories have their properties updated when
 	// retrieved via `getUserPatternCategories`. The rename modal expects an
 	// object that will match the pattern category entity.

--- a/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
@@ -37,6 +37,7 @@ export default function RenameCategoryMenuItem( { category, onClose } ) {
 						setIsModalOpen( false );
 						onClose();
 					} }
+					overlayClassName="edit-site-list__rename-modal"
 				/>
 			) }
 		</>

--- a/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
@@ -27,7 +27,7 @@ export default function RenameCategoryMenuItem( { category, onClose } ) {
 			</MenuItem>
 			{ isModalOpen && (
 				<RenamePatternCategoryModal
-					categoryId={ category.id }
+					category={ category }
 					onClose={ () => {
 						setIsModalOpen( false );
 						onClose();

--- a/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
@@ -20,6 +20,15 @@ export default function RenameCategoryMenuItem( { category, onClose } ) {
 		return null;
 	}
 
+	// User created pattern categories have their properties updated when
+	// retrieved via `getUserPatternCategories`. The rename modal expects an
+	// object that will match the pattern category entity.
+	const normalizedCategory = {
+		id: category.id,
+		slug: category.slug,
+		name: category.label,
+	};
+
 	return (
 		<>
 			<MenuItem onClick={ () => setIsModalOpen( true ) }>
@@ -27,7 +36,7 @@ export default function RenameCategoryMenuItem( { category, onClose } ) {
 			</MenuItem>
 			{ isModalOpen && (
 				<RenamePatternCategoryModal
-					category={ category }
+					category={ normalizedCategory }
 					onClose={ () => {
 						setIsModalOpen( false );
 						onClose();

--- a/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { MenuItem } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { RenamePatternCategoryModal } = unlock( patternsPrivateApis );
+
+export default function RenameCategoryMenuItem( { category, onClose } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	if ( ! category?.id ) {
+		return null;
+	}
+
+	return (
+		<>
+			<MenuItem onClick={ () => setIsModalOpen( true ) }>
+				{ __( 'Rename' ) }
+			</MenuItem>
+			{ isModalOpen && (
+				<RenamePatternCategoryModal
+					categoryId={ category.id }
+					onClose={ () => {
+						setIsModalOpen( false );
+						onClose();
+					} }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -222,3 +222,7 @@
 .edit-site-patterns__no-results {
 	color: $gray-600;
 }
+
+.edit-site-patterns__delete-modal {
+	width: $modal-width-small;
+}

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -101,6 +101,10 @@
 	background: $gray-900;
 	padding: $grid-unit-40 $grid-unit-40 $grid-unit-20;
 	z-index: z-index(".edit-site-patterns__header");
+
+	.edit-site-patterns__button {
+		color: $gray-600;
+	}
 }
 
 .edit-site-patterns__section {

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -44,8 +44,6 @@ export default function RenamePatternCategoryModal( {
 
 		try {
 			setIsSaving( true );
-			setName( '' );
-			onClose?.();
 
 			// User pattern category properties may differ as they can be
 			// normalized for use alongside template part areas, core pattern
@@ -63,6 +61,7 @@ export default function RenamePatternCategoryModal( {
 
 			invalidateResolution( 'getUserPatternCategories' );
 			onSuccess?.( savedRecord );
+			onClose();
 
 			createSuccessNotice( __( 'Pattern category renamed.' ), {
 				type: 'snackbar',
@@ -81,7 +80,7 @@ export default function RenamePatternCategoryModal( {
 	};
 
 	const onRequestClose = () => {
-		onClose?.();
+		onClose();
 		setName( '' );
 	};
 

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -40,7 +40,7 @@ export default function RenamePatternCategoryModal( {
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 
-	async function onRename( event ) {
+	const onRename = async ( event ) => {
 		event.preventDefault();
 
 		if ( ! name || name === category.name || isSaving ) {
@@ -83,10 +83,10 @@ export default function RenamePatternCategoryModal( {
 			setIsSaving( false );
 			setName( '' );
 		}
-	}
+	};
 
 	const onRequestClose = () => {
-		onClose();
+		onClose?.();
 		setName( '' );
 	};
 

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -65,7 +65,7 @@ export default function RenamePatternCategoryModal( { categoryId, onClose } ) {
 	async function onRename( event ) {
 		event.preventDefault();
 
-		if ( ! name || isSaving ) {
+		if ( ! name || name === category.name || isSaving ) {
 			return;
 		}
 		try {
@@ -126,7 +126,9 @@ export default function RenamePatternCategoryModal( { categoryId, onClose } ) {
 						<Button
 							variant="primary"
 							type="submit"
-							aria-disabled={ ! name || isSaving }
+							aria-disabled={
+								! name || name === category.name || isSaving
+							}
 							isBusy={ isSaving }
 						>
 							{ __( 'Save' ) }

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -27,12 +27,7 @@ export default function RenamePatternCategoryModal( {
 	onSuccess,
 	...props
 } ) {
-	// If the user created category has been retrieved via
-	// getUserPatternCategories the name value is assigned to the label property
-	// and `name` is overwritten with the slug value to match categories from
-	// core, template parts etc.
-	const originalName = decodeEntities( category.label || category.name );
-	const [ name, setName ] = useState( originalName );
+	const [ name, setName ] = useState( decodeEntities( category.name ) );
 	const [ isSaving, setIsSaving ] = useState( false );
 
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -25,6 +25,7 @@ export default function RenamePatternCategoryModal( {
 	onClose,
 	onError,
 	onSuccess,
+	...props
 } ) {
 	// If the user created category has been retrieved via
 	// getUserPatternCategories the name value is assigned to the label property
@@ -90,7 +91,11 @@ export default function RenamePatternCategoryModal( {
 	};
 
 	return (
-		<Modal title={ __( 'Rename' ) } onRequestClose={ onRequestClose }>
+		<Modal
+			title={ __( 'Rename' ) }
+			onRequestClose={ onRequestClose }
+			{ ...props }
+		>
 			<form onSubmit={ onRename }>
 				<VStack spacing="5">
 					<TextControl

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -20,7 +20,11 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { CATEGORY_SLUG } from './category-selector';
 
-export default function RenamePatternCategoryModal( { category, onClose } ) {
+export default function RenamePatternCategoryModal( {
+	category,
+	onClose,
+	onSuccess,
+} ) {
 	// If the user created category has been retrieved via
 	// getUserPatternCategories the name value is assigned to the label property
 	// and `name` is overwritten with the slug value to match categories from
@@ -50,13 +54,18 @@ export default function RenamePatternCategoryModal( { category, onClose } ) {
 			// normalized for use alongside template part areas, core pattern
 			// categories etc. As a result we won't just destructure the passed
 			// category object.
-			await saveEntityRecord( 'taxonomy', CATEGORY_SLUG, {
-				id: category.id,
-				slug: category.slug,
-				name,
-			} );
+			const savedRecord = await saveEntityRecord(
+				'taxonomy',
+				CATEGORY_SLUG,
+				{
+					id: category.id,
+					slug: category.slug,
+					name,
+				}
+			);
 
 			invalidateResolution( 'getUserPatternCategories' );
+			onSuccess?.( savedRecord );
 
 			createSuccessNotice( __( 'Pattern category renamed.' ), {
 				type: 'snackbar',

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -23,6 +23,7 @@ import { CATEGORY_SLUG } from './category-selector';
 export default function RenamePatternCategoryModal( {
 	category,
 	onClose,
+	onError,
 	onSuccess,
 } ) {
 	// If the user created category has been retrieved via
@@ -72,6 +73,7 @@ export default function RenamePatternCategoryModal( {
 				id: 'pattern-category-update',
 			} );
 		} catch ( error ) {
+			onError?.();
 			createErrorNotice( error.message, {
 				type: 'snackbar',
 				id: 'pattern-category-update',

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Modal,
+	Button,
+	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { CATEGORY_SLUG } from './category-selector';
+
+const usePatternCategory = ( categoryId ) => {
+	return useSelect(
+		( select ) => {
+			const record = select( coreStore ).getEditedEntityRecord(
+				'taxonomy',
+				CATEGORY_SLUG,
+				categoryId
+			);
+			const hasResolvedRecord = select( coreStore ).hasFinishedResolution(
+				'getEditedEntityRecord',
+				[ 'taxonomy', CATEGORY_SLUG, categoryId ]
+			);
+
+			return {
+				category: record,
+				hasResolved: hasResolvedRecord,
+			};
+		},
+		[ categoryId ]
+	);
+};
+
+export default function RenamePatternCategoryModal( { categoryId, onClose } ) {
+	const { category, hasResolved } = usePatternCategory( categoryId );
+	const [ name, setName ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	useEffect( () => {
+		if ( hasResolved && category?.name ) {
+			setName( decodeEntities( category.name ) );
+		}
+	}, [ hasResolved, category?.name ] );
+
+	const {
+		editEntityRecord,
+		invalidateResolution,
+		__experimentalSaveSpecifiedEntityEdits: saveSpecifiedEntityEdits,
+	} = useDispatch( coreStore );
+
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
+
+	async function onRename( event ) {
+		event.preventDefault();
+
+		if ( ! name || isSaving ) {
+			return;
+		}
+		try {
+			setIsSaving( true );
+
+			await editEntityRecord( 'taxonomy', CATEGORY_SLUG, categoryId, {
+				name,
+			} );
+
+			setName( '' );
+			onClose?.();
+
+			await saveSpecifiedEntityEdits(
+				'taxonomy',
+				CATEGORY_SLUG,
+				categoryId,
+				[ 'name' ],
+				{ throwOnError: true }
+			);
+
+			invalidateResolution( 'getUserPatternCategories' );
+
+			createSuccessNotice( __( 'Pattern category renamed.' ), {
+				type: 'snackbar',
+				id: 'pattern-category-update',
+			} );
+		} catch ( error ) {
+			createErrorNotice( error.message, {
+				type: 'snackbar',
+				id: 'pattern-category-update',
+			} );
+		} finally {
+			setIsSaving( false );
+			setName( '' );
+		}
+	}
+
+	const onRequestClose = () => {
+		onClose();
+		setName( '' );
+	};
+
+	return (
+		<Modal title={ __( 'Rename' ) } onRequestClose={ onRequestClose }>
+			<form onSubmit={ onRename }>
+				<VStack spacing="5">
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Name' ) }
+						value={ name }
+						onChange={ setName }
+						required
+					/>
+					<HStack justify="right">
+						<Button variant="tertiary" onClick={ onRequestClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							type="submit"
+							aria-disabled={ ! name || isSaving }
+							isBusy={ isSaving }
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -4,6 +4,7 @@
 import { lock } from './lock-unlock';
 import CreatePatternModal from './components/create-pattern-modal';
 import PatternsMenuItems from './components';
+import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
@@ -16,6 +17,7 @@ export const privateApis = {};
 lock( privateApis, {
 	CreatePatternModal,
 	PatternsMenuItems,
+	RenamePatternCategoryModal,
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/54699

## What?

Adds ability to rename or delete pattern categories from the Site Editor's pattern management page.

## Why?

There's currently no UI in the site editor for users to be able to rename or delete pattern categories. This means to correct typos in category names or clean up their categories list, a user needs to know about and navigate manually to `wp-admin/edit-tags.php?taxonomy=wp_pattern_category`


## How?

- Adds new RenamePatternCategoryModal to the patterns package, exported as a private API
- Adds two new menu item components to toggle the rename modal or delete confirm dialog
- Updates the pattern category header to include a new dropdown with the above menu items
- Small tweak of CSS to correct dropdown menu's ellipsis color
- Decodes entities when retrieving user-created pattern categories so they display correctly in sidebar


## Testing Instructions

1. Navigate to Appearance > Editor > Patterns
2. Select a user-created patterns category
3. Next to the pattern category's heading, there is a new dropdown
4. Try renaming the category. The heading should update as well as the category item in the sidebar
5. Test deleting the category ensuring you are redirected to the all patterns category
6. Test adding special characters to a category name and ensure it appears correctly in the sidebar and when renaming the category again.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/887111a4-7344-4419-9788-2979b3eff85d

