### PR TITLE
Performance tests: Fix canvas locator timeout

### DIFF
--- a/test/performance/fixtures/perf-utils.ts
+++ b/test/performance/fixtures/perf-utils.ts
@@ -54,9 +54,7 @@ export class PerfUtils {
 	 * @return URL of the saved draft.
 	 */
 	async saveDraft() {
-		await this.page
-			.getByRole( 'button', { name: 'Save draft' } )
-			.click( { timeout: 60_000 } );
+		await this.page.getByRole( 'button', { name: 'Save draft' } ).click();
 		await expect(
 			this.page.getByRole( 'button', { name: 'Saved' } )
 		).toBeDisabled();

--- a/test/performance/fixtures/perf-utils.ts
+++ b/test/performance/fixtures/perf-utils.ts
@@ -33,26 +33,19 @@ export class PerfUtils {
 	 * @return Locator for the editor canvas element.
 	 */
 	async getCanvas() {
-		return await Promise.any( [
-			( async () => {
-				const legacyCanvasLocator = this.page.locator(
-					'.wp-block-post-content'
-				);
-				await legacyCanvasLocator.waitFor( {
-					timeout: 120_000,
-				} );
-				return legacyCanvasLocator;
-			} )(),
-			( async () => {
-				const iframedCanvasLocator = this.page.frameLocator(
-					'[name=editor-canvas]'
-				);
-				await iframedCanvasLocator
-					.locator( 'body' )
-					.waitFor( { timeout: 120_000 } );
-				return iframedCanvasLocator;
-			} )(),
-		] );
+		const canvasLocator = this.page.locator(
+			'.wp-block-post-content, iframe[name=editor-canvas]'
+		);
+
+		const isFramed = await canvasLocator.evaluate(
+			( node ) => node.tagName === 'IFRAME'
+		);
+
+		if ( isFramed ) {
+			return canvasLocator.frameLocator( ':scope' );
+		}
+
+		return canvasLocator;
 	}
 
 	/**

--- a/test/performance/fixtures/perf-utils.ts
+++ b/test/performance/fixtures/perf-utils.ts
@@ -68,6 +68,8 @@ export class PerfUtils {
 	 * Disables the editor autosave function.
 	 */
 	async disableAutosave() {
+		await this.page.waitForFunction( () => window?.wp?.data );
+
 		await this.page.evaluate( () => {
 			return window.wp.data
 				.dispatch( 'core/editor' )
@@ -76,12 +78,6 @@ export class PerfUtils {
 					localAutosaveInterval: 100000000000,
 				} );
 		} );
-
-		const { autosaveInterval } = await this.page.evaluate( () => {
-			return window.wp.data.select( 'core/editor' ).getEditorSettings();
-		} );
-
-		expect( autosaveInterval ).toBe( 100000000000 );
 	}
 
 	/**
@@ -132,6 +128,10 @@ export class PerfUtils {
 			throw new Error( `File not found: ${ filepath }` );
 		}
 
+		await this.page.waitForFunction(
+			() => window?.wp?.blocks && window?.wp?.data
+		);
+
 		return await this.page.evaluate( ( html: string ) => {
 			const { parse } = window.wp.blocks;
 			const { dispatch } = window.wp.data;
@@ -152,6 +152,10 @@ export class PerfUtils {
 	 * Generates and loads a 1000 empty paragraphs into the editor canvas.
 	 */
 	async load1000Paragraphs() {
+		await this.page.waitForFunction(
+			() => window?.wp?.blocks && window?.wp?.data
+		);
+
 		await this.page.evaluate( () => {
 			const { createBlock } = window.wp.blocks;
 			const { dispatch } = window.wp.data;

--- a/test/performance/playwright.config.ts
+++ b/test/performance/playwright.config.ts
@@ -27,6 +27,7 @@ const config = defineConfig( {
 	),
 	use: {
 		...baseConfig.use,
+		actionTimeout: 120_000, // 2 minutes.
 		video: 'off',
 	},
 } );

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -70,9 +70,7 @@ test.describe( 'Post Editor Performance', () => {
 				const canvas = await perfUtils.getCanvas();
 
 				// Wait for the first block.
-				await canvas.locator( '.wp-block' ).first().waitFor( {
-					timeout: 120_000,
-				} );
+				await canvas.locator( '.wp-block' ).first().waitFor();
 
 				// Get the durations.
 				const loadingDurations = await metrics.getLoadingDurations();

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -86,9 +86,7 @@ test.describe( 'Site Editor Performance', () => {
 				const canvas = await perfUtils.getCanvas();
 
 				// Wait for the first block.
-				await canvas.locator( '.wp-block' ).first().waitFor( {
-					timeout: 120_000,
-				} );
+				await canvas.locator( '.wp-block' ).first().waitFor();
 
 				// Get the durations.
 				const loadingDurations = await metrics.getLoadingDurations();
@@ -142,7 +140,7 @@ test.describe( 'Site Editor Performance', () => {
 					// Spinner was used instead of the progress bar in an earlier version of the site editor.
 					'.edit-site-canvas-loader, .edit-site-canvas-spinner'
 				)
-				.waitFor( { state: 'hidden', timeout: 120_000 } );
+				.waitFor( { state: 'hidden' } );
 
 			const canvas = await perfUtils.getCanvas();
 


### PR DESCRIPTION
## What?
The current `getCanvas()` implementation leaves a locator timeout error in the trace zip, which can be confusing when debugging failures. It happens because we're using `Promise.any()` to detect which canvas selector – legacy or iframed – is found first. While the ignored promise doesn't fail a test, it will asynchronously throw a timeout error in the trace file, which can be misleading when inspecting that trace. 

Additionally, replace the per case increased timeouts with a globally increased `actionTimeout` for the performance tests. Giving all the actions more time makes more sense since we're often testing against large content in both post and site editors. 

## Testing Instructions
All tests should pass.