### PR TITLE
Post feature image block: wrap images with hrefs in an A tag

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -209,7 +209,17 @@ export default function PostFeaturedImageEdit( {
 			<>
 				{ controls }
 				<div { ...blockProps }>
-					{ placeholder() }
+					{ !! isLink ? (
+						<a
+							href={ postPermalink }
+							target={ linkTarget }
+							{ ...disabledClickProps }
+						>
+							{ placeholder() }
+						</a>
+					) : (
+						placeholder()
+					) }
 					<Overlay
 						attributes={ attributes }
 						setAttributes={ setAttributes }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -43,6 +43,11 @@ function getMediaSourceUrlBySizeSlug( media, slug ) {
 	);
 }
 
+const disabledClickProps = {
+	onClick: ( event ) => event.preventDefault(),
+	'aria-disabled': true,
+};
+
 export default function PostFeaturedImageEdit( {
 	clientId,
 	attributes,
@@ -67,9 +72,10 @@ export default function PostFeaturedImageEdit( {
 		postId
 	);
 
-	const { media, postType } = useSelect(
+	const { media, postType, postPermalink } = useSelect(
 		( select ) => {
-			const { getMedia, getPostType } = select( coreStore );
+			const { getMedia, getPostType, getEditedEntityRecord } =
+				select( coreStore );
 			return {
 				media:
 					featuredImage &&
@@ -77,10 +83,16 @@ export default function PostFeaturedImageEdit( {
 						context: 'view',
 					} ),
 				postType: postTypeSlug && getPostType( postTypeSlug ),
+				postPermalink: getEditedEntityRecord(
+					'postType',
+					postTypeSlug,
+					postId
+				)?.link,
 			};
 		},
-		[ featuredImage, postTypeSlug ]
+		[ featuredImage, postTypeSlug, postId ]
 	);
+
 	const mediaUrl = getMediaSourceUrlBySizeSlug( media, sizeSlug );
 
 	const imageSizes = useSelect(
@@ -295,7 +307,18 @@ export default function PostFeaturedImageEdit( {
 				</BlockControls>
 			) }
 			<figure { ...blockProps }>
-				{ image }
+				{ /* If the featured image is linked, wrap in an <a /> tag to trigger any inherited link element styles */ }
+				{ !! isLink ? (
+					<a
+						href={ postPermalink }
+						target={ linkTarget }
+						{ ...disabledClickProps }
+					>
+						{ image }
+					</a>
+				) : (
+					image
+				) }
 				<Overlay
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -103,6 +103,18 @@
 	> a {
 		cursor: default;
 	}
+
+	// When the Post Featured Image block is linked,
+	// and wrapped with a disabled <a /> tag
+	// ensure that the placeholder items are visible when selected.
+	&.is-selected .components-placeholder.has-illustration {
+		.components-button,
+		.components-placeholder__instructions,
+		.components-placeholder__label {
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
 }
 
 div[data-type="core/post-featured-image"] {

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -96,6 +96,13 @@
 		height: 100%;
 		width: 100%;
 	}
+
+	// When the Post Featured Image block is linked,
+	// it's wrapped with a disabled <a /> tag.
+	// Restore cursor style so it doesn't appear 'clickable'.
+	> a {
+		cursor: default;
+	}
 }
 
 div[data-type="core/post-featured-image"] {


### PR DESCRIPTION
Context: https://github.com/WordPress/gutenberg/issues/55336#issuecomment-1769712657
Props to @TheRadicalDreamer

## What?

From the back catalogue of wrapping A tag hits, comes: "Let's wrap the image element in an A tag (in the editor only)"!

So, in the editor, where `isLink` is `true` let's wrap the featured image in an A tag!


## Why?
Copy paste quote from https://github.com/WordPress/gutenberg/pull/55470:

> To ensure any inherited styles from the link element, such as border color, apply to the image in the editor. The goal is to match frontend behavior.
> 
> Where a border color hasn't been defined, it will default to the closest color. In the frontend, it will be the link element's color due to the wrapping <a />.
> 
> In the editor, it's the body color as the img is not wrapped by a link element.

Also, the CSS change is to force the cursor style to be default since, in the editor, because we don't want to indicate that the image is clickable.

## How?

As in https://github.com/WordPress/gutenberg/pull/55470, wraps post featured image in an A tag so that it simulates the frontend, and ensures any styles the IMG elements inherits from the A element are also displayed in the editor.

## Testing Instructions
For testing I've used Empty Theme, but any block theme will do. 

To ensure we can see the effect, it's important to set different colors for the body background and element links. Here are some test styles to whack into your theme.json.

```json
	"styles": {
		"color": {
			"background": "pink",
			"text": "green"
		},
		"elements": {
			"link": {
				"color": {
					"text": "red"
				}
			}
		}
	}
```

1. Get a few posts ready, each of which with a post featured image. 
2. In a block theme, insert a Query block into a site template, like on your home page, with at minimum a Post Featured Image block. Add a Site Title and any else you fancy.
3. Select a featured image in one of the posts within the Query block, ensure the "Link to post" toggle switch is activated in the block's setting. 
4. Now adjust the border width only (not the color). 
5. Save and compare the editor with the frontend. 
6. Are the border colors the same? Yes? You win! No? Please report here :) Thanks.
7. Also check adding a Post Featured Image in a single post  (with  "Link to post" activated and a border width only). 
8. In the Post editor, check that the border also applies correctly to the placeholder. (and that the media upload still works with a linked image).

<details>

<summary>Some example Query block code</summary>

```html

<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":10}} -->
<div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
<!-- wp:post-featured-image {"isLink":true,"style":{"border":{"width":"34px"}}} /-->

<!-- wp:post-title {"isLink":true} /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template --></div>
<!-- /wp:query -->
```

</details>




### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/6458278/2985addb-ba84-452f-8d34-431587599350

