### PR TITLE
Patterns: fix capabilities settings for pattern categories

### DIFF
--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -30,6 +30,10 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_in_nav_menus'  => false,
 		'show_in_rest'       => true,
 		'show_admin_column'  => true,
+		'capabilities'          => array(
+			'edit_terms'   => 'publish_posts',
+			'assign_terms' => 'publish_posts',
+		),
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );
 }

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -16,20 +16,20 @@
  */
 function gutenberg_register_taxonomy_patterns() {
 	$args = array(
-		'public'             => true,
-		'publicly_queryable' => false,
-		'hierarchical'       => false,
-		'labels'             => array(
+		'public'                => true,
+		'publicly_queryable'    => false,
+		'hierarchical'          => false,
+		'labels'                => array(
 			'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
 			'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
 		),
-		'query_var'          => false,
-		'rewrite'            => false,
-		'show_ui'            => true,
-		'_builtin'           => true,
-		'show_in_nav_menus'  => false,
-		'show_in_rest'       => true,
-		'show_admin_column'  => true,
+		'query_var'             => false,
+		'rewrite'               => false,
+		'show_ui'               => true,
+		'_builtin'              => true,
+		'show_in_nav_menus'     => false,
+		'show_in_rest'          => true,
+		'show_admin_column'     => true,
 		'rest_controller_class' => 'Gutenberg_REST_Pattern_Categories_Controller',
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -30,6 +30,7 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_in_nav_menus'  => false,
 		'show_in_rest'       => true,
 		'show_admin_column'  => true,
+		'rest_controller_class' => 'Gutenberg_REST_Pattern_Categories_Controller',
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );
 }

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -32,7 +32,6 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_admin_column'  => true,
 		'capabilities'       => array(
 			'edit_terms'   => 'publish_posts',
-			'assign_terms' => 'publish_posts',
 		),
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -30,9 +30,6 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_in_nav_menus'  => false,
 		'show_in_rest'       => true,
 		'show_admin_column'  => true,
-		'capabilities'       => array(
-			'edit_terms'   => 'publish_posts',
-		),
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );
 }

--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -30,7 +30,7 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_in_nav_menus'  => false,
 		'show_in_rest'       => true,
 		'show_admin_column'  => true,
