### PR TITLE
Hide footnotes block from the inserter

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -274,7 +274,7 @@ Display footnotes added to the page. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/footnotes
 -	**Category:** text
--	**Supports:** color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~multiple~~, ~~reusable~~
+-	**Supports:** color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~, ~~multiple~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Classic

--- a/packages/block-library/src/footnotes/block.json
+++ b/packages/block-library/src/footnotes/block.json
@@ -33,6 +33,7 @@
 		"html": false,
 		"multiple": false,
 		"reusable": false,
+		"inserter": false,
 		"spacing": {
 			"margin": true,
 			"padding": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adding the block within the editor adds an empty placeholder, whereas the actual action of adding a footnote via the block toolbar formats control is when a footnote is added to the post. I propose we remove the Footnotes block from the inserter. 

The block will still be appended to the content if a footnote is added, you just can't insert an empty footnotes block (which is a good thing). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Search for the footnotes block. -->
3. See no local results. 
4. Add paragraph text.
5. Create a footnote via the formats control.
6. See footnotes block rendered below the content.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-10-04 at 14 24 06](https://github.com/WordPress/gutenberg/assets/1813435/9d4c51ce-a11d-48ad-ba28-b870657b6830)|![CleanShot 2023-10-04 at 14 25 02](https://github.com/WordPress/gutenberg/assets/1813435/690cee76-b9be-4e9c-aa8d-397be8721ad0)|


