### PR TITLE
[Mobile] Remove `wd` usage and removes disabled tests

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-device-actions.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-device-actions.test.js
@@ -2,15 +2,7 @@
  * Internal dependencies
  */
 import { blockNames } from './pages/editor-page';
-import {
-	clearClipboard,
-	longPressMiddleOfElement,
-	tapSelectAllAboveElement,
-	tapCopyAboveElement,
-	tapPasteAboveElement,
-	toggleOrientation,
-	isAndroid,
-} from './helpers/utils';
+import { toggleOrientation, isAndroid } from './helpers/utils';
 import testData from './helpers/test-data';
 
 describe( 'Gutenberg Editor Rotation tests', () => {
@@ -53,103 +45,6 @@ describe( 'Gutenberg Editor Rotation tests', () => {
 
 		expect( html.toLowerCase() ).toBe(
 			testData.deviceRotationHtml.toLowerCase()
-		);
-	} );
-} );
-
-describe( 'Gutenberg Editor Paste tests', () => {
-	// skip iOS for now
-	if ( ! isAndroid() ) {
-		it( 'skips the tests on any platform other than Android', async () => {
-			expect( true ).toBe( true );
-		} );
-		return;
-	}
-
-	beforeAll( async () => {
-		await clearClipboard( editorPage.driver );
-	} );
-
-	it.skip( 'copies plain text from one paragraph block and pastes in another', async () => {
-		await editorPage.initializeEditor();
-		await editorPage.addNewBlock( blockNames.paragraph );
-		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
-			blockNames.paragraph
-		);
-
-		await editorPage.typeTextToTextBlock(
-			paragraphBlockElement,
-			testData.pastePlainText
-		);
-
-		// Copy content to clipboard.
-		await longPressMiddleOfElement(
-			editorPage.driver,
-			paragraphBlockElement
-		);
-		await tapSelectAllAboveElement(
-			editorPage.driver,
-			paragraphBlockElement
-		);
-		await tapCopyAboveElement( editorPage.driver, paragraphBlockElement );
-
-		// Create another paragraph block.
-		await editorPage.addNewBlock( blockNames.paragraph );
-		if ( isAndroid() ) {
-			// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
-			await editorPage.dismissAndroidClipboardSmartSuggestion();
-		}
-		const paragraphBlockElement2 = await editorPage.getTextBlockAtPosition(
-			blockNames.paragraph,
-			2
-		);
-
-		// Paste into second paragraph block.
-		await tapPasteAboveElement( editorPage.driver, paragraphBlockElement2 );
-
-		const text = await editorPage.getTextForParagraphBlockAtPosition( 2 );
-		expect( text ).toBe( testData.pastePlainText );
-	} );
-
-	it.skip( 'copies styled text from one paragraph block and pastes in another', async () => {
-		// Create paragraph block with styled text by editing html.
-		await editorPage.initializeEditor( {
-			initialData: testData.pasteHtmlText,
-		} );
-		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
-			blockNames.paragraph
-		);
-
-		// Copy content to clipboard.
-		await longPressMiddleOfElement(
-			editorPage.driver,
-			paragraphBlockElement
-		);
-		await tapSelectAllAboveElement(
-			editorPage.driver,
-			paragraphBlockElement
-		);
-		await tapCopyAboveElement( editorPage.driver, paragraphBlockElement );
-
-		// Create another paragraph block.
-		await editorPage.addNewBlock( blockNames.paragraph );
-		if ( isAndroid() ) {
-			// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
-			await editorPage.dismissAndroidClipboardSmartSuggestion();
-		}
-		const paragraphBlockElement2 = await editorPage.getTextBlockAtPosition(
-			blockNames.paragraph,
-			2
-		);
-
-		// Paste into second paragraph block.
-		await tapPasteAboveElement( editorPage.driver, paragraphBlockElement2 );
-
-		// Check styled text by verifying html contents.
-		const html = await editorPage.getHtmlContent();
-
-		expect( html.toLowerCase() ).toBe(
-			testData.pasteHtmlTextResult.toLowerCase()
 		);
 	} );
 } );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -2,18 +2,8 @@
  * Internal dependencies
  */
 import { blockNames } from './pages/editor-page';
-import {
-	clearClipboard,
-	dragAndDropAfterElement,
-	isAndroid,
-	setClipboard,
-	tapPasteAboveElement,
-} from './helpers/utils';
+import { clearClipboard, dragAndDropAfterElement } from './helpers/utils';
 import testData from './helpers/test-data';
