### PR TITLE
Chore: Fix: Potential access to properties of undefined object.

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -67,7 +67,7 @@ function useHasFontFamilyControl( settings ) {
 		.concat( fontFamiliesPerOrigin?.theme ?? [] )
 		.concat( fontFamiliesPerOrigin?.default ?? [] )
 		.sort( ( a, b ) =>
-			( a?.name || a?.slug ).localeCompare( b?.name || a?.slug )
+			( a?.name || a?.slug )?.localeCompare( b?.name || a?.slug )
 		);
 	return !! fontFamilies?.length;
 }


### PR DESCRIPTION
Our code was assuming that the font family may be undefined in `a?.name || a?.slug`. But if a is really undefined we then do `( a?.name || a?.slug ).localeCompare( b?.name || a?.slug )` which may cause accessing localeCompare of undefined which crashes the editor. If a may be undefined `( a?.name || a?.slug )` may also be undefined so we need to change `( a?.name || a?.slug )` to `( a?.name || a?.slug )?`.