### PR TITLE
Fix: LinkControl on site editor does not show font page and post page indication

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -85,19 +85,23 @@ function useArchiveLabel( templateSlug ) {
 
 export default function useSiteEditorSettings() {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
-	const { storedSettings, canvasMode, templateType } = useSelect(
-		( select ) => {
-			const { getSettings, getCanvasMode, getEditedPostType } = unlock(
-				select( editSiteStore )
-			);
-			return {
-				storedSettings: getSettings( setIsInserterOpened ),
-				canvasMode: getCanvasMode(),
-				templateType: getEditedPostType(),
-			};
-		},
-		[ setIsInserterOpened ]
-	);
+	const { storedSettings, canvasMode, templateType, siteSettings } =
+		useSelect(
+			( select ) => {
+				const { canUser, getEntityRecord } = select( coreStore );
+				const { getSettings, getCanvasMode, getEditedPostType } =
+					unlock( select( editSiteStore ) );
+				return {
+					storedSettings: getSettings( setIsInserterOpened ),
+					canvasMode: getCanvasMode(),
+					templateType: getEditedPostType(),
+					siteSettings: canUser( 'read', 'settings' )
+						? getEntityRecord( 'root', 'site' )
+						: undefined,
+				};
+			},
+			[ setIsInserterOpened ]
+		);
 
 	const settingsBlockPatterns =
 		storedSettings.__experimentalAdditionalBlockPatterns ?? // WP 6.0
@@ -180,6 +184,8 @@ export default function useSiteEditorSettings() {
 			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
 			__experimentalArchiveTitleTypeLabel: archiveLabels.archiveTypeLabel,
 			__experimentalArchiveTitleNameLabel: archiveLabels.archiveNameLabel,
+			pageOnFront: siteSettings?.page_on_front,
+			pageForPosts: siteSettings?.page_for_posts,
 		};
 	}, [
 		storedSettings,
@@ -189,5 +195,7 @@ export default function useSiteEditorSettings() {
 		canvasMode,
 		archiveLabels.archiveTypeLabel,
 		archiveLabels.archiveNameLabel,
+		siteSettings?.page_on_front,
+		siteSettings?.page_for_posts,
 	] );
 }


### PR DESCRIPTION
LinkControl part of the block editor has a UI to show when a page is the front page of a site or the blog page. It is working well on the post editor but it is not working at all on the site editor because some missing block editor settings are missing there. This PR fixes the issue.

cc: @MaggieCabrera as this is a follow-up to a task we previously worked on.

## Testing
Go to the site editor.
Add a link e.g.: in a paragraph or button to the front page of a site (select one on reading settings if you have not one yet). Verify the UI correctly shows it is the front page.
Add a link e.g.: in a paragraph or button to the blog page of a site (select one on reading settings if you have not one yet). Verify the UI correctly shows it is the blog page.



## Screenshots
### Before
<img width="243" alt="Screenshot 2023-10-30 at 10 32 20" src="https://github.com/WordPress/gutenberg/assets/11271197/13e706ed-1be1-43ca-9bbc-9fd9ee8359e3">

### After

<img width="240" alt="Screenshot 2023-10-30 at 10 32 28" src="https://github.com/WordPress/gutenberg/assets/11271197/14963302-8ee4-442c-bdb4-999ec94819c0">
