### PR TITLE
replace 'npx' with 'node' on test-playwright.js file'

### DIFF
--- a/packages/scripts/scripts/test-playwright.js
+++ b/packages/scripts/scripts/test-playwright.js
@@ -53,7 +53,7 @@ if ( ! process.env.WP_ARTIFACTS_PATH ) {
 }
 
 const testResult = spawn(
-	'npx',
+	'node',
 	[
 		require.resolve( '@playwright/test/cli' ),
 		'test',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes the error encountered while running playwright tests on Flywheel Local.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After running `test:e2e:playwright` on a Flywheel local setup, an error is encountered with the message: "sh: /Users/test/Local: is a directory."

This error occurs because the plugin's absolute path is` "/Users/test/Local Sites/*****,"` and the current command mistakenly removes the other parts of absolute path after space and interprets `"Local"` as a directory.

This PR addresses the issue by replacing `npx` with `node`, which resolves the error and allows the tests to run successfully. 

Is this the correct way to run test on [Local by Flywheel](https://localwp.com/)?
