### PR TITLE
[Mobile] Update E2E Simulators

### DIFF
--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             matrix:
                 xcode: ['14.2']
-                device: ['iPhone 13']
+                device: ['iPhone 14']
                 native-test-name: [gutenberg-editor-rendering]
 
         steps:

--- a/packages/react-native-editor/__device-tests__/README.md
+++ b/packages/react-native-editor/__device-tests__/README.md
@@ -14,8 +14,8 @@ Before setting up Appium, the required iOS and Android dependencies must be inst
 -   Complete the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide, which covers installing and setting up Xcode.
 -   Open [Xcode settings](https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-in-settings) to install the iOS 16.2 simulator runtime.
 -   Create the required simulators by running the follow scripts in your shell:
-    -   `xcrun simctl create "iPhone 13" "iPhone 13" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"`
-    -   `xcrun simctl create "iPad Pro (9.7-inch)" "iPad Pro (9.7-inch)" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"`
+    -   `xcrun simctl create "iPhone 14" "iPhone 14" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"`
+    -   `xcrun simctl create "iPad (10th generation)" "iPad (10th generation)" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"`
 
 ### Android
 

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -10,7 +10,7 @@ const ios = {
 
 exports.iosLocal = ( { iPadDevice = false } ) => ( {
 	...ios,
-	deviceName: ! iPadDevice ? 'iPhone 13' : 'iPad Pro (9.7-inch)',
+	deviceName: ! iPadDevice ? 'iPhone 14' : 'iPad (10th generation)',
 	pixelRatio: ! iPadDevice ? 3 : 2,
 	usePrebuiltWDA: true,
 } );
@@ -18,8 +18,8 @@ exports.iosLocal = ( { iPadDevice = false } ) => ( {
 exports.iosServer = ( { iPadDevice = false } ) => ( {
 	...ios,
 	deviceName: ! iPadDevice
-		? 'iPhone 13 Simulator'
-		: 'iPad Pro (9.7 inch) Simulator',
+		? 'iPhone 14 Simulator'
+		: 'iPad (10th generation) Simulator',
 	pixelRatio: ! iPadDevice ? 3 : 2,
 } );
 

--- a/packages/react-native-editor/bin/build_e2e_ios_app
+++ b/packages/react-native-editor/bin/build_e2e_ios_app
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-DEFAULT_DESTINATION='platform=iOS Simulator,name=iPhone 13'
+DEFAULT_DESTINATION='platform=iOS Simulator,name=iPhone 14'
 if [[ -z "${RN_EDITOR_E2E_IOS_DESTINATION-}" ]]; then
 	DESTINATION="$DEFAULT_DESTINATION"
 else

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -115,7 +115,7 @@
 		"test:e2e:android:local": "npm run test:e2e:bundle:android && npm run test:e2e:build-app:android && TEST_RN_PLATFORM=android npm run device-tests:local",
 		"test:e2e:bundle:ios": "mkdir -p ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app && npm run bundle:ios && cp bundle/ios/App.js ./ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/main.jsbundle && cp -r bundle/ios/assets ./ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/",
 		"test:e2e:build-app:ios": "npm run preios && ./bin/build_e2e_ios_app",
-		"test:e2e:build-wda": "xcodebuild -project ~/.appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'platform=iOS Simulator,name=iPhone 13' -derivedDataPath ios/build/WDA",
+		"test:e2e:build-wda": "xcodebuild -project ~/.appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ios/build/WDA",
 		"test:e2e:ios:local": "npm run test:e2e:bundle:ios && npm run test:e2e:build-app:ios && npm run test:e2e:build-wda && TEST_RN_PLATFORM=ios npm run device-tests:local",
 		"build:gutenberg": "cd gutenberg && npm ci && npm run build",
 		"clean": "npm run clean:build-artifacts; npm run clean:aztec; npm run clean:haste; npm run clean:metro; npm run clean:watchman",


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6322

## What?
This PR updates the E2E simulators.

## Why?
To use newer simulators available with the current Xcode version `14`.

## How?
Now it will use the `iPhone 14` and `iPad (10th generation)` simulators.

It also updates the documentation accordingly.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A