### PR TITLE
Augment `Block.Edit` filter docs with performance guidance

### DIFF
--- a/docs/reference-guides/filters/block-filters.md
+++ b/docs/reference-guides/filters/block-filters.md
@@ -227,8 +227,7 @@ var withInspectorControls = wp.compose.createHigherOrderComponent( function (
 			)
 		);
 	};
-},
-'withInspectorControls' );
+}, 'withInspectorControls' );
 
 wp.hooks.addFilter(
 	'editor.BlockEdit',
@@ -238,6 +237,29 @@ wp.hooks.addFilter(
 ```
 
 {% end %}
+
+Note that as this hook is run for _all blocks_, consuming it has potential for performance regressions particularly around block selection metrics.
+
+To mitigate this, consider whether any work you perform can be altered to run only under certain conditions.
+
+For example, if you are adding components that only need to render when the block is _selected_, then you can use the block's "selected" state (`props.isSelected`) to conditionalize your rendering.
+
+```js
+const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		return (
+			<>
+				<BlockEdit { ...props } />
+				{ props.isSelected && {
+					<InspectorControls>
+						<PanelBody>My custom control</PanelBody>
+					</InspectorControls>
+				}}
+			</>
+		);
+	};
+}, 'withInspectorControl' );
+```
 
 #### `editor.BlockListBlock`
 
@@ -288,8 +310,7 @@ var withClientIdClassName = wp.compose.createHigherOrderComponent( function (
 
 		return el( BlockListBlock, newProps );
 	};
-},
-'withClientIdClassName' );
+}, 'withClientIdClassName' );
 
 wp.hooks.addFilter(
 	'editor.BlockListBlock',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds some performance guidance/warnings to the docs around the `Block.Edit` filter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's easy to introduce performance regressions using these filters. See https://github.com/WordPress/gutenberg/pull/55250. We should help folks to avoid this.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a note to remind consumers that the hook is expensive and can introduce perf regressions. It prompts consumers to conditionally render their custom output especially if it's not needed on all blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Read words.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
