### PR TITLE
Update main toolbar buttons to be compact.

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -45,7 +45,7 @@ $grid-unit-80: 8 * $grid-unit;		// 64px
  */
 
 $icon-size: 24px;
-$button-size: 36px;
+$button-size: 32px;
 $button-size-next-default-40px: 40px; // transitionary variable for next default button size
 $button-size-small: 24px;
 $button-size-compact: 32px;

--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -35,6 +35,7 @@ export default function PreviewOptions( {
 		disabled: ! isEnabled,
 		__experimentalIsFocusable: ! isEnabled,
 		children: viewLabel,
+		size: 'compact',
 	};
 	const menuProps = {
 		'aria-label': __( 'View options' ),

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -109,6 +109,7 @@ function HeaderToolbar( { setListViewToggleElement } ) {
 				variant={ showIconLabels ? 'tertiary' : undefined }
 				aria-expanded={ isListViewOpen }
 				ref={ setListViewToggleElement }
+				size="compact"
 			/>
 		</>
 	);
@@ -162,17 +163,20 @@ function HeaderToolbar( { setListViewToggleElement } ) {
 									showIconLabels ? 'tertiary' : undefined
 								}
 								disabled={ isTextModeEnabled }
+								size="compact"
 							/>
 						) }
 						<ToolbarItem
 							as={ EditorHistoryUndo }
 							showTooltip={ ! showIconLabels }
 							variant={ showIconLabels ? 'tertiary' : undefined }
+							size="compact"
 						/>
 						<ToolbarItem
 							as={ EditorHistoryRedo }
 							showTooltip={ ! showIconLabels }
 							variant={ showIconLabels ? 'tertiary' : undefined }
+							size="compact"
 						/>
 						{ overflowItems }
 					</>

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -42,7 +42,7 @@
 	.edit-post-header-toolbar__left > .components-dropdown > .components-button.has-icon {
 		height: $button-size;
 		min-width: $button-size;
-		padding: 6px;
+		padding: 4px;
 
 		&.is-pressed {
 			background: $gray-900;
@@ -50,7 +50,7 @@
 
 		&:focus:not(:disabled) {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
-			outline: 1px solid transparent;
+			outline: $border-width solid transparent;
 		}
 
 		&::before {

--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -26,6 +26,7 @@ const MoreMenu = ( { showIconLabels } ) => {
 			toggleProps={ {
 				showTooltip: ! showIconLabels,
 				...( showIconLabels && { variant: 'tertiary' } ),
+				size: 'compact',
 			} }
 		>
 			{ ( { onClose } ) => (

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -176,6 +176,7 @@ export class PostPublishButton extends Component {
 			className: 'editor-post-publish-panel__toggle',
 			isBusy: isSaving && isPublished,
 			variant: 'primary',
+			size: 'compact',
 			onClick: this.createOnClick( onClickToggle ),
 		};
 

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -182,6 +182,7 @@ function ComplementaryArea( {
 							icon={ showIconLabels ? check : icon }
 							showTooltip={ ! showIconLabels }
 							variant={ showIconLabels ? 'tertiary' : undefined }
+							size="compact"
 						/>
 					) }
 				</PinnedItems>


### PR DESCRIPTION
## What?

Ongoing work on #46734. Change the top toolbar buttons to be compact, 32px height. This is not done yet, the inner padding of the top toolbar will also need to change so icons still align across the inspector, and the site editor needs addressing as well.

Before:

![before](https://github.com/WordPress/gutenberg/assets/1204802/613e84f8-252b-4255-842b-04933cc5cb8e)


After:

![after](https://github.com/WordPress/gutenberg/assets/1204802/3ce12768-ea23-49dd-a715-122d1c5197d4)



## Why?

Toggle buttons in the block toolbar are 32px. The inserter is 32px. Undo/redo buttons are 36px. This unifies the toolbar so that all toggle buttons are 32px, one size instead of two.

## How?

Using the `size="compact"` prop. Font size is the same.

## Testing Instructions

Since this chances a CSS variable, be sure to stop and restart npm run dev.

Not entirely ready for testing, as the site editor, and other interfaces that use the top toolbar, are not addressed yet. But ideally anything that has a top toolbar should have only 32px buttons there.