### PR TITLE
Rich Text: Cleanup excess `focusin`/`focusout` listeners

### DIFF
--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -168,7 +168,12 @@ export function useAnchor( { editableContentElement, settings = {} } ) {
 		editableContentElement.addEventListener( 'focusin', attach );
 		editableContentElement.addEventListener( 'focusout', detach );
 
-		return detach;
+		return () => {
+			detach();
+
+			editableContentElement.removeEventListener( 'focusin', attach );
+			editableContentElement.removeEventListener( 'focusout', detach );
+		};
 	}, [ editableContentElement, tagName, className ] );
 
 	return anchor;


### PR DESCRIPTION
## What?
This PR cleans up some `focusin` / `focusout` event listeners that we're adding but never removing when working with a link. 

## Why?
Currently, if you add a paragraph, and make part of it a link, every focus and blur of the link will attach new event listeners but will never clean them up, potentially leading to memory leaks.

## How?
This PR cleans up the excess `focusin` / `focusout` event listeners. We're already cleaning up the rest of the event listeners created there (`selectionchange` for example).

## Testing Instructions
* Verify inserting and editing links in paragraphs still works well.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None