### PR TITLE
Use all the settings origins for a block that consumes paths with merge.

### DIFF
--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -189,7 +189,12 @@ export default function useSetting( path ) {
 			// Return if the setting was found in either the block instance or the store.
 			if ( result !== undefined ) {
 				if ( PATHS_WITH_MERGE[ normalizedPath ] ) {
-					return result.custom ?? result.theme ?? result.default;
+					return [ 'default', 'theme', 'custom' ].reduce(
+						( acc, key ) => {
+							return acc.concat( result[ key ] ?? [] );
+						},
+						[]
+					);
 				}
 				return result;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Use all the settings origins for a block that consumes paths with merge.

## Why?
Because we are not displaying all the available settings if there are more than one origin in use.

## How?
By concatenating all the origins

## Testing Instructions
- Add content to a setting using more than one origin. ('theme' and 'custom', for example).
- Check that the component consuming that setting displays the content from all the origins.


Please take a look at the screencast below to see how you can test this using the editor UI.


## Screenshots or screencast <!-- if applicable -->

This change is not exclusive to font families and is not specific about the font library, I'm just showing the usage of the font library because it's easy to test the change using the UI because the installed fonts are in a different key than the theme ones.

https://github.com/WordPress/gutenberg/assets/1310626/ec2ccaa0-ad02-4d0b-ab02-5e7e19674622




Fixes https://github.com/WordPress/gutenberg/issues/55011

Co-authored-by: Jason Crist <146530+pbking@users.noreply.github.com>