### PR TITLE
Update: Remove useless self assignment.

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-init/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-init/view.js
@@ -40,7 +40,6 @@
 			initOne: ( { context: { isReady, calls } } ) => {
 				isReady[0] = true;
 				// Subscribe to changes in that prop.
-				isReady[0] = isReady[0];
 				calls[0]++;
 			},
 			initTwo: ( { context: { isReady, calls } } ) => {


### PR DESCRIPTION
In this code sample:
```
				isReady[0] = true;
				// Subscribe to changes in that prop.
				isReady[0] = isReady[0];
```
It seems `isReady[0] = isReady[0];`is not required at all and has no effect, this PR just removes that line.