### PR TITLE
Bug: PHP notice when an image with lightbox is deleted

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -167,15 +167,17 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 
 	// Note: We want to store the `src` in the context so we
 	// can set it dynamically when the lightbox is opened.
+	$img_width  = 'none';
+	$img_height = 'none';
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_uploaded_src = wp_get_attachment_url( $block['attrs']['id'] );
 		$img_metadata     = wp_get_attachment_metadata( $block['attrs']['id'] );
-		$img_width        = $img_metadata['width'];
-		$img_height       = $img_metadata['height'];
+		if ( ! empty( $img_metadata ) && is_array( $img_metadata ) ) {
+			$img_width  = $img_metadata['width'];
+			$img_height = $img_metadata['height'];
+		}
 	} else {
 		$img_uploaded_src = $processor->get_attribute( 'src' );
-		$img_width        = 'none';
-		$img_height       = 'none';
 	}
 
 	if ( isset( $block['attrs']['scale'] ) ) {

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -167,17 +167,15 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 
 	// Note: We want to store the `src` in the context so we
 	// can set it dynamically when the lightbox is opened.
-	$img_width  = 'none';
-	$img_height = 'none';
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_uploaded_src = wp_get_attachment_url( $block['attrs']['id'] );
 		$img_metadata     = wp_get_attachment_metadata( $block['attrs']['id'] );
-		if ( ! empty( $img_metadata ) && is_array( $img_metadata ) ) {
-			$img_width  = $img_metadata['width'];
-			$img_height = $img_metadata['height'];
-		}
+		$img_width        = $img_metadata['width'] ?? 'none';
+		$img_height       = $img_metadata['height'] ?? 'none';
 	} else {
 		$img_uploaded_src = $processor->get_attribute( 'src' );
+		$img_width        = 'none';
+		$img_height       = 'none';
 	}
 
 	if ( isset( $block['attrs']['scale'] ) ) {


### PR DESCRIPTION
`wp_get_attachment_metadata` return false if it has no metadata related to attachment, So, I added a condition to check before extrtacting the value from array. it help fixes: #55347 

## Testing Instructions
- Create a post or page.
- Add an image from the Media Library and set it to `Expand on Click`: `true`. 
- Publish and view the front end.
- Observe everything works as expected.
- Go to the Media Library.
- Delete the image that you previously added in the post.
- View the previous post in the front end, refresh the page if necessary.
- The image will be 'broken', and that is expected and PHP notice should not show.
