### PR TITLE
[Mobile]- Update E2E Device Actions test

### DIFF
--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -290,7 +290,7 @@ class EditorPage {
 		// On Android with the landspace orientation set, we use the
 		// driver functionality to hide the keyboard.
 		if ( isAndroid() && orientation === 'LANDSCAPE' ) {
-			return await this.driver.hideDeviceKeyboard();
+			return await this.driver.hideKeyboard();
 		}
 
 		const hideKeyboardButton = isAndroid()


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/pull/55166

## What?
This PR updates the Device Actions tests to WebdriverIO and Appium 2.

## Why?
To continue with the migration effort to support this new version and new driver.

## How?
Some of the tests are being skipped so I focused on those who are currently active.

The only change needed was to update the usage of `hideDeviceKeyboard` to `hideKeyboard`

## Testing Instructions
Local tests should pass by running the following command for both platforms:

**Android**
```
 TEST_RN_PLATFORM=android npm run native device-tests:local packages/react-native-editor/__device-tests__/gutenberg-editor-device-actions.test.js
```

**iOS**
```
 TEST_RN_PLATFORM=ios npm run native device-tests:local packages/react-native-editor/__device-tests__/gutenberg-editor-device-actions.test.js
```

I've also confirmed it runs on SauceLabs by triggering the test from a local command against the Appium 2 build.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A