### PR TITLE
E2E Tests - Organize test device configuration

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
-import deviceConfig from './device-config.json';
-
-const { ios: iOSConfig, android: androidConfig } = deviceConfig;
+import {
+	ios as iOSConfig,
+	android as androidConfig,
+} from './device-config.json';
 
 const ios = {
 	deviceOrientation: 'portrait',

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -29,17 +29,17 @@ exports.iosLocal = ( { iPadDevice = false } ) => ( {
 exports.iosServer = ( { iPadDevice = false } ) => ( {
 	...ios,
 	deviceName: ! iPadDevice
-		? iOSConfig.server.deviceName
-		: iOSConfig.server.deviceTabletName,
-	platformVersion: iOSConfig.server.platformVersion,
+		? iOSConfig.saucelabs.deviceName
+		: iOSConfig.saucelabs.deviceTabletName,
+	platformVersion: iOSConfig.local.platformVersion,
 	pixelRatio: ! iPadDevice
 		? iOSConfig.pixelRatio.iPhone
 		: iOSConfig.pixelRatio.iPad,
 } );
 
 exports.android = {
-	platformVersion: androidConfig.server.platformVersion,
-	deviceName: androidConfig.server.deviceName,
+	platformVersion: androidConfig.local.platformVersion,
+	deviceName: androidConfig.saucelabs.deviceName,
 	automationName: 'UiAutomator2',
 	appPackage: 'com.gutenberg',
 	appActivity: 'com.gutenberg.MainActivity',

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -1,5 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import deviceConfig from './device-config.json';
+
+const { ios: iOSConfig, android: androidConfig } = deviceConfig;
+
 const ios = {
-	platformVersion: '16.2', // Supported Sauce Labs platforms can be found here: https://saucelabs.com/rest/v1/info/platforms/appium
 	deviceOrientation: 'portrait',
 	automationName: 'XCUITest',
 	processArguments: {
@@ -10,22 +16,30 @@ const ios = {
 
 exports.iosLocal = ( { iPadDevice = false } ) => ( {
 	...ios,
-	deviceName: ! iPadDevice ? 'iPhone 14' : 'iPad (10th generation)',
-	pixelRatio: ! iPadDevice ? 3 : 2,
+	deviceName: ! iPadDevice
+		? iOSConfig.local.deviceName
+		: iOSConfig.local.deviceTabletName,
+	platformVersion: iOSConfig.local.platformVersion,
+	pixelRatio: ! iPadDevice
+		? iOSConfig.pixelRatio.iPhone
+		: iOSConfig.pixelRatio.iPad,
 	usePrebuiltWDA: true,
 } );
 
 exports.iosServer = ( { iPadDevice = false } ) => ( {
 	...ios,
 	deviceName: ! iPadDevice
-		? 'iPhone 14 Simulator'
-		: 'iPad (10th generation) Simulator',
-	pixelRatio: ! iPadDevice ? 3 : 2,
+		? iOSConfig.server.deviceName
+		: iOSConfig.server.deviceTabletName,
+	platformVersion: iOSConfig.server.platformVersion,
+	pixelRatio: ! iPadDevice
+		? iOSConfig.pixelRatio.iPhone
+		: iOSConfig.pixelRatio.iPad,
 } );
 
 exports.android = {
-	platformVersion: '11.0',
-	deviceName: 'Google Pixel 3 XL GoogleAPI Emulator',
+	platformVersion: androidConfig.server.platformVersion,
+	deviceName: androidConfig.server.deviceName,
 	automationName: 'UiAutomator2',
 	appPackage: 'com.gutenberg',
 	appActivity: 'com.gutenberg.MainActivity',

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -5,9 +5,11 @@
 			"deviceTabletName": "iPad (10th generation)",
 			"platformVersion": "16.2"
 		},
-		"server": {
+		"saucelabs": {
 			"deviceName": "iPhone 14 Simulator",
-			"deviceTabletName": "iPad (10th generation) Simulator",
+			"deviceTabletName": "iPad (10th generation) Simulator"
+		},
+		"buildkite": {
 			"platformVersion": "16.4"
 		},
 		"pixelRatio": {
@@ -20,9 +22,8 @@
 			"deviceName": "Pixel_3_XL_API_30",
 			"platformVersion": "11.0"
 		},
-		"server": {
-			"deviceName": "Google Pixel 3 XL GoogleAPI Emulator",
-			"platformVersion": "11.0"
+		"saucelabs": {
+			"deviceName": "Google Pixel 3 XL GoogleAPI Emulator"
 		}
 	}
 }

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -1,0 +1,28 @@
+{
+	"ios": {
+		"local": {
+			"deviceName": "iPhone 14",
+			"deviceTabletName": "iPad (10th generation)",
+			"platformVersion": "16.2"
+		},
+		"server": {
+			"deviceName": "iPhone 14 Simulator",
+			"deviceTabletName": "iPad (10th generation) Simulator",
+			"platformVersion": "16.4"
+		},
+		"pixelRatio": {
+			"iPhone": 3,
+			"iPad": 2
+		}
+	},
+	"android": {
+		"local": {
+			"deviceName": "Pixel_3_XL_API_30",
+			"platformVersion": "11.0"
+		},
+		"server": {
+			"deviceName": "Google Pixel 3 XL GoogleAPI Emulator",
+			"platformVersion": "11.0"
+		}
+	}
+}

--- a/packages/react-native-editor/bin/build-e2e-wda.sh
+++ b/packages/react-native-editor/bin/build-e2e-wda.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+# Load configurations from JSON file
+CONFIG_FILE="$(pwd)/__device-tests__/helpers/device-config.json"
+IOS_DEVICE_NAME=$(jq -r '.ios.local.deviceName' "$CONFIG_FILE")
+IOS_PLATFORM_VERSION=$(jq -r '.ios.local.platformVersion' "$CONFIG_FILE")
+
+xcodebuild -project ~/.appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination "platform=iOS Simulator,name=$IOS_DEVICE_NAME,OS=$IOS_PLATFORM_VERSION" -derivedDataPath ios/build/WDA

--- a/packages/react-native-editor/bin/build_e2e_ios_app
+++ b/packages/react-native-editor/bin/build_e2e_ios_app
@@ -2,7 +2,12 @@
 
 set -o pipefail
 
-DEFAULT_DESTINATION='platform=iOS Simulator,name=iPhone 14,OS=16.2'
+# Load configurations from JSON file
+CONFIG_FILE="$(pwd)/__device-tests__/helpers/device-config.json"
+IOS_DEVICE_NAME=$(jq -r '.ios.local.deviceName' "$CONFIG_FILE")
+IOS_PLATFORM_VERSION=$(jq -r '.ios.local.platformVersion' "$CONFIG_FILE")
+
+DEFAULT_DESTINATION="platform=iOS Simulator,name=$IOS_DEVICE_NAME,OS=$IOS_PLATFORM_VERSION"
 if [[ -z "${RN_EDITOR_E2E_IOS_DESTINATION-}" ]]; then
 	DESTINATION="$DEFAULT_DESTINATION"
 else

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -115,7 +115,7 @@
 		"test:e2e:android:local": "npm run test:e2e:bundle:android && npm run test:e2e:build-app:android && TEST_RN_PLATFORM=android npm run device-tests:local",
 		"test:e2e:bundle:ios": "mkdir -p ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app && npm run bundle:ios && cp bundle/ios/App.js ./ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/main.jsbundle && cp -r bundle/ios/assets ./ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/",
 		"test:e2e:build-app:ios": "npm run preios && ./bin/build_e2e_ios_app",
-		"test:e2e:build-wda": "xcodebuild -project ~/.appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' -derivedDataPath ios/build/WDA",
+		"test:e2e:build-wda": "./bin/build-e2e-wda.sh",
 		"test:e2e:ios:local": "npm run test:e2e:bundle:ios && npm run test:e2e:build-app:ios && npm run test:e2e:build-wda && TEST_RN_PLATFORM=ios npm run device-tests:local",
 		"build:gutenberg": "cd gutenberg && npm ci && npm run build",
 		"clean": "npm run clean:build-artifacts; npm run clean:aztec; npm run clean:haste; npm run clean:metro; npm run clean:watchman",


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6336

## What?
This PR unifies the different devices/versions we support for E2E tests used by different scripts.

## Why?
To have one only source of truth, however, we will still have the GitHub runners with the inline device/OS config.

## How?
By creating a new file `device-config.json` which will contain the device configuration for both `local` and `server` builds.

It also updates relevant scripts to use this config instead of inline values.

## Testing Instructions
CI checks should pass.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A