### PR TITLE
Update status entity label to `Status` and plural to `getStatuses`

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -224,12 +224,12 @@ export const rootEntitiesConfig = [
 		key: 'plugin',
 	},
 	{
-		label: __( 'Post status' ),
-		name: 'postStatus',
+		label: __( 'Status' ),
+		name: 'status',
 		kind: 'root',
 		baseURL: '/wp/v2/statuses',
 		baseURLParams: { context: 'edit' },
-		plural: 'postStatuses',
+		plural: 'statuses',
 		key: 'slug',
 	},
 ];

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -225,7 +225,7 @@ export const rootEntitiesConfig = [
 	},
 	{
 		label: __( 'Post status' ),
-		name: 'status',
+		name: 'postStatus',
 		kind: 'root',
 		baseURL: '/wp/v2/statuses',
 		baseURLParams: { context: 'edit' },

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -33,7 +33,7 @@ export default function PagePages() {
 		pageSize: PAGE_SIZE_VALUES[ 0 ],
 	} );
 	// Request post statuses to get the proper labels.
-	const { records: statuses } = useEntityRecords( 'root', 'status' );
+	const { records: statuses } = useEntityRecords( 'root', 'postStatus' );
 	const postStatuses =
 		statuses === null
 			? EMPTY_OBJECT

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -33,7 +33,7 @@ export default function PagePages() {
 		pageSize: PAGE_SIZE_VALUES[ 0 ],
 	} );
 	// Request post statuses to get the proper labels.
-	const { records: statuses } = useEntityRecords( 'root', 'postStatus' );
+	const { records: statuses } = useEntityRecords( 'root', 'status' );
 	const postStatuses =
 		statuses === null
 			? EMPTY_OBJECT


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/55050
Related https://github.com/WordPress/gutenberg/pull/55158

## What?

Updates the label of the status entity from `Post Status` to `Status` and the pluralized form of the method to `getStatuses`.

## Why?

In preparing the [documentation](https://github.com/WordPress/gutenberg/pull/55158) for `kind`, `name`, and `plural` properties of the entity config, I've realized the dynamically created methods for the status entity were inconsistent:

```js
// Collection
wp.data.select( 'core' ).getPostStatuses();
// Single record
wp.data.select( 'core' ).getStatus( recordId );
```

We should consolidate the word root to be `postStatus` (hence the dynamic methods would be `getPostStatus` and `getPostStatus`) or `status` (hence, they'd be `getStatus`, `getStatuses`).

## How?

Uses `status` as root everywhere: label, entity name, pluralized form.

## Testing Instructions

Extracted from https://github.com/WordPress/gutenberg/pull/55050

- Enable the "New admin views" experiment at "Gutenberg > Experiments".
- Visit "Appareance > Editor > Pages" and click "Manage all pages".
- Verify the page status is shown as before.
 
<img width="1142" alt="Captura de ecrã 2023-10-05, às 13 34 54" src="https://github.com/WordPress/gutenberg/assets/583546/f0c300e8-3f56-4ad5-9b65-24c2db8421b4">
