### PR TITLE
Fix autocomplete trigger character detection

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fix
 
 -   `Modal`: fix closing when contained iframe is focused ([#51602](https://github.com/WordPress/gutenberg/pull/51602)).
+-   `Autocomplete`: Fix disappearing results issue when using multiple triggers inline ([#55301](https://github.com/WordPress/gutenberg/pull/55301))
 
 ### Internal
 

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -218,101 +218,92 @@ export function useAutocomplete( {
 			return;
 		}
 
-		const lastTriggerPrefix = completers.reduce< string | null >(
-			( lastTrigger, { triggerPrefix } ) => {
-				const triggerIndex = textContent.lastIndexOf( triggerPrefix );
+		// Find the completer with the highest triggerPrefix index in the
+		// textContent.
+		const completer = completers.reduce< WPCompleter | null >(
+			( lastTrigger, currentCompleter ) => {
+				const triggerIndex = textContent.lastIndexOf(
+					currentCompleter.triggerPrefix
+				);
 				const lastTriggerIndex =
 					lastTrigger !== null
-						? textContent.lastIndexOf( lastTrigger )
+						? textContent.lastIndexOf( lastTrigger.triggerPrefix )
 						: -1;
 
 				return triggerIndex > lastTriggerIndex
-					? triggerPrefix
+					? currentCompleter
 					: lastTrigger;
 			},
 			null
 		);
 
-		const completer = completers.find(
-			( { triggerPrefix, allowContext } ) => {
-				if ( triggerPrefix !== lastTriggerPrefix ) {
-					return false;
-				}
-
-				const index = textContent.lastIndexOf( triggerPrefix );
-
-				if ( index === -1 ) {
-					return false;
-				}
-
-				const textWithoutTrigger = textContent.slice(
-					index + triggerPrefix.length
-				);
-
-				const tooDistantFromTrigger = textWithoutTrigger.length > 50; // 50 chars seems to be a good limit.
-				// This is a final barrier to prevent the effect from completing with
-				// an extremely long string, which causes the editor to slow-down
-				// significantly. This could happen, for example, if `matchingWhileBackspacing`
-				// is true and one of the "words" end up being too long. If that's the case,
-				// it will be caught by this guard.
-				if ( tooDistantFromTrigger ) return false;
-
-				const mismatch = filteredOptions.length === 0;
-				const wordsFromTrigger = textWithoutTrigger.split( /\s/ );
-				// We need to allow the effect to run when not backspacing and if there
-				// was a mismatch. i.e when typing a trigger + the match string or when
-				// clicking in an existing trigger word on the page. We do that if we
-				// detect that we have one word from trigger in the current textual context.
-				//
-				// Ex.: "Some text @a" <-- "@a" will be detected as the trigger word and
-				// allow the effect to run. It will run until there's a mismatch.
-				const hasOneTriggerWord = wordsFromTrigger.length === 1;
-				// This is used to allow the effect to run when backspacing and if
-				// "touching" a word that "belongs" to a trigger. We consider a "trigger
-				// word" any word up to the limit of 3 from the trigger character.
-				// Anything beyond that is ignored if there's a mismatch. This allows
-				// us to "escape" a mismatch when backspacing, but still imposing some
-				// sane limits.
-				//
-				// Ex: "Some text @marcelo sekkkk" <--- "kkkk" caused a mismatch, but
-				// if the user presses backspace here, it will show the completion popup again.
-				const matchingWhileBackspacing =
-					backspacing.current && wordsFromTrigger.length <= 3;
-
-				if (
-					mismatch &&
-					! ( matchingWhileBackspacing || hasOneTriggerWord )
-				) {
-					return false;
-				}
-
-				const textAfterSelection = getTextContent(
-					slice( record, undefined, getTextContent( record ).length )
-				);
-
-				if (
-					allowContext &&
-					! allowContext(
-						textContent.slice( 0, index ),
-						textAfterSelection
-					)
-				) {
-					return false;
-				}
-
-				if (
-					/^\s/.test( textWithoutTrigger ) ||
-					/\s\s+$/.test( textWithoutTrigger )
-				) {
-					return false;
-				}
-
-				return /[\u0000-\uFFFF]*$/.test( textWithoutTrigger );
-			}
-		);
-
 		if ( ! completer ) {
 			if ( autocompleter ) reset();
+			return;
+		}
+
+		const { allowContext, triggerPrefix } = completer;
+		const triggerIndex = textContent.lastIndexOf( triggerPrefix );
+		const textWithoutTrigger = textContent.slice(
+			triggerIndex + triggerPrefix.length
+		);
+
+		const tooDistantFromTrigger = textWithoutTrigger.length > 50; // 50 chars seems to be a good limit.
+		// This is a final barrier to prevent the effect from completing with
+		// an extremely long string, which causes the editor to slow-down
+		// significantly. This could happen, for example, if `matchingWhileBackspacing`
+		// is true and one of the "words" end up being too long. If that's the case,
+		// it will be caught by this guard.
+		if ( tooDistantFromTrigger ) return;
+
+		const mismatch = filteredOptions.length === 0;
+		const wordsFromTrigger = textWithoutTrigger.split( /\s/ );
+		// We need to allow the effect to run when not backspacing and if there
+		// was a mismatch. i.e when typing a trigger + the match string or when
+		// clicking in an existing trigger word on the page. We do that if we
+		// detect that we have one word from trigger in the current textual context.
+		//
+		// Ex.: "Some text @a" <-- "@a" will be detected as the trigger word and
+		// allow the effect to run. It will run until there's a mismatch.
+		const hasOneTriggerWord = wordsFromTrigger.length === 1;
+		// This is used to allow the effect to run when backspacing and if
+		// "touching" a word that "belongs" to a trigger. We consider a "trigger
+		// word" any word up to the limit of 3 from the trigger character.
+		// Anything beyond that is ignored if there's a mismatch. This allows
+		// us to "escape" a mismatch when backspacing, but still imposing some
+		// sane limits.
+		//
+		// Ex: "Some text @marcelo sekkkk" <--- "kkkk" caused a mismatch, but
+		// if the user presses backspace here, it will show the completion popup again.
+		const matchingWhileBackspacing =
+			backspacing.current && wordsFromTrigger.length <= 3;
+
+		if ( mismatch && ! ( matchingWhileBackspacing || hasOneTriggerWord ) ) {
+			return;
+		}
+
+		const textAfterSelection = getTextContent(
+			slice( record, undefined, getTextContent( record ).length )
+		);
+
+		if (
+			allowContext &&
+			! allowContext(
+				textContent.slice( 0, triggerIndex ),
+				textAfterSelection
+			)
+		) {
+			return;
+		}
+
+		if (
+			/^\s/.test( textWithoutTrigger ) ||
+			/\s\s+$/.test( textWithoutTrigger )
+		) {
+			return;
+		}
+
+		if ( ! /[\u0000-\uFFFF]*$/.test( textWithoutTrigger ) ) {
 			return;
 		}
 

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -279,6 +279,7 @@ export function useAutocomplete( {
 			backspacing.current && wordsFromTrigger.length <= 3;
 
 		if ( mismatch && ! ( matchingWhileBackspacing || hasOneTriggerWord ) ) {
+			if ( autocompleter ) reset();
 			return;
 		}
 
@@ -293,6 +294,7 @@ export function useAutocomplete( {
 				textAfterSelection
 			)
 		) {
+			if ( autocompleter ) reset();
 			return;
 		}
 
@@ -300,10 +302,12 @@ export function useAutocomplete( {
 			/^\s/.test( textWithoutTrigger ) ||
 			/\s\s+$/.test( textWithoutTrigger )
 		) {
+			if ( autocompleter ) reset();
 			return;
 		}
 
 		if ( ! /[\u0000-\uFFFF]*$/.test( textWithoutTrigger ) ) {
+			if ( autocompleter ) reset();
 			return;
 		}
 

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -218,8 +218,27 @@ export function useAutocomplete( {
 			return;
 		}
 
-		const completer = completers?.find(
+		const lastTriggerPrefix = completers.reduce< string | null >(
+			( lastTrigger, { triggerPrefix } ) => {
+				const triggerIndex = textContent.lastIndexOf( triggerPrefix );
+				const lastTriggerIndex =
+					lastTrigger !== null
+						? textContent.lastIndexOf( lastTrigger )
+						: -1;
+
+				return triggerIndex > lastTriggerIndex
+					? triggerPrefix
+					: lastTrigger;
+			},
+			null
+		);
+
+		const completer = completers.find(
 			( { triggerPrefix, allowContext } ) => {
+				if ( triggerPrefix !== lastTriggerPrefix ) {
+					return false;
+				}
+
 				const index = textContent.lastIndexOf( triggerPrefix );
 
 				if ( index === -1 ) {
@@ -258,8 +277,7 @@ export function useAutocomplete( {
 				// Ex: "Some text @marcelo sekkkk" <--- "kkkk" caused a mismatch, but
 				// if the user presses backspace here, it will show the completion popup again.
 				const matchingWhileBackspacing =
-					backspacing.current &&
-					textWithoutTrigger.split( /\s/ ).length <= 3;
+					backspacing.current && wordsFromTrigger.length <= 3;
 
 				if (
 					mismatch &&


### PR DESCRIPTION
## What?

Fix trigger character detection when using multiple different triggers inline.

| before | after |
| ------------- | ------------- |
| <video src="https://github.com/WordPress/gutenberg/assets/1451471/0b82ecb9-8c9b-4b94-81a8-cc960150e351"> | <video src="https://github.com/WordPress/gutenberg/assets/1451471/e1d32a07-a2c7-4352-92fe-ae2218c9ef8e"> |

Closes #55118 

## How?
The function that finds a completer for given text content performs multiple checks before returning a matching completer. The main issue here is that there are multiple trigger characters, and if they're used side by side, **the first one** that matches all the criteria is returned. For the given example above, the completers are toggled between the one for `@` and the one for `+` triggers as we type, that's why the popup sometimes disappears, as the matching string is different on each keystroke.
We should not be relying on the order of the triggers array, so to address this, I've added a step where the completer is picked by the closest trigger character to the end of the current text content. After that, all the checks that were there before are performed as well to ensure there are no regressions. 

## Testing Instructions

Follow the steps to reproduce what has been recorded on the **before** and **after** videos above.

0. checkout `trunk` and follow the steps described in #55118 to see the regression.
1. checkout this branch,
2. create a new post,
3. start typing a mention, trigger with `@`,
4. hit enter to apply the found mention,
5. hit space and start typing another mention; this time start with `+`,
6. type at least 4 characters of the searched mention,
7. ensure the results popup is visible on each keystroke.

All the E2E tests should pass.