### PR TITLE
Fix inconsistencies in excerpt length when doing AJAX requests vs regular HTTP requests vs REST API requests

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -94,6 +94,10 @@ function register_block_core_post_excerpt_length_filter( $value ) {
 		return $value;
 	}
 
+	if ( empty( $_REQUEST['context'] ) || ( 'edit' !== $_REQUEST['context'] ) ) {
+		return $value;
+	}
+
 	return 100;
 }
 add_filter( 'excerpt_length', 'register_block_core_post_excerpt_length_filter', PHP_INT_MAX );

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -83,16 +83,15 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  */
-add_filter(
-	'excerpt_length',
-	static function ( $value ) {
-		// This check needs to be inside the callback since the REST_REQUEST constant
-		// is not defined at the time add_filter() is called.
-		if ( ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-			return $value;
-		}
+function register_block_core_post_excerpt_length_filter( $value ) {
+	// This check needs to be inside the callback since the REST_REQUEST constant
+	// is not defined at the time add_filter() is called.
+	if ( ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+		return $value;
+	}
 
-		return 100;
-	},
-	PHP_INT_MAX
-);
+	return 100;
+}
+add_filter( 'excerpt_length', 'register_block_core_post_excerpt_length_filter', PHP_INT_MAX );
+
+

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -85,7 +85,7 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  *
  * @param integer $value Excerpt length.
  *
