### PR TITLE
Image block: wrap images with hrefs in an A tag

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -725,7 +725,6 @@ export default function Image( {
 			}
 		}
 		/* eslint-enable no-lonely-if */
-
 		img = (
 			<ResizableBox
 				style={ {
@@ -770,7 +769,9 @@ export default function Image( {
 				} }
 				resizeRatio={ align === 'center' ? 2 : 1 }
 			>
-				{ img }
+				{ /* If the image has a href, wrap in an <a /> tag to trigger any inherited link element styles */ }
+				{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+				{ !! href ? <a>{ img }</a> : img }
 			</ResizableBox>
 		);
 	}
@@ -784,7 +785,9 @@ export default function Image( {
 			{ /* Hide controls during upload to avoid component remount,
 				which causes duplicated image upload. */ }
 			{ ! temporaryURL && controls }
-			{ img }
+			{ /* If the image has a href, wrap in an <a /> tag to trigger any inherited link element styles */ }
+			{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+			{ !! href ? <a>{ img }</a> : img }
 			{ showCaption &&
 				( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -83,6 +83,11 @@ const scaleOptions = [
 	},
 ];
 
+const disabledClickProps = {
+	onClick: ( event ) => event.preventDefault(),
+	'aria-disabled': true,
+};
+
 export default function Image( {
 	temporaryURL,
 	attributes,
@@ -769,9 +774,7 @@ export default function Image( {
 				} }
 				resizeRatio={ align === 'center' ? 2 : 1 }
 			>
-				{ /* If the image has a href, wrap in an <a /> tag to trigger any inherited link element styles */ }
-				{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-				{ !! href ? <a>{ img }</a> : img }
+				{ img }
 			</ResizableBox>
 		);
 	}
@@ -786,8 +789,13 @@ export default function Image( {
 				which causes duplicated image upload. */ }
 			{ ! temporaryURL && controls }
 			{ /* If the image has a href, wrap in an <a /> tag to trigger any inherited link element styles */ }
-			{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-			{ !! href ? <a>{ img }</a> : img }
+			{ !! href ? (
+				<a href={ href } { ...disabledClickProps }>
+					{ img }
+				</a>
+			) : (
+				img
+			) }
 			{ showCaption &&
 				( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText


### PR DESCRIPTION
Maybe resolves: https://github.com/WordPress/gutenberg/issues/55336

## What?
This commit sees what happens when we wrap the image element in an A tag in the editor. 

## Why?
To ensure any inherited styles from the link element, such as border color, apply to the image in the editor. The goal is to match frontend behavior.

Where a border color hasn't been defined, it will default to the closest color. In the frontend, it will be the link element's color due to the wrapping `<a />`. 

In the editor, it's the body color as the img is not wrapped by a link element.

## Testing Instructions
It's best to use the 2023 theme, whose link elements have a different color to the editor body color.

1. Add an Image block
2. Add a link to the image
3. Add a border width in the image block settings sidebar. **Don't apply an color.**
4. Confirm that the border is visible, note the color.
5. Save and view the front of the website. Confirm that the border color matches the editor.
6. Check with the Gallery block

Ensure that Image block settings work in the editor, especially the resizer and other styles.

<details>

<summary>Some example block HTML (replace with your own image)</summary>

```html
<!-- wp:gallery {"linkTo":"none","sizeSlug":"full"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":23,"sizeSlug":"full","linkDestination":"custom","style":{"border":{"radius":"22px","width":"53px"}}} -->
<figure class="wp-block-image size-full has-custom-border"><a href="https://wordpress.org"><img src="http://localhost:8888/wp-content/uploads/2023/10/california-condor.jpg" alt="" class="wp-image-23" style="border-width:53px;border-radius:22px"/></a></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->

<!-- wp:image {"id":23,"width":"456px","height":"auto","sizeSlug":"full","linkDestination":"custom","style":{"border":{"width":"30px"}}} -->
<figure class="wp-block-image size-full is-resized has-custom-border"><a href="https://wordpress.org"><img src="http://localhost:8888/wp-content/uploads/2023/10/california-condor.jpg" alt="" class="wp-image-23" style="border-width:30px;width:456px;height:auto"/></a></figure>
<!-- /wp:image -->

<!-- wp:image {"id":23,"width":"509px","height":"auto","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full is-resized"><img src="http://localhost:8888/wp-content/uploads/2023/10/california-condor.jpg" alt="" class="wp-image-23" style="width:509px;height:auto"/></figure>
<!-- /wp:image -->

```

</details>

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

#### Before


https://github.com/WordPress/gutenberg/assets/6458278/b73e8113-3488-4bb3-9041-9d771ead2ee4



#### After



https://github.com/WordPress/gutenberg/assets/6458278/844fe279-57cd-47bd-9fd0-fa76d33a6eb8

