### PR TITLE
[Docs]: Update Usage Example for block variation picker: Fix Import from Wrong Package

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/README.md
+++ b/packages/block-editor/src/components/block-variation-picker/README.md
@@ -19,9 +19,9 @@ Renders the variations of a block.
 ```jsx
 import { useSelect } from '@wordpress/data';
 import {
-	__experimentalBlockVariationPicker as BlockVariationPicker,
-	store as blockEditorStore,
+	__experimentalBlockVariationPicker as BlockVariationPicker
 } from '@wordpress/block-editor';
+import { store as blocksStore } from '@wordpress/blocks';
 
 const MyBlockVariationPicker = ( { blockName } ) => {
 	const variations = useSelect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I updated the documentation for using the block variation picker component with the correct code. 
Initially, the store was imported from the wrong package, which was @wordpress/block-editor, and it was imported as "blockEditorStore" However, in the code, it's referred to as "blocksStore"

## Why?
The usage example can be confusing for users and might make it difficult for them to troubleshoot the issue. However, the problem is simply due to importing from the wrong package.

## How?
I fixed the import to use the right package, which is @wordpress/blocks. I also imported the store as "blocksStore" and that's what being used in the code.
