### PR TITLE
Patterns: Remove the version enforcement for npm in `engines` field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57445,8 +57445,7 @@
 				"@wordpress/url": "file:../url"
 			},
 			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=8 <9"
+				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -19,8 +19,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=16.0.0",
-		"npm": ">=8 <9"
+		"node": ">=16.0.0"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Based on the finding from @desrosj shared on WordPress Slack (link requires access with an account created at https://make.wordpress.org/chat):

https://wordpress.slack.com/archives/C02RQBWTW/p1696958476601589?thread_ts=1696924785.622849&cid=C02RQBWTW

>  I started seeing if Core could be updated easily, but seems that some GB packages don't explicitly allow 18.x (@wordpress/patterns is flagged running npm install, but there could be others if it stops at the first failure). So we'll need to land Gutenberg related changes first. May be worth getting those staged now.

It would be great to backport this change to the next WordPress Beta/RC.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It enforces projects using this package to use npm 8.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the limitation of using npm 8

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
