### PR TITLE
Reset "Expand on click" image styles when window is resized

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -200,6 +200,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->set_attribute( 'data-wp-init', 'effects.core.image.setCurrentSrc' );
 	$w->set_attribute( 'data-wp-on--load', 'actions.core.image.handleLoad' );
 	$w->set_attribute( 'data-wp-effect', 'effects.core.image.setButtonStyles' );
+	$w->set_attribute( 'data-wp-effect--setStylesOnResize', 'effects.core.image.setStylesOnResize' );
 	$body_content = $w->get_updated_html();
 
 	// Wrap the image in the body content with a button.

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -105,7 +105,10 @@ store(
 						context.core.image.scrollDelta = 0;
 
 						context.core.image.lightboxEnabled = true;
-						setStyles( context, event );
+						setStyles(
+							context,
+							event.target.previousElementSibling
+						);
 
 						context.core.image.scrollTopReset =
 							window.pageYOffset ||
@@ -338,6 +341,15 @@ store(
 							context.core.image.imageButtonHeight = offsetHeight;
 						}
 					},
+					setStylesOnResize: ( { state, context, ref } ) => {
+						if (
+							context.core.image.lightboxEnabled &&
+							( state.core.image.windowWidth ||
+								state.core.image.windowHeight )
+						) {
+							setStyles( context, ref );
+						}
+					},
 				},
 			},
 		},
@@ -362,7 +374,7 @@ store(
  * @param {Object} context - An Interactivity API context
  * @param {Object} event - A triggering event
  */
-function setStyles( context, event ) {
+function setStyles( context, ref ) {
 	// The reference img element lies adjacent
 	// to the event target button in the DOM.
 	let {
@@ -370,9 +382,8 @@ function setStyles( context, event ) {
 		naturalHeight,
 		offsetWidth: originalWidth,
 		offsetHeight: originalHeight,
-	} = event.target.previousElementSibling;
-	let { x: screenPosX, y: screenPosY } =
-		event.target.previousElementSibling.getBoundingClientRect();
+	} = ref;
+	let { x: screenPosX, y: screenPosY } = ref.getBoundingClientRect();
 
 	// Natural ratio of the image clicked to open the lightbox.
 	const naturalRatio = naturalWidth / naturalHeight;


### PR DESCRIPTION
## What?
Fix a bug where the "Expand on click" functionality doesn't work properly when resizing the window. Reported [here](https://github.com/WordPress/gutenberg/issues/54971).

## Why?
It breaks somehow the experience when you change the window size.

## How?
I added an effect that listens to the window height and width stored in the `state` and it is triggered when they change. In that effect, it recalculates the styles.

## Testing Instructions

**Before this pull request**
1. Add an Image to a page or post and toggle the option "Expand on click".
2. Go to the page and click on the image to expand it.
3. Resize the window.
4. Close the lightbox.

You should see that the width of the image is not correct and the zooming out is broken.

**After this pull request**

1. Add an Image to a page or post and toggle the option "Expand on click".
2. Go to the page and click on the image to expand it.
3. Resize the window.
4. Close the lightbox.

You should see that the width of the image is corrected and the zooming works fine.

## Screenshots or screencast

**Before this pull request**

https://github.com/WordPress/gutenberg/assets/34552881/a49e97e9-709f-4309-b8b8-c79a4b187d30


**After this pull request**

https://github.com/WordPress/gutenberg/assets/34552881/986b1fb3-8b9e-489a-9703-ddab147c0744

