### PR TITLE
[Mobile] E2E Tests - Utils - Update `typeString`

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -218,6 +218,9 @@ const typeString = async ( driver, element, str, clear ) => {
 
 	if ( clear ) {
 		await element.clearValue();
+		// This helps prevent skipping characters when the initial
+		// value was previously removed.
+		await driver.pause( 2000 );
 	}
 
 	await element.addValue( str );


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6321

## What?
This PR adds a `pause` after clearing the initial value in the `typeString` util.

## Why?
There's a flaky test on iOS where it would skip typing some characters after clearing the initial value. This might be related to the performance of the editor when typing/deleting text too fast.

## How?
By adding a `pause` timer after clearing the initial value.

## Testing Instructions
CI checks should pass in both PRs.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A