### PR TITLE
Update/post term add toggle for no terms message

### DIFF
--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -24,6 +24,10 @@
 		"suffix": {
 			"type": "string",
 			"default": ""
+		},
+		"showTermNoResults": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -15,7 +15,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
-import { Spinner, TextControl } from '@wordpress/components';
+import { Spinner, TextControl, ToggleControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
@@ -44,7 +44,7 @@ export default function PostTermsEdit( {
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { term, textAlign, separator, prefix, suffix } = attributes;
+	const { term, textAlign, separator, prefix, suffix, showTermNoResults } = attributes;
 	const { postId, postType } = context;
 
 	const selectedTerm = useSelect(
@@ -89,6 +89,14 @@ export default function PostTermsEdit( {
 						setAttributes( { separator: nextValue } );
 					} }
 					help={ __( 'Enter character(s) used to separate terms.' ) }
+				/>
+				<ToggleControl
+					label={ __( 'Show "No tags"' ) }
+					help={ __( 'Show/Hide "No tags" message. Note: We show always a message in the editor for easier block access' ) }
+					checked={ showTermNoResults }
+					onChange={() => 
+						setAttributes( { showTermNoResults: !!! showTermNoResults } )
+					}
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
@@ -135,8 +143,13 @@ export default function PostTermsEdit( {
 				{ hasPost &&
 					! isLoading &&
 					! hasPostTerms &&
-					( selectedTerm?.labels?.no_terms ||
-						__( 'Term items not found.' ) ) }
+					(
+						showTermNoResults 
+							? selectedTerm?.labels?.no_terms || __( 'Term items not found.' )
+							: __( 'Term items not found.' )
+
+					)
+				}
 				{ ! isLoading && hasPostTerms && ( isSelected || suffix ) && (
 					<RichText
 						allowedFormats={ ALLOWED_FORMATS }

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -24,7 +24,12 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 
 	$post_terms = get_the_terms( $block->context['postId'], $attributes['term'] );
 	if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {
-		return '';
+		if ( ! $attributes['showTermNoResults'] ) {
+			return '';
+		}
+		$tax = get_taxonomy( $attributes['term'] );
+		$labels = get_taxonomy_labels( $tax );
+		return '<div class="taxonomy-' . $attributes['term'] . ' wp-block-post-terms">' . esc_html( $labels->no_terms ) . '</div>';
 	}
 
 	$classes = array( 'taxonomy-' . $attributes['term'] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes #55527

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds new block property to "Tags" block.
This property allows editors to control whether they want to show/hide "No tags" message from public side. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There was no control previously for this and editor would show this "No tags" message on the editor and nothing on public side.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added new block property for "Tags" block, created ToggleControl to allow editor to change state of that property and used that property on PHP render function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post and give it some categories and tags
2. Open a another post and make sure it has no categories and tags
3. Open page and insert "Query loop" to page. Make sure "Tags" block is being used on inside the loop 
5. First post show render categories and tags normally
6. Second post should show "No tags" (or "No categories")
7. Go to editor and uncheck the new block property (See screenshot attached)
8. Go to public side and note that where "No tags" was show now there is nothing.
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="272" alt="Screenshot 2023-10-28 at 14 08 35" src="https://github.com/WordPress/gutenberg/assets/62872075/f2a20ae5-502a-4f03-b472-5019f850dbb7">
