### PR TITLE
Docs: Add a callout to the `wp-now` documentation to mention it's still experimental

### DIFF
--- a/docs/getting-started/devenv/get-started-with-wp-now.md
+++ b/docs/getting-started/devenv/get-started-with-wp-now.md
@@ -1,5 +1,5 @@
 <div class="callout callout-info">
-`wp-now` is still experimental. For a more comprehensive overview of their current status and roadmap, please check <a href="https://github.com/WordPress/wordpress-playground"> WordPress Playground's repository </a> and <a href="https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now">wp-now's</a>.
+<code>wp-now</code> is still experimental. For a more comprehensive overview of their current status and roadmap, please check <a href="https://github.com/WordPress/wordpress-playground"> WordPress Playground's repository </a> and <a href="https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now">wp-now's</a>.
 </div>
 
 # Get started with wp-now

--- a/docs/getting-started/devenv/get-started-with-wp-now.md
+++ b/docs/getting-started/devenv/get-started-with-wp-now.md
@@ -1,5 +1,5 @@
 <div class="callout callout-info">
-	`wp-now` is still experimental. For a more comprehensive overview of their current status and roadmap, please check <a href="https://github.com/WordPress/wordpress-playground"> WordPress Playground's repository </a> and <a href="https://developer.wordpress.org/block-editor/getting-started/create-block">wp-now's</a>.
+	`wp-now` is still experimental. For a more comprehensive overview of their current status and roadmap, please check <a href="https://github.com/WordPress/wordpress-playground"> WordPress Playground's repository </a> and <a href="https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now">wp-now's</a>.
 </div>
 
 # Get started with wp-now

--- a/docs/getting-started/devenv/get-started-with-wp-now.md
+++ b/docs/getting-started/devenv/get-started-with-wp-now.md
@@ -1,4 +1,4 @@
-<div class="callout callout-info">
+<div class="callout callout-alert">
 <code>wp-now</code> is still experimental. For a more comprehensive overview of their current status and roadmap, please check <a href="https://github.com/WordPress/wordpress-playground"> WordPress Playground's repository </a> and <a href="https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now">wp-now's</a>.
 </div>
 

--- a/docs/getting-started/devenv/get-started-with-wp-now.md
+++ b/docs/getting-started/devenv/get-started-with-wp-now.md
@@ -1,3 +1,7 @@
+<div class="callout callout-info">
+	`wp-now` is still experimental. For a more comprehensive overview of their current status and roadmap, please check <a href="https://github.com/WordPress/wordpress-playground"> WordPress Playground's repository </a> and <a href="https://developer.wordpress.org/block-editor/getting-started/create-block">wp-now's</a>.
+</div>
+
 # Get started with wp-now
 
 The [@wp-now/wp-now](https://www.npmjs.com/package/@wordpress/env) package (`wp-now`) is a lightweight tool powered by [WordPress Playground](https://developer.wordpress.org/playground/) that streamlines setting up a local WordPress environment.

--- a/docs/getting-started/devenv/get-started-with-wp-now.md
+++ b/docs/getting-started/devenv/get-started-with-wp-now.md
@@ -1,5 +1,5 @@
 <div class="callout callout-info">
-	`wp-now` is still experimental. For a more comprehensive overview of their current status and roadmap, please check <a href="https://github.com/WordPress/wordpress-playground"> WordPress Playground's repository </a> and <a href="https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now">wp-now's</a>.
+`wp-now` is still experimental. For a more comprehensive overview of their current status and roadmap, please check <a href="https://github.com/WordPress/wordpress-playground"> WordPress Playground's repository </a> and <a href="https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now">wp-now's</a>.
 </div>
 
 # Get started with wp-now


### PR DESCRIPTION
## What?
Update the `wp-now` documentation to mention it's still experimental.

## Why?
So that users understand the risks involved and use it at their own risk.

## How?
By adding a callout notice!
