### PR TITLE
build: Ignore generated Android files

### DIFF
--- a/packages/react-native-editor/.gitignore
+++ b/packages/react-native-editor/.gitignore
@@ -28,6 +28,11 @@ bundle/
 .gradle/
 android/app/src/main/assets/
 android/app/src/main/res/raw/
+android/app/src/main/res/drawable-hdpi/
+android/app/src/main/res/drawable-mdpi/
+android/app/src/main/res/drawable-xhdpi/
+android/app/src/main/res/drawable-xxhdpi/
+android/app/src/main/res/drawable-xxxhdpi/
 
 # iOS builds
 *.app.zip


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Ignore generated Android files when building for E2E tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
These assets are generated at build time for E2E testing. Seemingly, we
do not leverage these generated files for the binary/bundle that we
provide to the host apps. Therefore, we can safely ignore these files.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the relevant files to the Git ignore configuration.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
