### PR TITLE
docs: Update broken anchor link

### DIFF
--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -28,7 +28,7 @@ $ cd todo-list
 $ npm start
 ```
 
-The `slug` provided (`todo-list` in the example) defines the folder name for the scaffolded plugin and the internal block name. The WordPress plugin generated must [be installed manually](https://wordpress.org/documentation/article/manage-plugins/#manual-plugin-installation).
+The `slug` provided (`todo-list` in the example) defines the folder name for the scaffolded plugin and the internal block name. The WordPress plugin generated must [be installed manually](https://wordpress.org/documentation/article/manage-plugins/#manual-plugin-installation-1).
 
 
 _(requires `node` version `14.0.0` or above, and `npm` version `6.14.4` or above)_


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR updates the link to point to the correct anchor on the reference page.

## Why?

When users clicked the existing link, they were directed to the top of the page. This was caused by the URL not matching the updated destination anchor.

## How?

This PR updates the URL to match the destination anchor.

## Testing Instructions

1. View the packages/create-block/README.md file.
2. Click the "be installed manually" link.
3. The expected result should anchor you to the Manual Plugin Installation section of the Manage Plugins post.

### Testing Instructions for Keyboard
1. Press `tab` until you reach the "be installed manually" link.
2. Press `enter` to follow the link.
