### PR TITLE
useBlockSettings: add missing useMemo dependencies

### DIFF
--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -279,6 +279,8 @@ export function useBlockSettings( name, parentLayout ) {
 		isBackgroundEnabled,
 		isLinkEnabled,
 		isTextEnabled,
+		isHeadingEnabled,
+		isButtonEnabled,
 	] );
 
 	return useSettingsForBlockElement( rawSettings, name );


### PR DESCRIPTION
#53667 added support for two new settings, `color.heading` and `color.button`, but didn't add the variables to `useMemo` dependencies. This PR fixes that.