### PR TITLE
Fix: Use y-webrtc room name terminology instead of docName.

### DIFF
--- a/packages/sync/src/connect-indexdb.js
+++ b/packages/sync/src/connect-indexdb.js
@@ -20,8 +20,8 @@ import { IndexeddbPersistence } from 'y-indexeddb';
  * @return {Promise<() => void>} Promise that resolves when the connection is established.
  */
 export function connectIndexDb( objectId, objectType, doc ) {
-	const docName = `${ objectType }-${ objectId }`;
-	const provider = new IndexeddbPersistence( docName, doc );
+	const roomName = `${ objectType }-${ objectId }`;
+	const provider = new IndexeddbPersistence( roomName, doc );
 
 	return new Promise( ( resolve ) => {
 		provider.on( 'synced', () => {

--- a/packages/sync/src/connect-webrtc.js
+++ b/packages/sync/src/connect-webrtc.js
@@ -18,8 +18,8 @@ import { WebrtcProvider } from 'y-webrtc';
  * @return {Promise<() => void>} Promise that resolves when the connection is established.
  */
 export function connectWebRTC( objectId, objectType, doc ) {
-	const docName = `${ objectType }-${ objectId }`;
-	new WebrtcProvider( docName, doc, {
+	const roomName = `${ objectType }-${ objectId }`;
+	new WebrtcProvider( roomName, doc, {
 		// @ts-ignore
 		password: window.__experimentalCollaborativeEditingSecret,
 	} );


### PR DESCRIPTION
Small change to be consistent with y-webrtc terminology.
