### PR TITLE
Fix scrollbars on pattern transforms

### DIFF
--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -60,7 +60,7 @@ function PreviewPatternsPopover( { patterns, onSelect } ) {
 					className="block-editor-block-switcher__preview__popover"
 					position="bottom right"
 				>
-					<div className="block-editor-block-switcher__preview">
+					<div className="block-editor-block-switcher__preview is-pattern-list-preview">
 						<div className="block-editor-block-switcher__preview-title">
 							{ __( 'Preview' ) }
 						</div>

--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -61,9 +61,6 @@ function PreviewPatternsPopover( { patterns, onSelect } ) {
 					position="bottom right"
 				>
 					<div className="block-editor-block-switcher__preview is-pattern-list-preview">
-						<div className="block-editor-block-switcher__preview-title">
-							{ __( 'Preview' ) }
-						</div>
 						<BlockPatternsList
 							patterns={ patterns }
 							onSelect={ onSelect }

--- a/packages/block-editor/src/components/block-switcher/preview-block-popover.js
+++ b/packages/block-editor/src/components/block-switcher/preview-block-popover.js
@@ -18,7 +18,7 @@ export default function PreviewBlockPopover( { blocks } ) {
 					placement="bottom-start"
 					focusOnMount={ false }
 				>
-					<div className="block-editor-block-switcher__preview">
+					<div className="block-editor-block-switcher__preview is-single-pattern-preview">
 						<div className="block-editor-block-switcher__preview-title">
 							{ __( 'Preview' ) }
 						</div>

--- a/packages/block-editor/src/components/block-switcher/preview-block-popover.js
+++ b/packages/block-editor/src/components/block-switcher/preview-block-popover.js
@@ -18,7 +18,7 @@ export default function PreviewBlockPopover( { blocks } ) {
 					placement="bottom-start"
 					focusOnMount={ false }
 				>
-					<div className="block-editor-block-switcher__preview is-single-pattern-preview">
+					<div className="block-editor-block-switcher__preview">
 						<div className="block-editor-block-switcher__preview-title">
 							{ __( 'Preview' ) }
 						</div>

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -125,6 +125,10 @@
 		margin: $grid-unit-20 0;
 		// Use padding to prevent the pattern previews focus style from being cut-off.
 		padding: 0 $grid-unit-20;
+
+		&.is-single-pattern-preview {
+			overflow: hidden;
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -125,9 +125,10 @@
 		margin: $grid-unit-20 0;
 		// Use padding to prevent the pattern previews focus style from being cut-off.
 		padding: 0 $grid-unit-20;
+		overflow: hidden;
 
-		&.is-single-pattern-preview {
-			overflow: hidden;
+		&.is-pattern-list-preview {
+			overflow: unset;
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -98,6 +98,7 @@
 
 .block-editor-block-switcher__preview__popover {
 	display: none;
+	overflow: hidden;
 
 	// Position correctly. Needs specificity.
 	&.components-popover {
@@ -115,6 +116,7 @@
 		border-radius: $radius-block-ui;
 		outline: none;
 		box-shadow: none;
+		overflow: auto;
 	}
 
 	.block-editor-block-switcher__preview {
@@ -123,7 +125,6 @@
 		margin: $grid-unit-20 0;
 		// Use padding to prevent the pattern previews focus style from being cut-off.
 		padding: 0 $grid-unit-20;
-		overflow: hidden;
 	}
 }
 


### PR DESCRIPTION
## What?
Fixes #49289

The popover for pattern transforms had some unusual behaviour when scrolling.

## Why?
The CSS overflow rules were not quite right, and that caused a scrollbar to show in the main viewport rather than in the popover. Scrolling would cause the popover to struggle to position itself.

## How?
Fix the overflow rules. The popover itself should have no overflow, while the content is scrollable so has `overflow: auto`.

As an aside, having a big list of these huge previews in a small popover isn't really the best UX, so it might be something to improve upon.

## Testing Instructions
1. Add a Query Loop block
2. Select the Query Loop (Transform) button on the toolbar
3. Select Patterns
4. Try scrolling in the popover

In trunk: The popover isn't scrollable and the popover bounces around
In this branch: The popover is scrollable and doesn't bounce

It's also worth testing that there are no knock-on effects with other previews, I had to make sure https://github.com/WordPress/gutenberg/pull/44079 didn't regress by solving this. To test that:
- Add a group and add lots of content to it (e.g. multiple empty image blocks
- Try transforming the group to a stack/columns/cover
- The block preview shouldn't have scrollbar.

### Testing Instructions for Keyboard
The original issue isn't reproducible using only a keyboard, it's more of a mouse user bug.

## Screenshots or screencast <!-- if applicable -->
#### Before

https://github.com/WordPress/gutenberg/assets/677833/d8678673-99c3-4c95-81bc-b6e345711757


#### After

https://github.com/WordPress/gutenberg/assets/677833/0ff220f3-e63b-4e1a-b9d0-b6e9b6ecbb52


