### PR TITLE
Media & Text: Fix React warning

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -244,7 +244,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 				<ToggleControl
 					__nextHasNoMarginBottom
 					label={ __( 'Crop image to fill entire column' ) }
-					checked={ imageFill }
+					checked={ !! imageFill }
 					onChange={ () =>
 						setAttributes( {
 							imageFill: ! imageFill,


### PR DESCRIPTION
## What?
Fixes #54963.
Alternative to #54965.

PR fixes the React warning when toggling the "Crop image to fill entire column" option for the Media & Text block.

**Warning**

```
Warning: A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen.
```

## How?
Cast the `imageFill` value to a `boolean` when setting the `checked` prop. It's a `boolean `attribute with no default defined.

## Testing Instructions
1. Create a new post or page.
2. Add a media & text block. Select or upload an image.
3. Enable the option "Crop image to fill entire column"
4. Confirm that there is no JavaScript warning about the value changing from undefined to a defined value, and that the crop setting continues to work.
5. Deactivate Gutenberg, add two media and text blocks, one with the crop option enabled, one without. Activate Gutenberg again and confirm that there are no block validation errors.
