### PR TITLE
Block Example: Avoid a crash when block is not registered

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -580,6 +580,16 @@ export function switchToBlockType( blocks, name ) {
  * @return {Object} block.
  */
 export const getBlockFromExample = ( name, example ) => {
+	// If a Block is undefined, use the core/missing block as
+	// a placeholder to prevent a crash.
+	if ( undefined === getBlockType( name ) ) {
+		return createBlock( 'core/missing', {
+			originalName: name,
+			originalContent: '',
+			originalUndelimitedContent: '',
+		} );
+	}
+
 	return createBlock(
 		name,
 		example.attributes,

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -580,21 +580,19 @@ export function switchToBlockType( blocks, name ) {
  * @return {Object} block.
  */
 export const getBlockFromExample = ( name, example ) => {
-	// If a Block is undefined, use the core/missing block as
-	// a placeholder to prevent a crash.
-	if ( undefined === getBlockType( name ) ) {
+	try {
+		return createBlock(
+			name,
+			example.attributes,
+			( example.innerBlocks ?? [] ).map( ( innerBlock ) =>
+				getBlockFromExample( innerBlock.name, innerBlock )
+			)
+		);
+	} catch {
 		return createBlock( 'core/missing', {
 			originalName: name,
 			originalContent: '',
 			originalUndelimitedContent: '',
 		} );
 	}
-
-	return createBlock(
-		name,
-		example.attributes,
-		( example.innerBlocks ?? [] ).map( ( innerBlock ) =>
-			getBlockFromExample( innerBlock.name, innerBlock )
-		)
-	);
 };

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -17,6 +17,7 @@ import {
 	findTransform,
 	isWildcardBlockTransform,
 	isContainerGroupBlock,
+	getBlockFromExample,
 } from '../factory';
 import {
 	getBlockType,
@@ -2274,6 +2275,35 @@ describe( 'block factory', () => {
 		it( 'should return false when passed block name does not match the registered "Grouping" Block', () => {
 			setGroupingBlockName( 'registered-grouping-block' );
 			expect( isContainerGroupBlock( 'core/group' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getBlockFromExample', () => {
+		it( 'should replace unregistered block with core/missing block', () => {
+			registerBlockType( 'core/missing', {
+				title: 'Unsupported',
+			} );
+			registerBlockType( 'core/paragraph', {
+				title: 'Paragraph',
+			} );
+			registerBlockType( 'core/group', {
+				title: 'A block that groups other blocks.',
+			} );
+			const example = {
+				innerBlocks: [
+					{ name: 'core/paragraph' },
+					{ name: 'core/image' },
+				],
+			};
+			expect(
+				getBlockFromExample( 'core/group', example )
+			).toMatchObject( {
+				name: 'core/group',
+				innerBlocks: [
+					{ name: 'core/paragraph' },
+					{ name: 'core/missing' },
+				],
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixe #54786

## What?

This PR fixes a critical error that occurs when `getBlockFromExample()` is passed an unregistered block.

## Why?

This is because the `createBlock()` function running internally [throws an exception](https://github.com/WordPress/gutenberg/blob/b6b4cf6bff9fd4052fa62a42c6027d2c821b630a/packages/blocks/src/api/utils.js#L259) if the block does not exist.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

As far as reading [this comment](https://github.com/WordPress/gutenberg/pull/24287#discussion_r463010088), I think that throwing an exception when the block does not exist is the intended behavior. I think we should check if the block exists before running `createBlock()` and replace it with a `core/missing` block as a fallback if it doesn't exist, as shown in [this code](https://github.com/WordPress/gutenberg/blob/b6b4cf6bff9fd4052fa62a42c6027d2c821b630a/packages/blocks/src/api/templates.js#L118-L127).

Another approach might be to implicitly transform the unregistered block passed to the `createBlock()` function into a `core/missing` block instead of throwing an exception. However, I personally find this approach a bit unnatural.

## Testing Instructions

This PR should fix critical bugs that occur in the following four cases. In each case, I assume a scenario where the Columns block contains an Image block that is not registered in the example.

### Preview in block inserter

- Open the Post Editor.
- Run `wp.blocks.unregisterBlockType('core/image')` from the browser console.
- Open the main block inserter.
- Hover over the Columns block.
- The preview should display correctly.

![preview-block-inserter](https://github.com/WordPress/gutenberg/assets/54422211/501331e3-743a-45ef-a3e7-1a1be4cbf3d2)

### Preview block style

- Open the Post Editor.
- Run `wp.blocks.unregisterBlockType('core/image')` from the browser console.
- Run `wp.blocks.registerBlockStyle('core/columns',{name:'test',label:'Test'});` from the browser console.
- Insert a Columns block.
- In the block sidebar, hover over the "Test" style.
- The preview should display correctly.

![block-style](https://github.com/WordPress/gutenberg/assets/54422211/158c61c1-e0ac-4c0f-a541-7975fbf7da3b)

### Style Book

- Open the Site Editor.
- Run `wp.blocks.unregisterBlockType('core/image')` from the browser console.
- Click the Styles menu.
- Click the "Style book" button.
- The preview should display correctly.

![style-book](https://github.com/WordPress/gutenberg/assets/54422211/6e656a1d-2764-42b3-a300-3801b6616355)

### Preview in the Global Styles

- Open the Site Editor.
- Run `wp.blocks.unregisterBlockType('core/image')` from the browser console.
- Go to the editor canvas > Styles > Blocks > Columns.
- The preview should display correctly.

![global-styles](https://github.com/WordPress/gutenberg/assets/54422211/97f8fe2f-57ab-4e27-bd62-1cf92ba3201f)
