### PR TITLE
Add `status` entity and use it in "admin views" experiment

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -223,6 +223,14 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		key: 'plugin',
 	},
+	{
+		label: __( 'Post status' ),
+		name: 'status',
+		kind: 'root',
+		baseURL: '/wp/v2/statuses',
+		baseURLParams: { context: 'edit' },
+		plural: 'postStatuses',
+	},
 ];
 
 export const additionalEntityConfigLoaders = [

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -230,6 +230,7 @@ export const rootEntitiesConfig = [
 		baseURL: '/wp/v2/statuses',
 		baseURLParams: { context: 'edit' },
 		plural: 'postStatuses',
+		key: 'slug',
 	},
 ];
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -66,7 +66,7 @@ export default function PagePages() {
 			reset,
 		]
 	);
-	const { records, isResolving: isLoading } = useEntityRecords(
+	const { records: pages, isResolving: isLoadingPages } = useEntityRecords(
 		'postType',
 		'page',
 		queryArgs
@@ -161,8 +161,8 @@ export default function PagePages() {
 		<Page title={ __( 'Pages' ) }>
 			<DataViews
 				paginationInfo={ paginationInfo }
-				data={ records || EMPTY_ARRAY }
-				isLoading={ isLoading }
+				data={ pages || EMPTY_ARRAY }
+				isLoading={ isLoadingPages }
 				fields={ fields }
 				options={ {
 					manualSorting: true,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -9,7 +9,8 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState, useEffect, useMemo } from '@wordpress/element';
 
@@ -32,11 +33,10 @@ export default function PagePages() {
 		pageSize: PAGE_SIZE_VALUES[ 0 ],
 	} );
 	// Request post statuses to get the proper labels.
-	const [ postStatuses, setPostStatuses ] = useState( EMPTY_ARRAY );
-	useEffect( () => {
-		apiFetch( {
-			path: '/wp/v2/statuses',
-		} ).then( setPostStatuses );
+	// TODO: we should probably use `useEntityRecords` here.
+	const postStatuses = useSelect( ( select ) => {
+		const { getPostStatuses } = select( coreStore );
+		return getPostStatuses();
 	}, [] );
 
 	// TODO: probably memo other objects passed as state(ex:https://tanstack.com/table/v8/docs/examples/react/pagination-controlled).

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -138,7 +138,9 @@ export default function PagePages() {
 			{
 				header: 'Status',
 				id: 'status',
-				cell: ( props ) => postStatuses[ props.row.original.status ],
+				cell: ( props ) =>
+					postStatuses[ props.row.original.status ] ??
+					props.row.original.status,
 			},
 			{
 				header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/54966

## What?

Creates a new entity for the `statuses` [endpoint](https://developer.wordpress.org/rest-api/reference/post-statuses/) and updates the pages list to using it.

## Why?

https://github.com/WordPress/gutenberg/pull/54966/files#r1342580462 By using the core-data package, we leverage some basic behaviors such as caching. Note the before/after for the page status when navigating away and back to the page:

Before (trunk). The status is blank until the fetching is resolved:

https://github.com/WordPress/gutenberg/assets/583546/097a46c2-3102-44f4-a7fc-045da33e380a

After (this PR). The status is immediately shown, as a result of being available in the core store:

https://github.com/WordPress/gutenberg/assets/583546/c03d2186-8e0d-4de1-a0db-b4bed6d16a59

## How?

- Add a new config for the `status` entity.
- Update the pages list to use this new entity instead of fetching.

## Testing Instructions

- Enable the "New admin views" experiment at "Gutenberg > Experiments".
- Visit "Appareance > Editor > Pages" and click "Manage all pages".
- Verify the page status is shown as before.
 
<img width="1142" alt="Captura de ecrã 2023-10-05, às 13 34 54" src="https://github.com/WordPress/gutenberg/assets/583546/f0c300e8-3f56-4ad5-9b65-24c2db8421b4">
