### PR TITLE
Edit Post: Fix revision button misalignment

### DIFF
--- a/packages/edit-post/src/components/sidebar/last-revision/style.scss
+++ b/packages/edit-post/src/components/sidebar/last-revision/style.scss
@@ -4,6 +4,7 @@
 	height: $grid-unit-60;
 }
 
-.editor-post-last-revision__title.components-button {
+// Needs specificity to override button styles.
+.editor-post-last-revision__title.components-button.components-button {
 	padding: $grid-unit-20;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR fixes the misalignment of the revision button icon and text in the post editor.

### Before

![before](https://github.com/WordPress/gutenberg/assets/54422211/fd5b92a7-c62f-4a9e-96ea-910c07065288)

### After

![after](https://github.com/WordPress/gutenberg/assets/54422211/6510e6c0-66b6-4b41-85b5-96f4627eb7eb)


## Why?

The CSS for the Post Editor revision button shouldn't have changed in several years. Perhaps some enhancement to the Button component caused the CSS to have a lower priority than the button component's default style.

## How?
Added `.components-button` class to increase CSS specificity. This approach can be seen for example [here](https://github.com/WordPress/gutenberg/blob/820b13599bf12f5efa472e36a780cd63e86a67b3/packages/block-editor/src/components/button-block-appender/content.scss#L11-L14) and [here](https://github.com/WordPress/gutenberg/blob/820b13599bf12f5efa472e36a780cd63e86a67b3/packages/block-library/src/site-logo/editor.scss#L76). 

## Testing Instructions

- Make changes to your post and save it several times.
- Open the Post panel and confirm the revision button.