### PR TITLE
Migrating `DownloadableBlocksList` to use updated `Composite` implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55961,6 +55961,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/plugins": "file:../plugins",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/url": "file:../url",
 				"change-case": "^4.1.2"
 			},
@@ -69379,6 +69380,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/plugins": "file:../plugins",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/url": "file:../url",
 				"change-case": "^4.1.2"
 			}

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url",
 		"change-case": "^4.1.2"
 	},

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -94,9 +94,9 @@ function DownloadableBlockListItem( { composite, item, onClick } ) {
 
 	return (
 		<CompositeItem
-			__experimentalIsFocusable
 			render={
 				<Button
+					__experimentalIsFocusable
 					type="button"
 					role="option"
 					className="block-directory-downloadable-block-list-item"
@@ -110,7 +110,7 @@ function DownloadableBlockListItem( { composite, item, onClick } ) {
 						isInstalled,
 						isInstalling,
 					} ) }
-					showTooltip={ true }
+					showTooltip
 					tooltipPosition="top center"
 				/>
 			}

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -6,7 +6,7 @@ import {
 	Button,
 	Spinner,
 	VisuallyHidden,
-	__unstableCompositeItem as CompositeItem,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -20,6 +20,9 @@ import BlockRatings from '../block-ratings';
 import DownloadableBlockIcon from '../downloadable-block-icon';
 import DownloadableBlockNotice from '../downloadable-block-notice';
 import { store as blockDirectoryStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { CompositeItemV2: CompositeItem } = unlock( componentsPrivateApis );
 
 // Return the appropriate block item label, given the block data and status.
 function getDownloadableBlockLabel(
@@ -92,23 +95,27 @@ function DownloadableBlockListItem( { composite, item, onClick } ) {
 	return (
 		<CompositeItem
 			__experimentalIsFocusable
-			role="option"
-			as={ Button }
-			{ ...composite }
-			className="block-directory-downloadable-block-list-item"
-			onClick={ ( event ) => {
-				event.preventDefault();
-				onClick();
-			} }
-			isBusy={ isInstalling }
+			render={
+				<Button
+					type="button"
+					role="option"
+					className="block-directory-downloadable-block-list-item"
+					isBusy={ isInstalling }
+					onClick={ ( event ) => {
+						event.preventDefault();
+						onClick();
+					} }
+					label={ getDownloadableBlockLabel( item, {
+						hasNotice,
+						isInstalled,
+						isInstalling,
+					} ) }
+					showTooltip={ true }
+					tooltipPosition="top center"
+				/>
+			}
+			store={ composite }
 			disabled={ isInstalling || ! isInstallable }
-			label={ getDownloadableBlockLabel( item, {
-				hasNotice,
-				isInstalled,
-				isInstalling,
-			} ) }
-			showTooltip={ true }
-			tooltipPosition="top center"
 		>
 			<div className="block-directory-downloadable-block-list-item__icon">
 				<DownloadableBlockIcon icon={ icon } title={ title } />

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	__unstableComposite as Composite,
-	__unstableUseCompositeState as useCompositeState,
-} from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 
@@ -14,11 +11,14 @@ import { useDispatch } from '@wordpress/data';
  */
 import DownloadableBlockListItem from '../downloadable-block-list-item';
 import { store as blockDirectoryStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
+const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
+	unlock( componentsPrivateApis );
 const noop = () => {};
 
 function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
-	const composite = useCompositeState();
+	const composite = useCompositeStore();
 	const { installBlockType } = useDispatch( blockDirectoryStore );
 
 	if ( ! items.length ) {
@@ -27,7 +27,7 @@ function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
 
 	return (
 		<Composite
-			{ ...composite }
+			store={ composite }
 			role="listbox"
 			className="block-directory-downloadable-blocks-list"
 			aria-label={ __( 'Blocks available for install' ) }

--- a/packages/block-directory/src/lock-unlock.js
+++ b/packages/block-directory/src/lock-unlock.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'@wordpress/edit-site'
+	);

--- a/packages/block-directory/src/lock-unlock.js
+++ b/packages/block-directory/src/lock-unlock.js
@@ -6,5 +6,5 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
 		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
-		'@wordpress/edit-site'
+		'@wordpress/block-directory'
 	);

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -10,6 +10,7 @@
  * The list of core modules allowed to opt-in to the private APIs.
  */
 const CORE_MODULES_USING_PRIVATE_APIS = [
+	'@wordpress/block-directory',
 	'@wordpress/block-editor',
 	'@wordpress/block-library',
 	'@wordpress/blocks',


### PR DESCRIPTION
## What?
This PR updates [`AddCustomTemplateModalContent`](https://github.com/WordPress/gutenberg/blob/4f8052b9fb8ea19501113dd0a9ad6d6a5a611128/packages/block-directory/src/components/downloadable-blocks-list/index.js) and [`DownloadableBlockListItem`](https://github.com/WordPress/gutenberg/blob/4f8052b9fb8ea19501113dd0a9ad6d6a5a611128/packages/block-directory/src/components/downloadable-block-list-item/index.js) in `@wordpress/block-directory` to use the updated `Composite` implementation from #54225.

## Why?
In #54225, an updated implementation of `Composite` was added to `@wordpress/components`. As per #55224, all consumers of `Composite` need to migrate from the old version to the new version.

## How?
 - Removes `__unstableComposite` imports from `@wordpress/components`
 - Adds private `Composite*` exports from `@wordpress/components`
 - Refactors `DownloadableBlocksList` and `DownloadableBlockListItem` to use updated `Composite` components

## Testing Instructions

 - Open the block inserter sidebar in the editor, and enter a search term
 - Scroll to the bottom to find the "Available to install" options
 - The list of installable blocks should be presented as a `listbox`, the behaviour of which should be no different than before
 - Clicking on an option should start the install process, before adding it to the editor view

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/dfc4746f-5019-4b0a-bb74-18b10bcaaa4b" alt="The block inserter sidebar, with the search field circled in red." width="40%">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/a2f668f9-f6b3-4dfc-a956-82149dcb16f9" alt="" width="40%">
</p>

### Testing Instructions for Keyboard

The `listbox` containing the installable blocks should act as a single tab stop, with arrow keys used to navigate between items.