### PR TITLE
Add space before link on last page of Styles Welcome Guide

### DIFF
--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -116,9 +116,12 @@ export default function WelcomeGuideStyles() {
 								{ __( 'Learn more' ) }
 							</h1>
 							<p className="edit-site-welcome-guide__text">
-								{ __(
-									'New to block themes and styling your site? '
-								) }
+								{
+									// translators: Preserve trailing space
+									__(
+										'New to block themes and styling your site? '
+									)
+								}
 								<ExternalLink
 									href={ __(
 										'https://wordpress.org/documentation/article/styles-overview/'

--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -117,7 +117,7 @@ export default function WelcomeGuideStyles() {
 							</h1>
 							<p className="edit-site-welcome-guide__text">
 								{ __(
-									'New to block themes and styling your site?'
+									'New to block themes and styling your site? '
 								) }
 								<ExternalLink
 									href={ __(


### PR DESCRIPTION
## What?
Adds a space before the text link on the last page of the Styles "Welcome Guide".

Addresses https://github.com/WordPress/gutenberg/issues/55579.

## Why?
There should be spaces between sentences. This resolves the typo.

## How?
Just adds a space to some paragraph text.

## Testing Instructions
Follow steps from https://github.com/WordPress/gutenberg/issues/55579#issue-1959651291.
- ✅ With the patch applied, there should be a space after "...site?" and before the text link ("Here's a detailed...").

## Screenshot
<img width="251" alt="welcome-guide-styles-patched" src="https://github.com/WordPress/gutenberg/assets/824344/80c642ab-184a-467c-a35d-70dc7e2afc7a">
