### PR TITLE
Add hidden scope to WPBlockVariationScope

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -26,12 +26,17 @@ function VariationsButtons( {
 	selectedValue,
 	variations,
 } ) {
+	// Filters out the hidden scope transforms, which do not render in the block card.
+	const filteredVariations = variations.filter(
+		( variation ) => ! variation.scope.includes( 'hidden' )
+	);
+
 	return (
 		<fieldset className={ className }>
 			<VisuallyHidden as="legend">
 				{ __( 'Transform to variation' ) }
 			</VisuallyHidden>
-			{ variations.map( ( variation ) => (
+			{ filteredVariations.map( ( variation ) => (
 				<Button
 					key={ variation.name }
 					icon={ <BlockIcon icon={ variation.icon } showColors /> }
@@ -60,7 +65,12 @@ function VariationsDropdown( {
 	selectedValue,
 	variations,
 } ) {
-	const selectOptions = variations.map(
+	// Filters out the hidden scope transforms, which do not render in the block card.
+	const filteredVariations = variations.filter(
+		( variation ) => ! variation.scope.includes( 'hidden' )
+	);
+
+	const selectOptions = filteredVariations.map(
 		( { name, title, description } ) => ( {
 			value: name,
 			label: title,

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -10,7 +10,7 @@ const variations = [
 		title: __( 'Modified Date' ),
 		description: __( "Display a post's last updated date." ),
 		attributes: { displayType: 'modified' },
-		scope: [ 'block', 'inserter' ],
+		scope: [ 'block', 'inserter', 'transform', 'hidden' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes.displayType === 'modified',
 		icon: postDate,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -56,7 +56,7 @@ import { unlock } from '../lock-unlock';
 /**
  * Named block variation scopes.
  *
- * @typedef {'block'|'inserter'|'transform'} WPBlockVariationScope
+ * @typedef {'block'|'inserter'|'transform'|'hidden'} WPBlockVariationScope
  */
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a way for a block's variations to not render within the block card, while also maintaining transformability between each other. A follow-up to support #55520, where we don't need the transforms from H1 to H6 in the block inspector. This would also help with leaning in to variations more, especially around content -> content transformations. 

This PR adds support to the "Date" block's "Modified Date" variation. 

Note that `hidden` may not be the best scope value; open to suggestions. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add the "Date" block to a page.
2. See the "Modified Date" block variation within the "Transform to" popover, but not in the block card (sidebar inspector). 

## Screenshots or screencast <!-- if applicable -->


| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-10-20 at 15 20 14](https://github.com/WordPress/gutenberg/assets/1813435/2c55572d-778e-4ccb-8c07-f26206fcbeda)|![CleanShot 2023-10-20 at 15 22 30](https://github.com/WordPress/gutenberg/assets/1813435/254d7af1-e958-4e68-9669-7ecc67438f9b)|



