### PR TITLE
Block Theme Preview: Display loading state when activating

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -22,15 +22,20 @@ export default function SaveButton( {
 	__next40pxDefaultSize = false,
 } ) {
 	const { isDirty, isSaving, isSaveViewOpen } = useSelect( ( select ) => {
-		const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
-			select( coreStore );
+		const {
+			__experimentalGetDirtyEntityRecords,
+			isSavingEntityRecord,
+			isResolving,
+		} = select( coreStore );
 		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 		const { isSaveViewOpened } = select( editSiteStore );
+		const isActivatingTheme = isResolving( 'activateTheme' );
 		return {
 			isDirty: dirtyEntityRecords.length > 0,
-			isSaving: dirtyEntityRecords.some( ( record ) =>
-				isSavingEntityRecord( record.kind, record.name, record.key )
-			),
+			isSaving:
+				dirtyEntityRecords.some( ( record ) =>
+					isSavingEntityRecord( record.kind, record.name, record.key )
+				) || isActivatingTheme,
 			isSaveViewOpen: isSaveViewOpened(),
 		};
 	}, [] );

--- a/packages/edit-site/src/utils/use-activate-theme.js
+++ b/packages/edit-site/src/utils/use-activate-theme.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -22,6 +24,7 @@ const { useHistory, useLocation } = unlock( routerPrivateApis );
 export function useActivateTheme() {
 	const history = useHistory();
 	const location = useLocation();
+	const { startResolution, finishResolution } = useDispatch( coreStore );
 
 	return async () => {
 		if ( isPreviewingTheme() ) {
@@ -30,7 +33,9 @@ export function useActivateTheme() {
 				currentlyPreviewingTheme() +
 				'&_wpnonce=' +
 				window.WP_BLOCK_THEME_ACTIVATE_NONCE;
+			startResolution( 'activateTheme' );
 			await window.fetch( activationURL );
+			finishResolution( 'activateTheme' );
 			const { wp_theme_preview: themePreview, ...params } =
 				location.params;
 			history.replace( params );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We want to display the loading state when people are previewing the theme and activating it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Resolved https://github.com/WordPress/gutenberg/issues/55273

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use `startResolution` & `finishResolution` to record we're activating the theme. I'm not sure whether it's a good idea but it's simple enough and provides a better experience. Additionally, we can keep using the same way when we have the rest API to activate the theme.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to Appearance > Themes
2. Hover on a block theme
3. Click the ”Live Preview“ button
4. Click the “Activate” button in the Editor
5. Verify the button displays the loading state correctly

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/13596067/877a1782-fdcf-44bf-a91e-33596bb3c95f

https://github.com/WordPress/gutenberg/assets/13596067/c8fd3ea4-0b7e-40ed-a4c3-2853a9ab00b6
