### PR TITLE
Document updating the consent string to unlock private APIs.

### DIFF
--- a/packages/private-apis/README.md
+++ b/packages/private-apis/README.md
@@ -114,7 +114,6 @@ The consent string for unlocking private APIs is intended to change on a regular
 
 Updating the consent string is considered a task and can be done during the late stages of a WordPress release.
 
-
 #### Consent string history
 
 The final string in this list is the current version.

--- a/packages/private-apis/README.md
+++ b/packages/private-apis/README.md
@@ -102,9 +102,9 @@ To find out more about contributing to this package or Gutenberg as a whole, ple
 The consent string for unlocking private APIs is intended to change on a regular basis. To update the consent string:
 
 1. Come up with a new consent string, the string should mention that themes or plugins opting in to unstable and private features will break in future versions of WordPress.
-1. Ensure the consent string has not being used previously.
-1. Append the new string to the history list below.
-1. Replace the consent string in the following locations:
+2. Ensure the consent string has not being used previously.
+3. Append the new string to the history list below.
+4. Replace the consent string in the following locations:
    * twice in the documentation above
    * in the `src/implementation.js` file of this package
    * in the `src/lock-unlock.js` file located in packages consuming private APIs
@@ -120,4 +120,4 @@ Updating the consent string is considered a task and can be done during the late
 The final string in this list is the current version.
 
 1. I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.
-1. I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.
+2. I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.

--- a/packages/private-apis/README.md
+++ b/packages/private-apis/README.md
@@ -96,3 +96,28 @@ This is an individual package that's part of the Gutenberg project. The project 
 To find out more about contributing to this package or Gutenberg as a whole, please read the project's main [contributor guide](https://github.com/WordPress/gutenberg/tree/HEAD/CONTRIBUTING.md).
 
 <br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
+
+### Updating the consent string
+
+The consent string for unlocking private APIs is intended to change on a regular basis. To update the consent string:
+
+1. Come up with a new consent string, the string should mention that themes or plugins opting in to unstable and private features will break in future versions of WordPress.
+1. Ensure the consent string has not being used previously.
+1. Append the new string to the history list below.
+1. Replace the consent string in the following locations:
+   * twice in the documentation above
+   * in the `src/implementation.js` file of this package
+   * in the `src/lock-unlock.js` file located in packages consuming private APIs
+   * search the full code base for any other occurrences
+
+**Note**: The consent string is not used for user facing content and as such should _not_ be made translatable via the internationalization features of WordPress.
+
+Updating the consent string is considered a task and can be done during the late stages of a WordPress release.
+
+
+#### Consent string history
+
+The final string in this list is the current version.
+
+1. I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.
+1. I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Documenting the process for updating the consent string to unlock access to private APIs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The consent string is intended to be updated on a regular basis.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've put it in the package's readme file for now, please advise if it should be moved elsewhere.

## Testing Instructions

N/A: Docs change.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A: Docs change.

## Screenshots or screencast <!-- if applicable -->

N/A: Docs change.