### PR TITLE
Platform docs: Add a page to explain how to render HTML from a list of blocks

### DIFF
--- a/platform-docs/docs/basic-concepts/rendering.md
+++ b/platform-docs/docs/basic-concepts/rendering.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 ## HTML Serialization and Parsing
 
-After editing your blocks, you may choose to persist them as JSON, or serialize them to HTML.
+After editing your blocks, you may choose to persist them as JSON or serialize them to HTML.
 
 Given a block list object, you can retrieve an initial HTML version like so:
 
@@ -35,6 +35,6 @@ const blockList = parse( html );
 
 ## Going further
 
-Some of the customizations that the core blocks offer: like layout styles do not output the necessary CSS using the `serialize` function. Instead in the editor, an additional style element is appended to the document head. This is done to avoid bloating the HTML output with unnecessary CSS.
+Some of the customizations that the core blocks offer, like layout styles, do not output the necessary CSS using the `serialize` function. Instead in the editor, an additional style element is appended to the document head. This is done to avoid bloating the HTML output with unnecessary CSS.
 
 We're currently working on providing a utility that allows you to render blocks with all the necessary CSS.

--- a/platform-docs/docs/basic-concepts/rendering.md
+++ b/platform-docs/docs/basic-concepts/rendering.md
@@ -3,3 +3,38 @@ sidebar_position: 8
 ---
 
 # Rendering blocks
+
+## HTML Serialization and Parsing
+
+After editing your blocks, you may choose to persist them as JSON, or serialize them to HTML.
+
+Given a block list object, you can retrieve an initial HTML version like so:
+
+```js
+import { serialize } from '@wordpress/blocks';
+
+const blockList = [
+    {
+        name: 'core/paragraph',
+        attributes: {
+            content: 'Hello world!',
+        },
+    },
+];
+
+const html = serialize( blockList );
+```
+
+If needed, it is also possible to parse back the HTML into a block list object:
+
+```js
+import { parse } from '@wordpress/blocks';
+
+const blockList = parse( html );
+```
+
+## Going further
+
+Some of the customizations that the core blocks offer: like layout styles do not output the necessary CSS using the `serialize` function. Instead in the editor, an additional style element is appended to the document head. This is done to avoid bloating the HTML output with unnecessary CSS.
+
+We're currently working on providing a utility that allows you to render blocks with all the necessary CSS.


### PR DESCRIPTION
Related #53874

## What?

This PR add a small documentation page explaining how to possibly render a block list edited using the Gutenberg Block Editor.

It is very basic at the moment, and also it's not complete since we're missing the work in #54047 

### Test the documentation website

```
cd platform-docs
npm install
npm start
```