### PR TITLE
(WP 6.4-compat) Add missing `type` attribute in WP 6.4 compat's `block-hooks.php`

### DIFF
--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -290,7 +290,7 @@ function gutenberg_register_block_hooks_rest_field() {
 		array(
 			'schema' => array(
 				'description'       => __( 'This block is automatically inserted near any occurence of the block types used as keys of this map, into a relative position given by the corresponding value.', 'gutenberg' ),
-				'type' => 'object',
+				'type'              => 'object',
 				'patternProperties' => array(
 					'^[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$' => array(
 						'type' => 'string',

--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -290,6 +290,7 @@ function gutenberg_register_block_hooks_rest_field() {
 		array(
 			'schema' => array(
 				'description'       => __( 'This block is automatically inserted near any occurence of the block types used as keys of this map, into a relative position given by the corresponding value.', 'gutenberg' ),
+				'type' => 'object',
 				'patternProperties' => array(
 					'^[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$' => array(
 						'type' => 'string',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Add missing `type` attribute in WP 6.4 compat's `block-hooks.php`

## Why?

Activating Gutenberg 16.7+ in an env with WP 6.4 is causing failures in the following test: https://github.com/WordPress/wordpress-develop/blob/36d4e7ebcc2deb9ec9de7f4ffc4161135f87d1c5/tests/phpunit/tests/rest-api/rest-block-type-controller.php, because Gutenberg does not define the type in schema for block-type and block-hooks fields in its back compat shim. Example of a failure (there are around 10 if you try running it):

```
Unexpected incorrect usage notice for rest_sanitize_value_from_schema.
The "type" schema keyword for  is required. (This message was added in version 5.5.0.)
Failed asserting that an array is empty.
```

## How?

See "What". 

## Testing Instructions

1. Without applying this patch, Install Gutenberg 16.7 (or `trunk`) in a dev version of WP 6.4 with PHPUnit tests setup
2. Run https://github.com/WordPress/wordpress-develop/blob/36d4e7ebcc2deb9ec9de7f4ffc4161135f87d1c5/tests/phpunit/tests/rest-api/rest-block-type-controller.php;
3. Verify that tests fail;
4. Now build a new GB from this branch and install it in that WP 6.4 env
5. Run the test again - it should pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
