### PR TITLE
[Mobile] - Update E2E Block Insertion tests

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-@canary.test.js
@@ -60,7 +60,7 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 		await titleElement.click();
 
 		// Wait for editor to finish scrolling to the title
-		await editorPage.driver.sleep( 2000 );
+		await editorPage.driver.pause( 2000 );
 
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const emptyParagraphBlock = await editorPage.getBlockAtPosition(
@@ -107,20 +107,11 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		expect( await editorPage.assertSlashInserterPresent() ).toBe( true );
 
 		// Remove / character.
-		if ( isAndroid() ) {
-			await editorPage.typeTextToTextBlock(
-				paragraphBlockElement,
-				`${ shortText }`,
-				true
-			);
-		} else {
-			await paragraphBlockElement.type( '\b' );
-			await editorPage.typeTextToTextBlock(
-				paragraphBlockElement,
-				`${ shortText }`,
-				false
-			);
-		}
+		await editorPage.typeTextToTextBlock(
+			paragraphBlockElement,
+			`${ shortText }`,
+			true
+		);
 
 		// Check if the slash inserter UI no longer exists.
 		expect( await editorPage.assertSlashInserterPresent() ).toBe( false );
@@ -141,8 +132,7 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		expect( await editorPage.assertSlashInserterPresent() ).toBe( true );
 
 		// Find Image block button.
-		const imageButtonElement =
-			await editorPage.driver.elementByAccessibilityId( 'Image block' );
+		const imageButtonElement = await editorPage.driver.$( '~Image block' );
 		expect( imageButtonElement ).toBeTruthy();
 
 		// Add image block.
@@ -166,7 +156,12 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 
 		await editorPage.typeTextToTextBlock(
 			paragraphBlockElement,
-			'/img\n',
+			'/img',
+			false
+		);
+		await editorPage.typeTextToTextBlock(
+			paragraphBlockElement,
+			'\n',
 			false
 		);
 		expect(

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -368,12 +368,25 @@ const tapPasteAboveElement = async ( driver, element ) => {
 };
 
 const tapStatusBariOS = async ( driver ) => {
-	const action = new wd.TouchAction();
-	action.tap( { x: 20, y: 20 } );
-	await driver.performTouchAction( action );
+	await driver.touchPerform( [
+		{
+			action: 'press',
+			options: { x: 20, y: 20 },
+		},
+		{
+			action: 'wait',
+			options: {
+				ms: 100,
+			},
+		},
+		{
+			action: 'release',
+			options: {},
+		},
+	] );
 
 	// Wait for the scroll animation to finish
-	await driver.sleep( 3000 );
+	await driver.pause( 3000 );
 };
 
 const selectTextFromElement = async ( driver, element ) => {

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -216,7 +216,7 @@ const typeString = async ( driver, element, str, clear ) => {
 	await element.addValue( str );
 
 	if ( ! isAndroid() ) {
-		// Wait for the list auto-scroll animation to finish
+		// Await the completion of the scroll-to-text-input animation
 		await driver.pause( 3000 );
 	}
 };

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -3,7 +3,7 @@
  */
 const childProcess = require( 'child_process' );
 // eslint-disable-next-line import/no-extraneous-dependencies, import/named
-import { remote } from 'webdriverio';
+import { remote, Key } from 'webdriverio';
 // TODO: Replace usage of wd in favor of WebdriverIO
 const wd = null;
 const path = require( 'path' );
@@ -241,11 +241,11 @@ const getKeycode = ( str ) => {
 			[ backspace ]: 67,
 		}[ str ];
 	}
-	// On iOS, we map keycodes using the special keys defined in WebDriver.
-	// Reference: https://github.com/admc/wd/blob/master/lib/special-keys.js
+	// On iOS, we map keycodes using the special keys defined in WebdriverIO.
+	// Reference: https://webdriver.io/docs/api/browser/action/#special-characters
 	return {
-		'\n': wd.SPECIAL_KEYS.Enter,
-		[ backspace ]: wd.SPECIAL_KEYS[ 'Back space' ],
+		'\n': Key.Enter,
+		[ backspace ]: Key.Backspace,
 	}[ str ];
 };
 
@@ -266,12 +266,12 @@ const isKeycode = ( str ) => {
  */
 const pressKeycode = async ( driver, keycode ) => {
 	if ( isAndroid() ) {
-		// `pressKeycode` command is only implemented on Android
-		return await driver.pressKeycode( keycode );
+		// `pressKeyCode` command is only implemented on Android
+		return await driver.pressKeyCode( keycode );
 	}
-	// `keys` command only works on iOS. On Android, executing this
+	// `sendKeys` command only works on iOS. On Android, executing this
 	// results in typing a special character instead.
-	return await driver.keys( [ keycode ] );
+	return await driver.sendKeys( [ keycode ] );
 };
 
 // Calculates middle x,y and clicks that position

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -502,8 +502,7 @@ const dragAndDropAfterElement = async ( driver, element, nextElement ) => {
 
 const toggleHtmlMode = async ( driver, toggleOn ) => {
 	if ( isAndroid() ) {
-		const moreOptionsButton =
-			await driver.elementByAccessibilityId( 'More options' );
+		const moreOptionsButton = await driver.$( '~More options' );
 		await moreOptionsButton.click();
 
 		const showHtmlButtonXpath =
@@ -511,8 +510,7 @@ const toggleHtmlMode = async ( driver, toggleOn ) => {
 
 		await clickIfClickable( driver, showHtmlButtonXpath );
 	} else if ( toggleOn ) {
-		const moreOptionsButton =
-			await driver.elementByAccessibilityId( 'editor-menu-button' );
+		const moreOptionsButton = await driver.$( '~editor-menu-button' );
 		await moreOptionsButton.click();
 
 		await clickIfClickable(
@@ -521,9 +519,8 @@ const toggleHtmlMode = async ( driver, toggleOn ) => {
 		);
 	} else {
 		// This is to wait for the clipboard paste notification to disappear, currently it overlaps with the menu button
-		await driver.sleep( 3000 );
-		const moreOptionsButton =
-			await driver.elementByAccessibilityId( 'editor-menu-button' );
+		await driver.pause( 3000 );
+		const moreOptionsButton = await driver.$( '~editor-menu-button' );
 		await moreOptionsButton.click();
 		await clickIfClickable(
 			driver,

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -599,10 +599,10 @@ const waitForVisible = async (
 		return '';
 	} else if ( iteration !== 0 ) {
 		// wait before trying to locate element again
-		await driver.sleep( timeout );
+		await driver.pause( timeout );
 	}
 
-	const elements = await driver.elementsByXPath( elementLocator );
+	const elements = await driver.$$( elementLocator );
 	if ( elements.length === 0 ) {
 		// if locator is not visible, try again
 		return waitForVisible(

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -712,10 +712,9 @@ class EditorPage {
 		const autocompleterElementId = isAndroid()
 			? 'Slash inserter results'
 			: 'autocompleter';
-		const autocompleterElement =
-			await this.driver.elementsByAccessibilityId(
-				autocompleterElementId
-			);
+		const autocompleterElement = await this.driver.$$(
+			`~${ autocompleterElementId }`
+		);
 
 		if ( autocompleterElement?.[ 0 ] ) {
 			isPresent = await autocompleterElement[ 0 ].isDisplayed();

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -259,7 +259,7 @@ class EditorPage {
 		await toggleHtmlMode( this.driver, true );
 
 		const htmlContentView = await this.getTextViewForHtmlViewContent();
-		const text = await htmlContentView.text();
+		const text = await htmlContentView.getText();
 
 		await toggleHtmlMode( this.driver, false );
 		return text;

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -115,7 +115,7 @@ class EditorPage {
 
 		await waitForVisible( this.driver, blockLocator );
 
-		const elements = await this.driver.elementsByXPath( blockLocator );
+		const elements = await this.driver.$$( blockLocator );
 		const lastElementFound = elements[ elements.length - 1 ];
 		if ( elements.length === 0 && options.autoscroll ) {
 			const firstBlockVisible = await this.getFirstBlockVisible();

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -428,6 +428,8 @@ class EditorPage {
 				swipeRight: true,
 			} );
 			await addButton[ 0 ].click();
+			// Wait for Bottom sheet animation to finish
+			await this.driver.pause( 3000 );
 		}
 
 		// Click on block of choice.

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -978,11 +978,14 @@ class EditorPage {
 	}
 
 	async waitForElementToBeDisplayedById( id, timeout = 2000 ) {
-		return await this.driver.waitForElementByAccessibilityId(
-			id,
-			wd.asserters.isDisplayed,
-			timeout
-		);
+		const element = await this.driver.$( `~${ id }` );
+
+		if ( element ) {
+			return element;
+		}
+
+		await element.waitForDisplayed( { timeout } );
+		return element;
 	}
 
 	async waitForElementToBeDisplayedByXPath( id, timeout = 2000 ) {

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -199,8 +199,7 @@ class EditorPage {
 			}
 		}
 
-		const elements =
-			await this.driver.elementsByAccessibilityId( titleElement );
+		const elements = await this.driver.$$( `~${ titleElement }` );
 
 		if (
 			elements.length === 0 ||

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -469,12 +469,12 @@ class EditorPage {
 			const x = size.width / 2;
 			// Checks if the Block Button is available, and if not will scroll to the second half of the available buttons.
 			while (
-				! ( await this.driver.hasElementByAccessibilityId(
-					blockAccessibilityLabel
-				) ) &&
-				! ( await this.driver.hasElementByAccessibilityId(
-					blockAccessibilityLabelNewBlock
-				) )
+				! ( await this.driver
+					.$( `~${ blockAccessibilityLabel }` )
+					.isDisplayed() ) &&
+				! ( await this.driver
+					.$( `~${ blockAccessibilityLabelNewBlock }` )
+					.isDisplayed() )
 			) {
 				swipeFromTo(
 					this.driver,
@@ -484,29 +484,23 @@ class EditorPage {
 			}
 
 			if (
-				await this.driver.hasElementByAccessibilityId(
-					blockAccessibilityLabelNewBlock
-				)
+				await this.driver
+					.$( `~${ blockAccessibilityLabelNewBlock }` )
+					.isDisplayed()
 			) {
-				return await this.driver.elementByAccessibilityId(
-					blockAccessibilityLabelNewBlock
+				return await this.driver.$(
+					`~${ blockAccessibilityLabelNewBlock }`
 				);
 			}
 
-			return await this.driver.elementByAccessibilityId(
-				blockAccessibilityLabel
-			);
+			return await this.driver.$( `~${ blockAccessibilityLabel }` );
 		}
 
-		const blockButton = ( await this.driver.hasElementByAccessibilityId(
-			blockAccessibilityLabelNewBlock
-		) )
-			? await this.driver.elementByAccessibilityId(
-					blockAccessibilityLabelNewBlock
-			  )
-			: await this.driver.elementByAccessibilityId(
-					blockAccessibilityLabel
-			  );
+		const blockButton = ( await this.driver
+			.$( `~${ blockAccessibilityLabelNewBlock }` )
+			.isDisplayed() )
+			? await this.driver.$( `~${ blockAccessibilityLabelNewBlock }` )
+			: await this.driver.$( `~${ blockAccessibilityLabel }` );
 
 		const size = await this.driver.getWindowSize();
 		// The virtual home button covers the bottom 34 in portrait and 21 on landscape on iOS.
@@ -517,15 +511,14 @@ class EditorPage {
 			! ( await blockButton.isDisplayed() ) ||
 			( await EditorPage.isElementOutOfBounds( blockButton, { height } ) )
 		) {
-			await this.driver.execute( 'mobile: dragFromToForDuration', {
-				fromX: 50,
-				fromY: height,
-				toX: 50,
-				toY: EditorPage.getInserterPageHeight( height ),
-				duration: 0.5,
-			} );
+			await swipeFromTo(
+				this.driver,
+				{ x: 50, y: height },
+				{ x: 50, y: EditorPage.getInserterPageHeight( height ) },
+				3000
+			);
 			// Wait for dragging gesture
-			await this.driver.sleep( 2000 );
+			await this.driver.pause( 2000 );
 		}
 
 		return blockButton;

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -354,8 +354,8 @@ class EditorPage {
 
 		while ( locatorAttempts < maxLocatorAttempts ) {
 			element = byId
-				? await this.driver.elementsByAccessibilityId( elementSelector )
-				: await this.driver.elementsByXPath( elementSelector );
+				? await this.driver.$$( `~${ elementSelector }` )
+				: await this.driver.$$( elementSelector );
 			if ( await element[ 0 ]?.isDisplayed() ) {
 				break;
 			}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/pull/55166

## What?
This PR updates the Block Insertion tests to WebdriverIO and Appium 2.

## Why?
To continue with the migration effort to support this new version and new driver.

## How?
- Updates the typing-related helpers by removing custom implementations in favor of methods provided like [addValue](https://webdriver.io/docs/api/element/addValue), and [clearValue](https://webdriver.io/docs/api/element/clearValue) https://github.com/WordPress/gutenberg/pull/55167/commits/12728b0f44808831210407d3dbf0a9addaaf1235
- Updates `getKeycode` and `pressKeycode` https://github.com/WordPress/gutenberg/pull/55167/commits/812e55d121e27da198ab88e7863ff139e08e8f74
- Updates `tapStatusBariOS` https://github.com/WordPress/gutenberg/pull/55167/commits/1c96492f65f8d359dbc8017ebf21755c1b4b81ca
- Updates `toggleHtmlMode` https://github.com/WordPress/gutenberg/pull/55167/commits/7a2c78e372e74c75b713dd2d8d3e16ab5c68f638
- Updates `waitForVisible` https://github.com/WordPress/gutenberg/pull/55167/commits/56526e7a1918fa7b8ed563736d929bd9ff34f44d
- Updates `getBlockAtPosition` https://github.com/WordPress/gutenberg/pull/55167/commits/8b5bbb22453a3b0550b853ed15aab66132655055
- Updates `getTitleElement` https://github.com/WordPress/gutenberg/pull/55167/commits/b9b49d19610ce69f55b811ee9c31728c65cb1410
- Updates `getHtmlContent` https://github.com/WordPress/gutenberg/pull/55167/commits/3febfc29fdbb0b455bdb1007135aab8509f5e55f
- Updates `swipeToolbarToElement` https://github.com/WordPress/gutenberg/pull/55167/commits/7e017c0956b00affcd2c8fa9175fb9a3104dc708
- Updates `addNewBlock` https://github.com/WordPress/gutenberg/pull/55167/commits/fe61e8b9f531773ec880dd7f9513e53ea0640e51
- Updates `findBlockButton` https://github.com/WordPress/gutenberg/pull/55167/commits/30a0bd838498af2f2135578062f0fd0712049a80
- Updates `assertSlashInserterPresent` https://github.com/WordPress/gutenberg/pull/55167/commits/98def0b34e795401ccd4b31612af71b542a85c48
- Updates `waitForElementToBeDisplayedById` https://github.com/WordPress/gutenberg/pull/55167/commits/f47cc01ec99305edd304e6e13bedf5cc1003db73
- Updates the Block Insertion test https://github.com/WordPress/gutenberg/pull/55167/commits/6373b3c458ec0d876d4e9954eceb8588179ae398

## Testing Instructions
Local tests should pass by running the following command for both platforms:

```
 TEST_RN_PLATFORM=android npm run native device-tests:local packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-@canary.test.js
```

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A