### PR TITLE
Fix: Directive processor failing on updated HTML API

### DIFF
--- a/lib/experimental/interactivity-api/class-wp-directive-processor.php
+++ b/lib/experimental/interactivity-api/class-wp-directive-processor.php
@@ -20,7 +20,7 @@ if ( class_exists( 'WP_Directive_Processor' ) ) {
  * available.  Please restrain from investing unnecessary time and effort trying
  * to improve this code.
  */
-class WP_Directive_Processor extends WP_HTML_Tag_Processor {
+class WP_Directive_Processor extends Gutenberg_HTML_Tag_Processor_6_4 {
 
 	/**
 	 * An array of root blocks.

--- a/lib/load.php
+++ b/lib/load.php
@@ -76,8 +76,8 @@ require __DIR__ . '/experimental/editor-settings.php';
 require __DIR__ . '/compat/plugin/edit-site-routes-backwards-compat.php';
 require __DIR__ . '/compat/plugin/footnotes.php';
 
+require __DIR__ . '/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php';
 if ( ! class_exists( 'WP_HTML_Processor' ) ) {
-	require __DIR__ . '/compat/wordpress-6.4/html-api/class-gutenberg-html-tag-processor-6-4.php';
 	require __DIR__ . '/compat/wordpress-6.4/html-api/class-wp-html-active-formatting-elements.php';
 	require __DIR__ . '/compat/wordpress-6.4/html-api/class-wp-html-open-elements.php';
 	require __DIR__ . '/compat/wordpress-6.4/html-api/class-wp-html-processor-state.php';


### PR DESCRIPTION
Discovered after backporting the WordPress 6.4 release into Gutenberg.
https://wordpress.slack.com/archives/C02QB2JS7/p1697471144510409

Identified broken with the merge of WordPress/wordpress-develop#5475, which hadn't yet been backported into Gutenberg, and which wouldn't have been noticed because of the Directive Processor using `WP_HTML_Tag_Processor()` directly.