### PR TITLE
Add: Ability to persist dataviews on the database.

### DIFF
--- a/lib/experimental/data-views.php
+++ b/lib/experimental/data-views.php
@@ -4,7 +4,7 @@ function _gutenberg_register_data_views_post_type() {
 	register_post_type(
 		'wp_dataviews',
 		array(
-			'label'        => _x( 'Datavivews', 'post type general name', 'gutenberg' ),
+			'label'        => _x( 'Dataviews', 'post type general name', 'gutenberg' ),
 			'description'  => __( 'Post which stores the different data views configurations', 'gutenberg' ),
 			'public'       => false,
 			'show_ui'      => false,

--- a/lib/experimental/data-views.php
+++ b/lib/experimental/data-views.php
@@ -1,5 +1,13 @@
 <?php
+/**
+ * Dataviews custom post type and taxonomy.
+ *
+ * @package gutenberg
+ */
 
+/**
+ * Registers the `wp_dataviews` post type and the `wp_dataviews_type` taxonomy.
+ */
 function _gutenberg_register_data_views_post_type() {
 	register_post_type(
 		'wp_dataviews',
@@ -11,28 +19,28 @@ function _gutenberg_register_data_views_post_type() {
 			'show_in_rest' => true,
 			'rewrite'      => false,
 			'capabilities' => array(
-				'read'                   => 'edit_published_posts',
-			//	'create_posts'           => 'edit_published_posts',
-			//	'edit_posts'             => 'edit_published_posts',
-			//	'edit_published_posts'   => 'edit_published_posts',
-			//	'delete_published_posts' => 'delete_published_posts',
-			//	'edit_others_posts'      => 'edit_others_posts',
-			//	'delete_others_posts'    => 'edit_theme_options',
+				'read' => 'edit_published_posts',
+			// 'create_posts'           => 'edit_published_posts',
+			// 'edit_posts'             => 'edit_published_posts',
+			// 'edit_published_posts'   => 'edit_published_posts',
+			// 'delete_published_posts' => 'delete_published_posts',
+			// 'edit_others_posts'      => 'edit_others_posts',
+			// 'delete_others_posts'    => 'edit_theme_options',
 			),
 			'map_meta_cap' => true,
 			'supports'     => array( 'title', 'slug', 'editor' ),
 		)
 	);
 
-    register_taxonomy(
+	register_taxonomy(
 		'wp_dataviews_type',
 		array( 'wp_dataviews' ),
 		array(
 			'public'            => true,
 			'hierarchical'      => false,
 			'labels'            => array(
-				'name'          => __( 'Dataview types' ),
-				'singular_name' => __( 'Dataview type' ),
+				'name'          => __( 'Dataview types', 'gutenberg' ),
+				'singular_name' => __( 'Dataview type', 'gutenberg' ),
 			),
 			'rewrite'           => false,
 			'show_ui'           => false,

--- a/lib/experimental/data-views.php
+++ b/lib/experimental/data-views.php
@@ -1,0 +1,45 @@
+<?php
+
+function _gutenberg_register_data_views_post_type() {
+	register_post_type(
+		'wp_dataviews',
+		array(
+			'label'        => _x( 'Datavivews', 'post type general name', 'gutenberg' ),
+			'description'  => __( 'Post which stores the different data views configurations', 'gutenberg' ),
+			'public'       => false,
+			'show_ui'      => false,
+			'show_in_rest' => true,
+			'rewrite'      => false,
+			'capabilities' => array(
+				'read'                   => 'edit_published_posts',
+			//	'create_posts'           => 'edit_published_posts',
+			//	'edit_posts'             => 'edit_published_posts',
+			//	'edit_published_posts'   => 'edit_published_posts',
+			//	'delete_published_posts' => 'delete_published_posts',
+			//	'edit_others_posts'      => 'edit_others_posts',
+			//	'delete_others_posts'    => 'edit_theme_options',
+			),
+			'map_meta_cap' => true,
+			'supports'     => array( 'title', 'slug', 'editor' ),
+		)
+	);
+
+    register_taxonomy(
+		'wp_dataviews_type',
+		array( 'wp_dataviews' ),
+		array(
+			'public'            => true,
+			'hierarchical'      => false,
+			'labels'            => array(
+				'name'          => __( 'Dataview types' ),
+				'singular_name' => __( 'Dataview type' ),
+			),
+			'rewrite'           => false,
+			'show_ui'           => false,
+			'show_in_nav_menus' => false,
+			'show_in_rest'      => true,
+		)
+	);
+}
+
+add_action( 'init', '_gutenberg_register_data_views_post_type' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -256,3 +256,6 @@ require __DIR__ . '/block-supports/duotone.php';
 require __DIR__ . '/block-supports/shadow.php';
 require __DIR__ . '/block-supports/background.php';
 require __DIR__ . '/block-supports/behaviors.php';
+
+// Data views
+require_once __DIR__ . '/experimental/data-views.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -257,5 +257,5 @@ require __DIR__ . '/block-supports/shadow.php';
 require __DIR__ . '/block-supports/background.php';
 require __DIR__ . '/block-supports/behaviors.php';
 
-// Data views
+// Data views.
 require_once __DIR__ . '/experimental/data-views.php';

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -14,6 +14,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import Layout from '../layout';
 import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
+import DataviewsProvider from '../dataviews/provider';
 import { unlock } from '../../lock-unlock';
 
 const { RouterProvider } = unlock( routerPrivateApis );
@@ -38,8 +39,10 @@ export default function App() {
 			<GlobalStylesProvider>
 				<UnsavedChangesWarning />
 				<RouterProvider>
-					<Layout />
-					<PluginArea onError={ onPluginAreaError } />
+					<DataviewsProvider>
+						<Layout />
+						<PluginArea onError={ onPluginAreaError } />
+					</DataviewsProvider>
 				</RouterProvider>
 			</GlobalStylesProvider>
 		</SlotFillProvider>

--- a/packages/edit-site/src/components/dataviews/context.js
+++ b/packages/edit-site/src/components/dataviews/context.js
@@ -1,0 +1,7 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+const DataviewsContext = createContext( {} );
+export default DataviewsContext;

--- a/packages/edit-site/src/components/dataviews/provider.js
+++ b/packages/edit-site/src/components/dataviews/provider.js
@@ -1,0 +1,253 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useEffect, useState, useRef, useMemo } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import DataviewsContext from './context';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+// DEFAULT_STATUSES is intentionally sorted. Items do not have spaces in between them.
+// The reason for that is to match the default statuses coming from the endpoint
+// (entity request and useEffect to update the view).
+export const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All statuses but 'trash'.
+
+const DEFAULT_VIEWS = {
+	page: {
+		type: 'list',
+		filters: {
+			search: '',
+			status: DEFAULT_STATUSES,
+		},
+		page: 1,
+		perPage: 5,
+		sort: {
+			field: 'date',
+			direction: 'desc',
+		},
+		visibleFilters: [ 'search', 'author', 'status' ],
+		// All fields are visible by default, so it's
+		// better to keep track of the hidden ones.
+		hiddenFields: [ 'date', 'featured-image' ],
+		layout: {},
+	},
+};
+
+const PATH_TO_DATAVIEW_TYPE = {
+	'/pages': 'page',
+};
+
+function useDataviewTypeTaxonomyId( type ) {
+	const isCreatingATerm = useRef( false );
+	const {
+		dataViewTypeRecords,
+		dataViewTypeIsResolving,
+		dataViewTypeIsSaving,
+	} = useSelect(
+		( select ) => {
+			const { getEntityRecords, isResolving, isSavingEntityRecord } =
+				select( coreStore );
+			const dataViewTypeQuery = { slug: type };
+			return {
+				dataViewTypeRecords: getEntityRecords(
+					'taxonomy',
+					'wp_dataviews_type',
+					dataViewTypeQuery
+				),
+				dataViewTypeIsResolving: isResolving( 'getEntityRecords', [
+					'taxonomy',
+					'wp_dataviews_type',
+					dataViewTypeQuery,
+				] ),
+				dataViewTypeIsSaving: isSavingEntityRecord(
+					'taxonomy',
+					'wp_dataviews_type'
+				),
+			};
+		},
+		[ type ]
+	);
+	const { saveEntityRecord } = useDispatch( coreStore );
+	useEffect( () => {
+		if (
+			dataViewTypeRecords?.length === 0 &&
+			! dataViewTypeIsResolving &&
+			! dataViewTypeIsSaving &&
+			! isCreatingATerm.current
+		) {
+			isCreatingATerm.current = true;
+			saveEntityRecord( 'taxonomy', 'wp_dataviews_type', { name: type } );
+		}
+	}, [
+		type,
+		dataViewTypeRecords,
+		dataViewTypeIsResolving,
+		dataViewTypeIsSaving,
+		saveEntityRecord,
+	] );
+	useEffect( () => {
+		if ( dataViewTypeRecords?.length > 0 ) {
+			isCreatingATerm.current = false;
+		}
+	}, [ dataViewTypeRecords ] );
+	useEffect( () => {
+		isCreatingATerm.current = false;
+	}, [ type ] );
+	if ( dataViewTypeRecords?.length > 0 ) {
+		return dataViewTypeRecords[ 0 ].id;
+	}
+	return null;
+}
+
+function useDataviews( type, typeTaxonomyId ) {
+	const isCreatingADefaultView = useRef( false );
+	const { dataViewRecords, dataViewIsLoading, dataViewIsSaving } = useSelect(
+		( select ) => {
+			const { getEntityRecords, isResolving, isSavingEntityRecord } =
+				select( coreStore );
+			if ( ! typeTaxonomyId ) {
+				return {};
+			}
+			const dataViewQuery = {
+				wp_dataviews_type: typeTaxonomyId,
+				orderby: 'date',
+				order: 'asc',
+			};
+			return {
+				dataViewRecords: getEntityRecords(
+					'postType',
+					'wp_dataviews',
+					dataViewQuery
+				),
+				dataViewIsLoading: isResolving( 'getEntityRecords', [
+					'postType',
+					'wp_dataviews',
+					dataViewQuery,
+				] ),
+				dataViewIsSaving: isSavingEntityRecord(
+					'postType',
+					'wp_dataviews'
+				),
+			};
+		},
+		[ typeTaxonomyId ]
+	);
+	const { saveEntityRecord } = useDispatch( coreStore );
+	useEffect( () => {
+		if (
+			dataViewRecords?.length === 0 &&
+			! dataViewIsLoading &&
+			! dataViewIsSaving &&
+			! isCreatingADefaultView.current
+		) {
+			isCreatingADefaultView.current = true;
+			saveEntityRecord( 'postType', 'wp_dataviews', {
+				title: 'All',
+				status: 'publish',
+				wp_dataviews_type: typeTaxonomyId,
+				content: JSON.stringify( DEFAULT_VIEWS[ type ] ),
+			} );
+		}
+	}, [
+		type,
+		dataViewIsLoading,
+		dataViewRecords,
+		dataViewIsSaving,
+		typeTaxonomyId,
+		saveEntityRecord,
+	] );
+	useEffect( () => {
+		if ( dataViewRecords?.length > 0 ) {
+			isCreatingADefaultView.current = false;
+		}
+	}, [ dataViewRecords ] );
+	useEffect( () => {
+		isCreatingADefaultView.current = false;
+	}, [ typeTaxonomyId ] );
+	if ( dataViewRecords?.length > 0 ) {
+		return dataViewRecords;
+	}
+	return null;
+}
+
+function DataviewsProviderInner( { type, children } ) {
+	const [ currentViewId, setCurrentViewId ] = useState( null );
+	const dataviewTypeTaxonomyId = useDataviewTypeTaxonomyId( type );
+	const dataviews = useDataviews( type, dataviewTypeTaxonomyId );
+	const { editEntityRecord } = useDispatch( coreStore );
+	useEffect( () => {
+		if ( ! currentViewId && dataviews?.length > 0 ) {
+			setCurrentViewId( dataviews[ 0 ].id );
+		}
+	}, [ currentViewId, dataviews ] );
+	const editedViewRecord = useSelect(
+		( select ) => {
+			if ( ! currentViewId ) {
+				return;
+			}
+			const { getEditedEntityRecord } = select( coreStore );
+			const dataviewRecord = getEditedEntityRecord(
+				'postType',
+				'wp_dataviews',
+				currentViewId
+			);
+			return dataviewRecord;
+		},
+		[ currentViewId ]
+	);
+
+	const value = useMemo( () => {
+		return {
+			taxonomyId: dataviewTypeTaxonomyId,
+			dataviews,
+			currentViewId,
+			setCurrentViewId,
+			view: editedViewRecord?.content
+				? JSON.parse( editedViewRecord?.content )
+				: DEFAULT_VIEWS[ type ],
+			setView( view ) {
+				if ( ! currentViewId ) {
+					return;
+				}
+				editEntityRecord( 'postType', 'wp_dataviews', currentViewId, {
+					content: JSON.stringify( view ),
+				} );
+			},
+		};
+	}, [
+		type,
+		dataviewTypeTaxonomyId,
+		dataviews,
+		currentViewId,
+		editedViewRecord?.content,
+		editEntityRecord,
+	] );
+
+	return (
+		<DataviewsContext.Provider value={ value }>
+			{ children }
+		</DataviewsContext.Provider>
+	);
+}
+export default function DataviewsProvider( { children } ) {
+	const {
+		params: { path },
+	} = useLocation();
+	const viewType = PATH_TO_DATAVIEW_TYPE[ path ];
+
+	if ( window?.__experimentalAdminViews && viewType ) {
+		return (
+			<DataviewsProviderInner type={ viewType }>
+				{ children }
+			</DataviewsProviderInner>
+		);
+	}
+	return <> { children }</>;
+}

--- a/packages/edit-site/src/components/dataviews/sidebar-content.js
+++ b/packages/edit-site/src/components/dataviews/sidebar-content.js
@@ -1,0 +1,3 @@
+export default function DataViewsSidebarContent() {
+	return <p>Add views ui here</p>;
+}

--- a/packages/edit-site/src/components/dataviews/text-filter.js
+++ b/packages/edit-site/src/components/dataviews/text-filter.js
@@ -14,6 +14,9 @@ export default function TextFilter( { filter, view, onChangeView } ) {
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput(
 		view.filters[ filter.id ]
 	);
+	useEffect( () => {
+		setSearch( view.filters[ filter.id ] );
+	}, [ view ] );
 	const onChangeViewRef = useRef( onChangeView );
 	useEffect( () => {
 		onChangeViewRef.current = onChangeView;

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -8,7 +8,12 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import {
+	useContext,
+	useMemo,
+	useCallback,
+	useEffect,
+} from '@wordpress/element';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 
 /**

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -19,6 +19,8 @@ import Link from '../routes/link';
 import { DataViews } from '../dataviews';
 import useTrashPostAction from '../actions/trash-post';
 import Media from '../media';
+import DataviewsContext from '../dataviews/context';
+import { DEFAULT_STATUSES } from '../dataviews/provider';
 
 const EMPTY_ARRAY = [];
 const defaultConfigPerViewType = {
@@ -29,28 +31,8 @@ const defaultConfigPerViewType = {
 };
 
 export default function PagePages() {
-	// DEFAULT_STATUSES is intentionally sorted. Items do not have spaces in between them.
-	// The reason for that is to match defaultStatuses because we compare both strings below (see useEffect).
-	const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All statuses but 'trash'.
-	const [ view, setView ] = useState( {
-		type: 'list',
-		filters: {
-			search: '',
-			status: DEFAULT_STATUSES,
-		},
-		page: 1,
-		perPage: 5,
-		sort: {
-			field: 'date',
-			direction: 'desc',
-		},
-		visibleFilters: [ 'search', 'author', 'status' ],
-		// All fields are visible by default, so it's
-		// better to keep track of the hidden ones.
-		hiddenFields: [ 'date', 'featured-image' ],
-		layout: {},
-	} );
-
+	const { view, setView } = useContext( DataviewsContext );
+	// Request post statuses to get the proper labels.
 	const { records: statuses } = useEntityRecords( 'root', 'status' );
 	const defaultStatuses = useMemo( () => {
 		return statuses === null
@@ -239,7 +221,7 @@ export default function PagePages() {
 
 			setView( updatedView );
 		},
-		[ view ]
+		[ view, setView ]
 	);
 
 	// TODO: we need to handle properly `data={ data || EMPTY_ARRAY }` for when `isLoading`.

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -29,6 +29,7 @@ import { unlock } from '../../lock-unlock';
 import SidebarNavigationScreenPages from '../sidebar-navigation-screen-pages';
 import SidebarNavigationScreenPage from '../sidebar-navigation-screen-page';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import DataViewsSidebarContent from '../dataviews/sidebar-content';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -61,6 +62,7 @@ function SidebarScreens() {
 						title={ __( 'All Pages' ) }
 						description={ __( 'Manage your pages.' ) }
 						backPath="/page"
+						content={ <DataViewsSidebarContent /> }
 					/>
 				</NavigatorScreen>
 			) }


### PR DESCRIPTION
This PR adds the ability to persist the dataviews configuration on the database.
For now in order to make this PR even bigger the UI is not included.
In a follow-up PR, I will include UI to choose between different views, create new views etc...

## Testing
Go to the new page list change view settings like number of elements per page sorting etc.
Verify that when you change the view a button  "review one change" appears.
Click the button "review one change" Verify you can save the "All" dataview (default view).
Verify that when the view is saved after reload the view has the same settings applied.