### PR TITLE
test: Update Media Blocks tests for Appium 2

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
@@ -151,8 +151,7 @@ onlyOniOS( 'Gutenberg Editor Cover Block test', () => {
 		await editorPage.replaceMediaImage();
 
 		// First modal should no longer be presented.
-		const replaceButtons =
-			await editorPage.driver.elementsByAccessibilityId( 'Replace' );
+		const replaceButtons = await editorPage.driver.$$( '~Replace' );
 		// eslint-disable-next-line jest/no-conditional-expect
 		expect( replaceButtons.length ).toBe( 0 );
 

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
@@ -30,7 +30,7 @@ describe( 'Gutenberg Editor Audio Block tests', () => {
 		// tap on Media Library option
 		await editorPage.chooseMediaLibrary();
 		// wait until the media is added
-		await editorPage.driver.sleep( 500 );
+		await editorPage.driver.pause( 500 );
 
 		// get the html version of the content
 		const html = await editorPage.getHtmlContent();
@@ -65,7 +65,7 @@ describe( 'Gutenberg Editor File Block tests', () => {
 		// tap on Media Library option
 		await editorPage.chooseMediaLibrary();
 		// wait until the media is added
-		await editorPage.driver.sleep( 500 );
+		await editorPage.driver.pause( 500 );
 
 		// get the html version of the content
 		const html = await editorPage.getHtmlContent();

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -806,10 +806,13 @@ class EditorPage {
 	}
 
 	async enterCaptionToSelectedImageBlock( caption, clear = true ) {
-		const imageBlockCaptionField = await this.driver.elementByXPath(
+		const imageBlockCaptionButton = await this.driver.$(
 			'//XCUIElementTypeButton[starts-with(@name, "Image caption.")]'
 		);
-		await imageBlockCaptionField.click();
+		await imageBlockCaptionButton.click();
+		const imageBlockCaptionField = await imageBlockCaptionButton.$(
+			'//XCUIElementTypeTextView'
+		);
 		await typeString( this.driver, imageBlockCaptionField, caption, clear );
 	}
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -528,8 +528,7 @@ class EditorPage {
 		let navigateUpElements = [];
 		do {
 			await this.driver.pause( 2000 );
-			navigateUpElements =
-				await this.driver.elementsByAccessibilityId( 'Navigate Up' );
+			navigateUpElements = await this.driver.$$( `~Navigate Up` );
 			if ( navigateUpElements.length > 0 ) {
 				await navigateUpElements[ 0 ].click();
 			}
@@ -770,8 +769,7 @@ class EditorPage {
 			this.driver,
 			'//XCUIElementTypeOther[@name="Media Add image or video"]'
 		);
-		const addMediaButton =
-			await mediaSection.elementByAccessibilityId( 'Add image or video' );
+		const addMediaButton = await mediaSection.$( '~Add image or video' );
 		await addMediaButton.click();
 	}
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -527,7 +527,7 @@ class EditorPage {
 	async moveBlockSelectionUp( options = { toRoot: false } ) {
 		let navigateUpElements = [];
 		do {
-			await this.driver.sleep( 2000 );
+			await this.driver.pause( 2000 );
 			navigateUpElements =
 				await this.driver.elementsByAccessibilityId( 'Navigate Up' );
 			if ( navigateUpElements.length > 0 ) {

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -577,7 +577,7 @@ class EditorPage {
 		blockLocator += `[@${
 			this.accessibilityIdXPathAttrib
 		}="Move block up from row ${ position } to row ${ position - 1 }"]`;
-		const moveUpButton = await this.driver.elementByXPath( blockLocator );
+		const moveUpButton = await this.driver.$( `~${ blockLocator }` );
 		await moveUpButton.click();
 	}
 
@@ -793,8 +793,7 @@ class EditorPage {
 			this.accessibilityIdKey
 		);
 		const blockLocator = `//*[@${ this.accessibilityIdXPathAttrib }="${ accessibilityId }"]//XCUIElementTypeButton[@name="Image block. Empty"]`;
-		const imageBlockInnerElement =
-			await this.driver.elementByXPath( blockLocator );
+		const imageBlockInnerElement = await this.driver.$( blockLocator );
 		await imageBlockInnerElement.click();
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Relates to #55166. Update the Paragraph tests for Appium 2 and WebdriverIO.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improve the stability and quality of the automated tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Replace `sleep` with `pause` utility
- Replace `elementsByAccessibilityId` usage
- Replace `elementByXPath` usage
- Repair `enterCaptionToSelectedImageBlock` utility
    The `clearValue` method did not succeed on the caption Button element.
    Hence, the utility was expanded to instead type into the TextView.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Local tests should pass for both platforms when running the following commands:

```
npm run native test:e2e:ios:local -- -- gutenberg-editor-media-blocks
```

```
npm run native test:e2e:android:local -- -- gutenberg-editor-media-blocks
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
