### PR TITLE
DataViews: iterate on filter's API

### DIFF
--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -69,12 +69,12 @@ The fields describe the dataset. For example:
 			);
 		},
 		elements: [
-			{ value: 1, label: 'admin' }
-			{ value: 2, label: 'user' }
+			{ value: 1, label: 'Admin' }
+			{ value: 2, label: 'User' }
 		]
 		filters: [
-			{ id: 'author', type: 'enumeration' },
-			{ id: 'author_search', type: 'search' }
+			'enumeration',
+			{ id: 'author_search', type: 'search', name: __( 'Search by author' ) }
 		],
 	},
 ]
@@ -85,10 +85,12 @@ The fields describe the dataset. For example:
 - `getValue`: function that returns the value of the field.
 - `render`: function that renders the field.
 - `elements`: a set of valid values for the field.
-- `filters`: what filters are available. A filter is an object with `id` and `type` as properties:
-	- `id`: unique identifier for the filter. Matches the entity query param.
+- `filters`: what filters are available for the user to use. A filter contains the following properties:
+	- `id`: unique identifier for the filter. Matches the entity query param. If not provided, the field's `id` is used.
+	- `name`: nice looking name for the filter. If not provided, the field's `header` is used.
 	- `type`: the type of filter. One of `search` or `enumeration`.
-
+	- `resetLabel`: the label for the reset option of the filter. If none provided, `All` is used.
+	- `resetValue`: the value for the reset option of the filter. If none provedid, `''` is used.
 
 ## DataViews
 

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -16,8 +16,15 @@ export default function Filters( { fields, view, onChangeView } ) {
 			return;
 		}
 
-		field.filters.forEach( ( f ) => {
-			filters[ f.id ] = { type: f.type };
+		field.filters.forEach( ( filter ) => {
+			if ( 'string' === typeof filter ) {
+				filters[ field.id ] = { type: filter };
+			}
+
+			if ( 'object' === typeof filter ) {
+				filters[ filter.id ] = { ...filter };
+				delete filters[ filter.id ].id;
+			}
 		} );
 	} );
 

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -17,13 +17,36 @@ export default function Filters( { fields, view, onChangeView } ) {
 		}
 
 		field.filters.forEach( ( filter ) => {
+			let id = field.id;
 			if ( 'string' === typeof filter ) {
-				filters[ field.id ] = { type: filter };
+				filters[ id ] = {
+					id,
+					name: field.header,
+					type: filter,
+				};
 			}
 
 			if ( 'object' === typeof filter ) {
-				filters[ filter.id ] = { ...filter };
-				delete filters[ filter.id ].id;
+				id = filter.id || field.id;
+				filters[ id ] = {
+					id,
+					name: filter.name || field.header,
+					type: filter.type,
+				};
+			}
+
+			if ( 'enumeration' === filters[ id ]?.type ) {
+				const elements = [
+					{
+						value: filter.resetValue || '',
+						label: filter.resetLabel || __( 'All' ),
+					},
+					...( field.elements || [] ),
+				];
+				filters[ id ] = {
+					...filters[ id ],
+					elements,
+				};
 			}
 		} );
 	} );
