### PR TITLE
Fix server processing of an empty `data-wp-context` directive

### DIFF
--- a/lib/experimental/interactivity-api/directives/wp-context.php
+++ b/lib/experimental/interactivity-api/directives/wp-context.php
@@ -18,16 +18,11 @@ function gutenberg_interactivity_process_wp_context( $tags, $context ) {
 	}
 
 	$value = $tags->get_attribute( 'data-wp-context' );
-	if ( null === $value ) {
-		// No data-wp-context directive.
-		return;
-	}
 
-	$new_context = json_decode( $value, true );
-	if ( null === $new_context ) {
-		// If the JSON is not valid, we still add an empty array to the stack.
-		$new_context = array();
-	}
+	$new_context = json_decode(
+		is_string( $value ) && ! empty( $value ) ? $value : '{}',
+		true
+	);
 
-	$context->set_context( $new_context );
+	$context->set_context( $new_context ?? array() );
 }

--- a/phpunit/experimental/interactivity-api/directives/wp-context-test.php
+++ b/phpunit/experimental/interactivity-api/directives/wp-context-test.php
@@ -124,4 +124,56 @@ class Tests_Directives_Attributes_WpContext extends WP_UnitTestCase {
 			$context->get_context()
 		);
 	}
+
+	public function test_directive_keeps_working_with_an_empty_directive() {
+		$context = new WP_Directive_Context();
+
+		$markup = '
+			<div data-wp-context=\'{ "my-key": "some-value" }\'>
+				<div data-wp-context>
+				</div>
+			</div>
+		';
+		$tags   = new WP_HTML_Tag_Processor( $markup );
+
+		// Parent div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Children div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Still the same context.
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Closing children div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Still the same context.
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Closing parent div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Now the context is empty.
+		$this->assertSame(
+			array(),
+			$context->get_context()
+		);
+	}
+
 }

--- a/phpunit/experimental/interactivity-api/directives/wp-context-test.php
+++ b/phpunit/experimental/interactivity-api/directives/wp-context-test.php
@@ -175,5 +175,4 @@ class Tests_Directives_Attributes_WpContext extends WP_UnitTestCase {
 			$context->get_context()
 		);
 	}
-
 }

--- a/phpunit/experimental/interactivity-api/directives/wp-context-test.php
+++ b/phpunit/experimental/interactivity-api/directives/wp-context-test.php
@@ -125,12 +125,63 @@ class Tests_Directives_Attributes_WpContext extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_directive_keeps_working_with_an_empty_directive() {
+	public function test_directive_keeps_working_with_a_directive_without_value() {
 		$context = new WP_Directive_Context();
 
 		$markup = '
 			<div data-wp-context=\'{ "my-key": "some-value" }\'>
 				<div data-wp-context>
+				</div>
+			</div>
+		';
+		$tags   = new WP_HTML_Tag_Processor( $markup );
+
+		// Parent div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Children div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Still the same context.
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Closing children div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Still the same context.
+		$this->assertSame(
+			array( 'my-key' => 'some-value' ),
+			$context->get_context()
+		);
+
+		// Closing parent div.
+		$tags->next_tag( array( 'tag_closers' => 'visit' ) );
+		gutenberg_interactivity_process_wp_context( $tags, $context );
+
+		// Now the context is empty.
+		$this->assertSame(
+			array(),
+			$context->get_context()
+		);
+	}
+
+	public function test_directive_keeps_working_with_an_empty_directive() {
+		$context = new WP_Directive_Context();
+
+		$markup = '
+			<div data-wp-context=\'{ "my-key": "some-value" }\'>
+				<div data-wp-context="">
 				</div>
 			</div>
 		';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

This is a follow up on https://github.com/WordPress/gutenberg/pull/55436.

The previous PR fixed the problem when the JSON provided to `data-wp-context` was not valid, and this PR fixes the problem when the `data-wp-context` is empty.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because, as explained by @dmsnell in https://github.com/WordPress/gutenberg/pull/55368, the user might forget the enter any value:

```html
<div data-wp-context>...</div>
```

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I changed the logic a little bit to accommodate both checks (invalid JSON and empty value).

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This is covered by a new unit test, but if you want to test it out:

- Add an interactive block.
- Add a div with a `data-wp-context` directive and valid JSON.
- Add a nested div inside with an empty `data-wp-context`.
- Check that it doesn't trigger a fatal error and that the initial context is still valid.
