### PR TITLE
Use `accessorFn` instead of `cell` to render `status`

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -130,9 +130,8 @@ export default function PagePages() {
 			{
 				header: 'Status',
 				id: 'status',
-				cell: ( props ) =>
-					postStatuses[ props.row.original.status ] ??
-					props.row.original.status,
+				accessorFn: ( page ) =>
+					postStatuses[ page.status ] ?? page.status,
 			},
 			{
 				header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/54966

## What?

The fields ([ColumnsDef](https://tanstack.com/table/v8/docs/api/core/column-def#cell) in tanstack) provide two functions to render data for each cell: [accessorFn](https://tanstack.com/table/v8/docs/api/core/column-def#accessorfn) and [cell](https://tanstack.com/table/v8/docs/api/core/column-def#accessorfn). We were using `cell` to provide the data for the `status` but we should use `accessorFn` instead.

## Why?

The `accessorFn` is the callback that provides the value for this cell. On the other hand, `cell` is for rendering the data in the UI should you want to render anything different from the value (e.g.: wrap the value into a link, add a text transformation, etc.).

For example, let's say a cell wanted to access the value of `status` for its row. This is how you do it:

```js
{
  cell: ( props ) => {
    const status = props.row.getValue( 'status' );
    // do something with it...
  }
}
```

However, because the `status` row does not provide any `accessorFn`, `props.row.getValue( 'status' )` returns undefined. This PR fixes it and makes it return the proper value.

## Testing Instructions

Tests that it works as before visually for users:

- Enable the "New admin views" experiment at "Gutenberg > Experiments".
- Visit "Appareance > Editor > Pages" and click "Manage all pages".
- Verify the page status is shown as before.
 
<img width="1142" alt="Captura de ecrã 2023-10-05, às 13 34 54" src="https://github.com/WordPress/gutenberg/assets/583546/f0c300e8-3f56-4ad5-9b65-24c2db8421b4">

Make sure the value is returned for the cell:

- In some other cell, throw a console log and make sure the value (Published, Draft) is rendered:

```js
  cell: ( props ) => {
    console.log( props.row.getValue( 'status' ) );
  }
```