### PR TITLE
Iframe: event bubbling should retain the original target

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -45,6 +45,14 @@ function bubbleEvent( event, Constructor, frame ) {
 	}
 
 	const newEvent = new Constructor( event.type, init );
+	// This is a hacky way of keeping the original "target" of the event
+	// when calling dispatchEvent on the frame. This is needed because
+	// if the target is set to the iframe, some keyboard shortcuts may trigger
+	// inadvertantly (like global shortcuts when typing within inputs...)
+	Object.defineProperty( newEvent, 'target', {
+		writable: false,
+		value: event.target,
+	} );
 	if ( init.defaultPrevented ) {
 		newEvent.preventDefault();
 	}

--- a/storybook/stories/playground/box/index.js
+++ b/storybook/stories/playground/box/index.js
@@ -23,11 +23,7 @@ export default function EditorBox() {
 	}, [] );
 
 	return (
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<div
-			className="editor-box"
-			onKeyDown={ ( event ) => event.stopPropagation() }
-		>
+		<div className="editor-box">
 			<BlockEditorProvider
 				value={ blocks }
 				onInput={ updateBlocks }

--- a/storybook/stories/playground/fullpage/index.js
+++ b/storybook/stories/playground/fullpage/index.js
@@ -33,11 +33,7 @@ export default function EditorFullPage() {
 	} );
 
 	return (
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<div
-			className="playground"
-			onKeyDown={ ( event ) => event.stopPropagation() }
-		>
+		<div className="playground">
 			<BlockEditorProvider
 				value={ blocks }
 				onInput={ updateBlocks }

--- a/storybook/stories/playground/with-undo-redo/index.js
+++ b/storybook/stories/playground/with-undo-redo/index.js
@@ -27,11 +27,7 @@ export default function EditorWithUndoRedo() {
 	}, [] );
 
 	return (
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<div
-			className="editor-with-undo-redo"
-			onKeyDown={ ( event ) => event.stopPropagation() }
-		>
+		<div className="editor-with-undo-redo">
 			<BlockEditorProvider
 				value={ value.blocks }
 				selection={ value.selection }


### PR DESCRIPTION
## What?

In #54080 we changed how we capture keyboard shortcuts and in doing so we added keydown events bubbling to the editor iframe component.

One side effect I noticed was that in "playground" in storybook, when typing in the editor, typed characters conflicted with Storybook shortcuts. The weird thing is that even if there were no iframe used (so events are still bubbling on the same window), the conflicts didn't happen. So the issue was in the way we generated the "virtual" events in the iframe component (since in both with or without iframe, the event was propagated to the parent of the editor).

After multiple checks and attempts, it seems that copying the "target" property (which is supposed to be readonly) when creating the synthetic event is what was triggering the conflict. Some event handlers ignore events from inputs/contenteditable...

Let's see if the e2e tests of Gutenberg confirm the fix or not.

## Testing Instructions

1- Run storybook locally `npm run storybook:dev`
2- Open one of the playground stories
3- Type "s" within the editor, the Storybook sidebar shouldn't be toggling.