### PR TITLE
Fix: Add __next40pxDefaultSize to author select in PostAuthor.

### DIFF
--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -40,6 +40,7 @@ function PostAuthorSelect() {
 
 	return (
 		<SelectControl
+			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			className="post-author-selector"
 			label={ __( 'Author' ) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/55592