### PR TITLE
DataViews: limit users to those who have published pages

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -79,7 +79,7 @@ export default function PagePages() {
 	} = useEntityRecords( 'postType', 'page', queryArgs );
 
 	const { records: authors } = useEntityRecords( 'root', 'user', {
-		who: 'authors',
+		has_published_posts: true,
 	} );
 
 	const paginationInfo = useMemo(

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -79,7 +79,7 @@ export default function PagePages() {
 	} = useEntityRecords( 'postType', 'page', queryArgs );
 
 	const { records: authors } = useEntityRecords( 'root', 'user', {
-		has_published_posts: true,
+		has_published_posts: [ 'page' ],
 	} );
 
 	const paginationInfo = useMemo(


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

This changes how we query the [users endpoint](https://developer.wordpress.org/rest-api/reference/users/#list-users).

## Why?

We want to list users that actually have some post published. For the purposes of the pages page, there's no point in listing the ones that don't.

## How?

Use the `has_published_posts` param instead of the `who: authors`.

## Testing Instructions

- Have a site with a few users.
- Make sure some of them have created pages and some others didn't.
- With the experiment "wp-admin" enabled, go to "Site editor > Pages > Manage all pages".
- Verify the users listed in the author filter are only those who have published something.
