### PR TITLE
Command Palette: Fix a crash when transform to a block without icon

### DIFF
--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -22,6 +22,7 @@ import {
 /**
  * Internal dependencies
  */
+import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 
 export const useTransformCommands = () => {
@@ -100,7 +101,7 @@ export const useTransformCommands = () => {
 			name: 'core/block-editor/transform-to-' + name.replace( '/', '-' ),
 			// translators: %s: block title/name.
 			label: sprintf( __( 'Transform to %s' ), title ),
-			icon: icon.src,
+			icon: <BlockIcon icon={ icon } />,
 			callback: ( { close } ) => {
 				onBlockTransform( name );
 				close();


### PR DESCRIPTION
Fixes #55668

## What?

This PR fixes a critical error that occurs when trying to convert a block with no icon in the command palette.

## Why?

If the block has an icon, the `icon` variable will have a React element in the `src` key. But if it's not, the `icon` variable is a string called `block-defaut`, so it will fail to render.

## How?
To handle the case where the block does not have an icon, we need to use the `BlockIcon` component.

## Testing Instructions

Run the code below in your browser console to temporarily register a custom block.

```javascript
wp.blocks.registerBlockType( 'example/gutenpride', {
	title: 'text',
	edit: () => wp.element.createElement( 'div', { children: 'hello' } ),
	save: () => null,
    transforms: {
        from: [
            {
                type: 'block',
                isMultiBlock: true,
                blocks: [ 'core/paragraph' ],
                transform: () => {},
            },
        ],
    },
} )
```

- Insert a paragraph block.
- Run the Command Palette.
- Enter "Transform...".
- trunk: The editor should crash.
- This PR:
  - "Transform to gutenpride" should be displayed in the list and the transformation should be successful.
  - You should see the default block icon.
  - Other core blocks should still display block-specific icons.
  - Icons, like other command palette actions, should all be 24px in size.
