### PR TITLE
DataViews: Add featured image field to the page list

### DIFF
--- a/packages/edit-site/src/components/media/index.js
+++ b/packages/edit-site/src/components/media/index.js
@@ -3,7 +3,7 @@
  */
 import { useEntityRecord } from '@wordpress/core-data';
 
-function Media( { id, size } ) {
+function Media( { id, size, ...props } ) {
 	const { record: media } = useEntityRecord( 'root', 'media', id );
 	const sizesPerPriority = [ 'large', 'thumbnail' ];
 	const currentSize =
@@ -15,7 +15,13 @@ function Media( { id, size } ) {
 		return null;
 	}
 
-	return <img src={ mediaDetails.source_url } alt={ media.alt_text } />;
+	return (
+		<img
+			{ ...props }
+			src={ mediaDetails.source_url }
+			alt={ media.alt_text }
+		/>
+	);
 }
 
 export default Media;

--- a/packages/edit-site/src/components/media/index.js
+++ b/packages/edit-site/src/components/media/index.js
@@ -15,7 +15,7 @@ function Media( { id, size } ) {
 		return null;
 	}
 
-	return <img src={ mediaDetails.source_url } alt="" />;
+	return <img src={ mediaDetails.source_url } alt={ media.alt_text } />;
 }
 
 export default Media;

--- a/packages/edit-site/src/components/media/index.js
+++ b/packages/edit-site/src/components/media/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityRecord } from '@wordpress/core-data';
+
+function Media( { id, size } ) {
+	const { record: media } = useEntityRecord( 'root', 'media', id );
+	const sizesPerPriority = [ 'large', 'thumbnail' ];
+	const currentSize =
+		size ??
+		sizesPerPriority.find( ( s ) => !! media?.media_details?.sizes[ s ] );
+	const mediaDetails = media?.media_details?.sizes[ currentSize ];
+
+	if ( ! mediaDetails ) {
+		return null;
+	}
+
+	return <img src={ mediaDetails.source_url } alt="" />;
+}
+
+export default Media;

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -35,7 +35,7 @@ export default function PagePages() {
 		},
 		// All fields are visible by default, so it's
 		// better to keep track of the hidden ones.
-		hiddenFields: [ 'date' ],
+		hiddenFields: [ 'date', 'featured-image' ],
 	} );
 	// Request post statuses to get the proper labels.
 	const { records: statuses } = useEntityRecords( 'root', 'status' );

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -18,6 +18,7 @@ import Page from '../page';
 import Link from '../routes/link';
 import { DataViews } from '../dataviews';
 import useTrashPostAction from '../actions/trash-post';
+import Media from '../media';
 
 const EMPTY_ARRAY = [];
 const EMPTY_OBJECT = {};
@@ -76,6 +77,19 @@ export default function PagePages() {
 	const fields = useMemo(
 		() => [
 			{
+				id: 'featured-image',
+				header: __( 'Featured Image' ),
+				accessorFn: ( page ) => page.featured_media,
+				cell: ( props ) =>
+					!! props.row.original.featured_media ? (
+						<Media
+							id={ props.row.original.featured_media }
+							size="thumbnail"
+						/>
+					) : null,
+				enableSorting: false,
+			},
+			{
 				header: __( 'Title' ),
 				id: 'title',
 				accessorFn: ( page ) => page.title?.rendered || page.slug,
@@ -115,7 +129,7 @@ export default function PagePages() {
 				},
 			},
 			{
-				header: 'Status',
+				header: __( 'Status' ),
 				id: 'status',
 				accessorFn: ( page ) =>
 					postStatuses[ page.status ] ?? page.status,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -83,6 +83,7 @@ export default function PagePages() {
 				cell: ( props ) =>
 					!! props.row.original.featured_media ? (
 						<Media
+							className="edit-site-page-pages__featured-image"
 							id={ props.row.original.featured_media }
 							size="thumbnail"
 						/>

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -1,0 +1,4 @@
+.edit-site-page-pages__featured-image {
+	border-radius: $radius-block-ui;
+	max-height: 60px;
+}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -11,6 +11,7 @@
 @import "./components/header-edit-mode/document-actions/style.scss";
 @import "./components/list/style.scss";
 @import "./components/page/style.scss";
+@import "./components/page-pages/style.scss";
 @import "./components/page-patterns/style.scss";
 @import "./components/table/style.scss";
 @import "./components/sidebar-edit-mode/style.scss";


### PR DESCRIPTION
Related #55083 

## What?

The grid data view layout requires items to have a media to render per item. So before starting to explore the grid layout, I wanted to add a "media" field to the table view. This small PR just adds the featured image field to the pages list data view in the site editor.

I wanted to ensure that this field is actually hidden initially, in the initial view config but it's not possible yet to control the visibility from the view config. I believe @ntsekouras is working on that in parallel. 

## Testing Instructions

1- Add some pages with featured images
2- Make sure the featured image column in visible properly in the table view