### PR TITLE
Cover Block: Check for previously uploaded media before setting the dimRatio

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -183,7 +183,12 @@ function CoverEdit( {
 			__unstableMarkNextChangeAsNotPersistent();
 		}
 
-		const newDimRatio = dimRatio === 100 ? 50 : dimRatio;
+		// Only set a new dimRatio if there was no previous media selected
+		// to avoid resetting to 50 if it has been explicitly set to 100.
+		// See issue #52835 for context.
+		const newDimRatio =
+			originalUrl === undefined && dimRatio === 100 ? 50 : dimRatio;
+
 		const newIsDark = compositeIsDark(
 			newDimRatio,
 			newOverlayColor,


### PR DESCRIPTION
Fixes #52835
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Stop resetting the `dimRatio` to 50 when background media has previously been set and the `dimRatio` is 100.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's possible to use the overlay gradient color opacity settings on a cover block instead of using overlay opacity. In this scenario a user would set the overlay opacity to 100. By doing this when a new image is set, the overlay opacity is always reset to 50 rather than staying at a user set 100.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check for `originalUrl` when deciding whether or not to reset the `dimRatio` to 50 when it was previously 100. This means that when a user sets the background media for the first time, it will still set a 50 `dimRatio`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Insert a cover block and set a background image
2. Confirm that the overlay opacity has been set to 50
3. Change the overlay opacity to 100.
4. Adjust the overlay color to use a gradient, and set the opacity of the gradient to something less than opaque (so you can see the background image).
5. Replace the background image with a different image.
6. Confirm that the overlay opacity setting remains at 100.
7. Try and break it with different combinations of overlay opacity settings or media uploads. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/WordPress/gutenberg/assets/1464705/e701012e-f57d-41f3-b9f5-d99b6e1bf811">  | <video src="https://github.com/WordPress/gutenberg/assets/1464705/382bb019-6e28-4817-b42e-5c2a493124d0">  |










