### PR TITLE
Remove `@return void` from PHP function docs.

### DIFF
--- a/packages/block-library/src/form/index.php
+++ b/packages/block-library/src/form/index.php
@@ -83,8 +83,6 @@ add_filter( 'render_block_core_form_extra_fields', 'block_core_form_extra_fields
 
 /**
  * Sends an email if the form is a contact form.
- *
- * @return void
  */
 function block_core_form_send_email() {
 	check_ajax_referer( 'wp-block-form' );
@@ -126,8 +124,6 @@ add_action( 'wp_ajax_nopriv_wp_block_form_email_submit', 'block_core_form_send_e
 
 /**
  * Send the data export/remove request if the form is a privacy-request form.
- *
- * @return void
  */
 function block_core_form_privacy_form() {
 	// Get the POST data.

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -310,8 +310,6 @@ HTML;
  * @since 6.4.0
  *
  * @global WP_Scripts $wp_scripts
- *
- * @return void
  */
 function block_core_image_ensure_interactivity_dependency() {
 	global $wp_scripts;
@@ -327,8 +325,6 @@ add_action( 'wp_print_scripts', 'block_core_image_ensure_interactivity_dependenc
 
 /**
  * Registers the `core/image` block on server.
- *
- * @return void
  */
 function register_block_core_image() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -7,8 +7,6 @@
 
 /**
  *  Registers the `core/pattern` block on the server.
- *
- * @return void
  */
 function register_block_core_pattern() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -281,8 +281,6 @@ function classnames_for_block_core_search( $attributes ) {
  * @param array  $wrapper_styles Current collection of wrapper styles.
  * @param array  $button_styles  Current collection of button styles.
  * @param array  $input_styles   Current collection of input styles.
- *
- * @return void
  */
 function apply_block_core_search_border_style( $attributes, $property, $side, &$wrapper_styles, &$button_styles, &$input_styles ) {
 	$is_button_inside = isset( $attributes['buttonPosition'] ) && 'button-inside' === $attributes['buttonPosition'];
@@ -327,8 +325,6 @@ function apply_block_core_search_border_style( $attributes, $property, $side, &$
  * @param array  $wrapper_styles Current collection of wrapper styles.
  * @param array  $button_styles  Current collection of button styles.
  * @param array  $input_styles   Current collection of input styles.
- *
- * @return void
  */
 function apply_block_core_search_border_styles( $attributes, $property, &$wrapper_styles, &$button_styles, &$input_styles ) {
 	apply_block_core_search_border_style( $attributes, $property, null, $wrapper_styles, $button_styles, $input_styles );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes `@return void` from PHP docblocks in the block-library files, so they don't end up in core.

Follow up from [this comment](https://github.com/WordPress/wordpress-develop/pull/5439#discussion_r1352819331).


