### PR TITLE
Make layout support compatible with enhanced pagination

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -528,6 +528,26 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 }
 
 /**
+ * Generates an incremental ID that is independent per each different prefix.
+ *
+ * It is similar to `wp_unique_id`, but each prefix has it's own internal ID
+ * counter to make each prefix independent from each other. The ID starts at 1
+ * and increments on each call. The returned value is not universally unique,
+ * but it is unique across the life of the PHP process and it's stable per
+ * prefix.
+ *
+ * @param  string $prefix Prefix for the returned ID.
+ * @return string         Incremental ID per prefix.
+ */
+function gutenberg_incremental_id_per_prefix( $prefix = '' ) {
+	static $id_counters = array();
+	if ( ! array_key_exists( $prefix, $id_counters ) ) {
+			$id_counters[ $prefix ] = 0;
+	}
+	return $prefix . (string) ++$id_counters[ $prefix ];
+}
+
+/**
  * Renders the layout config to the block wrapper.
  *
  * @param  string $block_content Rendered block content.
@@ -608,7 +628,17 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$class_names        = array();
 	$layout_definitions = gutenberg_get_layout_definitions();
-	$container_class    = wp_unique_id( 'wp-container-' );
+
+	/*
+	* We use an incremental ID that is independent per prefix to make sure that
+	* rendering different numbers of blocks doesn't affect the IDs of other
+	* blocks. We need this to make the CSS class names stable across paginations
+	* for features like the enhanced pagination of the Query block.
+	*/
+	$container_class = gutenberg_incremental_id_per_prefix(
+		'wp-container-' .
+		str_replace( '/', '--', $block['blockName'] ) . '-'
+	);
 
 	// Set the correct layout type for blocks using legacy content width.
 	if ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] || isset( $used_layout['contentSize'] ) && $used_layout['contentSize'] ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -636,8 +636,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	* for features like the enhanced pagination of the Query block.
 	*/
 	$container_class = gutenberg_incremental_id_per_prefix(
-		'wp-container-' .
-		str_replace( '/', '--', $block['blockName'] ) . '-'
+		'wp-container-' . sanitize_title( $block['blockName'] ) . '-layout-'
 	);
 
 	// Set the correct layout type for blocks using legacy content width.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Partial fix for https://github.com/WordPress/gutenberg/issues/55230.

This fix makes the layout support compatible with the enhanced pagination by making sure that the generated class names are stable across paginations, even when the number of rendered posts are different.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the current implementation of enhanced pagination, we are still not detecting the CSS corresponding to each block. Therefore, for the enhanced pagination to work correctly, the CSS of the blocks present in the Post Template must be stable on all pages.

The number of posts rendered by the Query block are always the same, except that in the last page, where there can be only a fraction. If any of the blocks rendered on the Post Template use the `wp_unique_id` function, the ID (which is incremental) will be different than in the previous pages and the class names will vary.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By replacing the usage of `wp_unique_id` in the layout support (which is used by the Query block) with an implementation that uses IDs that are incremental only for that block. That way, the generated class names are never affected by the number of times `wp_unique_id` runs.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Create multiple posts so you can paginate with the Query block.
- Configure the number of posts shown in each page so that on the last page, the number is different.
- Add a Group block inside the Post Template (the Group block uses the layout support).
- Set the Query block to a grid with at least 2 columns.
- Enable the enhanced pagination.
- Go to the previous to last page.
- Navigate to the last page.
- Check that the last page is rendered with 2 columns instead of 1.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3305402/f7d8e711-76b8-48f9-a655-9a19183050aa

After:

https://github.com/WordPress/gutenberg/assets/3305402/7e931389-6dcd-49ba-9ecd-c6ffbc070b88
