### PR TITLE
Revert "Enable Block Renaming support for (almost) all blocks (#54426)"

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -41,7 +41,7 @@ Create and save content to reuse across your site. Update the pattern, and the c
 
 -	**Name:** core/block
 -	**Category:** reusable
--	**Supports:** ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
+-	**Supports:** ~~customClassName~~, ~~html~~, ~~inserter~~
 -	**Attributes:** ref
 
 ## Button
@@ -463,7 +463,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 
 -	**Name:** core/navigation
 -	**Category:** theme
--	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
+-	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link
@@ -530,7 +530,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 
 -	**Name:** core/pattern
 -	**Category:** theme
--	**Supports:** ~~html~~, ~~inserter~~, ~~renaming~~
+-	**Supports:** ~~html~~, ~~inserter~~
 -	**Attributes:** slug
 
 ## Author
@@ -911,7 +911,7 @@ Edit the different global regions of your site, like the header, footer, sidebar
 
 -	**Name:** core/template-part
 -	**Category:** theme
--	**Supports:** align, ~~html~~, ~~renaming~~, ~~reusable~~
+-	**Supports:** align, ~~html~~, ~~reusable~~
 -	**Attributes:** area, slug, tagName, theme
 
 ## Term Description

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -466,25 +466,3 @@ function gutenberg_should_render_lightbox( $block ) {
 }
 
 add_filter( 'render_block_data', 'gutenberg_should_render_lightbox', 15, 1 );