- * @return integer .
+ * @return integer Filtered excerpt length.
  */
 function register_block_core_post_excerpt_length_filter( $value ) {
 	// This check needs to be inside the callback since the REST_REQUEST constant

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -83,9 +83,9 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  *
- * @param integer $value Excerpt length.
+ * @param int $value Excerpt length.
  *
- * @return integer Filtered excerpt length.
+ * @return int Filtered excerpt length.
  */
 function register_block_core_post_excerpt_length_filter( $value ) {
 	// This check needs to be inside the callback since the REST_REQUEST constant

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -83,13 +83,23 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  */
-if ( is_admin() ||
-	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-	add_filter(
-		'excerpt_length',
-		static function () {
-			return 100;
-		},
-		PHP_INT_MAX
-	);
-}
+add_filter(
+	/**
+	 * Don't add the filter now, as at this point, REST_REQUEST is not set yet.
+	 * Add it later when REST_REQUEST is initialized.
+	 */
+	'rest_api_init',
+	static function () {
+		if ( ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return;
+		}
+		add_filter(
+			'excerpt_length',
+			static function () {
+				return 100;
+			},
+			PHP_INT_MAX
+		);
+	},
+	PHP_INT_MAX
+);

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -86,7 +86,7 @@ add_action( 'init', 'register_block_core_post_excerpt' );
 add_filter(
 	/**
 	 * Don't add the filter now, as at this point, REST_REQUEST is not set yet.
-	 * Add it later when REST_REQUEST is initialized.
+	 * Add it later when REST_REQUEST is defined.
 	 */
 	'rest_api_init',
 	static function () {

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -84,22 +84,15 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * Returns 100 because 100 is the max length in the setting.
  */
 add_filter(
-	/**
-	 * Don't add the filter now, as at this point, REST_REQUEST is not set yet.
-	 * Add it later when REST_REQUEST is defined.
-	 */
-	'rest_api_init',
-	static function () {
+	'excerpt_length',
+	static function ( $value ) {
+		// This check needs to be inside the callback since the REST_REQUEST constant
+		// is not defined at the time add_filter() is called.
 		if ( ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-			return;
+			return $value;
 		}
-		add_filter(
-			'excerpt_length',
-			static function () {
-				return 100;
-			},
-			PHP_INT_MAX
-		);
+
+		return 100;
 	},
 	PHP_INT_MAX
 );

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -82,6 +82,10 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * override the filter in the editor, otherwise
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
+ *
+ * @param integer $value Excerpt length.
+ *
+ * @return integer .
  */
 function register_block_core_post_excerpt_length_filter( $value ) {
 	// This check needs to be inside the callback since the REST_REQUEST constant
@@ -93,5 +97,3 @@ function register_block_core_post_excerpt_length_filter( $value ) {
 	return 100;
 }
 add_filter( 'excerpt_length', 'register_block_core_post_excerpt_length_filter', PHP_INT_MAX );
-
-

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -100,4 +100,4 @@ function register_block_core_post_excerpt_length_filter( $value ) {
 
 	return 100;
 }
-add_filter( 'excerpt_length', 'register_block_core_post_excerpt_length_filter', PHP_INT_MAX );
+add_filter( 'excerpt_length', 'register_block_core_post_excerpt_length_filter', 20 );

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -31,7 +31,7 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 	}
 
 	/**
-	 * Unit test for ensuring correct length of the post excerpt in the REST API context.
+	 * Unit test to ensure the correct length of the post excerpt in the REST API context.
 	 *
 	 * @dataProvider data_register_block_core_post_excerpt_length_filter
 	 *
@@ -57,6 +57,7 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 		     ->with( $this->equalTo( $expeceted_excerpt_length ) )
 		     ->willReturn( $expeceted_excerpt_length );
 
+		// Using PHP_INT_MAX for testing purposes only; this should be avoided in production code.
 		add_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );
 		rest_get_server()->dispatch( $request );
 		remove_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -1,13 +1,15 @@
 <?php
 
 /**
- * Tests for hooked blocks rendering.
+ * Functional unit test for wp_register_block_core_post_excerpt_length_filter().
  *
  * @package WordPress
  * @subpackage Blocks
- * @since 6.5.0
- *
+ */
+
+/**
  * @group blocks
+ * @covers ::register_block_core_post_excerpt_length_filter
  */
 class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST_TestCase {
 
@@ -29,9 +31,14 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 	}
 
 	/**
+	 * Unit test for ensuring correct length of the post excerpt in the REST API context.
+	 *
 	 * @dataProvider data_register_block_core_post_excerpt_length_filter
+	 *
+	 * @param int    $expeceted_excerpt_length Expected excerpt length.
+	 * @param string $context                  Current context.
 	 */
-	public function test_register_block_core_post_excerpt_length_filter( $expected_word_length, $context ) {
+	public function test_register_block_core_post_excerpt_length_filter( $expeceted_excerpt_length, $context ) {
 		wp_set_current_user( self::$admin_id );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id );
@@ -47,8 +54,8 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 
 		$mock->expects( $this->atLeastOnce() )
 		     ->method( 'excerpt_length_callback' )
-		     ->with( $this->equalTo( $expected_word_length ) )
-		     ->willReturn( $expected_word_length );
+		     ->with( $this->equalTo( $expeceted_excerpt_length ) )
+		     ->willReturn( $expeceted_excerpt_length );
 
 		add_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );
 		rest_get_server()->dispatch( $request );
@@ -56,6 +63,11 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 		unset ( $_REQUEST['context'] );
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function data_register_block_core_post_excerpt_length_filter() {
 		return array(
 			'no_edit_context' => array(

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -45,15 +45,15 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 		             ->addMethods( [ 'excerpt_length_callback' ] )
 		             ->getMock();
 
-		$mock->expects( $this->atLeast( 1 ) )
+		$mock->expects( $this->atLeastOnce() )
 		     ->method( 'excerpt_length_callback' )
 		     ->with( $this->equalTo( $expected_word_length ) )
 		     ->willReturn( $expected_word_length );
 
-		add_filter('excerpt_length', [$mock, 'excerpt_length_callback'], PHP_INT_MAX );
+		add_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );
 		rest_get_server()->dispatch( $request );
-		remove_filter('excerpt_length', [$mock, 'excerpt_length_callback'], PHP_INT_MAX );
-		unset ($_REQUEST['context']);
+		remove_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );
+		unset ( $_REQUEST['context'] );
 	}
 
 	public function data_register_block_core_post_excerpt_length_filter() {

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -59,7 +59,8 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 
 		// Using PHP_INT_MAX for testing purposes only; this should be avoided in production code.
 		add_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );
-		rest_get_server()->dispatch( $request );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( WP_Http::OK, $response->get_status(), 'Expected response status to be ' . WP_Http::OK );
 		remove_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );
 		unset ( $_REQUEST['context'] );
 	}

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Functional unit test for wp_register_block_core_post_excerpt_length_filter().
  *
@@ -17,7 +16,8 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 	protected static $admin_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$post_id = $factory->post->create( array(
+		self::$post_id = $factory->post->create(
+			array(
 				'post_excerpt' => '',
 			)
 		);
@@ -49,20 +49,20 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 
 		$request->set_param( '_locale', 'user' );
 		$mock = $this->getMockBuilder( stdClass::class )
-		             ->addMethods( [ 'excerpt_length_callback' ] )
-		             ->getMock();
+					->addMethods( array( 'excerpt_length_callback' ) )
+					->getMock();
 
 		$mock->expects( $this->atLeastOnce() )
-		     ->method( 'excerpt_length_callback' )
-		     ->with( $this->equalTo( $expeceted_excerpt_length ) )
-		     ->willReturn( $expeceted_excerpt_length );
+			->method( 'excerpt_length_callback' )
+			->with( $this->equalTo( $expeceted_excerpt_length ) )
+			->willReturn( $expeceted_excerpt_length );
 
 		// Using PHP_INT_MAX for testing purposes only; this should be avoided in production code.
-		add_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );
+		add_filter( 'excerpt_length', array( $mock, 'excerpt_length_callback' ), PHP_INT_MAX );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( WP_Http::OK, $response->get_status(), 'Expected response status to be ' . WP_Http::OK );
-		remove_filter( 'excerpt_length', [ $mock, 'excerpt_length_callback' ], PHP_INT_MAX );
-		unset ( $_REQUEST['context'] );
+		remove_filter( 'excerpt_length', array( $mock, 'excerpt_length_callback' ), PHP_INT_MAX );
+		unset( $_REQUEST['context'] );
 	}
 
 	/**
@@ -74,11 +74,11 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 		return array(
 			'no_edit_context' => array(
 				55, // Default filter value.
-				''
+				'',
 			),
 			'edit_context'    => array(
 				100,
-				'edit'
+				'edit',
 			),
 		);
 	}

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Tests for hooked blocks rendering.
  *
@@ -8,42 +9,61 @@
  *
  * @group blocks
  */
-class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_UnitTestCase {
-	/**
-	 *
-	 * @dataProvider data_register_block_core_post_excerpt_length_filter
-	 * @param $excerpt_length
-	 *
-	 * @return void
-	 */
-	public function test_register_block_core_post_excerpt_length_filter( $excerpt_length, $expected_excerpt_length, $rest_api_enabled, $context ) {
-		$_REQUEST['context'] = $context;
-		if ( $rest_api_enabled && ! defined( 'REST_REQUEST' ) ) {
-			define( REST_REQUEST, true );
-		}
-		$result = register_block_core_post_excerpt_length_filter( $excerpt_length );
+class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST_TestCase {
 
-		$this->assertSame( $expected_excerpt_length, $result );
+	protected static $post_id;
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$post_id = $factory->post->create( array(
+				'post_excerpt' => '',
+			)
+		);
+
+		self::$admin_id = $factory->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'superadmin',
+			)
+		);
+	}
+
+	/**
+	 * @dataProvider data_register_block_core_post_excerpt_length_filter
+	 */
+	public function test_register_block_core_post_excerpt_length_filter( $expected_word_length, $context ) {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id );
+		if ( '' !== $context ) {
+			$request->set_param( 'context', $context );
+			$_REQUEST['context'] = $context;
+		}
+
+		$request->set_param( '_locale', 'user' );
+		$mock = $this->getMockBuilder( stdClass::class )
+		             ->addMethods( [ 'excerpt_length_callback' ] )
+		             ->getMock();
+
+		$mock->expects( $this->atLeast( 1 ) )
+		     ->method( 'excerpt_length_callback' )
+		     ->with( $this->equalTo( $expected_word_length ) )
+		     ->willReturn( $expected_word_length );
+
+		add_filter('excerpt_length', [$mock, 'excerpt_length_callback'], PHP_INT_MAX );
+		rest_get_server()->dispatch( $request );
+		remove_filter('excerpt_length', [$mock, 'excerpt_length_callback'], PHP_INT_MAX );
+		unset ($_REQUEST['context']);
 	}
 
 	public function data_register_block_core_post_excerpt_length_filter() {
 		return array(
-			'rest_api_disabled_non_edit_context' => array(
-				10,
-				10,
-				false,
-				'',
+			'no_edit_context' => array(
+				55,
+				''
 			),
-			'rest_api_enabled_non_edit_context'  => array(
-				10,
-				10,
-				true,
-				'',
-			),
-			'rest_api_enabled_edit_context'      => array(
-				10,
-				10,
-				true,
+			'edit_context'    => array(
+				100,
 				'edit'
 			),
 		);

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -48,9 +48,14 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 		}
 
 		$request->set_param( '_locale', 'user' );
-		$mock = $this->getMockBuilder( stdClass::class )
-					->addMethods( array( 'excerpt_length_callback' ) )
-					->getMock();
+		$mock = $this->getMockBuilder( stdClass::class );
+		if ( method_exists( $mock, 'addMethods' ) ) {
+			$mock->addMethods( array( 'excerpt_length_callback' ) );
+		} else {
+			// Ensure compatibility with older PHPUnit versions.
+			$mock->setMethods( array( 'excerpt_length_callback' ) );
+		}
+		$mock = $mock->getMock();
 
 		$mock->expects( $this->atLeastOnce() )
 			->method( 'excerpt_length_callback' )

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -72,7 +72,7 @@ class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_Test_REST
 	public function data_register_block_core_post_excerpt_length_filter() {
 		return array(
 			'no_edit_context' => array(
-				55,
+				55, // Default filter value.
 				''
 			),
 			'edit_context'    => array(

--- a/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
+++ b/phpunit/tests/blocks/registerBlockCorePostExcerptLengthFilter.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests for hooked blocks rendering.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.5.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RegisterBlockCorePostExcerptLengthFilter extends WP_UnitTestCase {
+	/**
+	 *
+	 * @dataProvider data_register_block_core_post_excerpt_length_filter
+	 * @param $excerpt_length
+	 *
+	 * @return void
+	 */
+	public function test_register_block_core_post_excerpt_length_filter( $excerpt_length, $expected_excerpt_length, $rest_api_enabled, $context ) {
+		$_REQUEST['context'] = $context;
+		if ( $rest_api_enabled && ! defined( 'REST_REQUEST' ) ) {
+			define( REST_REQUEST, true );
+		}
+		$result = register_block_core_post_excerpt_length_filter( $excerpt_length );
+
+		$this->assertSame( $expected_excerpt_length, $result );
+	}
+
+	public function data_register_block_core_post_excerpt_length_filter() {
+		return array(
+			'rest_api_disabled_non_edit_context' => array(
+				10,
+				10,
+				false,
+				'',
+			),
+			'rest_api_enabled_non_edit_context'  => array(
+				10,
+				10,
+				true,
+				'',
+			),
+			'rest_api_enabled_edit_context'      => array(
+				10,
+				10,
+				true,
+				'edit'
+			),
+		);
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines: https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR addresses inconsistencies in excerpt length when making AJAX requests versus regular HTTP requests and REST API requests.

Fixes https://github.com/WordPress/gutenberg/issues/53570.

## Why?

When attempting to load posts via AJAX requests, the excerpt length is always set to 100 words. This issue arose because the previous implementation incorrectly initialized the filter, assuming that it needed to be initialized when `WP_ADMIN === true`. Consequently, the previous implementation would override the excerpt length when making AJAX requests via `admin-ajax.php`, leading to the problem with excerpt length.

## How?

Now, the excerpt length is only overridden when making REST API requests, which is the intended behavior.

## Testing Instructions

Steps to test this PR:
1. Do not check out this branch yet. Let's reproduce the bug first.
2. Activate a block theme, such as `Twenty Twenty-Four`.
3. Ensure that Gutenberg is enabled.
4. Add the following code to the `functions.php` file in your theme's folder: 
```php
function custom_excerpt_length( $length ) {
	return 20;
}

add_filter( 'excerpt_length', 'custom_excerpt_length', 1667 );
function get_latest_post() {
	$args = array(
		'post_type'      => 'post',
		'posts_per_page' => 1,
		'orderby'        => 'date',
		'order'          => 'DESC',
	);

	$latest_post = new WP_Query( $args );

	if ( $latest_post->have_posts() ) {
		while ( $latest_post->have_posts() ) {
			$latest_post->the_post();
			echo get_the_excerpt();
		}
		wp_reset_postdata();
	} else {
		echo 'No posts found.';
	}

	die();
}

add_action( 'wp_ajax_nopriv_get_latest_post', 'get_latest_post' );
add_action( 'wp_ajax_get_latest_post', 'get_latest_post' );
```
5. Build Gutenberg with `npm run build` to ensure that the Gutenberg's build/ directory has the correct version of the hook.
6. Create a new POST in the Site Editor. You can use any title. Use the following text as the post's content (just make sure to insert it into a `paragraph` block):

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. In euismod diam egestas massa facilisis, in imperdiet mi consequat. Etiam interdum vel tellus laoreet posuere. Aliquam ut sagittis elit. Nullam et orci nisl. Morbi quis vehicula ex, eget luctus odio. Vivamus a tincidunt arcu, id euismod ex. Praesent fringilla velit lorem, sit amet commodo mauris vulputate sodales. Vestibulum tempus, ipsum et ultricies interdum, ligula elit accumsan risus, vel tristique dolor est eu diam. Vivamus pharetra eget erat vel rutrum. Aliquam et ligula quis lorem molestie semper. Aenean convallis tortor nec velit ultricies semper. Maecenas felis erat, cursus nec varius et, auctor eu nulla. Phasellus et nibh imperdiet, placerat erat ut, tristique libero. Nam sed scelerisque enim.
```

7. Open the Site Editor (`wp-admin/site-editor.php`) page.
8. Execute the following code in the console of your browser:

```javascript
jQuery.ajax( {
    url: wpApiSettings.root + 'wp/v2/posts?per_page=1&orderby=date&order=desc',
    method: 'GET',
    beforeSend: function ( xhr ) {
        xhr.setRequestHeader( 'X-WP-Nonce', wpApiSettings.nonce );
    }
} ).done( function ( response ) {
    console.log( response[0].excerpt.rendered );
} );
```

9. Observe the response. Note that the excerpt length is 100 words, as expected, since the excerpt length in REST responses should be 100 words.

10. Execute the following code in the console of your browser:

```javascript
jQuery.ajax( {
    url: '/wp-admin/admin-ajax.php', // Assuming your WordPress installation is in the web root of your server.
    method: 'POST',
    data: {
        action: 'get_latest_post'
    }
} ).done( function ( response ) {
    console.log( response );
} );
```

11. Observe the response. Notice that the excerpt length is 100 words, even though the `custom_excerpt_length` hook in the `functions.php` file should limit the length to 20 words. The bug is confirmed.

12. Check out this PR.
13. In both `src/wp-includes/blocks/post-excerpt.php` and `build/wp-includes/blocks/post-excerpt.php`, replace:

```php
if ( is_admin() ||
	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
	add_filter(
		'excerpt_length',
		static function () {
			return 100;
		},
		PHP_INT_MAX
	);
}
```

with:

```php 
add_filter(
	'excerpt_length',
	static function ( $value ) {
		// This check needs to be inside the callback since the REST_REQUEST constant
		// is not defined at the time add_filter() is called.
		if ( ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
			return $value;
		}

		return 100;
	},
	PHP_INT_MAX
);
```

14. Build Gutenberg with `npm run build` to ensure that the Gutenberg's `build/` directory has the correct version of the hook.
15. Repeat step 8. Ensure that the excerpt length is still 100 words in the response.
16. Repeat step 10. Ensure that the excerpt length is 20 words in the response, just as specified in the `custom_excerpt_length` hook. The bug is fixed.
