### PR TITLE
Try to fix multi-block-selection flakiness

### DIFF
--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1188,10 +1188,17 @@ test.describe( 'Multi-block selection', () => {
 			attributes: { content: ']2' },
 		} );
 		// Focus and move the caret to the end.
-		await page
+		const secondParagraphBlock = page
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
-			.filter( { hasText: ']2' } )
-			.click();
+			.filter( { hasText: ']2' } );
+		const secondParagraphBlockBox =
+			await secondParagraphBlock.boundingBox();
+		await secondParagraphBlock.click( {
+			position: {
+				x: secondParagraphBlockBox.width - 1,
+				y: secondParagraphBlockBox.height / 2,
+			},
+		} );
 
 		await page.keyboard.press( 'ArrowLeft' );
 		const strongText = page

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1206,14 +1206,11 @@ test.describe( 'Multi-block selection', () => {
 			.getByText( '1', { exact: true } );
 		const strongBox = await strongText.boundingBox();
 		// Focus and move the caret to the end.
-		await page
-			.getByRole( 'document', { name: 'Block: Paragraph' } )
-			.filter( { hasText: '1[' } )
-			.click( {
-				// Ensure clicking on the right half of the element.
-				position: { x: strongBox.width - 1, y: strongBox.height / 2 },
-				modifiers: [ 'Shift' ],
-			} );
+		await strongText.click( {
+			// Ensure clicking on the right half of the element.
+			position: { x: strongBox.width - 1, y: strongBox.height / 2 },
+			modifiers: [ 'Shift' ],
+		} );
 		await page.keyboard.press( 'Backspace' );
 
 		// Ensure selection is in the correct place.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Follow-up to https://github.com/WordPress/gutenberg/pull/53564. Try to fix https://github.com/WordPress/gutenberg/issues/53524.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The test has become really flaky for the past two months since it was introduced.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. `.click()` with no `position` option specified will pick a [visible point](https://github.com/microsoft/playwright/blob/89e1f697386179eefe4817ca23d9cd7802ead8bf/packages/playwright-core/src/server/dom.ts#L251) but not guarantee to be in the center of the element.
2. Click directly on the `strongText` to avoid calculating clickable points based on the parent element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
CI should pass without flakiness.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A