### PR TITLE
Add align support to the image block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -378,7 +378,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 
 -	**Name:** core/image
 -	**Category:** media
--	**Supports:** anchor, color (~~background~~, ~~text~~), filter (duotone)
+-	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone)
 -	**Attributes:** align, alt, aspectRatio, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -138,12 +138,15 @@ function BlockEditAlignmentToolbarControls( {
 				nextAlign = '';
 			}
 		}
-
+		/**
+		 * This filter exists so that the image block can reset
+		 * its aspect ratio and custom size when the alignment is set
+		 * to either wide or full.
+		 */
 		const filteredAttributes = applyFilters(
-			'editor.hooks.updateAlignment',
-			nextAlign,
+			'block-library.image.alignmentUpdate',
 			blockName,
-			attributes
+			{ ...attributes, align: nextAlign }
 		);
 
 		setAttributes( filteredAttributes );

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { addFilter } from '@wordpress/hooks';
+import { addFilter, applyFilters } from '@wordpress/hooks';
 import {
 	getBlockSupport,
 	getBlockType,
@@ -138,7 +138,15 @@ function BlockEditAlignmentToolbarControls( {
 				nextAlign = '';
 			}
 		}
-		setAttributes( { align: nextAlign } );
+
+		const filteredAttributes = applyFilters(
+			'editor.hooks.updateAlignment',
+			nextAlign,
+			blockName,
+			attributes
+		);
+
+		setAttributes( filteredAttributes );
 	};
 
 	return (

--- a/packages/block-library/src/embed/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.native.js.snap
@@ -1,40 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Embed block alignment options sets Align center option 1`] = `
-"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"center"} -->
-<figure class="wp-block-embed aligncenter is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block alignment options sets Align left option 1`] = `
-"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"left"} -->
-<figure class="wp-block-embed alignleft is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block alignment options sets Align right option 1`] = `
-"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"right"} -->
-<figure class="wp-block-embed alignright is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block alignment options sets Full width option 1`] = `
-"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"full"} -->
-<figure class="wp-block-embed alignfull is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"
 `;
 
 exports[`Embed block alignment options sets Wide width option 1`] = `
-"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true,"align":"wide"} -->
-<figure class="wp-block-embed alignwide is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
+"<!-- wp:embed {"url":"https://twitter.com/notnownikki","type":"rich","providerNameSlug":"twitter","responsive":true} -->
+<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper">
 https://twitter.com/notnownikki
 </div></figure>
 <!-- /wp:embed -->"

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -10,7 +10,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"align": {
-			"type": "string"
+			"type": "string",
+			"default": ""
 		},
 		"url": {
 			"type": "string",
@@ -95,6 +96,7 @@
 		}
 	},
 	"supports": {
+		"align": [ "left", "center", "right", "wide", "full" ],
 		"anchor": true,
 		"color": {
 			"text": false,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -104,7 +104,6 @@ export function ImageEdit( {
 		url = '',
 		alt,
 		caption,
-		align,
 		id,
 		width,
 		height,
@@ -277,20 +276,6 @@ export function ImageEdit( {
 			} );
 		}
 	}, [] );
-
-	useEffect( () => {
-		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( align )
-			? {
-					width: undefined,
-					height: undefined,
-					aspectRatio: undefined,
-					scale: undefined,
-			  }
-			: {};
-		setAttributes( {
-			...extraUpdatedAttributes,
-		} );
-	}, [ align, setAttributes ] );
 
 	// If an image is temporary, revoke the Blob url when it is uploaded (and is
 	// no longer temporary).

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -104,6 +104,7 @@ export function ImageEdit( {
 		url = '',
 		alt,
 		caption,
+		align,
 		id,
 		width,
 		height,
@@ -276,6 +277,20 @@ export function ImageEdit( {
 			} );
 		}
 	}, [] );
+
+	useEffect( () => {
+		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( align )
+			? {
+					width: undefined,
+					height: undefined,
+					aspectRatio: undefined,
+					scale: undefined,
+			  }
+			: {};
+		setAttributes( {
+			...extraUpdatedAttributes,
+		} );
+	}, [ align, setAttributes ] );
 
 	// If an image is temporary, revoke the Blob url when it is uploaded (and is
 	// no longer temporary).

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -10,8 +10,6 @@ import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { Placeholder } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
-	BlockAlignmentControl,
-	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
 	useBlockProps,
