### PR TITLE
Image: Disable lightbox editor UI for linked images

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -377,6 +377,8 @@ export default function Image( {
 	const lightboxChecked =
 		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );
 
+	const lightboxToggleDisabled = linkDestination !== 'none';
+
 	const dimensionsControl = (
 		<DimensionsTool
 			value={ { width, height, scale, aspectRatio } }
@@ -555,6 +557,14 @@ export default function Image( {
 										lightbox: { enabled: newValue },
 									} );
 								} }
+								disabled={ lightboxToggleDisabled }
+								help={
+									lightboxToggleDisabled
+										? __(
+												'Expand on Click is disabled for linked images.'
+										  )
+										: ''
+								}
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -561,7 +561,7 @@ export default function Image( {
 								help={
 									lightboxToggleDisabled
 										? __(
-												'Expand on Click is disabled for linked images.'
+												'“Expand on click” scales the image up, and can’t be combined with a link.'
 										  )
 										: ''
 								}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR disables the lightbox editor UI when a link has been configured for an image.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/54916
Configured links for images will override the lightbox, so we should provide an indication in the UI to signal this to the user.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It checks to see if a link has been defined — if so, it disables the Expand on Click toggle and displays a help message.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add an image to a post.
2. Add a link to the image.
3. See that that Expand on Click toggle has been disabled.

Additionally, try toggling on Expand on Click before adding a link — see the toggle still gets disabled as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
<img width="1661" alt="Screenshot 2023-10-06 at 5 29 41 PM" src="https://github.com/WordPress/gutenberg/assets/5360536/8310f1a0-bec6-4d9f-bb93-849c5c7cfb13">
