### PR TITLE
Cherry-picked commits for WordPress 6.4 RC3

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -876,7 +876,6 @@ Edit the different global regions of your site, like the header, footer, sidebar
 Display the description of categories, tags and custom taxonomies when viewing an archive. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-description))
 
 -	**Name:** core/term-description
--	**Experimental:** fse
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -59,7 +59,8 @@ function render_block_core_file( $attributes, $content, $block ) {
 		$processor->next_tag();
 		$processor->set_attribute( 'data-wp-interactive', '' );
 		$processor->next_tag( 'object' );
-		$processor->set_attribute( 'data-wp-style--display', 'selectors.core.file.hasPdfPreview' );
+		$processor->set_attribute( 'data-wp-bind--hidden', '!selectors.core.file.hasPdfPreview' );
+		$processor->set_attribute( 'hidden', true );
 		return $processor->get_updated_html();
 	}
 

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -29,12 +29,6 @@
 	margin-bottom: 1em;
 }
 
-@media (max-width: 768px) {
-	.wp-block-file__embed {
-		display: none;
-	}
-}
-
 //This needs a low specificity so it won't override the rules from the button element if defined in theme.json.
 :where(.wp-block-file__button) {
 	border-radius: 2em;

--- a/packages/block-library/src/file/view.js
+++ b/packages/block-library/src/file/view.js
@@ -5,13 +5,13 @@ import { store } from '@wordpress/interactivity';
 /**
  * Internal dependencies
  */
-import { browserSupportsPdfs } from './utils';
+import { browserSupportsPdfs as hasPdfPreview } from './utils';
 
 store( {
 	selectors: {
 		core: {
 			file: {
-				hasPdfPreview: browserSupportsPdfs() ? 'inherit' : 'none',
+				hasPdfPreview,
 			},
 		},
 	},

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -12,10 +12,10 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useContainsThirdPartyBlocks } from '../utils';
+import { useUnsupportedBlockList } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'Plugin blocks are not supported yet. For the enhanced pagination to work, remove the plugin block, then re-enable "Enhanced pagination" in the Query Block settings.'
+	'You have added unsupported blocks. For the enhanced pagination to work, remove them, then re-enable "Enhanced pagination" in the Query Block settings.'
 );
 
 const modalDescriptionId =
@@ -28,11 +28,11 @@ export default function EnhancedPaginationModal( {
 } ) {
 	const [ isOpen, setOpen ] = useState( false );
 
-	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
+	const unsupported = useUnsupportedBlockList( clientId );
 
 	useEffect( () => {
-		setOpen( containsThirdPartyBlocks && enhancedPagination );
-	}, [ containsThirdPartyBlocks, enhancedPagination, setOpen ] );
+		setOpen( !! unsupported.length && enhancedPagination );
+	}, [ unsupported.length, enhancedPagination, setOpen ] );
 
 	return (
 		isOpen && (

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -12,10 +12,10 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useUnsupportedBlockList } from '../utils';
+import { useContainsThirdPartyBlocks } from '../utils';
 
 const disableEnhancedPaginationDescription = __(
-	'You have added unsupported blocks. For the enhanced pagination to work, remove them, then re-enable "Enhanced pagination" in the Query Block settings.'
+	'Plugin blocks are not supported yet. For the enhanced pagination to work, remove the plugin block, then re-enable "Enhanced pagination" in the Query Block settings.'
 );
 
 const modalDescriptionId =
@@ -28,11 +28,11 @@ export default function EnhancedPaginationModal( {
 } ) {
 	const [ isOpen, setOpen ] = useState( false );
 
-	const unsupported = useUnsupportedBlockList( clientId );
+	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
 
 	useEffect( () => {
-		setOpen( !! unsupported.length && enhancedPagination );
-	}, [ unsupported.length, enhancedPagination, setOpen ] );
+		setOpen( containsThirdPartyBlocks && enhancedPagination );
+	}, [ containsThirdPartyBlocks, enhancedPagination, setOpen ] );
 
 	return (
 		isOpen && (

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -3,22 +3,19 @@
  */
 import { ToggleControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { BlockTitle } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
-import { useContainsThirdPartyBlocks } from '../../utils';
+import { useUnsupportedBlockList } from '../../utils';
 
 export default function EnhancedPaginationControl( {
 	enhancedPagination,
 	setAttributes,
 	clientId,
 } ) {
-	const enhancedPaginationNotice = __(
-		"Enhanced pagination doesn't support plugin blocks yet. If you want to enable it, you have to remove all plugin blocks from the Query Loop."
-	);
-
-	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
+	const unsupported = useUnsupportedBlockList( clientId );
 
 	return (
 		<>
@@ -28,20 +25,32 @@ export default function EnhancedPaginationControl( {
 					'Browsing between pages won’t require a full page reload.'
 				) }
 				checked={ !! enhancedPagination }
-				disabled={ containsThirdPartyBlocks }
+				disabled={ unsupported.length }
 				onChange={ ( value ) => {
 					setAttributes( {
 						enhancedPagination: !! value,
 					} );
 				} }
 			/>
-			{ containsThirdPartyBlocks && (
+			{ !! unsupported.length && (
 				<Notice
 					status="warning"
 					isDismissible={ false }
 					className="wp-block-query__enhanced-pagination-notice"
 				>
-					{ enhancedPaginationNotice }
+					{ __(
+						"Enhanced pagination doesn't support the following blocks:"
+					) }
+					<ul>
+						{ unsupported.map( ( id ) => (
+							<li key={ id }>
+								<BlockTitle clientId={ id } />
+							</li>
+						) ) }
+					</ul>
+					{ __(
+						'If you want to enable it, you have to remove all unsupported blocks first.'
+					) }
 				</Notice>
 			) }
 		</>

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -3,19 +3,22 @@
  */
 import { ToggleControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { BlockTitle } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
-import { useUnsupportedBlockList } from '../../utils';
+import { useContainsThirdPartyBlocks } from '../../utils';
 
 export default function EnhancedPaginationControl( {
 	enhancedPagination,
 	setAttributes,
 	clientId,
 } ) {
-	const unsupported = useUnsupportedBlockList( clientId );
+	const enhancedPaginationNotice = __(
+		"Enhanced pagination doesn't support plugin blocks yet. If you want to enable it, you have to remove all plugin blocks from the Query Loop."
+	);
+
+	const containsThirdPartyBlocks = useContainsThirdPartyBlocks( clientId );
 
 	return (
 		<>
@@ -25,32 +28,20 @@ export default function EnhancedPaginationControl( {
 					'Browsing between pages won’t require a full page reload.'
 				) }
 				checked={ !! enhancedPagination }
-				disabled={ unsupported.length }
+				disabled={ containsThirdPartyBlocks }
 				onChange={ ( value ) => {
 					setAttributes( {
 						enhancedPagination: !! value,
 					} );
 				} }
 			/>
-			{ !! unsupported.length && (
+			{ containsThirdPartyBlocks && (
 				<Notice
 					status="warning"
 					isDismissible={ false }
 					className="wp-block-query__enhanced-pagination-notice"
 				>
-					{ __(
-						"Enhanced pagination doesn't support the following blocks:"
-					) }
-					<ul>
-						{ unsupported.map( ( id ) => (
-							<li key={ id }>
-								<BlockTitle clientId={ id } />
-							</li>
-						) ) }
-					</ul>
-					{ __(
-						'If you want to enable it, you have to remove all unsupported blocks first.'
-					) }
+					{ enhancedPaginationNotice }
 				</Notice>
 			) }
 		</>

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -346,21 +346,28 @@ export const usePatterns = ( clientId, name ) => {
 };
 
 /**
- * Hook that returns whether the Query Loop with the given `clientId` contains
- * any third-party block.
+ * Hook that returns a list of unsupported blocks inside the Query Loop with the
+ * given `clientId`.
  *
  * @param {string} clientId The block's client ID.
- * @return {boolean} True if it contains third-party blocks.
+ * @return {string[]} List of block titles.
  */
-export const useContainsThirdPartyBlocks = ( clientId ) => {
+export const useUnsupportedBlockList = ( clientId ) => {
 	return useSelect(
 		( select ) => {
 			const { getClientIdsOfDescendants, getBlockName } =
 				select( blockEditorStore );
 
-			return getClientIdsOfDescendants( clientId ).some(
-				( descendantClientId ) =>
-					! getBlockName( descendantClientId ).startsWith( 'core/' )
+			return getClientIdsOfDescendants( clientId ).filter(
+				( descendantClientId ) => {
+					const blockName = getBlockName( descendantClientId );
+					return (
+						! blockName.startsWith( 'core/' ) ||
+						blockName === 'core/post-content' ||
+						blockName === 'core/template-part' ||
+						blockName === 'core/block'
+					);
+				}
 			);
 		},
 		[ clientId ]

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -346,28 +346,21 @@ export const usePatterns = ( clientId, name ) => {
 };
 
 /**
- * Hook that returns a list of unsupported blocks inside the Query Loop with the
- * given `clientId`.
+ * Hook that returns whether the Query Loop with the given `clientId` contains
+ * any third-party block.
  *
  * @param {string} clientId The block's client ID.
- * @return {string[]} List of block titles.
+ * @return {boolean} True if it contains third-party blocks.
  */
-export const useUnsupportedBlockList = ( clientId ) => {
+export const useContainsThirdPartyBlocks = ( clientId ) => {
 	return useSelect(
 		( select ) => {
 			const { getClientIdsOfDescendants, getBlockName } =
 				select( blockEditorStore );
 
-			return getClientIdsOfDescendants( clientId ).filter(
-				( descendantClientId ) => {
-					const blockName = getBlockName( descendantClientId );
-					return (
-						! blockName.startsWith( 'core/' ) ||
-						blockName === 'core/post-content' ||
-						blockName === 'core/template-part' ||
-						blockName === 'core/block'
-					);
-				}
+			return getClientIdsOfDescendants( clientId ).some(
+				( descendantClientId ) =>
+					! getBlockName( descendantClientId ).startsWith( 'core/' )
 			);
 		},
 		[ clientId ]

--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
-	"__experimental": "fse",
 	"name": "core/term-description",
 	"title": "Term Description",
 	"category": "theme",

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -630,6 +630,7 @@ export const getUserPatternCategories =
 			{
 				per_page: -1,
 				_fields: 'id,name,description,slug',
+				context: 'view',
 			}
 		);
 


### PR DESCRIPTION
Latest commits for WordPress 6.4 RC3.

Included changes:

* https://github.com/WordPress/gutenberg/pull/55553
* https://github.com/WordPress/gutenberg/pull/55539
* https://github.com/WordPress/gutenberg/pull/55667
* https://github.com/WordPress/gutenberg/pull/55669

Merged/cherry-picked directly to `wp/6.4` for inclusion in RC3, separate to this PR:

* https://github.com/WordPress/gutenberg/pull/55604
* https://github.com/WordPress/gutenberg/pull/55676