### PR TITLE
Fix: Add home icon to the front page in LinkControl results.

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -11,6 +11,7 @@ import {
 	postList,
 	category,
 	file,
+	home,
 } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { safeDecodeURI, filterURLForDisplay, getPath } from '@wordpress/url';
@@ -31,6 +32,9 @@ function SearchItemIcon( { isURL, suggestion } ) {
 		icon = globe;
 	} else if ( suggestion.type in ICONS_MAP ) {
 		icon = ICONS_MAP[ suggestion.type ];
+		if ( suggestion.type === 'page' && suggestion.isFrontPage ) {
+			icon = home;
+		}
 	}
 
 	if ( icon ) {

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -102,8 +102,7 @@ const handleEntitySearch = async (
 export default function useSearchHandler(
 	suggestionsQuery,
 	allowDirectEntry,
-	withCreateSuggestion,
-	withURLSuggestion
+	withCreateSuggestion
 ) {
 	const { fetchSearchSuggestions, pageOnFront } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
@@ -128,7 +127,6 @@ export default function useSearchHandler(
 						{ ...suggestionsQuery, isInitialSuggestions },
 						fetchSearchSuggestions,
 						withCreateSuggestion,
-						withURLSuggestion,
 						pageOnFront
 				  );
 		},
@@ -138,7 +136,6 @@ export default function useSearchHandler(
 			pageOnFront,
 			suggestionsQuery,
 			withCreateSuggestion,
-			withURLSuggestion,
 		]
 	);
 }


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/54667.


## Testing
- Select a page as the home page of a site.
- Create a new post and add a link to that page verify on the link suggestion for that page it shows the homepage icon.
<img width="402" alt="Screenshot 2023-10-25 at 12 00 50" src="https://github.com/WordPress/gutenberg/assets/11271197/4569d5af-1b4e-4e00-a163-45bb88eabda6">
