### PR TITLE
Patterns: Register new media related categories

### DIFF
--- a/lib/compat/wordpress-6.5/block-patterns.php
+++ b/lib/compat/wordpress-6.5/block-patterns.php
@@ -14,6 +14,17 @@
  * @return void
  */
 function gutenberg_register_media_pattern_categories() {
+	// Update the default gallery category to better differentiate it with Images.
+	unregister_block_pattern_category( 'gallery' );
+	register_block_pattern_category(
+		'gallery',
+		array(
+			'label'       => _x( 'Gallery', 'Block pattern category' ),
+			'description' => __( 'Different layouts containing a collection of images.' ),
+		)
+	);
+
+	// Register new categories.
 	register_block_pattern_category(
 		'images',
 		array(

--- a/lib/compat/wordpress-6.5/block-patterns.php
+++ b/lib/compat/wordpress-6.5/block-patterns.php
@@ -14,24 +14,7 @@
  * @return void
  */
 function gutenberg_register_media_pattern_categories() {
-	// Update the default gallery category to better differentiate it with Images.
-	unregister_block_pattern_category( 'gallery' );
-	register_block_pattern_category(
-		'gallery',
-		array(
-			'label'       => _x( 'Gallery', 'Block pattern category' ),
-			'description' => __( 'Different layouts containing a collection of images.' ),
-		)
-	);
-
 	// Register new categories.
-	register_block_pattern_category(
-		'images',
-		array(
-			'label'       => _x( 'Images', 'Block pattern category' ),
-			'description' => __( 'Different layouts containing images.' ),
-		)
-	);
 	register_block_pattern_category(
 		'videos',
 		array(

--- a/lib/compat/wordpress-6.5/block-patterns.php
+++ b/lib/compat/wordpress-6.5/block-patterns.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Extends Core's wp-includes/block-patterns.php to add new media related
+ * pattern categories for WP 6.5.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds new pattern categories for better organization of media related patterns.
+ *
+ * Note: This should be removed when the minimum required WP version is >= 6.5.
+ *
+ * @return void
+ */
+function gutenberg_register_media_pattern_categories() {
+	unregister_block_pattern_category( 'media' );
+
+	register_block_pattern_category(
+		'images',
+		array(
+			'label'       => _x( 'Images', 'Block pattern category' ),
+			'description' => __( 'Different layouts containing images.' ),
+		)
+	);
+	register_block_pattern_category(
+		'videos',
+		array(
+			'label'       => _x( 'Videos', 'Block pattern category' ),
+			'description' => __( 'Different layouts containing videos.' ),
+		)
+	);
+	register_block_pattern_category(
+		'audio',
+		array(
+			'label'       => _x( 'Audio', 'Block pattern category' ),
+			'description' => __( 'Different layouts containing audio.' ),
+		)
+	);
+}
+add_action( 'init', 'gutenberg_register_media_pattern_categories' );

--- a/lib/compat/wordpress-6.5/block-patterns.php
+++ b/lib/compat/wordpress-6.5/block-patterns.php
@@ -14,8 +14,6 @@
  * @return void
  */
 function gutenberg_register_media_pattern_categories() {
-	unregister_block_pattern_category( 'media' );
-
 	register_block_pattern_category(
 		'images',
 		array(

--- a/lib/load.php
+++ b/lib/load.php
@@ -103,6 +103,9 @@ require __DIR__ . '/compat/wordpress-6.4/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.4/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.4/kses.php';
 
+// WordPress 6.5 compat.
+require __DIR__ . '/compat/wordpress-6.5/block-patterns.php';
+
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/blocks.php';


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/47847

## What?

Adds new media-related categories (Audio & Videos) in place of the existing Media category as per https://github.com/WordPress/gutenberg/issues/47847#issuecomment-1749570280

## Why?

Allows for better organisation of curated patterns.

## How?

- ~Deregisters Media block pattern category~ Media category remains due to BC concerns.
- Registers Audio, Images, and Videos categories

_Note: There didn't appear to be any curated patterns for the Media category currently in the directory. I'm not 100% certain on the backwards compatibility of removing the media category. Should themes be categorizing patterns under this they could register their own media category or assign patterns to the new categories. See: https://github.com/WordPress/gutenberg/issues/47847#issuecomment-1756931356_

## Testing Instructions

1. Activate TT3
2. In the post editor, navigate to the inserter and Patterns tab
3. ~Confirm the images category is present and contains patterns from the directory~ Images category should not display
4. Note the Audio and Video categories will not display as there currently aren't any core/theme/directory patterns assigned to them
5. Open the site editor's patterns page (Appearance > Editor > Patterns)
6. Neither of the new categories should show in the sidebar yet
7. Select the option in the sidebar to create a new pattern
8. Confirm the category selector in the create pattern modal suggests both Audio and Videos
9. Try adding patterns to each of the new categories and confirm they display in both the site and post editors


## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/60436221/9d3b55f7-7ee6-41ab-a080-583c7521768a


