### PR TITLE
Site Editor Styles Screen: Fix dancing styles previews

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -76,6 +76,19 @@
 }
 
 .edit-site-sidebar-navigation-screen__content .edit-site-global-styles-style-variations-container {
+	@include break-medium() {
+		// Safari does not currently support `scrollbar-gutter: stable`, so at
+		// particular viewport sizes it's possible for previews to render prior to a
+		// scrollbar appearing. This then causes a scrollbar to appear, which reduces
+		// the width of the container and can cause the preview's width to change.
+		// As a result, the preview can go into an endless loop of resizing, causing
+		// the preview elements to appear to "dance". A workaround is to provide a
+		// max-width for the container, which prevents the introduction of the scrollbar
+		// from causing the preview's width to change.
+		// See: https://github.com/WordPress/gutenberg/issues/55112
+		max-width: 292px;
+	}
+
 	.edit-site-global-styles-variations_item-preview {
 		border: $gray-900 $border-width solid;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/55112

Resolves an issue in Safari browsers when browsing the Styles screen in the site editor browse mode at particular viewport sizes that can result in the styles previews going into an endless loop of resizing, which gives the previews the appearance as though they're dancing / bobbing around.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As described in #55112, Safari does not have support for `scrollbar-gutter: stable` which is used by the navigator screens here: https://github.com/WordPress/gutenberg/blob/a1d941e23033efc3a8a5147a67451bdbb03f188b/packages/edit-site/src/components/sidebar/style.scss#L7

As a result, in browsers other than Safari, the container for the previews is always the same width irrespective of the presence of scrollbars, but in Safari, the showing / hiding of the scrollbar will result in the previews' dimensions being recalculated, and at certain viewports, this can result in an endless loop of resizing as described in https://github.com/WordPress/gutenberg/issues/55112#issuecomment-1752390866

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A simple fix (for now) is to add a `max-width` for the container that matches the rendered width in other browsers. Since the sidebar area is fixed to `360px` in `break-medium` ([here](https://github.com/WordPress/gutenberg/blob/83044ca64f3a8e37ec75156bb305e4c00f0e16d3/packages/base-styles/_variables.scss#L54)), we should be able to fairly safely use a hard-coded value here, too.

An alternative to this PR could be to refactor the previews to not recalculate their `ratio` so aggressively, but at this stage prior to 6.4, I thought that would likely be a harder fix to get over the line, and hopefully this fix is less risky.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In Safari, while running TT3 theme, open up the styles screen in the site editor browse mode
2. Resize the viewport vertically so that the previews _just_ become hidden so that a scrollbar becomes necessary
3. On `trunk` you should see the previews dancing around as they resize in a loop
4. With this PR applied, there should be no dancing 🕺
5. Double-check on other browsers that the width of the container area for the styles previews is otherwise unaffected (I tested on FF, Chrome, Edge, Safari on Mac, and Edge on Windows 11)
6. Also double-check that this change doesn't affect the full-width view in narrow viewports (i.e. mobile view still results in styles previews filling the container)

## Screenshots or screencast <!-- if applicable -->

### Before

Note the resizing / dancing effect when a scrollbar is introduced:

https://github.com/WordPress/gutenberg/assets/14988353/468977bf-0e66-4e25-b980-4989ad4ea13d

### After

Note that the size of the style previews buttons is unaffected when resizing the window, even though other icons / width is affected by the resized window:

https://github.com/WordPress/gutenberg/assets/14988353/d3ae1c43-e3b4-49e7-b574-d99e1a568436