### PR TITLE
Add Unit testing for duotone enhanced pagination.

### DIFF
--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -53,7 +53,7 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::render_duotone_support
 	 */
-	public function test_css_declarations_are_generated_even_with_empty_block_content() {
+	public function test_gutenberg_css_declarations_are_generated_even_with_empty_block_content() {
 		$block                           = array(
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|blue-orange' ) ) ),

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -45,6 +45,27 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertMatchesRegularExpression( $expected, WP_Duotone_Gutenberg::render_duotone_support( $block_content, $block ) );
 	}
 
+
+	/**
+	 * Tests whether the CSS declarations are generated even if the block content is
+	 * empty. We need this to make the CSS output stable across paginations for
+	 * features like the enhanced pagination of the Query block.
+	 *
+	 * @covers ::render_duotone_support
+	 */
+	public function test_css_declarations_are_generated_even_with_empty_block_content() {
+		$block                           = array(
+			'blockName' => 'core/image',
+			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|blue-orange' ) ) ),
+		);
+		$wp_block                        = new WP_Block( $block );
+		$block_css_declarations_property = new ReflectionProperty( 'WP_Duotone_Gutenberg', 'block_css_declarations' );
+		$block_css_declarations_property->setAccessible( true );
+		$block_css_declarations_property->setValue( array() );
+		WP_Duotone_Gutenberg::render_duotone_support( '', $block, $wp_block );
+		$this->assertNotEmpty( $block_css_declarations_property->getValue() );
+	}
+
 	public function data_get_slug_from_attribute() {
 		return array(
 			'pipe-slug'                       => array( 'var:preset|duotone|blue-orange', 'blue-orange' ),

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -48,22 +48,39 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 
 	/**
 	 * Tests whether the CSS declarations are generated even if the block content is
-	 * empty. We need this to make the CSS output stable across paginations for
+	 * empty. This is needed to make the CSS output stable across paginations for
 	 * features like the enhanced pagination of the Query block.
 	 *
 	 * @covers ::render_duotone_support
 	 */
 	public function test_gutenberg_css_declarations_are_generated_even_with_empty_block_content() {
-		$block                           = array(
+		$block    = array(
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|blue-orange' ) ) ),
 		);
-		$wp_block                        = new WP_Block( $block );
+		$wp_block = new WP_Block( $block );
+
+		/*
+		 * Handling to access the static WP_Duotone::$block_css_declarations property.
+		 *
+		 * Why is an instance needed?
+		 * WP_Duotone is a static class by design, meaning it only contains static properties and methods.
+		 * In production, it should not be instantiated. However, as of PHP 8.3, ReflectionProperty::setValue()
+		 * needs an object.
+		 */
+		$wp_duotone                      = new WP_Duotone_Gutenberg();
 		$block_css_declarations_property = new ReflectionProperty( 'WP_Duotone_Gutenberg', 'block_css_declarations' );
 		$block_css_declarations_property->setAccessible( true );
-		$block_css_declarations_property->setValue( array() );
+		$previous_value = $block_css_declarations_property->getValue();
+		$block_css_declarations_property->setValue( $wp_duotone, array() );
 		WP_Duotone_Gutenberg::render_duotone_support( '', $block, $wp_block );
-		$this->assertNotEmpty( $block_css_declarations_property->getValue() );
+		$actual = $block_css_declarations_property->getValue();
+
+		// Reset the property.
+		$block_css_declarations_property->setValue( $wp_duotone, $previous_value );
+		$block_css_declarations_property->setAccessible( false );
+
+		$this->assertNotEmpty( $actual );
 	}
 
 	public function data_get_slug_from_attribute() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A follow up of #55415.
This PR adds automated testing to those previous PR changes.
I also added the test in the Core backport.
https://github.com/WordPress/wordpress-develop/pull/5540/files

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To prevent unexpected crashes if duotone code changes.
