### PR TITLE
Image: Reimplement lightbox trigger as a minimal button in corner of image

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -207,7 +207,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->set_attribute( 'data-wp-effect--setStylesOnResize', 'effects.core.image.setStylesOnResize' );
 	$body_content = $w->get_updated_html();
 
-	// Wrap the image in the body content with a button.
+	// Add a button alongside image in the body content.
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -203,7 +203,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// We need to set an event callback on the `img` specifically
 	// because the `figure` element can also contain a caption, and
 	// we don't want to trigger the lightbox when the caption is clicked.
-	$w->set_attribute( 'data-wp-on--click', 'actions.core.image.callShowLightboxFromImage' );
+	$w->set_attribute( 'data-wp-on--click', 'actions.core.image.showLightbox' );
 	$w->set_attribute( 'data-wp-effect--setStylesOnResize', 'effects.core.image.setStylesOnResize' );
 	$body_content = $w->get_updated_html();
 
@@ -217,7 +217,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			type="button"
 			aria-haspopup="dialog"
 			aria-label="' . esc_attr( $aria_label ) . '"
-			data-wp-on--click="actions.core.image.callShowLightboxFromButton"
+			data-wp-on--click="actions.core.image.showLightbox"
 			data-wp-style--right="context.core.image.imageButtonRight"
 			data-wp-style--top="context.core.image.imageButtonTop"
 		>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -204,8 +204,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// because the `figure` element can also contain a caption, and
 	// we don't want to trigger the lightbox when the caption is clicked.
 	$w->set_attribute( 'data-wp-on--click', 'actions.core.image.callShowLightboxFromImage' );
-	$w->set_attribute( 'data-wp-on--mouseover', 'actions.core.image.handleMouseOver' );
-	$w->set_attribute( 'data-wp-on--mouseout', 'actions.core.image.handleMouseOut' );
 	$w->set_attribute( 'data-wp-effect--setStylesOnResize', 'effects.core.image.setStylesOnResize' );
 	$body_content = $w->get_updated_html();
 
@@ -220,7 +218,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			aria-haspopup="dialog"
 			aria-label="' . esc_attr( $aria_label ) . '"
 			data-wp-on--click="actions.core.image.callShowLightboxFromButton"
-			data-wp-class--show="context.core.image.isHovering"
 			data-wp-style--right="context.core.image.imageButtonRight"
 			data-wp-style--top="context.core.image.imageButtonTop"
 		>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -197,7 +197,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 		)
 	);
 	$w->next_tag( 'img' );
-	$w->set_attribute( 'data-wp-init', 'effects.core.image.setCurrentSrc' );
+	$w->set_attribute( 'data-wp-init', 'effects.core.image.initOriginImage' );
 	$w->set_attribute( 'data-wp-on--load', 'actions.core.image.handleLoad' );
 	$w->set_attribute( 'data-wp-effect', 'effects.core.image.setButtonStyles' );
 	// We need to set an event callback on the `img` specifically

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -199,6 +199,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->next_tag( 'img' );
 	$w->set_attribute( 'data-wp-init', 'effects.core.image.setCurrentSrc' );
 	$w->set_attribute( 'data-wp-on--load', 'actions.core.image.handleLoad' );
+	$w->set_attribute( 'data-wp-effect', 'effects.core.image.setButtonStyles' );
 	// We need to set an event callback on the `img` specifically
 	// because the `figure` element can also contain a caption, and
 	// we don't want to trigger the lightbox when the caption is clicked.
@@ -220,6 +221,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			aria-label="' . esc_attr( $aria_label ) . '"
 			data-wp-on--click="actions.core.image.callShowLightboxFromButton"
 			data-wp-class--show="context.core.image.isHovering"
+			data-wp-style--right="context.core.image.imageButtonRight"
+			data-wp-style--top="context.core.image.imageButtonTop"
 		>
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
 				<path d="M9 5H5V9" stroke="#FFFFFF" stroke-width="1.5"/>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -220,6 +220,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			data-wp-on--click="actions.core.image.showLightbox"
 			data-wp-style--right="context.core.image.imageButtonRight"
 			data-wp-style--top="context.core.image.imageButtonTop"
+			style="background: #000"
 		>
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
 				<path d="M9 5H5V9" stroke="#FFFFFF" stroke-width="1.5"/>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -214,10 +214,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			aria-haspopup="dialog"
 			aria-label="' . esc_attr( $aria_label ) . '"
 			data-wp-on--click="actions.core.image.showLightbox"
-			data-wp-style--width="context.core.image.imageButtonWidth"
-			data-wp-style--height="context.core.image.imageButtonHeight"
-			data-wp-style--left="context.core.image.imageButtonLeft"
-			data-wp-style--top="context.core.image.imageButtonTop"
 		>
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
 				<path d="M9 5H5V9" stroke="#FFFFFF" stroke-width="1.5"/>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -199,6 +199,9 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->next_tag( 'img' );
 	$w->set_attribute( 'data-wp-init', 'effects.core.image.setCurrentSrc' );
 	$w->set_attribute( 'data-wp-on--load', 'actions.core.image.handleLoad' );
