### PR TITLE
[WIP] Design Tools: Add section specific block type styles

### DIFF
--- a/lib/block-supports/section.php
+++ b/lib/block-supports/section.php
@@ -69,10 +69,57 @@ function gutenberg_render_section_support( $block_content, $block ) {
 	return $tags->get_updated_html();
 }
 
+/**
+ * Render the section's styles.
+ *
+ * In the case of nested sections, we want the parent section's styles to be
+ * rendered before their descendants. This solves the issue of a block type
+ * being styled in both the parent and descendant: we want the descendant style
+ * to take priority, and this is done by loaded it after, in the DOM order.
+ *
+ * @param string|null $pre_render The pre-rendered content. Default null.
+ * @param array       $block      The block being rendered.
+ *
+ * @return null
+ */
+function gutenberg_render_section_support_styles( $pre_render, $block ) {
+	$section_block_styles = _wp_array_get( $block, array( 'attrs', 'style', 'blocks' ), null );
+
+	if ( ! $section_block_styles ) {
+		return null;
+	}
+
+	$class_name = gutenberg_get_section_class_name( $block );
+	$config     = array(
+		'version' => 2,
+		'styles'  => array( 'blocks' => $section_block_styles ),
+	);
+
+	$theme_json     = new WP_Theme_JSON_Gutenberg( $config, 'blocks' );
+	$section_styles = $theme_json->get_stylesheet(
+		array( 'styles' ),
+		array( 'custom' ),
+		array(
+			'skip_root_layout_styles' => true,
+			'scope'                   => ".$class_name",
+		)
+	);
+
+	if ( empty( $section_styles ) ) {
+		return null;
+	}
+
+	wp_register_style( 'section-styles', false );
+	wp_add_inline_style( 'section-styles', $section_styles );
+	wp_enqueue_style( 'section-styles' );
+}
+
+
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'section',
 	array( 'register_attribute' => 'gutenberg_register_section_support' )
 );
 
+add_filter( 'pre_render_block', 'gutenberg_render_section_support_styles', 10, 2 );
 add_filter( 'render_block', 'gutenberg_render_section_support', 10, 2 );

