### PR TITLE
Image: Stop crashing with Lightbox on image blocks without an image

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -16,11 +16,13 @@
  * @return string The block content with the data-id attribute added.
  */
 function render_block_core_image( $attributes, $content, $block ) {
+	if ( false === stripos( $content, '<img' ) ) {
+		return '';
+	}
 
 	$processor = new WP_HTML_Tag_Processor( $content );
-	$processor->next_tag( 'img' );
 
-	if ( $processor->get_attribute( 'src' ) === null ) {
+	if ( ! $processor->next_tag( 'img' ) || null === $processor->get_attribute( 'src' ) ) {
 		return '';
 	}
 
@@ -125,11 +127,27 @@ function block_core_image_get_lightbox_settings( $block ) {
  * @return string Filtered block content.
  */
 function block_core_image_render_lightbox( $block_content, $block ) {
+	/*
+	 * If it's not possible that an IMG element exists then return the given
+	 * block content as-is. It may be that there's no actual image in the block
+	 * or it could be that another plugin already modified this HTML.
+	 */
+	if ( false === stripos( $block_content, '<img' ) ) {
+		return $block_content;
+	}
+
 	$processor = new WP_HTML_Tag_Processor( $block_content );
 
 	$aria_label = __( 'Enlarge image' );
+	/*
+	 * If there's definitely no IMG element in the block then return the given
+	 * block content as-is. There's nothing that this code can knowingly modify
+	 * to add the lightbox behavior.
+	 */
+	if ( ! $processor->next_tag( 'img' ) ) {
+		return $block_content;
+	}
 
-	$processor->next_tag( 'img' );
 	$alt_attribute = $processor->get_attribute( 'alt' );
 
 	// An empty alt attribute `alt=""` is valid for decorative images.

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -139,6 +139,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$processor = new WP_HTML_Tag_Processor( $block_content );
 
 	$aria_label = __( 'Enlarge image' );
+
 	/*
 	 * If there's definitely no IMG element in the block then return the given
 	 * block content as-is. There's nothing that this code can knowingly modify


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Resolves https://github.com/WordPress/gutenberg/issues/55214 https://github.com/WordPress/gutenberg/pull/55217
Trac ticket: [Core-59597](https://core.trac.wordpress.org/ticket/59597)

When rendering images with the lightbox "expand on click" function enabled, if an image block is encountered with no image (for example, a block was added but no image was ever selected), then WordPress would create a warning that an "undefined array key 0" was being accessed because the server code assumes an IMG element exists in the block's HTML.

In this patch a check is performed to ensure that an IMG block exists before processing the block. If one isn't, for any reason, the original given HTML for the block is passed through un-modified.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add an image block to a post, but don't add an image to it
2. Publish and view the post
3. See that there is no error in the content 