### PR TITLE
Patterns: Suggest commands when editing pattern in site editor

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -4,6 +4,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
+	edit,
 	trash,
 	rotateLeft,
 	rotateRight,
@@ -375,7 +376,7 @@ function usePatternCommands() {
 		commands.push( {
 			name: 'core/rename-pattern',
 			label: __( 'Rename pattern' ),
-			icon: symbol,
+			icon: edit,
 			callback: ( { close } ) => {
 				openModal( PATTERN_MODALS.rename );
 				close();
@@ -416,6 +417,7 @@ export function useEditModeCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/patterns',
 		hook: usePatternCommands,
+		context: 'site-editor-edit',
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
Addresses: https://github.com/WordPress/gutenberg/issues/52651#issuecomment-1760702410

## What?

- Updates the "Rename pattern" command to use edit/pencil icon
- Suggests pattern-related commands while editing a pattern in the site editor

**Note: It appears that the loader context is a string value so we can't cover both the `site-editor` and `site-editor-edit` contexts in terms of suggesting these pattern commands, unless we register the same loader twice. This PR errs towards only registering the commands for a single context at present**

## Why?

Makes it easier to rename or duplicate patterns after editing one

## How?

- Update the rename command's icon
- Add the `site-editor-edit` context to the pattern command loader

## Testing Instructions

1. Navigate to Appearance > Editor > Patterns
2. Select a user-created pattern
3. While on the view pattern page, open the command palette and confirm no new pattern suggestions
4. Search for rename/duplicate pattern commands and confirm they display in the suggestions
5. Close the command palette and click on the preview to enter edit mode
6. Open the command palette again and confirm the rename and duplicate pattern commands are suggested by default
7. Navigate to other entity pages such as Templates, Template Parts etc and confirm the pattern commands do not show


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/4541780a-33be-4925-8669-9e2ae305cd2f

