### PR TITLE
[DataViews]: Update the view config to include fields visibility

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -81,17 +81,17 @@ export default function DataViews( {
 				enableHiding: false,
 			} );
 		}
-		if ( view.fields?.hideable?.length ) {
+		if ( view.fields?.hidable?.length ) {
 			_columns = _columns.map( ( column ) => {
 				return {
 					...column,
-					enableHiding: view.fields.hideable.includes( column.id ),
+					enableHiding: view.fields.hidable.includes( column.id ),
 				};
 			} );
 		}
 
 		return _columns;
-	}, [ fields, actions, view.fields?.hideable ] );
+	}, [ fields, actions, view.fields?.hidable ] );
 
 	const columnVisibility = useMemo( () => {
 		if ( ! view.fields?.hidden?.size ) {

--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -45,7 +45,7 @@ export default function DataViews( {
 	options: { pageCount },
 } ) {
 	const columns = useMemo( () => {
-		let _columns = [ ...fields ];
+		const _columns = [ ...fields ];
 		if ( actions?.length ) {
 			_columns.push( {
 				header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,
@@ -81,23 +81,15 @@ export default function DataViews( {
 				enableHiding: false,
 			} );
 		}
-		if ( view.fields?.hidable?.length ) {
-			_columns = _columns.map( ( column ) => {
-				return {
-					...column,
-					enableHiding: view.fields.hidable.includes( column.id ),
-				};
-			} );
-		}
 
 		return _columns;
-	}, [ fields, actions, view.fields?.hidable ] );
+	}, [ fields, actions ] );
 
 	const columnVisibility = useMemo( () => {
-		if ( ! view.fields?.hidden?.size ) {
+		if ( ! view.fields?.hidden?.length ) {
 			return;
 		}
-		return Array.from( view.fields.hidden ).reduce(
+		return view.fields.hidden.reduce(
 			( accumulator, fieldId ) => ( {
 				...accumulator,
 				[ fieldId ]: false,
@@ -163,14 +155,17 @@ export default function DataViews( {
 			onChangeView( ( currentView ) => {
 				const hiddenFields = Object.entries(
 					columnVisibilityUpdater()
-				).reduce( ( accumulator, [ fieldId, value ] ) => {
-					if ( value ) {
-						accumulator.delete( fieldId );
-					} else {
-						accumulator.add( fieldId );
-					}
-					return accumulator;
-				}, new Set( currentView.fields.hidden ) );
+				).reduce(
+					( accumulator, [ fieldId, value ] ) => {
+						if ( value ) {
+							return accumulator.filter(
+								( id ) => id !== fieldId
+							);
+						}
+						return [ ...accumulator, fieldId ];
+					},
+					[ ...( currentView.fields.hidden || [] ) ]
+				);
 				return {
 					...currentView,
 					fields: {

--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -86,17 +86,17 @@ export default function DataViews( {
 	}, [ fields, actions ] );
 
 	const columnVisibility = useMemo( () => {
-		if ( ! view.fields?.hidden?.length ) {
+		if ( ! view.hiddenFields?.length ) {
 			return;
 		}
-		return view.fields.hidden.reduce(
+		return view.hiddenFields.reduce(
 			( accumulator, fieldId ) => ( {
 				...accumulator,
 				[ fieldId ]: false,
 			} ),
 			{}
 		);
-	}, [ view.fields?.hidden ] );
+	}, [ view.hiddenFields ] );
 
 	const dataView = useReactTable( {
 		data,
@@ -164,14 +164,11 @@ export default function DataViews( {
 						}
 						return [ ...accumulator, fieldId ];
 					},
-					[ ...( currentView.fields.hidden || [] ) ]
+					[ ...( currentView.hiddenFields || [] ) ]
 				);
 				return {
 					...currentView,
-					fields: {
-						...currentView.fields,
-						hidden: hiddenFields,
-					},
+					hiddenFields,
 				};
 			} );
 		},

--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -102,10 +102,10 @@ function PageSizeMenu( { dataView } ) {
 }
 
 function FieldsVisibilityMenu( { dataView } ) {
-	const hideableFields = dataView
+	const hidableFields = dataView
 		.getAllColumns()
 		.filter( ( columnn ) => columnn.getCanHide() );
-	if ( ! hideableFields?.length ) {
+	if ( ! hidableFields?.length ) {
 		return null;
 	}
 	return (
@@ -118,7 +118,7 @@ function FieldsVisibilityMenu( { dataView } ) {
 				</DropdownSubMenuTriggerV2>
 			}
 		>
-			{ hideableFields?.map( ( field ) => {
+			{ hidableFields?.map( ( field ) => {
 				return (
 					<DropdownMenuItemV2
 						key={ field.id }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState, useMemo } from '@wordpress/element';
+import { dateI18n, getDate, getSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -30,6 +31,12 @@ export default function PagePages() {
 		sort: {
 			field: 'date',
 			direction: 'desc',
+		},
+		fields: {
+			// All fields are visible by default, so it's
+			// better to keep track of the hidden ones.
+			hidden: new Set( [ 'date' ] ),
+			hideable: [ 'author', 'status', 'date' ],
 		},
 	} );
 	// Request post statuses to get the proper labels.
@@ -95,7 +102,6 @@ export default function PagePages() {
 				},
 				maxWidth: 400,
 				sortingFn: 'alphanumeric',
-				enableHiding: false,
 			},
 			{
 				header: __( 'Author' ),
@@ -115,6 +121,18 @@ export default function PagePages() {
 				id: 'status',
 				accessorFn: ( page ) =>
 					postStatuses[ page.status ] ?? page.status,
+				enableSorting: false,
+			},
+			{
+				header: 'Date',
+				id: 'date',
+				cell: ( props ) => {
+					const formattedDate = dateI18n(
+						getSettings().formats.datetimeAbbreviated,
+						getDate( props.row.original.date )
+					);
+					return <time>{ formattedDate }</time>;
+				},
 				enableSorting: false,
 			},
 		],

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -32,11 +32,9 @@ export default function PagePages() {
 			field: 'date',
 			direction: 'desc',
 		},
-		fields: {
-			// All fields are visible by default, so it's
-			// better to keep track of the hidden ones.
-			hidden: [ 'date' ],
-		},
+		// All fields are visible by default, so it's
+		// better to keep track of the hidden ones.
+		hiddenFields: [ 'date' ],
 	} );
 	// Request post statuses to get the proper labels.
 	const { records: statuses } = useEntityRecords( 'root', 'status' );

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -36,7 +36,7 @@ export default function PagePages() {
 			// All fields are visible by default, so it's
 			// better to keep track of the hidden ones.
 			hidden: new Set( [ 'date' ] ),
-			hideable: [ 'author', 'status', 'date' ],
+			hidable: [ 'author', 'status', 'date' ],
 		},
 	} );
 	// Request post statuses to get the proper labels.

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -35,8 +35,7 @@ export default function PagePages() {
 		fields: {
 			// All fields are visible by default, so it's
 			// better to keep track of the hidden ones.
-			hidden: new Set( [ 'date' ] ),
-			hidable: [ 'author', 'status', 'date' ],
+			hidden: [ 'date' ],
 		},
 	} );
 	// Request post statuses to get the proper labels.
@@ -102,6 +101,7 @@ export default function PagePages() {
 				},
 				maxWidth: 400,
 				sortingFn: 'alphanumeric',
+				enableHiding: false,
 			},
 			{
 				header: __( 'Author' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/55083

This PR updates the passed view config in DataViews component to handle the fields visibility.
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Everything should work as before
2. You can also see that I added a `date` field which is not visible by default.


