### PR TITLE
Improve toolbar button focus visual

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -64,7 +64,7 @@
  */
 
 @mixin block-toolbar-button-style__focus() {
-	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 4px $white;
+	box-shadow: inset 0 0 0 $border-width var(--wp-components-color-background, $white), 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -58,7 +58,7 @@
 
 		&:focus,
 		&.is-active:focus {
-			box-shadow: inset 0 0 0 $border-width var(--wp-components-color-background, #fff), 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+			@include block-toolbar-button-style__focus();
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update the block-toolbar-button-style__focus() mixin to use the same button focus states as the header toolbar.

## Why?
Consistency + these tiny details matter. 

## Testing
1. Check the block toolbar. 
2. Check the block styles (I updated it to use the same mixin, as it was using the same styles). 

## Screenshots or screencast <!-- if applicable -->
#### Before

https://github.com/WordPress/gutenberg/assets/1813435/4518c63f-e53d-4de0-af72-70a03d5b9d67


#### After 

https://github.com/WordPress/gutenberg/assets/1813435/ac74437d-1458-4858-9d85-a4b999c295a2

