### PR TITLE
Remove the extraneous template part title in replace control

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -4,7 +4,6 @@
 import { useSelect } from '@wordpress/data';
 import {
 	BlockSettingsMenuControls,
-	BlockTitle,
 	useBlockProps,
 	Warning,
 	store as blockEditorStore,
@@ -14,7 +13,7 @@ import {
 import { Spinner, Modal, MenuItem } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
-import { useState, createInterpolateElement } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -174,17 +173,7 @@ export default function TemplatePartEdit( {
 									}
 									aria-haspopup="dialog"
 								>
-									{ createInterpolateElement(
-										__( 'Replace <BlockTitle />' ),
-										{
-											BlockTitle: (
-												<BlockTitle
-													clientId={ clientId }
-													maximumLength={ 25 }
-												/>
-											),
-										}
-									) }
+									{ __( 'Replace' ) }
 								</MenuItem>
 							);
 						} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close https://github.com/WordPress/gutenberg/issues/55600. Remove the extraneous template part title in replace control.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/55600

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Simply remove the code.

### Testing Instructions for Keyboard
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to a template in the site editor
2. Select a template part in the canvas
3. <kbd>Shift</kbd>+<kbd>Tab</kbd> to navigate to the block toolbar
4. <kbd>ArrowRight</kbd> until you reach the "Options" menu item
5. Open the options dropdown and <kbd>ArrowDown</kbd> until you reach the "Replace" menu item
6. Note that it now says "Replace" only

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/2222ea49-f507-4730-9e01-f605c8285b0d)
