### PR TITLE
Migrating `BlockPatternList` to use updated `Composite` implementation

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -153,7 +153,7 @@ function BlockPatternPlaceholder() {
 	);
 }
 
-function BlockPatternList(
+function BlockPatternsList(
 	{
 		isDraggable,
 		blockPatterns,
@@ -224,4 +224,4 @@ function BlockPatternList(
 	);
 }
 
-export default forwardRef( BlockPatternList );
+export default forwardRef( BlockPatternsList );

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -28,7 +28,7 @@ import { speak } from '@wordpress/a11y';
  * Internal dependencies
  */
 import usePatternsState from './hooks/use-patterns-state';
-import BlockPatternList from '../block-patterns-list';
+import BlockPatternsList from '../block-patterns-list';
 import PatternsExplorerModal from './block-patterns-explorer/explorer';
 import MobileTabNavigation from './mobile-tab-navigation';
 import usePatternsPaging from './hooks/use-patterns-paging';
@@ -332,7 +332,7 @@ export function BlockPatternsCategoryPanel( {
 			</VStack>
 
 			{ currentCategoryPatterns.length > 0 && (
-				<BlockPatternList
+				<BlockPatternsList
 					ref={ scrollContainerRef }
 					shownPatterns={ pagingProps.categoryPatternsAsyncList }
 					blockPatterns={ pagingProps.categoryPatterns }

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -183,7 +183,7 @@ export async function searchGlobalInserter( category, searchTerm ) {
 		case 'Synced patterns': {
 			waitForInsertElement = async () => {
 				return await page.waitForXPath(
-					`//*[@role='button' and contains(., '${ searchTerm }')]`
+					`//*[@role="list" and @class="block-editor-block-patterns-list"]//*[@role="button" and contains(., '${ searchTerm }')]`
 				);
 			};
 			waitForNoResults = async () => {

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -183,7 +183,7 @@ export async function searchGlobalInserter( category, searchTerm ) {
 		case 'Synced patterns': {
 			waitForInsertElement = async () => {
 				return await page.waitForXPath(
-					`//*[@role='option' and contains(., '${ searchTerm }')]`
+					`//*[@role='button' and contains(., '${ searchTerm }')]`
 				);
 			};
 			waitForNoResults = async () => {

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -183,7 +183,7 @@ export async function searchGlobalInserter( category, searchTerm ) {
 		case 'Synced patterns': {
 			waitForInsertElement = async () => {
 				return await page.waitForXPath(
-					`//*[@role="list" and @class="block-editor-block-patterns-list"]//*[@role="button" and contains(., '${ searchTerm }')]`
+					`//*[@class="block-editor-inserter__panel-content"]//*[self::button or self::*[@role="button"]][contains(., '${ searchTerm }')]`
 				);
 			};
 			waitForNoResults = async () => {

--- a/packages/e2e-tests/specs/editor/various/allowed-patterns.test.js
+++ b/packages/e2e-tests/specs/editor/various/allowed-patterns.test.js
@@ -12,7 +12,7 @@ import {
 const checkPatternExistence = async ( name, available = true ) => {
 	await searchForPattern( name );
 	const patternElement = await page.waitForXPath(
-		`//div[@role = 'option']//div[contains(text(), '${ name }')]`,
+		`//div[@role = 'button']//div[contains(text(), '${ name }')]`,
 		{ timeout: 5000, visible: available, hidden: ! available }
 	);
 	const patternExists = !! patternElement;


### PR DESCRIPTION
## What?

This PR updates [`BlockPatternList` in `@wordpress/block-editor`](https://github.com/WordPress/gutenberg/blob/b4c4d77fd8fa7d4f6895cb0e7d88ea5e8af3f6f8/packages/block-editor/src/components/block-patterns-list/index.js) to use the updated `Composite` implementation from #54225.

As an aside to maintain consistency/integrity, `BlockPatternList` is renamed to `BlockPatternsList` so as to match both the file name and usage elsewhere.

## Why?

In #54225, an updated implementation of `Composite` was added to `@wordpress/components`. As per #55224, all consumers of `Composite` need to migrate from the old version to the new version.


## How?

 - Removes `__unstableComposite` imports from `@wordpress/components`
 - Adds private `Composite*` exports from `@wordpress/components`
 - Refactors `BlockPatternList`/`BlockPattern` to use updated `Composite` components


## Testing Instructions

> [!NOTE]
> To come...


### Testing Instructions for Keyboard

> [!NOTE]
> To come...