+	// We need to set an event callback on the `img` specifically
+	// because the `figure` element can also contain a caption, and
+	// we don't want to trigger the lightbox when the caption is clicked.
 	$w->set_attribute( 'data-wp-on--click', 'actions.core.image.callShowLightboxFromImage' );
 	$w->set_attribute( 'data-wp-on--mouseover', 'actions.core.image.handleMouseOver' );
 	$w->set_attribute( 'data-wp-on--mouseout', 'actions.core.image.handleMouseOut' );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -200,6 +200,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->set_attribute( 'data-wp-init', 'effects.core.image.setCurrentSrc' );
 	$w->set_attribute( 'data-wp-on--load', 'actions.core.image.handleLoad' );
 	$w->set_attribute( 'data-wp-on--click', 'actions.core.image.callShowLightboxFromImage' );
+	$w->set_attribute( 'data-wp-on--mouseover', 'actions.core.image.handleMouseOver' );
+	$w->set_attribute( 'data-wp-on--mouseout', 'actions.core.image.handleMouseOut' );
 	$w->set_attribute( 'data-wp-effect--setStylesOnResize', 'effects.core.image.setStylesOnResize' );
 	$body_content = $w->get_updated_html();
 
@@ -214,6 +216,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			aria-haspopup="dialog"
 			aria-label="' . esc_attr( $aria_label ) . '"
 			data-wp-on--click="actions.core.image.callShowLightboxFromButton"
+			data-wp-class--show="context.core.image.isHovering"
 		>
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
 				<path d="M9 5H5V9" stroke="#FFFFFF" stroke-width="1.5"/>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -167,6 +167,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->next_tag( 'figure' );
 	$w->add_class( 'wp-lightbox-container' );
 	$w->set_attribute( 'data-wp-interactive', true );
