### PR TITLE
[Block] File: Fix embedded PDF files in Safari

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -59,7 +59,8 @@ function render_block_core_file( $attributes, $content, $block ) {
 		$processor->next_tag();
 		$processor->set_attribute( 'data-wp-interactive', '' );
 		$processor->next_tag( 'object' );
-		$processor->set_attribute( 'data-wp-style--display', 'selectors.core.file.hasPdfPreview' );
+		$processor->set_attribute( 'data-wp-bind--hidden', '!selectors.core.file.hasPdfPreview' );
+		$processor->set_attribute( 'hidden', true );
 		return $processor->get_updated_html();
 	}
 

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -29,12 +29,6 @@
 	margin-bottom: 1em;
 }
 
-@media (max-width: 768px) {
-	.wp-block-file__embed {
-		display: none;
-	}
-}
-
 //This needs a low specificity so it won't override the rules from the button element if defined in theme.json.
 :where(.wp-block-file__button) {
 	border-radius: 2em;

--- a/packages/block-library/src/file/view.js
+++ b/packages/block-library/src/file/view.js
@@ -5,13 +5,13 @@ import { store } from '@wordpress/interactivity';
 /**
  * Internal dependencies
  */
-import { browserSupportsPdfs } from './utils';
+import { browserSupportsPdfs as hasPdfPreview } from './utils';
 
 store( {
 	selectors: {
 		core: {
 			file: {
-				hasPdfPreview: browserSupportsPdfs() ? 'inherit' : 'none',
+				hasPdfPreview,
 			},
 		},
 	},


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/55493:

> Embedded PDF files fail to render in Safari Version 17.0 when using Gutenberg 16.7.0 and higher. GB 16.6.0 works as expected.

## Why?

PDF files can not be visualized, even blocking the page and making it appear frozen.

## How?

Reverting changes from https://github.com/WordPress/gutenberg/pull/54343/commits/1b0c80112693b36614c14e121aa2544ba60d49e0.

In that commit, we moved from `hidden` to `display: none` to minimize any potential layout shifts, but it seems that the change wasn't tested in Safari.

Reverting this change, the feature works again, although it probably is a bug in Safari instead of something broken in the block's logic.

## Testing Instructions
1. Add the File Block to a page or post and embed a PDF
2. Enable "Show Inline Embed"
3. Publish the page
4. View the page in a Safari browser
5. Check that it works now as expected

## Screen recording


https://github.com/WordPress/gutenberg/assets/6917969/35da7f28-3d00-4886-975b-6ed52c52e9fc