--- a/lib/block-supports/section.php
+++ b/lib/block-supports/section.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Section support to enable per-section styling of block types.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Get the section class name.
+ *
+ * @param array $block Block object.
+ * @return string The unique class name.
+ */
+function gutenberg_get_section_class_name( $block ) {
+	return 'wp-section-' . md5( serialize( $block ) );
+}
+
+/**
+ * Registers the style attribute used by the section styling feature, if needed.
+ *
+ * @param WP_Block_Type $block_type Block type.
+ */
+function gutenberg_register_section_support( $block_type ) {
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( ! array_key_exists( 'style', $block_type->attributes ) ) {
+		$block_type->attributes['style'] = array( 'type' => 'object' );
+	}
+}
+
+/**
+ * Update the block content with the section's class name.
+ *
+ * @param string $block_content Rendered block content.
+ * @param array  $block         Block object.
+ *
+ * @return string Filtered block content.
+ */
+function gutenberg_render_section_support( $block_content, $block ) {
+	if ( ! $block_content || empty( $block['attrs'] ) ) {
+		return $block_content;
+	}
+
+	// While section styling is being explored, the blocks allowed to support
+	// it will be restricted.
+	$allow_list = array( 'core/group' );
+
+	if ( ! in_array( $block['blockName'], $allow_list, true ) ) {
+		return $block_content;
+	}
+
+	// Skip if there are no block types within this block's styles attribute.
+	$block_type_styles = _wp_array_get( $block, array( 'attrs', 'style', 'blocks' ), array() );
+
+	if ( ! count( $block_type_styles ) ) {
+		return $block_content;
+	}
+
+	// Apply the section's classname. Like the layout hook, this assumes the
+	// hook only applies to blocks with a single wrapper.
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+
+	if ( $tags->next_tag() ) {
+		$tags->add_class( gutenberg_get_section_class_name( $block ) );
+	}
+
+	return $tags->get_updated_html();
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'section',
+	array( 'register_attribute' => 'gutenberg_register_section_support' )
+);
+
+add_filter( 'render_block', 'gutenberg_render_section_support', 10, 2 );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1076,7 +1076,7 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		if ( in_array( 'styles', $types, true ) ) {
-			if ( false !== $root_style_key ) {
+			if ( false !== $root_style_key && empty( $options['skip_root_layout_styles'] ) ) {
 				$stylesheet .= $this->get_root_layout_rules( $style_nodes[ $root_style_key ]['selector'], $style_nodes[ $root_style_key ] );
 			}
 			$stylesheet .= $this->get_block_classes( $style_nodes );

--- a/lib/load.php
+++ b/lib/load.php
@@ -229,3 +229,4 @@ require __DIR__ . '/block-supports/dimensions.php';
 require __DIR__ . '/block-supports/duotone.php';
 require __DIR__ . '/block-supports/shadow.php';
 require __DIR__ . '/block-supports/behaviors.php';
+require __DIR__ . '/block-supports/section.php';

--- a/packages/block-editor/src/components/global-styles/index.js
+++ b/packages/block-editor/src/components/global-styles/index.js
@@ -9,6 +9,8 @@ export {
 export { getBlockCSSSelector } from './get-block-css-selector';
 export {
 	getLayoutStyles,
+	getBlockSelectors,
+	toStyles,
 	useGlobalStylesOutput,
 	useGlobalStylesOutputWithConfig,
 } from './use-global-styles-output';

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -757,214 +757,257 @@ export const toStyles = (
 	blockSelectors,
 	hasBlockGapSupport,
 	hasFallbackGapSupport,
-	disableLayoutStyles = false
+	disableLayoutStyles = false,
+	options = undefined
 ) => {
 	const nodesWithStyles = getNodesWithStyles( tree, blockSelectors );
 	const nodesWithSettings = getNodesWithSettings( tree, blockSelectors );
 	const useRootPaddingAlign = tree?.settings?.useRootPaddingAwareAlignments;
 	const { contentSize, wideSize } = tree?.settings?.layout || {};
+	const hasBodyStyles =
+		options.marginReset || options.rootPadding || options.layoutStyles;
 
-	/*
-	 * Reset default browser margin on the root body element.
-	 * This is set on the root selector **before** generating the ruleset
-	 * from the `theme.json`. This is to ensure that if the `theme.json` declares
-	 * `margin` in its `spacing` declaration for the `body` element then these
-	 * user-generated values take precedence in the CSS cascade.
-	 * @link https://github.com/WordPress/gutenberg/issues/36147.
-	 */
-	let ruleset = 'body {margin: 0;';
+	let ruleset = '';
 
-	if ( contentSize ) {
-		ruleset += ` --wp--style--global--content-size: ${ contentSize };`;
-	}
-
-	if ( wideSize ) {
-		ruleset += ` --wp--style--global--wide-size: ${ wideSize };`;
-	}
-
-	if ( useRootPaddingAlign ) {
+	if ( ! options || hasBodyStyles ) {
 		/*
-		 * These rules reproduce the ones from https://github.com/WordPress/gutenberg/blob/79103f124925d1f457f627e154f52a56228ed5ad/lib/class-wp-theme-json-gutenberg.php#L2508
-		 * almost exactly, but for the selectors that target block wrappers in the front end. This code only runs in the editor, so it doesn't need those selectors.
+		 * Reset default browser margin on the root body element.
+		 * This is set on the root selector **before** generating the ruleset
+		 * from the `theme.json`. This is to ensure that if the `theme.json` declares
+		 * `margin` in its `spacing` declaration for the `body` element then these
+		 * user-generated values take precedence in the CSS cascade.
+		 * @link https://github.com/WordPress/gutenberg/issues/36147.
 		 */
-		ruleset += `padding-right: 0; padding-left: 0; padding-top: var(--wp--style--root--padding-top); padding-bottom: var(--wp--style--root--padding-bottom) }
-			.has-global-padding { padding-right: var(--wp--style--root--padding-right); padding-left: var(--wp--style--root--padding-left); }
-			.has-global-padding :where(.has-global-padding) { padding-right: 0; padding-left: 0; }
-			.has-global-padding > .alignfull { margin-right: calc(var(--wp--style--root--padding-right) * -1); margin-left: calc(var(--wp--style--root--padding-left) * -1); }
-			.has-global-padding :where(.has-global-padding) > .alignfull { margin-right: 0; margin-left: 0; }
-			.has-global-padding > .alignfull:where(:not(.has-global-padding):not(.is-layout-flex):not(.is-layout-grid)) > :where(.wp-block:not(.alignfull),p,h1,h2,h3,h4,h5,h6,ul,ol) { padding-right: var(--wp--style--root--padding-right); padding-left: var(--wp--style--root--padding-left); }
-			.has-global-padding :where(.has-global-padding) > .alignfull:where(:not(.has-global-padding)) > :where(.wp-block:not(.alignfull),p,h1,h2,h3,h4,h5,h6,ul,ol) { padding-right: 0; padding-left: 0;`;
+		ruleset = 'body {margin: 0;';
+
+		if ( options.layoutStyles && contentSize ) {
+			ruleset += ` --wp--style--global--content-size: ${ contentSize };`;
+		}
+
+		if ( options.layoutStyles && wideSize ) {
+			ruleset += ` --wp--style--global--wide-size: ${ wideSize };`;
+		}
+
+		if ( options.rootPadding && useRootPaddingAlign ) {
+			/*
+			 * These rules reproduce the ones from https://github.com/WordPress/gutenberg/blob/79103f124925d1f457f627e154f52a56228ed5ad/lib/class-wp-theme-json-gutenberg.php#L2508
+			 * almost exactly, but for the selectors that target block wrappers in the front end. This code only runs in the editor, so it doesn't need those selectors.
+			 */
+			ruleset += `padding-right: 0; padding-left: 0; padding-top: var(--wp--style--root--padding-top); padding-bottom: var(--wp--style--root--padding-bottom) }
+				.has-global-padding { padding-right: var(--wp--style--root--padding-right); padding-left: var(--wp--style--root--padding-left); }
+				.has-global-padding :where(.has-global-padding) { padding-right: 0; padding-left: 0; }
+				.has-global-padding > .alignfull { margin-right: calc(var(--wp--style--root--padding-right) * -1); margin-left: calc(var(--wp--style--root--padding-left) * -1); }
+				.has-global-padding :where(.has-global-padding) > .alignfull { margin-right: 0; margin-left: 0; }
+				.has-global-padding > .alignfull:where(:not(.has-global-padding):not(.is-layout-flex):not(.is-layout-grid)) > :where(.wp-block:not(.alignfull),p,h1,h2,h3,h4,h5,h6,ul,ol) { padding-right: var(--wp--style--root--padding-right); padding-left: var(--wp--style--root--padding-left); }
+				.has-global-padding :where(.has-global-padding) > .alignfull:where(:not(.has-global-padding)) > :where(.wp-block:not(.alignfull),p,h1,h2,h3,h4,h5,h6,ul,ol) { padding-right: 0; padding-left: 0;`;
+		}
+
+		ruleset += '}';
 	}
 
-	ruleset += '}';
+	if ( ! options || options.blockStyles ) {
+		nodesWithStyles.forEach(
+			( {
+				selector,
+				duotoneSelector,
+				styles,
+				fallbackGapValue,
+				hasLayoutSupport,
+				featureSelectors,
+				styleVariationSelectors,
+			} ) => {
+				// Process styles for block support features with custom feature level
+				// CSS selectors set.
+				if ( featureSelectors ) {
+					const featureDeclarations = getFeatureDeclarations(
+						featureSelectors,
+						styles
+					);
 
-	nodesWithStyles.forEach(
-		( {
-			selector,
-			duotoneSelector,
-			styles,
-			fallbackGapValue,
-			hasLayoutSupport,
-			featureSelectors,
-			styleVariationSelectors,
-		} ) => {
-			// Process styles for block support features with custom feature level
-			// CSS selectors set.
-			if ( featureSelectors ) {
-				const featureDeclarations = getFeatureDeclarations(
-					featureSelectors,
-					styles
-				);
-
-				Object.entries( featureDeclarations ).forEach(
-					( [ cssSelector, declarations ] ) => {
-						if ( declarations.length ) {
-							const rules = declarations.join( ';' );
-							ruleset += `${ cssSelector }{${ rules };}`;
-						}
-					}
-				);
-			}
-
-			if ( styleVariationSelectors ) {
-				Object.entries( styleVariationSelectors ).forEach(
-					( [ styleVariationName, styleVariationSelector ] ) => {
-						const styleVariations =
-							styles?.variations?.[ styleVariationName ];
-						if ( styleVariations ) {
-							// If the block uses any custom selectors for block support, add those first.
-							if ( featureSelectors ) {
-								const featureDeclarations =
-									getFeatureDeclarations(
-										featureSelectors,
-										styleVariations
-									);
-
-								Object.entries( featureDeclarations ).forEach(
-									( [ baseSelector, declarations ] ) => {
-										if ( declarations.length ) {
-											const cssSelector =
-												concatFeatureVariationSelectorString(
-													baseSelector,
-													styleVariationSelector
-												);
-											const rules =
-												declarations.join( ';' );
-											ruleset += `${ cssSelector }{${ rules };}`;
-										}
-									}
-								);
-							}
-
-							// Otherwise add regular selectors.
-							const styleVariationDeclarations =
-								getStylesDeclarations(
-									styleVariations,
-									styleVariationSelector,
-									useRootPaddingAlign,
-									tree
-								);
-							if ( styleVariationDeclarations.length ) {
-								ruleset += `${ styleVariationSelector }{${ styleVariationDeclarations.join(
-									';'
-								) };}`;
+					Object.entries( featureDeclarations ).forEach(
+						( [ cssSelector, declarations ] ) => {
+							if ( declarations.length ) {
+								const rules = declarations.join( ';' );
+								const scopedSelector = options?.scopeSelector
+									? scopeSelector(
+											options.scopeSelector,
+											cssSelector
+									  )
+									: cssSelector;
+								ruleset += `${ scopedSelector }{${ rules };}`;
 							}
 						}
-					}
-				);
-			}
-
-			// Process duotone styles.
-			if ( duotoneSelector ) {
-				const duotoneStyles = {};
-				if ( styles?.filter ) {
-					duotoneStyles.filter = styles.filter;
-					delete styles.filter;
+					);
 				}
-				const duotoneDeclarations =
-					getStylesDeclarations( duotoneStyles );
-				if ( duotoneDeclarations.length ) {
-					ruleset += `${ duotoneSelector }{${ duotoneDeclarations.join(
+
+				if ( styleVariationSelectors ) {
+					Object.entries( styleVariationSelectors ).forEach(
+						( [ styleVariationName, styleVariationSelector ] ) => {
+							const styleVariations =
+								styles?.variations?.[ styleVariationName ];
+							if ( styleVariations ) {
+								// If the block uses any custom selectors for block support, add those first.
+								if ( featureSelectors ) {
+									const featureDeclarations =
+										getFeatureDeclarations(
+											featureSelectors,
+											styleVariations
+										);
+
+									Object.entries(
+										featureDeclarations
+									).forEach(
+										( [ baseSelector, declarations ] ) => {
+											if ( declarations.length ) {
+												const cssSelector =
+													concatFeatureVariationSelectorString(
+														baseSelector,
+														styleVariationSelector
+													);
+												const scopedSelector =
+													options?.scopeSelector
+														? scopeSelector(
+																options.scopeSelector,
+																cssSelector
+														  )
+														: cssSelector;
+												const rules =
+													declarations.join( ';' );
+												ruleset += `${ scopedSelector }{${ rules };}`;
+											}
+										}
+									);
+								}
+
+								// Otherwise add regular selectors.
+								const styleVariationDeclarations =
+									getStylesDeclarations(
+										styleVariations,
+										styleVariationSelector,
+										useRootPaddingAlign,
+										tree
+									);
+								if ( styleVariationDeclarations.length ) {
+									ruleset += `${ styleVariationSelector }{${ styleVariationDeclarations.join(
+										';'
+									) };}`;
+								}
+							}
+						}
+					);
+				}
+
+				// Process duotone styles.
+				if ( duotoneSelector ) {
+					const scopedSelector = options?.scopeSelector
+						? scopeSelector(
+								options.scopeSelector,
+								duotoneSelector
+						  )
+						: duotoneSelector;
+					const duotoneStyles = {};
+					if ( styles?.filter ) {
+						duotoneStyles.filter = styles.filter;
+						delete styles.filter;
+					}
+					const duotoneDeclarations =
+						getStylesDeclarations( duotoneStyles );
+					if ( duotoneDeclarations.length ) {
+						ruleset += `${ scopedSelector }{${ duotoneDeclarations.join(
+							';'
+						) };}`;
+					}
+				}
+
+				// Process blockGap and layout styles.
+				if (
+					! disableLayoutStyles &&
+					( ROOT_BLOCK_SELECTOR === selector || hasLayoutSupport )
+				) {
+					ruleset += getLayoutStyles( {
+						style: styles,
+						selector,
+						hasBlockGapSupport,
+						hasFallbackGapSupport,
+						fallbackGapValue,
+					} );
+				}
+
+				// Process the remaining block styles (they use either normal block class or __experimentalSelector).
+				const declarations = getStylesDeclarations(
+					styles,
+					selector,
+					useRootPaddingAlign,
+					tree
+				);
+				const cssSelector = options?.scopeSelector
+					? scopeSelector( options.scopeSelector, selector )
+					: selector;
+				if ( declarations?.length ) {
+					ruleset += `${ cssSelector }{${ declarations.join(
 						';'
 					) };}`;
 				}
-			}
 
-			// Process blockGap and layout styles.
-			if (
-				! disableLayoutStyles &&
-				( ROOT_BLOCK_SELECTOR === selector || hasLayoutSupport )
-			) {
-				ruleset += getLayoutStyles( {
-					style: styles,
-					selector,
-					hasBlockGapSupport,
-					hasFallbackGapSupport,
-					fallbackGapValue,
-				} );
-			}
-
-			// Process the remaining block styles (they use either normal block class or __experimentalSelector).
-			const declarations = getStylesDeclarations(
-				styles,
-				selector,
-				useRootPaddingAlign,
-				tree
-			);
-			if ( declarations?.length ) {
-				ruleset += `${ selector }{${ declarations.join( ';' ) };}`;
-			}
-
-			// Check for pseudo selector in `styles` and handle separately.
-			const pseudoSelectorStyles = Object.entries( styles ).filter(
-				( [ key ] ) => key.startsWith( ':' )
-			);
-
-			if ( pseudoSelectorStyles?.length ) {
-				pseudoSelectorStyles.forEach(
-					( [ pseudoKey, pseudoStyle ] ) => {
-						const pseudoDeclarations =
-							getStylesDeclarations( pseudoStyle );
-
-						if ( ! pseudoDeclarations?.length ) {
-							return;
-						}
-
-						// `selector` maybe provided in a form
-						// where block level selectors have sub element
-						// selectors appended to them as a comma separated
-						// string.
-						// e.g. `h1 a,h2 a,h3 a,h4 a,h5 a,h6 a`;
-						// Split and append pseudo selector to create
-						// the proper rules to target the elements.
-						const _selector = selector
-							.split( ',' )
-							.map( ( sel ) => sel + pseudoKey )
-							.join( ',' );
-
-						const pseudoRule = `${ _selector }{${ pseudoDeclarations.join(
-							';'
-						) };}`;
-
-						ruleset += pseudoRule;
-					}
+				// Check for pseudo selector in `styles` and handle separately.
+				const pseudoSelectorStyles = Object.entries( styles ).filter(
+					( [ key ] ) => key.startsWith( ':' )
 				);
+
+				if ( pseudoSelectorStyles?.length ) {
+					pseudoSelectorStyles.forEach(
+						( [ pseudoKey, pseudoStyle ] ) => {
+							const pseudoDeclarations =
+								getStylesDeclarations( pseudoStyle );
+
+							if ( ! pseudoDeclarations?.length ) {
+								return;
+							}
+
+							// `selector` maybe provided in a form
+							// where block level selectors have sub element
+							// selectors appended to them as a comma separated
+							// string.
+							// e.g. `h1 a,h2 a,h3 a,h4 a,h5 a,h6 a`;
+							// Split and append pseudo selector to create
+							// the proper rules to target the elements.
+							const _selector = selector
+								.split( ',' )
+								.map( ( sel ) => sel + pseudoKey )
+								.join( ',' );
+							const scopedSelector = options?.scopeSelector
+								? scopeSelector(
+										options?.scopeSelector,
+										_selector
+								  )
+								: _selector;
+
+							const pseudoRule = `${ scopedSelector }{${ pseudoDeclarations.join(
+								';'
+							) };}`;
+
+							ruleset += pseudoRule;
+						}
+					);
+				}
 			}
-		}
-	);
+		);
+	}
 
-	/* Add alignment / layout styles */
-	ruleset =
-		ruleset +
-		'.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
-	ruleset =
-		ruleset +
-		'.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
-	ruleset =
-		ruleset +
-		'.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+	if ( ! options || options.layoutStyles ) {
+		/* Add alignment / layout styles */
+		ruleset =
+			ruleset +
+			'.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
+		ruleset =
+			ruleset +
+			'.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
+		ruleset =
+			ruleset +
+			'.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+	}
 
-	if ( hasBlockGapSupport ) {
+	if ( hasBlockGapSupport && ( ! options || options.blockGap ) ) {
 		// Use fallback of `0.5em` just in case, however if there is blockGap support, there should nearly always be a real value.
 		const gapValue =
 			getGapCSSValue( tree?.styles?.spacing?.blockGap ) || '0.5em';
@@ -979,17 +1022,23 @@ export const toStyles = (
 			':where(.wp-site-blocks) > :last-child:last-child { margin-block-end: 0; }';
 	}
 
-	nodesWithSettings.forEach( ( { selector, presets } ) => {
-		if ( ROOT_BLOCK_SELECTOR === selector ) {
-			// Do not add extra specificity for top-level classes.
-			selector = '';
-		}
+	if ( ! options || options.presets ) {
+		nodesWithSettings.forEach( ( { selector, presets } ) => {
+			if ( ROOT_BLOCK_SELECTOR === selector ) {
+				// Do not add extra specificity for top-level classes.
+				selector = '';
+			}
 
-		const classes = getPresetsClasses( selector, presets );
-		if ( classes.length > 0 ) {
-			ruleset += classes;
-		}
-	} );
+			const scopedSelector = options?.scopeSelector
+				? scopeSelector( options?.scopeSelector, selector )
+				: selector;
+			const classes = getPresetsClasses( scopedSelector, presets );
+
+			if ( classes.length > 0 ) {
+				ruleset += classes;
+			}
+		} );
+	}
 
 	return ruleset;
 };

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -385,6 +385,38 @@ const elementTypes = [
 ];
 
 /**
+ * Override the default block element to include section styles.
+ *
+ * NOTE: This likely could/should be merged with the element styles however for
+ * a basic proof of concept it is being kept separate for now.
+ *
+ * @param {Function} BlockListBlock Original component.
+ * @return {Function} Wrapped component.
+ */
+const withSectionStyles = createHigherOrderComponent(
+	( BlockListBlock ) => ( props ) => {
+		// While exploring section styling the blocks supported will be limited.
+		if ( props.name !== 'core/group' ) {
+			return <BlockListBlock { ...props } />;
+		}
+
+		const sectionClass = `wp-section-${ useInstanceId( BlockListBlock ) }`;
+		const sectionStyles = props.attributes?.style?.blocks;
+
+		return (
+			<BlockListBlock
+				{ ...props }
+				className={
+					sectionStyles
+						? classnames( props.className, sectionClass )
+						: props.className
+				}
+			/>
+		);
+	}
+);
+
+/**
  * Override the default block element to include elements styles.
  *
  * @param {Function} BlockListBlock Original component
@@ -535,4 +567,10 @@ addFilter(
 	'editor.BlockListBlock',
 	'core/editor/with-elements-styles',
 	withElementsStyles
+);
+
+addFilter(
+	'editor.BlockListBlock',
+	'core/editor/with-section-styles',
+	withSectionStyles
 );


### PR DESCRIPTION
**🚧 🚧 🚧 This is a draft proof of concept and will be dusted off soon 🚧 🚧 🚧** 

_Note: This branch needs rebasing and conflicts resolved._

## What?

Adds new block support to facilitate application of section specific styles. These styles are stored within a container block's attributes and the style object. They are then treated as a theme.json partial and a stylesheet generated and enqueued from that.

**Note: This has been abandoned in favour of https://github.com/WordPress/gutenberg/pull/56234 so we can merge the concepts of color sets/colorways and section specific styling. Furthermore this will allow the section styles to be stored in theme.json and the global styles such that section styles can be re-used**

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
