### PR TITLE
Adjust the padding of the category item to make it visually balanced

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -295,7 +295,7 @@ $block-inserter-tabs-height: 44px;
 
 	.block-editor-inserter__patterns-category {
 		// Account for the icon on the right so that it's visually balanced.
-		padding-right: 4px;
+		padding-right: $grid-unit-05;
 	}
 }
 
@@ -540,7 +540,7 @@ $block-inserter-tabs-height: 44px;
 
 	.block-editor-inserter__media-tabs__media-category {
 		// Account for the icon on the right so that it's visually balanced.
-		padding-right: 4px;
+		padding-right: $grid-unit-05;
 
 		&.is-selected {
 			color: var(--wp-admin-theme-color);

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -292,6 +292,11 @@ $block-inserter-tabs-height: 44px;
 	div[role="listitem"]:last-child {
 		margin-top: auto;
 	}
+
+	.block-editor-inserter__patterns-category {
+		// Account for the icon on the right so that it's visually balanced.
+		padding-right: 4px;
+	}
 }
 
 .block-editor-inserter__patterns-category-dialog {
@@ -533,7 +538,10 @@ $block-inserter-tabs-height: 44px;
 		margin-top: auto;
 	}
 
-	&__media-category {
+	.block-editor-inserter__media-tabs__media-category {
+		// Account for the icon on the right so that it's visually balanced.
+		padding-right: 4px;
+
 		&.is-selected {
 			color: var(--wp-admin-theme-color);
 			position: relative;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and Why?
<!-- In a few words, what is the PR actually doing? -->
Close https://github.com/WordPress/gutenberg/issues/50753.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
As suggested in https://github.com/WordPress/gutenberg/issues/50753, adjust the `padding-right` value to `4px`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to the post editor
2. Open the global inserter
3. Visit the "Patterns" or "Media" tab
4. Expect the category items to be visually balanced with active items.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above ☝️. It's a UI-only change so not testable in screen readers.

## Screenshots or screencast <!-- if applicable -->

Media | Patterns
--- | ---
![image](https://github.com/WordPress/gutenberg/assets/7753001/ad59876f-75e9-46f7-bbcc-8d5fef763c6e) | ![image](https://github.com/WordPress/gutenberg/assets/7753001/e74a9a65-1987-4e41-a2cc-59c5586e279b)


