### PR TITLE
Block Editor: Subscribe only to block editor store in `useBlockSync`

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -293,7 +293,7 @@ export default function useBlockSync( {
 				} );
 			}
 			previousAreBlocksDifferent = areBlocksDifferent;
-		} );
+		}, blockEditorStore );
 
 		return () => {
 			subscribed.current = false;


### PR DESCRIPTION
## What?
This PR updates an inner subscription inside `useBlockSync` to only subscribe to the block editor store, instead of to all stores.

## Why?
While doing another quick timeboxing session on #54819 I noticed that we're currently subscribing to all stores in `useBlockSync` when syncing back from the block editor store to the controlling entity. However, we're using only the block editor store, so there's no need to subscribe to all other stores.

## How?
We're just adding the block editor as the store descriptor to subscribe to.

## Testing Instructions
Smoke test typing and verify all checks are green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None