### PR TITLE
Initial documentation of entity configuration

### DIFF
--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -42,22 +42,57 @@ function MyAuthorsListBase() {
 
 ## What's an entity?
 
-An entity represents a WordPress REST API endpoint. Each item within the entity is called entity record.
+An entity represents a WordPress REST API endpoint. Each item within the entity is called entity record. Available entities are defined in `rootEntitiesConfig` at ./src/entities.js.
 
-Available entities are defined in `rootEntitiesConfig` at ./src/entities.js and the follow this schema:
+What follows is a description of some of the properties of `rootEntitiesConfig`.
 
-- label
-- kind
-- name
-- baseURL
-- baseURLParams
-- key
-- getTitle
-- plural
-- rawAttributes
-- loadEntities
-- transientEdits
-- mergedEdits
+## baseURL
+
+- Type: string.
+- Example: `'/wp/v2/users'`.
+
+This property maps the entity to a given endpoint, representing its URL as defined in the [REST API handbook](https://developer.wordpress.org/rest-api/reference/#rest-api-developer-endpoint-reference).
+
+## baseURLParams
+
+- Type: `object`.
+- Example: `{ context: 'edit' }`.
+
+Additional parameters to the request, if the endpoint supports it. The additional arguments available to the request are listed under arguments section. As an example, see the user entity and the [users endpoint](https://developer.wordpress.org/rest-api/reference/users/#list-users). By providing `{ context: 'edit' }` the server response will include all the fields in the [user schema](https://developer.wordpress.org/rest-api/reference/users/#schema) that belong to the `edit` context.
+
+## key
+
+- Type: `string`.
+- Example: `'slug'`.
+
+The endpoint response may be in different formats. It can be a simple object, which maps to a single entity record. This is the case of the site entity (settings endpoint):
+
+```json
+{
+	"title": "...",
+	"description": "...",
+	"...": "..."
+}
+```
+
+The most common format is for the response to be a collection represented as an array, which maps to as many entity records as elements of the array. This is the case of the use entity (users endpoint):
+
+```json
+[
+	{ id: 1, "name": "...", "...": "..." },
+	{ id: 2, "name": "...", "...": "..." },
+	{ id: 3, "name": "...", "...": "..." },
+]
+```
+
+There's also cases in which a collection is represented as an object. In this case, for the entity records to be recognized by the entities engine, the entity configuration needs to provide which field is acting as `key` for the object. This is the case of the status entity, which sets `slug` as the collection's `key`:
+
+```json
+{
+	"publish": { "slug": "publish", "name": "Published", "...":  "..." },
+	"draft": { "slug": "draft", "name": "Draft", "...":  "..." }
+}
+```
 
 ## Actions
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -50,22 +50,22 @@ What follows is a description of some of the properties of `rootEntitiesConfig`.
 
 ## baseURL
 
-- Type: string.
-- Example: `'/wp/v2/users'`.
+-   Type: string.
+-   Example: `'/wp/v2/users'`.
 
 This property maps the entity to a given endpoint, taking its relative URL as value.
 
 ## baseURLParams
 
-- Type: `object`.
-- Example: `{ context: 'edit' }`.
+-   Type: `object`.
+-   Example: `{ context: 'edit' }`.
 
 Additional parameters to the request, added as a query string. Each property will be converted into a field/value pair. For example, given the `baseURL: '/wp/v2/users'` and the `baseURLParams: { context: 'edit' }` the URL would be `/wp/v2/users?context=edit`.
 
 ## key
 
-- Type: `string`.
-- Example: `'slug'`.
+-   Type: `string`.
+-   Example: `'slug'`.
 
 The entity engine aims to convert the API response into a number of entity records. Responses can come in different shapes, which are processed differently.
 
@@ -83,9 +83,9 @@ Responses that represent a collection shaped as an array, map to as many entity 
 
 ```json
 [
-	{ id: 1, "name": "...", "...": "..." },
-	{ id: 2, "name": "...", "...": "..." },
-	{ id: 3, "name": "...", "...": "..." },
+	{ "id": 1, "name": "...", "...": "..." },
+	{ "id": 2, "name": "...", "...": "..." },
+	{ "id": 3, "name": "...", "...": "..." }
 ]
 ```
 
@@ -93,9 +93,9 @@ There are also cases in which a response represents a collection shaped as an ob
 
 ```json
 {
-	"publish": { "slug": "publish", "name": "Published", "...":  "..." },
-	"draft": { "slug": "draft", "name": "Draft", "...":  "..." },
-	"future": { "slug": "future", "name": "Future", "...":  "..." }
+	"publish": { "slug": "publish", "name": "Published", "...": "..." },
+	"draft": { "slug": "draft", "name": "Draft", "...": "..." },
+	"future": { "slug": "future", "name": "Future", "...": "..." }
 }
 ```
 
@@ -898,8 +898,8 @@ via the `edit()` and `save()` mutation helpers provided by
 
 _Parameters_
 
--   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ./src/entities.js for a list of available kinds.
--   _name_ `string`: Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ./src/entities.js for a list of available names.
+-   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ../entities.ts for a list of available kinds.
+-   _name_ `string`: Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ../entities.ts for a list of available names.
 -   _recordId_ `string | number`: ID of the requested entity record.
 -   _options_ `Options`: Optional hook options.
 
@@ -946,8 +946,8 @@ the store state using `getEntityRecords()`, or resolved if missing.
 
 _Parameters_
 
--   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ./src/entities.js for a list of available kinds.
--   _name_ `string`: Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ./src/entities.js for a list of available names.
+-   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ../entities.ts for a list of available kinds.
+-   _name_ `string`: Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ../entities.ts for a list of available names.
 -   _queryArgs_ `Record< string, unknown >`: Optional HTTP query description for how to fetch the data, passed to the requested API endpoint.
 -   _options_ `Options`: Optional hook options.
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -65,7 +65,7 @@ Additional parameters to the request, if the endpoint supports it. The additiona
 - Type: `string`.
 - Example: `'slug'`.
 
-The endpoint response may be in different formats. It can be a simple object, which maps to a single entity record. This is the case of the site entity (settings endpoint):
+The endpoint response may be in different formats. It can be a simple object, which maps to a single entity record. This is the case for the site entity (settings endpoint):
 
 ```json
 {

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -42,7 +42,7 @@ function MyAuthorsListBase() {
 
 ## What's an entity?
 
-An entity represents a data source. Each item within the entity is called entity record. Available entities are defined in `rootEntitiesConfig` at ./src/entities.js.
+An entity represents a data source. Each item within the entity is called an entity record. Available entities are defined in `rootEntitiesConfig` at ./src/entities.js.
 
 As of right now, the default entities defined by this package map to the [REST API handbook](https://developer.wordpress.org/rest-api/reference/), though there is nothing in the design that prevents it from being used to interact with any other API.
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -85,7 +85,7 @@ The most common format is for the response to be a collection represented as an 
 ]
 ```
 
-There's also cases in which a collection is represented as an object. In this case, for the entity records to be recognized by the entities engine, the entity configuration needs to provide which field is acting as `key` for the object. This is the case of the status entity, which sets `slug` as the collection's `key`:
+There are also cases in which a collection is represented as an object. In this case, for the entity records to be recognized by the entities engine, the entity configuration must provide which field is acting as the `key` for the object. This is the case for the status entity, which sets `slug` as the collection's `key`:
 
 ```json
 {

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -839,8 +839,8 @@ via the `edit()` and `save()` mutation helpers provided by
 
 _Parameters_
 
--   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ../entities.ts for a list of available kinds.
--   _name_ `string`: Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ../entities.ts for a list of available names.
+-   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ./src/entities.js for a list of available kinds.
+-   _name_ `string`: Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ./src/entities.js for a list of available names.
 -   _recordId_ `string | number`: ID of the requested entity record.
 -   _options_ `Options`: Optional hook options.
 
@@ -887,8 +887,8 @@ the store state using `getEntityRecords()`, or resolved if missing.
 
 _Parameters_
 
--   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ../entities.ts for a list of available kinds.
--   _name_ `string`: Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ../entities.ts for a list of available names.
+-   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ./src/entities.js for a list of available kinds.
+-   _name_ `string`: Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ./src/entities.js for a list of available names.
 -   _queryArgs_ `Record< string, unknown >`: Optional HTTP query description for how to fetch the data, passed to the requested API endpoint.
 -   _options_ `Options`: Optional hook options.
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -75,7 +75,7 @@ The endpoint response may be in different formats. It can be a simple object, wh
 }
 ```
 
-The most common format is for the response to be a collection represented as an array, which maps to as many entity records as elements of the array. This is the case of the use entity (users endpoint):
+The most common format is for the response to be a collection represented as an array, which maps to as many entity records as elements of the array. This is the case for the user entity (users endpoint):
 
 ```json
 [

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -58,7 +58,7 @@ This property maps the entity to a given endpoint, representing its URL as defin
 - Type: `object`.
 - Example: `{ context: 'edit' }`.
 
-Additional parameters to the request, if the endpoint supports it. The additional arguments available to the request are listed under arguments section. As an example, see the user entity and the [users endpoint](https://developer.wordpress.org/rest-api/reference/users/#list-users). By providing `{ context: 'edit' }` the server response will include all the fields in the [user schema](https://developer.wordpress.org/rest-api/reference/users/#schema) that belong to the `edit` context.
+Additional parameters to the request, if the endpoint supports it. The additional arguments available to the request are listed under the arguments section. As an example, see the user entity and the [users endpoint](https://developer.wordpress.org/rest-api/reference/users/#list-users). By providing `{ context: 'edit' }` the server response will include all the fields in the [user schema](https://developer.wordpress.org/rest-api/reference/users/#schema) that belong to the `edit` context.
 
 ## key
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -40,6 +40,25 @@ function MyAuthorsListBase() {
 }
 ```
 
+## What's an entity?
+
+An entity represents a WordPress REST API endpoint. Each item within the entity is called entity record.
+
+Available entities are defined in `rootEntitiesConfig` at ./src/entities.js and the follow this schema:
+
+- label
+- kind
+- name
+- baseURL
+- baseURLParams
+- key
+- getTitle
+- plural
+- rawAttributes
+- loadEntities
+- transientEdits
+- mergedEdits
+
 ## Actions
 
 The following set of dispatching action creators are available on the object returned by `wp.data.dispatch( 'core' )`:

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -42,7 +42,9 @@ function MyAuthorsListBase() {
 
 ## What's an entity?
 
-An entity represents a WordPress REST API endpoint. Each item within the entity is called entity record. Available entities are defined in `rootEntitiesConfig` at ./src/entities.js.
+An entity represents a data source. Each item within the entity is called entity record. Available entities are defined in `rootEntitiesConfig` at ./src/entities.js.
+
+As of right now, the default entities defined by this package map to the [REST API handbook](https://developer.wordpress.org/rest-api/reference/), though there is nothing in the design that prevents it from being used to interact with any other API.
 
 What follows is a description of some of the properties of `rootEntitiesConfig`.
 
@@ -51,21 +53,23 @@ What follows is a description of some of the properties of `rootEntitiesConfig`.
 - Type: string.
 - Example: `'/wp/v2/users'`.
 
-This property maps the entity to a given endpoint, representing its URL as defined in the [REST API handbook](https://developer.wordpress.org/rest-api/reference/#rest-api-developer-endpoint-reference).
+This property maps the entity to a given endpoint, taking its relative URL as value.
 
 ## baseURLParams
 
 - Type: `object`.
 - Example: `{ context: 'edit' }`.
 
-Additional parameters to the request, if the endpoint supports it. The additional arguments available to the request are listed under the arguments section. As an example, see the user entity and the [users endpoint](https://developer.wordpress.org/rest-api/reference/users/#list-users). By providing `{ context: 'edit' }` the server response will include all the fields in the [user schema](https://developer.wordpress.org/rest-api/reference/users/#schema) that belong to the `edit` context.
+Additional parameters to the request, added as a query string. Each property will be converted into a field/value pair. For example, given the `baseURL: '/wp/v2/users'` and the `baseURLParams: { context: 'edit' }` the URL would be `/wp/v2/users?context=edit`.
 
 ## key
 
 - Type: `string`.
 - Example: `'slug'`.
 
-The endpoint response may be in different formats. It can be a simple object, which maps to a single entity record. This is the case for the site entity (settings endpoint):
+The entity engine aims to convert the API response into a number of entity records. Responses can come in different shapes, which are processed differently.
+
+Responses that represent a single object map to a single entity record. For example:
 
 ```json
 {
@@ -75,7 +79,7 @@ The endpoint response may be in different formats. It can be a simple object, wh
 }
 ```
 
-The most common format is for the response to be a collection represented as an array, which maps to as many entity records as elements of the array. This is the case for the user entity (users endpoint):
+Responses that represent a collection shaped as an array, map to as many entity records as elements of the array. For example:
 
 ```json
 [
@@ -85,12 +89,13 @@ The most common format is for the response to be a collection represented as an 
 ]
 ```
 
-There are also cases in which a collection is represented as an object. In this case, for the entity records to be recognized by the entities engine, the entity configuration must provide which field is acting as the `key` for the object. This is the case for the status entity, which sets `slug` as the collection's `key`:
+There are also cases in which a response represents a collection shaped as an object, whose key is one of the property's values. Each of the nested objects should be its own entity record. For this case not to be confused with single object/entities, the entity configuration must provide the property key that holds the value acting as the object key. In the following example, the `slug` property's value is acting as the object key, hence the entity config must declare `key: 'slug'` for each nested object to be processed as an individual entity record:
 
 ```json
 {
 	"publish": { "slug": "publish", "name": "Published", "...":  "..." },
-	"draft": { "slug": "draft", "name": "Draft", "...":  "..." }
+	"draft": { "slug": "draft", "name": "Draft", "...":  "..." },
+	"future": { "slug": "future", "name": "Future", "...":  "..." }
 }
 ```
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55153

## What?

This PR aims to create some initial docs explaining what is an entity and what it needs in terms of configuration.

## Why?

It's a crucial part of Gutenberg. Having some introductory high level documentation would help folks to navigate this part of our codebase.

## How?

Adds a new section in the `README.md` of the `core-data` package.

## See

Read the section ["What's an entity"](https://github.com/WordPress/gutenberg/blob/add/docs-for-entity-config/packages/core-data/README.md#whats-an-entity).
