### PR TITLE
Fix wrong notification message shown when an entity is moved to trash

### DIFF
--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -33,6 +33,7 @@ const postTypeEntity = {
 		item_updated: 'Updated Post',
 		item_published: 'Post published',
 		item_reverted_to_draft: 'Post reverted to draft.',
+		item_trashed: 'Post trashed.',
 	},
 };
 
@@ -286,7 +287,12 @@ describe( 'Post actions', () => {
 
 			// Check that there are no notices.
 			const notices = registry.select( noticesStore ).getNotices();
-			expect( notices ).toEqual( [] );
+			expect( notices ).toMatchObject( [
+				{
+					status: 'success',
+					content: 'Post trashed.',
+				},
+			] );
 
 			// Check the new status.
 			const { status } = registry.select( editorStore ).getCurrentPost();

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -23,21 +23,21 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 		return [];
 	}
 
-	// No notice is shown after trashing a post
-	if ( post.status === 'trash' && previousPost.status !== 'trash' ) {
-		return [];
-	}
-
 	const publishStatus = [ 'publish', 'private', 'future' ];
 	const isPublished = publishStatus.includes( previousPost.status );
 	const willPublish = publishStatus.includes( post.status );
+	const willTrash =
+		post.status === 'trash' && previousPost.status !== 'trash';
 
 	let noticeMessage;
 	let shouldShowLink = postType?.viewable ?? false;
 	let isDraft;
 
 	// Always should a notice, which will be spoken for accessibility.
-	if ( ! isPublished && ! willPublish ) {
+	if ( willTrash ) {
+		noticeMessage = postType.labels.item_trashed;
+		shouldShowLink = false;
+	} else if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.
 		noticeMessage = __( 'Draft saved.' );
 		isDraft = true;

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -17,6 +17,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 			item_scheduled: 'scheduled',
 			item_updated: 'updated',
 			view_item: 'view',
+			item_trashed: 'trash',
 		},
 		viewable: false,
 	};
@@ -74,7 +75,11 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 				},
 			],
 		],
-		[ 'when post will be trashed', [ 'publish', 'trash', true ], [] ],
+		[
+			'when post will be trashed',
+			[ 'publish', 'trash', true ],
+			[ 'trash', defaultExpectedAction ],
+		],
 	].forEach(
 		( [
 			description,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/19144

When moving a post to `trash` from the Document settings panel, the notification message after successful completion of operation is that the post has been reverted to draft. This PR uses the new labels added in [6.3] (https://core.trac.wordpress.org/changeset/55923) and shows the proper message.
<!-- In a few words, what is the PR actually doing? -->

Noting that in the redirect to the main list happens quite quickly and in order to view the snackbar,  we need slow internet connection. You can use the devtools for that.

## Testing Instructions
1. Open a published post.
2. On the Document settings panel, click on "Move to trash"
3. Post is correctly moved to trash, and proper message is shown.

