### PR TITLE
[Mobile] E2E Tests Update usage of `touchPerform`

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -481,23 +481,16 @@ const dragAndDropAfterElement = async ( driver, element, nextElement ) => {
 		? elementLocation.y + nextElementLocation.y + nextElementSize.height
 		: nextElementLocation.y + nextElementSize.height;
 
-	await driver.touchPerform( [
-		{
-			action: 'press',
-			options: { x, y },
-		},
-		{
-			action: 'wait',
-			options: {
-				ms: 5000,
-			},
-		},
-		{
-			action: 'moveTo',
-			options: { x, y: nextYPosition },
-		},
-		{ action: 'release' },
-	] );
+	await driver
+		.action( 'pointer', {
+			parameters: { pointerType: 'touch' },
+		} )
+		.move( { x, y } )
+		.down()
+		.pause( 5000 )
+		.move( { x, y: nextYPosition, duration: 500 } )
+		.up()
+		.perform();
 };
 
 const toggleHtmlMode = async ( driver, toggleOn ) => {

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -280,13 +280,14 @@ const clickMiddleOfElement = async ( driver, element ) => {
 	const location = await element.getLocation();
 	const size = await element.getSize();
 
-	await driver.touchPerform( [
-		{
-			action: 'press',
-			options: { x: location.x + size.width / 2, y: location.y },
-		},
-		{ action: 'release' },
-	] );
+	await driver
+		.action( 'pointer', {
+			parameters: { pointerType: 'touch' },
+		} )
+		.move( { x: location.x + size.width / 2, y: location.y } )
+		.down()
+		.up()
+		.perform();
 };
 
 // Clicks in the top left of an element.

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -293,13 +293,14 @@ const clickMiddleOfElement = async ( driver, element ) => {
 // Clicks in the top left of an element.
 const clickBeginningOfElement = async ( driver, element ) => {
 	const location = await element.getLocation();
-	await driver.touchPerform( [
-		{
-			action: 'press',
-			options: { x: location.x, y: location.y },
-		},
-		{ action: 'release' },
-	] );
+	await driver
+		.action( 'pointer', {
+			parameters: { pointerType: 'touch' },
+		} )
+		.move( { x: location.x, y: location.y } )
+		.down()
+		.up()
+		.perform();
 };
 
 // Long press to activate context menu.

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -341,22 +341,15 @@ const longPressMiddleOfElement = async (
 };
 
 const tapStatusBariOS = async ( driver ) => {
-	await driver.touchPerform( [
-		{
-			action: 'press',
-			options: { x: 20, y: 20 },
-		},
-		{
-			action: 'wait',
-			options: {
-				ms: 100,
-			},
-		},
-		{
-			action: 'release',
-			options: {},
-		},
-	] );
+	await driver
+		.action( 'pointer', {
+			parameters: { pointerType: 'touch' },
+		} )
+		.move( { x: 20, y: 20 } )
+		.down()
+		.up()
+		.pause( 100 )
+		.perform();
 
 	// Wait for the scroll animation to finish
 	await driver.pause( 3000 );


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6323
 
## What?
This PR updates the usage of `touchPerform` in favor of `actions`.

## Why?
To avoid the `unknown method: Not implemented` similar to what we did in https://github.com/WordPress/gutenberg/pull/55322/files#r1361132811

## How?
Replaces the usage of `touchPerform`.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A