### PR TITLE
Priority queue: request new idle callback for each item in queue

### DIFF
--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -83,22 +83,11 @@ export const createQueue = () => {
 	 * In the case that a callback adds a new callback to its own context then
 	 * the callback it adds will appear at the end of the iteration and will be
 	 * run only after all other existing contexts have finished executing.
-	 *
-	 * @param {IdleDeadline|number} deadline Idle callback deadline object, or
-	 *                                       animation frame timestamp.
 	 */
-	const runWaitingList = ( deadline ) => {
-		for ( const [ nextElement, callback ] of waitingList ) {
-			waitingList.delete( nextElement );
-			callback();
-
-			if (
-				'number' === typeof deadline ||
-				deadline.timeRemaining() <= 0
-			) {
-				break;
-			}
-		}
+	const runWaitingList = () => {
+		const [ nextElement, callback ] = waitingList.entries().next().value;
+		waitingList.delete( nextElement );
+		callback();
 
 		if ( waitingList.size === 0 ) {
 			isRunning = false;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Something I noticed while investigating performance issues is that we call as many callbacks as possible if there is time remaining. The problem with that is that these selectors trigger React re-renders that are running in a micro task, which then prolongs the idle callback, blocking user interaction.

We’re calling way too many items from the queue without knowing how long they’ll take, because part of the work is done in micro tasks.

The easiest solution is to request an idle callback for every callback in the priority queue. If the browser is idle, these will be handled immediately, but when there's a user interaction they can be interrupted.

An alternative solution could be queueing a microtask, but the former seems easier.

See how the moment the micro tasks run, we are over time?

![image](https://github.com/WordPress/gutenberg/assets/4710635/d7135705-eeb9-4889-a525-c473c5b9adfe)


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
