### PR TITLE
Block JSON schema: add heading/button key to color definition

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -283,6 +283,16 @@
 							"description": "This property adds block controls which allow the user to set text color in a block.\n\nWhen color support is declared, this property is enabled by default (along with background), so simply setting color will enable text color.\n\nText color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.text, its attributes definition is extended to include two new attributes: textColor and style",
 							"default": true
 						},
+						"heading": {
+							"type": "boolean",
+							"description": "This property adds block controls which allow the user to set heading colors in a block, heading color is disabled by default.\n\nHeading color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.heading, its attributes definition is extended to include the style attribute",
+							"default": false
+						},
+						"button": {
+							"type": "boolean",
+							"description": "This property adds block controls which allow the user to set button colors in a block, button color is disabled by default.\n\nButton color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.heading, its attributes definition is extended to include the style attribute",
+							"default": false
+						},
 						"enableContrastChecker": {
 							"type": "boolean",
 							"description": "Determines whether the contrast checker widget displays in the block editor UI.\n\nThe contrast checker appears only if the block declares support for color. It tests the readability of color combinations and warns if there is a potential issue. The property is enabled by default.\n\nSet to `false` to explicitly disable.",


### PR DESCRIPTION
Follow-up on #49131
Similar to #55674


## What?

This PR adds heading/button key to color definition in block.json schema.

## Why?
To allow developers to design block.json with reference to the correct schema.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Create the following JSON file locally, specifying the JSON schema changed by this PR.

```json
{
	"$schema": "https://schemas.wp.org/trunk/block.json",
	"apiVersion": 3,
	"name": "test/test",
	"title": "Test"
}
```

- You should see the `button` and `heading` keys listed in the `supports.color` property.
- The default value of ~`true`~ `false` should be set when the `button` or `heading` key is selected.

![block-json-schema](https://github.com/WordPress/gutenberg/assets/54422211/9a40b8a3-d0a5-48cf-af59-a5e8c278920d)
