### PR TITLE
useBlockControlsFill: avoid unneeded store subscriptions

### DIFF
--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -17,17 +17,20 @@ export default function useBlockControlsFill( group, shareWithChildBlocks ) {
 	const { clientId } = useBlockEditContext();
 	const isParentDisplayed = useSelect(
 		( select ) => {
+			if ( ! shareWithChildBlocks ) {
+				return false;
+			}
+
 			const { getBlockName, hasSelectedInnerBlock } =
 				select( blockEditorStore );
 			const { hasBlockSupport } = select( blocksStore );
+
 			return (
-				shareWithChildBlocks &&
 				hasBlockSupport(
 					getBlockName( clientId ),
 					'__experimentalExposeControlsToChildren',
 					false
-				) &&
-				hasSelectedInnerBlock( clientId )
+				) && hasSelectedInnerBlock( clientId )
 			);
 		},
 		[ shareWithChildBlocks, clientId ]


### PR DESCRIPTION
When a block renders a `<BlockControls>` markup, its contents are rendered in the slot only if the block is selected. The `useBlockControlsFill` ensures that, returning a non-null fill only when the block is selected.

This PR optimizes the `useBlockControlsFill` hook: if `shareWithChildBlocks` is false, it can return early without creating any subscriptions to the `block-editor` store. And reducing number of subscriptions helps fix #54819.

On a large post with 1000 blocks, I'm seeing (using the debug code from #55337) a reduction by 1500 subscriptions, from 77.5k to 76k.