### PR TITLE
Get the page count as derived data

### DIFF
--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -124,9 +124,3 @@ export function getQueriedTotalItems( state, query = {} ) {
 
 	return state.queries?.[ context ]?.[ stableKey ]?.meta?.totalItems ?? null;
 }
-
-export function getQueriedTotalPages( state, query = {} ) {
-	const { stableKey, context } = getQueryParts( query );
-
-	return state.queries?.[ context ]?.[ stableKey ]?.meta?.totalPages ?? null;
-}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -233,9 +233,6 @@ export const getEntityRecords =
 				const response = await apiFetch( { path, parse: false } );
 				records = Object.values( await response.json() );
 				meta = {
-					totalPages: parseInt(
-						response.headers.get( 'X-WP-TotalPages' )
-					),
 					totalItems: parseInt(
 						response.headers.get( 'X-WP-Total' )
 					),

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -14,11 +14,7 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import { STORE_NAME } from './name';
-import {
-	getQueriedItems,
-	getQueriedTotalItems,
-	getQueriedTotalPages,
-} from './queried-data';
+import { getQueriedItems, getQueriedTotalItems } from './queried-data';
 import { DEFAULT_ENTITY_KEY } from './entities';
 import {
 	getNormalizedCommaSeparable,
@@ -578,7 +574,10 @@ export const getEntityRecordsTotalPages = (
 	if ( ! queriedState ) {
 		return null;
 	}
-	return getQueriedTotalPages( queriedState, query );
+	if ( query.per_page === -1 ) return 1;
+	const totalItems = getQueriedTotalItems( queriedState, query );
+	if ( ! totalItems ) return totalItems;
+	return Math.ceil( totalItems / query.per_page );
 };
 
 type DirtyEntityRecord = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Recently there [was an update](https://github.com/WordPress/gutenberg/pull/55164) to core-data package to include the total number of records and pages per query.

There is a bug though in getting the total pages of a query, because internally in state we keep the queries with a stable key, which doesn't include the `perPage` argument. This makes sense in practice, but the stored value for total pages has the value of the last request.

I kept the same APIs, but I'm calculating the total pages based on the total number of records.

<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Go to the experiment of pages list in site editor
2. Change the records per row to 20
3. Then back to 5
4. Observe the pages are updated properly


