### PR TITLE
Site Editor: Do not display 'trashed' navigation menus in Sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,11 +13,24 @@ import { useLink } from '../routes/link';
 import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 export default function TemplatePartNavigationMenuListItem( { id } ) {
-	const [ title ] = useEntityProp(
-		'postType',
-		NAVIGATION_POST_TYPE,
-		'title',
-		id
+	const title = useSelect(
+		( select ) => {
+			if ( ! id ) {
+				return undefined;
+			}
+
+			const editedRecord = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				NAVIGATION_POST_TYPE,
+				id
+			);
+
+			// Do not display a 'trashed' navigation menu.
+			return editedRecord.status === 'trash'
+				? undefined
+				: editedRecord.title;
+		},
+		[ id ]
 	);
 
 	const linkInfo = useLink( {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu-list-item.js
@@ -1,37 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
+import useNavigationMenuTitle from './use-navigation-menu-title';
 import { useLink } from '../routes/link';
 import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 export default function TemplatePartNavigationMenuListItem( { id } ) {
-	const title = useSelect(
-		( select ) => {
-			if ( ! id ) {
-				return undefined;
-			}
-
-			const editedRecord = select( coreStore ).getEditedEntityRecord(
-				'postType',
-				NAVIGATION_POST_TYPE,
-				id
-			);
-
-			// Do not display a 'trashed' navigation menu.
-			return editedRecord.status === 'trash'
-				? undefined
-				: editedRecord.title;
-		},
-		[ id ]
-	);
+	const title = useNavigationMenuTitle( id );
 
 	const linkInfo = useLink( {
 		postId: id,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -3,35 +3,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalHeading as Heading } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import NavigationMenuEditor from '../sidebar-navigation-screen-navigation-menu/navigation-menu-editor';
-import { NAVIGATION_POST_TYPE } from '../../utils/constants';
+import useNavigationMenuTitle from './use-navigation-menu-title';
 
 export default function TemplatePartNavigationMenu( { id } ) {
-	const title = useSelect(
-		( select ) => {
-			if ( ! id ) {
-				return undefined;
-			}
-
-			const editedRecord = select( coreStore ).getEditedEntityRecord(
-				'postType',
-				NAVIGATION_POST_TYPE,
-				id
-			);
-
-			// Do not display a 'trashed' navigation menu.
-			return editedRecord.status === 'trash'
-				? undefined
-				: editedRecord.title;
-		},
-		[ id ]
-	);
+	const title = useNavigationMenuTitle( id );
 
 	if ( ! id || title === undefined ) {
 		return null;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/template-part-navigation-menu.js
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalHeading as Heading } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -12,11 +13,24 @@ import NavigationMenuEditor from '../sidebar-navigation-screen-navigation-menu/n
 import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 export default function TemplatePartNavigationMenu( { id } ) {
-	const [ title ] = useEntityProp(
-		'postType',
-		NAVIGATION_POST_TYPE,
-		'title',
-		id
+	const title = useSelect(
+		( select ) => {
+			if ( ! id ) {
+				return undefined;
+			}
+
+			const editedRecord = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				NAVIGATION_POST_TYPE,
+				id
+			);
+
+			// Do not display a 'trashed' navigation menu.
+			return editedRecord.status === 'trash'
+				? undefined
+				: editedRecord.title;
+		},
+		[ id ]
 	);
 
 	if ( ! id || title === undefined ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-title.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-navigation-menu-title.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
+
+export default function useNavigationMenuTitle( id ) {
+	return useSelect(
+		( select ) => {
+			if ( ! id ) {
+				return undefined;
+			}
+
+			const editedRecord = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				NAVIGATION_POST_TYPE,
+				id
+			);
+
+			// Do not display a 'trashed' navigation menu.
+			return editedRecord.status === 'trash'
+				? undefined
+				: editedRecord.title;
+		},
+		[ id ]
+	);
+}


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/54996#issuecomment-1746166667.

PR updates selectors for template parts navigation menu display components to avoid rendering trashed menu items.

## Why?
The Navigation block considers entities with this status as deleted. This fixes inconsistency.

## Testing Instructions
1. Open a Site Editor.
2. Set a navigation block and menu for the header template part.
3. Confirm it's displayed in the template part details sidebar on the left.
4. Move this nav menu into a trash. You can use the `wp-admin/edit.php?post_type=wp_navigation` screen.
5. Refresh the site editor template parts view.
6. Confirm that the trashed nav menu isn't any longer displayed.

### Testing Instructions for Keyboard
Same.

## Screenshot
![CleanShot 2023-10-05 at 09 14 13](https://github.com/WordPress/gutenberg/assets/240569/fdf1878c-9df2-4e79-afce-665d7a84943e)

