### PR TITLE
Block Editor: Optimize 'customClassName' controls

### DIFF
--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -39,6 +39,30 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
+function CustomClassNameControls( { attributes, setAttributes } ) {
+	const blockEditingMode = useBlockEditingMode();
+	if ( blockEditingMode !== 'default' ) {
+		return null;
+	}
+
+	return (
+		<InspectorControls group="advanced">
+			<TextControl
+				__nextHasNoMarginBottom
+				autoComplete="off"
+				label={ __( 'Additional CSS class(es)' ) }
+				value={ attributes.className || '' }
+				onChange={ ( nextValue ) => {
+					setAttributes( {
+						className: nextValue !== '' ? nextValue : undefined,
+					} );
+				} }
+				help={ __( 'Separate multiple classes with spaces.' ) }
+			/>
+		</InspectorControls>
+	);
+}
+
 /**
  * Override the default edit UI to include a new block inspector control for
  * assigning the custom class name, if block supports custom class name.
@@ -51,42 +75,23 @@ export function addAttribute( settings ) {
 export const withInspectorControl = createHigherOrderComponent(
 	( BlockEdit ) => {
 		return ( props ) => {
-			const blockEditingMode = useBlockEditingMode();
 			const hasCustomClassName = hasBlockSupport(
 				props.name,
 				'customClassName',
 				true
 			);
-			if ( hasCustomClassName && props.isSelected ) {
-				return (
-					<>
-						<BlockEdit { ...props } />
-						{ blockEditingMode === 'default' && (
-							<InspectorControls group="advanced">
-								<TextControl
-									__nextHasNoMarginBottom
-									autoComplete="off"
-									label={ __( 'Additional CSS class(es)' ) }
-									value={ props.attributes.className || '' }
-									onChange={ ( nextValue ) => {
-										props.setAttributes( {
-											className:
-												nextValue !== ''
-													? nextValue
-													: undefined,
-										} );
-									} }
-									help={ __(
-										'Separate multiple classes with spaces.'
-									) }
-								/>
-							</InspectorControls>
-						) }
-					</>
-				);
-			}
 
-			return <BlockEdit { ...props } />;
+			return (
+				<>
+					{ hasCustomClassName && props.isSelected && (
+						<CustomClassNameControls
+							attributes={ props.attributes }
+							setAttributes={ props.setAttributes }
+						/>
+					) }
+					<BlockEdit { ...props } />
+				</>
+			);
 		};
 	},
 	'withInspectorControl'

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -83,13 +83,13 @@ export const withInspectorControl = createHigherOrderComponent(
 
 			return (
 				<>
+					<BlockEdit { ...props } />
 					{ hasCustomClassName && props.isSelected && (
 						<CustomClassNameControls
 							attributes={ props.attributes }
 							setAttributes={ props.setAttributes }
 						/>
 					) }
-					<BlockEdit { ...props } />
 				</>
 			);
 		};


### PR DESCRIPTION
## What?
A micro-optimization for `customClassName` controls to avoid calling `useBlockEditingMode` for every block rendered in the editor.

## Why?
This check is only needed when the control is rendered for the selected block.

## How?
Move controls and hook into a new component, which only renders when the feature is supported and block selected.

## Testing Instructions
1. Open a post or page.
2. Insert a paragraph block.
3. Confirm that changing `Additional CSS class(es)` works as before. 

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-10-13 at 16 54 22](https://github.com/WordPress/gutenberg/assets/240569/de6286a8-5e15-41a3-8253-0047315e6481)
