### PR TITLE
DataViews: remove string from pages sidebar

### DIFF
--- a/packages/edit-site/src/components/dataviews/sidebar-content.js
+++ b/packages/edit-site/src/components/dataviews/sidebar-content.js
@@ -1,3 +1,4 @@
 export default function DataViewsSidebarContent() {
-	return <p>Add views ui here</p>;
+	// TODO: add views UI.
+	return null;
 }


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/55465

Removes placeholder string from UI.

| Before | After |
| --- | --- |
| <img width="631" alt="Captura de ecrã 2023-10-20, às 13 45 23" src="https://github.com/WordPress/gutenberg/assets/583546/29b103ae-fe3a-4194-ae6f-e3ce40857407"> | <img width="631" alt="Captura de ecrã 2023-10-20, às 13 45 03" src="https://github.com/WordPress/gutenberg/assets/583546/61648cd9-2919-4453-b54c-d74bdea7a3b3"> |

