### PR TITLE
Editor: use hooks instead of HoCs in PostExcerpt

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-excerpt/index.js
+++ b/packages/edit-post/src/components/sidebar/post-excerpt/index.js
@@ -20,15 +20,11 @@ import { store as editPostStore } from '../../../store';
 const PANEL_NAME = 'post-excerpt';
 
 export default function PostExcerpt() {
-	const { isOpened, isRemoved, isEnabled } = useSelect( ( select ) => {
-		const {
-			isEditorPanelRemoved,
-			isEditorPanelOpened,
-			isEditorPanelEnabled,
-		} = select( editPostStore );
+	const { isOpened, isEnabled } = useSelect( ( select ) => {
+		const { isEditorPanelOpened, isEditorPanelEnabled } =
+			select( editPostStore );
 
 		return {
-			isRemoved: isEditorPanelRemoved( PANEL_NAME ),
 			isOpened: isEditorPanelOpened( PANEL_NAME ),
 			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
 		};
@@ -36,10 +32,6 @@ export default function PostExcerpt() {
 
 	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
 	const toggleExcerptPanel = () => toggleEditorPanelOpened( PANEL_NAME );
-
-	if ( isRemoved ) {
-		return null;
-	}
 
 	if ( ! isEnabled ) {
 		return null;

--- a/packages/edit-post/src/components/sidebar/post-excerpt/index.js
+++ b/packages/edit-post/src/components/sidebar/post-excerpt/index.js
@@ -7,8 +7,7 @@ import {
 	PostExcerpt as PostExcerptForm,
 	PostExcerptCheck,
 } from '@wordpress/editor';
-import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,7 +19,28 @@ import { store as editPostStore } from '../../../store';
  */
 const PANEL_NAME = 'post-excerpt';
 
-function PostExcerpt( { isEnabled, isOpened, onTogglePanel } ) {
+export default function PostExcerpt() {
+	const { isOpened, isRemoved, isEnabled } = useSelect( ( select ) => {
+		const {
+			isEditorPanelRemoved,
+			isEditorPanelOpened,
+			isEditorPanelEnabled,
+		} = select( editPostStore );
+
+		return {
+			isRemoved: isEditorPanelRemoved( PANEL_NAME ),
+			isOpened: isEditorPanelOpened( PANEL_NAME ),
+			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
+		};
+	}, [] );
+
+	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
+	const toggleExcerptPanel = () => toggleEditorPanelOpened( PANEL_NAME );
+
+	if ( isRemoved ) {
+		return null;
+	}
+
 	if ( ! isEnabled ) {
 		return null;
 	}
@@ -30,27 +50,10 @@ function PostExcerpt( { isEnabled, isOpened, onTogglePanel } ) {
 			<PanelBody
 				title={ __( 'Excerpt' ) }
 				opened={ isOpened }
-				onToggle={ onTogglePanel }
+				onToggle={ toggleExcerptPanel }
 			>
 				<PostExcerptForm />
 			</PanelBody>
 		</PostExcerptCheck>
 	);
 }
-
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			isEnabled:
-				select( editPostStore ).isEditorPanelEnabled( PANEL_NAME ),
-			isOpened: select( editPostStore ).isEditorPanelOpened( PANEL_NAME ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		onTogglePanel() {
-			return dispatch( editPostStore ).toggleEditorPanelOpened(
-				PANEL_NAME
-			);
-		},
-	} ) ),
-] )( PostExcerpt );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is similar to #53389.

PR refactors `PostExcerpt` component to use `useDispatch` and `useSelect` hooks instead of the HoCs to handle the panel behaviour.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

* Open the Post sidebar
* Identify the Excerpt panel
* Check it works as expected
  * Close, Open, Enable, and Disable the panel

<img width="357" alt="Screenshot 2023-10-10 at 09 26 22" src="https://github.com/WordPress/gutenberg/assets/77539/2f9afc85-1290-48b8-8eba-e118d03c9162">
<img width="791" alt="Screenshot 2023-10-10 at 09 25 19" src="https://github.com/WordPress/gutenberg/assets/77539/445ad9d0-816a-4939-82d8-6af28911f979">


* Inspect the component
