### PR TITLE
Colors: Fix color button border radii

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -77,31 +77,18 @@ $swatch-gap: 12px;
 	border-right: 1px solid $gray-300;
 	border-bottom: 1px solid $gray-300;
 
-	// Identify the first instance as the item that is not a subsequent item to an
-	// item with the same class. The `~` selector is used instead of `+` to take
-	// into account any potential `ToolsPanelItem` placeholder item.
-	&:not(& ~ &) {
+	// Identify the first visible instance as placeholder items will not have this class.
+	&:nth-child(1 of &) {
 		margin-top: $grid-unit-30;
 		border-top-left-radius: $radius-block-ui;
 		border-top-right-radius: $radius-block-ui;
 		border-top: 1px solid $gray-300;
 	}
 
-	// Identify the last instance as an item without any subsequent siblings
-	// with the same class. The `~` selector is used instead of `+` to take
-	// into account any potential `ToolsPanelItem` placeholder item.
-	&:not(:has(~ &)) {
+	// Identify the last visible instance as placeholder items will not have this class.
+	&:nth-last-child(1 of &) {
 		border-bottom-left-radius: $radius-block-ui;
 		border-bottom-right-radius: $radius-block-ui;
-	}
-
-	// Less accurate fallback to detect the last instance of this item
-	// for older browsers not yet supporting the `:has()` selector.
-	@supports not selector(:has(*)) {
-		&.last {
-			border-bottom-left-radius: $radius-block-ui;
-			border-bottom-right-radius: $radius-block-ui;
-		}
 	}
 
 	> div,

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -77,14 +77,20 @@ $swatch-gap: 12px;
 	border-right: 1px solid $gray-300;
 	border-bottom: 1px solid $gray-300;
 
-	&.first {
+	// Identify the first instance as the item that is not a subsequent item to an
+	// item with the same class. The `~` selector is used instead of `+` to take
+	// into account any potential `ToolsPanelItem` placeholder item.
+	&:not(& ~ &) {
 		margin-top: $grid-unit-30;
 		border-top-left-radius: $radius-block-ui;
 		border-top-right-radius: $radius-block-ui;
 		border-top: 1px solid $gray-300;
 	}
 
-	&.last {
+	// Identify the last instance as an item without any subsequent siblings
+	// with the same class. The `~` selector is used instead of `+` to take
+	// into account any potential `ToolsPanelItem` placeholder item.
+	&:not(:has(~ &)) {
 		border-bottom-left-radius: $radius-block-ui;
 		border-bottom-right-radius: $radius-block-ui;
 	}

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -95,6 +95,15 @@ $swatch-gap: 12px;
 		border-bottom-right-radius: $radius-block-ui;
 	}
 
+	// Less accurate fallback to detect the last instance of this item
+	// for older browsers not yet supporting the `:has()` selector.
+	@supports not selector(:has(*)) {
+		&.last {
+			border-bottom-left-radius: $radius-block-ui;
+			border-bottom-right-radius: $radius-block-ui;
+		}
+	}
+
 	> div,
 	> div > button {
 		border-radius: inherit;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `Notice`: Remove margins from `Notice` component ([#54800](https://github.com/WordPress/gutenberg/pull/54800)).
+-   `ToolsPanel`: do not apply the `className` to prop to `ToolsPanelItem` components when rendered as placeholders ([#55207](https://github.com/WordPress/gutenberg/pull/55207)).
 -   `ColorPalette`/`ToggleGroupControl/ToggleGroupControlOptionBase`: add `type="button"` attribute to native `<button>`s ([#55125](https://github.com/WordPress/gutenberg/pull/55125)).
 
 ### Bug Fix

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -176,18 +176,16 @@ export function useToolsPanelItem(
 
 	const cx = useCx();
 	const classes = useMemo( () => {
-		const placeholderStyle =
-			shouldRenderPlaceholder &&
-			! isShown &&
-			styles.ToolsPanelItemPlaceholder;
+		const shouldApplyPlaceholderStyles =
+			shouldRenderPlaceholder && ! isShown;
 		const firstItemStyle =
 			firstDisplayedItem === label && __experimentalFirstVisibleItemClass;
 		const lastItemStyle =
 			lastDisplayedItem === label && __experimentalLastVisibleItemClass;
 		return cx(
 			styles.ToolsPanelItem,
-			placeholderStyle,
-			className,
+			shouldApplyPlaceholderStyles && styles.ToolsPanelItemPlaceholder,
+			! shouldApplyPlaceholderStyles && className,
 			firstItemStyle,
 			lastItemStyle
 		);

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -191,5 +191,8 @@ A function to call when the `Reset all` menu option is selected. As an argument,
 Advises the `ToolsPanel` that all of its `ToolsPanelItem` children should render
 placeholder content (instead of `null`) when they are toggled off and hidden.
 
+Note that placeholder items won't apply the `className` that would be
+normally applied to a visible `ToolsPanelItem` via the `className` prop.
+
 - Required: No
 - Default: `false`

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -50,6 +50,8 @@ export type ToolsPanelProps = {
 	/**
 	 * Advises the `ToolsPanel` that its child `ToolsPanelItem`s should render
 	 * placeholder content instead of null when they are toggled off and hidden.
+	 * Note that placeholder items won't apply the `className` that would be
+	 * normally applied to a visible `ToolsPanelItem` via the `className` prop.
 	 *
 	 * @default false
 	 */


### PR DESCRIPTION
Fixes #55051
Alternative approach to #55071

## What?

Applies the intended border radii to the last color item regardless of whether additional controls have been injected into the colors panel.

## Why?

The details matter.

## How?

There are 2 main aspects to this solution:
- The `ToolsPanelItem` component has been slightly tweaked, and it now applies the given `classname` only when the item is not being rendered as a placeholder
- Instead of using `first` and `last` classnames, this PR leverages a combination of the subsequent sibling selector (`~`), `:has()` and `:not()` to limit the first/last item logic to only the items that need to receive the border radius tweaks.

*NOTE: The `has()` selector [has decent support](https://caniuse.com/css-has), but at the time of writing it's not yet supported by all evergreen browsers (I'm looking at you, Firefox). While Firefox should include support in the next release, i decided to maintain the older (suboptimal) solution as a fallback for when `:has()` is not supported.*

## Testing Instructions

1. Edit a post and add a feature image and group block
2. Select the feature image block, open the style tab in the block inspector and confirm the overlay option there has border radii for all corners
3. Select the group block and, open the styles tab
4. Confirm the first color option has top left/right border radii
5. Confirm the last color option has bottom left/right border radii
6. Toggle on additional color controls from the color panel's menu
7. Ensure that hidden placeholder items do not interfere with the correct application of border radii
8. Test across browsers
9. When testing in Firefox, the issue described in #55051 should still be present, but everything else around the border radii should continue to work as expected.

### Testing Instructions for Keyboard

Changes are visual only. 

## Screenshots or screencast <!-- if applicable -->

<img width="420" alt="Screenshot 2023-10-05 at 2 37 10 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/cb74dd24-9804-4da0-962e-e32bc7dce0a8">


