### PR TITLE
Navigation block: Fix Inaccurate description of the Show icon button setting

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -20,7 +20,7 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 				__nextHasNoMarginBottom
 				label={ __( 'Show icon button' ) }
 				help={ __(
-					'Configure the visual appearance of the button opening the overlay menu.'
+					'Configure the visual appearance of the button opening and closing the overlay menu.'
 				) }
 				onChange={ ( value ) => setAttributes( { hasIcon: value } ) }
 				checked={ hasIcon }

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -20,7 +20,7 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 				__nextHasNoMarginBottom
 				label={ __( 'Show icon button' ) }
 				help={ __(
-					'Configure the visual appearance of the button opening and closing the overlay menu.'
+					'Configure the visual appearance of the button that toggles the overlay menu.'
 				) }
 				onChange={ ( value ) => setAttributes( { hasIcon: value } ) }
 				checked={ hasIcon }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Goal is to adjust the description of the "Show icon button" setting to be more precise.

Fixes #55163

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Make the description more accurate so its clear for users what to expect.

## Testing Instructions

1. Go to the site editor
2. Add a Navigation block if there is none yet.
3. Select the Navigation and observe the settings panel.
4. Observe the "Show icon button' setting visually shows both the opening and closing buttons.
5. Observe it description only mentions both the opening and closing button.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
