### PR TITLE
Block Supports: Backport optimization from Core for Elements Support

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -13,7 +13,7 @@
  * @return string                Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content, $block ) {
-	if ( ! $block_content || empty( $block['attrs'] ) ) {
+	if ( ! $block_content || ! isset( $block['attrs']['style']['elements'] ) ) {
 		return $block_content;
 	}
 
@@ -23,42 +23,42 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		'button'  => array(
 			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'button' ),
 			'paths' => array(
-				'style.elements.button.color.text',
-				'style.elements.button.color.background',
-				'style.elements.button.color.gradient',
+				array( 'button', 'color', 'text' ),
+				array( 'button', 'color', 'background' ),
+				array( 'button', 'color', 'gradient' ),
 			),
 		),
 		'link'    => array(
 			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'link' ),
 			'paths' => array(
-				'style.elements.link.color.text',
-				'style.elements.link.:hover.color.text',
+				array( 'link', 'color', 'text' ),
+				array( 'link', ':hover', 'color', 'text' ),
 			),
 		),
 		'heading' => array(
 			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'heading' ),
 			'paths' => array(
-				'style.elements.heading.color.text',
-				'style.elements.heading.color.background',
-				'style.elements.heading.color.gradient',
-				'style.elements.h1.color.text',
-				'style.elements.h1.color.background',
-				'style.elements.h1.color.gradient',
-				'style.elements.h2.color.text',
-				'style.elements.h2.color.background',
-				'style.elements.h2.color.gradient',
-				'style.elements.h3.color.text',
-				'style.elements.h3.color.background',
-				'style.elements.h3.color.gradient',
-				'style.elements.h4.color.text',
-				'style.elements.h4.color.background',
-				'style.elements.h4.color.gradient',
-				'style.elements.h5.color.text',
-				'style.elements.h5.color.background',
-				'style.elements.h5.color.gradient',
-				'style.elements.h6.color.text',
-				'style.elements.h6.color.background',
-				'style.elements.h6.color.gradient',
+				array( 'heading', 'color', 'text' ),
+				array( 'heading', 'color', 'background' ),
+				array( 'heading', 'color', 'gradient' ),
+				array( 'h1', 'color', 'text' ),
+				array( 'h1', 'color', 'background' ),
+				array( 'h1', 'color', 'gradient' ),
+				array( 'h2', 'color', 'text' ),
+				array( 'h2', 'color', 'background' ),
+				array( 'h2', 'color', 'gradient' ),
+				array( 'h3', 'color', 'text' ),
+				array( 'h3', 'color', 'background' ),
+				array( 'h3', 'color', 'gradient' ),
+				array( 'h4', 'color', 'text' ),
+				array( 'h4', 'color', 'background' ),
+				array( 'h4', 'color', 'gradient' ),
+				array( 'h5', 'color', 'text' ),
+				array( 'h5', 'color', 'background' ),
+				array( 'h5', 'color', 'gradient' ),
+				array( 'h6', 'color', 'text' ),
+				array( 'h6', 'color', 'background' ),
+				array( 'h6', 'color', 'gradient' ),
 			),
 		),
 	);
@@ -71,7 +71,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$element_colors_set = 0;
+	$elements_style_attributes = $block['attrs']['style']['elements'];
 
 	foreach ( $element_color_properties as $element_config ) {
 		if ( $element_config['skip'] ) {
@@ -79,24 +79,28 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		}
 
 		foreach ( $element_config['paths'] as $path ) {
-			if ( null !== _wp_array_get( $block['attrs'], explode( '.', $path ), null ) ) {
-				++$element_colors_set;
+			if ( null !== _wp_array_get( $elements_style_attributes, $path, null ) ) {
+				/*
+				 * It only takes a single custom attribute to require that the custom
+				 * class name be added to the block, so once one is found there's no
+				 * need to continue looking for others.
+				 *
+				 * As is done with the layout hook, this code assumes that the block
+				 * contains a single wrapper and that it's the first element in the
+				 * rendered output. That first element, if it exists, gets the class.
+				 */
+				$tags = new WP_HTML_Tag_Processor( $block_content );
+				if ( $tags->next_tag() ) {
+					$tags->add_class( wp_get_elements_class_name( $block ) );
+				}
+
+				return $tags->get_updated_html();
 			}
 		}
 	}
 
-	if ( ! $element_colors_set ) {
-		return $block_content;
-	}
-
-	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
-	// Add the class name to the first element, presuming it's the wrapper, if it exists.
-	$tags = new WP_HTML_Tag_Processor( $block_content );
-	if ( $tags->next_tag() ) {
-		$tags->add_class( wp_get_elements_class_name( $block ) );
-	}
-
-	return $tags->get_updated_html();
+	// If no custom attributes were found then there's nothing to modify.
+	return $block_content;
 }
 
 /**


### PR DESCRIPTION
## What?

Brings over optimization surfaced during the WordPress 6.4 beta release for block supports elements, which entails skipping needless iteration when it's known that the iteration need not continue.

See WordPress/wordpress-develop#5411
See [#59544-trac](https://core.trac.wordpress.org/ticket/59544)

## Why?

Keeps versions in sync. This optimization was performed in Core first in order to quickly address one of a number of performance issues that were raised during testing the beta release of WordPress 6.4. Its fix should also come back to Gutenberg, since that file is normally updated through the package update.

## How?

Copies code from Core into Gutenberg in the corresponding file.

## Testing Instructions

Verify that the backport is appropriately applied and that all tests pass.