### PR TITLE
Try to fix flaky synced pattern test

### DIFF
--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1129,7 +1129,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 
 		await expect(
 			editor.canvas.locator( '[data-type="core/block"]' )
-		).toBeFocused();
+		).toBeVisible();
 
 		await editor.insertBlock( { name: 'core/paragraph' } );
 

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1128,7 +1128,9 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'Enter' );
 
 		await expect(
-			editor.canvas.locator( '[data-type="core/block"]' )
+			editor.canvas.locator(
+				'[data-type="core/block"] [data-type="core/paragraph"]'
+			)
 		).toBeVisible();
 
 		await editor.insertBlock( { name: 'core/paragraph' } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #55284.

It seems to be the first focus check that is the problem, maybe focus after converting to a synced pattern is not guaranteed. Let's just wait for the block to be loaded, I think `toBeVisible` should do that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
