### PR TITLE
[Data views]: Refactor to allow the rendering to be generated using a fields description

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -22,6 +22,7 @@ export default function DataViews( {
 	fields,
 	actions,
 	data,
+	dataConfig,
 	isLoading = false,
 	paginationInfo,
 } ) {
@@ -29,9 +30,11 @@ export default function DataViews( {
 	const _fields = useMemo( () => {
 		return fields.map( ( field ) => ( {
 			...field,
-			render: field.render || field.getValue,
+			render:
+				dataConfig[ field.id ]?.view?.( field.getValue ) ||
+				field.getValue,
 		} ) );
-	}, [ fields ] );
+	}, [ fields, dataConfig ] );
 	return (
 		<div className="dataviews-wrapper">
 			<VStack spacing={ 4 }>

--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -22,7 +22,6 @@ export default function DataViews( {
 	fields,
 	actions,
 	data,
-	dataConfig,
 	isLoading = false,
 	paginationInfo,
 } ) {
@@ -30,11 +29,9 @@ export default function DataViews( {
 	const _fields = useMemo( () => {
 		return fields.map( ( field ) => ( {
 			...field,
-			render:
-				dataConfig[ field.id ]?.view?.( field.getValue ) ||
-				field.getValue,
+			render: field.render?.( field.getValue ) || field.getValue,
 		} ) );
-	}, [ fields, dataConfig ] );
+	}, [ fields ] );
 	return (
 		<div className="dataviews-wrapper">
 			<VStack spacing={ 4 }>

--- a/packages/edit-site/src/components/dataviews/field-types.js
+++ b/packages/edit-site/src/components/dataviews/field-types.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import Media from '../../components/media';
+
+export const coreFieldTypes = {
+	string: {
+		view:
+			( getValue ) =>
+			( { item } ) =>
+				getValue( { item } ),
+	},
+	date: {
+		view: ( { item, getValue } ) => <time>{ getValue( { item } ) }</time>,
+	},
+	image: {
+		view:
+			( getValue ) =>
+			( { item } ) => (
+				<Media id={ getValue( { item } ) } size={ [ 'thumbnail' ] } />
+			),
+	},
+};

--- a/packages/edit-site/src/components/dataviews/field-types.js
+++ b/packages/edit-site/src/components/dataviews/field-types.js
@@ -5,16 +5,18 @@ import Media from '../../components/media';
 
 export const coreFieldTypes = {
 	string: {
-		view:
+		render:
 			( getValue ) =>
 			( { item } ) =>
 				getValue( { item } ),
 	},
 	date: {
-		view: ( { item, getValue } ) => <time>{ getValue( { item } ) }</time>,
+		render:
+			( getValue ) =>
+			( { item } ) => <time>{ getValue( { item } ) }</time>,
 	},
 	image: {
-		view:
+		render:
 			( getValue ) =>
 			( { item } ) => (
 				<Media id={ getValue( { item } ) } size={ [ 'thumbnail' ] } />

--- a/packages/edit-site/src/components/dataviews/index.js
+++ b/packages/edit-site/src/components/dataviews/index.js
@@ -1,1 +1,2 @@
 export { default as DataViews } from './dataviews';
+export { coreFieldTypes } from './field-types';

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -20,7 +20,7 @@ export function ViewGrid( { data, fields, view, actions } ) {
 	);
 	const visibleFields = fields.filter(
 		( field ) =>
-			! view.hiddenFields.includes( field.id ) &&
+			! view.hiddenFields?.includes( field.id ) &&
 			field.id !== view.layout.mediaField
 	);
 	return (


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/55083

This PR introduces some core field types and use them for rendering of fields based on this config. If a fields needs to do more than the default behavior, it can override the prop. 

This approach makes the field's `getValue` prop, a required one. We need to check later on the nuances of mapping this to `accessorFn` for `list` view, but that's a separate issue to tackle.

The format I'm suggesting is a closure function that first gets the `getValue` function of a field, and this is needed because we normalize the `render` function in the main `DataViews` component. At that point we have no access to a single data record.

In the long run we will add more things to the field types, like an `edit` that could be something like:
```
edit( record, onChange) {
	return <TextControl value={record.name}  onChange={onChange} />;
},
```


## Testing Instructions
1. Everything should work as before


