### PR TITLE
test: Update Paragraph tests for Appium 2

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -285,10 +285,13 @@ const clickMiddleOfElement = async ( driver, element ) => {
 	const location = await element.getLocation();
 	const size = await element.getSize();
 
-	const action = await new wd.TouchAction( driver );
-	action.press( { x: location.x + size.width / 2, y: location.y } );
-	action.release();
-	await action.perform();
+	await driver.touchPerform( [
+		{
+			action: 'press',
+			options: { x: location.x + size.width / 2, y: location.y },
+		},
+		{ action: 'release' },
+	] );
 };
 
 // Clicks in the top left of an element.

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -297,10 +297,13 @@ const clickMiddleOfElement = async ( driver, element ) => {
 // Clicks in the top left of an element.
 const clickBeginningOfElement = async ( driver, element ) => {
 	const location = await element.getLocation();
-	const action = await new wd.TouchAction( driver );
-	action.press( { x: location.x, y: location.y } );
-	action.release();
-	await action.perform();
+	await driver.touchPerform( [
+		{
+			action: 'press',
+			options: { x: location.x, y: location.y },
+		},
+		{ action: 'release' },
+	] );
 };
 
 // Clicks in the top left of a text-based element outside of the TextInput

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -208,7 +208,7 @@ class EditorPage {
 	// This makes this function return elements without scrolling on iOS.
 	// So we are keeping this Android only.
 	async androidScrollAndReturnElement( accessibilityLabel ) {
-		const elements = await this.driver.elementsByXPath(
+		const elements = await this.driver.$$(
 			`//*[contains(@${ this.accessibilityIdXPathAttrib }, "${ accessibilityLabel }")]`
 		);
 		if ( elements.length === 0 ) {
@@ -327,7 +327,7 @@ class EditorPage {
 		}
 
 		const dismissClipboardSmartSuggestionLocator = `//*[@${ this.accessibilityIdXPathAttrib }="Dismiss Smart Suggestion"]`;
-		const smartSuggestions = await this.driver.elementsByXPath(
+		const smartSuggestions = await this.driver.$$(
 			dismissClipboardSmartSuggestionLocator
 		);
 		if ( smartSuggestions.length !== 0 ) {
@@ -612,12 +612,12 @@ class EditorPage {
 		const blockActionsMenuButtonLocator = `${ buttonElementName }[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockActionsMenuButtonIdentifier }")]`;
 		if ( isAndroid() ) {
 			const block = await this.getBlockAtPosition( blockName, position );
-			let checkList = await this.driver.elementsByXPath(
+			let checkList = await this.driver.$$(
 				blockActionsMenuButtonLocator
 			);
 			while ( checkList.length === 0 ) {
 				await swipeUp( this.driver, block ); // Swipe up to show remove icon at the bottom.
-				checkList = await this.driver.elementsByXPath(
+				checkList = await this.driver.$$(
 					blockActionsMenuButtonLocator
 				);
 			}
@@ -695,9 +695,7 @@ class EditorPage {
 			? `//android.widget.Button[contains(@content-desc, "Paragraph Block. Row")]//android.widget.EditText`
 			: `(//XCUIElementTypeButton[contains(@name, "Paragraph Block. Row")])`;
 
-		const locator = await this.driver.elementsByXPath(
-			paragraphBlockLocator
-		);
+		const locator = await this.driver.$$( paragraphBlockLocator );
 		return locator.length;
 	}
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -687,7 +687,7 @@ class EditorPage {
 			position
 		);
 
-		return await blockLocator.text();
+		return await blockLocator.getText();
 	}
 
 	async getNumberOfParagraphBlocks() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Relates to #55166. Update the Paragraph tests for Appium 2 and WebdriverIO.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improve the stability and quality of the automated tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update `clickMiddleOfElement` helper
- Update `clickBeginningOfElement` helper
- Update `getTextForParagraphBlockAtPosition` helper
- Replace `elementsByXPath` usage

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Local tests should pass for both platforms when running the following commands:

```
npm run native test:e2e:ios:local -- -- gutenberg-editor-paragraph
```

```
npm run native test:e2e:android:local -- -- gutenberg-editor-paragraph
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
