### PR TITLE
#53560 change button property "isSmall" to "size" on navigation menu-title

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Autocomplete`: Add `aria-live` announcements for Mac and IOS Voiceover to fix lack of support for `aria-owns` ([#54902](https://github.com/WordPress/gutenberg/pull/54902)).
 
+### Internal
+-	`Button`: deprecating `isSmall` prop in favour of `size="small"` ([#55503](https://github.com/WordPress/gutenberg/pull/55503)).
+
+
 ## 25.10.0 (2023-10-18)
 
 ### Enhancements

--- a/packages/components/src/navigation/menu/menu-title.tsx
+++ b/packages/components/src/navigation/menu/menu-title.tsx
@@ -66,7 +66,7 @@ export default function NavigationMenuTitle( {
 
 							{ hasSearch && (
 								<Button
-									isSmall
+									size="small"
 									variant="tertiary"
 									label={ searchButtonLabel }
 									onClick={ () => setIsSearching( true ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixed #53560 

## Why?
Because isSmall property is deprecated.
