### PR TITLE
Don't change error handling in WP_Theme_JSON_Gutenberg::set_spacing_sizes()

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3389,7 +3389,7 @@ class WP_Theme_JSON_Gutenberg {
 			|| ! is_numeric( $spacing_scale['mediumStep'] )
 			|| ( '+' !== $spacing_scale['operator'] && '*' !== $spacing_scale['operator'] ) ) {
 			if ( ! empty( $spacing_scale ) ) {
-				_doing_it_wrong( __METHOD__, __( 'Some of the theme.json settings.spacing.spacingScale values are invalid', 'gutenberg' ), '6.1.0' );
+				trigger_error( __( 'Some of the theme.json settings.spacing.spacingScale values are invalid', 'gutenberg' ), E_USER_NOTICE );
 			}
 			return null;
 		}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1282,7 +1282,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * @dataProvider data_set_spacing_sizes_when_invalid
 	 */
 	public function test_set_spacing_sizes_when_invalid( $spacing_scale, $expected_output ) {
-		$this->setExpectedIncorrectUsage( 'WP_Theme_JSON_Gutenberg::set_spacing_sizes' );
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Some of the theme.json settings.spacing.spacingScale values are invalid' );
 
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
@@ -1293,6 +1294,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			)
+		);
+
+		set_error_handler(
+			static function ( $errno, $errstr ) {
+				restore_error_handler();
+				throw new Exception( $errstr, $errno );
+			},
+			E_ALL
 		);
 
 		$theme_json->set_spacing_sizes();

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1296,6 +1296,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
+		// Ensure PHPUnit 10 compatibility.
 		set_error_handler(
 			static function ( $errno, $errstr ) {
 				restore_error_handler();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
https://github.com/WordPress/gutenberg/pull/55313 changed error handling in `WP_Theme_JSON_Gutenberg::set_spacing_sizes()`. Since changes from `WP_Theme_JSON_Gutenberg` will eventually be merged into Core, it's important to maintain parity between both codebases.

## Why?
`_doing_it_wrong()` is not a direct replacement for `trigger_error()`, since `_doing_it_wrong()` only triggers a PHP error if `WP_DEBUG` is enabled.

## How?
This PR reverts the changes introduced in https://github.com/WordPress/gutenberg/pull/55313 while maintaining PHPUnit 10 compatibility. 

## Testing Instructions
1. Make sure that the `WP_Theme_JSON_Gutenberg_Test` tests pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes using only the keyboard? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->