### PR TITLE
Core Data: Retrieve the pagination totals in the getEntityRecords calls

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -301,11 +301,33 @@ _Returns_
 
 ### getEntityRecordsTotalItems
 
-Undocumented declaration.
+Returns the Entity's total available records for a given query (ignoring pagination).
+
+_Parameters_
+
+-   _state_ `State`: State tree
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _query_ `GetRecordsHttpQuery`: Optional terms query. If requesting specific fields, fields must always include the ID. For valid query parameters see the [Reference](https://developer.wordpress.org/rest-api/reference/) in the REST API Handbook and select the entity kind. Then see the arguments available for "List [Entity kind]s".
+
+_Returns_
+
+-   `number | null`: number | null.
 
 ### getEntityRecordsTotalPages
 
-Undocumented declaration.
+Returns the number of available pages for the given query.
+
+_Parameters_
+
+-   _state_ `State`: State tree
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _query_ `GetRecordsHttpQuery`: Optional terms query. If requesting specific fields, fields must always include the ID. For valid query parameters see the [Reference](https://developer.wordpress.org/rest-api/reference/) in the REST API Handbook and select the entity kind. Then see the arguments available for "List [Entity kind]s".
+
+_Returns_
+
+-   `number | null`: number | null.
 
 ### getLastEntityDeleteError
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -299,6 +299,14 @@ _Returns_
 
 -   `EntityRecord[] | null`: Records.
 
+### getEntityRecordsTotalItems
+
+Undocumented declaration.
+
+### getEntityRecordsTotalPages
+
+Undocumented declaration.
+
 ### getLastEntityDeleteError
 
 Returns the specified entity record's last delete error.
@@ -630,6 +638,7 @@ _Parameters_
 -   _query_ `?Object`: Query Object.
 -   _invalidateCache_ `?boolean`: Should invalidate query caches.
 -   _edits_ `?Object`: Edits to reset.
+-   _meta_ `?Object`: Meta information about pagination.
 
 _Returns_
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Enhancements
+
+-   Add `getEntityRecordsTotalItems` and `getEntityRecordsTotalPages` selectors. [#55164](https://github.com/WordPress/gutenberg/pull/55164).
+
 ## 6.20.0 (2023-10-05)
 
 ## 6.19.0 (2023-09-20)

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -538,11 +538,33 @@ _Returns_
 
 ### getEntityRecordsTotalItems
 
-Undocumented declaration.
+Returns the Entity's total available records for a given query (ignoring pagination).
+
+_Parameters_
+
+-   _state_ `State`: State tree
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _query_ `GetRecordsHttpQuery`: Optional terms query. If requesting specific fields, fields must always include the ID. For valid query parameters see the [Reference](https://developer.wordpress.org/rest-api/reference/) in the REST API Handbook and select the entity kind. Then see the arguments available for "List [Entity kind]s".
+
+_Returns_
+
+-   `number | null`: number | null.
 
 ### getEntityRecordsTotalPages
 
-Undocumented declaration.
+Returns the number of available pages for the given query.
+
+_Parameters_
+
+-   _state_ `State`: State tree
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _query_ `GetRecordsHttpQuery`: Optional terms query. If requesting specific fields, fields must always include the ID. For valid query parameters see the [Reference](https://developer.wordpress.org/rest-api/reference/) in the REST API Handbook and select the entity kind. Then see the arguments available for "List [Entity kind]s".
+
+_Returns_
+
+-   `number | null`: number | null.
 
 ### getLastEntityDeleteError
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -160,6 +160,7 @@ _Parameters_
 -   _query_ `?Object`: Query Object.
 -   _invalidateCache_ `?boolean`: Should invalidate query caches.
 -   _edits_ `?Object`: Edits to reset.
+-   _meta_ `?Object`: Meta information about pagination.
 
 _Returns_
 
@@ -534,6 +535,14 @@ _Parameters_
 _Returns_
 
 -   `EntityRecord[] | null`: Records.
+
+### getEntityRecordsTotalItems
+
+Undocumented declaration.
+
+### getEntityRecordsTotalPages
+
+Undocumented declaration.
 
 ### getLastEntityDeleteError
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -80,6 +80,7 @@ export function addEntities( entities ) {
  * @param {?Object}      query           Query Object.
  * @param {?boolean}     invalidateCache Should invalidate query caches.
  * @param {?Object}      edits           Edits to reset.
+ * @param {?Object}      meta            Meta information about pagination.
  * @return {Object} Action object.
  */
 export function receiveEntityRecords(
@@ -88,7 +89,8 @@ export function receiveEntityRecords(
 	records,
 	query,
 	invalidateCache = false,
-	edits
+	edits,
+	meta
 ) {
 	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
 	// on the server.
@@ -102,9 +104,9 @@ export function receiveEntityRecords(
 	}
 	let action;
 	if ( query ) {
-		action = receiveQueriedItems( records, query, edits );
+		action = receiveQueriedItems( records, query, edits, meta );
 	} else {
-		action = receiveItems( records, edits );
+		action = receiveItems( records, edits, meta );
 	}
 
 	return {

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -120,6 +120,7 @@ export const rootEntitiesConfig = [
 		plural: 'mediaItems',
 		label: __( 'Media' ),
 		rawAttributes: [ 'caption', 'title', 'description' ],
+		supportsPagination: true,
 	},
 	{
 		name: 'taxonomy',
@@ -326,6 +327,7 @@ async function loadPostTypeEntities() {
 			},
 			syncObjectType: 'postType/' + postType.name,
 			getSyncObjectId: ( id ) => id,
+			supportsPagination: true,
 		};
 	} );
 }

--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -51,6 +51,8 @@ describe( 'useEntityRecords', () => {
 			hasResolved: false,
 			isResolving: false,
 			status: 'IDLE',
+			totalItems: null,
+			totalPages: null,
 		} );
 
 		// Fetch request should have been issued
@@ -65,6 +67,8 @@ describe( 'useEntityRecords', () => {
 			hasResolved: true,
 			isResolving: false,
 			status: 'SUCCESS',
+			totalItems: null,
+			totalPages: null,
 		} );
 	} );
 } );

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -3,6 +3,7 @@
  */
 import { addQueryArgs } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -28,6 +29,16 @@ interface EntityRecordsResolution< RecordType > {
 
 	/** Resolution status */
 	status: Status;
+
+	/**
+	 * The total number of available items (if not paginated).
+	 */
+	totalItems: number | null;
+
+	/**
+	 * The total number of pages.
+	 */
+	totalPages: number | null;
 }
 
 const EMPTY_ARRAY = [];
@@ -97,8 +108,35 @@ export default function useEntityRecords< RecordType >(
 		[ kind, name, queryAsString, options.enabled ]
 	);
 
+	const { totalItems, totalPages } = useSelect(
+		( select ) => {
+			if ( ! options.enabled ) {
+				return {
+					// Avoiding returning a new reference on every execution.
+					totalItems: null,
+					totalPages: null,
+				};
+			}
+			return {
+				totalItems: select( coreStore ).getEntityRecordsTotalItems(
+					kind,
+					name,
+					queryArgs
+				),
+				totalPages: select( coreStore ).getEntityRecordsTotalPages(
+					kind,
+					name,
+					queryArgs
+				),
+			};
+		},
+		[ kind, name, queryAsString, options.enabled ]
+	);
+
 	return {
 		records,
+		totalItems,
+		totalPages,
 		...rest,
 	};
 }

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -112,7 +112,6 @@ export default function useEntityRecords< RecordType >(
 		( select ) => {
 			if ( ! options.enabled ) {
 				return {
-					// Avoiding returning a new reference on every execution.
 					totalItems: null,
 					totalPages: null,
 				};

--- a/packages/core-data/src/queried-data/actions.js
+++ b/packages/core-data/src/queried-data/actions.js
@@ -3,14 +3,16 @@
  *
  * @param {Array}   items Items received.
  * @param {?Object} edits Optional edits to reset.
+ * @param {?Object} meta  Meta information about pagination.
  *
  * @return {Object} Action object.
  */
-export function receiveItems( items, edits ) {
+export function receiveItems( items, edits, meta ) {
 	return {
 		type: 'RECEIVE_ITEMS',
 		items: Array.isArray( items ) ? items : [ items ],
 		persistedEdits: edits,
+		meta,
 	};
 }
 
@@ -41,12 +43,13 @@ export function removeItems( kind, name, records, invalidateCache = false ) {
  * @param {Array}   items Queried items received.
  * @param {?Object} query Optional query object.
  * @param {?Object} edits Optional edits to reset.
+ * @param {?Object} meta  Meta information about pagination.
  *
  * @return {Object} Action object.
  */
-export function receiveQueriedItems( items, query = {}, edits ) {
+export function receiveQueriedItems( items, query = {}, edits, meta ) {
 	return {
-		...receiveItems( items, edits ),
+		...receiveItems( items, edits, meta ),
 		query,
 	};
 }

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -222,19 +222,22 @@ const receiveQueries = compose( [
 	// Queries shape is shared, but keyed by query `stableKey` part. Original
 	// reducer tracks only a single query object.
 	onSubKey( 'stableKey' ),
-] )( ( state = null, action ) => {
+] )( ( state = {}, action ) => {
 	const { type, page, perPage, key = DEFAULT_ENTITY_KEY } = action;
 
 	if ( type !== 'RECEIVE_ITEMS' ) {
 		return state;
 	}
 
-	return getMergedItemIds(
-		state || [],
-		action.items.map( ( item ) => item[ key ] ),
-		page,
-		perPage
-	);
+	return {
+		itemIds: getMergedItemIds(
+			state?.itemIds || [],
+			action.items.map( ( item ) => item[ key ] ),
+			page,
+			perPage
+		),
+		meta: action.meta,
+	};
 } );
 
 /**

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -266,9 +266,13 @@ const queries = ( state = {}, action ) => {
 							Object.entries( contextQueries ).map(
 								( [ query, queryItems ] ) => [
 									query,
-									queryItems.filter(
-										( queryId ) => ! removedItems[ queryId ]
-									),
+									{
+										...queryItems,
+										itemIds: queryItems.itemIds.filter(
+											( queryId ) =>
+												! removedItems[ queryId ]
+										),
+									},
 								]
 							)
 						),

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -33,7 +33,7 @@ function getQueriedItemsUncached( state, query ) {
 	let itemIds;
 
 	if ( state.queries?.[ context ]?.[ stableKey ] ) {
-		itemIds = state.queries[ context ][ stableKey ];
+		itemIds = state.queries[ context ][ stableKey ].itemIds;
 	}
 
 	if ( ! itemIds ) {
@@ -118,3 +118,15 @@ export const getQueriedItems = createSelector( ( state, query = {} ) => {
 	queriedItemsCache.set( query, items );
 	return items;
 } );
+
+export function getQueriedTotalItems( state, query = {} ) {
+	const { stableKey, context } = getQueryParts( query );
+
+	return state.queries?.[ context ]?.[ stableKey ]?.meta?.totalItems ?? null;
+}
+
+export function getQueriedTotalPages( state, query = {} ) {
+	const { stableKey, context } = getQueryParts( query );
+
+	return state.queries?.[ context ]?.[ stableKey ]?.meta?.totalPages ?? null;
+}

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -159,7 +159,7 @@ describe( 'reducer', () => {
 				default: { 1: true },
 			},
 			queries: {
-				default: { 's=a': [ 1 ] },
+				default: { 's=a': { itemIds: [ 1 ] } },
 			},
 		} );
 	} );
@@ -200,8 +200,8 @@ describe( 'reducer', () => {
 			},
 			queries: {
 				default: {
-					'': [ 1, 2, 3, 4 ],
-					's=a': [ 1, 3 ],
+					'': { itemIds: [ 1, 2, 3, 4 ] },
+					's=a': { itemIds: [ 1, 3 ] },
 				},
 			},
 		} );
@@ -218,8 +218,8 @@ describe( 'reducer', () => {
 			},
 			queries: {
 				default: {
-					'': [ 1, 2, 4 ],
-					's=a': [ 1 ],
+					'': { itemIds: [ 1, 2, 4 ] },
+					's=a': { itemIds: [ 1 ] },
 				},
 			},
 		} );
@@ -238,8 +238,8 @@ describe( 'reducer', () => {
 			},
 			queries: {
 				default: {
-					'': [ 'foo//bar1', 'foo//bar2', 'foo//bar3' ],
-					's=2': [ 'foo//bar2' ],
+					'': { itemIds: [ 'foo//bar1', 'foo//bar2', 'foo//bar3' ] },
+					's=2': { itemIds: [ 'foo//bar2' ] },
 				},
 			},
 		} );
@@ -258,8 +258,8 @@ describe( 'reducer', () => {
 			},
 			queries: {
 				default: {
-					'': [ 'foo//bar1', 'foo//bar3' ],
-					's=2': [],
+					'': { itemIds: [ 'foo//bar1', 'foo//bar3' ] },
+					's=2': { itemIds: [] },
 				},
 			},
 		} );

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -32,7 +32,7 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'': [ 1, 2 ],
+					'': { itemIds: [ 1, 2 ] },
 				},
 			},
 		};
@@ -56,7 +56,7 @@ describe( 'getQueriedItems', () => {
 					2: true,
 				},
 			},
-			queries: [ 1, 2 ],
+			queries: { itemIds: [ 1, 2 ] },
 		};
 
 		const resultA = getQueriedItems( state, {} );
@@ -81,8 +81,8 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'': [ 1, 2 ],
-					'include=1': [ 1 ],
+					'': { itemIds: [ 1, 2 ] },
+					'include=1': { itemIds: [ 1 ] },
 				},
 			},
 		};
@@ -116,7 +116,7 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'_fields=content': [ 1, 2 ],
+					'_fields=content': { itemIds: [ 1, 2 ] },
 				},
 			},
 		};
@@ -161,7 +161,7 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'_fields=content%2Cmeta.template': [ 1, 2 ],
+					'_fields=content%2Cmeta.template': { itemIds: [ 1, 2 ] },
 				},
 			},
 		};
@@ -198,7 +198,7 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'': [ 1, 2 ],
+					'': { itemIds: [ 1, 2 ] },
 				},
 			},
 		};
@@ -230,7 +230,7 @@ describe( 'getQueriedItems', () => {
 			},
 			queries: {
 				default: {
-					'': [ 1, 2 ],
+					'': { itemIds: [ 1, 2 ] },
 				},
 			},
 		};

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -242,7 +242,6 @@ export const getEntityRecords =
 				};
 			} else {
 				records = Object.values( await apiFetch( { path } ) );
-				meta = {};
 			}
 
 			// If we request fields but the result doesn't contain the fields,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -228,7 +228,23 @@ export const getEntityRecords =
 				...query,
 			} );
 
-			let records = Object.values( await apiFetch( { path } ) );
+			let records, meta;
+			if ( entityConfig.supportsPagination && query.per_page !== -1 ) {
+				const response = await apiFetch( { path, parse: false } );
+				records = Object.values( await response.json() );
+				meta = {
+					totalPages: parseInt(
+						response.headers.get( 'X-WP-TotalPages' )
+					),
+					totalItems: parseInt(
+						response.headers.get( 'X-WP-Total' )
+					),
+				};
+			} else {
+				records = Object.values( await apiFetch( { path } ) );
+				meta = {};
+			}
+
 			// If we request fields but the result doesn't contain the fields,
 			// explicitly set these fields as "undefined"
 			// that way we consider the query "fullfilled".
@@ -244,7 +260,15 @@ export const getEntityRecords =
 				} );
 			}
 
-			dispatch.receiveEntityRecords( kind, name, records, query );
+			dispatch.receiveEntityRecords(
+				kind,
+				name,
+				records,
+				query,
+				false,
+				undefined,
+				meta
+			);
 
 			// When requesting all fields, the list of results can be used to
 			// resolve the `getEntityRecord` selector in addition to `getEntityRecords`.

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -527,6 +527,17 @@ export const getEntityRecords = ( <
 	return getQueriedItems( queriedState, query );
 } ) as GetEntityRecords;
 
+/**
+ * Returns the Entity's total available records for a given query (ignoring pagination).
+ *
+ * @param state State tree
+ * @param kind  Entity kind.
+ * @param name  Entity name.
+ * @param query Optional terms query. If requesting specific
+ *              fields, fields must always include the ID. For valid query parameters see the [Reference](https://developer.wordpress.org/rest-api/reference/) in the REST API Handbook and select the entity kind. Then see the arguments available for "List [Entity kind]s".
+ *
+ * @return number | null.
+ */
 export const getEntityRecordsTotalItems = (
 	state: State,
 	kind: string,
@@ -543,6 +554,17 @@ export const getEntityRecordsTotalItems = (
 	return getQueriedTotalItems( queriedState, query );
 };
 
+/**
+ * Returns the number of available pages for the given query.
+ *
+ * @param state State tree
+ * @param kind  Entity kind.
+ * @param name  Entity name.
+ * @param query Optional terms query. If requesting specific
+ *              fields, fields must always include the ID. For valid query parameters see the [Reference](https://developer.wordpress.org/rest-api/reference/) in the REST API Handbook and select the entity kind. Then see the arguments available for "List [Entity kind]s".
+ *
+ * @return number | null.
+ */
 export const getEntityRecordsTotalPages = (
 	state: State,
 	kind: string,

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -14,7 +14,11 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import { STORE_NAME } from './name';
-import { getQueriedItems } from './queried-data';
+import {
+	getQueriedItems,
+	getQueriedTotalItems,
+	getQueriedTotalPages,
+} from './queried-data';
 import { DEFAULT_ENTITY_KEY } from './entities';
 import {
 	getNormalizedCommaSeparable,
@@ -522,6 +526,38 @@ export const getEntityRecords = ( <
 	}
 	return getQueriedItems( queriedState, query );
 } ) as GetEntityRecords;
+
+export const getEntityRecordsTotalItems = (
+	state: State,
+	kind: string,
+	name: string,
+	query: GetRecordsHttpQuery
+): number | null => {
+	// Queried data state is prepopulated for all known entities. If this is not
+	// assigned for the given parameters, then it is known to not exist.
+	const queriedState =
+		state.entities.records?.[ kind ]?.[ name ]?.queriedData;
+	if ( ! queriedState ) {
+		return null;
+	}
+	return getQueriedTotalItems( queriedState, query );
+};
+
+export const getEntityRecordsTotalPages = (
+	state: State,
+	kind: string,
+	name: string,
+	query: GetRecordsHttpQuery
+): number | null => {
+	// Queried data state is prepopulated for all known entities. If this is not
+	// assigned for the given parameters, then it is known to not exist.
+	const queriedState =
+		state.entities.records?.[ kind ]?.[ name ]?.queriedData;
+	if ( ! queriedState ) {
+		return null;
+	}
+	return getQueriedTotalPages( queriedState, query );
+};
 
 type DirtyEntityRecord = {
 	title: string;

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -172,7 +172,10 @@ describe( 'getEntityRecords', () => {
 			'root',
 			'postType',
 			Object.values( POST_TYPES ),
-			{}
+			{},
+			false,
+			undefined,
+			undefined
 		);
 	} );
 

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -226,7 +226,7 @@ describe( 'hasEntityRecords', () => {
 								},
 								queries: {
 									default: {
-										'': [ 'post', 'page' ],
+										'': { itemIds: [ 'post', 'page' ] },
 									},
 								},
 							},
@@ -361,7 +361,7 @@ describe( 'getEntityRecords', () => {
 								},
 								queries: {
 									default: {
-										'': [ 'post', 'page' ],
+										'': { itemIds: [ 'post', 'page' ] },
 									},
 								},
 							},
@@ -399,7 +399,9 @@ describe( 'getEntityRecords', () => {
 								},
 								queries: {
 									default: {
-										'_fields=id%2Ccontent': [ 1 ],
+										'_fields=id%2Ccontent': {
+											itemIds: [ 1 ],
+										},
 									},
 								},
 							},


### PR DESCRIPTION
Related to #55083
Follow-up to #55154

## What?

This PR adds support for retrieving the total items and total pages from the response of the getEntityRecords calls. It also automatically adds these values to the `useEntityRecords` returned object.

## Why?

This allows us to avoid the extra apiFetch request we're doing to fetch these headers in the page list in the site editor.

**Note**

I've noted a couple other places where these headers are directly consumed but I left these untouched for this PR.

## Testing Instructions

1- Open the page list in the site editor
2- Play with pagination (totals should be rendered properly)