### PR TITLE
Allow button blocks to be inserted from the "Add Link" modal.

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -85,6 +85,7 @@ function LinkControlTransforms( { clientId } ) {
 	const { replaceBlock } = useDispatch( blockEditorStore );
 
 	const featuredBlocks = [
+		'core/buttons',
 		'core/page-list',
 		'core/site-logo',
 		'core/social-links',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Buttons block can be added by clicking on the [+] that appears inline in the navigation block.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Bug fix.

fix: #54877 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add `core/buttons` to `featuredBlocks` in `<LinkUI />`.

## Testing Instructions
1. Edit site
2. Edit navigaton
3. Click Add Block button in navigation.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1908815/b18e6d34-096f-4401-931f-3690d82db9ea

