### PR TITLE
Make duotone support compatible with enhanced pagination

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -836,7 +836,6 @@ class WP_Duotone_Gutenberg {
 		$has_global_styles_duotone = array_key_exists( $block['blockName'], self::$global_styles_block_names );
 
 		if (
-			empty( $block_content ) ||
 			! $duotone_selector ||
 			( ! $has_duotone_attribute && ! $has_global_styles_duotone )
 		) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Partial fix for https://github.com/WordPress/gutenberg/issues/55230.

This fix makes the duotone compatible with the enhanced pagination by making sure that the CSS is always on the page, even when the posts have no featured image. It also prevents the duotone from interfering with other blocks using `wp_unique_id`.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the current implementation of enhanced pagination, we are still not detecting the CSS corresponding to each block. Therefore, for the enhanced pagination to work correctly, the CSS of the blocks present in the Post Template must be stable on all pages.

The featured image block can contain a duotone, but the duotone CSS is only inlined when the block is not empty. As posts can have or not have a featured image, if all posts on one page do not have a featured image, the duotone CSS will not load, and when you paginate, the CSS will not be applied to the posts that do have a featured image.

In addition, some duotone settings use the `wp_unique_id`, and as it is a conditional use, this can break the stability of the rest of the blocks that use `wp_unique_id` causing another series of problems like those described in https://github.com/WordPress/gutenberg/issues/55230.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Simply by making the duotone CSS render even when the block is empty. This seems to be the normal behavior of other types of block supports, because the duotone, according to my tests, is the only one that has this problem. This means that on some occasions, we will inline the CSS unnecessarily, for example, in a template that renders a post without a featured image. But we can add this optimization back (and even add it in other block supports) once the enhanced pagination is able to detect the CSS corresponding to each block.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Create multiple posts so you can paginate with the Query block.
- Make it so that on the first page of the Query block, none of the posts have featured images.
- Make it so that on the second page of the Query block, at least one post has a featured image.
- Add a duotone to the featured image.
- Enable the enhanced pagination setting.
- Check that the duotone works fine when you paginate.
- Repeat with different types of duotone: presets, CSS, custom, global styles…

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3305402/08ef6347-88e2-44d8-a9be-32e34b1730ca

After:

https://github.com/WordPress/gutenberg/assets/3305402/929679cc-37c0-4b65-bb99-fd0f0397de46
