### PR TITLE
Changing `Button` component toggled style selector

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   `Button`: Remove `aria-selected` CSS selector from styling 'active' buttons ([#54931](https://github.com/WordPress/gutenberg/pull/54931)).
 -   `Popover`: Apply the CSS in JS styles properly for components used within popovers. ([#54912](https://github.com/WordPress/gutenberg/pull/54912))
 -   `Button`: Remove hover styles when `aria-disabled` is set to `true` for the secondary variant. ([#54978](https://github.com/WordPress/gutenberg/pull/54978))
+-   `Button`: Revert toggled style selector to use a class instead of attributes ([#55065](https://github.com/WordPress/gutenberg/pull/55065)).
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -308,8 +308,7 @@
 	}
 
 	// Toggled style.
-	&[aria-pressed="true"],
-	&[aria-pressed="mixed"] {
+	&.is-pressed {
 		color: $components-color-foreground-inverted;
 		background: $components-color-foreground;
 


### PR DESCRIPTION
## What?
This PR changes how a toggled `Button` is styled, reverting the change from class to attribute selector in #54740.

## Why?
It was not properly anticipated that `Button` consumers might be relying on the `.is-pressed` class for styling, so until we can better assess how `.is-pressed` is used elsewhere, we should leave it in place.

See also #55004.

## How?
This PR undoes the selector change in #54740.

## Testing Instructions
This is an aesthetic change, so should make no behavioural difference. All unit tests should continue to pass.

Consuming components, including blocks, should also render as before. Any that rely on the presence of `.is-pressed`, such as the Search block toolbar, should now look as expected.

### To test the search block toolbar

* Insert a Search block.
* Activate "Toggle search label" from the block toolbar.
* The pressed styles should be applied correctly.
* Apply one of the styles in the "More" dropdown menu to the text.
* The pressed styles should be applied correctly.

#### Before

![Toolbar showing multiple items, with two rendered as dark squares, and a third correctly showing a white icon on a dark background](https://github.com/WordPress/gutenberg/assets/159848/d9ca8a9f-d568-468f-968e-b6bd9cc34b23)

#### After

![Toolbar showing multiple items, with three rendered as white icons on dark backgrounds](https://github.com/WordPress/gutenberg/assets/159848/c21b4b13-862d-472e-86b5-6dfe728a74f2)