### PR TITLE
Documentation: Add a page about the format library to the platform docs site

### DIFF
--- a/platform-docs/docs/basic-concepts/block-library.md
+++ b/platform-docs/docs/basic-concepts/block-library.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 4
 ---
 
 # Block Library

--- a/platform-docs/docs/basic-concepts/internationalization.md
+++ b/platform-docs/docs/basic-concepts/internationalization.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 7
 ---
 
 # Internationalization

--- a/platform-docs/docs/basic-concepts/rendering.md
+++ b/platform-docs/docs/basic-concepts/rendering.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 8
 ---
 
 # Rendering blocks

--- a/platform-docs/docs/basic-concepts/rich-text.md
+++ b/platform-docs/docs/basic-concepts/rich-text.md
@@ -1,5 +1,20 @@
 ---
-sidebar_position: 7
+sidebar_position: 5
 ---
 
 # RichText and Format Library
+
+Several block types (like paragraph, heading and more) allow users to type and mainpulate rich text content. In order to do so, they use the `RichText` component and the `@wordpress/rich-text` package.
+
+The `RichText` component is a wrapper around the `@wordpress/rich-text` package that provides a React-friendly API to manipulate rich text content. It allows the user to add and apply formats to the text content.
+
+By default, no format is available. You need to register formats in order to make them available to the user. The `@wordpress/format-library` provides a set of default formats to include in your application. It includes:
+
+-   bold, italic, superscript, subscript, strikethrough, links, inline code, inline image, text color, keyboard input (kbd), language (bdo).
+
+In order to register all formats from the format library, add the `@wordpress/format-library` as a dependency of your app and you can use the following code.
+
+```js
+import '@wordpress/format-library';
+import '@wordpress/format-library/build-style/style.css';
+```

--- a/platform-docs/docs/basic-concepts/rich-text.md
+++ b/platform-docs/docs/basic-concepts/rich-text.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # RichText and Format Library
 
-Several block types (like paragraph, heading and more) allow users to type and mainpulate rich text content. In order to do so, they use the `RichText` component and the `@wordpress/rich-text` package.
+Several block types (like paragraph, heading, and more) allow users to type and manipulate rich text content. In order to do so, they use the `RichText` component and the `@wordpress/rich-text` package.
 
 The `RichText` component is a wrapper around the `@wordpress/rich-text` package that provides a React-friendly API to manipulate rich text content. It allows the user to add and apply formats to the text content.
 

--- a/platform-docs/docs/basic-concepts/settings.md
+++ b/platform-docs/docs/basic-concepts/settings.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 ---
 
 # Block Editor Settings

--- a/platform-docs/docs/basic-concepts/undo-redo.md
+++ b/platform-docs/docs/basic-concepts/undo-redo.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 6
 ---
 
 # Undo Redo


### PR DESCRIPTION
Related #53874

## What?

This PR add a small documentation page about the format library package and how to leverage it in third-party block editors.
It's also weird that the "block library" package exports a function to register the blocks while the format library auto-registers the formats as soon as you import it. It might be good to unify at some point. cc @ellatrix 

**Note** I have personally tested all the code examples in a third-party vite install.

### Test the documentation website

```
cd platform-docs
npm install
npm start
```