-		'capabilities'          => array(
+		'capabilities'       => array(
 			'edit_terms'   => 'publish_posts',
 			'assign_terms' => 'publish_posts',
 		),

--- a/lib/compat/wordpress-6.4/blocks.php
+++ b/lib/compat/wordpress-6.4/blocks.php
@@ -21,3 +21,27 @@ function gutenberg_add_custom_capabilities_to_wp_block( $args ) {
 	return $args;
 }
 add_filter( 'register_wp_block_post_type_args', 'gutenberg_add_custom_capabilities_to_wp_block', 10, 1 );
+
+/**
+ * Updates the wp_block REST enpoint in order to modify the wp_pattern_category action
+ * links that are returned because as although the taxonomy is flat Author level users
+ * are only allowed to assign categories.
+ *
+ * Note: This should be removed when the minimum required WP version is >= 6.4.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/55379
+ *
+ * @param array  $args Register post type args.
+ * @param string $post_type The post type string.
+ *
+ * @return array Register post type args.
+ */
+function gutenberg_update_patterns_block_rest_controller_class( $args, $post_type ) {
+	if ( 'wp_block' === $post_type ) {
+		$args['rest_controller_class'] = 'Gutenberg_REST_Blocks_Controller_6_4';
+	}
+
+	return $args;
+}
+
+add_filter( 'register_post_type_args', 'gutenberg_update_patterns_block_rest_controller_class', 11, 2 );

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-blocks-controller-6-4.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-blocks-controller-6-4.php
@@ -28,7 +28,6 @@ class Gutenberg_REST_Blocks_Controller_6_4 extends Gutenberg_REST_Blocks_Control
 	 * @return array List of link relations.
 	 */
 	protected function get_available_actions( $post, $request ) {
-
 		if ( 'edit' !== $request['context'] ) {
 			return array();
 		}
@@ -60,7 +59,7 @@ class Gutenberg_REST_Blocks_Controller_6_4 extends Gutenberg_REST_Blocks_Control
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
 
 		foreach ( $taxonomies as $tax ) {
-			$tax_base   = ! empty( $tax->rest_base ) ? $tax->rest_base : $tax->name;
+			$tax_base = ! empty( $tax->rest_base ) ? $tax->rest_base : $tax->name;
 
 			if ( current_user_can( $tax->cap->edit_terms ) ) {
 				$rels[] = 'https://api.w.org/action-create-' . $tax_base;

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-blocks-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-blocks-controller.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Reusable blocks REST API: WP_REST_Blocks_Controller class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 5.0.0
+ */
+
+/**
+ * Controller which provides a REST endpoint for the editor to read, create,
+ * edit and delete reusable blocks. Blocks are stored as posts with the wp_block
+ * post type.
+ *
+ * @since 5.0.0
+ *
+ * @see WP_REST_Posts_Controller
+ * @see WP_REST_Controller
+ */
+class Gutenberg_REST_Blocks_Controller_6_4 extends Gutenberg_REST_Blocks_Controller {
+	/**
+	 * Gets the link relations available for the post and current user.
+	 *
+	 * @since 6.4.0 Ensures that only users with `edit_terms` capability can add taxonomy terms.
+	 *
+	 * @param WP_Post         $post    Post object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array List of link relations.
+	 */
+	protected function get_available_actions( $post, $request ) {
+
+		if ( 'edit' !== $request['context'] ) {
+			return array();
+		}
+
+		$rels = array();
+
+		$post_type = get_post_type_object( $post->post_type );
+
+		if ( 'attachment' !== $this->post_type && current_user_can( $post_type->cap->publish_posts ) ) {
+			$rels[] = 'https://api.w.org/action-publish';
+		}
+
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			$rels[] = 'https://api.w.org/action-unfiltered-html';
+		}
+
+		if ( 'post' === $post_type->name ) {
+			if ( current_user_can( $post_type->cap->edit_others_posts ) && current_user_can( $post_type->cap->publish_posts ) ) {
+				$rels[] = 'https://api.w.org/action-sticky';
+			}
+		}
+
+		if ( post_type_supports( $post_type->name, 'author' ) ) {
+			if ( current_user_can( $post_type->cap->edit_others_posts ) ) {
+				$rels[] = 'https://api.w.org/action-assign-author';
+			}
+		}
+
+		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+
+		foreach ( $taxonomies as $tax ) {
+			$tax_base   = ! empty( $tax->rest_base ) ? $tax->rest_base : $tax->name;
+
+			if ( current_user_can( $tax->cap->edit_terms ) ) {
+				$rels[] = 'https://api.w.org/action-create-' . $tax_base;
+			}
+
+			if ( current_user_can( $tax->cap->assign_terms ) ) {
+				$rels[] = 'https://api.w.org/action-assign-' . $tax_base;
+			}
+		}
+
+		return $rels;
+	}
+}

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php
@@ -21,9 +21,10 @@ class Gutenberg_REST_Pattern_Categories_Controller extends WP_REST_Terms_Control
 	 *
 	 * @since 6.4.0
 	 *
+	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
-	public function create_item_permissions_check() {
+	public function create_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( ! $this->check_is_taxonomy_allowed( $this->taxonomy ) ) {
 			return false;
 		}

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php
@@ -21,7 +21,6 @@ class Gutenberg_REST_Pattern_Categories_Controller extends WP_REST_Terms_Control
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item_permissions_check() {

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php
@@ -19,12 +19,12 @@ class Gutenberg_REST_Pattern_Categories_Controller extends WP_REST_Terms_Control
 	 * Make pattern categories behave more like a hierarchical taxonomy in terms of permissions.
 	 * Check the edit_terms cap to see whether term creation is possible.
 	 *
-     * @since 6.4.0
+	 * @since 6.4.0
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
-	public function create_item_permissions_check( $request ) {
+	public function create_item_permissions_check() {
 		if ( ! $this->check_is_taxonomy_allowed( $this->taxonomy ) ) {
 			return false;
 		}

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Gutenberg_REST_Pattern_Categories_Controller class
+ *
+ * Extends the WP_REST_Terms_Controller to handle permissions of pattern categories.
+ *
+ * @package Gutenberg
+ * @subpackage REST_API
+ * @since 6.4.0
+ */
+
+/**
+ * Extends the WP_REST_Terms_Controller to handle permissions of pattern categories.
+ *
+ * @access public
+ */
+class Gutenberg_REST_Pattern_Categories_Controller extends WP_REST_Terms_Controller {
+	/**
+	 * Make pattern categories behave more like a hierarchical taxonomy in terms of permissions.
+	 * Check the edit_terms cap to see whether term creation is possible.
+	 *
+     * @since 6.4.0
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! $this->check_is_taxonomy_allowed( $this->taxonomy ) ) {
+			return false;
+		}
+
+		$taxonomy_obj = get_taxonomy( $this->taxonomy );
+
+		// Patterns categories are a flat hierarchy (like tags), but work more like post categories in terms of permissions.
+		if ( ! current_user_can( $taxonomy_obj->cap->edit_terms ) ) {
+			return new WP_Error(
+				'rest_cannot_create',
+				__( 'Sorry, you are not allowed to create terms in this taxonomy.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -53,7 +53,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 6.4 compat.
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php';
-	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-blocks-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-blocks-controller-6-4.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/rest-api.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/theme-previews.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -53,6 +53,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 6.4 compat.
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-blocks-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/rest-api.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/theme-previews.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -53,6 +53,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 6.4 compat.
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-global-styles-revisions-controller-6-4.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.4/class-gutenberg-rest-pattern-categories-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/rest-api.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/theme-previews.php';
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -651,6 +651,7 @@ export const getUserPatternCategories =
 			{
 				per_page: -1,
 				_fields: 'id,name,description,slug',
+				context: 'view',
 			}
 		);
 

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -62,6 +62,7 @@ export {
 export { default as PostTaxonomies } from './post-taxonomies';
 export { FlatTermSelector as PostTaxonomiesFlatTermSelector } from './post-taxonomies/flat-term-selector';
 export { HierarchicalTermSelector as PostTaxonomiesHierarchicalTermSelector } from './post-taxonomies/hierarchical-term-selector';
+export { PatternCategoriesSelector as PostPatternCategoriesSelector } from './post-taxonomies/pattern-categories-selector';
 export { default as PostTaxonomiesCheck } from './post-taxonomies/check';
 export { default as PostTextEditor } from './post-text-editor';
 export { default as PostTitle } from './post-title';

--- a/packages/editor/src/components/post-taxonomies/pattern-categories-selector.js
+++ b/packages/editor/src/components/post-taxonomies/pattern-categories-selector.js
@@ -69,11 +69,6 @@ export function PatternCategoriesSelector( { slug } ) {
 		return null;
 	}
 
-	/**
-	 * Update terms for post.
-	 *
-	 * @param {number[]} termIds Term ids.
-	 */
 	const onUpdateTerms = ( termIds ) => {
 		editPost( { [ taxonomy.rest_base ]: termIds } );
 	};

--- a/packages/editor/src/components/post-taxonomies/pattern-categories-selector.js
+++ b/packages/editor/src/components/post-taxonomies/pattern-categories-selector.js
@@ -1,0 +1,124 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { addFilter } from '@wordpress/hooks';
+import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
+
+const { CategorySelector } = unlock( patternsPrivateApis );
+
+const EMPTY_ARRAY = [];
+
+const DEFAULT_QUERY = {
+	per_page: -1,
+	orderby: 'name',
+	order: 'asc',
+	_fields: 'id,name,parent',
+	context: 'view',
+};
+
+/*
+ * Pattern categories are a flat taxonomy but do not allow Author users and below to create
+ * new categories, so this selector overrides the default flat taxonomy selector for
+ * wp_block post types and users without 'create' capability for wp_pattern_category.
+ */
+export function PatternCategoriesSelector( { slug } ) {
+	const { hasAssignAction, terms, availableTerms, taxonomy, loading } =
+		useSelect(
+			( select ) => {
+				const { getCurrentPost, getEditedPostAttribute } =
+					select( editorStore );
+				const { getTaxonomy, getEntityRecords, isResolving } =
+					select( coreStore );
+				const _taxonomy = getTaxonomy( slug );
+				const post = getCurrentPost();
+
+				return {
+					hasAssignAction: _taxonomy
+						? post._links?.[
+								'wp:action-assign-' + _taxonomy.rest_base
+						  ] ?? false
+						: false,
+					terms: _taxonomy
+						? getEditedPostAttribute( _taxonomy.rest_base )
+						: EMPTY_ARRAY,
+					loading: isResolving( 'getEntityRecords', [
+						'taxonomy',
+						slug,
+						DEFAULT_QUERY,
+					] ),
+					availableTerms:
+						getEntityRecords( 'taxonomy', slug, DEFAULT_QUERY ) ||
+						EMPTY_ARRAY,
+					taxonomy: _taxonomy,
+				};
+			},
+			[ slug ]
+		);
+
+	const { editPost } = useDispatch( editorStore );
+
+	if ( ! hasAssignAction || loading ) {
+		return null;
+	}
+
+	/**
+	 * Update terms for post.
+	 *
+	 * @param {number[]} termIds Term ids.
+	 */
+	const onUpdateTerms = ( termIds ) => {
+		editPost( { [ taxonomy.rest_base ]: termIds } );
+	};
+
+	const onChange = ( term ) => {
+		const hasTerm = terms.includes( term.id );
+		const newTerms = hasTerm
+			? terms.filter( ( id ) => id !== term.id )
+			: [ ...terms, term.id ];
+		onUpdateTerms( newTerms );
+	};
+
+	const isCategorySelected = ( term ) => terms.includes( term.id );
+
+	const categoryOptions = availableTerms.map( ( term ) => ( {
+		...term,
+		label: term.name,
+	} ) );
+
+	return (
+		<CategorySelector
+			onChange={ onChange }
+			categoryOptions={ categoryOptions }
+			isCategorySelected={ isCategorySelected }
+			showLabel={ false }
+		/>
+	);
+}
+
+export default function patternCategorySelector( OriginalComponent ) {
+	return function ( props ) {
+		const canAddCategories = useSelect( ( select ) => {
+			const { canUser } = select( coreStore );
+			return canUser( 'create', 'wp_pattern_category' );
+		} );
+		if ( props.slug === 'wp_pattern_category' && ! canAddCategories ) {
+			return <PatternCategoriesSelector { ...props } />;
+		}
+
+		return <OriginalComponent { ...props } />;
+	};
+}
+
+addFilter(
+	'editor.PostTaxonomyType',
+	'core/pattern-category-selector',
+	patternCategorySelector
+);

--- a/packages/editor/src/components/post-taxonomies/pattern-categories-selector.js
+++ b/packages/editor/src/components/post-taxonomies/pattern-categories-selector.js
@@ -65,7 +65,7 @@ export function PatternCategoriesSelector( { slug } ) {
 
 	const { editPost } = useDispatch( editorStore );
 
-	if ( ! hasAssignAction || loading ) {
+	if ( ! hasAssignAction || loading || availableTerms.length === 0 ) {
 		return null;
 	}
 

--- a/packages/patterns/src/components/category-editor.js
+++ b/packages/patterns/src/components/category-editor.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import { FormTokenField } from '@wordpress/components';
+import { useDebounce } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import CategorySelector from './category-selector';
+
+const unescapeString = ( arg ) => {
+	return decodeEntities( arg );
+};
+
+export const CATEGORY_SLUG = 'wp_pattern_category';
+
+export default function CategoryEditor( {
+	categoryTerms,
+	onChange,
+	categoryMap,
+	canAddCategories,
+} ) {
+	const categoryOptions = Array.from( categoryMap.values() );
+	const [ search, setSearch ] = useState( '' );
+	const debouncedSearch = useDebounce( setSearch, 500 );
+
+	const suggestions = useMemo( () => {
+		return Array.from( categoryMap.values() )
+			.map( ( category ) => unescapeString( category.label ) )
+			.filter( ( category ) => {
+				if ( search !== '' ) {
+					return category
+						.toLowerCase()
+						.includes( search.toLowerCase() );
+				}
+				return true;
+			} )
+			.sort( ( a, b ) => a.localeCompare( b ) );
+	}, [ search, categoryMap ] );
+
+	function handleChange( termNames ) {
+		const uniqueTerms = termNames.reduce( ( terms, newTerm ) => {
+			if (
+				! terms.some(
+					( term ) => term.toLowerCase() === newTerm.toLowerCase()
+				)
+			) {
+				terms.push( newTerm );
+			}
+			return terms;
+		}, [] );
+
+		onChange( uniqueTerms );
+	}
+	const isCategorySelected = ( selectedCategory ) =>
+		categoryTerms.includes( selectedCategory.label );
+
+	const onCategorySelectChange = ( selectedCategory ) => {
+		if ( categoryTerms.includes( selectedCategory.label ) ) {
+			onChange(
+				categoryTerms.filter(
+					( categoryTerm ) => categoryTerm !== selectedCategory.label
+				)
+			);
+		} else {
+			onChange( [ ...categoryTerms, selectedCategory.label ] );
+		}
+	};
+
+	return (
+		<>
+			{ canAddCategories && (
+				<FormTokenField
+					className="patterns-menu-items__convert-modal-categories"
+					value={ categoryTerms }
+					suggestions={ suggestions }
+					onChange={ handleChange }
+					onInputChange={ debouncedSearch }
+					label={ __( 'Categories' ) }
+					tokenizeOnBlur
+					__experimentalExpandOnFocus
+					__next40pxDefaultSize
+				/>
+			) }
+			{ ! canAddCategories && categoryOptions.length > 0 && (
+				<CategorySelector
+					onChange={ onCategorySelectChange }
+					categoryMap={ categoryTerms }
+					categoryOptions={ categoryOptions }
+					isCategorySelected={ isCategorySelected }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/patterns/src/components/category-editor.js
+++ b/packages/patterns/src/components/category-editor.js
@@ -12,9 +12,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import CategorySelector from './category-selector';
 
-const unescapeString = ( arg ) => {
-	return decodeEntities( arg );
-};
+const unescapeString = ( arg ) => decodeEntities( arg );
 
 export const CATEGORY_SLUG = 'wp_pattern_category';
 

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -2,60 +2,18 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState } from '@wordpress/element';
-import {
-	FormTokenField,
-	CheckboxControl,
-	BaseControl,
-} from '@wordpress/components';
-import { useDebounce } from '@wordpress/compose';
-import { decodeEntities } from '@wordpress/html-entities';
 
-const unescapeString = ( arg ) => {
-	return decodeEntities( arg );
-};
+import { CheckboxControl, BaseControl } from '@wordpress/components';
+
+import { decodeEntities } from '@wordpress/html-entities';
 
 export const CATEGORY_SLUG = 'wp_pattern_category';
 
 export default function CategorySelector( {
-	categoryTerms,
 	onChange,
-	categoryMap,
-	canAddCategories,
+	isCategorySelected,
+	categoryOptions,
 } ) {
-	const categoryOptions = Array.from( categoryMap.values() );
-	const [ search, setSearch ] = useState( '' );
-	const debouncedSearch = useDebounce( setSearch, 500 );
-
-	const suggestions = useMemo( () => {
-		return Array.from( categoryMap.values() )
-			.map( ( category ) => unescapeString( category.label ) )
-			.filter( ( category ) => {
-				if ( search !== '' ) {
-					return category
-						.toLowerCase()
-						.includes( search.toLowerCase() );
-				}
-				return true;
-			} )
-			.sort( ( a, b ) => a.localeCompare( b ) );
-	}, [ search, categoryMap ] );
-
-	function handleChange( termNames ) {
-		const uniqueTerms = termNames.reduce( ( terms, newTerm ) => {
-			if (
-				! terms.some(
-					( term ) => term.toLowerCase() === newTerm.toLowerCase()
-				)
-			) {
-				terms.push( newTerm );
-			}
-			return terms;
-		}, [] );
-
-		onChange( uniqueTerms );
-	}
-
 	const renderTerms = ( renderedTerms ) => {
 		return renderedTerms.map( ( category ) => {
 			return (
@@ -65,22 +23,8 @@ export default function CategorySelector( {
 				>
 					<CheckboxControl
 						__nextHasNoMarginBottom
-						checked={ categoryTerms.includes( category.label ) }
-						onChange={ () => {
-							if ( categoryTerms.includes( category.label ) ) {
-								onChange(
-									categoryTerms.filter(
-										( categoryTerm ) =>
-											categoryTerm !== category.label
-									)
-								);
-							} else {
-								onChange( [
-									...categoryTerms,
-									category.label,
-								] );
-							}
-						} }
+						checked={ isCategorySelected( category ) }
+						onChange={ () => onChange( category ) }
 						label={ decodeEntities( category.label ) }
 					/>
 				</div>
@@ -89,38 +33,19 @@ export default function CategorySelector( {
 	};
 
 	return (
-		<>
-			{ canAddCategories && (
-				<FormTokenField
-					className="patterns-menu-items__convert-modal-categories"
-					value={ categoryTerms }
-					suggestions={ suggestions }
-					onChange={ handleChange }
-					onInputChange={ debouncedSearch }
-					label={ __( 'Categories' ) }
-					tokenizeOnBlur
-					__experimentalExpandOnFocus
-					__next40pxDefaultSize
-				/>
-			) }
-			{ ! canAddCategories && categoryOptions.length > 0 && (
-				<>
-					<BaseControl>
-						<BaseControl.VisualLabel>
-							{ __( 'Categories' ) }
-						</BaseControl.VisualLabel>
+		<BaseControl>
+			<BaseControl.VisualLabel>
+				{ __( 'Categories' ) }
+			</BaseControl.VisualLabel>
 
-						<div
-							className="patterns-menu-items__convert-modal__terms-list"
-							tabIndex="0"
-							role="group"
-							aria-label={ __( 'Categories' ) }
-						>
-							{ renderTerms( categoryOptions ) }
-						</div>
-					</BaseControl>
-				</>
-			) }
-		</>
+			<div
+				className="patterns-menu-items__convert-modal__terms-list"
+				tabIndex="0"
+				role="group"
+				aria-label={ __( 'Categories' ) }
+			>
+				{ renderTerms( categoryOptions ) }
+			</div>
+		</BaseControl>
 	);
 }

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
-import { FormTokenField } from '@wordpress/components';
+import { FormTokenField, SelectControl } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -17,7 +17,9 @@ export default function CategorySelector( {
 	categoryTerms,
 	onChange,
 	categoryMap,
+	canAddCategories,
 } ) {
+	const categoryOptions = Array.from( categoryMap.values() );
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
@@ -51,16 +53,28 @@ export default function CategorySelector( {
 	}
 
 	return (
-		<FormTokenField
-			className="patterns-menu-items__convert-modal-categories"
-			value={ categoryTerms }
-			suggestions={ suggestions }
-			onChange={ handleChange }
-			onInputChange={ debouncedSearch }
-			label={ __( 'Categories' ) }
-			tokenizeOnBlur
-			__experimentalExpandOnFocus
-			__next40pxDefaultSize
-		/>
+		<>
+			{ canAddCategories && (
+				<FormTokenField
+					className="patterns-menu-items__convert-modal-categories"
+					value={ categoryTerms }
+					suggestions={ suggestions }
+					onChange={ handleChange }
+					onInputChange={ debouncedSearch }
+					label={ __( 'Categories' ) }
+					tokenizeOnBlur
+					__experimentalExpandOnFocus
+					__next40pxDefaultSize
+				/>
+			) }
+			{ ! canAddCategories && categoryOptions.length > 0 && (
+				<SelectControl
+					options={ categoryOptions }
+					multiple
+					onChange={ ( terms ) => onChange( terms ) }
+					label={ __( 'Categories' ) }
+				/>
+			) }
+		</>
 	);
 }

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -2,17 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-
 import { CheckboxControl, BaseControl } from '@wordpress/components';
-
 import { decodeEntities } from '@wordpress/html-entities';
-
-export const CATEGORY_SLUG = 'wp_pattern_category';
 
 export default function CategorySelector( {
 	onChange,
 	isCategorySelected,
 	categoryOptions,
+	showLabel = true,
 } ) {
 	const renderTerms = ( renderedTerms ) => {
 		return renderedTerms.map( ( category ) => {
@@ -34,10 +31,11 @@ export default function CategorySelector( {
 
 	return (
 		<BaseControl>
-			<BaseControl.VisualLabel>
-				{ __( 'Categories' ) }
-			</BaseControl.VisualLabel>
-
+			{ showLabel && (
+				<BaseControl.VisualLabel>
+					{ __( 'Categories' ) }
+				</BaseControl.VisualLabel>
+			) }
 			<div
 				className="patterns-menu-items__convert-modal__terms-list"
 				tabIndex="0"

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -3,7 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
-import { FormTokenField, CheckboxControl } from '@wordpress/components';
+import {
+	FormTokenField,
+	CheckboxControl,
+	BaseControl,
+} from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -101,17 +105,20 @@ export default function CategorySelector( {
 			) }
 			{ ! canAddCategories && categoryOptions.length > 0 && (
 				<>
-					<div className="patterns-menu-items__convert-modal__terms-label">
-						{ __( 'Categories' ) }
-					</div>
-					<div
-						className="patterns-menu-items__convert-modal__terms-list"
-						tabIndex="0"
-						role="group"
-						aria-label={ __( 'Categories' ) }
-					>
-						{ renderTerms( categoryOptions ) }
-					</div>
+					<BaseControl>
+						<BaseControl.VisualLabel>
+							{ __( 'Categories' ) }
+						</BaseControl.VisualLabel>
+
+						<div
+							className="patterns-menu-items__convert-modal__terms-list"
+							tabIndex="0"
+							role="group"
+							aria-label={ __( 'Categories' ) }
+						>
+							{ renderTerms( categoryOptions ) }
+						</div>
+					</BaseControl>
 				</>
 			) }
 		</>

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -16,7 +16,7 @@ export default function CategorySelector( {
 			return (
 				<div
 					key={ category.id }
-					className="patterns-menu-items__convert-modal__terms-choice"
+					className="patterns-category-selector__terms-choice"
 				>
 					<CheckboxControl
 						__nextHasNoMarginBottom
@@ -37,7 +37,7 @@ export default function CategorySelector( {
 				</BaseControl.VisualLabel>
 			) }
 			<div
-				className="patterns-menu-items__convert-modal__terms-list"
+				className="patterns-category-selector__terms-list"
 				tabIndex="0"
 				role="group"
 				aria-label={ __( 'Categories' ) }

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
-import { FormTokenField, SelectControl } from '@wordpress/components';
+import { FormTokenField, CheckboxControl } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -52,6 +52,38 @@ export default function CategorySelector( {
 		onChange( uniqueTerms );
 	}
 
+	const renderTerms = ( renderedTerms ) => {
+		return renderedTerms.map( ( category ) => {
+			return (
+				<div
+					key={ category.id }
+					className="patterns-menu-items__convert-modal__terms-choice"
+				>
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ categoryTerms.includes( category.label ) }
+						onChange={ () => {
+							if ( categoryTerms.includes( category.label ) ) {
+								onChange(
+									categoryTerms.filter(
+										( categoryTerm ) =>
+											categoryTerm !== category.label
+									)
+								);
+							} else {
+								onChange( [
+									...categoryTerms,
+									category.label,
+								] );
+							}
+						} }
+						label={ decodeEntities( category.label ) }
+					/>
+				</div>
+			);
+		} );
+	};
+
 	return (
 		<>
 			{ canAddCategories && (
@@ -68,12 +100,19 @@ export default function CategorySelector( {
 				/>
 			) }
 			{ ! canAddCategories && categoryOptions.length > 0 && (
-				<SelectControl
-					options={ categoryOptions }
-					multiple
-					onChange={ ( terms ) => onChange( terms ) }
-					label={ __( 'Categories' ) }
-				/>
+				<>
+					<div className="patterns-menu-items__convert-modal__terms-label">
+						{ __( 'Categories' ) }
+					</div>
+					<div
+						className="patterns-menu-items__convert-modal__terms-list"
+						tabIndex="0"
+						role="group"
+						aria-label={ __( 'Categories' ) }
+					>
+						{ renderTerms( categoryOptions ) }
+					</div>
+				</>
 			) }
 		</>
 	);

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -48,41 +48,46 @@ export default function CreatePatternModal( {
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
-	const { corePatternCategories, userPatternCategories } = useSelect(
-		( select ) => {
-			const { getUserPatternCategories, getBlockPatternCategories } =
-				select( coreStore );
+	const { corePatternCategories, userPatternCategories, canAddCategories } =
+		useSelect( ( select ) => {
+			const {
+				getUserPatternCategories,
+				getBlockPatternCategories,
+				canUser,
+			} = select( coreStore );
 
 			return {
 				corePatternCategories: getBlockPatternCategories(),
 				userPatternCategories: getUserPatternCategories(),
+				canAddCategories: canUser( 'create', 'wp_pattern_category' ),
 			};
-		}
-	);
+		} );
 
 	const categoryMap = useMemo( () => {
 		// Merge the user and core pattern categories and remove any duplicates.
 		const uniqueCategories = new Map();
-		[ ...userPatternCategories, ...corePatternCategories ].forEach(
-			( category ) => {
-				if (
-					! uniqueCategories.has( category.label ) &&
-					// There are two core categories with `Post` label so explicitly remove the one with
-					// the `query` slug to avoid any confusion.
-					category.name !== 'query'
-				) {
-					// We need to store the name separately as this is used as the slug in the
-					// taxonomy and may vary from the label.
-					uniqueCategories.set( category.label, {
-						label: category.label,
-						value: category.label,
-						name: category.name,
-					} );
-				}
+		[
+			...userPatternCategories,
+			...( canAddCategories ? corePatternCategories : [] ),
+		].forEach( ( category ) => {
+			if (
+				! uniqueCategories.has( category.label ) &&
+				// There are two core categories with `Post` label so explicitly remove the one with
+				// the `query` slug to avoid any confusion.
+				category.name !== 'query'
+			) {
+				// We need to store the name separately as this is used as the slug in the
+				// taxonomy and may vary from the label.
+				uniqueCategories.set( category.label, {
+					label: category.label,
+					value: category.label,
+					name: category.name,
+					id: category.id,
+				} );
 			}
-		);
+		} );
 		return uniqueCategories;
-	}, [ userPatternCategories, corePatternCategories ] );
+	}, [ userPatternCategories, corePatternCategories, canAddCategories ] );
 
 	async function onCreate( patternTitle, sync ) {
 		if ( ! title || isSaving ) {
@@ -91,11 +96,18 @@ export default function CreatePatternModal( {
 
 		try {
 			setIsSaving( true );
-			const categories = await Promise.all(
-				categoryTerms.map( ( termName ) =>
-					findOrCreateTerm( termName )
-				)
-			);
+			let categories;
+			if ( canAddCategories ) {
+				categories = await Promise.all(
+					categoryTerms.map( ( termName ) =>
+						findOrCreateTerm( termName )
+					)
+				);
+			} else {
+				categories = categoryTerms.map(
+					( term ) => categoryMap.get( term ).id
+				);
+			}
 
 			const newPattern = await createPattern(
 				patternTitle,
@@ -177,6 +189,7 @@ export default function CreatePatternModal( {
 						categoryTerms={ categoryTerms }
 						onChange={ setCategoryTerms }
 						categoryMap={ categoryMap }
+						canAddCategories={ canAddCategories }
 					/>
 					<ToggleControl
 						label={ __( 'Synced' ) }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -24,7 +24,7 @@ import { PATTERN_DEFAULT_CATEGORY, PATTERN_SYNC_TYPES } from '../constants';
  * Internal dependencies
  */
 import { store as patternsStore } from '../store';
-import CategorySelector, { CATEGORY_SLUG } from './category-selector';
+import CategoryEditor, { CATEGORY_SLUG } from './category-editor';
 import { unlock } from '../lock-unlock';
 
 export default function CreatePatternModal( {
@@ -185,7 +185,7 @@ export default function CreatePatternModal( {
 						placeholder={ __( 'My pattern' ) }
 						className="patterns-create-modal__name-input"
 					/>
-					<CategorySelector
+					<CategoryEditor
 						categoryTerms={ categoryTerms }
 						onChange={ setCategoryTerms }
 						categoryMap={ categoryMap }

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -18,7 +18,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import { CATEGORY_SLUG } from './category-selector';
+import { CATEGORY_SLUG } from './category-editor';
 
 export default function RenamePatternCategoryModal( {
 	category,

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -26,20 +26,6 @@
 		border-bottom-left-radius: 2px;
 		border-bottom-right-radius: 2px;
 	}
-
-	.patterns-menu-items__convert-modal__terms-list {
-		max-height: 6rem;
-		overflow: auto;
-		border: 1px solid $gray-600;
-		padding: 8px;
-
-		.patterns-menu-items__convert-modal__terms-choice {
-			margin-bottom: $grid-unit-10;
-			&:last-child {
-				margin-bottom: 2px;
-			}
-		}
-	}
 }
 
 .patterns-create-modal__name-input input[type="text"] {
@@ -56,4 +42,18 @@
 	text-transform: uppercase;
 	display: inline-block;
 	padding: 0;
+}
+
+.patterns-category-selector__terms-list {
+	max-height: 6rem;
+	overflow: auto;
+	border: 1px solid $gray-600;
+	padding: 8px;
+
+	.patterns-category-selector__terms-choice {
+		margin-bottom: $grid-unit-10;
+		&:last-child {
+			margin-bottom: 2px;
+		}
+	}
 }

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -34,3 +34,29 @@
 	// Override the default 1px margin-x.
 	margin: 0;
 }
+
+.patterns-menu-items__convert-modal__terms-label {
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+	text-transform: uppercase;
+	display: inline-block;
+	padding: 0;
+}
+
+.patterns-menu-items__convert-modal__terms-list {
+	max-height: 6rem;
+	overflow: auto;
+	border: 1px solid $gray-600;
+	// Extra left padding prevents checkbox focus borders from being cut off.
+	padding-left: $border-width * 4 + $border-width-focus-fallback;
+	margin-top: -$border-width * 4 - $border-width-focus-fallback;
+	padding-top: $border-width * 4 + $border-width-focus-fallback;
+
+	.patterns-menu-items__convert-modal__terms-choice {
+		margin-bottom: $grid-unit-10;
+		&:last-child {
+			margin-bottom: $grid-unit-05;
+		}
+	}
+}

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -26,6 +26,20 @@
 		border-bottom-left-radius: 2px;
 		border-bottom-right-radius: 2px;
 	}
+
+	.patterns-menu-items__convert-modal__terms-list {
+		max-height: 6rem;
+		overflow: auto;
+		border: 1px solid $gray-600;
+		padding: 8px;
+
+		.patterns-menu-items__convert-modal__terms-choice {
+			margin-bottom: $grid-unit-10;
+			&:last-child {
+				margin-bottom: 2px;
+			}
+		}
+	}
 }
 
 .patterns-create-modal__name-input input[type="text"] {
@@ -42,20 +56,4 @@
 	text-transform: uppercase;
 	display: inline-block;
 	padding: 0;
-}
-
-.patterns-menu-items__convert-modal__terms-list {
-	max-height: 6rem;
-	overflow: auto;
-	border: 1px solid $gray-600;
-	// Extra left padding prevents checkbox focus borders from being cut off.
-	padding-left: $border-width * 4 + $border-width-focus-fallback;
-	padding-top: $border-width * 4 + $border-width-focus-fallback;
-
-	.patterns-menu-items__convert-modal__terms-choice {
-		margin-bottom: $grid-unit-10;
-		&:last-child {
-			margin-bottom: $grid-unit-05;
-		}
-	}
 }

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -50,7 +50,6 @@
 	border: 1px solid $gray-600;
 	// Extra left padding prevents checkbox focus borders from being cut off.
 	padding-left: $border-width * 4 + $border-width-focus-fallback;
-	margin-top: -$border-width * 4 - $border-width-focus-fallback;
 	padding-top: $border-width * 4 + $border-width-focus-fallback;
 
 	.patterns-menu-items__convert-modal__terms-choice {

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -7,6 +7,8 @@ import DuplicatePatternModal from './components/duplicate-pattern-modal';
 import RenamePatternModal from './components/rename-pattern-modal';
 import PatternsMenuItems from './components';
 import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
+import CategorySelector from './components/category-selector';
+
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
@@ -22,6 +24,7 @@ lock( privateApis, {
 	RenamePatternModal,
 	PatternsMenuItems,
 	RenamePatternCategoryModal,
+	CategorySelector,
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,


### PR DESCRIPTION
## What?
Fixes the capabilities settings for pattern categories so Authors and below can view existing user categories in the editor inserter patterns tab. Also prevents Authors from adding new categories, but still provides the ability for them to assign existing categories to their own patterns.

## Why?
Currently Authors and contributors get API errors when trying to view pattern categories, and Authors are able to add as well as assign pattern categories

## How?

- Sets the context of the categories API call to `view` so contributors can see the user categories list
- Limits users to a select list of existing categories if they do not have create capabilities for `wp_pattern_category` 

## Testing Instructions

- As an admin go to /`wp-admin/edit-tags.php?taxonomy=wp_pattern_category` and remove any categories
- Add some new patterns with some new custom categories, not the core pattern categories
- Log in as a Contributer user and make sure the new categories appear in the editor inserter Patterns tab
- Check that going to `/wp-admin/edit-tags.php?taxonomy=wp_pattern_category` gives an insufficient permissions error.
- Log in as an Author and make sure the new categories appear in the editor inserter Patterns tab
- Add a new pattern and make sure you can only select from the custom categories added above and that you can't add any new categories, and check pattern saves correctly and is available in the assigned categories
- Go to `wp-admin/edit.php?post_type=wp_block` and choose a pattern to edit, and make sure you can only select and not create categories in the right panel
- Check that going to `/wp-admin/edit-tags.php?taxonomy=wp_pattern_category` gives an insufficient permissions error
- As an admin delete all the pattern categories again
- Login as Author and add a new pattern and check that the category option is not shown because there are now no categories to select from
- Login as an Editor and add a new pattern and make sure you can assign new categories to a pattern as well as select existing ones

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/aa409910-21ad-4980-9877-6f900a6f2724

After:

https://github.com/WordPress/gutenberg/assets/3629020/f941a842-f7be-40e2-a919-0c6873013888






