### PR TITLE
[Mobile] - Appium 2 Migration - Updating more utils

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -442,10 +442,10 @@ const selectTextFromElement = async ( driver, element ) => {
 			} )
 			.move( { x: startX, y: centerY } )
 			.down()
-			.pause( timeout )
-			.move( { x: endX, y: centerY, duration: timeout } )
+			.pause( timeout ) // Long-press at the start of the element
+			.move( { x: endX, y: centerY, duration: 1000 } ) // Slowly drag to the end of the element to highlight all text
 			.up()
-			.pause( timeout )
+			.pause( timeout ) // Pause to wait for the context menu to show up
 			.perform();
 	} else {
 		// On iOS we can use the context menu to "Select all" text.

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -320,7 +320,7 @@ const clickElementOutsideOfTextInput = async ( driver, element ) => {
 const longPressMiddleOfElement = async (
 	driver,
 	element,
-	waitTime = 5000, // Setting to wait a bit longer because this is failing more frequently on the CI
+	waitTime = 1000,
 	customElementSize
 ) => {
 	const location = await element.getLocation();
@@ -329,11 +329,28 @@ const longPressMiddleOfElement = async (
 	const x = location.x + size.width / 2;
 	const y = location.y + size.height / 2;
 
-	const action = new wd.TouchAction( driver )
-		.longPress( { x, y } )
-		.wait( waitTime )
-		.release();
-	await action.perform();
+	// Focus on the element first, otherwise on iOS it fails to open the context menu.
+	// We can't do it all in one action because it detects it as a force press and it
+	// is not supported by the simulator.
+	await driver
+		.action( 'pointer', {
+			parameters: { pointerType: 'touch' },
+		} )
+		.move( { origin: element } )
+		.down()
+		.up()
+		.perform();
+
+	// Long-press
+	await driver
+		.action( 'pointer', {
+			parameters: { pointerType: 'touch' },
+		} )
+		.move( { x, y } )
+		.down()
+		.pause( waitTime )
+		.up()
+		.perform();
 };
 
 // Press "Select All" in floating context menu.

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -419,15 +419,15 @@ const tapStatusBariOS = async ( driver ) => {
 };
 
 const selectTextFromElement = async ( driver, element ) => {
-	if ( isAndroid() ) {
-		await longPressMiddleOfElement( driver, element, 0 );
-	} else {
-		await doubleTap( driver, element );
-		await driver.waitForElementByXPath(
-			'//XCUIElementTypeMenuItem[@name="Copy"]',
-			wd.asserters.isDisplayed,
-			4000
+	await longPressMiddleOfElement( driver, element );
+
+	// On iOS long-pressing doesn't select the text automatically
+	if ( ! isAndroid() ) {
+		const selectAllElement = await driver.$(
+			'//XCUIElementTypeMenuItem[@name="Select All"]'
 		);
+		await selectAllElement.waitForDisplayed( { timeout: 1000 } );
+		await selectAllElement.click();
 	}
 };
 


### PR DESCRIPTION
**Related PRs:**
- Part of https://github.com/WordPress/gutenberg/pull/55166
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6291

## What?
This PR migrates the `longPressMiddleOfElement` and `selectTextFromElement` utilities to Appium 2 and WebdriverIO.

## Why?
To continue with the migration effort to support this new version and new driver.

## How?
For the `longPressMiddleOfElement` utility, it changes the code to use [actions](https://webdriver.io/docs/api/browser/action/), for iOS it was needed to tap first before long-pressing, using the element's `click` functionality didn't work for this case.

It was not possible to use the same action to tap and then long-press due to the action being recognized as a force-press action which is not supported by the simulator.

The `selectTextFromElement` utility was also changed to avoid using the `doubleTap` utility and instead, it uses the context menu to select the text.

## Testing Instructions
CI checks should pass as well as its related PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/6291
### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A