### PR TITLE
Fix: Update page title when using enhanced pagination in query loop.

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Update the title when using enhanced pagination. ([#55446](https://github.com/WordPress/gutenberg/pull/55446))
+
 ## 2.5.0 (2023-10-18)
 
 ## 2.4.0 (2023-10-05)
@@ -16,7 +20,6 @@
 
 -   Remove `role` attribute when set to `null` in `data-wp-bind`. ([#54608](https://github.com/WordPress/gutenberg/pull/54608))
 -   Add `timeout` option to `navigate()`, with a default value of `10000` milliseconds. ([#54474](https://github.com/WordPress/gutenberg/pull/54474))
--   Update the title when using enhanced pagination. ([#55446](https://github.com/WordPress/gutenberg/pull/55446))
 
 ## 2.2.0 (2023-08-31)
 

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 -   Remove `role` attribute when set to `null` in `data-wp-bind`. ([#54608](https://github.com/WordPress/gutenberg/pull/54608))
 -   Add `timeout` option to `navigate()`, with a default value of `10000` milliseconds. ([#54474](https://github.com/WordPress/gutenberg/pull/54474))
+-   Update the title when using enhanced pagination. ([#55446](https://github.com/WordPress/gutenberg/pull/55446))
 
 ## 2.2.0 (2023-08-31)
 

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -55,7 +55,7 @@ const regionsToVdom = ( dom ) => {
 		const id = region.getAttribute( attrName );
 		regions[ id ] = toVdom( region );
 	} );
-	const title = dom.querySelector( 'title' ).innerHTML || null;
+	const title = dom.querySelector( 'title' ).innerText || null;
 	return { regions, title };
 };
 

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -50,14 +50,13 @@ const fetchPage = async ( url, { html } ) => {
 // `navigation-id` directive.
 const regionsToVdom = ( dom ) => {
 	const regions = {};
-	const titles = {};
 	const attrName = `data-${ directivePrefix }-navigation-id`;
 	dom.querySelectorAll( `[${ attrName }]` ).forEach( ( region ) => {
 		const id = region.getAttribute( attrName );
 		regions[ id ] = toVdom( region );
-		titles[ id ] = dom.querySelectorAll( 'title' )[ 0 ].innerHTML || null;
 	} );
-	return { regions, titles };
+	const title = dom.querySelector( 'title' ).innerHTML || null;
+	return { regions, title };
 };
 
 // Prefetch a page. We store the promise to avoid triggering a second fetch for
@@ -76,8 +75,8 @@ const renderRegions = ( page ) => {
 		const id = region.getAttribute( attrName );
 		const fragment = getRegionRootFragment( region );
 		render( page.regions[ id ], fragment );
-		if ( page.titles[ id ] ) {
-			document.title = page.titles[ id ];
+		if ( page.title ) {
+			document.title = page.title;
 		}
 	} );
 };

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -55,7 +55,7 @@ const regionsToVdom = ( dom ) => {
 		const id = region.getAttribute( attrName );
 		regions[ id ] = toVdom( region );
 	} );
-	const title = dom.querySelector( 'title' ).innerText || null;
+	const title = dom.querySelector( 'title' )?.innerText;
 	return { regions, title };
 };
 
@@ -75,10 +75,10 @@ const renderRegions = ( page ) => {
 		const id = region.getAttribute( attrName );
 		const fragment = getRegionRootFragment( region );
 		render( page.regions[ id ], fragment );
-		if ( page.title ) {
-			document.title = page.title;
-		}
 	} );
+	if ( page.title ) {
+		document.title = page.title;
+	}
 };
 
 // Variable to store the current navigation.

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -50,13 +50,14 @@ const fetchPage = async ( url, { html } ) => {
 // `navigation-id` directive.
 const regionsToVdom = ( dom ) => {
 	const regions = {};
+	const titles = {};
 	const attrName = `data-${ directivePrefix }-navigation-id`;
 	dom.querySelectorAll( `[${ attrName }]` ).forEach( ( region ) => {
 		const id = region.getAttribute( attrName );
 		regions[ id ] = toVdom( region );
+		titles[ id ] = dom.querySelectorAll( 'title' )[ 0 ].innerHTML || null;
 	} );
-
-	return { regions };
+	return { regions, titles };
 };
 
 // Prefetch a page. We store the promise to avoid triggering a second fetch for
@@ -75,6 +76,9 @@ const renderRegions = ( page ) => {
 		const id = region.getAttribute( attrName );
 		const fragment = getRegionRootFragment( region );
 		render( page.regions[ id ], fragment );
+		if ( page.titles[ id ] ) {
+			document.title = page.titles[ id ];
+		}
 	} );
 };
 

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -47,6 +47,7 @@ export default class InteractivityUtils {
 			content: `<!-- wp:${ block } /-->`,
 			status: 'publish' as 'publish',
 			date_gmt: '2023-01-01T00:00:00',
+			title: alias,
 		};
 
 		const { link } = await this.requestUtils.createPost( payload );

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -98,19 +98,16 @@ test.describe( 'Router regions', () => {
 		await expect( nestedRegionSsr ).toHaveText( 'content from page 1' );
 	} );
 
-	test( 'Page title is updated', async ( { page } ) => {
-		expect( await page.title() ).toBe(
+	test( 'Page title is updated 2', async ( { page } ) => {
+		await expect( page ).toHaveTitle(
 			'router regions – page 1 – gutenberg'
 		);
 		await page.getByTestId( 'next' ).click();
-		await page.waitForFunction(
-			() => document.title === 'router regions – page 2 – gutenberg'
-		);
-		expect( await page.title() ).toBe(
+		await expect( page ).toHaveTitle(
 			'router regions – page 2 – gutenberg'
 		);
 		await page.getByTestId( 'back' ).click();
-		expect( await page.title() ).toBe(
+		await expect( page ).toHaveTitle(
 			'router regions – page 1 – gutenberg'
 		);
 	} );

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -97,4 +97,21 @@ test.describe( 'Router regions', () => {
 		await page.getByTestId( 'back' ).click();
 		await expect( nestedRegionSsr ).toHaveText( 'content from page 1' );
 	} );
+
+	test( 'Page title is updated', async ( { page } ) => {
+		expect( await page.title() ).toBe(
+			'router regions – page 1 – gutenberg'
+		);
+		await page.getByTestId( 'next' ).click();
+		await page.waitForFunction(
+			() => document.title === 'router regions – page 2 – gutenberg'
+		);
+		expect( await page.title() ).toBe(
+			'router regions – page 2 – gutenberg'
+		);
+		await page.getByTestId( 'back' ).click();
+		expect( await page.title() ).toBe(
+			'router regions – page 1 – gutenberg'
+		);
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update the Document Title when the enhanced pagination is enabled on the Query Loop.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

User experience :-). 
To simulate a navigation, we should update page title, page description, and meta tags.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding the tittle to the Interactivity API router.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Enable enhanced pagination in your query loop.
- Add enough posts to have pagination.
- Check that the title is updating accordingly.
- Try with more than one query in the same page.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/37012961/669fb54e-b063-4f4b-837c-8e173e8c2dec

