### PR TITLE
Font Library: Change all references to 6.4.0 by 6.5.0 core version

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -6,7 +6,7 @@
  *
  * @package    WordPress
  * @subpackage Font Library
- * @since      6.4.0
+ * @since      6.5.0
  */
 
 if ( class_exists( 'WP_Font_Collection' ) ) {
@@ -16,14 +16,14 @@ if ( class_exists( 'WP_Font_Collection' ) ) {
 /**
  * Font Collection class.
  *
- * @since 6.4.0
+ * @since 6.5.0
  */
 class WP_Font_Collection {
 
 	/**
 	 * Font collection configuration.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @var array
 	 */
@@ -32,7 +32,7 @@ class WP_Font_Collection {
 	/**
 	 * WP_Font_Collection constructor.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $config Font collection config options.
 	 *                      See {@see wp_register_font_collection()} for the supported fields.
@@ -61,7 +61,7 @@ class WP_Font_Collection {
 	/**
 	 * Gets the font collection config.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return array An array containing the font collection config.
 	 */
@@ -72,7 +72,7 @@ class WP_Font_Collection {
 	/**
 	 * Gets the font collection data.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return array|WP_Error An array containing the list of font families in theme.json format on success,
 	 *                        else an instance of WP_Error on failure.

--- a/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
@@ -6,7 +6,7 @@
  *
  * @package    WordPress
  * @subpackage Font Library
- * @since      6.4.0
+ * @since      6.5.0
  */
 
 if ( class_exists( 'WP_Font_Family_Utils' ) ) {
@@ -16,7 +16,7 @@ if ( class_exists( 'WP_Font_Family_Utils' ) ) {
 /**
  * A class of utilities for working with the Font Library.
  *
- * @since 6.4.0
+ * @since 6.5.0
  */
 class WP_Font_Family_Utils {
 
@@ -26,7 +26,7 @@ class WP_Font_Family_Utils {
 	 * Creates a filename for a font face asset using font family, style, weight and
 	 * extension information.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param string $font_slug The font slug to use in the filename.
 	 * @param array  $font_face The font face array containing 'fontFamily', 'fontStyle', and
@@ -48,7 +48,7 @@ class WP_Font_Family_Utils {
 	/**
 	 * Merges two fonts and their font faces.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $font1 The first font to merge.
 	 * @param array $font2 The second font to merge.
@@ -79,7 +79,7 @@ class WP_Font_Family_Utils {
 	/**
 	 * Returns whether the given file has a font MIME type.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param string $filepath The file to check.
 	 * @return bool True if the file has a font MIME type, false otherwise.

--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -6,7 +6,7 @@
  *
  * @package    WordPress
  * @subpackage Font Library
- * @since      6.4.0
+ * @since      6.5.0
  */
 
 if ( class_exists( 'WP_Font_Family' ) ) {
@@ -16,14 +16,14 @@ if ( class_exists( 'WP_Font_Family' ) ) {
 /**
  * Font Library class.
  *
- * @since 6.4.0
+ * @since 6.5.0
  */
 class WP_Font_Family {
 
 	/**
 	 * Font family data.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @var array
 	 */
@@ -32,7 +32,7 @@ class WP_Font_Family {
 	/**
 	 * WP_Font_Family constructor.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $font_data Font family data.
 	 * @throws Exception If the font family data is missing the slug.
@@ -47,7 +47,7 @@ class WP_Font_Family {
 	/**
 	 * Gets the font family data.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return array An array in fontFamily theme.json format.
 	 */
@@ -58,7 +58,7 @@ class WP_Font_Family {
 	/**
 	 * Gets the font family data.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return string fontFamily in theme.json format as stringified JSON.
 	 */
@@ -69,7 +69,7 @@ class WP_Font_Family {
 	/**
 	 * Checks whether the font family has font faces defined.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return bool True if the font family has font faces defined, false otherwise.
 	 */
@@ -80,7 +80,7 @@ class WP_Font_Family {
 	/**
 	 * Removes font family assets.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return bool True if assets were removed, false otherwise.
 	 */
@@ -99,7 +99,7 @@ class WP_Font_Family {
 	/**
 	 * Removes a font family from the database and deletes its assets.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return bool|WP_Error True if the font family was uninstalled, WP_Error otherwise.
 	 */
@@ -128,7 +128,7 @@ class WP_Font_Family {
 	/**
 	 * Deletes a specified font asset file from the fonts directory.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param string $src The path of the font asset file to delete.
 	 * @return bool Whether the file was deleted.
@@ -145,7 +145,7 @@ class WP_Font_Family {
 	/**
 	 * Deletes all font face asset files associated with a given font face.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $font_face The font face array containing the 'src' attribute
 	 *                         with the file path(s) to be deleted.
@@ -167,7 +167,7 @@ class WP_Font_Family {
 	/**
 	 * Gets the overrides for the 'wp_handle_upload' function.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param string $filename The filename to be used for the uploaded file.
 	 * @return array The overrides for the 'wp_handle_upload' function.
@@ -194,7 +194,7 @@ class WP_Font_Family {
 	 * Downloads a font asset from a specified source URL and saves it to
 	 * the font directory.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param string $url      The source URL of the font asset to be downloaded.
 	 * @param string $filename The filename to save the downloaded font asset as.
@@ -244,7 +244,7 @@ class WP_Font_Family {
 	 *
 	 * This is used when uploading local fonts.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $font_face Font face to download.
 	 * @param array $file      Uploaded file.
@@ -290,7 +290,7 @@ class WP_Font_Family {
 	/**
 	 * Sanitizes the font family data using WP_Theme_JSON.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return array A sanitized font family definition.
 	 */
@@ -321,7 +321,7 @@ class WP_Font_Family {
 	 * Downloads the font face asset(s) associated with a font face. It works with
 	 * both single source URLs and arrays of multiple source URLs.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $font_face The font face array containing the 'src' attribute
 	 *                         with the source URL(s) of the assets.
@@ -364,7 +364,7 @@ class WP_Font_Family {
 	 * Downloads font face assets if the font family is a Google font,
 	 * or moves them if it is a local font.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $files An array of files to be installed.
 	 * @return bool True if the font faces were downloaded or moved successfully, false otherwise.
@@ -429,7 +429,7 @@ class WP_Font_Family {
 	/**
 	 * Gets the post for a font family.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return WP_Post|null The post for this font family object or
 	 *                      null if the post does not exist.
@@ -455,7 +455,7 @@ class WP_Font_Family {
 	 * Gets the data for this object from the database and
 	 * sets it to the data property.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return WP_Post|null The post for this font family object or
 	 *                      null if the post does not exist.
@@ -473,7 +473,7 @@ class WP_Font_Family {
 	/**
 	 * Creates a post for a font family.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return int|WP_Error Post ID if the post was created, WP_Error otherwise.
 	 */
@@ -500,7 +500,7 @@ class WP_Font_Family {
 	/**
 	 * Gets the font faces that are in both the existing and incoming font families.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $existing The existing font faces.
 	 * @param array $incoming The incoming font faces.
@@ -523,7 +523,7 @@ class WP_Font_Family {
 	/**
 	 * Updates a post for a font family.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param WP_Post $post The post to update.
 	 * @return int|WP_Error Post ID if the update was successful, WP_Error otherwise.
@@ -570,7 +570,7 @@ class WP_Font_Family {
 	 * Creates a post for a font in the Font Library if it doesn't exist,
 	 * or updates it if it does.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return int|WP_Error Post id if the post was created or updated successfully,
 	 *                      WP_Error otherwise.
@@ -589,7 +589,7 @@ class WP_Font_Family {
 	/**
 	 * Installs the font family into the library.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $files Optional. An array of files to be installed. Default null.
 	 * @return array|WP_Error An array of font family data on success, WP_Error otherwise.

--- a/lib/experimental/fonts/font-library/class-wp-font-library.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-library.php
@@ -6,7 +6,7 @@
  *
  * @package    WordPress
  * @subpackage Font Library
- * @since      6.4.0
+ * @since      6.5.0
  */
 
 if ( class_exists( 'WP_Font_Library' ) ) {
@@ -16,7 +16,7 @@ if ( class_exists( 'WP_Font_Library' ) ) {
 /**
  * Font Library class.
  *
- * @since 6.4.0
+ * @since 6.5.0
  */
 class WP_Font_Library {
 
@@ -25,7 +25,7 @@ class WP_Font_Library {
 	 *
 	 * This is necessary until a collection of valid mime-types per-file extension can be provided to 'upload_mimes' filter.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $php_version_id The version of PHP to provide mime types for. The default is the current PHP version.
 	 *
@@ -46,7 +46,7 @@ class WP_Font_Library {
 	/**
 	 * Font collections.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @var array
 	 */
@@ -55,7 +55,7 @@ class WP_Font_Library {
 	/**
 	 * Register a new font collection.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $config Font collection config options.
 	 *                      See {@see wp_register_font_collection()} for the supported fields.
@@ -75,7 +75,7 @@ class WP_Font_Library {
 	/**
 	 * Gets all the font collections available.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return array List of font collections.
 	 */
@@ -86,7 +86,7 @@ class WP_Font_Library {
 	/**
 	 * Gets a font collection.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param string $id Font collection id.
 	 * @return array List of font collections.
@@ -101,7 +101,7 @@ class WP_Font_Library {
 	/**
 	 * Gets the upload directory for fonts.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return string Path of the upload directory for fonts.
 	 */
@@ -112,7 +112,7 @@ class WP_Font_Library {
 	/**
 	 * Sets the upload directory for fonts.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $defaults {
 	 *     Default upload directory.
@@ -138,7 +138,7 @@ class WP_Font_Library {
 	/**
 	 * Sets the allowed mime types for fonts.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array $mime_types List of allowed mime types.
 	 * @return array Modified upload directory.

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
@@ -6,7 +6,7 @@
  *
  * @package    WordPress
  * @subpackage Font Library
- * @since      6.4.0
+ * @since      6.5.0
  */
 
 if ( class_exists( 'WP_REST_Font_Library_Controller' ) ) {
@@ -16,14 +16,14 @@ if ( class_exists( 'WP_REST_Font_Library_Controller' ) ) {
 /**
  * Font Library Controller class.
  *
- * @since 6.4.0
+ * @since 6.5.0
  */
 class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 
 	/**
 	 * Constructor.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 */
 	public function __construct() {
 		$this->rest_base = 'fonts';
@@ -33,7 +33,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Registers the routes for the objects of the controller.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -96,7 +96,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Gets a font collection.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -121,7 +121,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Gets the font collections available.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
@@ -137,7 +137,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Returns validation errors in font families data for installation.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array[] $font_families Font families to install.
 	 * @param array   $files         Files to install.
@@ -233,7 +233,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Validate input for the install endpoint.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param string          $param The font families to install.
 	 * @param WP_REST_Request $request The request object.
@@ -254,7 +254,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Gets the schema for the uninstall endpoint.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return array Schema array.
 	 */
@@ -283,7 +283,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Removes font families from the Font Library and all their assets.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -327,7 +327,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Checks whether the user has permissions to update the Font Library.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return true|WP_Error True if the request has write access for the item, WP_Error object otherwise.
 	 */
@@ -347,7 +347,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Checks whether the user has write permissions to the temp and fonts directories.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @return true|WP_Error True if the user has write permissions, WP_Error object otherwise.
 	 */
@@ -364,7 +364,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	/**
 	 * Checks whether the request needs write permissions.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param array[] $font_families Font families to install.
 	 * @return bool Whether the request needs write permissions.
@@ -389,7 +389,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	 * Takes a request containing new fonts to install, downloads their assets, and adds them
 	 * to the Font Library.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param WP_REST_Request $request The request object containing the new fonts to install
 	 *                                 in the request parameters.

--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -6,7 +6,7 @@
  *
  * @package    WordPress
  * @subpackage Font Library
- * @since      6.4.0
+ * @since      6.5.0
  */
 
 /**
@@ -17,7 +17,7 @@
  * provides instructions on where the could needs to go
  * in Core.
  *
- * @since 6.4.0
+ * @since 6.5.0
  */
 function gutenberg_init_font_library_routes() {
 	// @core-merge: This code will go into Core's `create_initial_post_types()`.
@@ -41,7 +41,7 @@ if ( ! function_exists( 'wp_register_font_collection' ) ) {
 	/**
 	 * Registers a new Font Collection in the Font Library.
 	 *
-	 * @since 6.4.0
+	 * @since 6.5.0
 	 *
 	 * @param string[] $config {
 	 *     Font collection associative array of configuration options.


### PR DESCRIPTION
## What?
Change all references to 6.4.0 by 6.5.0 core version

## Why?
Because the Font Library feature has been punted from 6.4.0 to 6.5.0

## How?
Updating all comments referencing 6.4.0

## Testing Instructions
This is not a functional change. So there is not much to test.

Closes: https://github.com/WordPress/gutenberg/issues/55263