### PR TITLE
Fix Block Rename UI perf regression

### DIFF
--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -189,13 +189,13 @@ function BlockRenameControl( props ) {
 
 export const withBlockRenameControl = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const { clientId, name, attributes, setAttributes } = props;
+		const { clientId, name, attributes, setAttributes, isSelected } = props;
 
 		const supportsBlockNaming = hasBlockSupport( name, 'renaming', true );
 
 		return (
 			<>
-				{ supportsBlockNaming && (
+				{ isSelected && supportsBlockNaming && (
 					<>
 						<BlockRenameControl
 							clientId={ clientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes performance regression with selecting blocks identified in https://github.com/WordPress/gutenberg/pull/54426#issuecomment-1755733955.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Performance is good.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Ensures that block renaming UI is only rendered for blocks which are seletected. Failure to do so leads to expensive slots being rendered for all blocks.

Perf tests caught this because it renders 1000 blocks 👏 👏 👏 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Verify that you can still rename all blocks via block options menu `Rename` (also in list view via same option).
- Verify that performance test output for `focus` `minFocus` and `maxFocus` are all ~100ms (as per [commit prior to the one which caused the regression](https://github.com/WordPress/gutenberg/actions/runs/6467142579/job/17556606187))

Also you can run the performance tests locally and compare the output on _this branch_ vs `trunk`. The command is:

```
npm run test:performance -- -g "Selecting blocks"
```

You should notice that the `focus` metric goes down significantly between `trunk` (regression) and this PR (proposed fix).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
