### PR TITLE
Fix focus loss after converting to a synced pattern

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -114,33 +114,28 @@ export default function ReusableBlockEdit( {
 			: InnerBlocks.ButtonBlockAppender,
 	} );
 
+	let children = null;
 	if ( hasAlreadyRendered ) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __( 'Block cannot be rendered inside itself.' ) }
-				</Warning>
-			</div>
+		children = (
+			<Warning>
+				{ __( 'Block cannot be rendered inside itself.' ) }
+			</Warning>
 		);
 	}
 
 	if ( isMissing ) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __( 'Block has been deleted or is unavailable.' ) }
-				</Warning>
-			</div>
+		children = (
+			<Warning>
+				{ __( 'Block has been deleted or is unavailable.' ) }
+			</Warning>
 		);
 	}
 
 	if ( ! hasResolved ) {
-		return (
-			<div { ...blockProps }>
-				<Placeholder>
-					<Spinner />
-				</Placeholder>
-			</div>
+		children = (
+			<Placeholder>
+				<Spinner />
+			</Placeholder>
 		);
 	}
 
@@ -156,7 +151,10 @@ export default function ReusableBlockEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div { ...innerBlocksProps } />
+			<div
+				children={ children }
+				{ ...( children === null ? innerBlocksProps : blockProps ) }
+			/>
 		</RecursionProvider>
 	);
 }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -151,10 +151,11 @@ export default function ReusableBlockEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div
-				children={ children }
-				{ ...( children === null ? innerBlocksProps : blockProps ) }
-			/>
+			{ children === null ? (
+				<div { ...innerBlocksProps } />
+			) : (
+				<div { ...blockProps }>{ children }</div>
+			) }
 		</RecursionProvider>
 	);
 }

--- a/packages/patterns/src/components/index.js
+++ b/packages/patterns/src/components/index.js
@@ -12,11 +12,12 @@ import PatternsManageButton from './patterns-manage-button';
 export default function PatternsMenuItems( { rootClientId } ) {
 	return (
 		<BlockSettingsMenuControls>
-			{ ( { selectedClientIds } ) => (
+			{ ( { selectedClientIds, onClose } ) => (
 				<>
 					<PatternConvertButton
 						clientIds={ selectedClientIds }
 						rootClientId={ rootClientId }
+						closeBlockSettingsMenu={ onClose }
 					/>
 					{ selectedClientIds.length === 1 && (
 						<PatternsManageButton

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -26,12 +26,17 @@ import { PATTERN_SYNC_TYPES } from '../constants';
 /**
  * Menu control to convert block(s) to a pattern block.
  *
- * @param {Object}   props              Component props.
- * @param {string[]} props.clientIds    Client ids of selected blocks.
- * @param {string}   props.rootClientId ID of the currently selected top-level block.
+ * @param {Object}   props                        Component props.
+ * @param {string[]} props.clientIds              Client ids of selected blocks.
+ * @param {string}   props.rootClientId           ID of the currently selected top-level block.
+ * @param {()=>void} props.closeBlockSettingsMenu Callback to close the block settings menu dropdown.
  * @return {import('react').ComponentType} The menu control or null.
  */
-export default function PatternConvertButton( { clientIds, rootClientId } ) {
+export default function PatternConvertButton( {
+	clientIds,
+	rootClientId,
+	closeBlockSettingsMenu,
+} ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	// Ignore reason: false positive of the lint rule.
@@ -104,6 +109,7 @@ export default function PatternConvertButton( { clientIds, rootClientId } ) {
 
 			replaceBlocks( clientIds, newBlock );
 			setEditingPattern( newBlock.clientId, true );
+			closeBlockSettingsMenu();
 		}
 
 		createSuccessNotice(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix focus loss when converting a block to a synced pattern via the block settings toolbar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As originally discovered in https://github.com/WordPress/gutenberg/pull/55406#pullrequestreview-1683885891, this bug seems to have been broken for a long time (3y+?).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The issue is that we're fetching the pattern after we convert it to a pattern. If the response comes late then we show a placeholder state. The placeholder state renders a different `<div>` which will get unmounted/removed after the entity is resolved. However, `replaceBlocks` triggers focusing the block immediately after it's inserted, which then attempts to focus the placeholder `<div>`. It succeeded, but the placeholder `<div>` unmounts thus the focus is lost.

The solution is to reuse the same `<div>` component for each state, so that React will attempt to render the same element without destroying and remounting them.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Added e2e tests.

1. Go to the post editor
2. Create a random block
3. Convert the block to a synced pattern via the block toolbar
4. Note that the converted pattern should be focused

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Go to the post editor
2. Create a random block
3. <kbd>Shift</kbd>+<kbd>Tab</kbd> to move focus to the block toolbar
4. Press <kbd>ArrowRight</kbd> until you reach the "Options" menuitem and hit <kbd>Enter</kbd>
5. Press <kbd>ArrowDown</kbd> until you reach the "Create pattern" menuitem and hit <kbd>Enter</kbd>
6. Expect the "Create pattern" dialog to be opened. Press <kbd>Tab</kbd> twice to focus on the "name" text input.
7. Give it a name and hit <kbd>Enter</kbd> to create a synced pattern.
8. Expect the focus to return to the newly created synced pattern in the editor.
9. Note that the converted pattern should be focused

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/f0973d50-e2cb-497a-9e90-d315eaf182c7

