### PR TITLE
Query Loop block: Reuse existing screen-reader-text CSS class for the enhanced pagination aria-live region

### DIFF
--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -48,7 +48,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 			$content           = substr_replace(
 				$content,
 				'<div
-					class="wp-block-query__enhanced-pagination-navigation-announce"
+					class="wp-block-query__enhanced-pagination-navigation-announce screen-reader-text"
 					aria-live="polite"
 					data-wp-text="context.core.query.message"
 				></div>

--- a/packages/block-library/src/query/style.scss
+++ b/packages/block-library/src/query/style.scss
@@ -50,14 +50,3 @@
 		opacity: 0;
 	}
 }
-
-.wp-block-query__enhanced-pagination-navigation-announce {
-	position: absolute;
-	clip: rect(0, 0, 0, 0);
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
-	border: 0;
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/55303

## What?
<!-- In a few words, what is the PR actually doing? -->
- The CSS class for the enhanced pagination aria-live region uses a ruleset that is meant to be equivalent to the screen-reader-text CSS class. However, the ruleset is not [the one recommended by the Accessibility handbook](https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/) and actually used in core. It is an old version.
- It should likely reuse the `screen-reader-text` CSS class already provided by the block library common CSS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We should always use the recommended, WordPress standard, CSS ruleset for visually hidden content.
We should not use redundant unnecessary CSS.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the custom unnecessary ruleset and reuses the `screen-reader-text` CSS class from the block library common CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add q Query Loop block and make sure the actual query produces enough results to have pagination.
- Enable 'Enhanced pagination' in the settings panel.
- Add a pagination block.
- Publish and view the front end.
- Use the pagination links to navigate to another paginated page.
- Inspect the source and find the element with CSS class `wp-block-query__enhanced-pagination-navigation-announce`.
- Observe the element does have a second CSS class `screen-reader-text`.
- Check the CSS ruleset to visually hide the element comes from the `screen-reader-text` CSS class in the block library `common.css`.
- Check the element is actually visually hidden on the page.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
