### PR TITLE
Rich text: only add some listeners to selected instance

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -59,247 +59,269 @@ function fixPlaceholderSelection( defaultView ) {
 export function useInputAndSelection( props ) {
 	const propsRef = useRef( props );
 	propsRef.current = props;
-	return useRefEffect( ( element ) => {
-		const { ownerDocument } = element;
-		const { defaultView } = ownerDocument;
+	return useRefEffect(
+		( element ) => {
+			const { ownerDocument } = element;
+			const { defaultView } = ownerDocument;
 
-		let isComposing = false;
+			let isComposing = false;
 
-		function onInput( event ) {
-			// Do not trigger a change if characters are being composed.
-			// Browsers  will usually emit a final `input` event when the
-			// characters are composed.
-			// As of December 2019, Safari doesn't support
-			// nativeEvent.isComposing.
-			if ( isComposing ) {
-				return;
-			}
-
-			let inputType;
-
-			if ( event ) {
-				inputType = event.inputType;
-			}
-
-			const { record, applyRecord, createRecord, handleChange } =
-				propsRef.current;
-
-			// The browser formatted something or tried to insert HTML.
-			// Overwrite it. It will be handled later by the format library if
-			// needed.
-			if (
-				inputType &&
-				( inputType.indexOf( 'format' ) === 0 ||
-					INSERTION_INPUT_TYPES_TO_IGNORE.has( inputType ) )
-			) {
-				applyRecord( record.current );
-				return;
-			}
-
-			const currentValue = createRecord();
-			const { start, activeFormats: oldActiveFormats = [] } =
-				record.current;
-
-			// Update the formats between the last and new caret position.
-			const change = updateFormats( {
-				value: currentValue,
-				start,
-				end: currentValue.start,
-				formats: oldActiveFormats,
-			} );
-
-			handleChange( change );
-		}
-
-		/**
-		 * Syncs the selection to local state. A callback for the
-		 * `selectionchange` event.
-		 */
-		function handleSelectionChange() {
-			const { record, applyRecord, createRecord, onSelectionChange } =
-				propsRef.current;
-
-			// Check if the implementor disabled editing. `contentEditable`
-			// does disable input, but not text selection, so we must ignore
-			// selection changes.
-			if ( element.contentEditable !== 'true' ) {
-				return;
-			}
-
-			// If the selection changes where the active element is a parent of
-			// the rich text instance (writing flow), call `onSelectionChange`
-			// for the rich text instance that contains the start or end of the
-			// selection.
-			if ( ownerDocument.activeElement !== element ) {
-				// Only process if the active elment is contentEditable, either
-				// this rich text instance or the writing flow parent. Fixes a
-				// bug in Firefox where it strangely selects the closest
-				// contentEditable element, even though the click was outside
-				// any contentEditable element.
-				if ( ownerDocument.activeElement.contentEditable !== 'true' ) {
+			function onInput( event ) {
+				// Do not trigger a change if characters are being composed.
+				// Browsers  will usually emit a final `input` event when the
+				// characters are composed.
+				// As of December 2019, Safari doesn't support
+				// nativeEvent.isComposing.
+				if ( isComposing ) {
 					return;
 				}
 
-				if ( ! ownerDocument.activeElement.contains( element ) ) {
-					return;
+				let inputType;
+
+				if ( event ) {
+					inputType = event.inputType;
 				}
 
-				const selection = defaultView.getSelection();
-				const { anchorNode, focusNode } = selection;
+				const { record, applyRecord, createRecord, handleChange } =
+					propsRef.current;
 
+				// The browser formatted something or tried to insert HTML.
+				// Overwrite it. It will be handled later by the format library if
+				// needed.
 				if (
-					element.contains( anchorNode ) &&
-					element !== anchorNode &&
-					element.contains( focusNode ) &&
-					element !== focusNode
+					inputType &&
+					( inputType.indexOf( 'format' ) === 0 ||
+						INSERTION_INPUT_TYPES_TO_IGNORE.has( inputType ) )
 				) {
-					const { start, end } = createRecord();
-					record.current.activeFormats = EMPTY_ACTIVE_FORMATS;
-					onSelectionChange( start, end );
-				} else if (
-					element.contains( anchorNode ) &&
-					element !== anchorNode
-				) {
-					const { start, end: offset = start } = createRecord();
-					record.current.activeFormats = EMPTY_ACTIVE_FORMATS;
-					onSelectionChange( offset );
-				} else if ( element.contains( focusNode ) ) {
-					const { start, end: offset = start } = createRecord();
-					record.current.activeFormats = EMPTY_ACTIVE_FORMATS;
-					onSelectionChange( undefined, offset );
-				}
-				return;
-			}
-
-			// In case of a keyboard event, ignore selection changes during
-			// composition.
-			if ( isComposing ) {
-				return;
-			}
-
-			const { start, end, text } = createRecord();
-			const oldRecord = record.current;
-
-			// Fallback mechanism for IE11, which doesn't support the input event.
-			// Any input results in a selection change.
-			if ( text !== oldRecord.text ) {
-				onInput();
-				return;
-			}
-
-			if ( start === oldRecord.start && end === oldRecord.end ) {
-				// Sometimes the browser may set the selection on the placeholder
-				// element, in which case the caret is not visible. We need to set
-				// the caret before the placeholder if that's the case.
-				if ( oldRecord.text.length === 0 && start === 0 ) {
-					fixPlaceholderSelection( defaultView );
+					applyRecord( record.current );
+					return;
 				}
 
-				return;
+				const currentValue = createRecord();
+				const { start, activeFormats: oldActiveFormats = [] } =
+					record.current;
+
+				// Update the formats between the last and new caret position.
+				const change = updateFormats( {
+					value: currentValue,
+					start,
+					end: currentValue.start,
+					formats: oldActiveFormats,
+				} );
+
+				handleChange( change );
 			}
 
-			const newValue = {
-				...oldRecord,
-				start,
-				end,
-				// _newActiveFormats may be set on arrow key navigation to control
-				// the right boundary position. If undefined, getActiveFormats will
-				// give the active formats according to the browser.
-				activeFormats: oldRecord._newActiveFormats,
-				_newActiveFormats: undefined,
-			};
+			/**
+			 * Syncs the selection to local state. A callback for the
+			 * `selectionchange` event.
+			 */
+			function handleSelectionChange() {
+				const { record, applyRecord, createRecord, onSelectionChange } =
+					propsRef.current;
 
-			const newActiveFormats = getActiveFormats(
-				newValue,
-				EMPTY_ACTIVE_FORMATS
-			);
+				// Check if the implementor disabled editing. `contentEditable`
+				// does disable input, but not text selection, so we must ignore
+				// selection changes.
+				if ( element.contentEditable !== 'true' ) {
+					return;
+				}
 
-			// Update the value with the new active formats.
-			newValue.activeFormats = newActiveFormats;
+				// If the selection changes where the active element is a parent of
+				// the rich text instance (writing flow), call `onSelectionChange`
+				// for the rich text instance that contains the start or end of the
+				// selection.
+				if ( ownerDocument.activeElement !== element ) {
+					// Only process if the active elment is contentEditable, either
+					// this rich text instance or the writing flow parent. Fixes a
+					// bug in Firefox where it strangely selects the closest
+					// contentEditable element, even though the click was outside
+					// any contentEditable element.
+					if (
+						ownerDocument.activeElement.contentEditable !== 'true'
+					) {
+						return;
+					}
 
-			// It is important that the internal value is updated first,
-			// otherwise the value will be wrong on render!
-			record.current = newValue;
-			applyRecord( newValue, { domOnly: true } );
-			onSelectionChange( start, end );
-		}
+					if ( ! ownerDocument.activeElement.contains( element ) ) {
+						return;
+					}
 
-		function onCompositionStart() {
-			isComposing = true;
-			// Do not update the selection when characters are being composed as
-			// this rerenders the component and might destroy internal browser
-			// editing state.
-			ownerDocument.removeEventListener(
-				'selectionchange',
-				handleSelectionChange
-			);
-			// Remove the placeholder. Since the rich text value doesn't update
-			// during composition, the placeholder doesn't get removed. There's
-			// no need to re-add it, when the value is updated on compositionend
-			// it will be re-added when the value is empty.
-			element.querySelector( `[${ PLACEHOLDER_ATTR_NAME }]` )?.remove();
-		}
+					const selection = defaultView.getSelection();
+					const { anchorNode, focusNode } = selection;
 
-		function onCompositionEnd() {
-			isComposing = false;
-			// Ensure the value is up-to-date for browsers that don't emit a final
-			// input event after composition.
-			onInput( { inputType: 'insertText' } );
-			// Tracking selection changes can be resumed.
+					if (
+						element.contains( anchorNode ) &&
+						element !== anchorNode &&
+						element.contains( focusNode ) &&
+						element !== focusNode
+					) {
+						const { start, end } = createRecord();
+						record.current.activeFormats = EMPTY_ACTIVE_FORMATS;
+						onSelectionChange( start, end );
+					} else if (
+						element.contains( anchorNode ) &&
+						element !== anchorNode
+					) {
+						const { start, end: offset = start } = createRecord();
+						record.current.activeFormats = EMPTY_ACTIVE_FORMATS;
+						onSelectionChange( offset );
+					} else if ( element.contains( focusNode ) ) {
+						const { start, end: offset = start } = createRecord();
+						record.current.activeFormats = EMPTY_ACTIVE_FORMATS;
+						onSelectionChange( undefined, offset );
+					}
+					return;
+				}
+
+				// In case of a keyboard event, ignore selection changes during
+				// composition.
+				if ( isComposing ) {
+					return;
+				}
+
+				const { start, end, text } = createRecord();
+				const oldRecord = record.current;
+
+				// Fallback mechanism for IE11, which doesn't support the input event.
+				// Any input results in a selection change.
+				if ( text !== oldRecord.text ) {
+					onInput();
+					return;
+				}
+
+				if ( start === oldRecord.start && end === oldRecord.end ) {
+					// Sometimes the browser may set the selection on the placeholder
+					// element, in which case the caret is not visible. We need to set
+					// the caret before the placeholder if that's the case.
+					if ( oldRecord.text.length === 0 && start === 0 ) {
+						fixPlaceholderSelection( defaultView );
+					}
+
+					return;
+				}
+
+				const newValue = {
+					...oldRecord,
+					start,
+					end,
+					// _newActiveFormats may be set on arrow key navigation to control
+					// the right boundary position. If undefined, getActiveFormats will
+					// give the active formats according to the browser.
+					activeFormats: oldRecord._newActiveFormats,
+					_newActiveFormats: undefined,
+				};
+
+				const newActiveFormats = getActiveFormats(
+					newValue,
+					EMPTY_ACTIVE_FORMATS
+				);
+
+				// Update the value with the new active formats.
+				newValue.activeFormats = newActiveFormats;
+
+				// It is important that the internal value is updated first,
+				// otherwise the value will be wrong on render!
+				record.current = newValue;
+				applyRecord( newValue, { domOnly: true } );
+				onSelectionChange( start, end );
+			}
+
+			function onCompositionStart() {
+				isComposing = true;
+				// Do not update the selection when characters are being composed as
+				// this rerenders the component and might destroy internal browser
+				// editing state.
+				ownerDocument.removeEventListener(
+					'selectionchange',
+					handleSelectionChange
+				);
+				// Remove the placeholder. Since the rich text value doesn't update
+				// during composition, the placeholder doesn't get removed. There's
+				// no need to re-add it, when the value is updated on compositionend
+				// it will be re-added when the value is empty.
+				element
+					.querySelector( `[${ PLACEHOLDER_ATTR_NAME }]` )
+					?.remove();
+			}
+
+			function onCompositionEnd() {
+				isComposing = false;
+				// Ensure the value is up-to-date for browsers that don't emit a final
+				// input event after composition.
+				onInput( { inputType: 'insertText' } );
+				// Tracking selection changes can be resumed.
+				ownerDocument.addEventListener(
+					'selectionchange',
+					handleSelectionChange
+				);
+			}
+
+			function onFocus() {
+				const { record, isSelected, onSelectionChange, applyRecord } =
+					propsRef.current;
+
+				// When the whole editor is editable, let writing flow handle
+				// selection.
+				if (
+					element.parentElement.closest( '[contenteditable="true"]' )
+				) {
+					return;
+				}
+
+				if ( ! isSelected ) {
+					// We know for certain that on focus, the old selection is invalid.
+					// It will be recalculated on the next mouseup, keyup, or touchend
+					// event.
+					const index = undefined;
+
+					record.current = {
+						...record.current,
+						start: index,
+						end: index,
+						activeFormats: EMPTY_ACTIVE_FORMATS,
+					};
+				} else {
+					applyRecord( record.current );
+					onSelectionChange(
+						record.current.start,
+						record.current.end
+					);
+				}
+			}
+
+			if ( ! props.isSelected ) {
+				element.addEventListener( 'focus', onFocus );
+				return () => {
+					element.removeEventListener( 'focus', onFocus );
+				};
+			}
+
+			element.addEventListener( 'input', onInput );
+			element.addEventListener( 'compositionstart', onCompositionStart );
+			element.addEventListener( 'compositionend', onCompositionEnd );
+			element.addEventListener( 'focus', onFocus );
 			ownerDocument.addEventListener(
 				'selectionchange',
 				handleSelectionChange
 			);
-		}
-
-		function onFocus() {
-			const { record, isSelected, onSelectionChange, applyRecord } =
-				propsRef.current;
-
-			// When the whole editor is editable, let writing flow handle
-			// selection.
-			if ( element.parentElement.closest( '[contenteditable="true"]' ) ) {
-				return;
-			}
-
-			if ( ! isSelected ) {
-				// We know for certain that on focus, the old selection is invalid.
-				// It will be recalculated on the next mouseup, keyup, or touchend
-				// event.
-				const index = undefined;
-
-				record.current = {
-					...record.current,
-					start: index,
-					end: index,
-					activeFormats: EMPTY_ACTIVE_FORMATS,
-				};
-			} else {
-				applyRecord( record.current );
-				onSelectionChange( record.current.start, record.current.end );
-			}
-		}
-
-		element.addEventListener( 'input', onInput );
-		element.addEventListener( 'compositionstart', onCompositionStart );
-		element.addEventListener( 'compositionend', onCompositionEnd );
-		element.addEventListener( 'focus', onFocus );
-		ownerDocument.addEventListener(
-			'selectionchange',
-			handleSelectionChange
-		);
-		return () => {
-			element.removeEventListener( 'input', onInput );
-			element.removeEventListener(
-				'compositionstart',
-				onCompositionStart
-			);
-			element.removeEventListener( 'compositionend', onCompositionEnd );
-			element.removeEventListener( 'focus', onFocus );
-			ownerDocument.removeEventListener(
-				'selectionchange',
-				handleSelectionChange
-			);
-		};
-	}, [] );
+			return () => {
+				element.removeEventListener( 'input', onInput );
+				element.removeEventListener(
+					'compositionstart',
+					onCompositionStart
+				);
+				element.removeEventListener(
+					'compositionend',
+					onCompositionEnd
+				);
+				element.removeEventListener( 'focus', onFocus );
+				ownerDocument.removeEventListener(
+					'selectionchange',
+					handleSelectionChange
+				);
+			};
+		},
+		[ props.isSelected ]
+	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Easier to see without whitespace changes: https://github.com/WordPress/gutenberg/pull/55530/files?diff=split&w=1

wip

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
