### PR TITLE
Workflows: Try using 10up's plugin deploy action

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -188,7 +188,7 @@ jobs:
                   path: trunk
 
             - name: Deploy WordPress Plugin
-              uses: 10up/action-wordpress-plugin-deploy@stable
+              uses: 10up/action-wordpress-plugin-deploy@abb939a0d0bfd01063e8d1933833209201557381 # v2.2.2
               with:
                   dry-run: true
 

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -167,19 +167,12 @@ jobs:
             VERSION: ${{ github.event.release.name }}
 
         steps:
-            - name: Check out Gutenberg trunk from WP.org plugin repo
-              run: svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
-
-            - name: Delete everything
-              working-directory: ./trunk
-              run: find . -maxdepth 1 -not -name ".svn" -not -name "." -not -name ".." -exec rm -rf {} +
-
-            - name: Download and unzip Gutenberg plugin asset into trunk folder
+            - name: Download and unzip Gutenberg plugin asset
               env:
                   PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
               run: |
                   curl -L -o gutenberg.zip $PLUGIN_URL
-                  unzip gutenberg.zip -d trunk
+                  unzip gutenberg.zip
                   rm gutenberg.zip
 
             - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
@@ -194,20 +187,11 @@ jobs:
                   name: changelog trunk
                   path: trunk
 
-            - name: Commit the content changes
-              working-directory: ./trunk
-              run: |
-                  svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
-                  svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                  svn commit -m "Committing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-                   --config-option=servers:global:http-timeout=300
-
-            - name: Create the SVN tag
-              working-directory: ./trunk
-              run: |
-                  svn copy "$PLUGIN_REPO_URL/trunk" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Tagging version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+            - name: Deploy WordPress Plugin
+              uses: 10up/action-wordpress-plugin-deploy@stable
+              env:
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
 
             - name: Update the plugin's stable version
               working-directory: ./trunk

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -189,6 +189,8 @@ jobs:
 
             - name: Deploy WordPress Plugin
               uses: 10up/action-wordpress-plugin-deploy@stable
+              with:
+                  dry-run: true
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -191,9 +191,6 @@ jobs:
               uses: 10up/action-wordpress-plugin-deploy@stable
               with:
                   dry-run: true
-              env:
-                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
 
             - name: Update the plugin's stable version
               working-directory: ./trunk


### PR DESCRIPTION
## What?
Try using https://github.com/10up/action-wordpress-plugin-asset-update to upload a Gutenberg release to the WP.org plugin repo.

See #53303 for context.

## Why?
To de-duplicate and remove some maintenance burden.

## How?
By using aforementioned action.

## Testing Instructions
Tricky, as all GH actions 😬 