### PR TITLE
Alternative: Fix template part area listing when a template has no edits

### DIFF
--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -299,12 +299,12 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 			{ per_page: -1 }
 		);
 
-		const clientIs =
+		const clientIds =
 			select( blockEditorStore ).__experimentalGetGlobalBlocksByName(
 				'core/template-part'
 			);
 		const blocks =
-			select( blockEditorStore ).getBlocksByClientId( clientIs );
+			select( blockEditorStore ).getBlocksByClientId( clientIds );
 
 		return getFilteredTemplatePartBlocks( blocks, templateParts );
 	}

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -292,22 +292,21 @@ export function isSaveViewOpened( state ) {
  * @return {Array} Template parts and their blocks in an array.
  */
 export const getCurrentTemplateTemplateParts = createRegistrySelector(
-	( select ) => ( state ) => {
-		const templateType = getEditedPostType( state );
-		const templateId = getEditedPostId( state );
-		const template = select( coreDataStore ).getEditedEntityRecord(
-			'postType',
-			templateType,
-			templateId
-		);
-
+	( select ) => () => {
 		const templateParts = select( coreDataStore ).getEntityRecords(
 			'postType',
 			TEMPLATE_PART_POST_TYPE,
 			{ per_page: -1 }
 		);
 
-		return getFilteredTemplatePartBlocks( template.blocks, templateParts );
+		const clientIs =
+			select( blockEditorStore ).__experimentalGetGlobalBlocksByName(
+				'core/template-part'
+			);
+		const blocks =
+			select( blockEditorStore ).getBlocksByClientId( clientIs );
+
+		return getFilteredTemplatePartBlocks( blocks, templateParts );
 	}
 );
 


### PR DESCRIPTION
## What?
Fixes #55061.
Alternative to #55085.

PR fixes the getCurrentTemplateTemplateParts selector returning an empty value when a template has no edits.

This is probably a side-effect of #52417.

Update: If anyone is wondering why areas are displayed when a template has no edits at all (loaded from the file). This is due to blocks like Query and core/pattern performing updates on the initial load. This loads blocks in the store.

## Why?
A record returned by `getEditedEntityRecord` will have an undefined `block` property when an entity has no edits. In the past, blocks were loaded into the store for a current recond via `useEntityBlockEditor`. This isn't the case anymore.

## How?
Use blocks from the block editor store. We can get all template part block `clientIds` with `__experimentalGetGlobalBlocksByName` and then grab block objects using `getBlocksByClientId`.


## Testing Instructions
1. Open a Site Editor.
2. Open the home template.
3. Make some edits, save and reload.
4. Confirm template areas are still listed in both template detail sidebars.
5. Confirm that clicking on the areas performs the intended action. Left sidebar - opens the template part. The right sidebar - selects the template part in the canvas.


## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-10-05 at 16 28 59](https://github.com/WordPress/gutenberg/assets/240569/26609ef5-3640-48ec-b751-df9beb53f5c0)
