### PR TITLE
test: Launch Android emulator when running E2E tests

### DIFF
--- a/packages/react-native-editor/bin/test-e2e.sh
+++ b/packages/react-native-editor/bin/test-e2e.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+# If TEST_RN_PLATFORM is empty or equal to "android", launch the Android emulator.
+if [ -z "$TEST_RN_PLATFORM" ] || [ "$TEST_RN_PLATFORM" = "android" ]; then
+	# Start the emulator if it is not already running
+	if [ -z "$(pgrep -f "Pixel_3_XL_API_30")" ]; then
+		echo "[info] Starting the Android emulator..."
+		emulator -avd Pixel_3_XL_API_30 -noaudio 2>&1 >/dev/null &
+		ANDROID_PID=$!
+
+		# Wait for the emulator to be ready.
+		echo "[info] Waiting for the Android emulator to be ready..."
+		adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'
+	fi
+fi
+
+# Pass along all arguments to Jest.
+cross-env NODE_ENV=test jest --runInBand --detectOpenHandles --forceExit --config ./jest_ui.config.js "$@"

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -106,7 +106,7 @@
 		"ios:fast": "react-native run-ios",
 		"device-tests": "cross-env NODE_ENV=test jest --forceExit --detectOpenHandles --no-cache --maxWorkers=3 --testPathIgnorePatterns='canary|gutenberg-editor-rendering' --config ./jest_ui.config.js",
 		"device-tests-canary": "cross-env NODE_ENV=test jest --forceExit --detectOpenHandles --no-cache --maxWorkers=2 --testPathPattern=@canary --config ./jest_ui.config.js",
-		"device-tests:local": "cross-env NODE_ENV=test jest --runInBand --detectOpenHandles --forceExit --config ./jest_ui.config.js",
+		"device-tests:local": "./bin/test-e2e.sh",
 		"device-tests:debug": "cross-env NODE_ENV=test node $NODE_DEBUG_OPTION --inspect-brk node_modules/jest/bin/jest --runInBand --detectOpenHandles --verbose --config ./jest_ui.config.js",
 		"appium:start": "node ./__device-tests__/helpers/appium-local-start.js",
 		"test:e2e:setup": "./bin/test-e2e-setup.sh",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Automatically launch the Android emulator when running E2E tests locally.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Resolves #55567. Automatically launching the emulator simplifies the steps required to
run E2E tests locally, ideally making them more approachable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add shell script to detect whether the emulator is running, and launch it if it
is not running.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Running the following should result in passing tests. It should also work if the
emulator is already running.

```
npm run native test:e2e:android:local -- -- -- --watch
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
