### PR TITLE
[RNMobile] Fix crash related to accessing undefined value in `TextColorEdit`

### DIFF
--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -11,6 +11,7 @@ import {
 	getPxFromCssUnit,
 	useSettings,
 	useMultipleOriginColorsAndGradients,
+	SETTINGS_DEFAULTS,
 } from '@wordpress/block-editor';
 
 export const BLOCK_STYLE_ATTRIBUTES = [
@@ -355,13 +356,17 @@ export function useMobileGlobalStylesColors( type = 'colors' ) {
 		[]
 	);
 	// Default editor colors/gradients if it's not a block-based theme.
-	const colorPalette =
+	const defaultPaletteSetting =
 		type === 'colors' ? 'color.palette' : 'color.gradients';
-	const [ editorDefaultPalette ] = useSettings( colorPalette );
+	const [ defaultPaletteValue ] = useSettings( defaultPaletteSetting );
+	// In edge cases, the default palette might be undefined. To avoid
+	// exceptions across the editor in that case, we explicitly return
+	// the default editor colors.
+	const defaultPalette = defaultPaletteValue ?? SETTINGS_DEFAULTS.colors;
 
 	return availableThemeColors.length >= 1
 		? availableThemeColors
-		: editorDefaultPalette;
+		: defaultPalette;
 }
 
 export function getColorsAndGradients(

--- a/packages/format-library/src/text-color/index.native.js
+++ b/packages/format-library/src/text-color/index.native.js
@@ -92,7 +92,7 @@ function TextColorEdit( {
 		[ value, colors ]
 	);
 
-	const hasColorsToChoose = colors?.length || ! allowCustomControl;
+	const hasColorsToChoose = colors.length || ! allowCustomControl;
 
 	const onPressButton = useCallback( () => {
 		if ( hasColorsToChoose ) {

--- a/packages/format-library/src/text-color/index.native.js
+++ b/packages/format-library/src/text-color/index.native.js
@@ -92,7 +92,7 @@ function TextColorEdit( {
 		[ value, colors ]
 	);
 
-	const hasColorsToChoose = colors.length || ! allowCustomControl;
+	const hasColorsToChoose = colors?.length || ! allowCustomControl;
 
 	const onPressButton = useCallback( () => {
 		if ( hasColorsToChoose ) {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Fix error when pasting deeply nested structure content [#55613]
+-   [*] Fix crash related to accessing undefined value in `TextColorEdit` [#55664]
 
 ## 1.107.0
 -   [*] Social Icons: Fix visibility of inactive icons when used with block based themes in dark mode [#55398]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a crash produced in an edge case related to potentially using retired themes.

Unfortunately, I couldn't manage to reproduce the issue. However, after inspecting several sessions, the pattern I identified is that all sites have retired themes that don't support FSE and have Global Styles limited.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6208.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The only setting related to theme colors that I narrowed down to produce the exceptions (due to accessing an undefined value) is `editorDefaultPalette` returned in `useMobileGlobalStylesColors` function. As far as I investigated, the only reason that would explain why this setting is `undefined` is that the `color` setting of the `block-editor` Redux store is removed. It's totally unclear to me why this might happen, at least I haven't found a potential culprit.

https://github.com/WordPress/gutenberg/blob/dded3a7571d71467248bb184ffbcaddd643c3522/packages/components/src/mobile/global-styles-context/utils.native.js#L360-L364

https://github.com/WordPress/gutenberg/blob/5a6d1d3d757a398e30b0b4a25418163866580ec5/packages/block-editor/src/store/defaults.js#L44-L101

For the rest of the theme color settings, the ones under `__experimentalFeatures` setting, seem we ensure that always have a value and never lead to an exception. In all tests I've performed forcing undefined values there, the editor ended up using the default colors provided in default settings.

https://github.com/WordPress/gutenberg/blob/5a6d1d3d757a398e30b0b4a25418163866580ec5/packages/components/src/mobile/global-styles-context/utils.native.js#L426-L434

https://github.com/WordPress/gutenberg/blob/5a6d1d3d757a398e30b0b4a25418163866580ec5/packages/components/src/mobile/global-styles-context/utils.native.js#L381-L396 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Switch the theme of a site to a retired one (e.g. Penscratch). **NOTE:** For WPCOM sites, we need to force the switch with internal tools.
2. Apply the following patch to force `colors` setting to be removed.
```patch
diff --git forkSrcPrefix/packages/editor/src/components/provider/index.native.js forkDstPrefix/packages/editor/src/components/provider/index.native.js
index 5fd6a4cdbb888b1ac3627dfd9e0c4312bdfc82f9..7124f0aaa71216b7b3daf95f5b1d0fb6ba5bb60e 100644
--- forkSrcPrefix/packages/editor/src/components/provider/index.native.js
+++ forkDstPrefix/packages/editor/src/components/provider/index.native.js
@@ -107,6 +107,9 @@ class NativeEditorProvider extends Component {
 			hostAppNamespace,
 		} );
 
+		// Force removing colors setting for testing purpose.
+		updateEditorSettings( { colors: undefined } );
+
 		this.subscriptionParentGetHtml = subscribeParentGetHtml( () => {
 			this.serializeToNativeAction();
 		} );
```
3. Open the app and navigate to the site with the retired theme.
4. Create a post.
5. Tap on the first Paragraph block.
6. Observe that the editor doesn't produce an exception.

**NOTE:** You might notice that no colors are displayed when opening the block settings of the Paragraph block. The same will be experienced in other blocks like Cover and Buttons. This is expected (yet not ideal) due to the side effect of removing the default editor colors. The purpose of this PR is to avoid the crash, so in the future, it would be great to investigate this edge case further and potentially provide a better solution to include the default colors.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A