### PR TITLE
Update external images panel in post publish sidebar

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -10,7 +10,6 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { upload } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
@@ -135,7 +134,7 @@ export default function PostFormatPanel() {
 		<PanelBody initialOpen={ true } title={ panelBodyTitle }>
 			<p>
 				{ __(
-					'There are some external images in the post which can be uploaded to the media library. Images coming from different domains may not always display correctly, load slowly for visitors, or be removed unexpectedly.'
+					'Upload external images to the Media Library. Images from different domains may load slowly, display incorrectly, or be removed unexpectedly.'
 				) }
 			</p>
 			<div
@@ -153,12 +152,8 @@ export default function PostFormatPanel() {
 				{ isUploading ? (
 					<Spinner />
 				) : (
-					<Button
-						icon={ upload }
-						variant="primary"
-						onClick={ uploadImages }
-					>
-						{ __( 'Upload all' ) }
+					<Button variant="primary" onClick={ uploadImages }>
+						{ __( 'Upload' ) }
 					</Button>
 				) }
 			</div>

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -729,7 +729,7 @@ test.describe( 'Image', () => {
 		await page
 			.getByRole( 'button', { name: 'Publish', exact: true } )
 			.click();
-		await page.getByRole( 'button', { name: 'Upload all' } ).click();
+		await page.getByRole( 'button', { name: 'Upload' } ).click();
 
 		await expect( page.locator( '.components-spinner' ) ).toHaveCount( 0 );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -729,7 +729,9 @@ test.describe( 'Image', () => {
 		await page
 			.getByRole( 'button', { name: 'Publish', exact: true } )
 			.click();
-		await page.getByRole( 'button', { name: 'Upload' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Upload', exact: true } )
+			.click();
 
 		await expect( page.locator( '.components-spinner' ) ).toHaveCount( 0 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Simplify copy and view of the external images help panel in the post publish sidebar. A small tweak I noticed while looking at https://github.com/WordPress/gutenberg/issues/54185.  

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post.
2. Add an image to the page via URL (or insert a pattern that uses an external image). 
2. Publish the post (with post publish sidebar available). 
3. See changes. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-10-20 at 16 40 33](https://github.com/WordPress/gutenberg/assets/1813435/2ebdd291-e60d-497b-9b28-afd8bc84955c)|![CleanShot 2023-10-20 at 16 45 37](https://github.com/WordPress/gutenberg/assets/1813435/074f05d4-4adf-4270-8e40-10d9705bd81f)|


