### PR TITLE
Latest Posts: sync updates from Core (6.4)

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -484,9 +484,10 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								.join( ' ' ) }
 							{ createInterpolateElement(
 								sprintf(
-									/* translators: 1: The static string "Read more", 2: The post title only visible to screen readers. */
-									__( '… <a>%1$s<span>: %2$s</span></a>' ),
-									__( 'Read more' ),
+									/* translators: 1: Hidden accessibility text: Post title */
+									__(
+										'… <a>Read more<span>: %1$s</span></a>'
+									),
 									titleTrimmed || __( '(no title)' )
 								),
 								{

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -152,10 +152,9 @@ function render_block_core_latest_posts( $attributes ) {
 				if ( $excerpt_length <= $block_core_latest_posts_excerpt_length ) {
 					$trimmed_excerpt  = substr( $trimmed_excerpt, 0, -11 );
 					$trimmed_excerpt .= sprintf(
-						/* translators: 1: A URL to a post, 2: The static string "Read more", 3: The post title only visible to screen readers. */
-						__( '… <a href="%1$s" rel="noopener noreferrer">%2$s<span class="screen-reader-text">: %3$s</span></a>' ),
+						/* translators: 1: A URL to a post, 2: Hidden accessibility text: Post title */
+						__( '… <a href="%1$s" rel="noopener noreferrer">Read more<span class="screen-reader-text">: %2$s</span></a>' ),
 						esc_url( $post_link ),
-						__( 'Read more' ),
 						esc_html( $title )
 					);
 				}


### PR DESCRIPTION
## What?
Follow up to:https://github.com/WordPress/gutenberg/pull/55029

Syncing changes from: https://github.com/WordPress/wordpress-develop/pull/5441 There were was suggestions from reviews about how to better structure the translated string. This PR syncs Gutenberg with those changes with Core.

## Testing Instructions
Testing instructions taken from https://github.com/WordPress/gutenberg/pull/55029


1. Create a few posts with text content.
2. Create another new post in a block theme and add a Latest Posts block
3. In the block setting sidebar, activate Post content > Excerpts radio button. Slide the "MAX NUMBER OF WORDS" so that the "Read more" link appears.
4. Save the post and preview in the frontend
5. Ensure the "Read more" link is consistent between editor and frontend - check that the screen reader text with the title appears in the source HTML
6. Check in other themes, especially 2021, 2019
7. Ensure that theme excerpt more copy takes precedence on the frontend. (2021 might show an extra ellipsis in the editor - it's inconsistent between themes, so I was aiming for the most general approach)
8. Play around with the "MAX NUMBER OF WORDS" attribute in various theme.
