### PR TITLE
Fix #55679 missing space in the string

### DIFF
--- a/packages/block-library/src/form/variations.js
+++ b/packages/block-library/src/form/variations.js
@@ -63,7 +63,7 @@ const variations = [
 		name: 'wp-privacy-form',
 		title: __( 'Experimental privacy request form' ),
 		keywords: [ 'GDPR' ],
-		description: __( 'A form torequest data exports and/or deletion.' ),
+		description: __( 'A form to request data exports and/or deletion.' ),
 		attributes: {
 			submissionMethod: 'custom',
 			action: '',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
It's adding a missing space in the string from Experimental privacy request form

## Why?
Because it was written incorrectly, with "torequest" instead of "to request"

## How?
It's adding the missing space to the string

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
