### PR TITLE
Rich text: use getPasteEventData

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -3,7 +3,6 @@
  */
 import { useRef } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
-import { getFilesFromDataTransfer } from '@wordpress/dom';
 import {
 	pasteHandler,
 	findTransform,
@@ -17,7 +16,7 @@ import { isURL } from '@wordpress/url';
  */
 import { addActiveFormats, isShortcode } from './utils';
 import { splitValue } from './split-value';
-import { shouldDismissPastedFiles } from '../../utils/pasting';
+import { getPasteEventData } from '../../utils/pasting';
 
 /** @typedef {import('@wordpress/rich-text').RichTextValue} RichTextValue */
 
@@ -45,32 +44,8 @@ export function usePasteHandler( props ) {
 			}
 
 			const { clipboardData } = event;
-
-			let plainText = '';
-			let html = '';
-
-			// IE11 only supports `Text` as an argument for `getData` and will
-			// otherwise throw an invalid argument error, so we try the standard
-			// arguments first, then fallback to `Text` if they fail.
-			try {
-				plainText = clipboardData.getData( 'text/plain' );
-				html = clipboardData.getData( 'text/html' );
-			} catch ( error1 ) {
-				try {
-					html = clipboardData.getData( 'Text' );
-				} catch ( error2 ) {
-					// Some browsers like UC Browser paste plain text by default and
-					// don't support clipboardData at all, so allow default
-					// behaviour.
-					return;
-				}
-			}
-
-			// Remove Windows-specific metadata appended within copied HTML text.
-			html = removeWindowsFragments( html );
-
-			// Strip meta tag.
-			html = removeCharsetMetaTag( html );
+			const { plainText, html, files } =
+				getPasteEventData( clipboardData );
 
 			event.preventDefault();
 
@@ -103,7 +78,6 @@ export function usePasteHandler( props ) {
 				return;
 			}
 
-			const files = [ ...getFilesFromDataTransfer( clipboardData ) ];
 			const isInternal = clipboardData.getData( 'rich-text' ) === 'true';
 
 			// If the data comes from a rich text instance, we can directly use it
@@ -128,17 +102,7 @@ export function usePasteHandler( props ) {
 				// Allows us to ask for this information when we get a report.
 				// eslint-disable-next-line no-console
 				window.console.log( 'Received items:\n\n', files );
-			}
 
-			// Process any attached files, unless we infer that the files in
-			// question are redundant "screenshots" of the actual HTML payload,
-			// as created by certain office-type programs.
-			//
-			// @see shouldDismissPastedFiles
-			if (
-				files?.length &&
-				! shouldDismissPastedFiles( files, html, plainText )
-			) {
 				const fromTransforms = getBlockTransforms( 'from' );
 				const blocks = files
 					.reduce( ( accumulator, file ) => {
@@ -227,49 +191,4 @@ export function usePasteHandler( props ) {
 			element.removeEventListener( 'paste', _onPaste );
 		};
 	}, [] );
-}
-
-/**
- * Normalizes a given string of HTML to remove the Windows-specific "Fragment"
- * comments and any preceding and trailing content.
- *
- * @param {string} html the html to be normalized
- * @return {string} the normalized html
- */
-function removeWindowsFragments( html ) {
-	const startStr = '<!--StartFragment-->';
-	const startIdx = html.indexOf( startStr );
-	if ( startIdx > -1 ) {
-		html = html.substring( startIdx + startStr.length );
-	} else {
-		// No point looking for EndFragment
-		return html;
-	}
-
-	const endStr = '<!--EndFragment-->';
-	const endIdx = html.indexOf( endStr );
-	if ( endIdx > -1 ) {
-		html = html.substring( 0, endIdx );
-	}
-
-	return html;
-}
-
-/**
- * Removes the charset meta tag inserted by Chromium.
- * See:
- * - https://github.com/WordPress/gutenberg/issues/33585
- * - https://bugs.chromium.org/p/chromium/issues/detail?id=1264616#c4
- *
- * @param {string} html the html to be stripped of the meta tag.
- * @return {string} the cleaned html
- */
-function removeCharsetMetaTag( html ) {
-	const metaTag = `<meta charset='utf-8'>`;
-
-	if ( html.startsWith( metaTag ) ) {
-		return html.slice( metaTag.length );
-	}
-
-	return html;
 }

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -43,9 +43,7 @@ export function usePasteHandler( props ) {
 				return;
 			}
 
-			const { clipboardData } = event;
-			const { plainText, html, files } =
-				getPasteEventData( clipboardData );
+			const { plainText, html, files } = getPasteEventData( event );
 
 			event.preventDefault();
 
@@ -78,7 +76,8 @@ export function usePasteHandler( props ) {
 				return;
 			}
 
-			const isInternal = clipboardData.getData( 'rich-text' ) === 'true';
+			const isInternal =
+				event.clipboardData.getData( 'rich-text' ) === 'true';
 
 			// If the data comes from a rich text instance, we can directly use it
 			// without filtering the data. The filters are only meant for externally


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The code is reusable through `getPasteEventData`, we can use it in RichText. Additionally we can improve `getPasteEventData` to strip the meta tag and the garbage from Word.

## Why?

Need to introduce more paste event handlers in #54543, so this makes it easier.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
