### PR TITLE
Fix flickering when focusing on global style variations

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -85,23 +85,35 @@
 
 .edit-site-global-styles-variations_item {
 	box-sizing: border-box;
+	// To round the outline in Windows 10 high contrast mode.
+	border-radius: $radius-block-ui;
 
 	.edit-site-global-styles-variations_item-preview {
 		padding: $border-width * 2;
 		border-radius: $radius-block-ui;
-		border: $gray-200 $border-width solid;
+		box-shadow: 0 0 0 $border-width $gray-200;
+		// Shown in Windows 10 high contrast mode.
+		outline: 1px solid transparent;
 	}
 
 	&.is-active .edit-site-global-styles-variations_item-preview {
-		border: $gray-900 $border-width solid;
+		box-shadow: 0 0 0 $border-width $gray-900;
+		// Shown in Windows 10 high contrast mode.
+		outline-width: 3px;
 	}
 
 	&:hover .edit-site-global-styles-variations_item-preview {
-		border: var(--wp-admin-theme-color) $border-width solid;
+		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 
 	&:focus .edit-site-global-styles-variations_item-preview {
-		border: var(--wp-admin-theme-color) var(--wp-admin-border-width-focus) solid;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	}
+
+	&:focus-visible {
+		// Shown in Windows 10 high contrast mode.
+		outline: 3px solid transparent;
+		outline-offset: 0;
 	}
 }
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -90,17 +90,16 @@
 	}
 
 	.edit-site-global-styles-variations_item-preview {
-		border: $gray-900 $border-width solid;
+		box-shadow: 0 0 0 $border-width $gray-900;
 	}
 	.edit-site-global-styles-variations_item.is-active .edit-site-global-styles-variations_item-preview {
-		border: $gray-100 $border-width solid;
+		box-shadow: 0 0 0 $border-width $gray-100;
 	}
 	.edit-site-global-styles-variations_item:hover .edit-site-global-styles-variations_item-preview {
-		border: var(--wp-admin-theme-color) $border-width solid;
+		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
-
 	.edit-site-global-styles-variations_item:focus .edit-site-global-styles-variations_item-preview {
-		border: var(--wp-admin-theme-color) var(--wp-admin-border-width-focus) solid;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 }
 


### PR DESCRIPTION
## What?

This PR prevents flickering that occurs when focusing on global style variations.

At the same time, it improves visibility in Windows high contrast mode, as explained later.

### Before

https://github.com/WordPress/gutenberg/assets/54422211/10725a51-da89-43a1-971e-824694e06d2e

### After

https://github.com/WordPress/gutenberg/assets/54422211/fbb8a884-72f5-4a4c-af59-5c0e40e0d11c

## Why?

Global style variations have the following four states.

- Default: **1px** border
- Selected (Active): **1px** dark border
- Hover: **1px** border with admin-theme-color
- Focus: **2px** border with admin-theme-color

As you can see, only the focus style has a thick border, so flickering occurs when the size of the element changes.

## How?

I used `box-shadow` instead of `border` so that it doesn't affect the size of the elements.

### Windows High Contrast Mode

In Windows high contrast mode, all borders have the same color. Because the default variation and the selected variation had the same 1px wide border, users using high contrast mode had no way of knowing which style variation was active. Also, it was impossible to determine which variation was focused or not based on just a 1px difference in the border.

In this PR, borders are replaced with box-shadow, so they are not displayed at all in high contrast mode. Instead, use transparent outlines, similar to the approach Gutenberg has traditionally taken.

In order to make it easier to understand the minimum required state, I have adjusted it so that it looks like the following.

- Default: 1px outline
- Selected (Active): 3px outline
- Focus: 3px outline with focus ring color

https://github.com/WordPress/gutenberg/assets/54422211/4e8ad030-db9a-476d-982b-dc1eb0d373ac

## Testing Instructions

In the following two places, confirm that the appearance is as expected no matter what operation you perform, and that flickering does not occur when you shift focus using the keyboard.

- Site editor Styles menu
- Browse styles in global styles in editor canvas