### PR TITLE
Only suppress admin notices when JavaScript is enabled.

### DIFF
--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -56,7 +56,7 @@ body.js.widgets-php {
 
 // Don't display admin notices on the Widgets screen.
 // Needs !important because plugins may add inline styles to notices.
-.widgets-php .notice {
+.js .widgets-php .notice {
 	display: none !important;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Only suppresses the display of notices on the widget block editor screen if JavaScript is available.

Fixes #55384

_Note: The PHP Unit tests are failing in `WP_Directive_Processor_Test`, it doesn't seem related so I am ignoring the problem for now._

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In WP-[r56671](https://core.trac.wordpress.org/changeset/56671) a notice was added to the widget screen indicating that JavaScript is required. This notice needs to be visible if JavaScript is unavailable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It adds `.js` as a parent selector to the CSS suppressing notices. WordPress adds the class to the body element if JS is available.

https://github.com/WordPress/wordpress-develop/blob/6837a90e49e82192224472ac35fe2a9cc7a9e2ac/src/wp-admin/admin-header.php#L247

## Testing Instructions
1. Run this against WordPress trunk (or 6.4 if it has been branched)
2. Enable a classic theme such as TT1
3. Open the Developer Tools
4. Open the Developer Tools settings
5. Disable JavaScript in the developer tools settings
6. Visit the widgets page
7. On this branch you should see the notice: The block widgets require JavaScript. Please enable JavaScript in your browser settings, or install the Classic Widgets plugin.

In Firefox and Chrome closing the dev tools should renable JavaScript.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![Screen Shot 2023-10-17 at 2 13 20 pm](https://github.com/WordPress/gutenberg/assets/519727/fbfe1ea6-4eb0-4a58-a947-d981e01b9c9a)

