### PR TITLE
LinkControl: Prevent horizontally long preview image from being stretched vertically

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -297,9 +297,9 @@ $preview-image-height: 140px;
 
 		img {
 			display: block; // remove unwanted space below image
-			max-width: 100%;
-			height: $preview-image-height; // limit height
-			max-height: $preview-image-height; // limit height
+			width: 100%;
+			height: 100%;
+			object-fit: contain;
 		}
 	}
 }


### PR DESCRIPTION
## What?

This PR fixes an issue where if the image ratio is long horizontally relative to the LinkControl's preview area ratio, it will be stretched vertically.

Example: https://make.wordpress.org/chat/

| Before | After |
|--------|--------|
|  ![before](https://github.com/WordPress/gutenberg/assets/54422211/ea7cd2a4-69b8-4ff2-9c4e-30646cf84109) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/d0d758fa-83d2-454c-bd43-03a95841b0f0) |
<!-- In a few words, what is the PR actually doing? -->

## Why?

`height:100%` stretches the image to fill the container, which has a height of 140px.

![link-regular](https://github.com/WordPress/gutenberg/assets/54422211/7ec9cce3-3507-4830-96e9-04be9261eee6)

This is fine for regular images, but if the image is long relative to the container's aspect ratio, it will be unintentionally stretched vertically.

## How?

I used object-fit:contain to fit the image within the container area while maintaining the image's aspect ratio.

## Testing Instructions

- Insert a inline link. To preview a horizontally long image, you might want to type `https://make.wordpress.org/chat/`.
- Make sure the image is displayed properly.
