### PR TITLE
Font-Library Modal: implement new `size` prop with a fixed height

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -51,7 +51,7 @@ function FontLibraryModal( {
 		<Modal
 			title={ __( 'Fonts' ) }
 			onRequestClose={ onRequestClose }
-			isFullScreen
+			size="large"
 			className="font-library-modal"
 		>
 			<TabPanel

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -1,11 +1,12 @@
 .font-library-modal {
-	// @todo: If a new prop is added to the Modal component that constrains
-	// the content width, we should use that prop instead of this style.
-	// see https://github.com/WordPress/gutenberg/issues/54471.
+	// @todo: If a new prop is added to the Modal component that fixes the height
+	// and/or constrains the origin, we should use that instead of this style.
+	// see https://github.com/WordPress/gutenberg/issues/55062.
 	&.font-library-modal {
 
 		@include break-medium() {
-			width: 65vw;
+			height: calc(100% - #{ $grid-unit-50 * 2 }); /* match full-screen `Modal` height */
+			max-height: none;
 		}
 	}
 


### PR DESCRIPTION
Related: 
- #54518
- #55062

## What?
Implement `Modal`'s new `size` prop to replace the current temporary fix.

## Why?
Before the `size` prop was introduced, the `isFullScreen` prop was used to make the Font Library `Modal` tall enough to comfortably hold all three of its internal tabs, while the width was fixed at `65vw` via CSS. This was an effective fix but the new prop makes things a little more clear.

## How?
Setting the `Modal` to `size="large"` instead of using the full-screen view eliminates the need for a fixed width. It does require a fixed _height_ instead, which was discussed in #55062.

I chose the `large` size because I felt like it balanced well across the Font Library's different tabs. `medium` looked a little better for the "Library" tab, but left the other two tabs feeling a bit cramped.

Future updates to `Modal` may introduce new props and/or height constraints that will make this custom style unneeded, at which point we'll revisit/remove this style. If those aren't added, this will likely be the recommended way to manage `Modal` heights going forward, and we'll just remove the `todo` comment.

## Testing Instructions
- Open the site editor and edit a page template or style
- Open they Styles sidebar, select Typography, and click on one of the listed font names to open the Font Library
- Confirm that on medium and large viewports, the `Modal` is full height and has the `has-size-large` class applied
- Confirm that on small viewports, the `Modal` is full screen
- Confirm that switching tabs within the Font Library does not cause the `Modal` height to change.

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast <!-- if applicable -->

**Before:**
![image](https://github.com/WordPress/gutenberg/assets/13856531/2ccb0302-cee1-48a6-ba5e-c3ccf30e16be)

**After:**
![image](https://github.com/WordPress/gutenberg/assets/13856531/eefbeca4-090b-43ee-9e0f-02118193b8a6)
