### PR TITLE
HTML API: Guard against non-string attribute values.

### DIFF
--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -136,11 +136,11 @@ function gutenberg_interactivity_evaluate_reference( $path, array $context = arr
 	);
 
 	/*
-	 * Check first if the directive path is preceded by a negator operator (!),
+	 * Check first if the directive path is preceded by a negation operator (!),
 	 * indicating that the value obtained from the Interactivity Store (or the
 	 * passed context) using the subsequent path should be negated.
 	 */
-	$should_negate_value = '!' === $path[0];
+	$should_negate_value = strlen( $path ) > 0 && '!' === $path[0];
 
 	$path          = $should_negate_value ? substr( $path, 1 ) : $path;
 	$path_segments = explode( '.', $path );

--- a/lib/experimental/interactivity-api/directives/wp-bind.php
+++ b/lib/experimental/interactivity-api/directives/wp-bind.php
@@ -26,6 +26,7 @@ function gutenberg_interactivity_process_wp_bind( $tags, $context ) {
 		}
 
 		$expr  = $tags->get_attribute( $attr );
+		$expr  = is_string( $expr ) ? $expr : '';
 		$value = gutenberg_interactivity_evaluate_reference( $expr, $context->get_context() );
 		$tags->set_attribute( $bound_attr, $value );
 	}

--- a/lib/experimental/interactivity-api/directives/wp-class.php
+++ b/lib/experimental/interactivity-api/directives/wp-class.php
@@ -26,6 +26,7 @@ function gutenberg_interactivity_process_wp_class( $tags, $context ) {
 		}
 
 		$expr      = $tags->get_attribute( $attr );
+		$expr      = is_string( $expr ) ? $expr : '';
 		$add_class = gutenberg_interactivity_evaluate_reference( $expr, $context->get_context() );
 		if ( $add_class ) {
 			$tags->add_class( $class_name );

--- a/lib/experimental/interactivity-api/directives/wp-context.php
+++ b/lib/experimental/interactivity-api/directives/wp-context.php
@@ -18,7 +18,7 @@ function gutenberg_interactivity_process_wp_context( $tags, $context ) {
 	}
 
 	$value = $tags->get_attribute( 'data-wp-context' );
-	if ( null === $value ) {
+	if ( ! is_string( $value ) || empty( $value ) ) {
 		// No data-wp-context directive.
 		return;
 	}

--- a/lib/experimental/interactivity-api/directives/wp-style.php
+++ b/lib/experimental/interactivity-api/directives/wp-style.php
@@ -26,9 +26,11 @@ function gutenberg_interactivity_process_wp_style( $tags, $context ) {
 		}
 
 		$expr        = $tags->get_attribute( $attr );
+		$expr        = is_string( $expr ) ? $expr : '';
 		$style_value = gutenberg_interactivity_evaluate_reference( $expr, $context->get_context() );
 		if ( $style_value ) {
 			$style_attr = $tags->get_attribute( 'style' );
+			$style_attr = is_string( $style_value ) ? $style_attr : '';
 			$style_attr = gutenberg_interactivity_set_style( $style_attr, $style_name, $style_value );
 			$tags->set_attribute( 'style', $style_attr );
 		} else {

--- a/lib/experimental/interactivity-api/directives/wp-text.php
+++ b/lib/experimental/interactivity-api/directives/wp-text.php
@@ -18,7 +18,7 @@ function gutenberg_interactivity_process_wp_text( $tags, $context ) {
 	}
 
 	$value = $tags->get_attribute( 'data-wp-text' );
-	if ( null === $value ) {
+	if ( ! is_string( $value ) || empty( $value ) ) {
 		return;
 	}
 

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -54,6 +54,7 @@ function render_block_core_cover( $attributes, $content ) {
 		$processor->next_tag();
 
 		$styles         = $processor->get_attribute( 'style' );
+		$styles         = is_string( $styles ) ? $styles : '';
 		$merged_styles  = ! empty( $styles ) ? $styles . ';' : '';
 		$merged_styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
 


### PR DESCRIPTION
## What?

For existing uses of the HTML API, guards against treating possibly-non-string attribute values as strings. This existing use exposes a risk of crashing.

## Why?

Crashing is bad 😄 
Also this is part of ongoing efforts to establish proper example usage of the HTML API throughout all of Core.

## How?

Because there are three ways for an attribute in HTML to exist, the HTML API reports three kinds of values for `get_attribute()` calls:
 - `null` means that no attribute exists of the given name
 - `true` means that the attribute exists but there is no value, e.g. `<input checked>`.
 - a string value means that the attribute exists and has a value, e.g. `<img src="test">`.

When operating on the value returned by `get_attribute()` then it's important to ensure that it's a string value before treating it as one. A call to `empty()` is not enough because a boolean attribute, being `true`, does not return `false` for `empty()`.

In this patch, blocks that read and then use attribute values as strings have been updated in order to guard against cases where the attribute might not be the string the code expects.

## Testing Instructions

There should be no functional or visual changes in this patch except where previously a site may have encountered unexpected HTML attribute values.

E.g. For the cover block, this is how it renders with no `style` attribute on the tag.
<img width="553" alt="Screenshot 2023-10-14 at 6 52 30 PM" src="https://github.com/WordPress/gutenberg/assets/5431237/246096f1-1180-4135-afee-e2314701b5bf">

By manually adding `style` without a value, it's possible to trigger the bug.
<img width="620" alt="Screenshot 2023-10-14 at 6 52 43 PM" src="https://github.com/WordPress/gutenberg/assets/5431237/c34bdad2-c54e-4e18-933d-ef117b00afef">

This leads to an unwanted `style` attribute in the page render, because `true` was coerced to a string.
<img width="310" alt="Screenshot 2023-10-14 at 6 53 07 PM" src="https://github.com/WordPress/gutenberg/assets/5431237/e11f27df-def5-4364-b509-8be023a28f58">

With this patch applied these cases should all disappear.