@@ -40,7 +63,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 				return (
 					<TextFilter
 						key={ filterName }
-						id={ filterName }
+						filter={ filter }
 						view={ view }
 						onChangeView={ onChangeView }
 					/>
@@ -50,8 +73,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 				return (
 					<InFilter
 						key={ filterName }
-						id={ filterName }
-						fields={ fields }
+						filter={ filter }
 						view={ view }
 						onChangeView={ onChangeView }
 					/>

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -14,21 +14,19 @@ import { unlock } from '../../lock-unlock';
 
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
-export default ( { id, fields, view, onChangeView } ) => {
-	const field = fields.find( ( f ) => f.id === id );
-
+export default ( { filter, view, onChangeView } ) => {
 	return (
 		<SelectControl
-			value={ view.filters[ id ] }
+			value={ view.filters[ filter.id ] }
 			prefix={
 				<InputControlPrefixWrapper
 					as="span"
 					className="dataviews__select-control-prefix"
 				>
-					{ field.header + ':' }
+					{ filter.name + ':' }
 				</InputControlPrefixWrapper>
 			}
-			options={ field?.elements || [] }
+			options={ filter.elements }
 			onChange={ ( value ) => {
 				if ( value === '' ) {
 					value = undefined;
@@ -38,7 +36,7 @@ export default ( { id, fields, view, onChangeView } ) => {
 					...currentView,
 					filters: cleanEmptyObject( {
 						...currentView.filters,
-						[ id ]: value,
+						[ filter.id ]: value,
 					} ),
 				} ) );
 			} }

--- a/packages/edit-site/src/components/dataviews/text-filter.js
+++ b/packages/edit-site/src/components/dataviews/text-filter.js
@@ -10,9 +10,9 @@ import { SearchControl } from '@wordpress/components';
  */
 import useDebouncedInput from '../../utils/use-debounced-input';
 
-export default function TextFilter( { id, view, onChangeView } ) {
+export default function TextFilter( { filter, view, onChangeView } ) {
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput(
-		view.filters[ id ]
+		view.filters[ filter.id ]
 	);
 	const onChangeViewRef = useRef( onChangeView );
 	useEffect( () => {
@@ -24,7 +24,7 @@ export default function TextFilter( { id, view, onChangeView } ) {
 			page: 1,
 			filters: {
 				...currentView.filters,
-				[ id ]: debouncedSearch,
+				[ filter.id ]: debouncedSearch,
 			},
 		} ) );
 	}, [ debouncedSearch ] );

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -133,7 +133,9 @@ export default function PagePages() {
 						</VStack>
 					);
 				},
-				filters: [ { id: 'search', type: 'search' } ],
+				filters: [
+					{ id: 'search', type: 'search', name: __( 'Search' ) },
+				],
 				maxWidth: 400,
 				sortingFn: 'alphanumeric',
 				enableHiding: false,
@@ -151,26 +153,26 @@ export default function PagePages() {
 					);
 				},
 				filters: [ 'enumeration' ],
-				elements: [
-					{
-						value: '',
-						label: __( 'All' ),
-					},
-					...( authors?.map( ( { id, name } ) => ( {
+				elements:
+					authors?.map( ( { id, name } ) => ( {
 						value: id,
 						label: name,
-					} ) ) || [] ),
-				],
+					} ) ) || [],
 			},
 			{
 				header: __( 'Status' ),
 				id: 'status',
 				getValue: ( { item } ) =>
 					postStatuses[ item.status ] ?? item.status,
-				filters: [ { type: 'enumeration', id: 'status' } ],
-				elements: [
-					{ label: __( 'All' ), value: 'publish,draft' },
-					...( ( postStatuses &&
+				filters: [
+					{
+						type: 'enumeration',
+						id: 'status',
+						resetValue: 'publish,draft',
+					},
+				],
+				elements:
+					( postStatuses &&
 						Object.entries( postStatuses )
 							.filter( ( [ slug ] ) =>
 								[ 'publish', 'draft' ].includes( slug )
@@ -179,8 +181,7 @@ export default function PagePages() {
 								value: slug,
 								label: name,
 							} ) ) ) ||
-						[] ),
-				],
+					[],
 				enableSorting: false,
 			},
 			{

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -150,7 +150,7 @@ export default function PagePages() {
 						</a>
 					);
 				},
-				filters: [ { id: 'author', type: 'enumeration' } ],
+				filters: [ 'enumeration' ],
 				elements: [
 					{
 						value: '',


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/55270

## What?

Introduces a few changes to the filters:

- Allow providing a string or an object to declare a filter.

```js
{
  id: 'field_id',
  header: 'Field Header',
  filters: [
    'enumeration', // Shorthand for { type: 'enumeration', id: 'field_id', name: 'Field Header' }
    { type: 'search',  id: 'author_search', name: __( 'Search by author' ) }
  ]
}
```

- Improves how the reset value of the filter is provided.

Before: the `field.elements` property held all values, including the "reset value". After: the `field.elements` property only holds the set of elements and the filter provides the "reset value" by default. The filter can also change it.

```js
{
  id: 'field-id',
  header: 'Field Header',
  elements: authors,
  filters: [
    'enumeration', // Reset option is: { value: "", label: "All" }
    { id: 'filter-id', type: 'enumeration', resetValue: "publish, draft" } // Reset option is { value: "publish, draft", label: "All" }
  ]
}
```

## Testing Instructions

Verify that the filters in the "Site editor > Pages > Manage all pages" experiment work as before.
