### PR TITLE
[Data views]: Update icons and design tweaks

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -35,7 +35,7 @@ export default function DataViews( {
 	}, [ fields ] );
 	return (
 		<div className="dataviews-wrapper">
-			<VStack spacing={ 4 }>
+			<VStack spacing={ 4 } justify="flex-start">
 				<HStack>
 					<HStack justify="start">
 						<Filters

--- a/packages/edit-site/src/components/dataviews/pagination.js
+++ b/packages/edit-site/src/components/dataviews/pagination.js
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __, _x, _n } from '@wordpress/i18n';
+import { chevronRight, chevronLeft, previous, next } from '@wordpress/icons';
 
 const PAGE_SIZE_VALUES = [ 5, 20, 50 ];
 function PageSizeControl( { view, onChangeView } ) {
@@ -77,9 +78,8 @@ function Pagination( {
 						onClick={ () => onChangeView( { ...view, page: 1 } ) }
 						disabled={ view.page === 1 }
 						aria-label={ __( 'First page' ) }
-					>
-						«
-					</Button>
+						icon={ previous }
+					/>
 					<Button
 						variant="tertiary"
 						onClick={ () =>
@@ -87,9 +87,8 @@ function Pagination( {
 						}
 						disabled={ view.page === 1 }
 						aria-label={ __( 'Previous page' ) }
-					>
-						‹
-					</Button>
+						icon={ chevronLeft }
+					/>
 					<HStack
 						justify="flex-start"
 						expanded={ false }
@@ -137,9 +136,8 @@ function Pagination( {
 						}
 						disabled={ view.page >= totalPages }
 						aria-label={ __( 'Next page' ) }
-					>
-						›
-					</Button>
+						icon={ chevronRight }
+					/>
 					<Button
 						variant="tertiary"
 						onClick={ () =>
@@ -147,9 +145,8 @@ function Pagination( {
 						}
 						disabled={ view.page >= totalPages }
 						aria-label={ __( 'Last page' ) }
-					>
-						»
-					</Button>
+						icon={ next }
+					/>
 				</HStack>
 			) }
 			<PageSizeControl view={ view } onChangeView={ onChangeView } />

--- a/packages/edit-site/src/components/dataviews/pagination.js
+++ b/packages/edit-site/src/components/dataviews/pagination.js
@@ -72,27 +72,37 @@ function Pagination( {
 				}
 			</Text>
 			{ !! totalItems && (
-				<HStack expanded={ false } spacing={ 1 }>
-					<Button
-						onClick={ () => onChangeView( { ...view, page: 0 } ) }
-						disabled={ view.page === 0 }
-						label={ __( 'First page' ) }
-						icon={ previous }
-						showTooltip
-					/>
-					<Button
-						onClick={ () =>
-							onChangeView( { ...view, page: view.page - 1 } )
-						}
-						disabled={ view.page === 0 }
-						label={ __( 'Previous page' ) }
-						icon={ chevronLeft }
-						showTooltip
-					/>
+				<HStack expanded={ false } spacing={ 3 }>
 					<HStack
 						justify="flex-start"
 						expanded={ false }
 						spacing={ 1 }
+					>
+						<Button
+							onClick={ () =>
+								onChangeView( { ...view, page: 0 } )
+							}
+							disabled={ view.page === 0 }
+							label={ __( 'First page' ) }
+							icon={ previous }
+							showTooltip
+							size="compact"
+						/>
+						<Button
+							onClick={ () =>
+								onChangeView( { ...view, page: view.page - 1 } )
+							}
+							disabled={ view.page === 0 }
+							label={ __( 'Previous page' ) }
+							icon={ chevronLeft }
+							showTooltip
+							size="compact"
+						/>
+					</HStack>
+					<HStack
+						justify="flex-start"
+						expanded={ false }
+						spacing={ 2 }
 					>
 						{ createInterpolateElement(
 							sprintf(
@@ -129,24 +139,35 @@ function Pagination( {
 							}
 						) }
 					</HStack>
-					<Button
-						onClick={ () =>
-							onChangeView( { ...view, page: view.page + 1 } )
-						}
-						disabled={ view.page >= totalPages - 1 }
-						label={ __( 'Next page' ) }
-						icon={ chevronRight }
-						showTooltip
-					/>
-					<Button
-						onClick={ () =>
-							onChangeView( { ...view, page: totalPages } )
-						}
-						disabled={ view.page >= totalPages - 1 }
-						label={ __( 'Last page' ) }
-						icon={ next }
-						showTooltip
-					/>
+					<HStack
+						justify="flex-start"
+						expanded={ false }
+						spacing={ 1 }
+					>
+						<Button
+							onClick={ () =>
+								onChangeView( { ...view, page: view.page + 1 } )
+							}
+							disabled={ view.page >= totalPages - 1 }
+							label={ __( 'Next page' ) }
+							icon={ chevronRight }
+							showTooltip
+							size="compact"
+						/>
+						<Button
+							onClick={ () =>
+								onChangeView( {
+									...view,
+									page: totalPages - 1,
+								} )
+							}
+							disabled={ view.page >= totalPages - 1 }
+							label={ __( 'Last page' ) }
+							icon={ next }
+							showTooltip
+							size="compact"
+						/>
+					</HStack>
 				</HStack>
 			) }
 			<PageSizeControl view={ view } onChangeView={ onChangeView } />

--- a/packages/edit-site/src/components/dataviews/pagination.js
+++ b/packages/edit-site/src/components/dataviews/pagination.js
@@ -80,9 +80,9 @@ function Pagination( {
 					>
 						<Button
 							onClick={ () =>
-								onChangeView( { ...view, page: 0 } )
+								onChangeView( { ...view, page: 1 } )
 							}
-							disabled={ view.page === 0 }
+							disabled={ view.page === 1 }
 							label={ __( 'First page' ) }
 							icon={ previous }
 							showTooltip
@@ -92,7 +92,7 @@ function Pagination( {
 							onClick={ () =>
 								onChangeView( { ...view, page: view.page - 1 } )
 							}
-							disabled={ view.page === 0 }
+							disabled={ view.page === 1 }
 							label={ __( 'Previous page' ) }
 							icon={ chevronLeft }
 							showTooltip
@@ -148,7 +148,7 @@ function Pagination( {
 							onClick={ () =>
 								onChangeView( { ...view, page: view.page + 1 } )
 							}
-							disabled={ view.page >= totalPages - 1 }
+							disabled={ view.page >= totalPages }
 							label={ __( 'Next page' ) }
 							icon={ chevronRight }
 							showTooltip
@@ -156,12 +156,9 @@ function Pagination( {
 						/>
 						<Button
 							onClick={ () =>
-								onChangeView( {
-									...view,
-									page: totalPages - 1,
-								} )
+								onChangeView( { ...view, page: totalPages } )
 							}
-							disabled={ view.page >= totalPages - 1 }
+							disabled={ view.page >= totalPages }
 							label={ __( 'Last page' ) }
 							icon={ next }
 							showTooltip

--- a/packages/edit-site/src/components/dataviews/pagination.js
+++ b/packages/edit-site/src/components/dataviews/pagination.js
@@ -6,46 +6,11 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalNumberControl as NumberControl,
-	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
-	SelectControl,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __, _x, _n } from '@wordpress/i18n';
 import { chevronRight, chevronLeft, previous, next } from '@wordpress/icons';
 
-const PAGE_SIZE_VALUES = [ 5, 20, 50 ];
-function PageSizeControl( { view, onChangeView } ) {
-	const label = __( 'Rows per page:' );
-	return (
-		<SelectControl
-			__nextHasNoMarginBottom
-			label={ label }
-			hideLabelFromVision
-			// TODO: This should probably use a label based on the wanted design
-			// and we could remove InputControlPrefixWrapper usage.
-			prefix={
-				<InputControlPrefixWrapper
-					as="span"
-					className="dataviews__select-control-prefix"
-				>
-					{ label }
-				</InputControlPrefixWrapper>
-			}
-			value={ view.perPage }
-			options={ PAGE_SIZE_VALUES.map( ( pageSize ) => ( {
-				value: pageSize,
-				label: pageSize,
-			} ) ) }
-			onChange={ ( value ) =>
-				onChangeView( { ...view, perPage: value, page: 1 } )
-			}
-		/>
-	);
-}
-
-// For now this is copied from the patterns list Pagination component, because
-// the datatable pagination starts from index zero(`0`). Eventually all lists will be
-// using this one.
 function Pagination( {
 	view,
 	onChangeView,
@@ -167,7 +132,6 @@ function Pagination( {
 					</HStack>
 				</HStack>
 			) }
-			<PageSizeControl view={ view } onChangeView={ onChangeView } />
 		</HStack>
 	);
 }

--- a/packages/edit-site/src/components/dataviews/pagination.js
+++ b/packages/edit-site/src/components/dataviews/pagination.js
@@ -76,16 +76,18 @@ function Pagination( {
 					<Button
 						onClick={ () => onChangeView( { ...view, page: 0 } ) }
 						disabled={ view.page === 0 }
-						aria-label={ __( 'First page' ) }
+						label={ __( 'First page' ) }
 						icon={ previous }
+						showTooltip
 					/>
 					<Button
 						onClick={ () =>
 							onChangeView( { ...view, page: view.page - 1 } )
 						}
-						disabled={ view.page === 1 }
-						aria-label={ __( 'Previous page' ) }
+						disabled={ view.page === 0 }
+						label={ __( 'Previous page' ) }
 						icon={ chevronLeft }
+						showTooltip
 					/>
 					<HStack
 						justify="flex-start"
@@ -131,17 +133,19 @@ function Pagination( {
 						onClick={ () =>
 							onChangeView( { ...view, page: view.page + 1 } )
 						}
-						disabled={ view.page >= totalPages }
-						aria-label={ __( 'Next page' ) }
+						disabled={ view.page >= totalPages - 1 }
+						label={ __( 'Next page' ) }
 						icon={ chevronRight }
+						showTooltip
 					/>
 					<Button
 						onClick={ () =>
 							onChangeView( { ...view, page: totalPages } )
 						}
-						disabled={ view.page >= totalPages }
-						aria-label={ __( 'Last page' ) }
+						disabled={ view.page >= totalPages - 1 }
+						label={ __( 'Last page' ) }
 						icon={ next }
+						showTooltip
 					/>
 				</HStack>
 			) }

--- a/packages/edit-site/src/components/dataviews/pagination.js
+++ b/packages/edit-site/src/components/dataviews/pagination.js
@@ -74,14 +74,12 @@ function Pagination( {
 			{ !! totalItems && (
 				<HStack expanded={ false } spacing={ 1 }>
 					<Button
-						variant="tertiary"
-						onClick={ () => onChangeView( { ...view, page: 1 } ) }
-						disabled={ view.page === 1 }
+						onClick={ () => onChangeView( { ...view, page: 0 } ) }
+						disabled={ view.page === 0 }
 						aria-label={ __( 'First page' ) }
 						icon={ previous }
 					/>
 					<Button
-						variant="tertiary"
 						onClick={ () =>
 							onChangeView( { ...view, page: view.page - 1 } )
 						}
@@ -130,7 +128,6 @@ function Pagination( {
 						) }
 					</HStack>
 					<Button
-						variant="tertiary"
 						onClick={ () =>
 							onChangeView( { ...view, page: view.page + 1 } )
 						}
@@ -139,7 +136,6 @@ function Pagination( {
 						icon={ chevronRight }
 					/>
 					<Button
-						variant="tertiary"
 						onClick={ () =>
 							onChangeView( { ...view, page: totalPages } )
 						}

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -1,6 +1,6 @@
 .dataviews-wrapper {
 	width: 100%;
-	min-height: calc(100% - 60px);
+	height: 100%;
 	overflow: auto;
 	padding: $grid-unit-40;
 

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -1,12 +1,16 @@
 .dataviews-wrapper {
 	width: 100%;
+	min-height: calc(100% - 60px);
+	overflow: auto;
 	padding: $grid-unit-40;
+
+	> div {
+		min-height: 100%;
+	}
 }
 
 .dataviews-pagination {
-	position: sticky;
-	bottom: $grid-unit-20;
-	background: $white;
+	margin-top: auto;
 }
 
 .dataviews-list-view {
@@ -34,11 +38,6 @@
 	tr {
 		border-bottom: 1px solid $gray-100;
 	}
-}
-
-.dataviews__select-control-prefix {
-	color: $gray-700;
-	text-wrap: nowrap;
 }
 
 .dataviews-view-grid__media {

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -3,6 +3,12 @@
 	padding: $grid-unit-40;
 }
 
+.dataviews-pagination {
+	position: sticky;
+	bottom: $grid-unit-20;
+	background: $white;
+}
+
 .dataviews-list-view {
 	width: 100%;
 	text-indent: 0;

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -50,7 +50,12 @@ export function ViewGrid( { data, fields, view, actions } ) {
 									) ) }
 								</VStack>
 							</FlexBlock>
-							<ItemActions item={ item } actions={ actions } />
+							<FlexBlock>
+								<ItemActions
+									item={ item }
+									actions={ actions }
+								/>
+							</FlexBlock>
 						</HStack>
 					</VStack>
 				);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/55095

This PR:
1. replaces the plain text for buttons with icons
2. places pagination row at the bottom of the frame

We can also add in this PR any other design tweaks we want in order to close the linked issue for now.


https://github.com/WordPress/gutenberg/assets/16275880/21ac1166-3c22-452e-bd84-b7ada5372087


