### PR TITLE
 Add blog icon to the blog home page in LinkControl search results 

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -33,11 +33,13 @@ function SearchItemIcon( { isURL, suggestion } ) {
 		icon = globe;
 	} else if ( suggestion.type in ICONS_MAP ) {
 		icon = ICONS_MAP[ suggestion.type ];
-		if ( suggestion.type === 'page' && suggestion.isFrontPage ) {
-			icon = home;
-		}
-		if ( suggestion.type === 'page' && suggestion.isBlogHome ) {
-			icon = verse;
+		if ( suggestion.type === 'page' ) {
+			if ( suggestion.isFrontPage ) {
+				icon = home;
+			}
+			if ( suggestion.isBlogHome ) {
+				icon = verse;
+			}
 		}
 	}
 

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -12,6 +12,7 @@ import {
 	category,
 	file,
 	home,
+	verse,
 } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { safeDecodeURI, filterURLForDisplay, getPath } from '@wordpress/url';
@@ -34,6 +35,9 @@ function SearchItemIcon( { isURL, suggestion } ) {
 		icon = ICONS_MAP[ suggestion.type ];
 		if ( suggestion.type === 'page' && suggestion.isFrontPage ) {
 			icon = home;
+		}
+		if ( suggestion.type === 'page' && suggestion.isBlogHome ) {
+			icon = verse;
 		}
 	}
 
@@ -137,6 +141,10 @@ export const LinkControlSearchItem = ( {
 function getVisualTypeName( suggestion ) {
 	if ( suggestion.isFrontPage ) {
 		return 'front page';
+	}
+
+	if ( suggestion.isBlogHome ) {
+		return 'blog home';
 	}
 
 	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.

--- a/packages/block-editor/src/components/link-control/search-results.js
+++ b/packages/block-editor/src/components/link-control/search-results.js
@@ -123,6 +123,7 @@ export default function LinkControlSearchResults( {
 								searchTerm={ currentInputValue }
 								shouldShowType={ shouldShowSuggestionsTypes }
 								isFrontPage={ suggestion?.isFrontPage }
+								isBlogHome={ suggestion?.isBlogHome }
 							/>
 						);
 					} ) }

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -52,7 +52,8 @@ const handleEntitySearch = async (
 	suggestionsQuery,
 	fetchSearchSuggestions,
 	withCreateSuggestion,
-	pageOnFront
+	pageOnFront,
+	pageForPosts
 ) => {
 	const { isInitialSuggestions } = suggestionsQuery;
 
@@ -60,8 +61,14 @@ const handleEntitySearch = async (
 
 	// Identify front page and update type to match.
 	results.map( ( result ) => {
+		console.log( pageForPosts );
 		if ( Number( result.id ) === pageOnFront ) {
 			result.isFrontPage = true;
+			return result;
+		}
+
+		if ( Number( result.id ) === pageForPosts ) {
+			result.isBlogHome = true;
 			return result;
 		}
 
@@ -104,15 +111,19 @@ export default function useSearchHandler(
 	allowDirectEntry,
 	withCreateSuggestion
 ) {
-	const { fetchSearchSuggestions, pageOnFront } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
+	const { fetchSearchSuggestions, pageOnFront, pageForPosts } = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore );
 
-		return {
-			pageOnFront: getSettings().pageOnFront,
-			fetchSearchSuggestions:
-				getSettings().__experimentalFetchLinkSuggestions,
-		};
-	}, [] );
+			return {
+				pageOnFront: getSettings().pageOnFront,
+				pageForPosts: getSettings().pageForPosts,
+				fetchSearchSuggestions:
+					getSettings().__experimentalFetchLinkSuggestions,
+			};
+		},
+		[]
+	);
 
 	const directEntryHandler = allowDirectEntry
 		? handleDirectEntry
@@ -127,13 +138,15 @@ export default function useSearchHandler(
 						{ ...suggestionsQuery, isInitialSuggestions },
 						fetchSearchSuggestions,
 						withCreateSuggestion,
-						pageOnFront
+						pageOnFront,
+						pageForPosts
 				  );
 		},
 		[
 			directEntryHandler,
 			fetchSearchSuggestions,
 			pageOnFront,
+			pageForPosts,
 			suggestionsQuery,
 			withCreateSuggestion,
 		]

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -61,13 +61,10 @@ const handleEntitySearch = async (
 
 	// Identify front page and update type to match.
 	results.map( ( result ) => {
-		console.log( pageForPosts );
 		if ( Number( result.id ) === pageOnFront ) {
 			result.isFrontPage = true;
 			return result;
-		}
-
-		if ( Number( result.id ) === pageForPosts ) {
+		} else if ( Number( result.id ) === pageForPosts ) {
 			result.isBlogHome = true;
 			return result;
 		}

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -93,6 +93,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		canUseUnfilteredHTML,
 		userCanCreatePages,
 		pageOnFront,
+		pageForPosts,
 		postType,
 		userPatternCategories,
 	} = useSelect( ( select ) => {
@@ -118,6 +119,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			hasUploadPermissions: canUser( 'create', 'media' ) ?? true,
 			userCanCreatePages: canUser( 'create', 'pages' ),
 			pageOnFront: siteSettings?.page_on_front,
+			pageForPosts: siteSettings?.page_for_posts,
 			postType: getCurrentPostType(),
 			userPatternCategories: getUserPatternCategories(),
 		};
@@ -218,6 +220,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
 			pageOnFront,
+			pageForPosts,
 			__experimentalPreferPatternsOnRoot: hasTemplate,
 		} ),
 		[
@@ -233,6 +236,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			createPageEntity,
 			userCanCreatePages,
 			pageOnFront,
+			pageForPosts,
 		]
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/54666

Select a page to show all your pots on General - Reading settings. 
Create a new post and add a link to that page verify on the link suggestion for that page it shows the blog home icon.



## Screenshots or screencast <!-- if applicable -->
<img width="552" alt="Screenshot 2023-10-25 at 12 27 57" src="https://github.com/WordPress/gutenberg/assets/3593343/525658d7-2376-4e4a-adc6-4c38c4b366ef">

