### PR TITLE
Update: Unset variable set by reference after a foreach loop.

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1065,6 +1065,7 @@ class WP_Theme_JSON_Gutenberg {
 			foreach ( $style_nodes as &$node ) {
 				$node['selector'] = static::scope_selector( $options['scope'], $node['selector'] );
 			}
+			unset( $node );
 		}
 
 		if ( ! empty( $options['root_selector'] ) ) {


### PR DESCRIPTION
In PHP  it is a good practice to unset $value if it was created by reference in a foreach loop, as the reference is still valid outside the loop, and this avoids accidental bugs.
