### PR TITLE
test: Update E2E utilities

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -11,7 +11,7 @@ const ios = {
 exports.iosLocal = ( { iPadDevice = false } ) => ( {
 	...ios,
 	deviceName: ! iPadDevice ? 'iPhone 13' : 'iPad Pro (9.7-inch)',
-	devicePixelRatio: ! iPadDevice ? 3 : 2,
+	pixelRatio: ! iPadDevice ? 3 : 2,
 	usePrebuiltWDA: true,
 } );
 
@@ -20,7 +20,7 @@ exports.iosServer = ( { iPadDevice = false } ) => ( {
 	deviceName: ! iPadDevice
 		? 'iPhone 13 Simulator'
 		: 'iPad Pro (9.7 inch) Simulator',
-	devicePixelRatio: ! iPadDevice ? 3 : 2,
+	pixelRatio: ! iPadDevice ? 3 : 2,
 } );
 
 exports.android = {

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -11,6 +11,7 @@ const ios = {
 exports.iosLocal = ( { iPadDevice = false } ) => ( {
 	...ios,
 	deviceName: ! iPadDevice ? 'iPhone 13' : 'iPad Pro (9.7-inch)',
+	devicePixelRatio: ! iPadDevice ? 3 : 2,
 	usePrebuiltWDA: true,
 } );
 
@@ -19,6 +20,7 @@ exports.iosServer = ( { iPadDevice = false } ) => ( {
 	deviceName: ! iPadDevice
 		? 'iPhone 13 Simulator'
 		: 'iPad Pro (9.7 inch) Simulator',
+	devicePixelRatio: ! iPadDevice ? 3 : 2,
 } );
 
 exports.android = {

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -448,7 +448,7 @@ const swipeFromTo = async (
 	driver,
 	from = defaultCoordinates,
 	to = defaultCoordinates,
-	delay
+	delay = 0
 ) =>
 	await driver
 		.action( 'pointer', {

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -450,26 +450,16 @@ const swipeFromTo = async (
 	to = defaultCoordinates,
 	delay
 ) =>
-	driver.touchPerform( [
-		{
-			action: 'press',
-			options: from,
-		},
-		{
-			action: 'wait',
-			options: {
-				ms: delay,
-			},
-		},
-		{
-			action: 'moveTo',
-			options: to,
-		},
-		{
-			action: 'release',
-			options: {},
-		},
-	] );
+	await driver
+		.action( 'pointer', {
+			parameters: { pointerType: 'touch' },
+		} )
+		.move( { ...from, duration: 0 } )
+		.down( { button: 0 } )
+		.move( { ...to, duration: 300 } )
+		.up( { button: 0 } )
+		.pause( delay )
+		.perform();
 
 // Starts from the middle of the screen and swipes downwards
 const swipeDown = async ( driver, delay = 3000 ) => {

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -174,7 +174,7 @@ const setupDriver = async () => {
 
 	const driver = await remote( {
 		...serverConfig,
-		logLevel: 'error',
+		logLevel: 'debug',
 		capabilities: {
 			platformName: PLATFORM_NAME,
 			...prefixKeysWithAppium( desiredCaps ),

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -569,7 +569,7 @@ const toggleOrientation = async ( driver ) => {
  */
 const toggleDarkMode = ( driver, darkMode = true ) => {
 	if ( isAndroid() ) {
-		return driver.execute( 'mobile: shell', [
+		return driver.executeScript( 'mobile: shell', [
 			{
 				command: `cmd uimode night  ${ darkMode ? 'yes' : 'no' }`,
 			},

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -576,9 +576,11 @@ const toggleDarkMode = ( driver, darkMode = true ) => {
 		] );
 	}
 
-	return driver.execute( 'mobile: setAppearance', {
-		style: darkMode ? 'dark' : 'light',
-	} );
+	return driver.executeScript( 'mobile: setAppearance', [
+		{
+			style: darkMode ? 'dark' : 'light',
+		},
+	] );
 };
 
 const isEditorVisible = async ( driver ) => {

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -174,7 +174,7 @@ const setupDriver = async () => {
 
 	const driver = await remote( {
 		...serverConfig,
-		logLevel: 'debug',
+		logLevel: 'error',
 		capabilities: {
 			platformName: PLATFORM_NAME,
 			...prefixKeysWithAppium( desiredCaps ),

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -301,7 +301,10 @@ class EditorPage {
 	async waitForKeyboardToBeHidden() {
 		const { addButtonLocation } = this.initialValues;
 		const addButton = await this.getAddBlockButton();
-		const location = await addButton.getLocation();
+		let location;
+		if ( addButton ) {
+			location = await addButton.getLocation();
+		}
 		let YLocation = addButtonLocation?.y;
 		const currentOrientation = await this.driver.getOrientation();
 		const isLandscape = currentOrientation === 'LANDSCAPE';
@@ -315,7 +318,7 @@ class EditorPage {
 			);
 		}
 
-		if ( location.y < YLocation ) {
+		if ( ! addButton || location?.y < YLocation ) {
 			await this.waitForKeyboardToBeHidden();
 		}
 	}

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -67,8 +67,7 @@ class EditorPage {
 	}
 
 	async getAddBlockButton() {
-		const elements =
-			await this.driver.elementsByAccessibilityId( ADD_BLOCK_ID );
+		const elements = await this.driver.$$( `~${ ADD_BLOCK_ID }` );
 		return elements[ 0 ];
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Related PRs
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6281

## What?
<!-- In a few words, what is the PR actually doing? -->
Update E2E utilities for Appium 2 and WebdriverIO.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improve the stability and quality of the automated tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Set static device pixel ratio
 WebdriverIO (the replacement for the deprecated WD driver library) does
 not have a method for retrieving a device's pixel ratio. Therefore, this
 sets an explicit value for each of our test devices.
- Update the `getAddBlockButton` utility


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See https://github.com/wordpress-mobile/gutenberg-mobile/pull/6281. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
