### PR TITLE
refactor: Remove unused E2E test helpers

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -2,14 +2,10 @@
  * Internal dependencies
  */
 import { blockNames } from './pages/editor-page';
-import { clearClipboard, dragAndDropAfterElement } from './helpers/utils';
+import { dragAndDropAfterElement } from './helpers/utils';
 import testData from './helpers/test-data';
 
 describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
-	beforeEach( async () => {
-		await clearClipboard( editorPage.driver );
-	} );
-
 	it( 'should be able to drag & drop a block', async () => {
 		// Initialize the editor with a Spacer and Paragraph block
 		await editorPage.initializeEditor( {

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -682,13 +682,6 @@ const clickIfClickable = async (
 	}
 };
 
-// Only for Android
-const waitIfAndroid = async () => {
-	if ( isAndroid() ) {
-		await editorPage.driver.sleep( 1000 );
-	}
-};
-
 /**
  * Content type definitions.
  * Note: Android only supports plaintext.
@@ -770,5 +763,4 @@ module.exports = {
 	typeString,
 	waitForMediaLibrary,
 	waitForVisible,
-	waitIfAndroid,
 };

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -682,25 +682,6 @@ const clickIfClickable = async (
 	}
 };
 
-/**
- * Content type definitions.
- * Note: Android only supports plaintext.
- *
- * @typedef {"plaintext" | "image" | "url"} ClipboardContentType
- */
-
-/**
- * Helper to set content in the clipboard.
- *
- * @param {Object}               driver      Driver
- * @param {string}               content     Content to set in the clipboard
- * @param {ClipboardContentType} contentType Type of the content
- */
-const setClipboard = async ( driver, content, contentType = 'plaintext' ) => {
-	const base64String = Buffer.from( content ).toString( 'base64' );
-	await driver.setClipboard( base64String, contentType );
-};
-
 const launchApp = async ( driver, initialProps = {} ) => {
 	if ( isAndroid() ) {
 		await driver.execute( 'mobile: startActivity', {
@@ -738,7 +719,6 @@ module.exports = {
 	launchApp,
 	longPressMiddleOfElement,
 	selectTextFromElement,
-	setClipboard,
 	setupDriver,
 	stopDriver,
 	swipeDown,

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -701,16 +701,6 @@ const setClipboard = async ( driver, content, contentType = 'plaintext' ) => {
 	await driver.setClipboard( base64String, contentType );
 };
 
-/**
- * Helper to clear the clipboard
- *
- * @param {Object}               driver      Driver
- * @param {ClipboardContentType} contentType Type of the content
- */
-const clearClipboard = async ( driver, contentType = 'plaintext' ) => {
-	await driver.setClipboard( '', contentType );
-};
-
 const launchApp = async ( driver, initialProps = {} ) => {
 	if ( isAndroid() ) {
 		await driver.execute( 'mobile: startActivity', {
@@ -737,7 +727,6 @@ const launchApp = async ( driver, initialProps = {} ) => {
 
 module.exports = {
 	backspace,
-	clearClipboard,
 	clickBeginningOfElement,
 	clickIfClickable,
 	clickMiddleOfElement,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Remove unused E2E test helpers.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to https://github.com/WordPress/gutenberg/issues/55251. Reduce code complexity. These can be reinstated from 
Git history when beneficial.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Remove unused `waitIfAndroid` utility
- Remove unused `clearClipboard` utility
- Remove unused `setClipboard` utility

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
