### PR TITLE
[Data Views]: Add drop down with action in headers

### DIFF
--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -144,6 +144,31 @@ const sortingItemsInfo = {
 	asc: { icon: arrowUp, label: __( 'Sort ascending' ) },
 	desc: { icon: arrowDown, label: __( 'Sort descending' ) },
 };
+export function FieldSortingItems( { field, dataView } ) {
+	const sortedDirection = field.getIsSorted();
+	return Object.entries( sortingItemsInfo ).map( ( [ direction, info ] ) => (
+		<DropdownMenuItemV2
+			key={ direction }
+			prefix={ <Icon icon={ info.icon } /> }
+			suffix={ sortedDirection === direction && <Icon icon={ check } /> }
+			onSelect={ ( event ) => {
+				event.preventDefault();
+				if ( sortedDirection === direction ) {
+					dataView.resetSorting();
+				} else {
+					dataView.setSorting( [
+						{
+							id: field.id,
+							desc: direction === 'desc',
+						},
+					] );
+				}
+			} }
+		>
+			{ info.label }
+		</DropdownMenuItemV2>
+	) );
+}
 function SortMenu( { dataView } ) {
 	const sortableFields = dataView
 		.getAllColumns()
@@ -170,7 +195,6 @@ function SortMenu( { dataView } ) {
 			}
 		>
 			{ sortableFields?.map( ( field ) => {
-				const sortedDirection = field.getIsSorted();
 				return (
 					<DropdownSubMenuV2
 						key={ field.id }
@@ -183,40 +207,10 @@ function SortMenu( { dataView } ) {
 						}
 						side="left"
 					>
-						{ Object.entries( sortingItemsInfo ).map(
-							( [ direction, info ] ) => {
-								return (
-									<DropdownMenuItemV2
-										key={ direction }
-										prefix={ <Icon icon={ info.icon } /> }
-										suffix={
-											sortedDirection === direction && (
-												<Icon icon={ check } />
-											)
-										}
-										onSelect={ ( event ) => {
-											event.preventDefault();
-											if (
-												sortedDirection === direction
-											) {
-												dataView.resetSorting();
-											} else {
-												dataView.setSorting( [
-													{
-														id: field.id,
-														desc:
-															direction ===
-															'desc',
-													},
-												] );
-											}
-										} }
-									>
-										{ info.label }
-									</DropdownMenuItemV2>
-								);
-							}
-						) }
+						<FieldSortingItems
+							field={ field }
+							dataView={ dataView }
+						/>
 					</DropdownSubMenuV2>
 				);
 			} ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/55083

This PR adds a drop down menu in headers with sorting and hide field actions based on the following design:

![271988133-5b48e9eb-212e-4624-bff2-f5a454218f22](https://github.com/WordPress/gutenberg/assets/16275880/2793d48c-5f1b-4df4-a70b-a115899858d5)


## Testing Instructions
1. Everything should work as before
2. The drop down appears only if a column is sortable or hidable or both
3. Action in drop down work as expected

