### PR TITLE
DataViews: In list view, automatically insert header menu separators

### DIFF
--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -28,7 +28,7 @@ import {
 	privateApis as componentsPrivateApis,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useMemo, Children, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -75,53 +75,66 @@ function HeaderMenu( { dataView, header } ) {
 				/>
 			}
 		>
-			{ isSortable && (
-				<DropdownMenuGroupV2>
-					{ Object.entries( sortingItemsInfo ).map(
-						( [ direction, info ] ) => (
-							<DropdownMenuItemV2
-								key={ direction }
-								prefix={ <Icon icon={ info.icon } /> }
-								suffix={
-									sortedDirection === direction && (
-										<Icon icon={ check } />
-									)
-								}
-								onSelect={ ( event ) => {
-									event.preventDefault();
-									if ( sortedDirection === direction ) {
-										dataView.resetSorting();
-									} else {
-										dataView.setSorting( [
-											{
-												id: header.column.id,
-												desc: direction === 'desc',
-											},
-										] );
+			<WithSeparators>
+				{ isSortable && (
+					<DropdownMenuGroupV2>
+						{ Object.entries( sortingItemsInfo ).map(
+							( [ direction, info ] ) => (
+								<DropdownMenuItemV2
+									key={ direction }
+									prefix={ <Icon icon={ info.icon } /> }
+									suffix={
+										sortedDirection === direction && (
+											<Icon icon={ check } />
+										)
 									}
-								} }
-							>
-								{ info.label }
-							</DropdownMenuItemV2>
-						)
-					) }
-				</DropdownMenuGroupV2>
-			) }
-			{ isSortable && isHidable && <DropdownMenuSeparatorV2 /> }
-			{ isHidable && (
-				<DropdownMenuItemV2
-					prefix={ <Icon icon={ unseen } /> }
-					onSelect={ ( event ) => {
-						event.preventDefault();
-						header.column.getToggleVisibilityHandler()( event );
-					} }
-				>
-					{ __( 'Hide' ) }
-				</DropdownMenuItemV2>
-			) }
+									onSelect={ ( event ) => {
+										event.preventDefault();
+										if ( sortedDirection === direction ) {
+											dataView.resetSorting();
+										} else {
+											dataView.setSorting( [
+												{
+													id: header.column.id,
+													desc: direction === 'desc',
+												},
+											] );
+										}
+									} }
+								>
+									{ info.label }
+								</DropdownMenuItemV2>
+							)
+						) }
+					</DropdownMenuGroupV2>
+				) }
+				{ isHidable && (
+					<DropdownMenuItemV2
+						prefix={ <Icon icon={ unseen } /> }
+						onSelect={ ( event ) => {
+							event.preventDefault();
+							header.column.getToggleVisibilityHandler()( event );
+						} }
+					>
+						{ __( 'Hide' ) }
+					</DropdownMenuItemV2>
+				) }
+			</WithSeparators>
 		</DropdownMenuV2>
 	);
 }
+
+function WithSeparators( { children } ) {
+	return Children.toArray( children )
+		.filter( Boolean )
+		.map( ( child, i ) => (
+			<Fragment key={ i }>
+				{ i > 0 && <DropdownMenuSeparatorV2 /> }
+				{ child }
+			</Fragment>
+		) );
+}
+
 function ViewList( {
 	view,
 	onChangeView,


### PR DESCRIPTION
This should be [reviewed with whitespace changes hidden](https://github.com/WordPress/gutenberg/pull/55412/files?diff=unified&w=1).

In HeaderMenu, avoid the very error-prone logic involved in manually adding separators in between top-level items, and instead rely on an introspective component (WithSeparators) to do that task reliably. The complexity that this eliminates is expected to grow as more features result in more top-level items in header menus.

No visible or functional change is expected from this PR, but for reference these are the menus in question:

<img width="285" alt="Screenshot 2023-10-17 at 14 27 38" src="https://github.com/WordPress/gutenberg/assets/150562/1daac54d-7b1b-4130-bc4a-d81d6ce60a4d">

Before, a separator needed to be manually inserted in between the sorting group (top) and the visibility item (bottom).

Minor part of #55083