### PR TITLE
Patterns: fix bug with authors and contributors not seeing user pattern categories

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -651,6 +651,7 @@ export const getUserPatternCategories =
 			{
 				per_page: -1,
 				_fields: 'id,name,description,slug',
+				context: 'view',
 			}
 		);
 


### PR DESCRIPTION
## What?
Changes context of the API call to retrieve pattern categories

## Why?
Currently the default context is `edit` which causes authors and contributors to get a 403, and so user pattern categories do not display in the pattern inserter for them,

## How?
Sets context to `view` in the `getUserPatternCategories` resolver.

## Testing Instructions

- As a site admin add some new patterns and assign some custom category names to them
- Log in as an Author user, then a Contributor user, and check that the new user pattern categories appear in the post editor inserter patterns tab

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/742c48eb-e3c2-422a-8227-37fb45112afd

After:

https://github.com/WordPress/gutenberg/assets/3629020/2695c4d0-ad7a-420c-968f-3ea602a7115c



