### PR TITLE
Documentation: Explain how to translate Gutenberg in standalone apps using the editor packages

### DIFF
--- a/platform-docs/docs/basic-concepts/internationalization.md
+++ b/platform-docs/docs/basic-concepts/internationalization.md
@@ -16,7 +16,7 @@ setLocaleData( { 'Type / to choose a block': [ 'Taper / pour choisir un bloc' ] 
 
 # RTL Support
 
-By default, the Gutenberg UI is optimized for left-to-right (LTR) languages. But Gutenberg scripts and styles include support for right-to-left (RTL) languages as well. To enable RTL support, we need to perform to a few actions:
+By default, the Gutenberg UI is optimized for left-to-right (LTR) languages. But Gutenberg scripts and styles include support for right-to-left (RTL) languages as well. To enable RTL support, we need to perform a few actions:
 
 First, we need to define that our locale is RTL using `@wordpress/i18n`.
 

--- a/platform-docs/docs/basic-concepts/internationalization.md
+++ b/platform-docs/docs/basic-concepts/internationalization.md
@@ -4,4 +4,36 @@ sidebar_position: 7
 
 # Internationalization
 
+The Gutenberg block editor uses the `@wordpress/i18n` package to provide internationalization support.
+
+Translations can be provided by calling the `setLocaleData` function with a domain and a locale data object. The locale data object should be in the [Jed-formatted JSON object shape](http://messageformat.github.io/Jed/).
+
+```js
+import { setLocaleData } from '@wordpress/i18n';
+
+setLocaleData( { 'Type / to choose a block': [ 'Taper / pour choisir un bloc' ] } );
+```
+
 # RTL Support
+
+By default, the Gutenberg UI is optimized for left-to-right (LTR) languages. But Gutenberg scripts and styles include support for right-to-left (RTL) languages as well. To enable RTL support, we need to perform to a few actions:
+
+First, we need to define that our locale is RTL using `@wordpress/i18n`.
+
+```js
+import { setLocaleData } from '@wordpress/i18n';
+
+setLocaleData( { 'text direction\u0004ltr': [ 'rtl' ] } );
+```
+
+Second, we need to load the RTL CSS stylesheets instead of the LTR ones. For each of the stylesheets that you load from `@wordpress` packages, there's an RTL version that you can use instead.
+
+For example, when loading the `@wordpress/components` stylesheet, you can load the RTL version by using `@wordpress/components/build-style/style-rtl.css` instead of `@wordpress/components/build-style/style.css`.
+
+Finally, make sure to add a `dir` property to the `html` element of your document (or any parent element of your editor).
+
+```html
+<html dir="rtl">
+    <!-- rest of your app -->
+</html>
+```


### PR DESCRIPTION
Related #53874

## What?

This PR add a small documentation page about the i18n of the @wordpress packages. It explains how to load translations and how to switch to RTL if needed. I think there's a missing part about the localization (@wordpress/date package).

I also think that it would be good to explain here how to generate the list of all strings from the packages. (or provide translations and strings for some languages). I'm not sure whether it's possible to just provide the WordPress ones here from GlotPress, maybe there's a way/link to download them and use them manually. 

Anyway, I think the current docs should be fine for a start.

**Note** I have personally tested all the code examples in a third-party vite install.

### Test the documentation website

```
cd platform-docs
npm install
npm start
```