+	$w->set_attribute( 'data-wp-on--click', 'actions.core.image.showLightbox' );
 
 	$w->set_attribute(
 		'data-wp-context',
@@ -199,7 +200,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->next_tag( 'img' );
 	$w->set_attribute( 'data-wp-init', 'effects.core.image.setCurrentSrc' );
 	$w->set_attribute( 'data-wp-on--load', 'actions.core.image.handleLoad' );
-	$w->set_attribute( 'data-wp-effect', 'effects.core.image.setButtonStyles' );
 	$w->set_attribute( 'data-wp-effect--setStylesOnResize', 'effects.core.image.setStylesOnResize' );
 	$body_content = $w->get_updated_html();
 
@@ -218,7 +218,14 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			data-wp-style--height="context.core.image.imageButtonHeight"
 			data-wp-style--left="context.core.image.imageButtonLeft"
 			data-wp-style--top="context.core.image.imageButtonTop"
-		></button>';
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+				<path d="M9 5H5V9" stroke="#FFFFFF" stroke-width="1.5"/>
+				<path d="M15 19L19 19L19 15" stroke="#FFFFFF" stroke-width="1.5"/>
+				<path d="M15 5H19V9" stroke="#FFFFFF" stroke-width="1.5"/>
+				<path d="M9 19L5 19L5 15" stroke="#FFFFFF" stroke-width="1.5"/>
+			</svg>
+		</button>';
 
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
 

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -167,7 +167,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->next_tag( 'figure' );
 	$w->add_class( 'wp-lightbox-container' );
 	$w->set_attribute( 'data-wp-interactive', true );
-	$w->set_attribute( 'data-wp-on--click', 'actions.core.image.showLightbox' );
 
 	$w->set_attribute(
 		'data-wp-context',
@@ -200,6 +199,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$w->next_tag( 'img' );
 	$w->set_attribute( 'data-wp-init', 'effects.core.image.setCurrentSrc' );
 	$w->set_attribute( 'data-wp-on--load', 'actions.core.image.handleLoad' );
+	$w->set_attribute( 'data-wp-on--click', 'actions.core.image.callShowLightboxFromImage' );
 	$w->set_attribute( 'data-wp-effect--setStylesOnResize', 'effects.core.image.setStylesOnResize' );
 	$body_content = $w->get_updated_html();
 
@@ -213,7 +213,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			type="button"
 			aria-haspopup="dialog"
 			aria-label="' . esc_attr( $aria_label ) . '"
-			data-wp-on--click="actions.core.image.showLightbox"
+			data-wp-on--click="actions.core.image.callShowLightboxFromButton"
 		>
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
 				<path d="M9 5H5V9" stroke="#FFFFFF" stroke-width="1.5"/>

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -161,6 +161,10 @@
 		cursor: zoom-in;
 	}
 
+	img:hover + button {
+		opacity: 1;
+	}
+
 	button {
 		opacity: 0;
 		border: none;
@@ -175,10 +179,6 @@
 		text-align: center;
 		padding: 0;
 		border-radius: 10%;
-
-		&.show {
-			opacity: 1;
-		}
 
 		&:focus-visible {
 			outline: 5px auto #212121;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -174,8 +174,8 @@
 		height: 24px;
 		position: absolute;
 		z-index: 100;
-		top: 5px;
-		right: 5px;
+		top: 10px;
+		right: 10px;
 		text-align: center;
 		padding: 0;
 		border-radius: 10%;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -168,10 +168,10 @@
 	button {
 		opacity: 0;
 		border: none;
-		background: #1e1e1e;
+		background: #000;
 		cursor: zoom-in;
-		width: 25px;
-		height: 25px;
+		width: 24px;
+		height: 24px;
 		position: absolute;
 		z-index: 100;
 		top: 5px;
@@ -198,7 +198,7 @@
 		&:hover,
 		&:focus,
 		&:not(:hover):not(:active):not(.has-background) {
-			background: #1e1e1e;
+			background: #000;
 			border: none;
 		}
 	}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -156,12 +156,9 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	cursor: zoom-in;
 
-	&:hover {
-		button {
-			opacity: 1;
-		}
+	img {
+		cursor: zoom-in;
 	}
 
 	button {
@@ -179,6 +176,10 @@
 		padding: 0;
 		border-radius: 10%;
 
+		&.show {
+			opacity: 1;
+		}
+
 		&:focus-visible {
 			outline: 5px auto #212121;
 			outline: 5px auto -webkit-focus-ring-color;
@@ -187,6 +188,7 @@
 
 		&:hover {
 			cursor: pointer;
+			opacity: 1;
 		}
 
 		&:focus {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -156,15 +156,28 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
+	cursor: zoom-in;
+
+	&:hover {
+		button {
+			opacity: 1;
+		}
+	}
 
 	button {
+		opacity: 0;
 		border: none;
-		background: none;
+		background: #1e1e1e;
 		cursor: zoom-in;
-		width: 100%;
-		height: 100%;
+		width: 25px;
+		height: 25px;
 		position: absolute;
 		z-index: 100;
+		top: 5px;
+		right: 5px;
+		text-align: center;
+		padding: 0;
+		border-radius: 10%;
 
 		&:focus-visible {
 			outline: 5px auto #212121;
@@ -172,10 +185,18 @@
 			outline-offset: 5px;
 		}
 
+		&:hover {
+			cursor: pointer;
+		}
+
+		&:focus {
+			opacity: 1;
+		}
+
 		&:hover,
 		&:focus,
 		&:not(:hover):not(:active):not(.has-background) {
-			background: none;
+			background: #1e1e1e;
 			border: none;
 		}
 	}

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -199,15 +199,6 @@ store(
 							}
 						}
 					},
-					// We need to use a handler to know whether the mouse is hovering
-					// so we know when to show the lightbox trigger button. We are unable
-					// to use just CSS for this because the button is not a child of the image.
-					handleMouseOver( { context } ) {
-						context.core.image.isHovering = true;
-					},
-					handleMouseOut( { context } ) {
-						context.core.image.isHovering = false;
-					},
 					handleKeydown: ( { context, actions, event } ) => {
 						if ( context.core.image.lightboxEnabled ) {
 							if ( event.key === 'Tab' || event.keyCode === 9 ) {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -348,26 +348,26 @@ store(
 								context.core.image.imageButtonTop =
 									( offsetHeight - referenceHeight ) / 2 +
 									buttonOffsetTop +
-									15;
+									10;
 								context.core.image.imageButtonRight =
-									buttonOffsetRight + 15;
+									buttonOffsetRight + 10;
 							} else {
 								// If it reaches the height first, keep
 								// the height and compute the width.
 								const referenceWidth =
 									offsetHeight * naturalRatio;
 								context.core.image.imageButtonTop =
-									buttonOffsetTop + 15;
+									buttonOffsetTop + 10;
 								context.core.image.imageButtonRight =
 									( offsetWidth - referenceWidth ) / 2 +
 									buttonOffsetRight +
-									15;
+									10;
 							}
 						} else {
 							context.core.image.imageButtonTop =
-								buttonOffsetTop + 15;
+								buttonOffsetTop + 10;
 							context.core.image.imageButtonRight =
-								buttonOffsetRight + 15;
+								buttonOffsetRight + 10;
 						}
 					},
 					setStylesOnResize: ( { state, context, ref } ) => {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -347,6 +347,33 @@ store(
 							return;
 						}
 
+						const figure = ref.parentElement;
+						const figureComputedStyle =
+							window.getComputedStyle( figure );
+
+						const figureWidth =
+							ref.parentElement.offsetWidth -
+							parseFloat( figureComputedStyle.marginLeft ) -
+							parseFloat( figureComputedStyle.marginRight );
+
+						// We need special handling for the height because
+						// a caption will cause the figure to be taller than
+						// the image, which means we need to account for that
+						// when calculating the placement of the button in the
+						// top right corner of the image.
+						let figureHeight = ref.parentElement.offsetHeight;
+						const caption = figure.querySelector( 'figcaption' );
+						if ( caption ) {
+							figureHeight =
+								figureHeight -
+								parseFloat( figureComputedStyle.marginTop ) -
+								parseFloat( figureComputedStyle.marginBottom ) -
+								caption.offsetHeight;
+						}
+
+						const buttonOffsetTop = figureHeight - offsetHeight;
+						const buttonOffsetRight = figureWidth - offsetWidth;
+
 						// In the case of an image with object-fit: contain, the
 						// size of the <img> element can be larger than the image itself,
 						// so we need to calculate where to place the button.
@@ -356,29 +383,36 @@ store(
 							// Offset ratio of the image.
 							const offsetRatio = offsetWidth / offsetHeight;
 
-							if ( naturalRatio > offsetRatio ) {
+							if ( naturalRatio >= offsetRatio ) {
 								// If it reaches the width first, use a fixed
 								// position for the X axis and calculate Y position.
-								context.core.image.imageButtonRight = 25;
+								context.core.image.imageButtonRight =
+									buttonOffsetRight + 25;
 								const imageHeight = offsetWidth / naturalRatio;
 								context.core.image.imageButtonTop =
-									( offsetHeight - imageHeight ) / 2 + 25;
+									( offsetHeight - imageHeight ) / 2 +
+									buttonOffsetTop +
+									25;
 							} else {
 								// If it reaches the height first, use a fixed
 								// position for the Y axis and calculate X position.
-								context.core.image.imageButtonTop = 25;
+								context.core.image.imageButtonTop =
+									buttonOffsetTop + 25;
 								const imageWidth = offsetHeight * naturalRatio;
 								context.core.image.imageButtonRight =
-									( offsetWidth - imageWidth ) / 2 + 25;
+									( offsetWidth - imageWidth ) / 2 +
+									buttonOffsetRight +
+									25;
 							}
 						} else {
-							// TO DO : Add handling for custom widths and heights.
-
-							// In most other cases, we can just put the button in
-							// the top right corner of the containing element.
-
+							// In other cases, we can just put the button in
+							// the top right corner of the containing element,
+							// accounting for the fact that users may have resized
+							// the image, which will require us to reposition
+							// the button on the X axis but not the Y axis.
 							context.core.image.imageButtonTop = 25;
-							context.core.image.imageButtonRight = 25;
+							context.core.image.imageButtonRight =
+								buttonOffsetRight + 25;
 						}
 					},
 					setStylesOnResize: ( { state, context, ref } ) => {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -196,9 +196,10 @@ store(
 							}
 						}
 					},
+					// This is fired just by lazily loaded
+					// images on the page, not all images.
 					handleLoad: ( { context, effects, ref } ) => {
 						context.core.image.imageLoaded = true;
-						context.core.image.imageRef = ref;
 						context.core.image.imageCurrentSrc = ref.currentSrc;
 						effects.core.image.setButtonStyles( {
 							context,
@@ -263,17 +264,14 @@ store(
 		effects: {
 			core: {
 				image: {
-					setCurrentSrc: ( { context, ref } ) => {
+					initOriginImage: ( { context, ref } ) => {
+						context.core.image.imageRef = ref;
 						if ( ref.complete ) {
 							context.core.image.imageLoaded = true;
 							context.core.image.imageCurrentSrc = ref.currentSrc;
 						}
 					},
 					initLightbox: async ( { context, ref } ) => {
-						context.core.image.figureRef =
-							ref.querySelector( 'figure' );
-						context.core.image.imageRef =
-							ref.querySelector( 'img' );
 						if ( context.core.image.lightboxEnabled ) {
 							const focusableElements =
 								ref.querySelectorAll( focusableSelectors );

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -309,14 +309,14 @@ store(
 						}
 
 						const figure = ref.parentElement;
-						const figureWidth = ref.parentElement.offsetWidth;
+						const figureWidth = ref.parentElement.clientWidth;
 
 						// We need special handling for the height because
 						// a caption will cause the figure to be taller than
 						// the image, which means we need to account for that
 						// when calculating the placement of the button in the
 						// top right corner of the image.
-						let figureHeight = ref.parentElement.offsetHeight;
+						let figureHeight = ref.parentElement.clientHeight;
 						const caption = figure.querySelector( 'figcaption' );
 						if ( caption ) {
 							const captionComputedStyle =

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -93,7 +93,7 @@ store(
 		actions: {
 			core: {
 				image: {
-					showLightbox: ( { context, event }, image ) => {
+					showLightbox: ( { context, event } ) => {
 						// We can't initialize the lightbox until the reference
 						// image is loaded, otherwise the UX is broken.
 						if ( ! context.core.image.imageLoaded ) {
@@ -106,7 +106,7 @@ store(
 						context.core.image.pointerType = event.pointerType;
 
 						context.core.image.lightboxEnabled = true;
-						setStyles( context, image );
+						setStyles( context, context.core.image.imageRef );
 
 						context.core.image.scrollTopReset =
 							window.pageYOffset ||
@@ -133,41 +133,6 @@ store(
 							'scroll',
 							scrollCallback,
 							false
-						);
-					},
-					// When opening the lightbox via clicking an image,
-					// we can use the event target directly and pass it to the
-					// showLightbox action, which uses it to create the styles.
-					callShowLightboxFromImage: ( {
-						context,
-						event,
-						actions,
-					} ) => {
-						actions.core.image.showLightbox(
-							{
-								context,
-								event,
-							},
-							event.target
-						);
-					},
-					// When opening the lightbox via clicking the button,
-					// we need to reach into event target's parent element to
-					// get the image element needed to create the styles.
-					callShowLightboxFromButton: ( {
-						context,
-						event,
-						actions,
-					} ) => {
-						actions.core.image.showLightbox(
-							{
-								context,
-								event,
-							},
-							// The event target we receive when clicking the button
-							// is the SVG element inside of it, so we need to go to
-							// the parent element's sibling to get the image.
-							event.target.parentElement.previousElementSibling
 						);
 					},
 					hideLightbox: async ( { context, event } ) => {
@@ -233,6 +198,7 @@ store(
 					},
 					handleLoad: ( { context, effects, ref } ) => {
 						context.core.image.imageLoaded = true;
+						context.core.image.imageRef = ref;
 						context.core.image.imageCurrentSrc = ref.currentSrc;
 						effects.core.image.setButtonStyles( {
 							context,

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -240,9 +240,13 @@ store(
 							}
 						}
 					},
-					handleLoad: ( { context, ref } ) => {
+					handleLoad: ( { context, effects, ref } ) => {
 						context.core.image.imageLoaded = true;
 						context.core.image.imageCurrentSrc = ref.currentSrc;
+						effects.core.image.setButtonStyles( {
+							context,
+							ref,
+						} );
 					},
 					handleTouchStart: () => {
 						isTouching = true;
@@ -348,13 +352,7 @@ store(
 						}
 
 						const figure = ref.parentElement;
-						const figureComputedStyle =
-							window.getComputedStyle( figure );
-
-						const figureWidth =
-							ref.parentElement.offsetWidth -
-							parseFloat( figureComputedStyle.marginLeft ) -
-							parseFloat( figureComputedStyle.marginRight );
+						const figureWidth = ref.parentElement.offsetWidth;
 
 						// We need special handling for the height because
 						// a caption will cause the figure to be taller than
@@ -364,11 +362,13 @@ store(
 						let figureHeight = ref.parentElement.offsetHeight;
 						const caption = figure.querySelector( 'figcaption' );
 						if ( caption ) {
+							const captionComputedStyle =
+								window.getComputedStyle( caption );
 							figureHeight =
 								figureHeight -
-								parseFloat( figureComputedStyle.marginTop ) -
-								parseFloat( figureComputedStyle.marginBottom ) -
-								caption.offsetHeight;
+								caption.offsetHeight -
+								parseFloat( captionComputedStyle.marginTop ) -
+								parseFloat( captionComputedStyle.marginBottom );
 						}
 
 						const buttonOffsetTop = figureHeight - offsetHeight;
@@ -384,33 +384,31 @@ store(
 							const offsetRatio = offsetWidth / offsetHeight;
 
 							if ( naturalRatio >= offsetRatio ) {
-								// If it reaches the width first, use a fixed
-								// position for the X axis and calculate Y position.
-								context.core.image.imageButtonRight =
-									buttonOffsetRight + 25;
-								const imageHeight = offsetWidth / naturalRatio;
+								// If it reaches the width first, keep
+								// the width and compute the height.
+								const referenceHeight =
+									offsetWidth / naturalRatio;
 								context.core.image.imageButtonTop =
-									( offsetHeight - imageHeight ) / 2 +
+									( offsetHeight - referenceHeight ) / 2 +
 									buttonOffsetTop +
 									25;
+								context.core.image.imageButtonRight =
+									buttonOffsetRight + 25;
 							} else {
-								// If it reaches the height first, use a fixed
-								// position for the Y axis and calculate X position.
+								// If it reaches the height first, keep
+								// the height and compute the width.
+								const referenceWidth =
+									offsetHeight * naturalRatio;
 								context.core.image.imageButtonTop =
 									buttonOffsetTop + 25;
-								const imageWidth = offsetHeight * naturalRatio;
 								context.core.image.imageButtonRight =
-									( offsetWidth - imageWidth ) / 2 +
+									( offsetWidth - referenceWidth ) / 2 +
 									buttonOffsetRight +
 									25;
 							}
 						} else {
-							// In other cases, we can just put the button in
-							// the top right corner of the containing element,
-							// accounting for the fact that users may have resized
-							// the image, which will require us to reposition
-							// the button on the X axis but not the Y axis.
-							context.core.image.imageButtonTop = 25;
+							context.core.image.imageButtonTop =
+								buttonOffsetTop + 25;
 							context.core.image.imageButtonRight =
 								buttonOffsetRight + 25;
 						}

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -348,26 +348,26 @@ store(
 								context.core.image.imageButtonTop =
 									( offsetHeight - referenceHeight ) / 2 +
 									buttonOffsetTop +
-									25;
+									15;
 								context.core.image.imageButtonRight =
-									buttonOffsetRight + 25;
+									buttonOffsetRight + 15;
 							} else {
 								// If it reaches the height first, keep
 								// the height and compute the width.
 								const referenceWidth =
 									offsetHeight * naturalRatio;
 								context.core.image.imageButtonTop =
-									buttonOffsetTop + 25;
+									buttonOffsetTop + 15;
 								context.core.image.imageButtonRight =
 									( offsetWidth - referenceWidth ) / 2 +
 									buttonOffsetRight +
-									25;
+									15;
 							}
 						} else {
 							context.core.image.imageButtonTop =
-								buttonOffsetTop + 25;
+								buttonOffsetTop + 15;
 							context.core.image.imageButtonRight =
-								buttonOffsetRight + 25;
+								buttonOffsetRight + 15;
 						}
 					},
 					setStylesOnResize: ( { state, context, ref } ) => {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -333,6 +333,54 @@ store(
 							}
 						}
 					},
+					setButtonStyles: ( { context, ref } ) => {
+						const {
+							naturalWidth,
+							naturalHeight,
+							offsetWidth,
+							offsetHeight,
+						} = ref;
+
+						// If the image isn't loaded yet, we can't
+						// calculate where the button should be.
+						if ( naturalWidth === 0 || naturalHeight === 0 ) {
+							return;
+						}
+
+						// In the case of an image with object-fit: contain, the
+						// size of the <img> element can be larger than the image itself,
+						// so we need to calculate where to place the button.
+						if ( context.core.image.scaleAttr === 'contain' ) {
+							// Natural ratio of the image.
+							const naturalRatio = naturalWidth / naturalHeight;
+							// Offset ratio of the image.
+							const offsetRatio = offsetWidth / offsetHeight;
+
+							if ( naturalRatio > offsetRatio ) {
+								// If it reaches the width first, use a fixed
+								// position for the X axis and calculate Y position.
+								context.core.image.imageButtonRight = 25;
+								const imageHeight = offsetWidth / naturalRatio;
+								context.core.image.imageButtonTop =
+									( offsetHeight - imageHeight ) / 2 + 25;
+							} else {
+								// If it reaches the height first, use a fixed
+								// position for the Y axis and calculate X position.
+								context.core.image.imageButtonTop = 25;
+								const imageWidth = offsetHeight * naturalRatio;
+								context.core.image.imageButtonRight =
+									( offsetWidth - imageWidth ) / 2 + 25;
+							}
+						} else {
+							// TO DO : Add handling for custom widths and heights.
+
+							// In most other cases, we can just put the button in
+							// the top right corner of the containing element.
+
+							context.core.image.imageButtonTop = 25;
+							context.core.image.imageButtonRight = 25;
+						}
+					},
 					setStylesOnResize: ( { state, context, ref } ) => {
 						if (
 							context.core.image.lightboxEnabled &&

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -191,14 +191,9 @@ store(
 							}
 						}
 					},
-					handleLoad: ( { state, context, effects, ref } ) => {
+					handleLoad: ( { context, ref } ) => {
 						context.core.image.imageLoaded = true;
 						context.core.image.imageCurrentSrc = ref.currentSrc;
-						effects.core.image.setButtonStyles( {
-							state,
-							context,
-							ref,
-						} );
 					},
 					handleTouchStart: () => {
 						isTouching = true;
@@ -280,65 +275,6 @@ store(
 								];
 
 							ref.querySelector( '.close-button' ).focus();
-						}
-					},
-					setButtonStyles: ( { state, context, ref } ) => {
-						const {
-							naturalWidth,
-							naturalHeight,
-							offsetWidth,
-							offsetHeight,
-						} = ref;
-
-						// If the image isn't loaded yet, we can't
-						// calculate how big the button should be.
-						if ( naturalWidth === 0 || naturalHeight === 0 ) {
-							return;
-						}
-
-						// Subscribe to the window dimensions so we can
-						// recalculate the styles if the window is resized.
-						if (
-							( state.core.image.windowWidth ||
-								state.core.image.windowHeight ) &&
-							context.core.image.scaleAttr === 'contain'
-						) {
-							// In the case of an image with object-fit: contain, the
-							// size of the img element can be larger than the image itself,
-							// so we need to calculate the size of the button to match.
-
-							// Natural ratio of the image.
-							const naturalRatio = naturalWidth / naturalHeight;
-							// Offset ratio of the image.
-							const offsetRatio = offsetWidth / offsetHeight;
-
-							if ( naturalRatio > offsetRatio ) {
-								// If it reaches the width first, keep
-								// the width and recalculate the height.
-								context.core.image.imageButtonWidth =
-									offsetWidth;
-								const buttonHeight = offsetWidth / naturalRatio;
-								context.core.image.imageButtonHeight =
-									buttonHeight;
-								context.core.image.imageButtonTop =
-									( offsetHeight - buttonHeight ) / 2;
-							} else {
-								// If it reaches the height first, keep
-								// the height and recalculate the width.
-								context.core.image.imageButtonHeight =
-									offsetHeight;
-								const buttonWidth = offsetHeight * naturalRatio;
-								context.core.image.imageButtonWidth =
-									buttonWidth;
-								context.core.image.imageButtonLeft =
-									( offsetWidth - buttonWidth ) / 2;
-							}
-						} else {
-							// In all other cases, we can trust that the size of
-							// the image is the right size for the button as well.
-
-							context.core.image.imageButtonWidth = offsetWidth;
-							context.core.image.imageButtonHeight = offsetHeight;
 						}
 					},
 					setStylesOnResize: ( { state, context, ref } ) => {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -182,6 +182,12 @@ store(
 							} );
 						}
 					},
+					handleMouseOver( { context } ) {
+						context.core.image.isHovering = true;
+					},
+					handleMouseOut( { context } ) {
+						context.core.image.isHovering = false;
+					},
 					handleKeydown: ( { context, actions, event } ) => {
 						if ( context.core.image.lightboxEnabled ) {
 							if ( event.key === 'Tab' || event.keyCode === 9 ) {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -161,7 +161,7 @@ store(
 							event.target.parentElement.previousElementSibling
 						);
 					},
-					hideLightbox: async ( { context } ) => {
+					hideLightbox: async ( { context, event } ) => {
 						context.core.image.hideAnimationEnabled = true;
 						if ( context.core.image.lightboxEnabled ) {
 							// We want to wait until the close animation is completed
@@ -178,9 +178,12 @@ store(
 							}, 450 );
 
 							context.core.image.lightboxEnabled = false;
-							context.core.image.lastFocusedElement.focus( {
-								preventScroll: true,
-							} );
+
+							if ( event.pointerType !== 'mouse' ) {
+								context.core.image.lastFocusedElement.focus( {
+									preventScroll: true,
+								} );
+							}
 						}
 					},
 					handleMouseOver( { context } ) {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -93,7 +93,7 @@ store(
 		actions: {
 			core: {
 				image: {
-					showLightbox: ( { context }, image ) => {
+					showLightbox: ( { context, event }, image ) => {
 						// We can't initialize the lightbox until the reference
 						// image is loaded, otherwise the UX is broken.
 						if ( ! context.core.image.imageLoaded ) {
@@ -103,6 +103,7 @@ store(
 						context.core.image.lastFocusedElement =
 							window.document.activeElement;
 						context.core.image.scrollDelta = 0;
+						context.core.image.pointerType = event.pointerType;
 
 						context.core.image.lightboxEnabled = true;
 						setStyles( context, image );
@@ -303,7 +304,9 @@ store(
 									focusableElements.length - 1
 								];
 
-							ref.querySelector( '.close-button' ).focus();
+							if ( context.core.image.pointerType !== 'mouse' ) {
+								ref.querySelector( '.close-button' ).focus();
+							}
 						}
 					},
 					setStylesOnResize: ( { state, context, ref } ) => {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -93,7 +93,7 @@ store(
 		actions: {
 			core: {
 				image: {
-					showLightbox: ( { context, event } ) => {
+					showLightbox: ( { context }, image ) => {
 						// We can't initialize the lightbox until the reference
 						// image is loaded, otherwise the UX is broken.
 						if ( ! context.core.image.imageLoaded ) {
@@ -105,10 +105,7 @@ store(
 						context.core.image.scrollDelta = 0;
 
 						context.core.image.lightboxEnabled = true;
-						setStyles(
-							context,
-							event.target.previousElementSibling
-						);
+						setStyles( context, image );
 
 						context.core.image.scrollTopReset =
 							window.pageYOffset ||
@@ -135,6 +132,32 @@ store(
 							'scroll',
 							scrollCallback,
 							false
+						);
+					},
+					callShowLightboxFromImage: ( {
+						context,
+						event,
+						actions,
+					} ) => {
+						actions.core.image.showLightbox(
+							{
+								context,
+								event,
+							},
+							event.target
+						);
+					},
+					callShowLightboxFromButton: ( {
+						context,
+						event,
+						actions,
+					} ) => {
+						actions.core.image.showLightbox(
+							{
+								context,
+								event,
+							},
+							event.target.parentElement.previousElementSibling
 						);
 					},
 					hideLightbox: async ( { context } ) => {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -188,7 +188,11 @@ store(
 
 							context.core.image.lightboxEnabled = false;
 
-							if ( event.pointerType !== 'mouse' ) {
+							// We want to avoid drawing attention to the button
+							// after the lightbox closes for mouse and touch users.
+							// Note that the `event.pointerType` property returns
+							// as an empty string if a keyboard fired the event.
+							if ( event.pointerType === '' ) {
 								context.core.image.lastFocusedElement.focus( {
 									preventScroll: true,
 								} );
@@ -319,13 +323,12 @@ store(
 									focusableElements.length - 1
 								];
 
-							// We want to avoid drawing unnecessary attention to the
-							// close button for mouse users. Note that even if opening
+							// We want to avoid drawing unnecessary attention to the close
+							// button for mouse and touch users. Note that even if opening
 							// the lightbox via keyboard, the event fired is of type
 							// `pointerEvent`, so we need to rely on the `event.pointerType`
-							// property, which returns `mouse` for mouse events and
-							// as an empty string for keyboard events.
-							if ( context.core.image.pointerType !== 'mouse' ) {
+							// property, which returns an empty string for keyboard events.
+							if ( context.core.image.pointerType === '' ) {
 								ref.querySelector( '.close-button' ).focus();
 							}
 						}

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -135,6 +135,9 @@ store(
 							false
 						);
 					},
+					// When opening the lightbox via clicking an image,
+					// we can use the event target directly and pass it to the
+					// showLightbox action, which uses it to create the styles.
 					callShowLightboxFromImage: ( {
 						context,
 						event,
@@ -148,6 +151,9 @@ store(
 							event.target
 						);
 					},
+					// When opening the lightbox via clicking the button,
+					// we need to reach into event target's parent element to
+					// get the image element needed to create the styles.
 					callShowLightboxFromButton: ( {
 						context,
 						event,
@@ -158,6 +164,9 @@ store(
 								context,
 								event,
 							},
+							// The event target we receive when clicking the button
+							// is the SVG element inside of it, so we need to go to
+							// the parent element's sibling to get the image.
 							event.target.parentElement.previousElementSibling
 						);
 					},
@@ -186,6 +195,9 @@ store(
 							}
 						}
 					},
+					// We need to use a handler to know whether the mouse is hovering
+					// so we know when to show the lightbox trigger button. We are unable
+					// to use just CSS for this because the button is not a child of the image.
 					handleMouseOver( { context } ) {
 						context.core.image.isHovering = true;
 					},
@@ -307,6 +319,12 @@ store(
 									focusableElements.length - 1
 								];
 
+							// We want to avoid drawing unnecessary attention to the
+							// close button for mouse users. Note that even if opening
+							// the lightbox via keyboard, the event fired is of type
+							// `pointerEvent`, so we need to rely on the `event.pointerType`
+							// property, which returns `mouse` for mouse events and
+							// as an empty string for keyboard events.
 							if ( context.core.image.pointerType !== 'mouse' ) {
 								ref.querySelector( '.close-button' ).focus();
 							}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR changes the lightbox trigger so that it exists in the top right corner of the image rather than overlaying it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/55097
Having the lightbox overlay the entire image interrupts key browser functionality and is prone to failing with certain themes and layouts.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR changes the styles of the button and removes the JavaScript handling that was calculating the button position dynamically.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add an image to a post
2. Enable 'Expand on Click' in the image block settings
3. Publish and view the post
4. Hover over the image with a mouse and see that the lightbox trigger becomes visible in the top right corner. Notice that hovering over the button will cause the cursor to become a pointer. Try clicking on the button and ensure the lightbox opens.
5. Notice also that hovering over the image causes the cursor to become a magnifying glass. Click on the image and ensure the lightbox opens.

Additionally:
- Try adding a `title` to the image. Hover over the image and ensure the `title` appears in a tooltip.
- Try right clicking on an image and ensuring the image contextual menu appears as expected in Chrome, Safari, Firefox, Opera.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. While viewing the post, tab to the image and make sure the lightbox trigger appears on focus. 
2. Press `Enter` or `Spacebar` to ensure the lightbox opens as expected.

## Screenshot
<img width="1297" alt="Screenshot 2023-10-10 at 10 36 50 AM" src="https://github.com/WordPress/gutenberg/assets/5360536/983cd177-2595-40ba-b3be-2fdab688f8f0">