### PR TITLE
DataViews: Fix the actions menu in the list view

### DIFF
--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -155,14 +155,19 @@ function ViewList( {
 				header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,
 				id: 'actions',
 				cell: ( props ) => {
-					return <FieldActions item={ props.row.original } />;
+					return (
+						<FieldActions
+							item={ props.row.original }
+							actions={ actions }
+						/>
+					);
 				},
 				enableHiding: false,
 			} );
 		}
 
 		return _columns;
-	}, [ fields, actions ] );
+	}, [ fields, actions, view ] );
 
 	const columnVisibility = useMemo( () => {
 		if ( ! view.hiddenFields?.length ) {


### PR DESCRIPTION
In the new "page list" page of the site editor, right now in trunk the "actions menu" is broken in the list view due to a small omission, this PR fixes it.

**Testing instructions**

 - Open the site editor
 - Open the pages -> browse all pages page
 - Open the "actions menu" of a given page in the default list view
 - No JS error is triggered.