### PR TITLE
Enable users to sort by `date`

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -193,7 +193,6 @@ export default function PagePages() {
 					);
 					return <time>{ formattedDate }</time>;
 				},
-				enableSorting: false,
 			},
 		],
 		[ postStatuses, authors ]

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -186,6 +186,7 @@ export default function PagePages() {
 			{
 				header: 'Date',
 				id: 'date',
+				getValue: ( { item } ) => item.date,
 				render: ( { item } ) => {
 					const formattedDate = dateI18n(
 						getSettings().formats.datetimeAbbreviated,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

Follow-up to https://github.com/WordPress/gutenberg/pull/55247#discussion_r1354740897

## What?

This PR enables users to sort by date.

## Why?

The pages table is already sorted by `date` in descending order. Users can change the sorting to Title and Author, but they cannot go back to Date once they've done so:

| Before | After |
| --- | --- |
| <img width="451" alt="Captura de ecrã 2023-10-16, às 16 45 41" src="https://github.com/WordPress/gutenberg/assets/583546/03f78629-ab52-4e7d-b168-e1bbb8a6f82f"> | <img width="451" alt="Captura de ecrã 2023-10-16, às 16 46 53" src="https://github.com/WordPress/gutenberg/assets/583546/0a50a1d2-16c0-4312-ae9c-a3d9646c50e1"> |

## Testing Instructions

- Enable the wp-admin experiment and go to "Site editor > Pages > Manage all pages".
- In the table view, sort by date.

| Column action | View actions |
| --- | --- |
| <img width="236" alt="Captura de ecrã 2023-10-16, às 16 50 29" src="https://github.com/WordPress/gutenberg/assets/583546/5dbb6acb-9a52-48b0-873a-0a4be7b615f7"> | <img width="451" alt="Captura de ecrã 2023-10-16, às 16 46 53" src="https://github.com/WordPress/gutenberg/assets/583546/0a50a1d2-16c0-4312-ae9c-a3d9646c50e1"> |