### PR TITLE
Packages: Ensure only changed packages get published for WP releases

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -53,7 +53,9 @@ jobs:
               with:
                   path: publish
                   ref: wp/${{ github.event.inputs.wp_version }}
-                  fetch-depth: 100
+                  # We need to ensure that Lerna can read the commit created during the previous npm publishing.
+                  # Lerna assumes that all packages will be published if it can't access the necessary information.
+                  fetch-depth: 999
                   token: ${{ secrets.GUTENBERG_TOKEN }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -53,6 +53,7 @@ jobs:
               with:
                   path: publish
                   ref: wp/${{ github.event.inputs.wp_version }}
+                  fetch-depth: 100
                   token: ${{ secrets.GUTENBERG_TOKEN }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -54,7 +54,7 @@ jobs:
                   path: publish
                   ref: wp/${{ github.event.inputs.wp_version }}
                   # We need to ensure that Lerna can read the commit created during the previous npm publishing.
-                  # Lerna assumes that all packages will be published if it can't access the necessary information.
+                  # Lerna assumes that all packages need publishing if it can't access the necessary information.
                   fetch-depth: 999
                   token: ${{ secrets.GUTENBERG_TOKEN }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -86,7 +86,7 @@ async function checkoutNpmReleaseBranch( {
 	 * Note that we are grabbing an arbitrary depth of commits (999) during the fetch.
 	 * When Lerna attempts to determine if a package needs an update, it looks at
 	 * `git` history to find the commit created during the previous npm publishing.
-	 * Lerna assumes that all packages will be published if it can't access
+	 * Lerna assumes that all packages need publishing if it can't access
 	 * the necessary information.
 	 */
 	await SimpleGit( gitWorkingDirectoryPath )

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -83,24 +83,14 @@ async function checkoutNpmReleaseBranch( {
 	/*
 	 * Create the release branch.
 	 *
-	 * Note that we are grabbing an arbitrary depth of commits
-	 * during the fetch. When `lerna` attempts to determine if
-	 * a package needs an update, it looks at `git` history,
-	 * and if we have pruned that history it will pre-emptively
-	 * publish when it doesn't need to.
-	 *
-	 * We could set a different arbitrary depth if this isn't
-	 * long enough or if it's excessive. We could also try and
-	 * find a way to more specifically fetch what we expect to
-	 * change. For example, if we knew we'll be performing
-	 * updates every two weeks, we might be conservative and
-	 * use `--shallow-since=4.weeks.ago`.
-	 *
-	 * At the time of writing, a depth of 100 pulls in all
-	 * `trunk` commits from within the past week.
+	 * Note that we are grabbing an arbitrary depth of commits (999) during the fetch.
+	 * When Lerna attempts to determine if a package needs an update, it looks at
+	 * `git` history to find the commit created during the previous npm publishing.
+	 * Lerna assumes that all packages will be published if it can't access
+	 * the necessary information.
 	 */
 	await SimpleGit( gitWorkingDirectoryPath )
-		.fetch( 'origin', npmReleaseBranch, [ '--depth=100' ] )
+		.fetch( 'origin', npmReleaseBranch, [ '--depth=999' ] )
 		.checkout( npmReleaseBranch );
 	log(
 		'>> The local npm release branch ' +


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tries to fix the issue with publishing unmodified WordPress packages when targeting the WordPress core to avoid all the potential issues encountered yesterday during WordPress 6.1.4 and 6.3.2 releases. It also aligns with how it worked before the upgrade to Node 16 / npm 8 that forced us to stop using the Node script for npm publishing when dealing with branches that use older versions of Node & npm.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It turned out the [Checkout GitHub action](https://github.com/actions/checkout) by default fetches only the last commit in the branch:

```
# Number of commits to fetch. 0 indicates all history for all branches and tags.
# Default: 1
fetch-depth: ''
```

In effect, Lerna didn't have access to the previous commit used for npm publishing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix mirror the behavior that worked well in the past and it is still used for npm publishing when targeting the latest packages of the bugfix release:

https://github.com/WordPress/gutenberg/blob/ef21f207827e1ac9e23c307ca2a7efaf4366b6c6/bin/plugin/commands/packages.js#L103

The number `100` here is randomly picked based on some quick assessments from the past. 


