### PR TITLE
Global styles: disable revisions menu item when panel is open

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -129,7 +129,7 @@ function GlobalStylesRevisionsMenu() {
 	}, [] );
 	const { useGlobalStylesReset } = unlock( blockEditorPrivateApis );
 	const [ canReset, onReset ] = useGlobalStylesReset();
-	const { goTo } = useNavigator();
+	const { goTo, location } = useNavigator();
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
@@ -148,6 +148,7 @@ function GlobalStylesRevisionsMenu() {
 						<MenuGroup>
 							{ hasRevisions && (
 								<MenuItem
+									disabled={ location?.path === '/revisions' }
 									onClick={ loadRevisions }
 									icon={
 										<RevisionsCountBadge>


### PR DESCRIPTION
## What?

A small PR to disable global styles revisions menu item when the global styles revisions is open



## Why?
Remarked upon in https://github.com/WordPress/gutenberg/issues/55486#issuecomment-1779017432, to provide a visual cue to users that the menu item is active. 

## How?
Via the `disabled` prop on `<MenuItem />`

## Testing Instructions

1. Using a block theme like 2024, head over to the Site Editor `/wp-admin/site-editor.php`
2. Change a style such as the site background color and then save to create a revisions
3. Open the revisions panel by clicking on the "backup" icon and then "Revisions history"
4. Observe that the "Revisions history" menu item is now disabled


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
| <img width="350" alt="Screenshot 2023-10-25 at 2 25 05 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/09a07bcb-a6bc-4b10-a742-828ed5ea55ee">  | <img width="350" alt="Screenshot 2023-10-25 at 2 23 52 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/b65a30d2-8005-4755-b641-2460d2c2d586">  |



