### PR TITLE
Query block: remove unnecessary class

### DIFF
--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -48,7 +48,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 			$content           = substr_replace(
 				$content,
 				'<div
-					class="wp-block-query__enhanced-pagination-navigation-announce screen-reader-text"
+					class="screen-reader-text"
 					aria-live="polite"
 					data-wp-text="context.core.query.message"
 				></div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove an unnecessary class on the Query block.

Mentioned in https://github.com/WordPress/gutenberg/pull/55309#discussion_r1361898911.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because nobody has a real need for that class yet and we are not using it. By exposing it, we will introduce a breaking change if we want to change it later.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just remove it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check that the screen reader keeps working fine when the enhanced pagination is enabled.