### PR TITLE
Navigation block: Change aria-haspopup to dialog

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -744,7 +744,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	$responsive_container_markup = sprintf(
-		'<button aria-haspopup="true" %3$s class="%6$s" %10$s>%8$s</button>
+		'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
 			<div class="%5$s" style="%7$s" id="%1$s" %11$s>
 				<div class="wp-block-navigation__responsive-close" tabindex="-1">
 					<div class="wp-block-navigation__responsive-dialog" %12$s>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Changes the `aria-haspopup="true"` to `aria-haspopup="dialog"` for the navigation block mobile menu trigger.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The trigger opens a menu but it is actually a dialog.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup

> The availability and type of popup the interactive element will trigger should be identified with the aria-haspopup state.

Since the trigger always opens a dialog and a menu is contained within the dialog, I think it is more correct to say the button opens a dialog, not a menu.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changes the attribute.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Start a screen reader.
2. Create and insert a navigation block.
3. View the front-end.
4. Zoom in until you reach mobile view.
5. Check the mobile menu button to see if it contains `aria-haspopup="dialog"`.
6. Screen reader should announce that the button opens a dialog vs. a menu.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

No keyboard change.

## Notes

Interested in gathering other Accessibility Team opinions to make sure I'm not totally off base here.