### PR TITLE
Remove 16:10 from 10:16 options from AspectRatioDropdown

### DIFF
--- a/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
+++ b/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
@@ -75,10 +75,6 @@ export default function AspectRatioDropdown( { toggleProps } ) {
 						value={ aspect }
 						aspectRatios={ [
 							{
-								title: __( '16:10' ),
-								aspect: 16 / 10,
-							},
-							{
 								title: __( '16:9' ),
 								aspect: 16 / 9,
 							},
@@ -101,10 +97,6 @@ export default function AspectRatioDropdown( { toggleProps } ) {
 						} }
 						value={ aspect }
 						aspectRatios={ [
-							{
-								title: __( '10:16' ),
-								aspect: 10 / 16,
-							},
 							{
 								title: __( '9:16' ),
 								aspect: 9 / 16,

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -313,7 +313,7 @@ test.describe( 'Image', () => {
 		await editor.clickBlockToolbarButton( 'Crop' );
 		await editor.clickBlockToolbarButton( 'Aspect Ratio' );
 		await page.click(
-			'role=menu[name="Aspect Ratio"i] >> role=menuitemradio[name="16:10"i]'
+			'role=menu[name="Aspect Ratio"i] >> role=menuitemradio[name="16:9"i]'
 		);
 		await editor.clickBlockToolbarButton( 'Apply' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #48041 and aligns all the aspect ratio options throughout blocks. Follow-up to https://github.com/WordPress/gutenberg/pull/48969.

## Why?
Consistency across the board; there's already an option for 16:9. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
 1. Open a post or page.
2. Insert an image block.
3. Add an image.
4. Click on the "Crop" icon within the block toolbar.
5. Click on the "Aspect ratio" icon to see the options. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-10-04 at 12 55 43](https://github.com/WordPress/gutenberg/assets/1813435/6e51eefd-5432-4e1c-83b5-63c6337c0fad)|![CleanShot 2023-10-04 at 12 55 14](https://github.com/WordPress/gutenberg/assets/1813435/6e0d9396-630b-4af4-b458-1ce9379007fd)|

Other aspect ratio options (which will be further consolidated together):
![CleanShot 2023-10-04 at 12 56 12](https://github.com/WordPress/gutenberg/assets/1813435/4caccd7b-46e0-4ef8-990f-c2d3ea76f7aa)
![CleanShot 2023-10-04 at 12 56 54](https://github.com/WordPress/gutenberg/assets/1813435/426f9fa2-222a-4f09-bc49-d2fac10d0750)
