### PR TITLE
Plugin upload workflow: Add 300s timeout to svn commit command

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -200,7 +200,8 @@ jobs:
                   svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
                   svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
                   svn commit -m "Committing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
+                   --config-option=servers:global:http-timeout=60
 
             - name: Create the SVN tag
               working-directory: ./trunk
@@ -254,4 +255,5 @@ jobs:
             - name: Add the new version directory and commit changes to the SVN repository
               run: |
                   svn import "$VERSION" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Committing version $VERSION" \
-                  --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                  --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
+                  --config-option=servers:global:http-timeout=60

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -201,7 +201,7 @@ jobs:
                   svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
                   svn commit -m "Committing version $VERSION" \
                    --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-                   --config-option=servers:global:http-timeout=60
+                   --config-option=servers:global:http-timeout=300
 
             - name: Create the SVN tag
               working-directory: ./trunk
@@ -256,4 +256,4 @@ jobs:
               run: |
                   svn import "$VERSION" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Committing version $VERSION" \
                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-                  --config-option=servers:global:http-timeout=60
+                  --config-option=servers:global:http-timeout=300


### PR DESCRIPTION
## What?
Add a ~60s~ 300s timeout to the svn commit (and import) commands in the plugin upload workflow.

Fixes #55295.

## Why?
The Gutenberg release workflow that uploads the plugin to the WordPress.org plugin repositoty frequently experiences a [timeout](https://github.com/WordPress/gutenberg/issues/55295#issuecomment-1778888170) that results in the relevant tag not being created (see [here](https://github.com/WordPress/gutenberg/issues/55295#issuecomment-1759296539) for a list of recent failures), requiring to be created manually instead.

## How?
Some [investigation](https://github.com/WordPress/gutenberg/issues/55295#issuecomment-1778899470) seems to have revealed that this timeout might be due to some post-commit hooks running on the server side. To remediate this, this PR adds the `http-timeout` option to give the svn command more time.

## Testing Instructions
Hard to test in isolation; I'd suggest we give it a try for the next GB release.


