### PR TITLE
[Mobile] - Update closePicker util and updates Image Block test data

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-media-blocks-@canary.test.js
@@ -15,7 +15,7 @@ describe( 'Gutenberg Editor Audio Block tests', () => {
 
 		// dismiss the media picker automatically opened when adding an audio block
 		await waitForMediaLibrary( editorPage.driver );
-		await editorPage.closePicker();
+		await editorPage.closeMediaPicker();
 
 		// verify there's an audio block
 		const block = await editorPage.getFirstBlockVisible();
@@ -50,7 +50,7 @@ describe( 'Gutenberg Editor File Block tests', () => {
 
 		// dismiss the media picker automatically opened when adding a file block
 		await waitForMediaLibrary( editorPage.driver );
-		await editorPage.closePicker();
+		await editorPage.closeMediaPicker();
 
 		// verify there's a file block
 		const block = await editorPage.getFirstBlockVisible();
@@ -82,7 +82,7 @@ onlyOniOS( 'Gutenberg Editor Image Block tests', () => {
 	it( 'should be able to add an image block', async () => {
 		await editorPage.initializeEditor();
 		await editorPage.addNewBlock( blockNames.image );
-		await editorPage.closePicker();
+		await editorPage.closeMediaPicker();
 
 		const imageBlock = await editorPage.getBlockAtPosition(
 			blockNames.image

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -77,7 +77,7 @@ exports.blockInsertionHtmlFromTitle = `<!-- wp:paragraph -->
 <p>The finer continuum interprets the polynomial rabbit. When can the geology runs? An astronomer runs. Should a communist consent?</p>
 <!-- /wp:paragraph -->`;
 
-exports.imageCaption = `C'est la vie my friends`;
+exports.imageCaption = `Autumn meets winter`;
 
 exports.imageCompletehtml = `<!-- wp:image {"id":1,"sizeslug":"large"} -->
 <figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/><figcaption>C'est la vie my friends</figcaption></figure>
@@ -96,7 +96,7 @@ exports.imageCompletehtml = `<!-- wp:image {"id":1,"sizeslug":"large"} -->
 <!-- /wp:paragraph -->`;
 
 exports.imageShortHtml = `<!-- wp:image {"id":1,"sizeslug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground" class="wp-image-1"/><figcaption class="wp-element-caption">C'est la vie my friends</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground" class="wp-image-1"/><figcaption class="wp-element-caption">Autumn meets winter</figcaption></figure>
 <!-- /wp:image -->`;
 
 exports.unsupportedBlockHtml = `<!-- wp:jetpack/gif {"giphyUrl":"https://giphy.com/embed/3orieS4jfHJaKwkeli","searchText":"example"} /-->`;

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -816,28 +816,20 @@ class EditorPage {
 		await typeString( this.driver, imageBlockCaptionField, caption, clear );
 	}
 
-	async closePicker() {
-		if ( isAndroid() ) {
-			// Wait for media block picker to load before closing
-			const locator =
-				'//android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup';
-			await waitForVisible( this.driver, locator );
+	async closeMediaPicker() {
+		// Wait for media block picker to load before closing
+		const locator = '~WordPress Media Library';
+		await this.driver.$( locator ).waitForDisplayed();
 
-			const { width, height } = await this.driver.getWindowSize();
-			await this.driver
-				.action( 'pointer', {
-					parameters: { pointerType: 'touch' },
-				} )
-				.move( { x: width * 0.5, y: height * 0.1 } )
-				.down( { button: 0 } )
-				.up( { button: 0 } )
-				.perform();
-		} else {
-			await clickIfClickable(
-				this.driver,
-				'//XCUIElementTypeButton[@name="Cancel"]'
-			);
-		}
+		const { width, height } = await this.driver.getWindowSize();
+		await this.driver
+			.action( 'pointer', {
+				parameters: { pointerType: 'touch' },
+			} )
+			.move( { x: width * 0.5, y: height * 0.1 } )
+			.down( { button: 0 } )
+			.up( { button: 0 } )
+			.perform();
 	}
 
 	// =============================


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6301

## What?
Related to the Appium 2 migration in https://github.com/WordPress/gutenberg/pull/55166.

This PR updates the name of the `closePicker` util and its logic, it also updates the test data for the Image block.

## Why?
The `closePicker` logic was related to the media picker only so it makes sense to update the name to `closeMediaPicker` It also updates its logic so it works the same for both platforms,  I was seeing some issues with a flaky test on iOS and slowness while looking for the `Cancel` button of the picker by the Xpath.

For the Image block test data, we were getting flaky tests due to issues with the autocorrect and the French string being auto-corrected.

## How?
For the `closeMediaPicker`, now it looks for the `WordPress Media Library` ID for both iOS and Android and it dismisses the picker using the same `touch` approach.

The image block caption is now in English to avoid the flaky test due to auto-correcting the string.

## Testing Instructions
Local tests should pass by running the following command for both platforms:

**Android**
```
 TEST_RN_PLATFORM=android npm run native device-tests:local gutenberg-editor-media-blocks-@canary.test
```

**iOS**
```
 TEST_RN_PLATFORM=ios npm run native device-tests:local gutenberg-editor-media-blocks-@canary.test
```

I've also confirmed it runs on SauceLabs by triggering the test from a local command against the Appium 2 build.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A