### PR TITLE
Fix server processing of `wp-context` getting out of sync

### DIFF
--- a/lib/experimental/interactivity-api/class-wp-directive-context.php
+++ b/lib/experimental/interactivity-api/class-wp-directive-context.php
@@ -65,9 +65,10 @@ class WP_Directive_Context {
 	 * @return void
 	 */
 	public function set_context( $context ) {
-		if ( $context ) {
-			array_push( $this->stack, array_replace_recursive( $this->get_context(), $context ) );
-		}
+		array_push(
+			$this->stack,
+			array_replace_recursive( $this->get_context(), $context )
+		);
 	}
 
 	/**

--- a/lib/experimental/interactivity-api/directives/wp-context.php
+++ b/lib/experimental/interactivity-api/directives/wp-context.php
@@ -25,8 +25,8 @@ function gutenberg_interactivity_process_wp_context( $tags, $context ) {
 
 	$new_context = json_decode( $value, true );
 	if ( null === $new_context ) {
-		// Invalid JSON defined in the directive.
-		return;
+		// If the JSON is not valid, we still add an empty array to the stack.
+		$new_context = array();
 	}
 
 	$context->set_context( $new_context );

--- a/phpunit/experimental/interactivity-api/directives/wp-context-test.php
+++ b/phpunit/experimental/interactivity-api/directives/wp-context-test.php
@@ -73,4 +73,55 @@ class Tests_Directives_Attributes_WpContext extends WP_UnitTestCase {
 			$context->get_context()
 		);
 	}
+
+	public function test_directive_keeps_working_after_malformed_context_objects() {
+		$context = new WP_Directive_Context();
+
+		$markup = '
+			<div data-wp-context=\'{ "my-key": "some-value" }\'>
+				<div data-wp-context=\'{ "wrong_json_object: }\'>
+				</div>
+			</div>
+		';
+		$tags   = new WP_HTML_Tag_Processor( $markup );
+
+		// Parent div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Children div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Still the same context.
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Closing children div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Still the same context.
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Closing parent div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Now the context is empty.
+		$this->assertSame(
+			array(),
+			$context->get_context()
+		);
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix a problem where the internal stack of contexts could get out of sync when the JSON is not valid during the server processing of `wp-context`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As spotted by @darerodz [here](https://github.com/WordPress/gutenberg/pull/54816#discussion_r1348576341), the internal stack of contexts can get out of sync when a call to `set_context` fails.

> For context, the "Fatal error" that can be seen in [#54816 (comment)](https://github.com/WordPress/gutenberg/pull/54816#discussion_r1347222457) is caused by a problem inside[`gutenberg_interactivity_process_wp_context`](https://github.com/WordPress/gutenberg/blob/9b8d5c1dc353872f98fd1a3fca811e00a45c0de3/lib/experimental/interactivity-api/directives/wp-context.php#L14) implementation, which is calling `$context->rewind_context()` even when no context where added on a potential failure. That could empty the context stack and make subsequent `$context->set_context( $new_context )` calls fail.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Make sure that we're always adding a new `array` to the stack, even if the JSON is not valid.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This is covered by a unit test, but if you want to test it out:

- Add an interactive block.
- Add a div with valid JSON in a `wp-context` directive.
- Add nested divs inside with `wp-context` and invalid JSONs.
- Check that it doesn't do a fatal error and that the initial context is still valid.
