### PR TITLE
Preferences modal: fix the position of sticky heading when blocks are hidden

### DIFF
--- a/packages/edit-post/src/components/block-manager/style.scss
+++ b/packages/edit-post/src/components/block-manager/style.scss
@@ -18,12 +18,12 @@
 	text-align: center;
 	position: sticky;
 	// When sticking, tuck the top border beneath the modal header border
-	top: -1px;
+	top: ($grid-unit-05 + 1) * -1;
 	z-index: z-index(".edit-post-block-manager__disabled-blocks-count");
 
 	// Stick the category titles to the bottom
 	~ .edit-post-block-manager__results .edit-post-block-manager__category-title {
-		top: 35px;
+		top: $grid-unit-40 - 1;
 	}
 	.is-link {
 		margin-left: 12px;


### PR DESCRIPTION
Follow-up on #52248

## What?

This PR fixes the misalignment of the fixed header when the blocks are hidden in the preferences modal of the Post Editor.

![preferences-modal](https://github.com/WordPress/gutenberg/assets/54422211/894e13a6-45d8-4323-b1db-31392c7ffb08)

## Why?

We should have also considered the message displayed when the block is hidden.

## How?

Similar to #52248, I shifted the message and header when the block is hidden by 4px. Also, I'm using variables rather than hard-coded values.

## Testing Instructions

- Open the Post Editor.
- Open the Preferences modal and click "Blocks" tab.
- Uncheck some blocks and scroll up and down.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/d811513b-09ee-4def-9da2-f1957ef5cb24

