### PR TITLE
Block Editor: Avoid rendering empty Slot for block alignments

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -120,17 +120,20 @@ export const withToolbarControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const blockEdit = <BlockEdit key="edit" { ...props } />;
 		const { name: blockName } = props;
-
-		const blockEditingMode = useBlockEditingMode();
-		if ( blockEditingMode !== 'default' ) {
-			return blockEdit;
-		}
-
+		// Compute the block valid alignments by taking into account,
+		// if the theme supports wide alignments or not and the layout's
+		// availble alignments. We do that for conditionally rendering
+		// Slot.
 		const blockAllowedAlignments = getValidAlignments(
 			getBlockSupport( blockName, 'align' ),
 			hasBlockSupport( blockName, 'alignWide', true )
 		);
-		if ( blockAllowedAlignments.length === 0 ) {
+
+		const validAlignments = useAvailableAlignments(
+			blockAllowedAlignments
+		).map( ( { name } ) => name );
+		const blockEditingMode = useBlockEditingMode();
+		if ( ! validAlignments.length || blockEditingMode !== 'default' ) {
 			return blockEdit;
 		}
 
@@ -151,7 +154,7 @@ export const withToolbarControls = createHigherOrderComponent(
 					<BlockAlignmentControl
 						value={ props.attributes.align }
 						onChange={ updateAlignment }
-						controls={ blockAllowedAlignments }
+						controls={ validAlignments }
 					/>
 				</BlockControls>
 				{ blockEdit }


### PR DESCRIPTION
## What?
Fixes #55687.
A regression was introduced in #55449.

PR restores the `useAvailableAlignments` call in the `withToolbarControls` HoC to avoid rendering an empty block toolbars slot.

P.S. A similar optimization was attempted in #34593 but later was restored via #35822 for similar reasons.

## Why?
There's a mismatch between values returned by `getValidAlignments` and `useAvailableAlignments`. The latter takes alignments available for the given layout, which will be none for the root-level blocks in the site editor (#30079).

## Testing Instructions
1. Using TT4.
2. Open a template in the Site Editor.
3. Select root level block - Group or Template part.
4. Confirm that the empty block toolbars slot isn't rendered.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-10-30 at 12 43 06](https://github.com/WordPress/gutenberg/assets/240569/edf78205-657d-4b47-bbe8-9216e3500eb6)
