### PR TITLE
Query Loop: Disallow "enhanced pagination" with core blocks that may contain third-party blocks

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -25,7 +25,6 @@ import {
 import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
-import useBlockDisplayTitle from './components/block-title/use-block-display-title';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -54,5 +53,4 @@ lock( privateApis, {
 	ReusableBlocksRenameHint,
 	useReusableBlocksRenameHint,
 	usesContextKey,
-	useBlockDisplayTitle,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -25,6 +25,7 @@ import {
 import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
+import useBlockDisplayTitle from './components/block-title/use-block-display-title';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -53,4 +54,5 @@ lock( privateApis, {
 	ReusableBlocksRenameHint,
 	useReusableBlocksRenameHint,
 	usesContextKey,
+	useBlockDisplayTitle,
 } );

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -12,10 +12,10 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useContainsThirdPartyBlocks } from '../utils';
+import { useUnsupportedBlockList } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Plugin blocks and core blocks that may contain them are not supported yet. For the enhanced pagination to work, remove the disallowed block, then re-enable "Enhanced pagination" in the Query Block settings.'
+	'Plugin blocks and globally synced blocks are not supported yet. For the enhanced pagination to work, remove the unsupported blocks, then re-enable "Enhanced pagination" in the Query Block settings.'
 );
 
 const modalDescriptionId =
@@ -28,11 +28,11 @@ export default function EnhancedPaginationModal( {
 } ) {
 	const [ isOpen, setOpen ] = useState( false );
 
-	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
+	const unsupported = useUnsupportedBlockList( clientId );
 
 	useEffect( () => {
-		setOpen( containsThirdPartyBlocks && enhancedPagination );
-	}, [ containsThirdPartyBlocks, enhancedPagination, setOpen ] );
+		setOpen( !! unsupported.length && enhancedPagination );
+	}, [ unsupported.length, enhancedPagination, setOpen ] );
 
 	return (
 		isOpen && (

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -15,7 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { useUnsupportedBlockList } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Plugin blocks and globally synced blocks are not supported yet. For the enhanced pagination to work, remove the unsupported blocks, then re-enable "Enhanced pagination" in the Query Block settings.'
+	'You have added unsupported blocks. For the enhanced pagination to work, remove them, then re-enable "Enhanced pagination" in the Query Block settings.'
 );
 
 const modalDescriptionId =

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -15,7 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Plugin blocks are not supported yet. For the enhanced pagination to work, remove the plugin block, then re-enable "Enhanced pagination" in the Query Block settings.'
+	'Plugin blocks and core blocks that may contain them are not supported yet. For the enhanced pagination to work, remove the plugin block, then re-enable "Enhanced pagination" in the Query Block settings.'
 );
 
 const modalDescriptionId =

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -15,7 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Plugin blocks and core blocks that may contain them are not supported yet. For the enhanced pagination to work, remove the plugin block, then re-enable "Enhanced pagination" in the Query Block settings.'
+	'Plugin blocks and core blocks that may contain them are not supported yet. For the enhanced pagination to work, remove the disallowed block, then re-enable "Enhanced pagination" in the Query Block settings.'
 );
 
 const modalDescriptionId =

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -15,7 +15,7 @@ export default function EnhancedPaginationControl( {
 	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		"Enhanced pagination doesn't support plugin blocks or blocks that may contain them yet. If you want to enable it, you have to remove all plugin blocks from the Query Loop."
+		"Enhanced pagination doesn't support plugin blocks or blocks that may contain them yet. If you want to enable it, you have to remove all disallowed blocks from the Query Loop."
 	);
 
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -3,6 +3,7 @@
  */
 import { ToggleControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { BlockTitle } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -14,10 +15,6 @@ export default function EnhancedPaginationControl( {
 	setAttributes,
 	clientId,
 } ) {
-	const enhancedPaginationNotice = __(
-		"Enhanced pagination doesn't support plugin blocks or globally synced blocks yet. If you want to enable it, you have to remove all unsupported blocks from the Query Loop."
-	);
-
 	const unsupported = useUnsupportedBlockList( clientId );
 
 	return (
@@ -41,12 +38,19 @@ export default function EnhancedPaginationControl( {
 					isDismissible={ false }
 					className="wp-block-query__enhanced-pagination-notice"
 				>
-					{ enhancedPaginationNotice }
+					{ __(
+						"Enhanced pagination doesn't support the following blocks:"
+					) }
 					<ul>
-						{ unsupported.map( ( title ) => (
-							<li key={ title }>{ title }</li>
+						{ unsupported.map( ( id ) => (
+							<li key={ id }>
+								<BlockTitle clientId={ id } />
+							</li>
 						) ) }
 					</ul>
+					{ __(
+						'If you want to enable it, you have to remove all unsupported blocks first.'
+					) }
 				</Notice>
 			) }
 		</>

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -15,7 +15,7 @@ export default function EnhancedPaginationControl( {
 	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		"Enhanced pagination doesn't support plugin blocks yet. If you want to enable it, you have to remove all plugin blocks from the Query Loop."
+		"Enhanced pagination doesn't support plugin blocks or blocks that may contain them yet. If you want to enable it, you have to remove all plugin blocks from the Query Loop."
 	);
 
 	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useContainsThirdPartyBlocks } from '../../utils';
+import { useUnsupportedBlockList } from '../../utils';
 
 export default function EnhancedPaginationControl( {
 	enhancedPagination,
@@ -15,10 +15,10 @@ export default function EnhancedPaginationControl( {
 	clientId,
 } ) {
 	const enhancedPaginationNotice = __(
-		"Enhanced pagination doesn't support plugin blocks or blocks that may contain them yet. If you want to enable it, you have to remove all disallowed blocks from the Query Loop."
+		"Enhanced pagination doesn't support plugin blocks or globally synced blocks yet. If you want to enable it, you have to remove all unsupported blocks from the Query Loop."
 	);
 
-	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
+	const unsupported = useUnsupportedBlockList( clientId );
 
 	return (
 		<>
@@ -28,20 +28,25 @@ export default function EnhancedPaginationControl( {
 					'Browsing between pages won’t require a full page reload.'
 				) }
 				checked={ !! enhancedPagination }
-				disabled={ containsThirdPartyBlocks }
+				disabled={ unsupported.length }
 				onChange={ ( value ) => {
 					setAttributes( {
 						enhancedPagination: !! value,
 					} );
 				} }
 			/>
-			{ containsThirdPartyBlocks && (
+			{ !! unsupported.length && (
 				<Notice
 					status="warning"
 					isDismissible={ false }
 					className="wp-block-query__enhanced-pagination-notice"
 				>
 					{ enhancedPaginationNotice }
+					<ul>
+						{ unsupported.map( ( title ) => (
+							<li key={ title }>{ title }</li>
+						) ) }
+					</ul>
 				</Notice>
 			) }
 		</>

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -347,7 +347,7 @@ export const usePatterns = ( clientId, name ) => {
 
 /**
  * Hook that returns whether the Query Loop with the given `clientId` contains
- * any third-party block.
+ * any third-party block, or a block that could contain them.
  *
  * @param {string} clientId The block's client ID.
  * @return {boolean} True if it contains third-party blocks.
@@ -359,8 +359,15 @@ export const useContainsThirdPartyBlocks = ( clientId ) => {
 				select( blockEditorStore );
 
 			return getClientIdsOfDescendants( clientId ).some(
-				( descendantClientId ) =>
-					! getBlockName( descendantClientId ).startsWith( 'core/' )
+				( descendantClientId ) => {
+					const blockName = getBlockName( descendantClientId );
+					return (
+						! blockName.startsWith( 'core/' ) ||
+						blockName === 'core/post-content' ||
+						blockName === 'core/template-part' ||
+						blockName === 'core/block'
+					);
+				}
 			);
 		},
 		[ clientId ]

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -4,23 +4,9 @@
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
-import {
-	store as blockEditorStore,
-	privateApis as blockEditorPrivateApis,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
-import {
-	cloneBlock,
-	store as blocksStore,
-	getBlockType,
-} from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../lock-unlock';
-
-const { useBlockDisplayTitle } = unlock( blockEditorPrivateApis );
+import { cloneBlock, store as blocksStore } from '@wordpress/blocks';
 
 /** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
 
@@ -367,13 +353,13 @@ export const usePatterns = ( clientId, name ) => {
  * @return {string[]} List of block titles.
  */
 export const useUnsupportedBlockList = ( clientId ) => {
-	const unsupported = useSelect(
+	return useSelect(
 		( select ) => {
 			const { getClientIdsOfDescendants, getBlockName } =
 				select( blockEditorStore );
 
-			return getClientIdsOfDescendants( clientId )
-				.filter( ( descendantClientId ) => {
+			return getClientIdsOfDescendants( clientId ).filter(
+				( descendantClientId ) => {
 					const blockName = getBlockName( descendantClientId );
 					return (
 						! blockName.startsWith( 'core/' ) ||
@@ -381,26 +367,9 @@ export const useUnsupportedBlockList = ( clientId ) => {
 						blockName === 'core/template-part' ||
 						blockName === 'core/block'
 					);
-				} )
-				.map( ( descendantClientId ) => ( {
-					title: getBlockType( getBlockName( descendantClientId ) )
-						.title,
-					descendantClientId,
-				} ) );
+				}
+			);
 		},
 		[ clientId ]
 	);
-
-	const titles = unsupported.map( ( { descendantClientId, title } ) => {
-		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const displayTitle = useBlockDisplayTitle( {
-			clientId: descendantClientId,
-		} );
-
-		return title !== displayTitle
-			? `${ displayTitle } (${ title })`
-			: title;
-	} );
-
-	return [ ...new Set( titles ).values() ];
 };


### PR DESCRIPTION
## What?
Disables enhanced pagination when blocks that can contain third-party blocks are inserted inside the Query Loop block. These blocks are the following:
- The Post Content block
- Template parts
- Patterns

## Why?
The content of those blocks can be edited outside of the Query Loop context, thus allowing the addition of third-party blocks without the required validation.

## How?
Adding the names of the aforementioned blocks to the `useContainsThirdPartyBlocks` util.

## Testing Instructions
1. Go to the Blog Home template.
2. Activate "enhanced pagination" in the Query Loop block.
5. Insert the Post Content block inside the Query Loop, at any position.
6. Ensure a modal appears, indicating that the "enhanced pagination" will be disabled.
10. Click on "OK".
11. Ensure the setting is disabled and the new block is kept.
12. Try to enable the setting―it shouldn't be possible.
13. Remove the block manually and try again.
14. Ensure the setting can be enabled this time.
15. Repeat with any Pattern or Template Part; it should behave the same.

## Screenshots or screencast


https://github.com/WordPress/gutenberg/assets/6917969/d04b8f45-e377-4eb2-a1cb-022ff1142dd8

