### PR TITLE
Template Part block: Fall back to current theme if no theme attribute is given.

### DIFF
--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -44,7 +44,6 @@ function render_block_core_pattern( $attributes ) {
 	// Backward compatibility for handling Block Hooks and injecting the theme attribute in the Gutenberg plugin.
 	// This can be removed when the minimum supported WordPress is >= 6.4.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && ! function_exists( 'traverse_and_serialize_blocks' ) ) {
-		$content = _inject_theme_attribute_in_block_template_content( $content );
 		$blocks  = parse_blocks( $content );
 		$content = gutenberg_serialize_blocks( $blocks );
 	}

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -25,7 +25,7 @@ function render_block_core_template_part( $attributes ) {
 		$theme = get_stylesheet();
 	}
 
-	if ( isset( $attributes['slug'] ) ) {
+	if ( isset( $attributes['slug'] ) && get_stylesheet() === $theme ) {
 		$template_part_id    = $theme . '//' . $attributes['slug'];
 		$template_part_query = new WP_Query(
 			array(

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -18,12 +18,7 @@ function render_block_core_template_part( $attributes ) {
 	$template_part_id = null;
 	$content          = null;
 	$area             = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
-
-	if ( isset( $attribues['theme'] ) ) {
-		$theme = $attributes['theme'];
-	} else {
-		$theme = get_stylesheet();
-	}
+	$theme            = isset( $attributes['theme'] ) ? $attributes['theme'] : get_stylesheet();
 
 	if ( isset( $attributes['slug'] ) && get_stylesheet() === $theme ) {
 		$template_part_id    = $theme . '//' . $attributes['slug'];

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -19,12 +19,14 @@ function render_block_core_template_part( $attributes ) {
 	$content          = null;
 	$area             = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 
-	if (
-		isset( $attributes['slug'] ) &&
-		isset( $attributes['theme'] ) &&
-		get_stylesheet() === $attributes['theme']
-	) {
-		$template_part_id    = $attributes['theme'] . '//' . $attributes['slug'];
+	if ( isset( $attribues['theme'] ) ) {
+		$theme = $attributes['theme'];
+	} else {
+		$theme = get_stylesheet();
+	}
+
+	if ( isset( $attributes['slug'] ) ) {
+		$template_part_id    = $theme . '//' . $attributes['slug'];
 		$template_part_query = new WP_Query(
 			array(
 				'post_type'           => 'wp_template_part',
@@ -34,7 +36,7 @@ function render_block_core_template_part( $attributes ) {
 					array(
 						'taxonomy' => 'wp_theme',
 						'field'    => 'name',
-						'terms'    => $attributes['theme'],
+						'terms'    => $theme,
 					),
 				),
 				'posts_per_page'      => 1,


### PR DESCRIPTION
Part of the task in WordPress Core seeking performance improvements:
- https://github.com/WordPress/wordpress-develop/pull/5455.
- https://core.trac.wordpress.org/ticket/59583

An alternative approach to #53423.

Result of a [discussion](https://wordpress.slack.com/archives/C02RQBWTW/p1696959836535969?thread_ts=1696880738.627909&cid=C02RQBWTW) with @felixarntz, aiming to fix the performance regression re-introduced by https://core.trac.wordpress.org/changeset/56818.

## What?
If a Template Part block is encountered that doesn't have a `theme` attribute, fall back to the current them (`get_stylesheet()`) instead.

## Why?
This should allow removing injection of the `theme` attribute during rendering of the Template Part block.

## How?
By falling back to the current theme (`get_stylesheet()`) if `$attributes['theme']` isn't set.

## Testing Instructions
Verify that Template Parts blocks that are part of patterns still work, both on the frontend and in the editor. Specifically, verify that there are no `Template part has been deleted or is unavailable` errors.

_Will be followed up by a Core PR to remove `theme` attribute injection on the frontend._

cc/ @gziolo 
