### PR TITLE
Migrating `AddCustomTemplateModalContent` to use updated `Composite` implementation

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -43,7 +43,6 @@ function SuggestionListItem( {
 		<CompositeItem
 			render={
 				<Button
-					type="button"
 					role="option"
 					className={ baseCssClass }
 					onClick={ () =>

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -9,11 +9,9 @@ import {
 	FlexItem,
 	SearchControl,
 	TextHighlight,
+	privateApis as componentsPrivateApis,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
-	__unstableComposite as Composite,
-	__unstableUseCompositeState as useCompositeState,
-	__unstableCompositeItem as CompositeItem,
 } from '@wordpress/components';
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -21,8 +19,15 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import { unlock } from '../../lock-unlock';
 import useDebouncedInput from '../../utils/use-debounced-input';
 import { mapToIHasNameAndId } from './utils';
+
+const {
+	CompositeV2: Composite,
+	CompositeItemV2: CompositeItem,
+	useCompositeStoreV2: useCompositeStore,
+} = unlock( componentsPrivateApis );
 
 const EMPTY_ARRAY = [];
 
@@ -31,22 +36,24 @@ function SuggestionListItem( {
 	search,
 	onSelect,
 	entityForSuggestions,
-	composite,
 } ) {
 	const baseCssClass =
 		'edit-site-custom-template-modal__suggestions_list__list-item';
 	return (
 		<CompositeItem
-			role="option"
-			as={ Button }
-			{ ...composite }
-			className={ baseCssClass }
-			onClick={ () =>
-				onSelect(
-					entityForSuggestions.config.getSpecificTemplate(
-						suggestion
-					)
-				)
+			render={
+				<Button
+					type="button"
+					role="option"
+					className={ baseCssClass }
+					onClick={ () =>
+						onSelect(
+							entityForSuggestions.config.getSpecificTemplate(
+								suggestion
+							)
+						)
+					}
+				/>
 			}
 		>
 			<Text
@@ -112,7 +119,7 @@ function useSearchSuggestions( entityForSuggestions, search ) {
 }
 
 function SuggestionList( { entityForSuggestions, onSelect } ) {
-	const composite = useCompositeState( { orientation: 'vertical' } );
+	const composite = useCompositeStore( { orientation: 'vertical' } );
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput();
 	const suggestions = useSearchSuggestions(
 		entityForSuggestions,
@@ -136,7 +143,7 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 			) }
 			{ !! suggestions?.length && (
 				<Composite
-					{ ...composite }
+					store={ composite }
 					role="listbox"
 					className="edit-site-custom-template-modal__suggestions_list"
 					aria-label={ __( 'Suggestions list' ) }
@@ -148,7 +155,6 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 							search={ debouncedSearch }
 							onSelect={ onSelect }
 							entityForSuggestions={ entityForSuggestions }
-							composite={ composite }
 						/>
 					) ) }
 				</Composite>


### PR DESCRIPTION
## What?

This PR updates [`AddCustomTemplateModalContent` in `@wordpress/edit-site`](https://github.com/WordPress/gutenberg/blob/6a04d57b280490ec1a33c168c3f3f47603b08161/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js) to use the updated `Composite` implementation from #54225.

## Why?
In #54225, an updated implementation of `Composite` was added to `@wordpress/components`. As per #55224, all consumers of `Composite` need to migrate from the old version to the new version.

## How?
 - Removes `__unstableComposite*` imports from `@wordpress/components`
 - Adds private `Composite*` exports from `@wordpress/components`
 - Refactors `SuggestionList` and `SuggestionListItem` to use updated `Composite` components

## Testing Instructions

Open the "Add Template" dialog from the "Design > Templates" sidebar and select the "Pages" option.

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/0122f912-e35c-4ea5-9621-11c06fc08b49" alt="Gutenberg sidebar, titled 'Design'. The 'Templates' option is circled in red." width="40%">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/3c938bc2-4804-4114-8830-773cbecd360a" alt="Gutenberg sidebar, titled 'Templates'. The 'Add New Template' button is circled in red." width="40%">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/ee114d4e-a99e-442f-8f27-930ad0d56540" alt="Modal dialog, titled 'Add template'. The 'Pages' option is circled in red." width="80%">
</p>

The list of available pages should be presented as a `listbox`, the behaviour of which should be no different than before. Selecting an option should take you to an editor for the chosen view.

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/ab4ecf9a-2af9-4e8d-9a01-553a2ca227e7" alt="Modal dialog, titled 'Add template: Page'. The list of available pages is circled in red." width="80%">
</p>

### Testing Instructions for Keyboard

The `listbox` on the "Pages" view should act as a single tab stop, with arrow keys used to navigate between items. It's questionable if this is the appropriate behaviour, but it is outside the scope of this PR to change that!