### PR TITLE
DataViews: pass `search` filter as global, unattached from fields

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -20,6 +20,7 @@ export default function DataViews( {
 	view,
 	onChangeView,
 	fields,
+	filters,
 	actions,
 	data,
 	isLoading = false,
@@ -38,6 +39,7 @@ export default function DataViews( {
 				<HStack>
 					<HStack justify="start">
 						<Filters
+							filters={ filters }
 							fields={ fields }
 							view={ view }
 							onChangeView={ onChangeView }

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -9,8 +9,16 @@ import { __ } from '@wordpress/i18n';
 import TextFilter from './text-filter';
 import InFilter from './in-filter';
 
-export default function Filters( { fields, view, onChangeView } ) {
-	const filters = {};
+export default function Filters( { filters, fields, view, onChangeView } ) {
+	const filterIndex = {};
+	filters.forEach( ( filter ) => {
+		if ( 'object' !== typeof filter || ! filter?.id || ! filter?.type ) {
+			return;
+		}
+
+		filterIndex[ filter.id ] = filter;
+	} );
+
 	fields.forEach( ( field ) => {
 		if ( ! field.filters ) {
 			return;
@@ -19,7 +27,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 		field.filters.forEach( ( filter ) => {
 			let id = field.id;
 			if ( 'string' === typeof filter ) {
-				filters[ id ] = {
+				filterIndex[ id ] = {
 					id,
 					name: field.header,
 					type: filter,
@@ -28,14 +36,14 @@ export default function Filters( { fields, view, onChangeView } ) {
 
 			if ( 'object' === typeof filter ) {
 				id = filter.id || field.id;
-				filters[ id ] = {
+				filterIndex[ id ] = {
 					id,
 					name: filter.name || field.header,
 					type: filter.type,
 				};
 			}
 
-			if ( 'enumeration' === filters[ id ]?.type ) {
+			if ( 'enumeration' === filterIndex[ id ]?.type ) {
 				const elements = [
 					{
 						value: filter.resetValue || '',
@@ -43,8 +51,8 @@ export default function Filters( { fields, view, onChangeView } ) {
 					},
 					...( field.elements || [] ),
 				];
-				filters[ id ] = {
-					...filters[ id ],
+				filterIndex[ id ] = {
+					...filterIndex[ id ],
 					elements,
 				};
 			}
@@ -53,7 +61,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 
 	return (
 		view.visibleFilters?.map( ( filterName ) => {
-			const filter = filters[ filterName ];
+			const filter = filterIndex[ filterName ];
 
 			if ( ! filter ) {
 				return null;

--- a/packages/edit-site/src/components/dataviews/text-filter.js
+++ b/packages/edit-site/src/components/dataviews/text-filter.js
@@ -28,7 +28,7 @@ export default function TextFilter( { filter, view, onChangeView } ) {
 			},
 		} ) );
 	}, [ debouncedSearch ] );
-	const searchLabel = __( 'Filter list' );
+	const searchLabel = filter?.name || __( 'Filter list' );
 	return (
 		<SearchControl
 			onChange={ setSearch }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -133,9 +133,6 @@ export default function PagePages() {
 						</VStack>
 					);
 				},
-				filters: [
-					{ id: 'search', type: 'search', name: __( 'Search' ) },
-				],
 				maxWidth: 400,
 				sortingFn: 'alphanumeric',
 				enableHiding: false,
@@ -200,6 +197,8 @@ export default function PagePages() {
 		[ postStatuses, authors ]
 	);
 
+	const filters = useMemo( () => [ { id: 'search', type: 'search' } ] );
+
 	const trashPostAction = useTrashPostAction();
 	const actions = useMemo( () => [ trashPostAction ], [ trashPostAction ] );
 	const onChangeView = useCallback(
@@ -228,6 +227,7 @@ export default function PagePages() {
 			<DataViews
 				paginationInfo={ paginationInfo }
 				fields={ fields }
+				filters={ filters }
 				actions={ actions }
 				data={ pages || EMPTY_ARRAY }
 				isLoading={ isLoadingPages }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -197,7 +197,9 @@ export default function PagePages() {
 		[ postStatuses, authors ]
 	);
 
-	const filters = useMemo( () => [ { id: 'search', type: 'search' } ] );
+	const filters = useMemo( () => [
+		{ id: 'search', type: 'search', name: __( 'Filter list' ) },
+	] );
 
 	const trashPostAction = useTrashPostAction();
 	const actions = useMemo( () => [ trashPostAction ], [ trashPostAction ] );


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/55270#discussion_r1362600986 and https://github.com/WordPress/gutenberg/pull/55440#discussion_r1363746285

## What?

Extracts the `search` filter from the fields definition and pass it directly to the DataViews component.

## Why?

The `search` filter is a cross-field filter and doesn't benefit from any field information. It's clearer if we make that obvious by passing it directly to the `DataViews` component. See the following conversations https://github.com/WordPress/gutenberg/pull/55270#discussion_r1362600986 and https://github.com/WordPress/gutenberg/pull/55440#discussion_r1363746285 as well.

## How?

Pass filters as a new property of the DataViews component. These filters and the ones bound to the fields are treated the same.

## Testing Instructions

- Enable the "new admin" experiment.
- Go to the site editor > pages > manage pages.
- Use the `search` filter and verify that it works properly.
