### PR TITLE
List View: Change the aria-description attribute to aria-describedby

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -260,7 +260,8 @@ function ListViewComponent(
 		return null;
 	}
 
-	const describedById = description && 'block-editor-list-view-description';
+	const describedById =
+		description && `block-editor-list-view-description-${ instanceId }`;
 
 	return (
 		<AsyncModeProvider value={ true }>

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -6,7 +6,10 @@ import {
 	useMergeRefs,
 	__experimentalUseFixedWindowList as useFixedWindowList,
 } from '@wordpress/compose';
-import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
+import {
+	__experimentalTreeGrid as TreeGrid,
+	VisuallyHidden,
+} from '@wordpress/components';
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import {
@@ -257,12 +260,19 @@ function ListViewComponent(
 		return null;
 	}
 
+	const describedById = description && 'block-editor-list-view-description';
+
 	return (
 		<AsyncModeProvider value={ true }>
 			<ListViewDropIndicator
 				listViewRef={ elementRef }
 				blockDropTarget={ blockDropTarget }
 			/>
+			{ description && (
+				<VisuallyHidden id={ describedById }>
+					{ description }
+				</VisuallyHidden>
+			) }
 			<TreeGrid
 				id={ id }
 				className="block-editor-list-view-tree"
@@ -272,8 +282,7 @@ function ListViewComponent(
 				onExpandRow={ expandRow }
 				onFocusRow={ focusRow }
 				applicationAriaLabel={ __( 'Block navigation structure' ) }
-				// eslint-disable-next-line jsx-a11y/aria-props
-				aria-description={ description }
+				aria-describedby={ describedById }
 			>
 				<ListViewContext.Provider value={ contextValue }>
 					<ListViewBranch


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes the `aria-description' attribute to `aria-describedby`.

Fixes https://github.com/WordPress/gutenberg/issues/55165.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
aria-description is new in ARIA 1.3, which is not a finalized recommendation yet. As such, we can't use it, yet. We should instead use the traditional method to provide an accessible description:

## How?
1. Put the description in a hidden div, if there is one. Give it a unique Id.
2. Also add an an aria-describedby attribute to the List View
3. Remove the `aria-description` attribute.

## Testing Instructions
1. Open the site editor
2. Open the main list view
3. Confirm that there is no `aria-describedby` attribute
4. Select a navigation block
5. Open the list view for the navigation block (in the inspector)
6. Confirm that the list view has an `aria-describedby` attribute which points to a hidden div containing the description of the list view. Alternatively check that accessibility properties in the browser show that the list view has a description.
 
## Screenshots or screencast <!-- if applicable -->
<img width="1843" alt="Screenshot 2023-10-11 at 15 28 19" src="https://github.com/WordPress/gutenberg/assets/275961/2a965ab9-27f1-4506-b6ce-585f2db163aa">