-
-/**
- * Registers the metadata block attribute for all block types.
- *
- * @param array $args Array of arguments for registering a block type.
- * @return array $args
- */
-function gutenberg_register_metadata_attribute( $args ) {
-	// Setup attributes if needed.
-	if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
-		$args['attributes'] = array();
-	}
-
-	if ( ! array_key_exists( 'metadata', $args['attributes'] ) ) {
-		$args['attributes']['metadata'] = array(
-			'type' => 'object',
-		);
-	}
-
-	return $args;
-}
-add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -79,6 +79,27 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 }
 
 
+/**
+ * Registers the metadata block attribute for block types.
+ *
+ * @param array $args Array of arguments for registering a block type.
+ * @return array $args
+ */
+function gutenberg_register_metadata_attribute( $args ) {
+	// Setup attributes if needed.
+	if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
+		$args['attributes'] = array();
+	}
+
+	if ( ! array_key_exists( 'metadata', $args['attributes'] ) ) {
+		$args['attributes']['metadata'] = array(
+			'type' => 'object',
+		);
+	}
+
+	return $args;
+}
+add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' );
 
 
 $gutenberg_experiments = get_option( 'gutenberg-experiments' );

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -4,7 +4,7 @@
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { __, sprintf } from '@wordpress/i18n';
-import { hasBlockSupport } from '@wordpress/blocks';
+import { getBlockSupport } from '@wordpress/blocks';
 import {
 	MenuItem,
 	__experimentalHStack as HStack,
@@ -191,7 +191,15 @@ export const withBlockRenameControl = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { clientId, name, attributes, setAttributes } = props;
 
-		const supportsBlockNaming = hasBlockSupport( name, 'renaming', true );
+		const metaDataSupport = getBlockSupport(
+			name,
+			'__experimentalMetadata',
+			false
+		);
+
+		const supportsBlockNaming = !! (
+			true === metaDataSupport || metaDataSupport?.name
+		);
 
 		return (
 			<>

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -19,9 +19,9 @@ import './position';
 import './layout';
 import './content-lock-ui';
 import './metadata';
+import './metadata-name';
 import './custom-fields';
 import './block-hooks';
-import './block-renaming';
 import './block-rename-ui';
 
 export { useCustomSides } from './dimensions';

--- a/packages/block-editor/src/hooks/metadata-name.js
+++ b/packages/block-editor/src/hooks/metadata-name.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+import { hasBlockMetadataSupport } from './metadata';
 
 /**
  * Filters registered block settings, adding an `__experimentalLabel` callback if one does not already exist.
@@ -17,10 +20,10 @@ export function addLabelCallback( settings ) {
 		return settings;
 	}
 
-	const supportsBlockNaming = hasBlockSupport(
+	const supportsBlockNaming = hasBlockMetadataSupport(
 		settings,
-		'renaming',
-		true // default value
+		'name',
+		false // default value
 	);
 
 	// Check whether block metadata is supported before using it.

--- a/packages/block-editor/src/hooks/metadata.js
+++ b/packages/block-editor/src/hooks/metadata.js
@@ -2,7 +2,18 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
+import { getBlockSupport } from '@wordpress/blocks';
+
 const META_ATTRIBUTE_NAME = 'metadata';
+
+export function hasBlockMetadataSupport( blockType, feature = '' ) {
+	// Only core blocks are allowed to use __experimentalMetadata until the fetaure is stablised.
+	if ( ! blockType.name.startsWith( 'core/' ) ) {
+		return false;
+	}
+	const support = getBlockSupport( blockType, '__experimentalMetadata' );
+	return !! ( true === support || support?.[ feature ] );
+}
 
 /**
  * Filters registered block settings, extending attributes to include `metadata`.
@@ -18,18 +29,39 @@ export function addMetaAttribute( blockTypeSettings ) {
 		return blockTypeSettings;
 	}
 
-	blockTypeSettings.attributes = {
-		...blockTypeSettings.attributes,
-		[ META_ATTRIBUTE_NAME ]: {
-			type: 'object',
-		},
-	};
+	const supportsBlockNaming = hasBlockMetadataSupport(
+		blockTypeSettings,
+		'name'
+	);
+
+	if ( supportsBlockNaming ) {
+		blockTypeSettings.attributes = {
+			...blockTypeSettings.attributes,
+			[ META_ATTRIBUTE_NAME ]: {
+				type: 'object',
+			},
+		};
+	}
 
 	return blockTypeSettings;
+}
+
+export function addSaveProps( extraProps, blockType, attributes ) {
+	if ( hasBlockMetadataSupport( blockType ) ) {
+		extraProps[ META_ATTRIBUTE_NAME ] = attributes[ META_ATTRIBUTE_NAME ];
+	}
+
+	return extraProps;
 }
 
 addFilter(
 	'blocks.registerBlockType',
 	'core/metadata/addMetaAttribute',
 	addMetaAttribute
+);
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'core/metadata/save-props',
+	addSaveProps
 );

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -15,7 +15,6 @@
 	"supports": {
 		"customClassName": false,
 		"html": false,
-		"inserter": false,
-		"renaming": false
+		"inserter": false
 	}
 }

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -24,6 +24,7 @@
 		"__experimentalOnEnter": true,
 		"__experimentalOnMerge": true,
 		"__experimentalSettings": true,
+		"__experimentalMetadata": true,
 		"align": [ "wide", "full" ],
 		"anchor": true,
 		"ariaLabel": true,

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -29,12 +29,10 @@ export const settings = {
 	__experimentalLabel( attributes, { context } ) {
 		const { content, level } = attributes;
 
-		const customName = attributes?.metadata?.name;
-
 		// In the list view, use the block's content as the label.
 		// If the content is empty, fall back to the default label.
-		if ( context === 'list-view' && ( customName || content ) ) {
-			return attributes?.metadata?.name || content;
+		if ( context === 'list-view' && content ) {
+			return content;
 		}
 
 		if ( context === 'accessibility' ) {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -133,8 +133,7 @@
 				}
 			}
 		},
-		"interactivity": true,
-		"renaming": false
+		"interactivity": true
 	},
 	"viewScript": "file:./view.min.js",
 	"editorStyle": "wp-block-navigation-editor",

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -28,17 +28,7 @@ export const settings = {
 		},
 	},
 	__experimentalLabel( attributes, { context } ) {
-		const customName = attributes?.metadata?.name;
-
-		if ( context === 'list-view' && customName ) {
-			return customName;
-		}
-
 		if ( context === 'accessibility' ) {
-			if ( customName ) {
-				return customName;
-			}
-
 			const { content } = attributes;
 			return ! content || content.length === 0 ? __( 'Empty' ) : content;
 		}

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -7,8 +7,7 @@
 	"description": "Show a block pattern.",
 	"supports": {
 		"html": false,
-		"inserter": false,
-		"renaming": false
+		"inserter": false
 	},
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -23,8 +23,7 @@
 	"supports": {
 		"align": true,
 		"html": false,
-		"reusable": false,
-		"renaming": false
+		"reusable": false
 	},
 	"editorStyle": "wp-block-template-part-editor"
 }

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -145,27 +145,6 @@ test.describe( 'Block Renaming', () => {
 				},
 			] );
 		} );
-
-		test( 'does not allow renaming of blocks that do not support renaming', async ( {
-			// use `core/template-part` as the block
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/navigation',
-			} );
-
-			// Opens the block options menu and check there is not a `Rename` option
-			await editor.clickBlockToolbarButton( 'Options' );
-			//
-
-			const renameMenuItem = page.getByRole( 'menuitem', {
-				name: 'Rename',
-			} );
-
-			// TODO: assert that the locator didn't find a DOM node at all.
-			await expect( renameMenuItem ).toBeHidden();
-		} );
 	} );
 
 	test.describe( 'Block inspector renaming', () => {
@@ -239,42 +218,6 @@ test.describe( 'Block Renaming', () => {
 					},
 				},
 			] );
-		} );
-
-		test( 'does not allow renaming of blocks that do not support renaming', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/navigation',
-			} );
-
-			await editor.openDocumentSettingsSidebar();
-
-			const settingsTab = page
-				.getByRole( 'region', {
-					name: 'Editor settings',
-				} )
-				.getByRole( 'tab', { name: 'Settings' } );
-
-			await settingsTab.click();
-
-			const advancedPanelToggle = page
-				.getByRole( 'region', {
-					name: 'Editor settings',
-				} )
-				.getByRole( 'button', {
-					name: 'Advanced',
-					expanded: false,
-				} );
-
-			await advancedPanelToggle.click();
-
-			const nameInput = page.getByRole( 'textbox', {
-				name: 'Block name',
-			} );
-
-			await expect( nameInput ).toBeHidden();
 		} );
 	} );
 } );


### PR DESCRIPTION




<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This reverts commit 7aa5a913473c223402549a9060aafac652153965.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Perf regression https://github.com/WordPress/gutenberg/pull/54426#issuecomment-1755733955

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`git revert 7aa5a913473c223402549a9060aafac652153965` 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
