### PR TITLE
test: Ignore local environment setup

### DIFF
--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -52,7 +52,7 @@ const registerGutenberg = ( {
 			this.editorComponent = setup();
 
 			// Apply optional setup configuration, enabling modification via hooks.
-			if ( typeof require.context === 'function' ) {
+			if ( __DEV__ && typeof require.context === 'function' ) {
 				const req = require.context( './', false, /setup-local\.js$/ );
 				req.keys().forEach( ( key ) => req( key ).default() );
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Do not apply local environment configuration added in #54957 to non-dev environments.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Local environment setup configuration is intended for the development
workflow. Applying it to the testing environment produced unexpected
outcomes where one's local configuration can cause tests to fail.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a `__DEV__` conditional to the logic applying the `setup-local.js`
configuration file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a local file: `packages/react-native-editor/src/setup-local.js`
1. Add the following example configuration to the file to clear out the Demo editor's initial HTML.
    <details><summary>Example configuration</summary>

    ```
    /**
     * WordPress dependencies
     */
    import { addFilter } from '@wordpress/hooks';
    
    export default () => {
    	addFilter(
    		'native.block_editor_props',
    		'core/react-native-editor',
    		( props ) => {
    			return {
    				...props,
    				initialHtml,
    			};
    		}
    	);
    };
    
    const initialHtml = ``;
    ```
    </details>
1. Verify the tests should pass on both platforms when running the following
   commands.

```
npm run native test:e2e:ios:local -- -- gutenberg-editor-search
```

```
npm run native test:e2e:android:local -- -- gutenberg-editor-search
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
