### PR TITLE
Post Content Block: Add tagName selector

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -606,7 +606,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Name:** core/post-content
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** 
+-	**Attributes:** tagName
 
 ## Date
 

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -7,6 +7,12 @@
 	"description": "Displays the contents of a post or page.",
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType", "queryId" ],
+	"attributes": {
+		"tagName": {
+			"type": "string",
+			"default": "div"
+		}
+	},
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -85,8 +85,11 @@ function EditableContent( { context = {}, tagName: TagName = 'div' } ) {
 }
 
 function Content( props ) {
-	const { context: { queryId, postType, postId } = {}, layoutClassNames, tagName } =
-		props;
+	const {
+		context: { queryId, postType, postId } = {},
+		layoutClassNames,
+		tagName,
+	} = props;
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
 	if ( userCanEdit === undefined ) {
 		return null;
@@ -207,7 +210,7 @@ export default function PostContentEdit( {
 				{ contextPostId && contextPostType ? (
 					<Content
 						context={ context }
-						layoutClassNames={layoutClassNames}
+						layoutClassNames={ layoutClassNames }
 						tagName={ tagName }
 					/>
 				) : (

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -3,12 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	InspectorControls,
 	useBlockProps,
 	useInnerBlocksProps,
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentalUseHasRecursion as useHasRecursion,
 	Warning,
 } from '@wordpress/block-editor';
+import { SelectControl } from '@wordpress/components';
 import {
 	useEntityProp,
 	useEntityBlockEditor,
@@ -25,6 +27,7 @@ function ReadOnlyContent( {
 	userCanEdit,
 	postType,
 	postId,
+	tagName: TagName = 'div',
 } ) {
 	const [ , , content ] = useEntityProp(
 		'postType',
@@ -34,18 +37,18 @@ function ReadOnlyContent( {
 	);
 	const blockProps = useBlockProps( { className: layoutClassNames } );
 	return content?.protected && ! userCanEdit ? (
-		<div { ...blockProps }>
+		<TagName { ...blockProps }>
 			<Warning>{ __( 'This content is password protected.' ) }</Warning>
-		</div>
+		</TagName>
 	) : (
-		<div
+		<TagName
 			{ ...blockProps }
 			dangerouslySetInnerHTML={ { __html: content?.rendered } }
-		></div>
+		></TagName>
 	);
 }
 
-function EditableContent( { context = {} } ) {
+function EditableContent( { context = {}, tagName: TagName = 'div' } ) {
 	const { postType, postId } = context;
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
@@ -78,11 +81,11 @@ function EditableContent( { context = {} } ) {
 			template: ! hasInnerBlocks ? initialInnerBlocks : undefined,
 		}
 	);
-	return <div { ...props } />;
+	return <TagName { ...props } />;
 }
 
 function Content( props ) {
-	const { context: { queryId, postType, postId } = {}, layoutClassNames } =
+	const { context: { queryId, postType, postId } = {}, layoutClassNames, tagName } =
 		props;
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
 	if ( userCanEdit === undefined ) {
@@ -100,6 +103,7 @@ function Content( props ) {
 			userCanEdit={ userCanEdit }
 			postType={ postType }
 			postId={ postId }
+			tagName={ tagName }
 		/>
 	);
 }
@@ -138,9 +142,51 @@ function RecursionError() {
 	);
 }
 
+/**
+ * Render inspector controls for the PostContent block.
+ *
+ * @param {Object}   props                 Component props.
+ * @param {string}   props.tagName         The HTML tag name.
+ * @param {Function} props.onSelectTagName onChange function for the SelectControl.
+ *
+ * @return {JSX.Element}                The control group.
+ */
+function PostContentEditControls( { tagName, onSelectTagName } ) {
+	const htmlElementMessages = {
+		main: __(
+			'The <main> element should be used for the primary content of your document only. '
+		),
+		section: __(
+			"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
+		),
+		article: __(
+			'The <article> element should represent a self-contained, syndicatable portion of the document.'
+		),
+	};
+	return (
+		<InspectorControls group="advanced">
+			<SelectControl
+				__nextHasNoMarginBottom
+				label={ __( 'HTML element' ) }
+				options={ [
+					{ label: __( 'Default (<div>)' ), value: 'div' },
+					{ label: '<main>', value: 'main' },
+					{ label: '<section>', value: 'section' },
+					{ label: '<article>', value: 'article' },
+				] }
+				value={ tagName }
+				onChange={ onSelectTagName }
+				help={ htmlElementMessages[ tagName ] }
+			/>
+		</InspectorControls>
+	);
+}
+
 export default function PostContentEdit( {
 	context,
 	__unstableLayoutClassNames: layoutClassNames,
+	attributes: { tagName = 'div' },
+	setAttributes,
 } ) {
 	const { postId: contextPostId, postType: contextPostType } = context;
 	const hasAlreadyRendered = useHasRecursion( contextPostId );
@@ -150,15 +196,24 @@ export default function PostContentEdit( {
 	}
 
 	return (
-		<RecursionProvider uniqueId={ contextPostId }>
-			{ contextPostId && contextPostType ? (
-				<Content
-					context={ context }
-					layoutClassNames={ layoutClassNames }
-				/>
-			) : (
-				<Placeholder layoutClassNames={ layoutClassNames } />
-			) }
-		</RecursionProvider>
+		<>
+			<PostContentEditControls
+				tagName={ tagName }
+				onSelectTagName={ ( value ) =>
+					setAttributes( { tagName: value } )
+				}
+			/>
+			<RecursionProvider uniqueId={ contextPostId }>
+				{ contextPostId && contextPostType ? (
+					<Content
+						context={ context }
+						layoutClassNames={layoutClassNames}
+						tagName={ tagName }
+					/>
+				) : (
+					<Placeholder layoutClassNames={ layoutClassNames } />
+				) }
+			</RecursionProvider>
+		</>
 	);
 }

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -52,6 +52,12 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$tag_name = $attributes['tagName'];
+
+	if ( ! $tag_name ) {
+		$tag_name = 'div';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
 
 	return (

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -55,9 +55,9 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
 
 	return (
-		'<div ' . $wrapper_attributes . '>' .
+		'<' . $tag_name . ' ' . $wrapper_attributes . '>' .
 			$content .
-		'</div>'
+		'</' . $tag_name . '>'
 	);
 }
 

--- a/test/integration/fixtures/blocks/core__post-content.json
+++ b/test/integration/fixtures/blocks/core__post-content.json
@@ -2,7 +2,9 @@
 	{
 		"name": "core/post-content",
 		"isValid": true,
-		"attributes": {},
+		"attributes": {
+			"tagName": "div"
+		},
 		"innerBlocks": []
 	}
 ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add the "tagName" selector to the Post Content Block.

## Why?
This PR introduces the possibility to change the block's default wrapper (div) to a more semantic alternative (main, section, and article) optionally.

## How?
This code is based on the group tag selector.

## Testing Instructions
1. Open the site editor.
2. Insert the post content block.
3. Open the block settings.
4. Click on the advanced section.
5. That's all! There is now a new selector available to change the default block wrapper.

## Screenshots
![image](https://github.com/WordPress/gutenberg/assets/52340161/434cf4a9-32a0-4adf-9c86-904e4db37af7)

