### PR TITLE
test: Update E2E test utils

### DIFF
--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -823,7 +823,15 @@ class EditorPage {
 				'//android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup';
 			await waitForVisible( this.driver, locator );
 
-			await swipeDown( this.driver );
+			const { width, height } = await this.driver.getWindowSize();
+			await this.driver
+				.action( 'pointer', {
+					parameters: { pointerType: 'touch' },
+				} )
+				.move( { x: width * 0.5, y: height * 0.1 } )
+				.down( { button: 0 } )
+				.up( { button: 0 } )
+				.perform();
 		} else {
 			await clickIfClickable(
 				this.driver,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Related PRs

- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6293

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix a utility to close the bottom sheet that was not performing as expected in
Appium 2.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to https://github.com/WordPress/gutenberg/pull/55166. The utility failed to close the bottom sheet.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It was unclear as to why the swipe gesture failed to close the bottom
sheet, but a simple tap towards the middle-top of the display achieves
the same result.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
