### PR TITLE
Fix missing data in email submissions

### DIFF
--- a/packages/block-library/src/form/index.php
+++ b/packages/block-library/src/form/index.php
@@ -96,7 +96,7 @@ function block_core_form_send_email() {
 		'<a href="' . esc_url( get_site_url( null, $params['_wp_http_referer'] ) ) . '">' . get_bloginfo( 'name' ) . '</a>'
 	);
 
-	$skip_fields = array( 'formAction', '_ajax_nonce', 'action' );
+	$skip_fields = array( 'formAction', '_ajax_nonce', 'action', '_wp_http_referer' );
 	foreach ( $params as $key => $value ) {
 		if ( in_array( $key, $skip_fields, true ) ) {
 			continue;
@@ -109,7 +109,7 @@ function block_core_form_send_email() {
 
 	// Send the email.
 	$result = wp_mail(
-		str_replace( 'mailto:', '', $params['wp-email-address'] ),
+		str_replace( 'mailto:', '', $params['formAction'] ),
 		__( 'Form submission', 'gutenberg' ),
 		$content
 	);

--- a/packages/block-library/src/form/view.js
+++ b/packages/block-library/src/form/view.js
@@ -20,6 +20,8 @@ document.querySelectorAll( 'form.wp-block-form' ).forEach( function ( form ) {
 		formData.formAction = form.action;
 		formData._ajax_nonce = wpBlockFormSettings.nonce;
 		formData.action = wpBlockFormSettings.action;
+		formData._wp_http_referer = window.location.href;
+		formData.formAction = form.action;
 
 		try {
 			const response = await fetch( wpBlockFormSettings.ajaxUrl, {


### PR DESCRIPTION
## What?
Fixes an issue with form submissions from the experimental form block, when using the email method.

## Why?
Because emails were not being sent when submitting a form

## How?
Adds missing data to the script, which then lets the form submission email to be properly sent.

## Testing Instructions
1. Add a form block in a post/page
2. In the form block's settings, select "Send an email" in the "submissions method" firld, and then enter your email address in the "email for form submissions" field
3. Save the post and view in on the front
4. Submit something in the form, and you should now get the email (Note: this will also depend on #55690. If that PR doesn't get merged before this one, then you'll need to manually change the type of the button to `submit` from your browser's tools, so the form can be properly submitted)

### Testing Instructions for Keyboard
Not applicable
