### PR TITLE
Pages list: set `status` as no sortable

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -116,6 +116,7 @@ export default function PagePages() {
 				id: 'status',
 				accessorFn: ( page ) =>
 					postStatuses[ page.status ] ?? page.status,
+				enableSorting: false,
 			},
 			{
 				header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/55196

## What?

Prevents the `status` column from being sortable.

## Why?

It was unintentionally made sortable at https://github.com/WordPress/gutenberg/pull/55196 Apparently, when a tanstack column has a `accesorFn` it is made sortable.

We cannot sort the pages table by this field because the [REST API endpoint for pages](https://developer.wordpress.org/rest-api/reference/pages/#arguments) doesn't allow us sorting by post status.

## How?

Set it to non-sortable via `enableSorting` column definition.

## Testing Instructions

Test that the `status` column is not sortable.

- Enable the "New admin views" experiment at "Gutenberg > Experiments".
- Visit "Appareance > Editor > Pages" and click "Manage all pages".
- Verify that clicking on the page status header doesn't do anything.
- Verify that only `title` and `author` are listed as fields to sort by in the view config:

<img width="452" alt="Captura de ecrã 2023-10-10, às 16 54 38" src="https://github.com/WordPress/gutenberg/assets/583546/92a924a4-b842-4b5d-8e98-a85857dc2475">
