### PR TITLE
Fix filtering for downloadable blocks in inserter.

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -4,9 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { withSelect } from '@wordpress/data';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -72,10 +72,9 @@ function DownloadableBlocksPanel( {
 }
 
 export default compose( [
-	withSelect( ( select, { filterValue, rootClientId = null } ) => {
+	withSelect( ( select, { filterValue } ) => {
 		const { getDownloadableBlocks, isRequestingDownloadableBlocks } =
 			select( blockDirectoryStore );
-		const { canInsertBlockType } = select( blockEditorStore );
 
 		const hasPermission = select( coreStore ).canUser(
 			'read',
@@ -84,8 +83,9 @@ export default compose( [
 
 		function getInstallableBlocks( term ) {
 			const downloadableBlocks = getDownloadableBlocks( term );
-			const installableBlocks = downloadableBlocks.filter( ( block ) =>
-				canInsertBlockType( block, rootClientId, true )
+			// Filter out blocks that are already installed.
+			const installableBlocks = downloadableBlocks.filter(
+				( block ) => ! getBlockType( block.name )
 			);
 
 			if ( downloadableBlocks.length === installableBlocks.length ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #55209.

Changes how the `downloadableItems` passed to `DownloadableBlocksPanel` are calculated so that if blocks are hidden in the post editor a list of downloadable blocks still shows.

The problem was we were using `canInsertBlockType` to check if the downloadable blocks could be used, but that function only checks against a list of blocks that are already installed. A block that's not installed won't be on the list, so it would always return false. 

The reason this logic magically worked if there were no blocks hidden in the editor is that `allowedBlockTypes` is a boolean if there are no _disallowed_ block types, but a list if there are 😅 

I changed the logic to filter out blocks already installed, because I noticed installed blocks were still appearing in the downloadable blocks results and if a block is installed but hidden, we don't want it appearing there. I may be missing something here though - is there any reason we might want installed blocks to still appear on the list? If so, we could add logic to check the installed blocks against `allowedBlockTypes` instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the post editor, search for a term in the inserter, e.g. "Searching";
2. Note the results that appear;
3. Go to Options > Preferences > Blocks and hide a couple of blocks;
4. Search the inserter again and check the same results appear;
5. Install one of the blocks;
6. In Options > Preferences > Blocks hide the block just installed;
7. Search again and check that installed block doesn't appear.

With MathML block installed and hidden:

#### before

<img width="348" alt="Screenshot 2023-10-11 at 3 11 17 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/875700e0-843d-4076-8afb-0840e014ac3c">

#### after

<img width="345" alt="Screenshot 2023-10-11 at 3 45 09 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/f58e178d-a3ef-43a9-b21c-bc57f731bc1a">
