### PR TITLE
List: fix forward merging of nested list

### DIFF
--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1361,11 +1361,8 @@ test.describe( 'List (@firefox)', () => {
 <!-- /wp:list -->` );
 	} );
 
-	test( 'should merge two list items with nested lists', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( {
+	test.describe( 'should merge two list items with nested lists', () => {
+		const start = {
 			name: 'core/list',
 			innerBlocks: [
 				{
@@ -1399,22 +1396,8 @@ test.describe( 'List (@firefox)', () => {
 					],
 				},
 			],
-		} );
-
-		// Navigate to the third item.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowDown' );
-
-		await page.keyboard.press( 'Backspace' );
-
-		// Test caret position.
-		await page.keyboard.type( '‸' );
-
-		await expect.poll( editor.getBlocks ).toMatchObject( [
+		};
+		const end = [
 			{
 				name: 'core/list',
 				innerBlocks: [
@@ -1439,6 +1422,43 @@ test.describe( 'List (@firefox)', () => {
 					},
 				],
 			},
-		] );
+		];
+
+		test( 'Backspace', async ( { editor, page } ) => {
+			await editor.insertBlock( start );
+
+			// Navigate to the start of the third item.
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+
+			await page.keyboard.press( 'Backspace' );
+
+			// Test caret position.
+			await page.keyboard.type( '‸' );
+
+			await expect.poll( editor.getBlocks ).toMatchObject( end );
+		} );
+
+		test( 'Delete (forward)', async ( { editor, page } ) => {
+			await editor.insertBlock( start );
+
+			// Navigate to the end of the second item.
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowRight' );
+
+			await page.keyboard.press( 'Delete' );
+
+			// Test caret position.
+			await page.keyboard.type( '‸' );
+
+			await expect.poll( editor.getBlocks ).toMatchObject( end );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #53353. Does what #52949 does, but for forward merging as well.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

With this setup:

* parent 1
  * child 1.1 ↦
* parent 2
  * child 2.1
  
Press the Delete key (forward Backspace, fn+Backspace on Mac) at the position of ↦. Now check the List View panel and make sure that there are no list items with two lists.

I added an e2e test.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
