### PR TITLE
[WIP] Colors: Fix color button border radii

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -77,14 +77,18 @@ $swatch-gap: 12px;
 	border-right: 1px solid $gray-300;
 	border-bottom: 1px solid $gray-300;
 
+
 	&.first {
 		margin-top: $grid-unit-30;
-		border-top-left-radius: $radius-block-ui;
-		border-top-right-radius: $radius-block-ui;
 		border-top: 1px solid $gray-300;
 	}
 
-	&.last {
+	&:nth-child(1 of &:not([class*="ToolsPanelItemPlaceholder"])) {
+		border-top-left-radius: $radius-block-ui;
+		border-top-right-radius: $radius-block-ui;
+	}
+
+	&:nth-last-child(1 of &:not([class*="ToolsPanelItemPlaceholder"])) {
 		border-bottom-left-radius: $radius-block-ui;
 		border-bottom-right-radius: $radius-block-ui;
 	}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/55051

## What?

Applies the intended border radii to the last color item regardless of whether additional controls have been injected into the colors panel.

## Why?

The details matter.

## Why not `Item` and `ItemGroup`?

This was explored when the color panel was initially switched to the `ToolsPanel` and ad hoc controls were allowed to be rendered into it via a slot. See https://github.com/WordPress/gutenberg/pull/34027.

**TL;DR**
- Slots don't guarantee the order of their fills
- To maintain the order of controls in the panel hidden DOM elements are added for controls that aren't toggled on for display
- The `first` and `last` classes were the accepted workaround to allow pseudo ItemGroup styling
- Which items should get these classes is calculated by the ToolsPanel so that the panel's state (which items are hidden) can be taken into account

## How?

Leverages `nth-child(1 of selector)` and `nth-last-child(1 of selector)` to target the first and last items of a given class that haven't been hidden via the placeholder item style.

These selectors are working for me in: Chrome, Safari, Firebox, Edge, and Opera.

**NOTE: One downside here is that we rely on a partial class match for the final generated class name for hidden placeholder items.**

If this approach was accepted we could simplify and clean up the ToolsPanel components to remove the need for first/last classes to be applied.

An alternative approach here is that we could pass an additional prop to the ToolsPanel allowing for the first/last item calculation to filter on a class name as well. This would avoid depending on a component class but does alter the component's API and complicate the code further.

I've gone with CSS only as the simplest option first but am happy to go the alternative route if so desired.

## Testing Instructions

1. Edit a post and add a feature image and group block
2. Select the feature image block, open the style tab in the block inspector and confirm the overlay option there has border radii for all corners
3. Select the group block and, open the styles tab
4. Confirm the first color option has top left/right border radii
5. Confirm the last color option has bottom left/right border radii
6. Toggle on additional color controls from the color panel's menu
7. Ensure that hidden placeholder items do not interfere with the correct application of border radii
8. Test across browsers

### Testing Instructions for Keyboard

Changes are visual only. 

## Screenshots or screencast <!-- if applicable -->

<img width="420" alt="Screenshot 2023-10-05 at 2 37 10 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/cb74dd24-9804-4da0-962e-e32bc7dce0a8">


