### PR TITLE
Writing flow: preserve block when merging into empty paragraph

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -494,6 +494,8 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 					}
 
 					moveFirstItemUp( rootClientId );
+				} else {
+					removeBlock( clientId );
 				}
 			}
 		},

--- a/packages/block-editor/src/components/rich-text/use-delete.js
+++ b/packages/block-editor/src/components/rich-text/use-delete.js
@@ -43,7 +43,7 @@ export function useDelete( props ) {
 				// an intentional user interaction distinguishing between Backspace and
 				// Delete to remove the empty field, but also to avoid merge & remove
 				// causing destruction of two fields (merge, then removed merged).
-				if ( onRemove && isEmpty( value ) && isReverse ) {
+				else if ( onRemove && isEmpty( value ) && isReverse ) {
 					onRemove( ! isReverse );
 				}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1014,17 +1014,12 @@ export const mergeBlocks =
 
 		if ( ! blockAType ) return;
 
-		if (
-			! blockAType.merge &&
-			! getBlockSupport( blockA.name, '__experimentalOnMerge' )
-		) {
-			dispatch.selectBlock( blockA.clientId );
-			return;
-		}
-
 		const blockB = select.getBlock( clientIdB );
 
-		if ( ! blockAType.merge ) {
+		if (
+			! blockAType.merge &&
+			getBlockSupport( blockA.name, '__experimentalOnMerge' )
+		) {
 			// If there's no merge function defined, attempt merging inner
 			// blocks.
 			const blocksWithTheSameType = switchToBlockType(

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1102,6 +1102,11 @@ export const mergeBlocks =
 			return;
 		}
 
+		if ( ! blockAType.merge ) {
+			dispatch.selectBlock( blockA.clientId );
+			return;
+		}
+
 		const blockBType = getBlockType( blockB.name );
 		const { clientId, attributeKey, offset } = select.getSelectionStart();
 		const selectedBlockType =

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -13,6 +13,7 @@ import {
 	switchToBlockType,
 	synchronizeBlocksWithTemplate,
 	getBlockSupport,
+	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
 import { speak } from '@wordpress/a11y';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -1009,6 +1010,12 @@ export const mergeBlocks =
 
 		const [ clientIdA, clientIdB ] = blocks;
 		const blockA = select.getBlock( clientIdA );
+
+		if ( isUnmodifiedDefaultBlock( blockA ) ) {
+			dispatch.removeBlock( clientIdA, false );
+			return;
+		}
+
 		const blockAType = getBlockType( blockA.name );
 
 		if ( ! blockAType ) return;

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1012,7 +1012,20 @@ export const mergeBlocks =
 		const blockA = select.getBlock( clientIdA );
 
 		if ( isUnmodifiedDefaultBlock( blockA ) ) {
-			dispatch.removeBlock( clientIdA, false );
+			dispatch.removeBlock(
+				clientIdA,
+				select.isBlockSelected( clientIdA )
+			);
+			return;
+		}
+
+		const blockB = select.getBlock( clientIdB );
+
+		if ( isUnmodifiedDefaultBlock( blockB ) ) {
+			dispatch.removeBlock(
+				clientIdB,
+				select.isBlockSelected( clientIdB )
+			);
 			return;
 		}
 
@@ -1027,8 +1040,6 @@ export const mergeBlocks =
 			dispatch.selectBlock( blockA.clientId );
 			return;
 		}
-
-		const blockB = select.getBlock( clientIdB );
 
 		if ( ! blockAType.merge ) {
 			// If there's no merge function defined, attempt merging inner

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1010,25 +1010,6 @@ export const mergeBlocks =
 
 		const [ clientIdA, clientIdB ] = blocks;
 		const blockA = select.getBlock( clientIdA );
-
-		if ( isUnmodifiedDefaultBlock( blockA ) ) {
-			dispatch.removeBlock(
-				clientIdA,
-				select.isBlockSelected( clientIdA )
-			);
-			return;
-		}
-
-		const blockB = select.getBlock( clientIdB );
-
-		if ( isUnmodifiedDefaultBlock( blockB ) ) {
-			dispatch.removeBlock(
-				clientIdB,
-				select.isBlockSelected( clientIdB )
-			);
-			return;
-		}
-
 		const blockAType = getBlockType( blockA.name );
 
 		if ( ! blockAType ) return;
@@ -1040,6 +1021,8 @@ export const mergeBlocks =
 			dispatch.selectBlock( blockA.clientId );
 			return;
 		}
+
+		const blockB = select.getBlock( clientIdB );
 
 		if ( ! blockAType.merge ) {
 			// If there's no merge function defined, attempt merging inner
@@ -1105,6 +1088,22 @@ export const mergeBlocks =
 					}
 				}
 			} );
+			return;
+		}
+
+		if ( isUnmodifiedDefaultBlock( blockA ) ) {
+			dispatch.removeBlock(
+				clientIdA,
+				select.isBlockSelected( clientIdA )
+			);
+			return;
+		}
+
+		if ( isUnmodifiedDefaultBlock( blockB ) ) {
+			dispatch.removeBlock(
+				clientIdB,
+				select.isBlockSelected( clientIdB )
+			);
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #16436.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When merging a heading into an empty paragraph, the heading should be preserved and the paragraph removed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
