### PR TITLE
Fix: Wrong condition on cover block dimRatioToClass.

### DIFF
--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -29,7 +29,7 @@ export function mediaPosition( { x, y } = DEFAULT_FOCAL_POINT ) {
 }
 
 export function dimRatioToClass( ratio ) {
-	return ratio === 50 || ! ratio === undefined
+	return ratio === 50 || ratio === undefined
 		? null
 		: 'has-background-dim-' + 10 * Math.round( ratio / 10 );
 }


### PR DESCRIPTION
Watching the code it is obvious that the condition `! ratio === undefined` does not make sense. The condition should be `ratio === undefined`. This PR fixes the issue.