### PR TITLE
Iframe / block drag chip: Fix positioning when dragging over an iframe

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -38,7 +38,14 @@ function bubbleEvent( event, Constructor, frame ) {
 		init[ key ] = event[ key ];
 	}
 
-	if ( event instanceof frame.ownerDocument.defaultView.MouseEvent ) {
+	// Check if the event is a MouseEvent generated within the iframe.
+	// If so, adjust the coordinates to be relative to the position of
+	// the iframe. This ensures that components such as Draggable
+	// receive coordinates relative to the window, instead of relative
+	// to the iframe. Without this, the Draggable event handler would
+	// result in components "jumping" position as soon as the user
+	// drags over the iframe.
+	if ( event instanceof frame.contentDocument.defaultView.MouseEvent ) {
 		const rect = frame.getBoundingClientRect();
 		init.clientX += rect.left;
 		init.clientY += rect.top;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #55074

Fix issue where dragged components would "jump" when dragged over the editor iframe.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #54080 the `bubbleEvents` function for the iframe was refactored so that a reusable `bubbleEvent` handler could be used to enable bubbling up keyboard events. However, that change unintentionally introduced a change to the check that determines whether to add an offset to the `clientX` and `clientY` positions of mouse events. Prior to #54080 the check was to see whether the event was an instance of the `contentDocument`'s `MouseEvent`, however #54080 used `ownerDocument`.

It's a subtle difference, but checking against the `contentDocument` means that we're checking the event was generated within the iframe, whereas checking against the `ownerDocument` checks that the event was generated by the owner document, which is not where we want the offset to be applied. In practice, on `trunk` the logic for the offset was never being hit, because the if statement appeared to always evaluate to `false`.

Note: this PR does _not_ fix the issue in Storybook when using the `Docs` view for the `Draggable` component as described in #55074 — I believe that's because the Docs view in Storybook is not using the `Iframe` component from the block editor package, so it never receives the offset logic for the event.

An alternative could potentially be to include logic like what's in the `Iframe` component for the `Draggable` component, but that's outside the scope of this PR — the goal (and proposal) of this PR is to get back to the working state prior to #54080 🤞 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the check within `bubbleEvent` to use `contentDocument` instead of `ownerDocument` so that we're checking that the event occurred within the iframe.
* Add an explanatory comment to capture the desired behaviour.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. On `trunk` drag a block from the list view into the post editor canvas, notice that the drag chip position jumps
2. Repeat in the site editor and / or dragging a block from the block inserter
3. Apply this PR, and check that the positioning is now correct

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2023-10-09 15 52 22](https://github.com/WordPress/gutenberg/assets/14988353/832437b9-a957-4cfc-b1fe-de16052ce9a4) | ![2023-10-09 15 50 26](https://github.com/WordPress/gutenberg/assets/14988353/826065cd-73b3-4e98-a922-bc8ef7944dd4) |