### PR TITLE
Remove top spacing on 782px wide screen

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -24,7 +24,7 @@ html.interface-interface-skeleton__html-container {
 	bottom: 0;
 
 	// Adjust to admin-bar going small.
-	@media (min-width: #{ ($break-medium + 1) }) {
+	@media (min-width: #{ ($break-medium) }) {
 		top: $admin-bar-height;
 
 		.is-fullscreen-mode & {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes the top spacing that occurs on a 782px wide screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
https://github.com/WordPress/gutenberg/issues/55349 There was CSS media query in use to avoid the top spacing but it was not covering the case when screen is exactly equal to 782px wide. This PR will solve this issue. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR simply updates the CSS media query to consider the 782px wide screen also, previously it was considering 783px wide and more.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the Post Edit screen
2. Switch to responsive mode from the inspector panel and set width to 782px

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/40795917/4237d139-701c-418a-89f1-e3bf7af458af

