### PR TITLE
useAvailableAlignments: avoid useSelect subscription when alignments array is empty

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -19,29 +19,43 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	if ( ! controls.includes( 'none' ) ) {
 		controls = [ 'none', ...controls ];
 	}
-	const {
-		wideControlsEnabled = false,
-		themeSupportsLayout,
-		isBlockBasedTheme,
-	} = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
-		return {
-			wideControlsEnabled: settings.alignWide,
-			themeSupportsLayout: settings.supportsLayout,
-			isBlockBasedTheme: settings.__unstableIsBlockBasedTheme,
-		};
-	}, [] );
+	const isNoneOnly = controls.length === 1 && controls[ 0 ] === 'none';
+
+	const [ wideControlsEnabled, themeSupportsLayout, isBlockBasedTheme ] =
+		useSelect(
+			( select ) => {
+				// If `isNoneOnly` is true, we'll be returning early because there is
+				// nothing to filter on an empty array. We won't need the info from
+				// the `useSelect` but we must call it anyway because Rules of Hooks.
+				// So the callback returns early to avoid block editor subscription.
+				if ( isNoneOnly ) {
+					return [ false, false, false ];
+				}
+
+				const settings = select( blockEditorStore ).getSettings();
+				return [
+					settings.alignWide ?? false,
+					settings.supportsLayout,
+					settings.__unstableIsBlockBasedTheme,
+				];
+			},
+			[ isNoneOnly ]
+		);
 	const layout = useLayout();
+
+	if ( isNoneOnly ) {
+		return EMPTY_ARRAY;
+	}
+
 	const layoutType = getLayoutType( layout?.type );
-	const layoutAlignments = layoutType.getAlignments(
-		layout,
-		isBlockBasedTheme
-	);
 
 	if ( themeSupportsLayout ) {
-		const alignments = layoutAlignments.filter(
-			( { name: alignmentName } ) => controls.includes( alignmentName )
+		const layoutAlignments = layoutType.getAlignments(
+			layout,
+			isBlockBasedTheme
+		);
+		const alignments = layoutAlignments.filter( ( alignment ) =>
+			controls.includes( alignment.name )
 		);
 		// While we treat `none` as an alignment, we shouldn't return it if no
 		// other alignments exist.
@@ -55,25 +69,26 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	if ( layoutType.name !== 'default' && layoutType.name !== 'constrained' ) {
 		return EMPTY_ARRAY;
 	}
-	const { alignments: availableAlignments = DEFAULT_CONTROLS } = layout;
-	const enabledControls = controls
-		.filter(
-			( control ) =>
-				( layout.alignments || // Ignore the global wideAlignment check if the layout explicitely defines alignments.
-					wideControlsEnabled ||
-					! WIDE_CONTROLS.includes( control ) ) &&
-				availableAlignments.includes( control )
-		)
-		.map( ( enabledControl ) => ( { name: enabledControl } ) );
+
+	const alignments = controls
+		.filter( ( control ) => {
+			if ( layout.alignments ) {
+				return layout.alignments.includes( control );
+			}
+
+			if ( ! wideControlsEnabled && WIDE_CONTROLS.includes( control ) ) {
+				return false;
+			}
+
+			return DEFAULT_CONTROLS.includes( control );
+		} )
+		.map( ( name ) => ( { name } ) );
 
 	// While we treat `none` as an alignment, we shouldn't return it if no
 	// other alignments exist.
-	if (
-		enabledControls.length === 1 &&
-		enabledControls[ 0 ].name === 'none'
-	) {
+	if ( alignments.length === 1 && alignments[ 0 ].name === 'none' ) {
 		return EMPTY_ARRAY;
 	}
 
-	return enabledControls;
+	return alignments;
 }


### PR DESCRIPTION
Three optimizations related to the `useAvailableAlignments` hook and the `align` attribute.

There's an observation that if the `controls` array passed to `useAvailableAlignments( controls )` is an `[]` empty array or `[ 'none' ]`, the return value of the hook is going to be `[]`. The hook filters the `controls` array depending on what the theme and the parent layout says, but there's not much to do with an empty array.

Therefore, in this case, we can make the `useSelect` inside `useAvailableAlignments` into a noop, so that it doesn't select from `core/block-editor` store at all and doesn't create a subscription.

The second observation is that sometimes we call `useAvailableAlignments` twice. The `withToolbarControls` HOC calls it the first time, and then the `BlockAlignmentControl` component calls it the second time, on the result of the first call. We can remove the `withToolbarControls` call. It checks only for an empty array anyway, and the `BlockAlignmentControl` will do the same check once again.

The third optimization is in the `withDataAlign` HOC. If the `align` attribute is `undefined`, which it almost always is, the HOC does nothing at all. All the hook calls can be extracted into the helper `BlockListBlockWithDataAlign` component that is rendered only when `align` is defined.

On a large post with 1400 blocks I was able to reduce the `core/block-editor` subscriptions by 2900, i.e., 2 per block.

This improvement is a part of the program outlined in #54819.