### PR TITLE
Try: Only render LastRevision component if plugin is active

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/last-revision.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/last-revision.js
@@ -31,6 +31,10 @@ const useRevisionData = () => {
 function PostLastRevisionCheck( { children } ) {
 	const { lastRevisionId, revisionsCount } = useRevisionData();
 
+	if ( ! process.env.IS_GUTENBERG_PLUGIN ) {
+		return null;
+	}
+
 	if ( ! lastRevisionId || revisionsCount < 2 ) {
 		return null;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds a check for `IS_GUTENBERG_PLUGIN` to the `LastRevision` component. Please see this Slack thread for more context: https://wordpress.slack.com/archives/C055Y7FKS7N/p1696947482790409.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The API that enables this feature to work (i.e. populates `lastRevisionId` and `revisionsCount`) has recently been [fixed in Core](https://core.trac.wordpress.org/changeset/56819). Currently, the `LastRevision` component renders if these variables are set, and will not render if these variables are not set. However, in order to provide more control of this feature from the Gutenberg plugin side, we should consider temporarily putting this behind the `IS_GUTENBERG_PLUGIN` feature flag.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a check for `! process.env.IS_GUTENBERG_PLUGIN` which will render `null` if true, i.e. if the Gutenberg plugin is not active, render nothing.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Make sure you're using WP trunk as that's where the latest API fix is
2. Go to the Site Editor
3. View a template that has multiple revisions (or make a couple of small changes to a template and save them)
4. Ensure that you can see the `LastRevision` component in the Template side panel when the GB plugin is active
