### PR TITLE
Site Editor: Fix template part area listing when a template has no edits

### DIFF
--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -307,7 +307,7 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 			{ per_page: -1 }
 		);
 
-		return getFilteredTemplatePartBlocks( template.blocks, templateParts );
+		return getFilteredTemplatePartBlocks( template, templateParts );
 	}
 );
 

--- a/packages/edit-site/src/store/test/utils.js
+++ b/packages/edit-site/src/store/test/utils.js
@@ -98,16 +98,6 @@ const FLATTENED_BLOCKS = [
 	},
 ];
 
-const SINGLE_TEMPLATE_PART_BLOCK = {
-	clientId: '1',
-	name: 'core/template-part',
-	innerBlocks: [],
-	attributes: {
-		slug: 'aside',
-		theme: 'my-theme',
-	},
-};
-
 const TEMPLATE_PARTS = [
 	{
 		id: 'my-theme//header',
@@ -126,11 +116,32 @@ const TEMPLATE_PARTS = [
 	},
 ];
 
+const TEMPLATE_NESTED_BLOCKS = {
+	blocks: NESTED_BLOCKS,
+};
+
+const TEMAPLATE_SINGLE_BLOCK = {
+	blocks: [
+		{
+			clientId: '1',
+			name: 'core/template-part',
+			innerBlocks: [],
+			attributes: {
+				slug: 'aside',
+				theme: 'my-theme',
+			},
+		},
+	],
+};
+
 describe( 'utils', () => {
 	describe( 'getFilteredTemplatePartBlocks', () => {
 		it( 'returns a flattened list of filtered template parts preserving a depth-first order', () => {
 			const flattenedFilteredTemplateParts =
-				getFilteredTemplatePartBlocks( NESTED_BLOCKS, TEMPLATE_PARTS );
+				getFilteredTemplatePartBlocks(
+					TEMPLATE_NESTED_BLOCKS,
+					TEMPLATE_PARTS
+				);
 			expect( flattenedFilteredTemplateParts ).toEqual(
 				FLATTENED_BLOCKS
 			);
@@ -139,9 +150,15 @@ describe( 'utils', () => {
 		it( 'returns a cached result when passed the same params', () => {
 			// Clear the cache and call the function twice.
 			getFilteredTemplatePartBlocks.clear();
-			getFilteredTemplatePartBlocks( NESTED_BLOCKS, TEMPLATE_PARTS );
+			getFilteredTemplatePartBlocks(
+				TEMPLATE_NESTED_BLOCKS,
+				TEMPLATE_PARTS
+			);
 			expect(
-				getFilteredTemplatePartBlocks( NESTED_BLOCKS, TEMPLATE_PARTS )
+				getFilteredTemplatePartBlocks(
+					TEMPLATE_NESTED_BLOCKS,
+					TEMPLATE_PARTS
+				)
 			).toEqual( FLATTENED_BLOCKS );
 
 			// The function has been called twice with the same params, so the cache size should be 1.
@@ -157,7 +174,7 @@ describe( 'utils', () => {
 			// Call the function again, with different params.
 			expect(
 				getFilteredTemplatePartBlocks(
-					[ SINGLE_TEMPLATE_PART_BLOCK ],
+					TEMAPLATE_SINGLE_BLOCK,
 					TEMPLATE_PARTS
 				)
 			).toEqual( [

--- a/packages/edit-site/src/store/test/utils.js
+++ b/packages/edit-site/src/store/test/utils.js
@@ -120,7 +120,7 @@ const TEMPLATE_NESTED_BLOCKS = {
 	blocks: NESTED_BLOCKS,
 };
 
-const TEMAPLATE_SINGLE_BLOCK = {
+const TEMPLATE_SINGLE_BLOCK = {
 	blocks: [
 		{
 			clientId: '1',

--- a/packages/edit-site/src/store/test/utils.js
+++ b/packages/edit-site/src/store/test/utils.js
@@ -174,7 +174,7 @@ describe( 'utils', () => {
 			// Call the function again, with different params.
 			expect(
 				getFilteredTemplatePartBlocks(
-					TEMAPLATE_SINGLE_BLOCK,
+					TEMPLATE_SINGLE_BLOCK,
 					TEMPLATE_PARTS
 				)
 			).toEqual( [

--- a/packages/edit-site/src/store/utils.js
+++ b/packages/edit-site/src/store/utils.js
@@ -6,21 +6,30 @@ import memoize from 'memize';
 /**
  * WordPress dependencies
  */
-import { isTemplatePart } from '@wordpress/blocks';
+import { isTemplatePart, parse } from '@wordpress/blocks';
 
-const EMPTY_ARRAY = [];
+function getBlocksFromRecord( record ) {
+	if ( record?.blocks ) {
+		return record?.blocks;
+	}
+
+	return record?.content && typeof record.content !== 'function'
+		? parse( record.content )
+		: [];
+}
 
 /**
  * Get a flattened and filtered list of template parts and the matching block for that template part.
  *
- * Takes a list of blocks defined within a template, and a list of template parts, and returns a
+ * Takes a template, and a list of template parts, and returns a
  * flattened list of template parts and the matching block for that template part.
  *
- * @param {Array}  blocks        Blocks to flatten.
+ * @param {Object} template      Current template.
  * @param {?Array} templateParts Available template parts.
  * @return {Array} An array of template parts and their blocks.
  */
-function getFilteredTemplatePartBlocks( blocks = EMPTY_ARRAY, templateParts ) {
+function getFilteredTemplatePartBlocks( template, templateParts ) {
+	const blocks = getBlocksFromRecord( template );
 	const templatePartsById = templateParts
 		? // Key template parts by their ID.
 		  templateParts.reduce(


### PR DESCRIPTION
## What?
Fixes #55061.

PR fixes the `getCurrentTemplateTemplateParts` selector returning an empty value when a template has no edits.

This is probably a side-effect of #52417.

Update: If anyone is wondering why areas are displayed when a template has no edits at all (loaded from the file). This is due to blocks like Query and `core/pattern` performing updates on the initial load. This loads `blocks` in the store.

## Why?
A record returned by `getEditedEntityRecord` will have an undefined `block` property when an entity has no edits. In the past, blocks were loaded into the store for a current recond via `useEntityBlockEditor`. This isn't the case anymore.

## How?
Adds a helper `getBlocksFromRecord` method, which returns blocks from a record based on available values.

## Testing Instructions
1. Open a Site Editor.
2. Open the home template.
3. Make some edits, save and reload.
4. Confirm template areas are still listed in both template detail sidebars.


## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-10-05 at 16 28 59](https://github.com/WordPress/gutenberg/assets/240569/26609ef5-3640-48ec-b751-df9beb53f5c0)