-
-// Tests associated with this const are temporarily off for both platforms due to failures.
-// They should be enabled for Android-only when a fix is in place.
-const onlyOnAndroid = it.skip;
 
 describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 	beforeEach( async () => {
@@ -51,72 +41,6 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 			await editorPage.getTextForParagraphBlockAtPosition( 1 );
 		expect( firstBlockText ).toMatch( testData.shortText );
 	} );
-
-	onlyOnAndroid(
-		'should be able to long-press on a text-based block to paste a text in a focused textinput',
-		async () => {
-			await editorPage.initializeEditor();
-			// Add a Paragraph block
-			await editorPage.addNewBlock( blockNames.paragraph );
-			const paragraphBlockElement =
-				await editorPage.getTextBlockAtPosition( blockNames.paragraph );
-
-			// Set clipboard text
-			await setClipboard( editorPage.driver, testData.shortText );
-
-			// Dismiss auto-suggestion popup
-			if ( isAndroid() ) {
-				// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
-				await editorPage.dismissAndroidClipboardSmartSuggestion();
-			}
-
-			// Paste into the Paragraph block
-			await tapPasteAboveElement(
-				editorPage.driver,
-				paragraphBlockElement
-			);
-			const paragraphText =
-				await editorPage.getTextForParagraphBlockAtPosition( 1 );
-
-			// Expect to have the pasted text in the Paragraph block
-			expect( paragraphText ).toMatch( testData.shortText );
-		}
-	);
-
-	onlyOnAndroid(
-		'should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput',
-		async () => {
-			await editorPage.initializeEditor();
-			// Add a Shortcode block
-			await editorPage.addNewBlock( blockNames.shortcode );
-			const shortcodeBlockElement =
-				await editorPage.getShortBlockTextInputAtPosition(
-					blockNames.shortcode
-				);
-
-			// Set clipboard text
-			await setClipboard( editorPage.driver, testData.shortText );
-
-			// Dismiss auto-suggestion popup
-			if ( isAndroid() ) {
-				// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
-				await editorPage.dismissAndroidClipboardSmartSuggestion();
-			}
-
-			// Paste into the Shortcode block
-			await tapPasteAboveElement(
-				editorPage.driver,
-				shortcodeBlockElement
-			);
-			const shortcodeText = await shortcodeBlockElement.text();
-
-			// Expect to have the pasted text in the Shortcode block
-			expect( shortcodeText ).toMatch( testData.shortText );
-
-			// Remove the block
-			await editorPage.removeBlock();
-		}
-	);
 
 	it( 'should be able to drag & drop a text-based block when another textinput is focused', async () => {
 		// Initialize the editor with two Paragraph blocks

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -4,8 +4,7 @@
 const childProcess = require( 'child_process' );
 // eslint-disable-next-line import/no-extraneous-dependencies, import/named
 import { remote, Key } from 'webdriverio';
-// TODO: Replace usage of wd in favor of WebdriverIO
-const wd = null;
+
 const crypto = require( 'crypto' );
 const path = require( 'path' );
 /**
@@ -46,9 +45,6 @@ const localAppiumPort = serverConfigs.local.port; // Port to spawn appium proces
 let appiumProcess;
 
 const backspace = '\u0008';
-
-// $block-edge-to-content value
-const blockEdgeToContent = 16;
 
 const IOS_BUNDLE_ID = 'org.wordpress.gutenberg.development';
 const ANDROID_COMPONENT_NAME = 'com.gutenberg/.MainActivity';
@@ -232,12 +228,6 @@ const typeString = async ( driver, element, str, clear ) => {
 	}
 };
 
-const doubleTap = async ( driver, element ) => {
-	const action = new wd.TouchAction( driver );
-	action.tap( { el: element, count: 2 } );
-	await action.perform();
-};
-
 /**
  * Returns the mapped keycode for a string to use in `pressKeycode` function.
  *
@@ -311,16 +301,6 @@ const clickBeginningOfElement = async ( driver, element ) => {
 	] );
 };
 
-// Clicks in the top left of a text-based element outside of the TextInput
-const clickElementOutsideOfTextInput = async ( driver, element ) => {
-	const location = await element.getLocation();
-	const y = isAndroid() ? location.y - blockEdgeToContent : location.y;
-	const x = isAndroid() ? location.x - blockEdgeToContent : location.x;
-
-	const action = new wd.TouchAction( driver ).press( { x, y } ).release();
-	await action.perform();
-};
-
 // Long press to activate context menu.
 const longPressMiddleOfElement = async (
 	driver,
@@ -356,49 +336,6 @@ const longPressMiddleOfElement = async (
 		.pause( waitTime )
 		.up()
 		.perform();
-};
-
-// Press "Select All" in floating context menu.
-const tapSelectAllAboveElement = async ( driver, element ) => {
-	const location = await element.getLocation();
-	const action = await new wd.TouchAction( driver );
-	const x = location.x + 300;
-	const y = location.y - 50;
-	action.press( { x, y } );
-	action.release();
-	await action.perform();
-};
-
-// Press "Copy" in floating context menu.
-const tapCopyAboveElement = async ( driver, element ) => {
-	const location = await element.getLocation();
-	const action = await new wd.TouchAction( driver );
-	const x = location.x + 220;
-	const y = location.y - 50;
-	action.wait( 2000 );
-	action.press( { x, y } );
-	action.wait( 2000 );
-	action.release();
-	await action.perform();
-};
-
-// Press "Paste" in floating context menu.
-const tapPasteAboveElement = async ( driver, element ) => {
-	await longPressMiddleOfElement( driver, element );
-
-	if ( isAndroid() ) {
-		const location = await element.getLocation();
-		const action = await new wd.TouchAction( driver );
-		action.wait( 2000 );
-		action.press( { x: location.x + 100, y: location.y - 50 } );
-		action.wait( 2000 );
-		action.release();
-		await action.perform();
-	} else {
-		const pasteButtonLocator = '//XCUIElementTypeMenuItem[@name="Paste"]';
-		await clickIfClickable( driver, pasteButtonLocator );
-		await driver.sleep( 3000 ); // Wait for paste notification to disappear.
-	}
 };
 
 const tapStatusBariOS = async ( driver ) => {
@@ -818,10 +755,8 @@ module.exports = {
 	backspace,
 	clearClipboard,
 	clickBeginningOfElement,
-	clickElementOutsideOfTextInput,
 	clickIfClickable,
 	clickMiddleOfElement,
-	doubleTap,
 	dragAndDropAfterElement,
 	isAndroid,
 	isEditorVisible,
@@ -836,9 +771,6 @@ module.exports = {
 	swipeDown,
 	swipeFromTo,
 	swipeUp,
-	tapCopyAboveElement,
-	tapPasteAboveElement,
-	tapSelectAllAboveElement,
 	tapStatusBariOS,
 	timer,
 	toggleDarkMode,

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -2,16 +2,13 @@
  * Internal dependencies
  */
 const {
-	doubleTap,
 	isAndroid,
 	isEditorVisible,
-	setClipboard,
 	setupDriver,
 	stopDriver,
 	swipeDown,
 	swipeFromTo,
 	swipeUp,
-	tapPasteAboveElement,
 	toggleHtmlMode,
 	typeString,
 	waitForVisible,
@@ -256,21 +253,6 @@ class EditorPage {
 
 		await toggleHtmlMode( this.driver, false );
 		return text;
-	}
-
-	// Set html editor content explicitly.
-	async setHtmlContent( html ) {
-		await toggleHtmlMode( this.driver, true );
-
-		await setClipboard( this.driver, html );
-
-		const htmlContentView = await this.getTextViewForHtmlViewContent();
-
-		await htmlContentView.click();
-		await doubleTap( this.driver, htmlContentView );
-		await tapPasteAboveElement( this.driver, htmlContentView );
-
-		await toggleHtmlMode( this.driver, false );
 	}
 
 	async dismissKeyboard() {


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6311

## What?
This is part of https://github.com/WordPress/gutenberg/pull/55166.

It removes the remaining usage of `wd` and it also removes a few disabled tests.

## Why?
Now that we use WebdriverIO we continue to remove the pending usage of `wd`.

It also removes some disabled tests that have been disabled for a long time now, these were flaky tests that mostly rely on copying/pasting text using the context menu of the device.

With those removals, we also removed some of the utils that were still using the `wd` library. We can always bring these tests back once we have some stable utils that don't introduce any flakiness.

## How?
- Removes references to the `wd` library
- Removes `skipped` tests
- Removes utils that relied on the `wd` library and that weren't being used after removing the disabled tests.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A