### PR TITLE
Template Parts: Add a replace flow to the inspector controls

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -32,6 +32,7 @@ import {
 	useAlternativeBlockPatterns,
 	useAlternativeTemplateParts,
 	useTemplatePartArea,
+	useCreateTemplatePartFromBlocks,
 } from './utils/hooks';
 
 function ReplaceButton( {
@@ -155,6 +156,11 @@ export default function TemplatePartEdit( {
 		hasReplacements &&
 		( area === 'header' || area === 'footer' );
 
+	const createFromBlocks = useCreateTemplatePartFromBlocks(
+		area,
+		setAttributes
+	);
+
 	// We don't want to render a missing state if we have any inner blocks.
 	// A new template part is automatically created if we have any inner blocks but no entity.
 	if (
@@ -189,13 +195,12 @@ export default function TemplatePartEdit( {
 	const partsAsPatterns = templateParts.map( ( templatePart ) =>
 		mapTemplatePartToBlockPattern( templatePart )
 	);
-	const patternsAndParts = [ ...blockPatterns, ...partsAsPatterns ];
 
-	const onTemplatePartSelect = ( { templatePart } ) => {
+	const onTemplatePartSelect = ( templatePart ) => {
 		setAttributes( {
 			slug: templatePart.slug,
 			theme: templatePart.theme,
-			area: templatePart.area,
+			area: undefined,
 		} );
 		createSuccessNotice(
 			sprintf(
@@ -263,16 +268,31 @@ export default function TemplatePartEdit( {
 					} }
 				</BlockSettingsMenuControls>
 
-				{ canReplace && patternsAndParts.length && (
-					<InspectorControls>
-						<PanelBody title={ __( 'Replace' ) }>
-							<TemplatesList
-								availableTemplates={ patternsAndParts }
-								onSelect={ onTemplatePartSelect }
-							/>
-						</PanelBody>
-					</InspectorControls>
-				) }
+				{ canReplace &&
+					( partsAsPatterns.length > 0 ||
+						blockPatterns.length > 0 ) && (
+						<InspectorControls>
+							<PanelBody title={ __( 'Replace' ) }>
+								<TemplatesList
+									availableTemplates={ partsAsPatterns }
+									onSelect={ ( pattern ) => {
+										onTemplatePartSelect(
+											pattern.templatePart
+										);
+									} }
+								/>
+								<TemplatesList
+									availableTemplates={ blockPatterns }
+									onSelect={ ( pattern, blocks ) => {
+										createFromBlocks(
+											blocks,
+											pattern.title
+										);
+									} }
+								/>
+							</PanelBody>
+						</InspectorControls>
+					) }
 
 				{ isEntityAvailable && (
 					<TemplatePartInnerBlocks

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -74,7 +74,7 @@ function ReplaceButton( {
 function TemplatesList( { availableTemplates, onSelect } ) {
 	const shownTemplates = useAsyncList( availableTemplates );
 
-	if ( ! availableTemplates || availableTemplates?.length < 2 ) {
+	if ( ! availableTemplates ) {
 		return null;
 	}
 

--- a/packages/block-library/src/template-part/edit/selection-modal.js
+++ b/packages/block-library/src/template-part/edit/selection-modal.js
@@ -5,7 +5,6 @@ import { useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
-import { parse } from '@wordpress/blocks';
 import { useAsyncList } from '@wordpress/compose';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import {
@@ -21,7 +20,7 @@ import {
 	useAlternativeTemplateParts,
 	useCreateTemplatePartFromBlocks,
 } from './utils/hooks';
-import { createTemplatePartId } from './utils/create-template-part-id';
+import { mapTemplatePartToBlockPattern } from './utils/map-template-part-to-block-pattern';
 import { searchPatterns } from '../../utils/search-patterns';
 
 export default function TemplatePartSelectionModal( {
@@ -39,12 +38,9 @@ export default function TemplatePartSelectionModal( {
 	);
 	// We can map template parts to block patters to reuse the BlockPatternsList UI
 	const filteredTemplateParts = useMemo( () => {
-		const partsAsPatterns = templateParts.map( ( templatePart ) => ( {
-			name: createTemplatePartId( templatePart.theme, templatePart.slug ),
-			title: templatePart.title.rendered,
-			blocks: parse( templatePart.content.raw ),
-			templatePart,
-		} ) );
+		const partsAsPatterns = templateParts.map( ( templatePart ) =>
+			mapTemplatePartToBlockPattern( templatePart )
+		);
 
 		return searchPatterns( partsAsPatterns, searchValue );
 	}, [ templateParts, searchValue ] );

--- a/packages/block-library/src/template-part/edit/utils/map-template-part-to-block-pattern.js
+++ b/packages/block-library/src/template-part/edit/utils/map-template-part-to-block-pattern.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { createTemplatePartId } from './create-template-part-id';
+
+/**
+ * This maps the properties of a template part to those of a block pattern.
+ * @param {Object} templatePart
+ * @return {Object} The template part in the shape of block pattern.
+ */
+export function mapTemplatePartToBlockPattern( templatePart ) {
+	return {
+		name: createTemplatePartId( templatePart.theme, templatePart.slug ),
+		title: templatePart.title.rendered,
+		blocks: parse( templatePart.content.raw ),
+		templatePart,
+	};
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This exposes the option to replace a template part with another, from the inspector controls for the block. This is similar to the idea in https://github.com/WordPress/gutenberg/issues/44582.

## Why?
It's already possible to do this, using the "replace" option in the More Settings for the block in the toolbar, but this isn't very discoverable, so adding it to the inspector controls makes it easier to do.

## How?
Just add block previews in the sidebar and then hook them up to the setAttribute function to switch the slugs for the template part.

## Testing Instructions
0. Switch to a theme that has multiple template parts for each template area (TT4 has 4 footer template parts)
1. Open the site editor
2. Go to Templates
3. Select a template part block that has an area specified (e.g. the footer in TT4)
4. Open the inspector controls
5. Confirm that you see 2 other footer template parts 
6. Click on one of these template parts
7. Confirm that the template is updated with the new footer template part

## Screenshots or screencast <!-- if applicable -->
<img width="1035" alt="Screenshot 2023-10-06 at 14 49 26" src="https://github.com/WordPress/gutenberg/assets/275961/f9bea437-0be2-49ae-9315-d3991220ee19">

## Questions
1. Is it OK to only show other template parts here, or should we show patterns too?
9. Should I add a link to open the modal that has more options?