### PR TITLE
Iframe: try proper URL instead of blob

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -594,3 +594,24 @@ remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
 // Enqueue stored styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
+
+add_action( 'template_redirect', function() {
+	if ( ! isset( $_GET['gutenberg-iframe'] ) ) {
+		return;
+	}
+
+	$assets = _gutenberg_get_iframed_editor_assets_6_4();
+	?><!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<script>window.frameElement._load()</script>
+		<style>html{height:auto!important;min-height:100%;}body{margin:0}</style>
+		<?php echo $assets['styles'] ?>
+		<?php echo $assets['scripts'] ?>
+	</head>
+	<body>
+		<script>document.currentScript.parentElement.remove()</script>
+	</body>
+</html><?php
+}, 0 );

--- a/lib/compat/wordpress-6.4/script-loader.php
+++ b/lib/compat/wordpress-6.4/script-loader.php
@@ -195,6 +195,7 @@ add_filter(
 	static function ( $settings ) {
 		// We must override what core is passing now.
 		$settings['__unstableResolvedAssets'] = _gutenberg_get_iframed_editor_assets_6_4();
+		$settings['__unstablePreviewUrl'] = get_site_url( null, '?gutenberg-iframe' );
 		return $settings;
 	}
 );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -103,11 +103,12 @@ function Iframe( {
 	forwardedRef: ref,
 	...props
 } ) {
-	const { resolvedAssets, isPreviewMode } = useSelect( ( select ) => {
+	const { resolvedAssets, isPreviewMode, url } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 		return {
 			resolvedAssets: settings.__unstableResolvedAssets,
 			isPreviewMode: settings.__unstableIsPreviewMode,
+			url: settings.__unstablePreviewUrl,
 		};
 	}, [] );
 	const { styles = '', scripts = '' } = resolvedAssets;
@@ -221,11 +222,13 @@ function Iframe( {
 </html>`;
 
 	const [ src, cleanup ] = useMemo( () => {
-		const _src = URL.createObjectURL(
-			new window.Blob( [ html ], { type: 'text/html' } )
-		);
-		return [ _src, () => URL.revokeObjectURL( _src ) ];
-	}, [ html ] );
+		const _src =
+			url ??
+			URL.createObjectURL(
+				new window.Blob( [ html ], { type: 'text/html' } )
+			);
+		return [ _src, () => ! html && URL.revokeObjectURL( _src ) ];
+	}, [ html, url ] );
 
 	useEffect( () => cleanup, [ cleanup ] );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -103,15 +103,13 @@ function Iframe( {
 	forwardedRef: ref,
 	...props
 } ) {
-	const { resolvedAssets, isPreviewMode, url } = useSelect( ( select ) => {
+	const { isPreviewMode, url } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 		return {
-			resolvedAssets: settings.__unstableResolvedAssets,
 			isPreviewMode: settings.__unstableIsPreviewMode,
 			url: settings.__unstablePreviewUrl,
 		};
 	}, [] );
-	const { styles = '', scripts = '' } = resolvedAssets;
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
 	const compatStyles = useCompatibilityStyles();
@@ -213,8 +211,6 @@ function Iframe( {
 		<meta charset="utf-8">
 		<script>window.frameElement._load()</script>
 		<style>html{height:auto!important;min-height:100%;}body{margin:0}</style>
-		${ styles }
-		${ scripts }
 	</head>
 	<body>
 		<script>document.currentScript.parentElement.remove()</script>

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -270,4 +270,5 @@ export const SETTINGS_DEFAULTS = {
 	],
 
 	__unstableResolvedAssets: { styles: [], scripts: [] },
+	__unstablePreviewUrl: '',
 };

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -269,6 +269,5 @@ export const SETTINGS_DEFAULTS = {
 		},
 	],
 
-	__unstableResolvedAssets: { styles: [], scripts: [] },
 	__unstablePreviewUrl: '',
 };

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -75,6 +75,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableHasCustomAppender',
 	'__unstableIsPreviewMode',
 	'__unstableResolvedAssets',
+	'__unstablePreviewUrl',
 	'__unstableIsBlockBasedTheme',
 ];
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -74,7 +74,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'widgetTypesToHideFromLegacyWidgetBlock',
 	'__unstableHasCustomAppender',
 	'__unstableIsPreviewMode',
-	'__unstableResolvedAssets',
 	'__unstablePreviewUrl',
 	'__unstableIsBlockBasedTheme',
 ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Blob URLs are not working for Playground in some cases (@adamziel could you elaborate on which cases? Non static resources?) because the iframe is not controlled by the service worker. https://github.com/WordPress/wordpress-playground/issues/646#issuecomment-1743044654

This PR has the potential to fix that by using the http protocol.

Upside: there's no longer a need to pass assets to JS.
Downside: what about standalone Gutenberg? We need a blob fallback...

Alternative: keep a Playground patch and ServiceWorker to be fixed in Chrome for iframeDoc and blob URLs. https://github.com/w3c/ServiceWorker/issues/765

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
