### PR TITLE
Data: Fix `combineReducers()` types

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-  Fix `combineReducers()` types ([#55321](https://github.com/WordPress/gutenberg/pull/55321)).
+
 ## 9.13.0 (2023-10-05)
 
 ### Enhancements

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -3,6 +3,7 @@
  */
 import defaultRegistry from './default-registry';
 import * as plugins from './plugins';
+import { combineReducers as combineReducersModule } from './redux-store';
 
 /** @typedef {import('./types').StoreDescriptor} StoreDescriptor */
 
@@ -75,7 +76,7 @@ export { plugins };
  * @return {Function} A reducer that invokes every reducer inside the reducers
  *                    object, and constructs a state object with the same shape.
  */
-export { combineReducers } from './redux-store';
+export const combineReducers = combineReducersModule;
 
 /**
  * Given a store descriptor, returns an object containing the store's selectors pre-bound to state


### PR DESCRIPTION
## What?
This PR fixes the built types of the `combineReducers` utility that we export from `@wordpress/data`.

## Why?
In #54606 we broke the types of `combineReducers` because the inline JSDoc type definition for the `combineReducers` export no longer worked with the new `export { module }` syntax.

This bug was reported in https://github.com/WordPress/gutenberg/pull/54606#issuecomment-1758704189

## How?
We're using the `export const` syntax and that resolves the inline JSDoc type so it properly picks it up as it did before.

## Testing Instructions
* Check out the built types of the `@wodpress/data` package and verify that the `combineReducers` type properly uses the type definition from the package's types.
* Verify all checks are green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None