### PR TITLE
Update consent string for using private APIs.

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -162,7 +162,7 @@ do so by opting-in to `@wordpress/private-apis`:
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/block-editor' // Name of the package calling __dangerousOptInToUnstableAPIsOnlyForCoreModules,
 		// (not the name of the package whose APIs you want to access)
 	);

--- a/packages/block-editor/src/lock-unlock.js
+++ b/packages/block-editor/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/block-editor'
 	);

--- a/packages/block-library/src/lock-unlock.js
+++ b/packages/block-library/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/block-library'
 	);

--- a/packages/blocks/src/lock-unlock.js
+++ b/packages/blocks/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/blocks'
 	);

--- a/packages/commands/src/lock-unlock.js
+++ b/packages/commands/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/commands'
 	);

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -34,7 +34,7 @@ import Theme from './theme';
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/components'
 	);
 

--- a/packages/core-commands/src/lock-unlock.js
+++ b/packages/core-commands/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/core-commands'
 	);

--- a/packages/core-data/src/private-apis.js
+++ b/packages/core-data/src/private-apis.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/core-data'
 	);

--- a/packages/customize-widgets/src/lock-unlock.js
+++ b/packages/customize-widgets/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/customize-widgets'
 	);

--- a/packages/data/src/lock-unlock.js
+++ b/packages/data/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/data'
 	);

--- a/packages/edit-post/src/lock-unlock.js
+++ b/packages/edit-post/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/edit-post'
 	);

--- a/packages/edit-site/src/lock-unlock.js
+++ b/packages/edit-site/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/edit-site'
 	);

--- a/packages/edit-widgets/src/lock-unlock.js
+++ b/packages/edit-widgets/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/edit-widgets'
 	);

--- a/packages/editor/src/lock-unlock.js
+++ b/packages/editor/src/lock-unlock.js
@@ -4,6 +4,6 @@
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/editor'
 	);

--- a/packages/patterns/src/lock-unlock.js
+++ b/packages/patterns/src/lock-unlock.js
@@ -4,6 +4,6 @@
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/patterns'
 	);

--- a/packages/private-apis/README.md
+++ b/packages/private-apis/README.md
@@ -12,7 +12,7 @@ Every `@wordpress` package wanting to privately access or expose experimental AP
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/block-editor' // Name of the package calling __dangerousOptInToUnstableAPIsOnlyForCoreModules,
 		// (not the name of the package whose APIs you want to access)
 	);
@@ -22,7 +22,7 @@ Each package may only opt in once. The function name communicates that plugins a
 
 The function will throw an error if the following conditions are not met:
 
-1. The first argument must exactly match the required consent string: `'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.'`.
+1. The first argument must exactly match the required consent string: `'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.'`.
 2. The second argument must be a known `@wordpress` package that hasn't yet opted into `@wordpress/private-apis`
 
 Once the opt-in is complete, the obtained `lock()` and `unlock()` utilities enable hiding `__experimental` APIs from the naked eye:

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -51,7 +51,7 @@ const registeredPrivateApis = [];
  * CHANGE MAY OCCUR IN EITHER A MAJOR OR MINOR RELEASE.
  */
 const requiredConsent =
-	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.';
+	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.';
 
 /** @type {boolean} */
 let allowReRegistration;

--- a/packages/private-apis/src/test/index.js
+++ b/packages/private-apis/src/test/index.js
@@ -16,7 +16,7 @@ beforeEach( () => {
 } );
 
 const requiredConsent =
-	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.';
+	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.';
 
 describe( '__dangerousOptInToUnstableAPIsOnlyForCoreModules', () => {
 	it( 'Should require a consent string', () => {

--- a/packages/reusable-blocks/src/lock-unlock.js
+++ b/packages/reusable-blocks/src/lock-unlock.js
@@ -4,6 +4,6 @@
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
 export const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 	'@wordpress/reusable-blocks'
 );

--- a/packages/router/src/lock-unlock.js
+++ b/packages/router/src/lock-unlock.js
@@ -5,6 +5,6 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/router'
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updating the consent string used for opting in to private APIs.

Fixes #49784.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Private APIs are intended to be used by WordPress and Gutenberg only. The consent string promises that it will change on a regular basis, this is that change.

If possible, it would be good to get this in to WordPress 6.4 -- it's late but intentionally so as the goal is to actively discourage extenders from using these APIs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The consent string is changed to `I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.`

This was achieved by doing a global search and replace in my editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Ensure features using private APIs continue to work in both Gutenberg and WordPress.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Not Applicable.

## Screenshots or screencast <!-- if applicable -->
