### PR TITLE
`Divider`: migrate from `reakit` to `@ariakit/react`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Internal
 
 -   Introduce experimental new version of `DropdownMenu` based on `ariakit` ([#54939](https://github.com/WordPress/gutenberg/pull/54939))
+-   Migrate `Divider` from `reakit` to `ariakit` ([#55622](https://github.com/WordPress/gutenberg/pull/55622))
 
 ## 25.10.0 (2023-10-18)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Migrate `Divider` from `reakit` to `ariakit` ([#55622](https://github.com/WordPress/gutenberg/pull/55622))
+
 ## 25.11.0 (2023-11-02)
 
 ### Enhancements
@@ -15,7 +19,6 @@
 ### Internal
 
 -   Introduce experimental new version of `DropdownMenu` based on `ariakit` ([#54939](https://github.com/WordPress/gutenberg/pull/54939))
--   Migrate `Divider` from `reakit` to `ariakit` ([#55622](https://github.com/WordPress/gutenberg/pull/55622))
 
 ## 25.10.0 (2023-10-18)
 

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { Separator } from 'reakit';
+import * as Ariakit from '@ariakit/react';
 import type { ForwardedRef } from 'react';
 
 /**
@@ -20,8 +20,8 @@ function UnconnectedDivider(
 	const contextProps = useContextSystem( props, 'Divider' );
 
 	return (
-		<Separator
-			as={ DividerView }
+		<Ariakit.Separator
+			render={ <DividerView /> }
 			{ ...contextProps }
 			ref={ forwardedRef }
 		/>

--- a/packages/components/src/divider/stories/index.story.tsx
+++ b/packages/components/src/divider/stories/index.story.tsx
@@ -23,6 +23,9 @@ const meta: Meta< typeof Divider > = {
 		marginEnd: {
 			control: { type: 'text' },
 		},
+		wrapElement: {
+			control: { type: null },
+		},
 	},
 	parameters: {
 		controls: { expanded: true },

--- a/packages/components/src/divider/stories/index.story.tsx
+++ b/packages/components/src/divider/stories/index.story.tsx
@@ -26,6 +26,11 @@ const meta: Meta< typeof Divider > = {
 		wrapElement: {
 			control: { type: null },
 		},
+		ref: {
+			table: {
+				disable: true,
+			},
+		},
 	},
 	parameters: {
 		controls: { expanded: true },

--- a/packages/components/src/divider/types.ts
+++ b/packages/components/src/divider/types.ts
@@ -11,7 +11,7 @@ import type { SpaceInput } from '../utils/space';
 
 export type DividerProps = Omit<
 	SeparatorProps,
-	'children' | 'unstable_system' | 'orientation'
+	'children' | 'unstable_system' | 'orientation' | 'as' | 'render'
 > & {
 	/**
 	 * Adjusts all margins on the inline dimension.

--- a/packages/components/src/divider/types.ts
+++ b/packages/components/src/divider/types.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import type { SeparatorProps } from 'reakit';
+import type { SeparatorProps } from '@ariakit/react';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?

Migrate `Divider` from `reakit` to `ariakit`.

## Why?

Part of #53278

As stated in the linked issue [Reakit](https://reakit.io/) does not explicitly support React 18 (causing peer dependency warnings) and Reakit has already been succeeded by [Ariakit](https://ariakit.org/), so it will not receive any more updates.

## How?

In this case we switch out the Reakit for the Ariakit imports.

## Testing Instructions

- There shouldn't be any type errors
- Components unit tests should pass
- Verify the component still looks and works as expected (verify via Storybook)