### PR TITLE
[Mobile] Improve Screen recording on Android for Appium 2

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/get-android-emulator-id.js
+++ b/packages/react-native-editor/__device-tests__/helpers/get-android-emulator-id.js
@@ -9,12 +9,7 @@ export function getAndroidEmulatorID() {
 
 		const lines = adbOutput
 			.split( '\n' )
-			.filter(
-				( line ) =>
-					line &&
-					! line.startsWith( 'List' ) &&
-					line.includes( 'emulator-' )
-			);
+			.filter( ( line ) => line && line.includes( 'emulator-' ) );
 
 		if ( lines.length === 0 ) {
 			// eslint-disable-next-line no-console

--- a/packages/react-native-editor/__device-tests__/helpers/get-android-emulator-id.js
+++ b/packages/react-native-editor/__device-tests__/helpers/get-android-emulator-id.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+const childProcess = require( 'child_process' );
+
+export function getAndroidEmulatorID() {
+	try {
+		const adbOutput = childProcess.execSync( 'adb devices -l' ).toString();
+
+		const lines = adbOutput
+			.split( '\n' )
+			.filter(
+				( line ) =>
+					line &&
+					! line.startsWith( 'List' ) &&
+					line.includes( 'emulator-' )
+			);
+
+		if ( lines.length === 0 ) {
+			// eslint-disable-next-line no-console
+			console.error( 'No available emulators found.' );
+			return null;
+		}
+		const firstEmulatorLine = lines[ 0 ];
+		// Extract device ID from the beginning of the line
+		return firstEmulatorLine.split( /\s+/ )[ 0 ];
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			'Failed to fetch the first available emulator ID:',
+			error.message
+		);
+		return null;
+	}
+}

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -20,6 +20,7 @@ const {
 	prefixKeysWithAppium,
 } = require( './caps' );
 const AppiumLocal = require( './appium-local' );
+import { getAndroidEmulatorID } from './get-android-emulator-id';
 
 // Platform setup.
 const defaultPlatform = 'android';
@@ -104,10 +105,14 @@ const setupDriver = async () => {
 	if ( isAndroid() ) {
 		desiredCaps = { ...android };
 		if ( isLocalEnvironment() ) {
+			const androidDeviceID = getAndroidEmulatorID();
 			desiredCaps.app = path.resolve( localAndroidAppPath );
+			desiredCaps.udid = androidDeviceID;
 			try {
 				const androidVersion = childProcess
-					.execSync( 'adb shell getprop ro.build.version.release' )
+					.execSync(
+						`adb -s ${ androidDeviceID } shell getprop ro.build.version.release`
+					)
 					.toString()
 					.replace( /^\s+|\s+$/g, '' );
 				delete desiredCaps.platformVersion;

--- a/packages/react-native-editor/jest_ui_setup_after_env.js
+++ b/packages/react-native-editor/jest_ui_setup_after_env.js
@@ -14,6 +14,7 @@ jest.setTimeout( 1000000 ); // In milliseconds.
 
 let iOSScreenRecordingProcess;
 let androidScreenRecordingProcess;
+let deviceID;
 
 const isMacOSEnvironment = () => {
 	return process.platform === 'darwin';
@@ -21,20 +22,75 @@ const isMacOSEnvironment = () => {
 
 const IOS_RECORDINGS_DIR = './ios-screen-recordings';
 const ANDROID_RECORDINGS_DIR = './android-screen-recordings';
+const ANDROID_EMULATOR_DIR = '/sdcard/';
 
 const getScreenRecordingFileNameBase = ( testPath, id ) => {
 	const suiteName = path.basename( testPath, '.test.js' );
 	return `${ suiteName }.${ id }`;
 };
 
+function deleteRecordingFile( filePath ) {
+	if ( fs.existsSync( filePath ) ) {
+		try {
+			fs.unlinkSync( filePath );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error(
+				`Failed to delete ${ filePath }. Error: ${ error.message }`
+			);
+		}
+	}
+}
+
+async function getAndroidDeviceID() {
+	try {
+		const session = await global.editorPage.driver.getSession();
+		return session.deviceUDID;
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Failed to fetch Android device ID:', error.message );
+		return null;
+	}
+}
+
 let allPassed = true;
+
+function logAndroidError( data ) {
+	// eslint-disable-next-line no-console
+	console.log( `Android screen recording error => ${ data }` );
+}
+
+// Setup the listener before each test.
+beforeEach( () => {
+	if (
+		androidScreenRecordingProcess &&
+		androidScreenRecordingProcess.stderr
+	) {
+		androidScreenRecordingProcess.stderr.on( 'data', logAndroidError );
+	}
+} );
+
+// Cleanup the listener after each test.
+afterEach( () => {
+	if (
+		androidScreenRecordingProcess &&
+		androidScreenRecordingProcess.stderr
+	) {
+		androidScreenRecordingProcess.stderr.removeListener(
+			'data',
+			logAndroidError
+		);
+	}
+} );
 
 // eslint-disable-next-line jest/no-jasmine-globals, no-undef
 jasmine.getEnv().addReporter( {
-	specStarted: ( { testPath, id } ) => {
+	specStarted: async ( { testPath, id } ) => {
 		if ( ! isMacOSEnvironment() ) {
 			return;
 		}
+
+		deviceID = await getAndroidDeviceID();
 
 		const fileName =
 			getScreenRecordingFileNameBase( testPath, id ) + '.mp4';
@@ -44,7 +100,20 @@ jasmine.getEnv().addReporter( {
 				fs.mkdirSync( ANDROID_RECORDINGS_DIR );
 			}
 
+			// Use the "mkdir -p" command to create the
+			// ANDROID_EMULATOR_DIR directory if it doesn't exists.
+			try {
+				childProcess.execSync(
+					`adb -s ${ deviceID } shell "mkdir -p ${ ANDROID_EMULATOR_DIR }" 2>/dev/null`
+				);
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( `Failed to create the directory: ${ error }` );
+			}
+
 			androidScreenRecordingProcess = childProcess.spawn( 'adb', [
+				'-s',
+				deviceID,
 				'shell',
 				'screenrecord',
 				'--verbose',
@@ -52,14 +121,8 @@ jasmine.getEnv().addReporter( {
 				'1M',
 				'--size',
 				'720x1280',
-				`/sdcard/${ fileName }`,
+				`${ ANDROID_EMULATOR_DIR }${ fileName }`,
 			] );
-
-			androidScreenRecordingProcess.stderr.on( 'data', ( data ) => {
-				// eslint-disable-next-line no-console
-				console.log( `Android screen recording error => ${ data }` );
-			} );
-
 			return;
 		}
 
@@ -85,6 +148,7 @@ jasmine.getEnv().addReporter( {
 	},
 	specDone: ( { testPath, id, status } ) => {
 		allPassed = allPassed && status !== 'failed';
+		const isTestSkipped = status === 'pending';
 
 		if ( ! isMacOSEnvironment() ) {
 			return;
@@ -97,9 +161,16 @@ jasmine.getEnv().addReporter( {
 			// Wait for kill.
 			childProcess.execSync( 'sleep 1' );
 
+			const recordingFilePath = `${ ANDROID_RECORDINGS_DIR }/${ fileNameBase }.mp4`;
+
+			if ( isTestSkipped ) {
+				deleteRecordingFile( recordingFilePath );
+				return;
+			}
+
 			try {
 				childProcess.execSync(
-					`adb pull /sdcard/${ fileNameBase }.mp4 ${ ANDROID_RECORDINGS_DIR }`
+					`adb -s ${ deviceID } pull ${ ANDROID_EMULATOR_DIR }${ fileNameBase }.mp4 ${ ANDROID_RECORDINGS_DIR }`
 				);
 			} catch ( error ) {
 				// Some (old) Android devices don't support screen recording or
@@ -113,22 +184,27 @@ jasmine.getEnv().addReporter( {
 				);
 			}
 
-			const oldPath = `${ ANDROID_RECORDINGS_DIR }/${ fileNameBase }.mp4`;
 			const newPath = `${ ANDROID_RECORDINGS_DIR }/${ fileNameBase }.${ status }.mp4`;
 
-			if ( fs.existsSync( oldPath ) ) {
-				fs.renameSync( oldPath, newPath );
+			if ( fs.existsSync( recordingFilePath ) ) {
+				fs.renameSync( recordingFilePath, newPath );
 			}
 			return;
 		}
 
 		iOSScreenRecordingProcess.kill( 'SIGINT' );
 
-		const oldPath = `${ IOS_RECORDINGS_DIR }/${ fileNameBase }.mp4`;
+		const recordingFilePath = `${ IOS_RECORDINGS_DIR }/${ fileNameBase }.mp4`;
+
+		if ( isTestSkipped ) {
+			deleteRecordingFile( recordingFilePath );
+			return;
+		}
+
 		const newPath = `${ IOS_RECORDINGS_DIR }/${ fileNameBase }.${ status }.mp4`;
 
-		if ( fs.existsSync( oldPath ) ) {
-			fs.renameSync( oldPath, newPath );
+		if ( fs.existsSync( recordingFilePath ) ) {
+			fs.renameSync( recordingFilePath, newPath );
 		}
 	},
 } );

--- a/packages/react-native-editor/jest_ui_setup_after_env.js
+++ b/packages/react-native-editor/jest_ui_setup_after_env.js
@@ -42,13 +42,13 @@ function deleteRecordingFile( filePath ) {
 	}
 }
 
-async function getAndroidDeviceID() {
+async function getDeviceID() {
 	try {
 		const session = await global.editorPage.driver.getSession();
 		return session.deviceUDID;
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
-		console.error( 'Failed to fetch Android device ID:', error.message );
+		console.error( 'Failed to fetch the device ID:', error.message );
 		return null;
 	}
 }
@@ -90,7 +90,7 @@ jasmine.getEnv().addReporter( {
 			return;
 		}
 
-		deviceID = await getAndroidDeviceID();
+		deviceID = await getDeviceID();
 
 		const fileName =
 			getScreenRecordingFileNameBase( testPath, id ) + '.mp4';

--- a/packages/react-native-editor/jest_ui_setup_after_env.js
+++ b/packages/react-native-editor/jest_ui_setup_after_env.js
@@ -9,6 +9,7 @@ const childProcess = require( 'child_process' );
  * Internal dependencies
  */
 const { isAndroid } = require( './__device-tests__/helpers/utils' );
+import { getAndroidEmulatorID } from './__device-tests__/helpers/get-android-emulator-id';
 
 jest.setTimeout( 1000000 ); // In milliseconds.
 
@@ -42,32 +43,6 @@ function deleteRecordingFile( filePath ) {
 	}
 }
 
-function getFirstAvailableAndroidEmulatorID() {
-	try {
-		const adbOutput = childProcess.execSync( 'adb devices -l' ).toString();
-
-		// Split by line and extract the device ID from the first line (excluding the header)
-		const lines = adbOutput
-			.split( '\n' )
-			.filter( ( line ) => line && ! line.startsWith( 'List' ) );
-		if ( lines.length === 0 ) {
-			// eslint-disable-next-line no-console
-			console.error( 'No available devices found.' );
-			return null;
-		}
-		const firstDeviceLine = lines[ 0 ];
-		// Extract device ID from the beginning of the line
-		return firstDeviceLine.split( /\s+/ )[ 0 ];
-	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error(
-			'Failed to fetch the first available device ID:',
-			error.message
-		);
-		return null;
-	}
-}
-
 let allPassed = true;
 
 // eslint-disable-next-line jest/no-jasmine-globals, no-undef
@@ -77,7 +52,7 @@ jasmine.getEnv().addReporter( {
 			return;
 		}
 
-		androidDeviceID = getFirstAvailableAndroidEmulatorID();
+		androidDeviceID = getAndroidEmulatorID();
 		const fileName =
 			getScreenRecordingFileNameBase( testPath, id ) + '.mp4';
 

--- a/packages/react-native-editor/jest_ui_setup_after_env.js
+++ b/packages/react-native-editor/jest_ui_setup_after_env.js
@@ -101,7 +101,7 @@ jasmine.getEnv().addReporter( {
 			}
 
 			// Use the "mkdir -p" command to create the
-			// ANDROID_EMULATOR_DIR directory if it doesn't exists.
+			// ANDROID_EMULATOR_DIR directory if it doesn't exist.
 			try {
 				childProcess.execSync(
 					`adb -s ${ deviceID } shell "mkdir -p ${ ANDROID_EMULATOR_DIR }" 2>/dev/null`

--- a/packages/react-native-editor/jest_ui_setup_after_env.js
+++ b/packages/react-native-editor/jest_ui_setup_after_env.js
@@ -45,6 +45,8 @@ function deleteRecordingFile( filePath ) {
 async function getDeviceID() {
 	try {
 		const session = await global.editorPage.driver.getSession();
+		// eslint-disable-next-line no-console
+		console.log( 'session', session );
 		return session.deviceUDID;
 	} catch ( error ) {
 		// eslint-disable-next-line no-console

--- a/packages/react-native-editor/jest_ui_setup_after_env.js
+++ b/packages/react-native-editor/jest_ui_setup_after_env.js
@@ -52,11 +52,12 @@ jasmine.getEnv().addReporter( {
 			return;
 		}
 
-		androidDeviceID = getAndroidEmulatorID();
 		const fileName =
 			getScreenRecordingFileNameBase( testPath, id ) + '.mp4';
 
 		if ( isAndroid() ) {
+			androidDeviceID = getAndroidEmulatorID();
+
 			if ( ! fs.existsSync( ANDROID_RECORDINGS_DIR ) ) {
 				fs.mkdirSync( ANDROID_RECORDINGS_DIR );
 			}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/pull/55166

## What?
This PR updates the logic related to detecting the Android device and how it triggers the `adb` commands, now it will use the first emulator ID available to avoid issues of multiple devices connected.

## Why?
To avoid showing warnings when multiple devices were connected.

It also updates the logic related to screen recordings to avoid having empty files for `skipped` tests

## How?
It adds a `getAndroidEmulatorID` function to get the first available emulator, this avoids issues when multiple devices are connected.

It cleans up empty screen recordings for `skipped` tests.

## Testing Instructions
CI checks should pass.

Screen recording artifacts should be stored.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A