### PR TITLE
Fix duotone not showing in site editor style block level styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -54,9 +54,8 @@ function useMultiOriginColorPresets(
 }
 
 export function useHasFiltersPanel( settings ) {
-	const hasDuotone = useHasDuotoneControl( settings );
-
-	return hasDuotone;
+	// TODO: Add customDuotone when we have a control for custom duotone filters.
+	return settings.color.defaultDuotone;
 }
 
 function useHasDuotoneControl( settings ) {

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -54,8 +54,7 @@ function useMultiOriginColorPresets(
 }
 
 export function useHasFiltersPanel( settings ) {
-	// TODO: Add customDuotone when we have a control for custom duotone filters.
-	return settings.color.defaultDuotone;
+	return useHasDuotoneControl( settings );
 }
 
 function useHasDuotoneControl( settings ) {

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -58,11 +58,7 @@ export function useHasFiltersPanel( settings ) {
 }
 
 function useHasDuotoneControl( settings ) {
-	return (
-		settings.color.customDuotone ||
-		settings.color.defaultDuotone ||
-		settings.color.duotone.length > 0
-	);
+	return settings.color.defaultDuotone || settings.color.duotone.length > 0;
 }
 
 function FiltersToolsPanel( {

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -58,7 +58,11 @@ export function useHasFiltersPanel( settings ) {
 }
 
 function useHasDuotoneControl( settings ) {
-	return settings.color.customDuotone || settings.color.defaultDuotone;
+	return (
+		settings.color.customDuotone ||
+		settings.color.defaultDuotone ||
+		settings.color.duotone.length > 0
+	);
 }
 
 function FiltersToolsPanel( {

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -150,11 +150,6 @@ export default function FiltersPanel( {
 	const hasDuotone = () => !! value?.filter?.duotone;
 	const resetDuotone = () => setDuotone( undefined );
 
-	const disableCustomColors = ! settings?.color?.custom;
-	const disableCustomDuotone =
-		! settings?.color?.customDuotone ||
-		( colorPalette?.length === 0 && disableCustomColors );
-
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {
 			...previousValue,
@@ -212,12 +207,9 @@ export default function FiltersPanel( {
 									<DuotonePicker
 										colorPalette={ colorPalette }
 										duotonePalette={ duotonePalette }
-										disableCustomColors={
-											disableCustomColors
-										}
-										disableCustomDuotone={
-											disableCustomDuotone
-										}
+										// TODO: Re-enable both when custom colors are supported for block-level styles.
+										disableCustomColors
+										disableCustomDuotone
 										value={ duotone }
 										onChange={ setDuotone }
 									/>

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -58,7 +58,11 @@ export function useHasFiltersPanel( settings ) {
 }
 
 function useHasDuotoneControl( settings ) {
-	return settings.color.defaultDuotone || settings.color.duotone.length > 0;
+	return (
+		settings.color.customDuotone ||
+		settings.color.defaultDuotone ||
+		settings.color.duotone.length > 0
+	);
 }
 
 function FiltersToolsPanel( {

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -150,6 +150,11 @@ export default function FiltersPanel( {
 	const hasDuotone = () => !! value?.filter?.duotone;
 	const resetDuotone = () => setDuotone( undefined );
 
+	const disableCustomColors = ! settings?.color?.custom;
+	const disableCustomDuotone =
+		! settings?.color?.customDuotone ||
+		( colorPalette?.length === 0 && disableCustomColors );
+
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {
 			...previousValue,
@@ -207,9 +212,12 @@ export default function FiltersPanel( {
 									<DuotonePicker
 										colorPalette={ colorPalette }
 										duotonePalette={ duotonePalette }
-										// TODO: Re-enable both when custom colors are supported for block-level styles.
-										disableCustomColors
-										disableCustomDuotone
+										disableCustomColors={
+											disableCustomColors
+										}
+										disableCustomDuotone={
+											disableCustomDuotone
+										}
 										value={ duotone }
 										onChange={ setDuotone }
 									/>

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -283,13 +283,7 @@ function ScreenBlock( { name, variation } ) {
 					inheritedValue={ inheritedStyleWithLayout }
 					value={ styleWithLayout }
 					onChange={ setStyle }
-					settings={ {
-						...settings,
-						color: {
-							...settings.color,
-							customDuotone: false, //TO FIX: Custom duotone only works on the block level right now
-						},
-					} }
+					settings={ settings }
 					includeLayoutControls
 				/>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue where the block-level duotone controls weren't available in the site editor styles controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Have a theme with `settings.color.defaultDuotone` enabled and/or `settings.color.duotone` as a non-empty array.
2. Open the site editor styles controls > blocks > image (or any other block that supports duotone).
3. See that the duotone selector is available with the enabled UI controls from theme.json. The custom (gradient-style & shadows/highlights) picker should never be shown.
4. Blocks without duotone support or themes without any of the settings above should not show the filter panel at all. Themes with _only_ `settings.color.customDuotone` and neither of the other settings should not show the filters panel at all.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

Screenshots show TT4 with these relevant settings. `settings.color.customDuotone` is `true` by default; however the custom color picker controls aren't shown because custom colors aren't supported in this context yet (see #50332).

```
{
	settings: {
		color: {
			defaultDuotone: false,
			duotone: [...]
		}
	}
}
```


### Before

![image filter style controls before change](https://github.com/WordPress/gutenberg/assets/5129775/ff05de0f-bb3a-4801-ae09-2840f1ff27b2)

### After

![image filter style controls after change](https://github.com/WordPress/gutenberg/assets/5129775/7243fde2-6df5-46da-a90d-e423792d1e6d)
