### PR TITLE
ProgressBar: use text color to ensure enough contrast against background

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `ProgressBar`: use text color to ensure enough contrast against background ([#55285](https://github.com/WordPress/gutenberg/pull/55285)).
 -   `Notice`: Remove margins from `Notice` component ([#54800](https://github.com/WordPress/gutenberg/pull/54800)).
 -   Allow using CSS level 4 viewport-relative units ([54415](https://github.com/WordPress/gutenberg/pull/54415))
 -   `ToolsPanel`: do not apply the `className` to prop to `ToolsPanelItem` components when rendered as placeholders ([#55207](https://github.com/WordPress/gutenberg/pull/55207)).

--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -27,9 +27,11 @@ export const Track = styled.div`
 	width: 100%;
 	max-width: 160px;
 	height: ${ CONFIG.borderWidthFocus };
-	background-color: var(
-		--wp-components-color-gray-300,
-		${ COLORS.gray[ 300 ] }
+	/* Text color at 10% opacity */
+	background-color: color-mix(
+		in srgb,
+		var( --wp-components-color-foreground, ${ COLORS.gray[ 900 ] } ),
+		transparent 90%
 	);
 	border-radius: ${ CONFIG.radiusBlockUi };
 `;
@@ -43,7 +45,12 @@ export const Indicator = styled.div< {
 	top: 0;
 	height: 100%;
 	border-radius: ${ CONFIG.radiusBlockUi };
-	background-color: ${ COLORS.theme.accent };
+	/* Text color at 90% opacity */
+	background-color: color-mix(
+		in srgb,
+		var( --wp-components-color-foreground, ${ COLORS.gray[ 900 ] } ),
+		transparent 10%
+	);
 
 	${ ( { isIndeterminate, value } ) =>
 		isIndeterminate

--- a/packages/components/src/progress-bar/styles.ts
+++ b/packages/components/src/progress-bar/styles.ts
@@ -34,6 +34,10 @@ export const Track = styled.div`
 		transparent 90%
 	);
 	border-radius: ${ CONFIG.radiusBlockUi };
+
+	// Windows high contrast mode.
+	outline: 2px solid transparent;
+	outline-offset: 2px;
 `;
 
 export const Indicator = styled.div< {
@@ -51,6 +55,10 @@ export const Indicator = styled.div< {
 		var( --wp-components-color-foreground, ${ COLORS.gray[ 900 ] } ),
 		transparent 10%
 	);
+
+	// Windows high contrast mode.
+	outline: 2px solid transparent;
+	outline-offset: -2px;
 
 	${ ( { isIndeterminate, value } ) =>
 		isIndeterminate


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

As discussed in https://github.com/WordPress/gutenberg/issues/54202#issuecomment-1729616558 and following comments,  this PR tweaks the colors used for the `ProgressBar` component (both track and indicator) to be based on the text color.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Using the text color should ensure that the progress bar always has enough contrast when rendered against the background color.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Using the `--wp-components-color-foreground` variable for the text color
- Using the [`color-mix()` CSS function](https://caniuse.com/?search=color-mix) to tweak the text color's opacity
- Adding styles for high contrast mode (as mentioned in https://github.com/WordPress/gutenberg/issues/54202#issuecomment-1757877018)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In Storybook:
- open the `ProgressBar` story
- Check that the progress bar is using the current text color and looks good
- Using the tools in Storybook's top toolbar, change the Theme and observe how ProgressBar changes its color based on the theme
- Using browser web tool, simulate a high contrast mode (this can be done in Chrome by simulating the `forced-colors: active` mode)

In the side editor:
- load the site editor, make sure that the progress bar is always well visible
- in the global styles, tweak the background color
- reload the site editor: the background color of the loading screen should follow the background color chosen in the previous step. The progress bar should still have enough contrast

## Screenshots or screencast <!-- if applicable -->

Storybook:

https://github.com/WordPress/gutenberg/assets/1083581/c3175619-0f97-458e-8e7b-8ecb6b952fbe

Site editor:

https://github.com/WordPress/gutenberg/assets/1083581/70ea76cd-8de1-4724-8e81-d75d0e84f046

