### PR TITLE
Ensure Term Description block is registered in core

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -919,7 +919,6 @@ Edit the different global regions of your site, like the header, footer, sidebar
 Display the description of categories, tags and custom taxonomies when viewing an archive. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-description))
 
 -	**Name:** core/term-description
--	**Experimental:** fse
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign

--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
-	"__experimental": "fse",
 	"name": "core/term-description",
 	"title": "Term Description",
 	"category": "theme",


### PR DESCRIPTION
## What?

With this PR, changes are made so that the Term Description block (`core/term-description`) is available in core without the need to install the Gutenberg plugin.

## Why?

As per https://github.com/WordPress/gutenberg/issues/55665, 6.4-RC2 saw a breaking change in which the Term Description block was no longer available within the full-site editor. This regression was introduced in https://github.com/WordPress/gutenberg/pull/51053.

## How?

Due to the urgency of this fix, this PR simply reverts https://github.com/WordPress/gutenberg/pull/51053 so that the Term Description block is not completely broken without the Gutenberg plugin installed.

The original bug, in which the block is available in places it shouldn't be (i.e. the post editor), can be addressed separately to this PR. The thinking here is as follows:

1. We're extremely tight on time, given we're late into Friday and the hope is to have 6.4 finalised on Monday. 
2. The original bug (https://github.com/WordPress/gutenberg/issues/38552) wasn't a new regression and had been reproducible in core for over a year. There isn't an urgency to include a fix for it in 6.4 and we can address it separately.

## Testing Instructions

1. With a block theme, open _Appearance_ → _Editor_.
2. Open _Templates_ → _All Archives_.
4. Try to add the Term Description block, verify its availability within the inserter.

### Testing Instructions for Keyboard

N/A