### PR TITLE
test: Improve local Android E2E test script

### DIFF
--- a/packages/react-native-editor/__device-tests__/README.md
+++ b/packages/react-native-editor/__device-tests__/README.md
@@ -44,13 +44,7 @@ npm run native test:e2e:ios:local
 
 ### Android
 
-Before running E2E tests on Android, launch the emulator using the following script.
-
-```shell
-emulator -avd Pixel_3_XL_API_30 -noaudio
-```
-
-The following script will run all of the E2E tests.
+The following script will launch the correct Android emulator and run all of the E2E tests.
 
 ```shell
 npm run native test:e2e:android:local

--- a/packages/react-native-editor/bin/test-e2e.sh
+++ b/packages/react-native-editor/bin/test-e2e.sh
@@ -2,8 +2,8 @@
 
 set -o pipefail
 
-# If TEST_RN_PLATFORM is empty or equal to "android", launch the Android emulator.
-if [ -z "$TEST_RN_PLATFORM" ] || [ "$TEST_RN_PLATFORM" = "android" ]; then
+# If TEST_RN_PLATFORM is empty or equal to "android" and not the CI server, launch the Android emulator.
+if [ -z "$TEST_RN_PLATFORM" ] || [ "$TEST_RN_PLATFORM" = "android" ] && [ -z "$GITHUB_ACTIONS" ]; then
 	# Load configurations from JSON file
 	CONFIG_FILE="$(pwd)/__device-tests__/helpers/device-config.json"
 	ANDROID_DEVICE_NAME=$(jq -r '.android.local.deviceName' "$CONFIG_FILE")

--- a/packages/react-native-editor/bin/test-e2e.sh
+++ b/packages/react-native-editor/bin/test-e2e.sh
@@ -4,10 +4,14 @@ set -o pipefail
 
 # If TEST_RN_PLATFORM is empty or equal to "android", launch the Android emulator.
 if [ -z "$TEST_RN_PLATFORM" ] || [ "$TEST_RN_PLATFORM" = "android" ]; then
+	# Load configurations from JSON file
+	CONFIG_FILE="$(pwd)/__device-tests__/helpers/device-config.json"
+	ANDROID_DEVICE_NAME=$(jq -r '.android.local.deviceName' "$CONFIG_FILE")
+
 	# Start the emulator if it is not already running
-	if [ -z "$(pgrep -f "Pixel_3_XL_API_30")" ]; then
+	if [ -z "$(pgrep -f "$ANDROID_DEVICE_NAME")" ]; then
 		echo "[info] Starting the Android emulator..."
-		emulator -avd Pixel_3_XL_API_30 -noaudio 2>&1 >/dev/null &
+		emulator -avd "$ANDROID_DEVICE_NAME" -noaudio 2>&1 >/dev/null &
 		ANDROID_PID=$!
 
 		# Wait for the emulator to be ready.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improve Android E2E test script. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to https://github.com/WordPress/gutenberg/pull/55662#discussion_r1376500436. Mitigate errors by simplifying E2E scripts.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update Android E2E test documentation.
- Android E2E reads device from configuration file. 
- Disable emulator launch for the Github Actions CI server. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
* Documentation is accurate. 
* E2E script works locally: `npm run native test:e2e:android:local -- -- -- --watch`
* CI servers do not attempt to launch the emulator

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
