### PR TITLE
test: iOS E2E tests set OS version

### DIFF
--- a/packages/react-native-editor/__device-tests__/README.md
+++ b/packages/react-native-editor/__device-tests__/README.md
@@ -70,7 +70,7 @@ You can filter which test runs by one of two ways:
 npm run native test:e2e:ios:local gutenberg-editor-paragraph.test.js
 
 # Enable watch mode on iOS
-npm run native test:e2e:ios:local -- --watch
+npm run native test:e2e:ios:local -- -- -- --watch
 ```
 
 ## Speeding Up Test Runs
@@ -90,7 +90,11 @@ While we must run all of these at least once to produce a testable app, it is of
 By default `device-tests:local` runs tests for Android. To run tests on iOS, you can prefix the script with the `TEST_RN_PLATFORM` environment variable.
 
 ```shell
+# Run tests on iOS
 TEST_RN_PLATFORM=ios npm run native device-tests:local
+
+# Run tests on iOS with watch mode enabled
+TEST_RN_PLATFORM=ios npm run native device-tests:local -- -- --watch
 ```
 
 ## Debugging Tests

--- a/packages/react-native-editor/bin/build_e2e_ios_app
+++ b/packages/react-native-editor/bin/build_e2e_ios_app
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-DEFAULT_DESTINATION='platform=iOS Simulator,name=iPhone 14'
+DEFAULT_DESTINATION='platform=iOS Simulator,name=iPhone 14,OS=16.2'
 if [[ -z "${RN_EDITOR_E2E_IOS_DESTINATION-}" ]]; then
 	DESTINATION="$DEFAULT_DESTINATION"
 else

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -115,7 +115,7 @@
 		"test:e2e:android:local": "npm run test:e2e:bundle:android && npm run test:e2e:build-app:android && TEST_RN_PLATFORM=android npm run device-tests:local",
 		"test:e2e:bundle:ios": "mkdir -p ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app && npm run bundle:ios && cp bundle/ios/App.js ./ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/main.jsbundle && cp -r bundle/ios/assets ./ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/",
 		"test:e2e:build-app:ios": "npm run preios && ./bin/build_e2e_ios_app",
-		"test:e2e:build-wda": "xcodebuild -project ~/.appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ios/build/WDA",
+		"test:e2e:build-wda": "xcodebuild -project ~/.appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' -derivedDataPath ios/build/WDA",
 		"test:e2e:ios:local": "npm run test:e2e:bundle:ios && npm run test:e2e:build-app:ios && npm run test:e2e:build-wda && TEST_RN_PLATFORM=ios npm run device-tests:local",
 		"build:gutenberg": "cd gutenberg && npm ci && npm run build",
 		"clean": "npm run clean:build-artifacts; npm run clean:aztec; npm run clean:haste; npm run clean:metro; npm run clean:watchman",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Explicitly set the OS version for the iOS simulator used for running E2E tests
locally.

Fix incorrect example commands in the documentation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Without setting this, cryptic errors result where Xcode may attempt to
build the app for the local development machine, rather than the
targeted iOS simulator.

```
** BUILD FAILED **

❌ gutenberg/packages/react-native-editor/ios/GutenbergDemo.xcodeproj: Provisioning profile "Gutenberg Development" doesn't include the currently selected device "MacBook Pro" (identifier [REDACTED]). (in target 'GutenbergDemo' from project 'GutenbergDemo')
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Set 16.2 as the iOS version used for local E2E test commands.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Running `npm run native test:e2e:ios:local -- -- -- --watch` works locally.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
