### PR TITLE
Fix broken list markup in navigation block when 3rd party blocks are used as decendants of navigation block

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -118,7 +118,7 @@ class WP_Navigation_Block_Renderer {
 		 * @param array $needs_list_item_wrapper The list of blocks that need a list item wrapper.
 		 * @return array The list of blocks that need a list item wrapper.
 		 */
-		$needs_list_item_wrapper = apply_filters( 'block_core_navigation_needs_list_item_wrapper', static::$needs_list_item_wrapper );
+		$needs_list_item_wrapper = apply_filters( 'block_core_navigation_blocks_requiring_list_item_wrapper', static::$needs_list_item_wrapper );
 
 		return in_array( $block->name, $needs_list_item_wrapper, true );
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -11,24 +11,6 @@
 class WP_Navigation_Block_Renderer {
 
 	/**
-	 * Used to determine whether or not a navigation has submenus.
-	 */
-	private static $has_submenus = false;
-
-	/**
-	 * Used to determine which blocks are wrapped in an <li>.
-	 *
-	 * @var array
-	 */
-	private static $nav_blocks_wrapped_in_list_item = array(
-		'core/navigation-link',
-		'core/home-link',
-		'core/site-title',
-		'core/site-logo',
-		'core/navigation-submenu',
-	);
-
-	/**
 	 * Used to determine which blocks need an <li> wrapper.
 	 *
 	 * @var array
@@ -161,7 +143,9 @@ class WP_Navigation_Block_Renderer {
 		$is_list_open      = false;
 
 		foreach ( $inner_blocks as $inner_block ) {
-			$is_list_item = in_array( $inner_block->name, static::$nav_blocks_wrapped_in_list_item, true );
+			$inner_block_markup = static::get_markup_for_inner_block( $inner_block );
+ 			$p                  = new WP_HTML_Tag_Processor( $inner_block_markup );
+ 			$is_list_item       = $p->next_tag( 'LI' );
 
 			if ( $is_list_item && ! $is_list_open ) {
 				$is_list_open       = true;
@@ -176,7 +160,7 @@ class WP_Navigation_Block_Renderer {
 				$inner_blocks_html .= '</ul>';
 			}
 
-			$inner_blocks_html .= static::get_markup_for_inner_block( $inner_block );
+			$inner_blocks_html .= $inner_block_markup;
 		}
 
 		if ( $is_list_open ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -144,8 +144,8 @@ class WP_Navigation_Block_Renderer {
 
 		foreach ( $inner_blocks as $inner_block ) {
 			$inner_block_markup = static::get_markup_for_inner_block( $inner_block );
- 			$p                  = new WP_HTML_Tag_Processor( $inner_block_markup );
- 			$is_list_item       = $p->next_tag( 'LI' );
+			$p                  = new WP_HTML_Tag_Processor( $inner_block_markup );
+			$is_list_item       = $p->next_tag( 'LI' );
 
 			if ( $is_list_item && ! $is_list_open ) {
 				$is_list_open       = true;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -11,6 +11,11 @@
 class WP_Navigation_Block_Renderer {
 
 	/**
+	 * Used to determine whether or not a navigation has submenus.
+	 */
+	private static $has_submenus = false;
+
+	/**
 	 * Used to determine which blocks need an <li> wrapper.
 	 *
 	 * @var array

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -108,7 +108,8 @@ class WP_Navigation_Block_Renderer {
 		/**
 		 * Filter the list of blocks that need a list item wrapper.
 		 *
-		 * This filter allows developers to add or remove blocks that need a list item wrapper.
+		 * Affords ability to customize which blocks need a list item wrapper when rendered 
+		 * within a core/navigation block.
 		 * This is useful for blocks that are not list items but should be wrapped in a list
 		 * item when used as a child of a navigation block.
 		 *

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -104,7 +104,22 @@ class WP_Navigation_Block_Renderer {
 	 * @return bool Returns whether or not a block needs a list item wrapper.
 	 */
 	private static function does_block_need_a_list_item_wrapper( $block ) {
-		return in_array( $block->name, static::$needs_list_item_wrapper, true );
+
+		/**
+		 * Filter the list of blocks that need a list item wrapper.
+		 *
+		 * This filter allows developers to add or remove blocks that need a list item wrapper.
+		 * This is useful for blocks that are not list items but should be wrapped in a list
+		 * item when used as a child of a navigation block.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array $needs_list_item_wrapper The list of blocks that need a list item wrapper.
+		 * @return array The list of blocks that need a list item wrapper.
+		 */
+		$needs_list_item_wrapper = apply_filters( 'block_core_navigation_needs_list_item_wrapper', static::$needs_list_item_wrapper );
+
+		return in_array( $block->name, $needs_list_item_wrapper, true );
 	}
 
 	/**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -118,7 +118,7 @@ class WP_Navigation_Block_Renderer {
 		 * @param array $needs_list_item_wrapper The list of blocks that need a list item wrapper.
 		 * @return array The list of blocks that need a list item wrapper.
 		 */
-		$needs_list_item_wrapper = apply_filters( 'block_core_navigation_blocks_requiring_list_item_wrapper', static::$needs_list_item_wrapper );
+		$needs_list_item_wrapper = apply_filters( 'block_core_navigation_listable_blocks', static::$needs_list_item_wrapper );
 
 		return in_array( $block->name, $needs_list_item_wrapper, true );
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -108,7 +108,7 @@ class WP_Navigation_Block_Renderer {
 		/**
 		 * Filter the list of blocks that need a list item wrapper.
 		 *
-		 * Affords ability to customize which blocks need a list item wrapper when rendered 
+		 * Affords the ability to customize which blocks need a list item wrapper when rendered
 		 * within a core/navigation block.
 		 * This is useful for blocks that are not list items but should be wrapped in a list
 		 * item when used as a child of a navigation block.

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -118,8 +118,8 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 			'testsuite/sample-block',
 			array(
 				'api_version'     => 2,
-				'render_callback' => function ( $attributes, $content ) {
-					return '<div class="wp-block-testsuite-sample-block">' . $content . '</div>';
+				'render_callback' => function ( $attributes ) {
+					return '<div class="wp-block-testsuite-sample-block">' . $attributes['content'] . '</div>';
 				},
 			)
 		);

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -73,11 +73,11 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	public function test_gutenberg_get_markup_for_inner_block_heading() {
 
 		// We are testing the site title block because we manually add list items around it.
-		$parsed_blocks    = parse_blocks(
+		$parsed_blocks = parse_blocks(
 			'<!-- wp:heading --><h2 class="wp-block-heading">Hello World</h2><!-- /wp:heading -->'
 		);
-		$parsed_block     = $parsed_blocks[0];
-		$context          = array();
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array();
 		$heading_block = new WP_Block( $parsed_block, $context );
 
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
@@ -113,11 +113,11 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		);
 
 		// We are testing the site title block because we manually add list items around it.
-		$parsed_blocks    = parse_blocks(
+		$parsed_blocks = parse_blocks(
 			'<!-- wp:heading --><h2 class="wp-block-heading">Hello Filtered World</h2><!-- /wp:heading -->'
 		);
-		$parsed_block     = $parsed_blocks[0];
-		$context          = array();
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array();
 		$heading_block = new WP_Block( $parsed_block, $context );
 
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -104,9 +104,9 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a block can be added to the list of blocks which require a wrapping list item. 
-     * This allows extenders to opt in to the rendering behavior of the Navigation block  
-     * which helps to preserve accessible markup.
+	 * Test that a block can be added to the list of blocks which require a wrapping list item.
+	 * This allows extenders to opt in to the rendering behavior of the Navigation block
+	 * which helps to preserve accessible markup.
 	 *
 	 * @group navigation-renderer
 	 *

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -130,7 +130,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		};
 
 		add_filter(
-			'block_core_navigation_needs_list_item_wrapper',
+			'block_core_navigation_blocks_requiring_list_item_wrapper',
 			$filter_needs_list_item_wrapper_function,
 			10,
 			1
@@ -154,7 +154,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$expected = '<li class="wp-block-navigation-item"><div class="wp-block-testsuite-sample-block">Hello World</div></li>';
 		$this->assertEquals( $expected, $result );
 
-		remove_filter( 'block_core_navigation_needs_list_item_wrapper', $filter_needs_list_item_wrapper_function, 10, 1 );
+		remove_filter( 'block_core_navigation_blocks_requiring_list_item_wrapper', $filter_needs_list_item_wrapper_function, 10, 1 );
 
 		unregister_block_type( 'testsuite/sample-block' );
 	}

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -84,7 +84,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 
 		// We are testing the site title block because we manually add list items around it.
 		$parsed_blocks = parse_blocks(
-			'<!-- wp:testsuite/sample-block {"content":"Hello World"} --><div class="wp-block-testsuite-sample-block">Hello World</div><!-- /wp:testsuite/sample-block -->'
+			'<!-- wp:testsuite/sample-block {"content":"Hello World"} /-->'
 		);
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array();
@@ -138,7 +138,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 
 		// We are testing the site title block because we manually add list items around it.
 		$parsed_blocks = parse_blocks(
-			'<!-- wp:testsuite/sample-block {"content":"Hello World"} --><div class="wp-block-testsuite-sample-block">Hello World</div><!-- /wp:testsuite/sample-block -->'
+			'<!-- wp:testsuite/sample-block {"content":"Hello World"} /-->'
 		);
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array();

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -130,7 +130,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		};
 
 		add_filter(
-			'block_core_navigation_blocks_requiring_list_item_wrapper',
+			'block_core_navigation_listable_blocks',
 			$filter_needs_list_item_wrapper_function,
 			10,
 			1
@@ -154,7 +154,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$expected = '<li class="wp-block-navigation-item"><div class="wp-block-testsuite-sample-block">Hello World</div></li>';
 		$this->assertEquals( $expected, $result );
 
-		remove_filter( 'block_core_navigation_blocks_requiring_list_item_wrapper', $filter_needs_list_item_wrapper_function, 10, 1 );
+		remove_filter( 'block_core_navigation_listable_blocks', $filter_needs_list_item_wrapper_function, 10, 1 );
 
 		unregister_block_type( 'testsuite/sample-block' );
 	}

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -76,8 +76,8 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 			'testsuite/sample-block',
 			array(
 				'api_version'     => 2,
-				'render_callback' => function ( $attributes, $content ) {
-					return '<div class="wp-block-testsuite-sample-block">' . $content . '</div>';
+				'render_callback' => function ( $attributes ) {
+					return '<div class="wp-block-testsuite-sample-block">' . $attributes['content'] . '</div>';
 				},
 			)
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Use the HTML_Tag_Processor to check if an inner block markup is wrapped in a `li` element instead of using an hardcoded list of allowed inner blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The hard-coded list of blocks that it should be applied to prevented custom blocks from getting the handling which led to inaccessible markup.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the `HTML_Tag_Processor` to check if the wrapper element is an `li` element

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
