### PR TITLE
Remove the lightbox filter and view file when the lightbox setting is disabled.

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -39,16 +39,6 @@ function render_block_core_image( $attributes, $content, $block ) {
 	$script_handles      = $block->block_type->view_script_handles;
 
 	/*
-	 * Remove the filter and the JavaScript view file if previously added by
-	 * other Image blocks.
-	 */
-	remove_filter( 'render_block_core/image', 'block_core_image_render_lightbox', 15 );
-	// If the script is not needed, and it is still in the `view_script_handles`, remove it.
-	if ( in_array( $view_js_file_handle, $script_handles, true ) ) {
-		$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_js_file_handle ) );
-	}
-
-	/*
 	 * If the lightbox is enabled and the image is not linked, add the filter
 	 * and the JavaScript view file.
 	 */
@@ -73,6 +63,16 @@ function render_block_core_image( $attributes, $content, $block ) {
 		 * rendered changes, or if a new kind of filter is introduced.
 		 */
 		add_filter( 'render_block_core/image', 'block_core_image_render_lightbox', 15, 2 );
+	} else {
+		/*
+		* Remove the filter and the JavaScript view file if previously added by
+		* other Image blocks.
+		*/
+		remove_filter( 'render_block_core/image', 'block_core_image_render_lightbox', 15 );
+		// If the script is not needed, and it is still in the `view_script_handles`, remove it.
+		if ( in_array( $view_js_file_handle, $script_handles, true ) ) {
+			$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_js_file_handle ) );
+		}
 	}
 
 	return $processor->get_updated_html();

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -65,9 +65,9 @@ function render_block_core_image( $attributes, $content, $block ) {
 		add_filter( 'render_block_core/image', 'block_core_image_render_lightbox', 15, 2 );
 	} else {
 		/*
-		* Remove the filter and the JavaScript view file if previously added by
-		* other Image blocks.
-		*/
+		 * Remove the filter and the JavaScript view file if previously added by
+		 * other Image blocks.
+		 */
 		remove_filter( 'render_block_core/image', 'block_core_image_render_lightbox', 15 );
 		// If the script is not needed, and it is still in the `view_script_handles`, remove it.
 		if ( in_array( $view_js_file_handle, $script_handles, true ) ) {

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -32,44 +32,46 @@ function render_block_core_image( $attributes, $content, $block ) {
 		$processor->set_attribute( 'data-id', $attributes['data-id'] );
 	}
 
-	$lightbox_enabled  = false;
 	$link_destination  = isset( $attributes['linkDestination'] ) ? $attributes['linkDestination'] : 'none';
 	$lightbox_settings = block_core_image_get_lightbox_settings( $block->parsed_block );
 
-	// If the lightbox is enabled and the image is not linked, flag the lightbox to be rendered.
-	if ( isset( $lightbox_settings ) && 'none' === $link_destination ) {
+	$view_js_file_handle = 'wp-block-image-view';
+	$script_handles      = $block->block_type->view_script_handles;
 
-		if ( isset( $lightbox_settings['enabled'] ) && true === $lightbox_settings['enabled'] ) {
-			$lightbox_enabled = true;
-		}
+	/*
+	 * Remove the filter and the JavaScript view file if previously added by
+	 * other Image blocks.
+	 */
+	remove_filter( 'render_block_core/image', 'block_core_image_render_lightbox', 15 );
+	// If the script is not needed, and it is still in the `view_script_handles`, remove it.
+	if ( in_array( $view_js_file_handle, $script_handles, true ) ) {
+		$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_js_file_handle ) );
 	}
 
-	// If at least one block in the page has the lightbox, mark the block type as interactive.
-	if ( $lightbox_enabled ) {
+	/*
+	 * If the lightbox is enabled and the image is not linked, add the filter
+	 * and the JavaScript view file.
+	 */
+	if (
+		isset( $lightbox_settings ) &&
+		'none' === $link_destination &&
+		isset( $lightbox_settings['enabled'] ) &&
+		true === $lightbox_settings['enabled']
+	) {
 		$block->block_type->supports['interactivity'] = true;
-	}
 
-	// Determine whether the view script should be enqueued or not.
-	$view_js_file = 'wp-block-image-view';
-	if ( ! wp_script_is( $view_js_file ) ) {
-		$script_handles = $block->block_type->view_script_handles;
-
-		// If the script is not needed, and it is still in the `view_script_handles`, remove it.
-		if ( ! $lightbox_enabled && in_array( $view_js_file, $script_handles, true ) ) {
-			$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_js_file ) );
+		if ( ! in_array( $view_js_file_handle, $script_handles, true ) ) {
+			$block->block_type->view_script_handles = array_merge( $script_handles, array( $view_js_file_handle ) );
 		}
-		// If the script is needed, but it was previously removed, add it again.
-		if ( $lightbox_enabled && ! in_array( $view_js_file, $script_handles, true ) ) {
-			$block->block_type->view_script_handles = array_merge( $script_handles, array( $view_js_file ) );
-		}
-	}
 
-	if ( $lightbox_enabled ) {
-		// This render needs to happen in a filter with priority 15 to ensure that it
-		// runs after the duotone filter and that duotone styles are applied to the image
-		// in the lightbox. We also need to ensure that the lightbox works with any plugins
-		// that might use filters as well. We can consider removing this in the future if the
-		// way the blocks are rendered changes, or if a new kind of filter is introduced.
+		/*
+		 * This render needs to happen in a filter with priority 15 to ensure
+		 * that it runs after the duotone filter and that duotone styles are
+		 * applied to the image in the lightbox. We also need to ensure that the
+		 * lightbox works with any plugins that might use filters as well. We
+		 * can consider removing this in the future if the way the blocks are
+		 * rendered changes, or if a new kind of filter is introduced.
+		 */
 		add_filter( 'render_block_core/image', 'block_core_image_render_lightbox', 15, 2 );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/55119

## What?
<!-- In a few words, what is the PR actually doing? -->
With multiple image block on a page, setting one image to open in the lightbox makes all following images open in the lightbox, even if the related setting is disabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Clearly not the expected behavior.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Makes sure the filter that adds the lightbox markup and the view JavaScript file are removed when not needed.
- Simplifies the code as there is really no need to set a `$lightbox_enabled` flag that stays true for all the following blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Create a post.
- Add four image blocks.
- Set only the second image block to open the image in the lightbox.
- Publish and view the front end.
- Observe the first image has no lightbox enabled.
- Observe the second image does have the lightbox enabled, as expected.
- Check the lightbox works as expected.
- Observe the third image has no lightbox enabled, as expected.
- Observe the fourth image has no lightbox enabled, as expevted.

Additionally:
- Set only the first image to open in the lightbox.
- Save and view the front end.
- Observe that only the first image opens in the lightbox.
- Check the lightbox works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
