### PR TITLE
[create-block] Add ABSPATH check

### DIFF
--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -31,7 +31,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	die( 'Silence is golden.' );
+	exit; // Exit if accessed directly.
 }
 
 /**

--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -30,6 +30,10 @@
  * @package           {{namespace}}
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it registers also all assets so they can be enqueued

--- a/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
@@ -31,7 +31,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	die( 'Silence is golden.' );
+	exit; // Exit if accessed directly.
 }
 
 /**

--- a/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
@@ -30,6 +30,10 @@
  * @package           {{namespace}}
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it registers also all assets so they can be enqueued

--- a/packages/create-block/lib/templates/es5/$slug.php.mustache
+++ b/packages/create-block/lib/templates/es5/$slug.php.mustache
@@ -31,7 +31,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	die( 'Silence is golden.' );
+	exit; // Exit if accessed directly.
 }
 
 /**

--- a/packages/create-block/lib/templates/es5/$slug.php.mustache
+++ b/packages/create-block/lib/templates/es5/$slug.php.mustache
@@ -30,6 +30,10 @@
  * @package           {{namespace}}
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
 /**
  * Registers all block assets so that they can be enqueued through the block editor
  * in the corresponding context.

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -31,7 +31,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	die( 'Silence is golden.' );
+	exit; // Exit if accessed directly.
 }
 
 /**

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -30,6 +30,10 @@
  * @package           {{namespace}}
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it registers also all assets so they can be enqueued


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds the direct file access call to the create-block stub files. This impacts users that run `npx @wordpress/create-block my-plugin`

## Why?

To prevent direct access to the file by default. 

(I was also reminded by the plugin team a recent submission of mine was missing it)

## How?

Added the following to the `/plugin-name.php` stub files

```php
if ( ! defined( 'ABSPATH' ) ) {
	exit; // Exit if accessed directly.
}
```

I know there are many ways to write this code, so I arbitrarily picked one I've seen in a core project (performance plugin)

(_edit_) Technically I think `defined( 'ABSPATH' ) or exit;` would actually be the fastest given the the `NOT` opcode call is not there, but arguably it's less readable code for newer devs.

#### Alternatives in core:

https://github.com/WordPress/gutenberg/blob/trunk/lib/demo.php#L8
```php
if ( ! defined( 'ABSPATH' ) ) {
	die( 'Silence is golden.' );
}
```

https://github.com/WordPress/gutenberg/blob/trunk/lib/demo.php#L8
```php
if ( ! defined( 'ABSPATH' ) ) {
	die();
}
```

https://github.com/WordPress/WordPress/blob/master/wp-includes/rss-functions.php#L9
```php
if ( ! defined( 'ABSPATH' ) ) {
	exit();
}
```

https://github.com/WordPress/WordPress/blob/master/wp-admin/admin-footer.php#L10
```php
if ( ! defined( 'ABSPATH' ) ) {
	die( '-1' );
}
```

#### Health Check: 
https://github.com/WordPress/health-check/blob/trunk/pages/site-status.php#L9
```php
if ( ! defined( 'ABSPATH' ) ) {
	die( 'We\'re sorry, but you can not directly access this file.' );
}
```

#### Performance plugin:
https://github.com/WordPress/performance/blob/trunk/modules/images/webp-uploads/can-load.php#L9
```php
if ( ! defined( 'ABSPATH' ) ) {
	exit; // Exit if accessed directly.
}
```

Some others I've seen in the wild
```php
if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
defined('ABSPATH') or die;
defined( 'ABSPATH' ) || exit;

```

