### PR TITLE
[Mobile]- Update E2E Drag & Drop

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -504,12 +504,23 @@ const dragAndDropAfterElement = async ( driver, element, nextElement ) => {
 		? elementLocation.y + nextElementLocation.y + nextElementSize.height
 		: nextElementLocation.y + nextElementSize.height;
 
-	const action = new wd.TouchAction( driver )
-		.press( { x, y } )
-		.wait( 5000 )
-		.moveTo( { x, y: nextYPosition } )
-		.release();
-	await action.perform();
+	await driver.touchPerform( [
+		{
+			action: 'press',
+			options: { x, y },
+		},
+		{
+			action: 'wait',
+			options: {
+				ms: 5000,
+			},
+		},
+		{
+			action: 'moveTo',
+			options: { x, y: nextYPosition },
+		},
+		{ action: 'release' },
+	] );
 };
 
 const toggleHtmlMode = async ( driver, toggleOn ) => {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/pull/55166

## What?
This PR updates the Drag & Drop tests to WebdriverIO and Appium 2.

## Why?
To continue with the migration effort to support this new version and new driver.

## How?
- Migrates the `dragAndDropAfterElement` utility to WebdriverIO.

## Testing Instructions
Local tests should pass by running the following command for both platforms:

**Android**
```
 TEST_RN_PLATFORM=android npm run native device-tests:local gutenberg-editor-drag-and-drop.test.js
```

**iOS**
```
 TEST_RN_PLATFORM=ios npm run native device-tests:local gutenberg-editor-drag-and-drop.test.js
```

I've also confirmed it runs on SauceLabs by triggering the test from a local command against the Appium 2 build.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A