### PR TITLE
Fix the position of the callout in the "Get started with wp-scripts" doc.

### DIFF
--- a/docs/getting-started/devenv/get-started-with-wp-scripts.md
+++ b/docs/getting-started/devenv/get-started-with-wp-scripts.md
@@ -19,11 +19,11 @@ The package abstracts away much of the initial setup, configuration, and boilerp
 
 ## Quick start
 
-### Installation
-
 <div class="callout callout-tip">
     If you want to build a custom block, the <a href="https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-create-block/"><code>@wordpress/create-block</code></a> package allows you to scaffold the structure of files needed to create and register a block. It generates all the necessary code to start a project and integrates a modern JavaScript build setup (using <code>wp-scripts</code>) with no configuration required. Refer to <a href="https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-create-block/">Get started with <code>create-block</code></a> for more details.
 </div>
+
+### Installation
 
 Ensure you have Node.js and `npm` installed on your computer. Review the [Node.js development environment](https://developer.wordpress.org/block-editor/getting-started/devenv/nodejs-development-environment/) guide if not. 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix the position of the callout so the doc reads better. 

| Before | After |
|-|-|
| <img width="801" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/f4a76fc9-b8bf-42b3-a7e2-c8475adfa7b2"> |<img width="822" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/f4509636-c062-4bf8-9cf1-7728e090e836">|

