### PR TITLE
Improve DimensionsTool control layout

### DIFF
--- a/packages/block-editor/src/components/dimensions-tool/index.js
+++ b/packages/block-editor/src/components/dimensions-tool/index.js
@@ -131,31 +131,6 @@ function DimensionsTool( {
 					onChange( nextValue );
 				} }
 			/>
-			{ showScaleControl && (
-				<ScaleTool
-					panelId={ panelId }
-					options={ scaleOptions }
-					defaultValue={ defaultScale }
-					value={ lastScale }
-					onChange={ ( nextScale ) => {
-						const nextValue = { ...value };
-
-						// 'fill' is CSS default, so it gets treated as null.
-						nextScale = nextScale === 'fill' ? null : nextScale;
-
-						setLastScale( nextScale );
-
-						// Update scale.
-						if ( ! nextScale ) {
-							delete nextValue.scale;
-						} else {
-							nextValue.scale = nextScale;
-						}
-
-						onChange( nextValue );
-					} }
-				/>
-			) }
 			<WidthHeightTool
 				panelId={ panelId }
 				units={ unitsOptions }
@@ -205,6 +180,31 @@ function DimensionsTool( {
 					onChange( nextValue );
 				} }
 			/>
+			{ showScaleControl && (
+				<ScaleTool
+					panelId={ panelId }
+					options={ scaleOptions }
+					defaultValue={ defaultScale }
+					value={ lastScale }
+					onChange={ ( nextScale ) => {
+						const nextValue = { ...value };
+
+						// 'fill' is CSS default, so it gets treated as null.
+						nextScale = nextScale === 'fill' ? null : nextScale;
+
+						setLastScale( nextScale );
+
+						// Update scale.
+						if ( ! nextScale ) {
+							delete nextValue.scale;
+						} else {
+							nextValue.scale = nextScale;
+						}
+
+						onChange( nextValue );
+					} }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/components/dimensions-tool/scale-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/scale-tool.js
@@ -110,7 +110,7 @@ export default function ScaleTool( {
 				help={ scaleHelp[ displayValue ] }
 				value={ displayValue }
 				onChange={ onChange }
-				__nextHasNoMarginBottom
+				size={ '__unstable-large' }
 			>
 				{ options.map( ( option ) => (
 					<ToggleGroupControlOption


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Moves ScaleTool below WidthHeightTool, as it is a less important control than the width/height controls, and makes it a bit easier to scan. Also aligns with the Featured Image block's aspect ratio implementation. 

I also set the ToggleGroupControl to use the large size, to fit in with the rest of the controls. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert an image block. 
3. Add an image.
4. Set an aspect ratio.
5. See "Scale" control below the width/height controls. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-10-04 at 15 05 44](https://github.com/WordPress/gutenberg/assets/1813435/782dbb0d-a445-4714-9f29-c52742793764)|![CleanShot 2023-10-04 at 15 05 13](https://github.com/WordPress/gutenberg/assets/1813435/5b44ed0d-7974-467e-b848-434c8fc6fc7c)|

