### PR TITLE
Focus submenu button when clicked

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -90,7 +90,11 @@ function block_core_navigation_add_directives_to_submenu( $w, $block_attributes 
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 		$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.handleMenuFocusout' );
 		$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
+
+		// This is a fix for Safari. It can be removed once we add an overlay to
+		// capture the clicks, instead of relying on the focusout event.
 		$w->set_attribute( 'tabindex', '-1' );
+
 		if ( ! isset( $block_attributes['openSubmenusOnClick'] ) || false === $block_attributes['openSubmenusOnClick'] ) {
 			$w->set_attribute( 'data-wp-on--mouseenter', 'actions.core.navigation.openMenuOnHover' );
 			$w->set_attribute( 'data-wp-on--mouseleave', 'actions.core.navigation.closeMenuOnHover' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -91,8 +91,10 @@ function block_core_navigation_add_directives_to_submenu( $w, $block_attributes 
 		$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.handleMenuFocusout' );
 		$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
 
-		// This is a fix for Safari. It can be removed once we add an overlay to
-		// capture the clicks, instead of relying on the focusout event.
+		// This is a fix for Safari. Without it, Safari doesn't change the active
+		// element when the user clicks on a button. It can be removed once we add
+		// an overlay to capture the clicks, instead of relying on the focusout
+		// event.
 		$w->set_attribute( 'tabindex', '-1' );
 
 		if ( ! isset( $block_attributes['openSubmenusOnClick'] ) || false === $block_attributes['openSubmenusOnClick'] ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -90,6 +90,7 @@ function block_core_navigation_add_directives_to_submenu( $w, $block_attributes 
 		$w->set_attribute( 'data-wp-effect', 'effects.core.navigation.initMenu' );
 		$w->set_attribute( 'data-wp-on--focusout', 'actions.core.navigation.handleMenuFocusout' );
 		$w->set_attribute( 'data-wp-on--keydown', 'actions.core.navigation.handleMenuKeydown' );
+		$w->set_attribute( 'tabindex', '-1' );
 		if ( ! isset( $block_attributes['openSubmenusOnClick'] ) || false === $block_attributes['openSubmenusOnClick'] ) {
 			$w->set_attribute( 'data-wp-on--mouseenter', 'actions.core.navigation.openMenuOnHover' );
 			$w->set_attribute( 'data-wp-on--mouseleave', 'actions.core.navigation.closeMenuOnHover' );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -20,11 +20,10 @@ const openMenu = ( store, menuOpenedOn ) => {
 	if ( context.core.navigation.type === 'overlay' ) {
 		// Add a `has-modal-open` class to the <html> root.
 		document.documentElement.classList.add( 'has-modal-open' );
-	} else {
-		// Ensure that Safari on iOS/iPadOS trigger the mouseleave events.
-		document.body.setAttribute( 'tabindex', '-1' );
 	}
 };
+
+document.addEventListener( 'click', () => {} );
 
 const closeMenu = ( store, menuClosedOn ) => {
 	const { context, selectors } = store;
@@ -42,8 +41,6 @@ const closeMenu = ( store, menuClosedOn ) => {
 		context.core.navigation.previousFocus = null;
 		if ( context.core.navigation.type === 'overlay' ) {
 			document.documentElement.classList.remove( 'has-modal-open' );
-		} else {
-			document.body.removeAttribute( 'tabindex' );
 		}
 	}
 };

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -14,9 +14,8 @@ const focusableSelectors = [
 ];
 
 const openMenu = ( store, menuOpenedOn ) => {
-	const { context, ref, selectors } = store;
+	const { context, selectors } = store;
 	selectors.core.navigation.menuOpenedBy( store )[ menuOpenedOn ] = true;
-	context.core.navigation.previousFocus = ref;
 	if ( context.core.navigation.type === 'overlay' ) {
 		// Add a `has-modal-open` class to the <html> root.
 		document.documentElement.classList.add( 'has-modal-open' );
@@ -35,7 +34,7 @@ const closeMenu = ( store, menuClosedOn ) => {
 				window.document.activeElement
 			)
 		) {
-			context.core.navigation.previousFocus.focus();
+			context.core.navigation.previousFocus?.focus();
 		}
 		context.core.navigation.modal = null;
 		context.core.navigation.previousFocus = null;
@@ -132,6 +131,8 @@ wpStore( {
 					closeMenu( store, 'hover' );
 				},
 				openMenuOnClick( store ) {
+					const { context, ref } = store;
+					context.core.navigation.previousFocus = ref;
 					openMenu( store, 'click' );
 				},
 				closeMenuOnClick( store ) {
@@ -142,13 +143,14 @@ wpStore( {
 					openMenu( store, 'focus' );
 				},
 				toggleMenuOnClick: ( store ) => {
-					const { selectors } = store;
+					const { selectors, context, ref } = store;
 					const menuOpenedBy =
 						selectors.core.navigation.menuOpenedBy( store );
 					if ( menuOpenedBy.click || menuOpenedBy.focus ) {
 						closeMenu( store, 'click' );
 						closeMenu( store, 'focus' );
 					} else {
+						context.core.navigation.previousFocus = ref;
 						openMenu( store, 'click' );
 					}
 				},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -13,6 +13,11 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
+// This is a fix for Safari in iOS/iPadOS. Without it, Safari doesn't focus out
+// when the user taps in the body. It can be removed once we add an overlay to
+// capture the clicks, instead of relying on the focusout event.
+document.addEventListener( 'click', () => {} );
+
 const openMenu = ( store, menuOpenedOn ) => {
 	const { context, selectors } = store;
 	selectors.core.navigation.menuOpenedBy( store )[ menuOpenedOn ] = true;

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -22,6 +22,9 @@ const openMenu = ( store, menuOpenedOn ) => {
 	}
 };
 
+// This is a fix for Safari in iOS/iPadOS. Without it, Safari doesn't focus out
+// when the user taps in the body. It can be removed once we add an overlay to
+// capture the clicks, instead of relying on the focusout event.
 document.addEventListener( 'click', () => {} );
 
 const closeMenu = ( store, menuClosedOn ) => {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -21,14 +21,6 @@ const openMenu = ( store, menuOpenedOn ) => {
 		// Add a `has-modal-open` class to the <html> root.
 		document.documentElement.classList.add( 'has-modal-open' );
 	}
-	// Focus the clicked button manually because Safari
-	// doesn't place focus on it.
-	if (
-		menuOpenedOn === 'click' &&
-		context.core.navigation.type === 'submenu'
-	) {
-		ref.focus();
-	}
 };
 
 const closeMenu = ( store, menuClosedOn ) => {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -21,6 +21,14 @@ const openMenu = ( store, menuOpenedOn ) => {
 		// Add a `has-modal-open` class to the <html> root.
 		document.documentElement.classList.add( 'has-modal-open' );
 	}
+	// Focus the clicked button manually because Safari
+	// doesn't place focus on it.
+	if (
+		menuOpenedOn === 'click' &&
+		context.core.navigation.type === 'submenu'
+	) {
+		ref.focus();
+	}
 };
 
 const closeMenu = ( store, menuClosedOn ) => {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -20,6 +20,9 @@ const openMenu = ( store, menuOpenedOn ) => {
 	if ( context.core.navigation.type === 'overlay' ) {
 		// Add a `has-modal-open` class to the <html> root.
 		document.documentElement.classList.add( 'has-modal-open' );
+	} else {
+		// Ensure that Safari on iOS/iPadOS trigger the mouseleave events.
+		document.body.setAttribute( 'tabindex', '-1' );
 	}
 };
 
@@ -39,6 +42,8 @@ const closeMenu = ( store, menuClosedOn ) => {
 		context.core.navigation.previousFocus = null;
 		if ( context.core.navigation.type === 'overlay' ) {
 			document.documentElement.classList.remove( 'has-modal-open' );
+		} else {
+			document.body.removeAttribute( 'tabindex' );
 		}
 	}
 };

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -3,7 +3,7 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'Navigation block - Frontend interactivity', () => {
+test.describe( 'Navigation block - Frontend interactivity (@firefox, @webkit)', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
@@ -133,10 +133,14 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			const secondLevelElement = page.getByRole( 'link', {
 				name: 'Nested Submenu Link 1',
 			} );
+			const lastFirstLevelElement = page.getByRole( 'link', {
+				name: 'Complex Submenu Link 2',
+			} );
 
 			// Test: submenu opens on click
 			await expect( innerElement ).toBeHidden();
 			await simpleSubmenuButton.click();
+			await expect( simpleSubmenuButton ).toBeFocused();
 			await expect( innerElement ).toBeVisible();
 
 			// Test: submenu closes on click outside submenu
@@ -145,10 +149,12 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 			// Test: nested submenu opens on click
 			await complexSubmenuButton.click();
+			await expect( complexSubmenuButton ).toBeFocused();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
 
 			await nestedSubmenuButton.click();
+			await expect( nestedSubmenuButton ).toBeFocused();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeVisible();
 
@@ -160,6 +166,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			// Test: submenu opens on Enter keypress
 			await simpleSubmenuButton.focus();
 			await pageUtils.pressKeys( 'Enter' );
+			await expect( simpleSubmenuButton ).toBeFocused();
 			await expect( innerElement ).toBeVisible();
 
 			// Test: submenu closes on ESC key and focuses parent link
@@ -168,27 +175,29 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( simpleSubmenuButton ).toBeFocused();
 
 			// Test: submenu closes on tab outside submenu
-			await simpleSubmenuButton.focus();
 			await pageUtils.pressKeys( 'Enter' );
+			await expect( simpleSubmenuButton ).toBeFocused();
 			await expect( innerElement ).toBeVisible();
 			// Tab to first element, then tab outside the submenu.
 			await pageUtils.pressKeys( 'Tab', { times: 2, delay: 50 } );
-			await expect( innerElement ).toBeHidden();
 			await expect( complexSubmenuButton ).toBeFocused();
+			await expect( innerElement ).toBeHidden();
 
 			// Test: only nested submenu closes on tab outside
-			await complexSubmenuButton.focus();
 			await pageUtils.pressKeys( 'Enter' );
+			await expect( complexSubmenuButton ).toBeFocused();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
 
 			await nestedSubmenuButton.click();
+			await expect( nestedSubmenuButton ).toBeFocused();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeVisible();
 
 			// Tab to nested submenu first element, then tab outside the nested
 			// submenu.
 			await pageUtils.pressKeys( 'Tab', { times: 2, delay: 50 } );
+			await expect( lastFirstLevelElement ).toBeFocused();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
 			// Tab outside the complex submenu.
@@ -222,7 +231,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await editor.saveSiteEditorEntities();
 		} );
 
-		test( 'submenu opens on click in the arrow', async ( { page } ) => {
+		test( 'submenu click on the arrow interactions', async ( { page } ) => {
 			await page.goto( '/' );
 			const arrowButton = page.getByRole( 'button', {
 				name: 'Submenu submenu',
@@ -239,12 +248,41 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 
 			await expect( firstLevelElement ).toBeHidden();
 			await expect( secondLevelElement ).toBeHidden();
+			// Open first submenu level
 			await arrowButton.click();
+			await expect( arrowButton ).toBeFocused();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
+
+			// Close first submenu level, check that it closes and focus is on the arrow button
+			await arrowButton.click();
+			await expect( arrowButton ).toBeFocused();
+			// Move the mouse so the hover on the button doesn't keep the menu open
+			await page.mouse.move( 400, 400 );
+			await expect( firstLevelElement ).toBeHidden();
+			await expect( secondLevelElement ).toBeHidden();
+
+			// Open first submenu level one more time so we can test the nested submenu
+			await arrowButton.click();
+			await expect( arrowButton ).toBeFocused();
+			await expect( firstLevelElement ).toBeVisible();
+			await expect( secondLevelElement ).toBeHidden();
+
+			// Nested submenu open
 			await nestedSubmenuArrowButton.click();
+			await expect( nestedSubmenuArrowButton ).toBeFocused();
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeVisible();
+
+			// Nested submenu close
+			await nestedSubmenuArrowButton.click();
+			await expect( nestedSubmenuArrowButton ).toBeFocused();
+			// Move the mouse so the hover on the button doesn't keep the menu open
+			await page.mouse.move( 400, 400 );
+			await expect( firstLevelElement ).toBeVisible();
+			await expect( secondLevelElement ).toBeHidden();
+
+			// Close menu via click on the body
 			await page.click( 'body' );
 			await expect( firstLevelElement ).toBeHidden();
 			await expect( secondLevelElement ).toBeHidden();

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -332,8 +332,8 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( firstLevelElement ).toBeVisible();
 			await expect( secondLevelElement ).toBeHidden();
 
-			// Close all the menus with click on a non-body element outside the menu
-			await page.getByText( 'Just another Gutenberg site' ).click();
+			// Close the menu via click on the body
+			await page.click( 'body' );
 			await expect( firstLevelElement ).toBeHidden();
 
 			// Tests not covered: Tabbing to close menus


### PR DESCRIPTION
## What?
This pull request adds some JavaScript logic to ensure focus the submenu button when it is clicked. It solves this issue: https://github.com/WordPress/gutenberg/issues/54991

It also adds a fix for closing the submenu overlay on a click outside the submenu on iOS.

## Why?
It seems that Safari doesn't place the focus on the button element but on a parent `div`, which causes some issues with the directives assuming the focus is on the button. We can see the difference between Chrome and Safari:

**Chrome**

https://github.com/WordPress/gutenberg/assets/34552881/021bbbda-fb39-4b26-af8b-6dd4a504790b

**Safari**

https://github.com/WordPress/gutenberg/assets/34552881/2017fb96-f4d6-47f4-b433-568b473b3f7f

## How?
I added some JavaScript logic that, when the submenu button is clicked, it focuses it. It'd be great if someone from the accessibility team could double-check if this approach is correct or if it will break something I am unaware of. cc: @afercia, @alexstine , @jeryj , @joedolson  

## Testing Instructions
1. Add a navigation block with an item with submenu.
2. In the block settings, enable the "Show arrow" setting.
3. Open the site in Safari.
4. Click on the arrow to open the submenu.
5. Check that the `activeElement` is the arrow button.
6. Click outside of the submenu and check it is closed.
7. Open the submenu again by clicking the arrow.
8. Press the ESC key and check that the submenu is closed.

On iOS:
1. Click on the arrow to open the submenu.
2. Click on the arrow to close the submenu.
3. Click on the arrow to open the submenu.
4. Click on the body to close the submenu.
