### PR TITLE
Update: Remove path awareness from data-views specific code.

### DIFF
--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -17,7 +17,24 @@ import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
 import DataviewsProvider from '../dataviews/provider';
 import { unlock } from '../../lock-unlock';
 
-const { RouterProvider } = unlock( routerPrivateApis );
+const { RouterProvider, useLocation } = unlock( routerPrivateApis );
+
+const PATH_TO_DATAVIEW_TYPE = {
+	'/pages': 'page',
+};
+
+function DataviewsProviderWithType( { children } ) {
+	const {
+		params: { path },
+	} = useLocation();
+	const viewType = PATH_TO_DATAVIEW_TYPE[ path ];
+	if ( ! viewType ) {
+		return <>{ children }</>;
+	}
+	return (
+		<DataviewsProvider type={ viewType }>{ children }</DataviewsProvider>
+	);
+}
 
 export default function App() {
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -39,10 +56,10 @@ export default function App() {
 			<GlobalStylesProvider>
 				<UnsavedChangesWarning />
 				<RouterProvider>
-					<DataviewsProvider>
+					<DataviewsProviderWithType>
 						<Layout />
 						<PluginArea onError={ onPluginAreaError } />
-					</DataviewsProvider>
+					</DataviewsProviderWithType>
 				</RouterProvider>
 			</GlobalStylesProvider>
 		</SlotFillProvider>

--- a/packages/edit-site/src/components/dataviews/provider.js
+++ b/packages/edit-site/src/components/dataviews/provider.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as routerPrivateApis } from '@wordpress/router';
 import {
 	useEffect,
 	useState,
@@ -15,10 +14,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { unlock } from '../../lock-unlock';
 import DataviewsContext from './context';
-
-const { useLocation } = unlock( routerPrivateApis );
 
 // DEFAULT_STATUSES is intentionally sorted. Items do not have spaces in between them.
 // The reason for that is to match the default statuses coming from the endpoint
@@ -44,10 +40,6 @@ const DEFAULT_VIEWS = {
 		hiddenFields: [ 'date', 'featured-image' ],
 		layout: {},
 	},
-};
-
-const PATH_TO_DATAVIEW_TYPE = {
-	'/pages': 'page',
 };
 
 function useDataviewTypeTaxonomyId( type ) {
@@ -183,7 +175,7 @@ function useDataviews( type, typeTaxonomyId ) {
 	return null;
 }
 
-function DataviewsProviderInner( { type, children } ) {
+function DataviewsProvider( { type, children } ) {
 	const [ currentViewId, setCurrentViewId ] = useState( null );
 	const dataviewTypeTaxonomyId = useDataviewTypeTaxonomyId( type );
 	const dataviews = useDataviews( type, dataviewTypeTaxonomyId );
@@ -241,21 +233,6 @@ function DataviewsProviderInner( { type, children } ) {
 			{ children }
 		</DataviewsContext.Provider>
 	);
-}
-function DataviewsProvider( { children } ) {
-	const {
-		params: { path },
-	} = useLocation();
-	const viewType = PATH_TO_DATAVIEW_TYPE[ path ];
-
-	if ( viewType ) {
-		return (
-			<DataviewsProviderInner type={ viewType }>
-				{ children }
-			</DataviewsProviderInner>
-		);
-	}
-	return <>{ children }</>;
 }
 
 let DataviewsProviderExported = Fragment;


### PR DESCRIPTION
This PR addresses a comment by @ntsekouras at https://github.com/WordPress/gutenberg/pull/55465#discussion_r1366557067, and removes path awareness from dataviews-specific code (e.g: code inside packages/edit-site/src/components/dataviews/).
After this change, the provider only receives a type of dataview e.g.: page or product. The edit site code using the provider is the one that checks the path and depending on the path passes the correct type.

## Testing
Verify data views continue to work as expected and are correctly persisted.