### PR TITLE
Fix pattern category renaming causing potential duplicate categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55957,6 +55957,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",
@@ -70798,6 +70799,7 @@
 			"version": "file:packages/patterns",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",

--- a/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
@@ -5,6 +5,10 @@ import { MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
+/**
+ * Internal dependencies
+ */
+import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
 
 /**
  * Internal dependencies
@@ -16,6 +20,25 @@ const { RenamePatternCategoryModal } = unlock( patternsPrivateApis );
 export default function RenameCategoryMenuItem( { category, onClose } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
+	return (
+		<>
+			<MenuItem onClick={ () => setIsModalOpen( true ) }>
+				{ __( 'Rename' ) }
+			</MenuItem>
+			{ isModalOpen && (
+				<RenameModal
+					category={ category }
+					onClose={ () => {
+						setIsModalOpen( false );
+						onClose();
+					} }
+				/>
+			) }
+		</>
+	);
+}
+
+function RenameModal( { category, onClose } ) {
 	// User created pattern categories have their properties updated when
 	// retrieved via `getUserPatternCategories`. The rename modal expects an
 	// object that will match the pattern category entity.
@@ -25,21 +48,15 @@ export default function RenameCategoryMenuItem( { category, onClose } ) {
 		name: category.label,
 	};
 
+	// Optimization - only use pattern categories when the modal is open.
+	const existingCategories = usePatternCategories();
+
 	return (
-		<>
-			<MenuItem onClick={ () => setIsModalOpen( true ) }>
-				{ __( 'Rename' ) }
-			</MenuItem>
-			{ isModalOpen && (
-				<RenamePatternCategoryModal
-					category={ normalizedCategory }
-					onClose={ () => {
-						setIsModalOpen( false );
-						onClose();
-					} }
-					overlayClassName="edit-site-list__rename-modal"
-				/>
-			) }
-		</>
+		<RenamePatternCategoryModal
+			category={ normalizedCategory }
+			existingCategories={ existingCategories }
+			onClose={ onClose }
+			overlayClassName="edit-site-list__rename-modal"
+		/>
 	);
 }

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -31,6 +31,7 @@
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -35,7 +35,7 @@ export default function RenamePatternCategoryModal( {
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ validationMessage, setValidationMessage ] = useState( false );
 	const validationMessageId = validationMessage
-		? `patterns-rename-pattern-category-modal__description-${ id }`
+		? `patterns-rename-pattern-category-modal__validation-message-${ id }`
 		: undefined;
 
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
@@ -134,20 +134,25 @@ export default function RenamePatternCategoryModal( {
 		>
 			<form onSubmit={ onSave }>
 				<VStack spacing="5">
-					<TextControl
-						ref={ textControlRef }
-						__nextHasNoMarginBottom
-						label={ __( 'Name' ) }
-						value={ name }
-						onChange={ onChange }
-						aria-describedby={ validationMessageId }
-						required
-					/>
-					{ validationMessage && (
-						<span id={ validationMessageId }>
-							{ validationMessage }
-						</span>
-					) }
+					<VStack spacing="2">
+						<TextControl
+							ref={ textControlRef }
+							__nextHasNoMarginBottom
+							label={ __( 'Name' ) }
+							value={ name }
+							onChange={ onChange }
+							aria-describedby={ validationMessageId }
+							required
+						/>
+						{ validationMessage && (
+							<span
+								className="patterns-rename-pattern-category-modal__validation-message"
+								id={ validationMessageId }
+							>
+								{ validationMessage }
+							</span>
+						) }
+					</VStack>
 					<HStack justify="right">
 						<Button variant="tertiary" onClick={ onRequestClose }>
 							{ __( 'Cancel' ) }

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -22,6 +22,7 @@ import { CATEGORY_SLUG } from './category-selector';
 
 export default function RenamePatternCategoryModal( {
 	category,
+	existingCategories,
 	onClose,
 	onError,
 	onSuccess,
@@ -31,7 +32,6 @@ export default function RenamePatternCategoryModal( {
 	const [ isSaving, setIsSaving ] = useState( false );
 
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
-
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 
@@ -39,6 +39,15 @@ export default function RenamePatternCategoryModal( {
 		event.preventDefault();
 
 		if ( ! name || name === category.name || isSaving ) {
+			return;
+		}
+
+		// Check existing categories to avoid creating duplicates.
+		if (
+			existingCategories.patternCategories.find( ( existingCategory ) => {
+				return existingCategory.label === name;
+			} )
+		) {
 			return;
 		}
 

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -54,7 +54,9 @@ export default function RenamePatternCategoryModal( {
 		// Check existing categories to avoid creating duplicates.
 		if (
 			existingCategories.patternCategories.find( ( existingCategory ) => {
-				return existingCategory.label === name;
+				return (
+					existingCategory.label.toLowerCase() === name.toLowerCase()
+				);
 			} )
 		) {
 			speak( __( 'This category already exists.' ), 'assertive' );

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -38,7 +39,15 @@ export default function RenamePatternCategoryModal( {
 	const onRename = async ( event ) => {
 		event.preventDefault();
 
-		if ( ! name || name === category.name || isSaving ) {
+		if ( isSaving ) {
+			return;
+		}
+
+		if ( ! name || name === category.name ) {
+			speak(
+				__( 'Please enter a new name for this category.' ),
+				'assertive'
+			);
 			return;
 		}
 
@@ -48,6 +57,7 @@ export default function RenamePatternCategoryModal( {
 				return existingCategory.label === name;
 			} )
 		) {
+			speak( __( 'This category already exists.' ), 'assertive' );
 			return;
 		}
 

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -34,3 +34,12 @@
 	// Override the default 1px margin-x.
 	margin: 0;
 }
+
+.patterns-rename-pattern-category-modal__validation-message {
+	color: $alert-red;
+
+	// Match the input size.
+	@include break-medium() {
+		width: $grid-unit * 40;
+	}
+}


### PR DESCRIPTION
## What?
Fixes #55564

As described in #55564, it's possible to create duplicate patten categories when renaming a category.

This PR should prevent that happening.

## Why?
Duplicates are undesirable. Users should instead reassign a pattern to the category with the existing name.

## How?
Check existing categories prior to renaming. If a match is found, avoid renaming and show an error below the input.

I have added a spoken message for screenreader users.

## Testing Instructions
1. Create a custom pattern category (add new pattern, type a non-existing category name into Categories input)
2. Rename category (via ellipsis menu in top right)
3. Choose an existing category name
4. A message should appear informing you of the existing category.

### Testing Instructions for Keyboard
Prerequisite - you need an existing custom pattern category.

1. Open the site editor
2. Tab to 'Patterns' in the navigation sidebar and select it.
3. Tab to your custom pattern category and select it.
4. Navigate to the 'Patterns Content' region
5. Tab to the Actions menu and open it
6. Select the 'Rename' option from the menu
7. Try renaming to an existing category (e.g. 'Featured')
8. Tab to save button and select it
9. You should hear a spoken message "This category already exists ...".
10. Focus should be returned to the affected input

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/677833/67aa32cc-588c-4e94-9c8a-979a2fe60848



