### PR TITLE
DataViews: Update the view actions menu to be independent from current view APIs

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -195,7 +195,11 @@ export default function DataViews( {
 			<VStack spacing={ 4 }>
 				<HStack justify="space-between">
 					<TextFilter onChange={ dataView.setGlobalFilter } />
-					<ViewActions dataView={ dataView } />
+					<ViewActions
+						fields={ fields }
+						view={ view }
+						onChangeView={ onChangeView }
+					/>
 				</HStack>
 				{ /* This component will be selected based on viewConfigs. Now we only have the list view. */ }
 				<ListView dataView={ dataView } isLoading={ isLoading } />

--- a/packages/edit-site/src/components/dataviews/list-view.js
+++ b/packages/edit-site/src/components/dataviews/list-view.js
@@ -8,7 +8,14 @@ import { flexRender } from '@tanstack/react-table';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { chevronDown, chevronUp, unseen } from '@wordpress/icons';
+import {
+	chevronDown,
+	chevronUp,
+	unseen,
+	check,
+	arrowUp,
+	arrowDown,
+} from '@wordpress/icons';
 import {
 	Button,
 	Icon,
@@ -20,7 +27,6 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { FieldSortingItems } from './view-actions';
 
 const {
 	DropdownMenuV2,
@@ -29,6 +35,10 @@ const {
 	DropdownMenuSeparatorV2,
 } = unlock( componentsPrivateApis );
 
+const sortingItemsInfo = {
+	asc: { icon: arrowUp, label: __( 'Sort ascending' ) },
+	desc: { icon: arrowDown, label: __( 'Sort descending' ) },
+};
 const sortIcons = { asc: chevronUp, desc: chevronDown };
 function HeaderMenu( { dataView, header } ) {
 	if ( header.isPlaceholder ) {
@@ -43,6 +53,7 @@ function HeaderMenu( { dataView, header } ) {
 	if ( ! isSortable && ! isHidable ) {
 		return text;
 	}
+	const sortedDirection = header.column.getIsSorted();
 	return (
 		<DropdownMenuV2
 			align="start"
@@ -57,10 +68,34 @@ function HeaderMenu( { dataView, header } ) {
 		>
 			{ isSortable && (
 				<DropdownMenuGroupV2>
-					<FieldSortingItems
-						field={ header.column }
-						dataView={ dataView }
-					/>
+					{ Object.entries( sortingItemsInfo ).map(
+						( [ direction, info ] ) => (
+							<DropdownMenuItemV2
+								key={ direction }
+								prefix={ <Icon icon={ info.icon } /> }
+								suffix={
+									sortedDirection === direction && (
+										<Icon icon={ check } />
+									)
+								}
+								onSelect={ ( event ) => {
+									event.preventDefault();
+									if ( sortedDirection === direction ) {
+										dataView.resetSorting();
+									} else {
+										dataView.setSorting( [
+											{
+												id: header.column.id,
+												desc: direction === 'desc',
+											},
+										] );
+									}
+								} }
+							>
+								{ info.label }
+							</DropdownMenuItemV2>
+						)
+					) }
 				</DropdownMenuGroupV2>
 			) }
 			{ isSortable && isHidable && <DropdownMenuSeparatorV2 /> }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -52,8 +52,8 @@ export default function PagePages() {
 			per_page: view.perPage,
 			page: view.page + 1, // tanstack starts from zero.
 			_embed: 'author',
-			order: view.sort.direction,
-			orderby: view.sort.field,
+			order: view.sort?.direction,
+			orderby: view.sort?.field,
 			search: view.search,
 			status: [ 'publish', 'draft' ],
 		} ),


### PR DESCRIPTION
Related #55083 

## What?

This is PR is a prerequisite to implement alternative views (grid) for the DataViews component. The "DataViews" menu is common to all view types, so it shouldn't be using internal APIs that are specific to one given view type (tan stack APIs). So this PR refactors that component to rely on the `view` and `fields` object instead of `dataView` object that we receive from tanstack.

## Testing Instructions

1- Open the browse all pages in the site editor
2- Use the view actions menu (top right) to tweak the sort, the visibility of fields...
