### PR TITLE
[WIP] Commands: Allow command context to be an array 

### DIFF
--- a/packages/commands/src/store/selectors.js
+++ b/packages/commands/src/store/selectors.js
@@ -33,7 +33,9 @@ export const getCommandLoaders = createSelector(
 	( state, contextual = false ) =>
 		Object.values( state.commandLoaders ).filter( ( loader ) => {
 			const isContextual =
-				loader.context && loader.context === state.context;
+				loader.context && Array.isArray( loader.context )
+					? loader.context.includes( state.context )
+					: loader.context && loader.context === state.context;
 			return contextual ? isContextual : ! isContextual;
 		} ),
 	( state ) => [ state.commandLoaders, state.context ]


### PR DESCRIPTION
## What?
Just an exploration to see if command contexts can be easily extended to allow for an array

## Why?
Sometimes it might make sense to load commands in multiple contexts, eg. https://github.com/WordPress/gutenberg/pull/55332, and currently to do this the same loader would need to be registered twice.

## How?
Updates the `getCommandLoaders `selector` to check if the context is an array or a string.

## Testing Instructions
Will add testing instructions if we decide this is a good idea.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
