### PR TITLE
Fix PHP notice when an image with lightbox is deleted in the behaviors file

### DIFF
--- a/lib/block-supports/behaviors.php
+++ b/lib/block-supports/behaviors.php
@@ -109,8 +109,8 @@ function gutenberg_render_behaviors_support_lightbox( $block_content, $block ) {
 	if ( isset( $block['attrs']['id'] ) ) {
 		$img_uploaded_src = wp_get_attachment_url( $block['attrs']['id'] );
 		$img_metadata     = wp_get_attachment_metadata( $block['attrs']['id'] );
-		$img_width        = $img_metadata['width'];
-		$img_height       = $img_metadata['height'];
+		$img_width        = $img_metadata['width'] ?? 'none';
+		$img_height       = $img_metadata['height'] ?? 'none';
 	} else {
 		$img_uploaded_src = $processor->get_attribute( 'src' );
 		$img_width        = 'none';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Follow-up to https://github.com/WordPress/gutenberg/pull/55370

## What?
<!-- In a few words, what is the PR actually doing? -->
Aookues the same fix from https://github.com/WordPress/gutenberg/pull/55370 to the behaviiors file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Not sure how to make a theme use the `behaviors.php` file, but to my understanding thie file may be still used.
This change only applies the wame efix for the Image block from https://github.com/WordPress/gutenberg/pull/55370

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
