### PR TITLE
Add heading block variations and transforms

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -221,6 +221,20 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 						{ ( { onClose } ) =>
 							showDropDown && (
 								<div className="block-editor-block-switcher__container">
+									{ hasPatternTransformation && (
+										<PatternTransformationsMenu
+											blocks={ blocks }
+											patterns={ patterns }
+											onSelect={ (
+												transformedBlocks
+											) => {
+												onPatternTransform(
+													transformedBlocks
+												);
+												onClose();
+											} }
+										/>
+									) }
 									{ hasBlockOrBlockVariationTransforms && (
 										<BlockTransformationsMenu
 											className="block-editor-block-switcher__transforms__menugroup"
@@ -238,20 +252,6 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 											onSelectVariation={ ( name ) => {
 												onBlockVariationTransform(
 													name
-												);
-												onClose();
-											} }
-										/>
-									) }
-									{ hasPatternTransformation && (
-										<PatternTransformationsMenu
-											blocks={ blocks }
-											patterns={ patterns }
-											onSelect={ (
-												transformedBlocks
-											) => {
-												onPatternTransform(
-													transformedBlocks
 												);
 												onClose();
 											} }

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -221,20 +221,6 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 						{ ( { onClose } ) =>
 							showDropDown && (
 								<div className="block-editor-block-switcher__container">
-									{ hasPatternTransformation && (
-										<PatternTransformationsMenu
-											blocks={ blocks }
-											patterns={ patterns }
-											onSelect={ (
-												transformedBlocks
-											) => {
-												onPatternTransform(
-													transformedBlocks
-												);
-												onClose();
-											} }
-										/>
-									) }
 									{ hasBlockOrBlockVariationTransforms && (
 										<BlockTransformationsMenu
 											className="block-editor-block-switcher__transforms__menugroup"
@@ -252,6 +238,20 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 											onSelectVariation={ ( name ) => {
 												onBlockVariationTransform(
 													name
+												);
+												onClose();
+											} }
+										/>
+									) }
+									{ hasPatternTransformation && (
+										<PatternTransformationsMenu
+											blocks={ blocks }
+											patterns={ patterns }
+											onSelect={ (
+												transformedBlocks
+											) => {
+												onPatternTransform(
+													transformedBlocks
 												);
 												onClose();
 											} }

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -85,7 +85,7 @@
 }
 
 .components-popover.block-editor-block-switcher__popover .components-popover__content {
-	min-width: 300px;
+	min-width: 248px;
 }
 
 .block-editor-block-switcher__popover__preview__parent {

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -16,7 +16,6 @@ import {
 	RichText,
 	useBlockProps,
 	store as blockEditorStore,
-	HeadingLevelDropdown,
 } from '@wordpress/block-editor';
 
 /**
@@ -91,12 +90,6 @@ function HeadingEdit( {
 	return (
 		<>
 			<BlockControls group="block">
-				<HeadingLevelDropdown
-					value={ level }
-					onChange={ ( newLevel ) =>
-						setAttributes( { level: newLevel } )
-					}
-				/>
 				<AlignmentControl
 					value={ textAlign }
 					onChange={ ( nextAlign ) => {

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -13,6 +13,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -53,6 +54,7 @@ export const settings = {
 		}
 	},
 	transforms,
+	variations,
 	deprecated,
 	merge( attributes, attributesToMerge ) {
 		return {

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	headingLevel1,
+	headingLevel2,
+	headingLevel3,
+	headingLevel4,
+	headingLevel5,
+	headingLevel6,
+} from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'heading-1',
+		title: __( 'Heading 1' ),
+		icon: headingLevel1,
+		attributes: { level: 1 },
+		scope: [ 'transform', 'hidden' ],
+		isActive: ( blockAttributes ) => blockAttributes.level === 1,
+	},
+	{
+		name: 'heading-2',
+		title: __( 'Heading 2' ),
+		icon: headingLevel2,
+		attributes: { level: 2 },
+		scope: [ 'transform', 'hidden' ],
+		isActive: ( blockAttributes ) => blockAttributes.level === 2,
+	},
+	{
+		name: 'heading-3',
+		title: __( 'Heading 3' ),
+		icon: headingLevel3,
+		attributes: { level: 3 },
+		scope: [ 'transform', 'hidden' ],
+		isActive: ( blockAttributes ) => blockAttributes.level === 3,
+	},
+	{
+		name: 'heading-4',
+		title: __( 'Heading 4' ),
+		icon: headingLevel4,
+		attributes: { level: 4 },
+		scope: [ 'transform', 'hidden' ],
+		isActive: ( blockAttributes ) => blockAttributes.level === 4,
+	},
+	{
+		name: 'heading-5',
+		title: __( 'Heading 5' ),
+		icon: headingLevel5,
+		attributes: { level: 5 },
+		scope: [ 'transform', 'hidden' ],
+		isActive: ( blockAttributes ) => blockAttributes.level === 5,
+	},
+	{
+		name: 'heading-6',
+		title: __( 'Heading 6' ),
+		icon: headingLevel6,
+		attributes: { level: 6 },
+		scope: [ 'transform', 'hidden' ],
+		isActive: ( blockAttributes ) => blockAttributes.level === 6,
+	},
+];
+
+export default variations;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of #55067, to support more intuitive transforming between content—initially between paragraphs and headings of any level. 

Wanted to give it a spin and see how it felt live. I do think that more cleaning up will improve the flow a bit more (listed in "Follow-ups" below.

## How?
- Add variations for the heading block.
- Remove HeadingLevelDropdown from the heading block. The block icon now serves as the transform flow (as it does for every other block). I.e. click on "H1" to change it to any other heading level, or other blocks. 

## Follow-ups

- [ ] Add support for transforming to block variations, to add transforms from paragraph blocks to the six heading levels. This way you can quickly switch from paragraphs to any heading level.
- [ ] Consider moving the pattern transform UI below block transforms, as block transforms should remain in the same place across all blocks. This would map the pattern transform functionality to behave like block styles, as they too are added at the end of the popover if supported.
- [ ] https://github.com/WordPress/gutenberg/pull/55522
- [ ] Refine available transforms to focus on content to content transforming.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a heading block.
3. See it as an H2 block, per current behavior.
4. Click the block icon to change it to any other heading variation. 
5. See heading variation transformed to. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1813435/738c5cb4-a5b8-4daf-bd07-b0a592be5a02
