### PR TITLE
Improve modal and fullscreen/starter content view

### DIFF
--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -17,9 +17,10 @@
 
 .block-library-template-part__selection-search {
 	background: $white;
+	box-shadow: 0 -$grid-unit-10 0 6px $white; // Fill in the space around the search.
 	position: sticky;
 	top: 0;
-	padding: $grid-unit-20 0;
+	padding: $grid-unit-10 0;
 	z-index: z-index(".block-library-template-part__selection-search");
 }
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -91,13 +91,12 @@
 // modal screen).
 .components-modal__header {
 	box-sizing: border-box;
-	border-bottom: $border-width solid transparent;
 	padding: 0 $grid-unit-40;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
-	height: $header-height + $grid-unit-15;
+	height: $header-height + $grid-unit-10;
 	width: 100%;
 	z-index: z-index(".components-modal__header");
 	position: absolute;
@@ -120,7 +119,7 @@
 	}
 
 	.components-modal__content.has-scrolled-content:not(.hide-header) & {
-		border-bottom-color: $gray-300;
+		box-shadow: 0 0 0 1px rgba($black, 0.13);
 	}
 
 	& + p {
@@ -149,7 +148,7 @@
 // Modal contents.
 .components-modal__content {
 	flex: 1;
-	margin-top: $header-height + $grid-unit-15;
+	margin-top: $header-height + $grid-unit-10;
 	// Small top padding required to avoid cutting off the visible outline when the first child element is focusable.
 	padding: $grid-unit-05 * 0.5 $grid-unit-40 $grid-unit-40;
 	overflow: auto;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,7 +5,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba($black, 0.35);
+	background-color: rgba($black, 0.4);
 	z-index: z-index(".components-modal__screen-overlay");
 	display: flex;
 	// backdrop-filter: blur($grid-unit);
@@ -45,8 +45,8 @@
 				max-height: none;
 			}
 			@include break-medium() {
-				width: calc(100% - #{ $grid-unit-50 * 2 });
-				height: calc(100% - #{ $grid-unit-50 * 2 });
+				width: calc(100% - #{ $header-height * 2 + $border-width });
+				height: calc(100% - #{ $header-height * 2 + $border-width });
 				max-width: none;
 			}
 		}
@@ -92,7 +92,7 @@
 .components-modal__header {
 	box-sizing: border-box;
 	border-bottom: $border-width solid transparent;
-	padding: $grid-unit-30 $grid-unit-40 $grid-unit-10;
+	padding: 0 $grid-unit-40;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -151,7 +151,7 @@
 	flex: 1;
 	margin-top: $header-height + $grid-unit-15;
 	// Small top padding required to avoid cutting off the visible outline when the first child element is focusable.
-	padding: $grid-unit-05 $grid-unit-40 $grid-unit-40;
+	padding: $grid-unit-05 * 0.5 $grid-unit-40 $grid-unit-40;
 	overflow: auto;
 
 	&.hide-header {

--- a/packages/edit-post/src/components/start-page-options/style.scss
+++ b/packages/edit-post/src/components/start-page-options/style.scss
@@ -1,19 +1,26 @@
-// 2 column masonry layout.
 .edit-post-start-page-options__modal-content .block-editor-block-patterns-list {
-	column-count: 2;
-	column-gap: $grid-unit-30;
 
-	@include break-medium() {
-		column-count: 3;
+	@include break-small() {
+		column-count: 2;
+		column-gap: $grid-unit-30;
 	}
 
 	@include break-wide() {
-		column-count: 4;
+		column-count: 3;
+		column-gap: $grid-unit-40;
 	}
 
 	.block-editor-block-patterns-list__list-item {
 		break-inside: avoid-column;
 		margin-bottom: $grid-unit-30;
+
+		@include break-small() {
+			margin-bottom: $grid-unit-40;
+		}
+
+		.block-editor-block-patterns-list__item-title {
+			display: none;
+		}
 
 		.block-editor-block-preview__container {
 			min-height: 100px;

--- a/packages/edit-site/src/components/start-template-options/style.scss
+++ b/packages/edit-site/src/components/start-template-options/style.scss
@@ -27,18 +27,19 @@ $actions-height: 92px;
 
 .edit-site-start-template-options__modal-content .block-editor-block-patterns-list {
 	column-count: 2;
-	column-gap: $grid-unit-30;
-
-	@include break-medium() {
-		column-count: 3;
-	}
+	column-gap: $grid-unit-40;
 
 	@include break-wide() {
-		column-count: 4;
+		column-count: 3;
 	}
 
 	.block-editor-block-patterns-list__list-item {
 		break-inside: avoid-column;
+		margin-bottom: $grid-unit-30;
+
+		@include break-small() {
+			margin-bottom: $grid-unit-40;
+		}
 
 		.block-editor-block-patterns-list__item-title {
 			display: none;

--- a/packages/interface/src/components/preferences-modal-tabs/style.scss
+++ b/packages/interface/src/components/preferences-modal-tabs/style.scss
@@ -3,7 +3,7 @@ $vertical-tabs-width: 160px;
 .interface-preferences__tabs {
 	.components-tab-panel__tabs {
 		position: absolute;
-		top: $header-height + $grid-unit-30;
+		top: $header-height + $grid-unit-10;
 		// Aligns button text instead of button box.
 		left: $grid-unit-20;
 		width: $vertical-tabs-width;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Tweaks to make the fullscreen modal display better, as well as the starter content modal. Follow-up would include consolidating the template/template part modals (without so we don't have to duplicate styles. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Activate Twenty Twenty-Four.
2. Add a new page. 
3. See the new starter content modal.
4. Navigate to the site editor. 
5. Click on the header.
6. Click on block options > "Replace" to option the template part replace modal. 
7. See changes. 

## Visuals
![CleanShot 2023-10-20 at 16 58 52](https://github.com/WordPress/gutenberg/assets/1813435/12e1cace-4742-4d89-8020-3cbc4dce0aa9)


| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-10-20 at 17 00 40](https://github.com/WordPress/gutenberg/assets/1813435/5a61c4f2-cb33-4598-ae21-3645ba6f39fc)|![CleanShot 2023-10-20 at 16 58 52](https://github.com/WordPress/gutenberg/assets/1813435/22713dd8-72ba-495f-bac6-abcd736c8059)|


| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-10-20 at 17 17 46](https://github.com/WordPress/gutenberg/assets/1813435/9d50cfa3-b445-4aa0-9807-e66e1f2a1877)|![CleanShot 2023-10-20 at 17 16 26](https://github.com/WordPress/gutenberg/assets/1813435/583fd321-d627-40d2-b7a2-19a5deb3c0cd)|