@@ -106,7 +104,6 @@ export function ImageEdit( {
 		url = '',
 		alt,
 		caption,
-		align,
 		id,
 		width,
 		height,
@@ -255,16 +252,6 @@ export function ImageEdit( {
 		}
 	}
 
-	function updateAlignment( nextAlign ) {
-		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( nextAlign )
-			? { width: undefined, height: undefined }
-			: {};
-		setAttributes( {
-			...extraUpdatedAttributes,
-			align: nextAlign,
-		} );
-	}
-
 	let isTemp = isTemporaryImage( id, url );
 
 	// Upload a temporary image on mount.
@@ -375,14 +362,6 @@ export function ImageEdit( {
 				clientId={ clientId }
 				blockEditingMode={ blockEditingMode }
 			/>
-			{ ! url && blockEditingMode === 'default' && (
-				<BlockControls group="block">
-					<BlockAlignmentControl
-						value={ align }
-						onChange={ updateAlignment }
-					/>
-				</BlockControls>
-			) }
 			<MediaPlaceholder
 				icon={ <BlockIcon icon={ icon } /> }
 				onSelect={ onSelectImage }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -44,7 +44,6 @@ import {
 	MEDIA_TYPE_IMAGE,
 	BlockControls,
 	InspectorControls,
-	BlockAlignmentToolbar,
 	BlockStyles,
 	store as blockEditorStore,
 	blockSettingsScreens,
@@ -212,7 +211,6 @@ export class ImageEdit extends Component {
 		this.onSetFeatured = this.onSetFeatured.bind( this );
 		this.onFocusCaption = this.onFocusCaption.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
-		this.updateAlignment = this.updateAlignment.bind( this );
 		this.accessibilityLabelCreator =
 			this.accessibilityLabelCreator.bind( this );
 		this.setMappedAttributes = this.setMappedAttributes.bind( this );
@@ -388,18 +386,6 @@ export class ImageEdit extends Component {
 			url,
 			width: undefined,
 			height: undefined,
-		} );
-	}
-
-	updateAlignment( nextAlign ) {
-		const extraUpdatedAttributes = Object.values(
-			WIDE_ALIGNMENTS.alignments
-		).includes( nextAlign )
-			? { width: undefined, height: undefined }
-			: {};
-		this.props.setAttributes( {
-			...extraUpdatedAttributes,
-			align: nextAlign,
 		} );
 	}
 
@@ -711,10 +697,6 @@ export class ImageEdit extends Component {
 						onClick={ open }
 					/>
 				</ToolbarGroup>
-				<BlockAlignmentToolbar
-					value={ align }
-					onChange={ this.updateAlignment }
-				/>
 			</BlockControls>
 		);
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -25,7 +25,6 @@ import {
 	MediaReplaceFlow,
 	store as blockEditorStore,
 	useSettings,
-	BlockAlignmentControl,
 	__experimentalImageEditor as ImageEditor,
 	__experimentalGetElementClassName,
 	__experimentalUseBorderProps as useBorderProps,
@@ -333,21 +332,6 @@ export default function Image( {
 		} );
 	}
 
-	function updateAlignment( nextAlign ) {
-		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( nextAlign )
-			? {
-					width: undefined,
-					height: undefined,
-					aspectRatio: undefined,
-					scale: undefined,
-			  }
-			: {};
-		setAttributes( {
-			...extraUpdatedAttributes,
-			align: nextAlign,
-		} );
-	}
-
 	useEffect( () => {
 		if ( ! isSelected ) {
 			setIsEditingImage( false );
@@ -435,12 +419,6 @@ export default function Image( {
 	const controls = (
 		<>
 			<BlockControls group="block">
-				{ hasNonContentControls && (
-					<BlockAlignmentControl
-						value={ align }
-						onChange={ updateAlignment }
-					/>
-				) }
 				{ hasNonContentControls && (
 					<ToolbarButton
 						onClick={ () => {

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -59,19 +59,25 @@ export const settings = {
 
 export const init = () => {
 	addFilter(
-		'editor.hooks.updateAlignment',
-		'core/image/update-alignment',
-		( nextAlign, blockName ) =>
-			blockName === 'core/image' &&
-			[ 'wide', 'full' ].includes( nextAlign )
-				? {
+		'block-library.image.alignmentUpdate',
+		'core/block-library/filters',
+		( blockName, updatedAttributes ) => {
+			if ( blockName !== 'core/image' ) {
+				return updatedAttributes;
+			}
+			if ( [ 'wide', 'full' ].includes( updatedAttributes.align ) ) {
+				return {
+					...updatedAttributes,
+					...{
 						width: undefined,
 						height: undefined,
 						aspectRatio: undefined,
 						scale: undefined,
-						align: nextAlign,
-				  }
-				: { align: nextAlign }
+					},
+				};
+			}
+			return updatedAttributes;
+		}
 	);
 	initBlock( { name, metadata, settings } );
 };

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -13,6 +13,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import { addFilter } from '@wordpress/hooks';
 
 const { name } = metadata;
 
@@ -56,4 +57,21 @@ export const settings = {
 	deprecated,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () => {
+	addFilter(
+		'editor.hooks.updateAlignment',
+		'core/image/update-alignment',
+		( nextAlign, blockName ) =>
+			blockName === 'core/image' &&
+			[ 'wide', 'full' ].includes( nextAlign )
+				? {
+						width: undefined,
+						height: undefined,
+						aspectRatio: undefined,
+						scale: undefined,
+						align: nextAlign,
+				  }
+				: { align: nextAlign }
+	);
+	initBlock( { name, metadata, settings } );
+};

--- a/packages/block-library/src/image/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/image/test/__snapshots__/transforms.native.js.snap
@@ -11,7 +11,7 @@ exports[`Image block transformations to Columns block 1`] = `
 `;
 
 exports[`Image block transformations to Cover block 1`] = `
-"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":1,"dimRatio":50,"style":{"color":{}}} -->
+"<!-- wp:cover {"url":"https://cldup.com/cXyG__fTLN.jpg","id":1,"dimRatio":50,"align":"","style":{"color":{}}} -->
 <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span><img class="wp-block-cover__image-background wp-image-1" alt="" src="https://cldup.com/cXyG__fTLN.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size">Mountain</p>
 <!-- /wp:paragraph --></div></div>
@@ -25,7 +25,7 @@ exports[`Image block transformations to File block 1`] = `
 `;
 
 exports[`Image block transformations to Gallery block 1`] = `
-"<!-- wp:gallery {"linkTo":"none"} -->
+"<!-- wp:gallery {"linkTo":"none","align":""} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->
 <figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
 <!-- /wp:image --></figure>

--- a/test/integration/fixtures/blocks/core__gallery-with-caption.json
+++ b/test/integration/fixtures/blocks/core__gallery-with-caption.json
@@ -19,6 +19,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190",
 					"alt": "Image gallery image",
 					"caption": "",
@@ -32,6 +33,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580",
 					"alt": "Image gallery image",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__gallery.json
+++ b/test/integration/fixtures/blocks/core__gallery.json
@@ -19,6 +19,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190",
 					"alt": "Image gallery image",
 					"caption": "",
@@ -32,6 +33,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580",
 					"alt": "Image gallery image",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__gallery__columns.json
+++ b/test/integration/fixtures/blocks/core__gallery__columns.json
@@ -19,6 +19,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190",
 					"alt": "Image gallery image",
 					"caption": "",
@@ -32,6 +33,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580",
 					"alt": "Image gallery image",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-1.json
@@ -14,6 +14,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 					"alt": "title",
 					"linkDestination": "none"
@@ -24,6 +25,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
 					"alt": "title",
 					"linkDestination": "none"

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-2.json
@@ -14,6 +14,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 					"alt": "title",
 					"caption": "",
@@ -26,6 +27,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
 					"alt": "title",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-3.json
@@ -13,6 +13,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 					"alt": "title",
 					"caption": "",
@@ -24,6 +25,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
 					"alt": "title",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-4.json
@@ -14,6 +14,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190",
 					"alt": "",
 					"caption": "",
@@ -26,6 +27,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580",
 					"alt": "",
 					"caption": "",
@@ -38,6 +40,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "https://sergioestevaofolio.files.wordpress.com/2017/05/cropped-l1005945-2-2.jpg?w=580",
 					"alt": "",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-5.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-5.json
@@ -14,6 +14,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg",
 					"alt": "",
 					"caption": "",
@@ -28,6 +29,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg",
 					"alt": "",
 					"caption": "",
@@ -42,6 +44,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg",
 					"alt": "",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-6.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-6.json
@@ -14,6 +14,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg",
 					"alt": "",
 					"caption": "",
@@ -28,6 +29,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg",
 					"alt": "",
 					"caption": "",
@@ -42,6 +44,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg",
 					"alt": "",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-7.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-7.json
@@ -18,6 +18,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg",
 					"alt": "",
 					"caption": "",
@@ -32,6 +33,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg",
 					"alt": "",
 					"caption": "",
@@ -46,6 +48,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg",
 					"alt": "",
 					"caption": "",
@@ -77,6 +80,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg",
 					"alt": "",
 					"caption": "",
@@ -91,6 +95,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg",
 					"alt": "",
 					"caption": "",
@@ -105,6 +110,7 @@
 				"name": "core/image",
 				"isValid": true,
 				"attributes": {
+					"align": "",
 					"url": "http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg",
 					"alt": "",
 					"caption": "",

--- a/test/integration/fixtures/blocks/core__image.json
+++ b/test/integration/fixtures/blocks/core__image.json
@@ -3,6 +3,7 @@
 		"name": "core/image",
 		"isValid": true,
 		"attributes": {
+			"align": "",
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": ""

--- a/test/integration/fixtures/blocks/core__image__attachment-link.json
+++ b/test/integration/fixtures/blocks/core__image__attachment-link.json
@@ -3,6 +3,7 @@
 		"name": "core/image",
 		"isValid": true,
 		"attributes": {
+			"align": "",
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": "",

--- a/test/integration/fixtures/blocks/core__image__custom-link-class.json
+++ b/test/integration/fixtures/blocks/core__image__custom-link-class.json
@@ -3,6 +3,7 @@
 		"name": "core/image",
 		"isValid": true,
 		"attributes": {
+			"align": "",
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": "",

--- a/test/integration/fixtures/blocks/core__image__custom-link-rel.json
+++ b/test/integration/fixtures/blocks/core__image__custom-link-rel.json
@@ -3,6 +3,7 @@
 		"name": "core/image",
 		"isValid": true,
 		"attributes": {
+			"align": "",
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": "",

--- a/test/integration/fixtures/blocks/core__image__custom-link.json
+++ b/test/integration/fixtures/blocks/core__image__custom-link.json
@@ -3,6 +3,7 @@
 		"name": "core/image",
 		"isValid": true,
 		"attributes": {
+			"align": "",
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": "",

--- a/test/integration/fixtures/blocks/core__image__media-link.json
+++ b/test/integration/fixtures/blocks/core__image__media-link.json
@@ -3,6 +3,7 @@
 		"name": "core/image",
 		"isValid": true,
 		"attributes": {
+			"align": "",
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": "",


### PR DESCRIPTION
Closes #19103

This PR removes the custom align control from the image block and makes the block support align controls. 

From the tests we run the only issue is the expected snapshot problem, nothing else.

## Approach

This PR proposes a new filter on the align support behavior. This approach would allow other blocks that support align to filter the behavior when it sets "wide" or "full", which are opinionated values that may lead to specific collateral uodates - like it is the case with the image block.

The downsides of this filter are:

- it may have a slight performance cost
- it creates new public API for a very specific feature
- almost the same thing could be achieved with the existing filters on attributes or even block edit

In #55346 a simpler alternative approach is explored where we limit the resetting to the image block and make sure there is only one undo step which undoes both the align setting and the other attributes resetting via `__unstableMarkNextChangeAsNotPersistent`.
