### PR TITLE
DataViews: Add Grid Layout

### DIFF
--- a/packages/edit-site/src/components/dataviews/field-actions.js
+++ b/packages/edit-site/src/components/dataviews/field-actions.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
+
+function FieldActions( { item, actions } ) {
+	return (
+		<DropdownMenu icon={ moreVertical } label={ __( 'Actions' ) }>
+			{ () => (
+				<MenuGroup>
+					{ actions.map( ( action ) => (
+						<MenuItem
+							key={ action.id }
+							onClick={ () => action.perform( item ) }
+							isDestructive={ action.isDesctructive }
+						>
+							{ action.label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+}
+
+export default FieldActions;

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -34,3 +34,14 @@
 	color: $gray-700;
 	text-wrap: nowrap;
 }
+
+.dataviews-view-grid__media {
+	width: 100%;
+	height: 200px;
+
+	> * {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+}

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -37,11 +37,10 @@
 
 .dataviews-view-grid__media {
 	width: 100%;
-	height: 200px;
+	min-height: 200px;
 
 	> * {
-		width: 100%;
-		height: 100%;
+		max-width: 100%;
 		object-fit: cover;
 	}
 }

--- a/packages/edit-site/src/components/dataviews/text-filter.js
+++ b/packages/edit-site/src/components/dataviews/text-filter.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { SearchControl } from '@wordpress/components';
 
 /**
@@ -14,12 +14,16 @@ export default function TextFilter( { view, onChangeView } ) {
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput(
 		view.search
 	);
+	const onChangeViewRef = useRef( onChangeView );
 	useEffect( () => {
-		onChangeView( ( currentView ) => ( {
+		onChangeViewRef.current = onChangeView;
+	}, [ onChangeView ] );
+	useEffect( () => {
+		onChangeViewRef.current( ( currentView ) => ( {
 			...currentView,
 			search: debouncedSearch,
 		} ) );
-	}, [ debouncedSearch, onChangeView ] );
+	}, [ debouncedSearch ] );
 	const searchLabel = __( 'Filter list' );
 	return (
 		<SearchControl

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -1,3 +1,71 @@
-export function ViewGrid() {
-	return 'Grid';
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalGrid as Grid,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+	CardMedia,
+	FlexBlock,
+	Placeholder,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import FieldActions from './field-actions';
+
+export function ViewGrid( { data, fields, view, actions } ) {
+	const mediaField = fields.find(
+		( field ) => field.id === view.layoutConfig.mediaField
+	);
+	const visibleFields = fields.filter(
+		( field ) =>
+			! view.hiddenFields.includes( field.id ) &&
+			field.id !== view.layoutConfig.mediaField
+	);
+	return (
+		<Grid gap={ 6 } columns={ 2 }>
+			{ data.map( ( item, index ) => {
+				return (
+					<Card key={ index }>
+						<CardMedia>
+							{ ( mediaField &&
+								mediaField.render( { item } ) ) || (
+								<Placeholder
+									withIllustration
+									style={ {
+										width: '100%',
+										minHeight: '200px',
+									} }
+								/>
+							) }
+						</CardMedia>
+
+						<CardBody>
+							<HStack justify="space-between" alignment="top">
+								<FlexBlock>
+									<VStack>
+										{ visibleFields.map( ( field ) => (
+											<div key={ field.id }>
+												{ field.render
+													? field.render( { item } )
+													: field.accessorFn( item ) }
+											</div>
+										) ) }
+									</VStack>
+								</FlexBlock>
+								<FieldActions
+									item={ item }
+									actions={ actions }
+								/>
+							</HStack>
+						</CardBody>
+					</Card>
+				);
+			} ) }
+		</Grid>
+	);
 }

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -16,12 +16,12 @@ import FieldActions from './field-actions';
 
 export function ViewGrid( { data, fields, view, actions } ) {
 	const mediaField = fields.find(
-		( field ) => field.id === view.layoutConfig.mediaField
+		( field ) => field.id === view.layout.mediaField
 	);
 	const visibleFields = fields.filter(
 		( field ) =>
 			! view.hiddenFields.includes( field.id ) &&
-			field.id !== view.layoutConfig.mediaField
+			field.id !== view.layout.mediaField
 	);
 	return (
 		<Grid gap={ 6 } columns={ 2 }>

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -30,7 +30,7 @@ export function ViewGrid( { data, fields, view, actions } ) {
 					<VStack key={ index }>
 						<div className="dataviews-view-grid__media">
 							{ ( mediaField &&
-								mediaField.render( { item } ) ) || (
+								mediaField.render( { item, view } ) ) || (
 								<Placeholder
 									withIllustration
 									style={ {
@@ -47,7 +47,7 @@ export function ViewGrid( { data, fields, view, actions } ) {
 									{ visibleFields.map( ( field ) => (
 										<div key={ field.id }>
 											{ field.render
-												? field.render( { item } )
+												? field.render( { item, view } )
 												: field.accessorFn( item ) }
 										</div>
 									) ) }

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -5,9 +5,6 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	Card,
-	CardBody,
-	CardMedia,
 	FlexBlock,
 	Placeholder,
 } from '@wordpress/components';
@@ -30,8 +27,8 @@ export function ViewGrid( { data, fields, view, actions } ) {
 		<Grid gap={ 6 } columns={ 2 }>
 			{ data.map( ( item, index ) => {
 				return (
-					<Card key={ index }>
-						<CardMedia>
+					<VStack key={ index }>
+						<div className="dataviews-view-grid__media">
 							{ ( mediaField &&
 								mediaField.render( { item } ) ) || (
 								<Placeholder
@@ -42,28 +39,23 @@ export function ViewGrid( { data, fields, view, actions } ) {
 									} }
 								/>
 							) }
-						</CardMedia>
+						</div>
 
-						<CardBody>
-							<HStack justify="space-between" alignment="top">
-								<FlexBlock>
-									<VStack>
-										{ visibleFields.map( ( field ) => (
-											<div key={ field.id }>
-												{ field.render
-													? field.render( { item } )
-													: field.accessorFn( item ) }
-											</div>
-										) ) }
-									</VStack>
-								</FlexBlock>
-								<FieldActions
-									item={ item }
-									actions={ actions }
-								/>
-							</HStack>
-						</CardBody>
-					</Card>
+						<HStack justify="space-between" alignment="top">
+							<FlexBlock>
+								<VStack>
+									{ visibleFields.map( ( field ) => (
+										<div key={ field.id }>
+											{ field.render
+												? field.render( { item } )
+												: field.accessorFn( item ) }
+										</div>
+									) ) }
+								</VStack>
+							</FlexBlock>
+							<FieldActions item={ item } actions={ actions } />
+						</HStack>
+					</VStack>
 				);
 			} ) }
 		</Grid>

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -24,7 +24,7 @@ export function ViewGrid( { data, fields, view, actions } ) {
 			field.id !== view.layout.mediaField
 	);
 	return (
-		<Grid gap={ 6 } columns={ 2 }>
+		<Grid gap={ 8 } columns={ 2 } alignment="top">
 			{ data.map( ( item, index ) => {
 				return (
 					<VStack key={ index }>

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -21,16 +21,12 @@ import {
 	check,
 	arrowUp,
 	arrowDown,
-	moreVertical,
 } from '@wordpress/icons';
 import {
 	Button,
 	Icon,
 	privateApis as componentsPrivateApis,
 	VisuallyHidden,
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
 } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 
@@ -38,6 +34,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import FieldActions from './field-actions';
 
 const {
 	DropdownMenuV2,
@@ -135,38 +132,24 @@ function ViewList( {
 	paginationInfo,
 } ) {
 	const columns = useMemo( () => {
-		const _columns = [ ...fields ];
+		const _columns = [
+			...fields.map( ( field ) => {
+				const column = { ...field };
+				delete column.render;
+				column.cell = ( props ) => {
+					return field.render
+						? field.render( { item: props.row.original } )
+						: field.accessorFn( props.row.original );
+				};
+				return column;
+			} ),
+		];
 		if ( actions?.length ) {
 			_columns.push( {
 				header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,
 				id: 'actions',
 				cell: ( props ) => {
-					return (
-						<DropdownMenu
-							icon={ moreVertical }
-							label={ __( 'Actions' ) }
-						>
-							{ () => (
-								<MenuGroup>
-									{ actions.map( ( action ) => (
-										<MenuItem
-											key={ action.id }
-											onClick={ () =>
-												action.perform(
-													props.row.original
-												)
-											}
-											isDestructive={
-												action.isDesctructive
-											}
-										>
-											{ action.label }
-										</MenuItem>
-									) ) }
-								</MenuGroup>
-							) }
-						</DropdownMenu>
-					);
+					return <FieldActions item={ props.row.original } />;
 				},
 				enableHiding: false,
 			} );

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -138,7 +138,7 @@ function ViewList( {
 				delete column.render;
 				column.cell = ( props ) => {
 					return field.render
-						? field.render( { item: props.row.original } )
+						? field.render( { item: props.row.original, view } )
 						: field.accessorFn( props.row.original );
 				};
 				return column;

--- a/packages/edit-site/src/components/media/index.js
+++ b/packages/edit-site/src/components/media/index.js
@@ -3,14 +3,12 @@
  */
 import { useEntityRecord } from '@wordpress/core-data';
 
-function Media( { id, size, ...props } ) {
+function Media( { id, size = [ 'large', 'medium', 'thumbnail' ], ...props } ) {
 	const { record: media } = useEntityRecord( 'root', 'media', id );
-	const sizesPerPriority = [ 'large', 'thumbnail' ];
-	const currentSize =
-		size ??
-		sizesPerPriority.find( ( s ) => !! media?.media_details?.sizes[ s ] );
+	const currentSize = size.find(
+		( s ) => !! media?.media_details?.sizes[ s ]
+	);
 	const mediaDetails = media?.media_details?.sizes[ currentSize ];
-
 	if ( ! mediaDetails ) {
 		return null;
 	}

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -89,12 +89,16 @@ export default function PagePages() {
 				id: 'featured-image',
 				header: __( 'Featured Image' ),
 				accessorFn: ( page ) => page.featured_media,
-				render: ( { item } ) =>
+				render: ( { item, view: currentView } ) =>
 					!! item.featured_media ? (
 						<Media
 							className="edit-site-page-pages__featured-image"
 							id={ item.featured_media }
-							size="thumbnail"
+							size={
+								currentView.type === 'list'
+									? [ 'thumbnail', 'medium', 'large', 'full' ]
+									: [ 'large', 'medium', 'full', 'thumbnail' ]
+							}
 						/>
 					) : null,
 				enableSorting: false,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -97,7 +97,7 @@ export default function PagePages() {
 							size={
 								currentView.type === 'list'
 									? [ 'thumbnail', 'medium', 'large', 'full' ]
-									: [ 'large', 'medium', 'full', 'thumbnail' ]
+									: [ 'large', 'full', 'medium', 'thumbnail' ]
 							}
 						/>
 					) : null,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -42,6 +42,7 @@ export default function PagePages() {
 		// All fields are visible by default, so it's
 		// better to keep track of the hidden ones.
 		hiddenFields: [ 'date', 'featured-image' ],
+		layout: {},
 	} );
 	// Request post statuses to get the proper labels.
 	const { records: statuses } = useEntityRecords( 'root', 'status' );
@@ -172,7 +173,7 @@ export default function PagePages() {
 			if ( updatedView.type !== view.type ) {
 				updatedView = {
 					...updatedView,
-					layoutConfig: {
+					layout: {
 						...defaultConfigPerViewType[ updatedView.type ],
 					},
 				};

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -1,4 +1,3 @@
 .edit-site-page-pages__featured-image {
 	border-radius: $radius-block-ui;
-	max-height: 60px;
 }


### PR DESCRIPTION
Related #55083 

## What?

This PR implements the initial render for the "grid view" in the DataViews component. Details in inline comments.

## Testing Instructions

1- Open the page list pages in the site editor
2- Switch the layout type to "grid"
3- Try things like "field visibility", "sort", "pagination", "search" all of these should work as expected in both views.

**Very early screenshot**

This is a bit early obviously, but it's worth discussing the several inline comments I've added to the PR. It's a future defining PR in some aspects.

<img width="1085" alt="Screenshot 2023-10-13 at 3 50 48 PM" src="https://github.com/WordPress/gutenberg/assets/272444/d9edc3fb-a7c3-4896-95e3-9964483a6aad">
