### PR TITLE
Components: Expose `Tabs` as private API

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Allow using CSS level 4 viewport-relative units ([54415](https://github.com/WordPress/gutenberg/pull/54415))
 -   `ToolsPanel`: do not apply the `className` to prop to `ToolsPanelItem` components when rendered as placeholders ([#55207](https://github.com/WordPress/gutenberg/pull/55207)).
 -   `GradientPicker`: remove overflow styles and padding from `ColorPicker` popovers ([#55265](https://github.com/WordPress/gutenberg/pull/55265)).
+-   `Tabs`: Expose via private APIs ([#55327](https://github.com/WordPress/gutenberg/pull/55327)).
 -   `ColorPalette`/`ToggleGroupControl/ToggleGroupControlOptionBase`: add `type="button"` attribute to native `<button>`s ([#55125](https://github.com/WordPress/gutenberg/pull/55125)).
 
 ### Bug Fix

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -61,6 +61,6 @@ lock( privateApis, {
 	DropdownSubMenuV2,
 	DropdownSubMenuTriggerV2,
 	ProgressBar,
-	Theme,
 	Tabs,
+	Theme,
 } );

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -31,6 +31,7 @@ import {
 } from './dropdown-menu-v2';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
+import Tabs from './tabs';
 
 export const { lock, unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -61,4 +62,5 @@ lock( privateApis, {
 	DropdownSubMenuTriggerV2,
 	ProgressBar,
 	Theme,
+	Tabs,
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Exposes the new `Tabs` component as a private API.

## Why?
To experiment with `Tabs` in the editor as a substitute for `TabPabel` implementations, or use cases where `TabPanel` wasn't suitable and custom solutions were needed instead.

## How?
Adding `Tabs` to the package's list of private APIs

## Testing Instructions
All tests should pass, but no impactful changes are being made on this PR.
