### PR TITLE
PagePages: Fix unintended object mutation inside component

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -39,13 +39,15 @@ export default function PagePages() {
 	} );
 	// Request post statuses to get the proper labels.
 	const { records: statuses } = useEntityRecords( 'root', 'status' );
-	const postStatuses =
-		statuses === null
-			? EMPTY_OBJECT
-			: statuses.reduce( ( acc, status ) => {
-					acc[ status.slug ] = status.name;
-					return acc;
-			  }, EMPTY_OBJECT );
+	const postStatuses = useMemo(
+		() =>
+			statuses === null
+				? EMPTY_OBJECT
+				: Object.fromEntries(
+						statuses.map( ( { slug, name } ) => [ slug, name ] )
+				  ),
+		[ statuses ]
+	);
 
 	const queryArgs = useMemo(
 		() => ( {


### PR DESCRIPTION
Fixes subtle bug introduced in #55050.

See my detailed explanation in the original PR: https://github.com/WordPress/gutenberg/pull/55050#pullrequestreview-1674445822

- Don't reuse references when updating `postStatuses`
- Don't accidentally mutate `EMPTY_OBJECT`

Part of #55083