### PR TITLE
Cover: Fix media type check in the onSelectMedia hook

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -166,9 +166,12 @@ function CoverEdit( {
 
 	const onSelectMedia = async ( newMedia ) => {
 		const mediaAttributes = attributesFromMedia( newMedia );
+		const isImage = [ newMedia?.type, newMedia?.media_type ].includes(
+			IMAGE_BACKGROUND_TYPE
+		);
 
 		const averageBackgroundColor = await getMediaColor(
-			newMedia?.type === IMAGE_BACKGROUND_TYPE ? newMedia?.url : undefined
+			isImage ? newMedia?.url : undefined
 		);
 
 		let newOverlayColor = overlayColor.color;


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/55086

Fix a bug where when setting an initial image to the Cover block, the overlay color is always set to `#FFF` when it should be an average color of the uploaded image. 

Related discussion: https://wordpress.slack.com/archives/C02QB2JS7/p1696833027605459

## How?

The `onSelectMedia` handler is called twice:
1. Initially, with the minimal data containing only `url` (blob) and `type` fields. The `type` field is `image` so the average background color is calculated and applied. However, this is only visible for a split second, because 
2. The second time the handler is called, it receives fully uploaded media data, where the `type` field's value is now `attachment`. Because the average background color is being calculated only for images, it is now failing and the color is reset to the default value. 

To address this inconsistency, I've modified the condition to also check the `media_type` field in the uploaded media data. This seems to rectify the problem.

## Testing Instructions
1. checkout `trunk`
2. add cover block
3. drop an image file
4. inspect the DOM and see that the overlay is white
5. checkout this branch
6. repeat steps 2-3
7. confirm the average color of the image has been set instead of white.