### PR TITLE
Dataviews: list all pages, not only those with publish and draft statuses

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -51,7 +51,7 @@ export default function PagePages() {
 	} );
 
 	const { records: statuses } = useEntityRecords( 'root', 'status' );
-	const { postStatuses, allStatuses } = useMemo( () => {
+	const { postStatuses, defaultStatuses } = useMemo( () => {
 		return {
 			postStatuses:
 				statuses === null
@@ -59,10 +59,12 @@ export default function PagePages() {
 					: Object.fromEntries(
 							statuses.map( ( { slug, name } ) => [ slug, name ] )
 					  ),
-			allStatuses:
-				statuses
-					.filter( ( { slug } ) => slug !== 'trash' )
-					.map( ( { slug } ) => slug ) || DEFAULT_STATUSES,
+			defaultStatuses:
+				statuses === null
+					? DEFAULT_STATUSES
+					: statuses
+							.filter( ( { slug } ) => slug !== 'trash' )
+							.map( ( { slug } ) => slug ),
 		};
 	}, [ statuses ] );
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -30,11 +30,12 @@ const defaultConfigPerViewType = {
 };
 
 export default function PagePages() {
+	const allStatuses = 'publish, draft';
 	const [ view, setView ] = useState( {
 		type: 'list',
 		filters: {
 			search: '',
-			status: 'publish, draft',
+			status: allStatuses,
 		},
 		page: 1,
 		perPage: 5,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -202,7 +202,7 @@ export default function PagePages() {
 					{
 						type: 'enumeration',
 						id: 'status',
-						resetValue: 'publish,draft',
+						resetValue: defaultStatuses,
 					},
 				],
 				elements:

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -21,7 +21,6 @@ import useTrashPostAction from '../actions/trash-post';
 import Media from '../media';
 
 const EMPTY_ARRAY = [];
-const EMPTY_OBJECT = {};
 const defaultConfigPerViewType = {
 	list: {},
 	grid: {
@@ -51,22 +50,13 @@ export default function PagePages() {
 	} );
 
 	const { records: statuses } = useEntityRecords( 'root', 'status' );
-	const { postStatuses, defaultStatuses } = useMemo( () => {
-		return {
-			postStatuses:
-				statuses === null
-					? EMPTY_OBJECT
-					: Object.fromEntries(
-							statuses.map( ( { slug, name } ) => [ slug, name ] )
-					  ),
-			defaultStatuses:
-				statuses === null
-					? DEFAULT_STATUSES
-					: statuses
-							.filter( ( { slug } ) => slug !== 'trash' )
-							.map( ( { slug } ) => slug )
-							.join(),
-		};
+	const defaultStatuses = useMemo( () => {
+		return statuses === null
+			? DEFAULT_STATUSES
+			: statuses
+					.filter( ( { slug } ) => slug !== 'trash' )
+					.map( ( { slug } ) => slug )
+					.join();
 	}, [ statuses ] );
 
 	useEffect( () => {
@@ -197,7 +187,8 @@ export default function PagePages() {
 				header: __( 'Status' ),
 				id: 'status',
 				getValue: ( { item } ) =>
-					postStatuses[ item.status ] ?? item.status,
+					statuses?.find( ( { slug } ) => slug === item.status )
+						?.name ?? item.status,
 				filters: [
 					{
 						type: 'enumeration',
@@ -206,13 +197,10 @@ export default function PagePages() {
 					},
 				],
 				elements:
-					( postStatuses &&
-						Object.entries( postStatuses )
-							.map( ( [ slug, name ] ) => ( {
-								value: slug,
-								label: name,
-							} ) ) ) ||
-					[],
+					statuses?.map( ( { slug, name } ) => ( {
+						value: slug,
+						label: name,
+					} ) ) || [],
 				enableSorting: false,
 			},
 			{
@@ -228,7 +216,7 @@ export default function PagePages() {
 				},
 			},
 		],
-		[ postStatuses, authors ]
+		[ statuses, authors ]
 	);
 
 	const trashPostAction = useTrashPostAction();

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -30,9 +30,6 @@ const defaultConfigPerViewType = {
 };
 
 export default function PagePages() {
-	// The pages endpoint depends on the request to the status endpoint (see status filter).
-	// This is a convenience to avoid a double request to the pages endpoint
-	// unless it is strictly necessary (the statuses are different from the default ones).
 	const DEFAULT_STATUSES = 'publish,future,draft,pending,private'; // All statuses but 'trash'.
 	const [ view, setView ] = useState( {
 		type: 'list',
@@ -73,7 +70,20 @@ export default function PagePages() {
 	}, [ statuses ] );
 
 	useEffect( () => {
-		if ( DEFAULT_STATUSES !== defaultStatuses ) {
+		// Only update the view if the statuses received from the endpoint
+		// are different from the DEFAULT_STATUSES provided initially.
+		//
+		// The pages endpoint depends on the status endpoint via the status filter.
+		// Initially, this code filters the pages request by DEFAULT_STATUTES,
+		// instead of using the default (publish).
+		// https://developer.wordpress.org/rest-api/reference/pages/#list-pages
+		//
+		// By doing so, it avoids a second request to the pages endpoint
+		// upon receiving the statuses when they are the same (most common scenario).
+		if (
+			DEFAULT_STATUSES.split( ',' ).sort().join() !==
+			defaultStatuses.split( ',' ).sort().join()
+		) {
 			setView( {
 				...view,
 				filters: {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -30,12 +30,12 @@ const defaultConfigPerViewType = {
 };
 
 export default function PagePages() {
-	const allStatuses = 'publish, draft';
+	const DEFAULT_STATUSES = 'publish, draft, future, pending, private'; // All but 'trash'.
 	const [ view, setView ] = useState( {
 		type: 'list',
 		filters: {
 			search: '',
-			status: allStatuses,
+			status: DEFAULT_STATUSES,
 		},
 		page: 1,
 		perPage: 5,
@@ -49,17 +49,22 @@ export default function PagePages() {
 		hiddenFields: [ 'date', 'featured-image' ],
 		layout: {},
 	} );
-	// Request post statuses to get the proper labels.
+
 	const { records: statuses } = useEntityRecords( 'root', 'status' );
-	const postStatuses = useMemo(
-		() =>
-			statuses === null
-				? EMPTY_OBJECT
-				: Object.fromEntries(
-						statuses.map( ( { slug, name } ) => [ slug, name ] )
-				  ),
-		[ statuses ]
-	);
+	const { postStatuses, allStatuses } = useMemo( () => {
+		return {
+			postStatuses:
+				statuses === null
+					? EMPTY_OBJECT
+					: Object.fromEntries(
+							statuses.map( ( { slug, name } ) => [ slug, name ] )
+					  ),
+			allStatuses:
+				statuses
+					.filter( ( { slug } ) => slug !== 'trash' )
+					.map( ( { slug } ) => slug ) || DEFAULT_STATUSES,
+		};
+	}, [ statuses ] );
 
 	const queryArgs = useMemo(
 		() => ( {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -29,7 +29,9 @@ const defaultConfigPerViewType = {
 };
 
 export default function PagePages() {
-	const DEFAULT_STATUSES = 'publish,future,draft,pending,private'; // All statuses but 'trash'.
+	// DEFAULT_STATUSES is intentionally sorted. Items do not have spaces in between them.
+	// The reason for that is to match defaultStatuses because we compare both strings below (see useEffect).
+	const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All statuses but 'trash'.
 	const [ view, setView ] = useState( {
 		type: 'list',
 		filters: {
@@ -56,6 +58,7 @@ export default function PagePages() {
 			: statuses
 					.filter( ( { slug } ) => slug !== 'trash' )
 					.map( ( { slug } ) => slug )
+					.sort()
 					.join();
 	}, [ statuses ] );
 
@@ -70,10 +73,7 @@ export default function PagePages() {
 		//
 		// By doing so, it avoids a second request to the pages endpoint
 		// upon receiving the statuses when they are the same (most common scenario).
-		if (
-			DEFAULT_STATUSES.split( ',' ).sort().join() !==
-			defaultStatuses.split( ',' ).sort().join()
-		) {
+		if ( DEFAULT_STATUSES !== defaultStatuses ) {
 			setView( {
 				...view,
 				filters: {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -174,9 +174,6 @@ export default function PagePages() {
 				elements:
 					( postStatuses &&
 						Object.entries( postStatuses )
-							.filter( ( [ slug ] ) =>
-								[ 'publish', 'draft' ].includes( slug )
-							)
 							.map( ( [ slug, name ] ) => ( {
 								value: slug,
 								label: name,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/55270#discussion_r1362602798

## What?

Updates the pages page to retrieve all the pages (not only those with publish & draft status). Also lists all statuses in the states filter.

## Why?

We want to show all status.

## Testing Instructions

- Create a few pages with different statuses: publish, draft, scheduled, trash, etc.
- Enable the "new admin" experiment.
- Go to the site editor > pages > manage pages. Verify that all but trashed pages are listed upon first load.
- Use the status filter
  - A specific item should only show pages with that status. For example, use trash and you'll see the trashed pages.
  - "All" will list pages with any status other than trash. This mimics the existing wp-admin interaction of today.


https://github.com/WordPress/gutenberg/assets/583546/aa19db9b-68dc-40b1-b87a-49ad744b9c6b

