### PR TITLE
useBlockSync: fix typo and simplify test

### DIFF
--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -31,7 +31,7 @@ const TestWrapper = withRegistryProvider( ( props ) => {
 		props.setRegistry( props.registry );
 	}
 	useBlockSync( props );
-	return <p>Test.</p>;
+	return null;
 } );
 
 describe( 'useBlockSync hook', () => {

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -180,7 +180,7 @@ export default function useBlockSync( {
 			// bound sync, unset the outbound value to avoid considering it in
 			// subsequent renders.
 			pendingChanges.current.outgoing = [];
-			const hadSelecton = hasSelectedBlock();
+			const hadSelection = hasSelectedBlock();
 			const selectionAnchor = getSelectionStart();
 			const selectionFocus = getSelectionEnd();
 			setControlledBlocks();
@@ -195,7 +195,7 @@ export default function useBlockSync( {
 				const selectionStillExists = getBlock(
 					selectionAnchor.clientId
 				);
-				if ( hadSelecton && ! selectionStillExists ) {
+				if ( hadSelection && ! selectionStillExists ) {
 					selectBlock( clientId );
 				} else {
 					resetSelection( selectionAnchor, selectionFocus );


### PR DESCRIPTION
Two little fixes for `useBlockSync` that I made when debugging the hook:
1. Fix a typo in `hadSelection` variable name
2. Make the unit test `TestWrapper` component return `null`, as it doesn't need to render anything. Only the effects matter. Replaces a `<p>` element which is just noise.

Somewhat related to #55041.