### PR TITLE
Blocks: Skip unnecessary esc_attr() in HTML API call in Social Link block

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -62,10 +62,10 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$processor = new WP_HTML_Tag_Processor( $link );
 	$processor->next_tag( 'a' );
 	if ( $open_in_new_tab ) {
-		$processor->set_attribute( 'rel', esc_attr( $rel ) . ' noopener nofollow' );
+		$processor->set_attribute( 'rel', trim( $rel . ' noopener nofollow' ) );
 		$processor->set_attribute( 'target', '_blank' );
 	} elseif ( '' !== $rel ) {
-		$processor->set_attribute( 'rel', esc_attr( $rel ) );
+		$processor->set_attribute( 'rel', trim( $rel ) );
 	}
 	return $processor->get_updated_html();
 }


### PR DESCRIPTION
## What?

Removes unnecessary calls to `esc_attr()` and adds a call to `trim()` around `rel` values in the Social Links block. Potentially addresses Core-59682

## Why?

Because the HTML API already escapes values passed into it, it's not only unnecessary to manually wrap attribute values in `esc_attr()`, but can be confusing and lead to mixed-escaped or double-escaped values. It's better to avoid the extra work and leave things plain as PHP values.

## How?

This patch removes the call to `esc_attr()` and replaces it with `trim()`, which not only removes the extra work but also ensures that the `rel` values don't have leading or trailing whitespace.

## Testing

There should be no functional or visual changes in this PR. 