### PR TITLE
Form block: use `type="submit"` for buttons

### DIFF
--- a/packages/block-library/src/form-submit-button/edit.js
+++ b/packages/block-library/src/form-submit-button/edit.js
@@ -14,6 +14,7 @@ const TEMPLATE = [
 				{
 					text: __( 'Submit' ),
 					tagName: 'button',
+					type: 'submit',
 				},
 			],
 		],


### PR DESCRIPTION
## What?
This PR changes the type of the submit buttons (inside a form block) to use `type="submit"`.

## Why?
The submit buttons were using the default `type="button"`, and as a result, clicking the buttons wasn't always working.

## How?
By tweaking the template for the `form-submit-button` block.

## Testing Instructions
1. Make sure the forms experiment is enabled
2. Add a form block in a page and save it
3. Inspect the frontend of the saved block and check that the submit button for the form has a type of submit.

### Testing Instructions for Keyboard
Not applicable

## Screenshots or screencast <!-- if applicable -->
