### PR TITLE
Add missing package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57184,6 +57184,9 @@
 			},
 			"engines": {
 				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"packages/interactivity": {
@@ -57191,12 +57194,16 @@
 			"version": "2.4.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@babel/runtime": "^7.16.0",
 				"@preact/signals": "^1.1.3",
 				"deepsignal": "^1.3.6",
 				"preact": "^10.13.2"
 			},
 			"engines": {
 				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"packages/interface": {
@@ -57610,6 +57617,9 @@
 			},
 			"engines": {
 				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"packages/react-native-aztec": {
@@ -70262,6 +70272,7 @@
 		"@wordpress/interactivity": {
 			"version": "file:packages/interactivity",
 			"requires": {
+				"@babel/runtime": "^7.16.0",
 				"@preact/signals": "^1.1.3",
 				"deepsignal": "^1.3.6",
 				"preact": "^10.13.2"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -32,6 +32,9 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/primitives": "file:../primitives"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -25,9 +25,13 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
+		"@babel/runtime": "^7.16.0",
 		"@preact/signals": "^1.1.3",
 		"deepsignal": "^1.3.6",
 		"preact": "^10.13.2"
+	},
+	"peerDependencies": {
+		"react": "^18.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -32,6 +32,9 @@
 		"@wordpress/i18n": "file:../i18n",
 		"utility-types": "^3.10.0"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add missing peer dependencies of `@wordpress/icons`, `@wordpress/interactivity`, and `@wordpress/react-i18n` on `react`.

Add missing dependency of `@wordpress/interactivity` on `@babel/runtime`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Build code transformations can introduce dependencies on packages such as `react` and `@babel/runtime`. These need to be declared if the package is to function correctly with yarn's p'n'p or pnpm with hoisting disabled.

Fixes #55171

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding the missing dependencies. Normally I'd probably have done the `@babel/runtime` dep as a peer dep, but I see you use a normal dependency everywhere else so I followed along.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Follow the reproduction instructions in the linked bug to set up the test and reproduce the bug.
2. Do `yarn add <package>@file:/path/to/gutenberg/packages/<package>` or `pnpm add <package>@file:/path/to/gutenberg/packages/<package>` to point yarn or pnpm at the locally built version of the package.
3. Repeat the final instruction in the reproduction to check that the bug is fixed.