### PR TITLE
Quote Block: Fix the Quote block layout supports.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -774,7 +774,7 @@ Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Ju
 
 -	**Name:** core/quote
 -	**Category:** text
--	**Supports:** anchor, color (background, gradients, heading, link, text), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** anchor, color (background, gradients, heading, link, text), layout (~~allowEditing~~), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** align, citation, value
 
 ## Read More

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -54,6 +54,9 @@
 				"background": true,
 				"text": true
 			}
+		},
+		"layout": {
+			"allowEditing": false
 		}
 	},
 	"styles": [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix #55076
Quote Block: Fix the Quote block layout supports.

## trunk
https://github.com/WordPress/gutenberg/assets/42362903/51cdbedf-975d-40ec-a397-e847d0816e32

## this branch
https://github.com/WordPress/gutenberg/assets/42362903/d648f269-1eeb-4592-9afa-42af5e3562a9


## Testing Instructions
1. Place Image Block in the Quote block.
or paste the HTML below.
```HTML
<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>aaa</p>
<!-- /wp:paragraph -->

<!-- wp:image {"align":"center","id":7335,"width":"311px","height":"auto","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image aligncenter size-full is-resized"><img src="https://s.w.org/images/core/5.3/MtBlanc1.jpg" alt="" class="wp-image-7335" style="object-fit:cover;width:311px;height:auto"/></figure>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>bbb</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->
```
2. Change the align.
3. The alignment change.

Added block supports in the same way as the Details block🗒
https://github.com/WordPress/gutenberg/blob/1aae9e88d86bbc0db5dda5ae190ecbd4b0e0e355/packages/block-library/src/details/block.json#L59-L61