### PR TITLE
Fix callouts in E2E test documentation

### DIFF
--- a/docs/contributors/code/e2e/README.md
+++ b/docs/contributors/code/e2e/README.md
@@ -4,7 +4,7 @@ This living document serves to prescribe instructions and best practices for wri
 
 <div class="callout callout-info">
 
-See the dedicated guide if you're working with the previous Jest + Puppeteer framework. See the [migration guide](https://github.com/WordPress/gutenberg/tree/HEAD/docs/contributors/code/e2e/migration.md) if you're migrating tests from Jest + Puppeteer.
+See the dedicated guide if you're working with the previous Jest + Puppeteer framework. See the <a href="https://github.com/WordPress/gutenberg/tree/HEAD/docs/contributors/code/e2e/migration.md">migration guide</a> if you're migrating tests from Jest + Puppeteer.
 </div>
 
 

--- a/docs/contributors/code/e2e/migration.md
+++ b/docs/contributors/code/e2e/migration.md
@@ -19,8 +19,9 @@ This document outlines a typical flow of migrating a Jest + Puppeteer test to Pl
 
 Before migrating a test utility function, think twice about whether it's necessary. Playwright offers a lot of readable and powerful APIs which make a lot of the utils obsolete. Try implementing the same thing inline directly in the test first. Only follow the below guide if that doesn't work for you. Some examples of utils that deserve to be implemented in the `e2e-test-utils-playwright` package include complex browser APIs (like `pageUtils.dragFiles` and `pageUtils.pressKeys`) and APIs that set states (`requestUtils.*`).
 
-> **Note**
-> The `e2e-test-utils-playwright` package is not meant to be a drop-in replacement of the Jest + Puppeteer's `e2e-test-utils` package. Some utils are only created to ease the migration process, but they are not necessarily required.
+<div class="callout callout-info">
+The <code>e2e-test-utils-playwright</code> package is not meant to be a drop-in replacement of the Jest + Puppeteer's <code>e2e-test-utils</code> package. Some utils are only created to ease the migration process, but they are not necessarily required.
+</div>
 
 Playwright utilities are organized a little differently from those in the `e2e-test-utils` package. The `e2e-test-utils-playwright` package has the following folders that utils are divided up into:
 - `admin` - Utilities related to WordPress admin or WordPress admin's user interface (e.g. `visitAdminPage`).


### PR DESCRIPTION
## What?
PR fixes the link and converts the markdown note into a callout.

## How?
Based on callout docs: https://developer.wordpress.org/block-editor/contributors/documentation/#callout-notices

## Testing Instructions
It is hard to test without deploying changes to the documentation site. Confirm that the markup matches the documentation.
