### PR TITLE
Docs: Sidebar Block editor handbook - create-block before wp-scripts

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -30,15 +30,15 @@
 		"parent": "devenv"
 	},
 	{
-		"title": "Get started with wp-scripts",
-		"slug": "get-started-with-wp-scripts",
-		"markdown_source": "../docs/getting-started/devenv/get-started-with-wp-scripts.md",
-		"parent": "devenv"
-	},
-	{
 		"title": "Get started with create-block",
 		"slug": "get-started-with-create-block",
 		"markdown_source": "../docs/getting-started/devenv/get-started-with-create-block.md",
+		"parent": "devenv"
+	},
+	{
+		"title": "Get started with wp-scripts",
+		"slug": "get-started-with-wp-scripts",
+		"markdown_source": "../docs/getting-started/devenv/get-started-with-wp-scripts.md",
 		"parent": "devenv"
 	},
 	{

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -13,10 +13,10 @@
 						"docs/getting-started/devenv/get-started-with-wp-env.md": []
 					},
 					{
-						"docs/getting-started/devenv/get-started-with-wp-scripts.md": []
+						"docs/getting-started/devenv/get-started-with-create-block.md": []
 					},
 					{
-						"docs/getting-started/devenv/get-started-with-create-block.md": []
+						"docs/getting-started/devenv/get-started-with-wp-scripts.md": []
 					}
 				]
 			},


### PR DESCRIPTION
## What?
Change the order in the sidebar so [Get started with create-block](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-create-block/) appears before [Get started with wp-scripts](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts/)

## Why?
Because the most common "journey" is people discovering "wp-scripts" through the use of "create-block". This learning journey would be a bit better by locating "Get started with create-block" first in the sidebar, just after "Get started with wp-env"
