### PR TITLE
Form: update copy

### DIFF
--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -107,7 +107,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 						help={
 							submissionMethod === 'custom'
 								? __(
-										'Select the method to use for form submissions. Additional options for the "custom" mode can be found in the "Andvanced" section.'
+										'Select the method to use for form submissions. Additional options for the "custom" mode can be found in the "Advanced" section.'
 								  )
 								: __(
 										'Select the method to use for form submissions.'


### PR DESCRIPTION


## What?
Fixes https://github.com/WordPress/gutenberg/issues/55464

Updates spelling of "Advanced"



## Screenshots or screencast
![2023-10-19 10 43 14](https://github.com/WordPress/gutenberg/assets/6458278/53b3ac9d-4aec-478a-a6cb-a41af01b2969)


