### PR TITLE
[Data views]: Normalize `render` fields function

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -5,6 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,6 +26,12 @@ export default function DataViews( {
 	paginationInfo,
 } ) {
 	const ViewComponent = view.type === 'list' ? ViewList : ViewGrid;
+	const _fields = useMemo( () => {
+		return fields.map( ( field ) => ( {
+			...field,
+			render: field.render || field.accessorFn,
+		} ) );
+	}, [ fields ] );
 	return (
 		<div className="dataviews-wrapper">
 			<VStack spacing={ 4 }>
@@ -37,7 +44,7 @@ export default function DataViews( {
 					/>
 				</HStack>
 				<ViewComponent
-					fields={ fields }
+					fields={ _fields }
 					view={ view }
 					onChangeView={ onChangeView }
 					paginationInfo={ paginationInfo }

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -29,8 +29,7 @@ export function ViewGrid( { data, fields, view, actions } ) {
 				return (
 					<VStack key={ index }>
 						<div className="dataviews-view-grid__media">
-							{ ( mediaField &&
-								mediaField.render( { item, view } ) ) || (
+							{ mediaField?.render( item, view ) || (
 								<Placeholder
 									withIllustration
 									style={ {
@@ -46,9 +45,7 @@ export function ViewGrid( { data, fields, view, actions } ) {
 								<VStack>
 									{ visibleFields.map( ( field ) => (
 										<div key={ field.id }>
-											{ field.render
-												? field.render( { item, view } )
-												: field.accessorFn( item ) }
+											{ field.render( item, view ) }
 										</div>
 									) ) }
 								</VStack>

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -133,9 +133,8 @@ function ViewList( {
 } ) {
 	const columns = useMemo( () => {
 		const _columns = fields.map( ( field ) => {
-			const column = { ...field };
-			delete column.render;
-			column.cell = ( props ) => field.render( props.row.original, view );
+			const { render, ...column } = field;
+			column.cell = ( props ) => render( props.row.original, view );
 			return column;
 		} );
 		if ( actions?.length ) {

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -132,18 +132,12 @@ function ViewList( {
 	paginationInfo,
 } ) {
 	const columns = useMemo( () => {
-		const _columns = [
-			...fields.map( ( field ) => {
-				const column = { ...field };
-				delete column.render;
-				column.cell = ( props ) => {
-					return field.render
-						? field.render( { item: props.row.original, view } )
-						: field.accessorFn( props.row.original );
-				};
-				return column;
-			} ),
-		];
+		const _columns = fields.map( ( field ) => {
+			const column = { ...field };
+			delete column.render;
+			column.cell = ( props ) => field.render( props.row.original, view );
+			return column;
+		} );
 		if ( actions?.length ) {
 			_columns.push( {
 				header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -89,7 +89,7 @@ export default function PagePages() {
 				id: 'featured-image',
 				header: __( 'Featured Image' ),
 				accessorFn: ( page ) => page.featured_media,
-				render: ( { item, view: currentView } ) =>
+				render: ( item, currentView ) =>
 					!! item.featured_media ? (
 						<Media
 							className="edit-site-page-pages__featured-image"
@@ -107,7 +107,7 @@ export default function PagePages() {
 				header: __( 'Title' ),
 				id: 'title',
 				accessorFn: ( page ) => page.title?.rendered || page.slug,
-				render: ( { item: page } ) => {
+				render: ( page ) => {
 					return (
 						<VStack spacing={ 1 }>
 							<Heading as="h3" level={ 5 }>
@@ -134,7 +134,7 @@ export default function PagePages() {
 				header: __( 'Author' ),
 				id: 'author',
 				accessorFn: ( page ) => page._embedded?.author[ 0 ]?.name,
-				render: ( { item } ) => {
+				render: ( item ) => {
 					const author = item._embedded?.author[ 0 ];
 					return (
 						<a href={ `user-edit.php?user_id=${ author.id }` }>
@@ -153,7 +153,7 @@ export default function PagePages() {
 			{
 				header: 'Date',
 				id: 'date',
-				render: ( { item } ) => {
+				render: ( item ) => {
 					const formattedDate = dateI18n(
 						getSettings().formats.datetimeAbbreviated,
 						getDate( item.date )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/55083
<!-- In a few words, what is the PR actually doing? -->

This PR normalizes the `render` fields function to have similar signature, in order for views to call just one function. I haven't yet removed `accessorFn` since it's used in tanstack(list view) and we have to investigate more before doing so.

## Testing Instructions
1. The list of pages should work exactly as before.

