### PR TITLE
WP_Theme_JSON_Gutenberg Unit tests: fix phpunit warnings about set_spacing_sizes

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3389,7 +3389,7 @@ class WP_Theme_JSON_Gutenberg {
 			|| ! is_numeric( $spacing_scale['mediumStep'] )
 			|| ( '+' !== $spacing_scale['operator'] && '*' !== $spacing_scale['operator'] ) ) {
 			if ( ! empty( $spacing_scale ) ) {
-				trigger_error( __( 'Some of the theme.json settings.spacing.spacingScale values are invalid', 'gutenberg' ), E_USER_NOTICE );
+				_doing_it_wrong( __METHOD__, __( 'Some of the theme.json settings.spacing.spacingScale values are invalid', 'gutenberg' ), '6.1.0' );
 			}
 			return null;
 		}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1282,9 +1282,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * @dataProvider data_set_spacing_sizes_when_invalid
 	 */
 	public function test_set_spacing_sizes_when_invalid( $spacing_scale, $expected_output ) {
-		$this->expectNotice();
-		$this->expectNoticeMessage( 'Some of the theme.json settings.spacing.spacingScale values are invalid' );
-
+		$this->setExpectedIncorrectUsage( 'WP_Theme_JSON_Gutenberg::set_spacing_sizes' );
+	
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => 2,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1283,7 +1283,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_set_spacing_sizes_when_invalid( $spacing_scale, $expected_output ) {
 		$this->setExpectedIncorrectUsage( 'WP_Theme_JSON_Gutenberg::set_spacing_sizes' );
-	
+
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => 2,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`WP_Theme_JSON_Gutenberg` unit tests: fix phpunit warnings about `set_spacing_sizes()`.

## Why?
To avoid the warnings on the console:
```
There were 5 warnings:

1) WP_Theme_JSON_Gutenberg_Test::test_set_spacing_sizes_when_invalid with data set "invalid_spacing_scale_values_missing_operator" (array('', 1.5, 1, 4, 'rem'), null)
Expecting E_STRICT, E_NOTICE, and E_USER_NOTICE is deprecated and will no longer be possible in PHPUnit 10.

2) WP_Theme_JSON_Gutenberg_Test::test_set_spacing_sizes_when_invalid with data set "invalid_spacing_scale_values_non_numeric_increment" (array('+', 'add two to previous value', 1, 4, 'rem'), null)
Expecting E_STRICT, E_NOTICE, and E_USER_NOTICE is deprecated and will no longer be possible in PHPUnit 10.

3) WP_Theme_JSON_Gutenberg_Test::test_set_spacing_sizes_when_invalid with data set "invalid_spacing_scale_values_non_numeric_steps" (array('+', 1.5, 'spiral staircase preferred', 4, 'rem'), null)
Expecting E_STRICT, E_NOTICE, and E_USER_NOTICE is deprecated and will no longer be possible in PHPUnit 10.

4) WP_Theme_JSON_Gutenberg_Test::test_set_spacing_sizes_when_invalid with data set "invalid_spacing_scale_values_non_numeric_medium_step" (array('+', 1.5, 5, 'That which is just right', 'rem'), null)
Expecting E_STRICT, E_NOTICE, and E_USER_NOTICE is deprecated and will no longer be possible in PHPUnit 10.

5) WP_Theme_JSON_Gutenberg_Test::test_set_spacing_sizes_when_invalid with data set "invalid_spacing_scale_values_missing_unit" (array('+', 1.5, 5, 4), null)
Expecting E_STRICT, E_NOTICE, and E_USER_NOTICE is deprecated and will no longer be possible in PHPUnit 10.

```


## How?
using core function [_doing_it_wrong()](https://developer.wordpress.org/reference/functions/_doing_it_wrong/) to throw the notice and using `setExpectedIncorrectUsage` to assert the incorrect usage notice.


## Testing Instructions
Run PHP unit tests with and without this change.
You should not see the warning running this PR.

