### PR TITLE
Improve `Button` saving state accessibility.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -44,6 +44,7 @@
 ### Bug Fix
 
 -   `Autocomplete`: Add `aria-live` announcements for Mac and IOS Voiceover to fix lack of support for `aria-owns` ([#54902](https://github.com/WordPress/gutenberg/pull/54902)).
+-   Improve Button saving state accessibility. ([#55547](https://github.com/WordPress/gutenberg/pull/55547))
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -242,6 +242,9 @@
 	&.is-secondary.is-busy:disabled,
 	&.is-secondary.is-busy[aria-disabled="true"] {
 		animation: components-button__busy-animation 2500ms infinite linear;
+		@media (prefers-reduced-motion: reduce) {
+			animation-duration: 0s;
+		}
 		opacity: 1;
 		background-size: 100px 100%;
 		// Disable reason: This function call looks nicer when each argument is on its own line.

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -242,6 +242,8 @@
 	&.is-secondary.is-busy:disabled,
 	&.is-secondary.is-busy[aria-disabled="true"] {
 		animation: components-button__busy-animation 2500ms infinite linear;
+		// This should be refactored to use the reduce-motion("animation") mixin
+		// as soon as https://github.com/WordPress/gutenberg/issues/55566 is closed.
 		@media (prefers-reduced-motion: reduce) {
 			animation-duration: 0s;
 		}

--- a/packages/edit-site/src/components/save-hub/style.scss
+++ b/packages/edit-site/src/components/save-hub/style.scss
@@ -18,4 +18,11 @@
 	&[aria-disabled="true"]:hover {
 		color: inherit;
 	}
+
+	&:not(.is-primary) {
+		&.is-busy,
+		&.is-busy[aria-disabled="true"]:hover {
+			color: $gray-900;
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/55545

## What?
<!-- In a few words, what is the PR actually doing? -->
The saving buttons animation doesn't respect the OS-level preference 'Reduce motion'.
Additioanlly, the gray saving button doesn't have a sufficient color contrast ratio.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All animaitons should be disabled when users enable the OS-level preference 'Reduce motion'. This is even more important for animations that could potentially trigger seizure.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add an ad-hoc media query to disable the saving animation.
- Note that is not possible to use the `reduce-motion` mixin because it sets `animation-duration: 1ms` but it doesn't reset `animation-iteration-count` which is `infinite` for this specific animation. I don't know why the `reduce-motion` mixin doesn't reset _all_ the animation properties to 0 but it would be better to revisit it to have a mixin that is guaranteed to work with all animations / transitions.
- Uses the darker `gray-900` for the gray saving button text.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Enable the 'Reduce motion' preference in your operaring system.
- Edit a post.
- Click the Update button.
- Observe the button gradient animation does not run.
- Go to the Site editor, edit a template and save your changes.
- Go to 'Manage all templates' and reset the customization of the edited template.
- Observe in the left bottom corner of the screen the gray Saving button animation does not run.
- Observe the button text color `#1e1e1e` has now a sufficient color contrast with the gray colors used in the background gradient `#fafafa` and `#e0e0e0`.
- Go to the Site Editor > Design > Styles
- Select a new Style.
- Save your changes.
- Observe the blue Saving button animation does not run.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
