### PR TITLE
Escape on Block Toolbar returns focus to Editor Canvas

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -588,6 +588,18 @@ _Properties_
 -   _isDisabled_ `boolean`: Whether or not the user should be prevented from inserting this item.
 -   _frecency_ `number`: Heuristic that combines frequency and recency.
 
+### getLastFocus
+
+Returns the element of the last element that had focus when focus left the editor canvas.
+
+_Parameters_
+
+-   _state_ `Object`: Block editor state.
+
+_Returns_
+
+-   `Object`: Element.
+
 ### getLastMultiSelectedBlockClientId
 
 Returns the client ID of the last block in the multi-selection set, or null if there is no multi-selection.
@@ -1650,6 +1662,18 @@ _Parameters_
 
 -   _clientId_ `string`: The block's clientId.
 -   _hasControlledInnerBlocks_ `boolean`: True if the block's inner blocks are controlled.
+
+### setLastFocus
+
+Action that sets the element that had focus when focus leaves the editor canvas.
+
+_Parameters_
+
+-   _lastFocus_ `Object`: The last focused element.
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### setNavigationMode
 

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import {
+	forwardRef,
 	useLayoutEffect,
 	useEffect,
 	useRef,
@@ -31,7 +32,10 @@ import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 import { useHasAnyBlockControls } from '../block-controls/use-has-block-controls';
 
-function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
+function UnforwardBlockContextualToolbar(
+	{ focusOnMount, isFixed, ...props },
+	ref
+) {
 	// When the toolbar is fixed it can be collapsed
 	const [ isCollapsed, setIsCollapsed ] = useState( false );
 	const toolbarButtonRef = useRef();
@@ -184,6 +188,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 
 	return (
 		<NavigableToolbar
+			ref={ ref }
 			focusOnMount={ focusOnMount }
 			className={ classes }
 			/* translators: accessibility text for the block toolbar */
@@ -220,4 +225,4 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	);
 }
 
-export default BlockContextualToolbar;
+export default forwardRef( UnforwardBlockContextualToolbar );

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -190,6 +190,7 @@ function UnforwardBlockContextualToolbar(
 		<NavigableToolbar
 			ref={ ref }
 			focusOnMount={ focusOnMount }
+			focusEditorOnEscape
 			className={ classes }
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -175,7 +175,10 @@ export default function BlockTools( {
 				) }
 				{ ! isZoomOutMode &&
 					( hasFixedToolbar || ! isLargeViewport ) && (
-						<BlockContextualToolbar isFixed />
+						<BlockContextualToolbar
+							ref={ selectedBlockToolsRef }
+							isFixed
+						/>
 					) }
 
 				{ showEmptyBlockSideInserter && (

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -88,6 +88,8 @@ export default function BlockTools( {
 		moveBlocksDown,
 	} = useDispatch( blockEditorStore );
 
+	const selectedBlockToolsRef = useRef( null );
+
 	function onKeyDown( event ) {
 		if ( event.defaultPrevented ) return;
 
@@ -130,6 +132,15 @@ export default function BlockTools( {
 				insertBeforeBlock( clientIds[ 0 ] );
 			}
 		} else if ( isMatch( 'core/block-editor/unselect', event ) ) {
+			if ( selectedBlockToolsRef.current.contains( event.target ) ) {
+				// This shouldn't be necessary, but we have a combination of a few things all combining to create a situation where:
+				// - Because the block toolbar uses createPortal to populate the block toolbar fills, we can't rely on the React event bubbling to hit the onKeyDown listener for the block toolbar
+				// - Since we can't use the React tree, we use the DOM tree which _should_ handle the event bubbling correctly from a `createPortal` element.
+				// - This bubbles via the React tree, which hits this `unselect` escape keypress before the block toolbar DOM event listener has access to it.
+				// An alternative would be to remove the addEventListener on the navigableToolbar and use this event to handle it directly right here. That feels hacky too though.
+				return;
+			}
+
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {
 				event.preventDefault();
@@ -177,6 +188,7 @@ export default function BlockTools( {
 					needed for navigation and zoom-out mode. */ }
 				{ ! showEmptyBlockSideInserter && hasSelectedBlock && (
 					<SelectedBlockTools
+						ref={ selectedBlockToolsRef }
 						__unstableContentRef={ __unstableContentRef }
 						clientId={ clientId }
 					/>

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -132,7 +132,7 @@ export default function BlockTools( {
 				insertBeforeBlock( clientIds[ 0 ] );
 			}
 		} else if ( isMatch( 'core/block-editor/unselect', event ) ) {
-			if ( selectedBlockToolsRef.current.contains( event.target ) ) {
+			if ( selectedBlockToolsRef?.current?.contains( event.target ) ) {
 				// This shouldn't be necessary, but we have a combination of a few things all combining to create a situation where:
 				// - Because the block toolbar uses createPortal to populate the block toolbar fills, we can't rely on the React event bubbling to hit the onKeyDown listener for the block toolbar
 				// - Since we can't use the React tree, we use the DOM tree which _should_ handle the event bubbling correctly from a `createPortal` element.

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -1,0 +1,274 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef, useRef, useEffect } from '@wordpress/element';
+import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
+
+/**
+ * Internal dependencies
+ */
+import BlockSelectionButton from './block-selection-button';
+import BlockContextualToolbar from './block-contextual-toolbar';
+import { store as blockEditorStore } from '../../store';
+import BlockPopover from '../block-popover';
+import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
+import Inserter from '../inserter';
+import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
+
+function selector( select ) {
+	const {
+		__unstableGetEditorMode,
+		hasMultiSelection,
+		isTyping,
+		getLastMultiSelectedBlockClientId,
+	} = select( blockEditorStore );
+
+	return {
+		editorMode: __unstableGetEditorMode(),
+		hasMultiSelection: hasMultiSelection(),
+		isTyping: isTyping(),
+		lastClientId: hasMultiSelection()
+			? getLastMultiSelectedBlockClientId()
+			: null,
+	};
+}
+
+function UnforwardSelectedBlockPopover(
+	{
+		clientId,
+		rootClientId,
+		isEmptyDefaultBlock,
+		capturingClientId,
+		__unstablePopoverSlot,
+		__unstableContentRef,
+	},
+	ref
+) {
+	const { editorMode, hasMultiSelection, isTyping, lastClientId } = useSelect(
+		selector,
+		[]
+	);
+
+	const isInsertionPointVisible = useSelect(
+		( select ) => {
+			const {
+				isBlockInsertionPointVisible,
+				getBlockInsertionPoint,
+				getBlockOrder,
+			} = select( blockEditorStore );
+
+			if ( ! isBlockInsertionPointVisible() ) {
+				return false;
+			}
+
+			const insertionPoint = getBlockInsertionPoint();
+			const order = getBlockOrder( insertionPoint.rootClientId );
+			return order[ insertionPoint.index ] === clientId;
+		},
+		[ clientId ]
+	);
+	const isToolbarForced = useRef( false );
+	const { shouldShowContextualToolbar, canFocusHiddenToolbar } =
+		useShouldContextualToolbarShow();
+
+	const { stopTyping } = useDispatch( blockEditorStore );
+
+	const showEmptyBlockSideInserter =
+		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
+	const shouldShowBreadcrumb =
+		! hasMultiSelection &&
+		( editorMode === 'navigation' || editorMode === 'zoom-out' );
+
+	useShortcut(
+		'core/block-editor/focus-toolbar',
+		() => {
+			isToolbarForced.current = true;
+			stopTyping( true );
+		},
+		{
+			isDisabled: ! canFocusHiddenToolbar,
+		}
+	);
+
+	useEffect( () => {
+		isToolbarForced.current = false;
+	} );
+
+	// Stores the active toolbar item index so the block toolbar can return focus
+	// to it when re-mounting.
+	const initialToolbarItemIndexRef = useRef();
+
+	useEffect( () => {
+		// Resets the index whenever the active block changes so this is not
+		// persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+		initialToolbarItemIndexRef.current = undefined;
+	}, [ clientId ] );
+
+	const popoverProps = useBlockToolbarPopoverProps( {
+		contentElement: __unstableContentRef?.current,
+		clientId,
+	} );
+
+	if ( showEmptyBlockSideInserter ) {
+		return (
+			<BlockPopover
+				clientId={ capturingClientId || clientId }
+				__unstableCoverTarget
+				bottomClientId={ lastClientId }
+				className={ classnames(
+					'block-editor-block-list__block-side-inserter-popover',
+					{
+						'is-insertion-point-visible': isInsertionPointVisible,
+					}
+				) }
+				__unstablePopoverSlot={ __unstablePopoverSlot }
+				__unstableContentRef={ __unstableContentRef }
+				resize={ false }
+				shift={ false }
+				{ ...popoverProps }
+			>
+				<div className="block-editor-block-list__empty-block-inserter">
+					<Inserter
+						position="bottom right"
+						rootClientId={ rootClientId }
+						clientId={ clientId }
+						__experimentalIsQuick
+					/>
+				</div>
+			</BlockPopover>
+		);
+	}
+
+	if ( shouldShowBreadcrumb || shouldShowContextualToolbar ) {
+		return (
+			<BlockPopover
+				clientId={ capturingClientId || clientId }
+				bottomClientId={ lastClientId }
+				className={ classnames(
+					'block-editor-block-list__block-popover',
+					{
+						'is-insertion-point-visible': isInsertionPointVisible,
+					}
+				) }
+				__unstablePopoverSlot={ __unstablePopoverSlot }
+				__unstableContentRef={ __unstableContentRef }
+				resize={ false }
+				{ ...popoverProps }
+			>
+				{ shouldShowContextualToolbar && (
+					<BlockContextualToolbar
+						ref={ ref }
+						// If the toolbar is being shown because of being forced
+						// it should focus the toolbar right after the mount.
+						focusOnMount={ isToolbarForced.current }
+						__experimentalInitialIndex={
+							initialToolbarItemIndexRef.current
+						}
+						__experimentalOnIndexChange={ ( index ) => {
+							initialToolbarItemIndexRef.current = index;
+						} }
+						// Resets the index whenever the active block changes so
+						// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+						key={ clientId }
+					/>
+				) }
+				{ shouldShowBreadcrumb && (
+					<BlockSelectionButton
+						clientId={ clientId }
+						rootClientId={ rootClientId }
+					/>
+				) }
+			</BlockPopover>
+		);
+	}
+
+	return null;
+}
+
+const SelectedBlockPopover = forwardRef( UnforwardSelectedBlockPopover );
+
+function wrapperSelector( select ) {
+	const {
+		getSelectedBlockClientId,
+		getFirstMultiSelectedBlockClientId,
+		getBlockRootClientId,
+		getBlock,
+		getBlockParents,
+		__experimentalGetBlockListSettingsForBlocks,
+	} = select( blockEditorStore );
+
+	const clientId =
+		getSelectedBlockClientId() || getFirstMultiSelectedBlockClientId();
+
+	if ( ! clientId ) {
+		return;
+	}
+
+	const { name, attributes = {} } = getBlock( clientId ) || {};
+	const blockParentsClientIds = getBlockParents( clientId );
+
+	// Get Block List Settings for all ancestors of the current Block clientId.
+	const parentBlockListSettings = __experimentalGetBlockListSettingsForBlocks(
+		blockParentsClientIds
+	);
+
+	// Get the clientId of the topmost parent with the capture toolbars setting.
+	const capturingClientId = blockParentsClientIds.find(
+		( parentClientId ) =>
+			parentBlockListSettings[ parentClientId ]
+				?.__experimentalCaptureToolbars
+	);
+
+	return {
+		clientId,
+		rootClientId: getBlockRootClientId( clientId ),
+		name,
+		isEmptyDefaultBlock:
+			name && isUnmodifiedDefaultBlock( { name, attributes } ),
+		capturingClientId,
+	};
+}
+
+function UnforwardWrappedBlockPopover(
+	{ __unstablePopoverSlot, __unstableContentRef },
+	ref
+) {
+	const selected = useSelect( wrapperSelector, [] );
+
+	if ( ! selected ) {
+		return null;
+	}
+
+	const {
+		clientId,
+		rootClientId,
+		name,
+		isEmptyDefaultBlock,
+		capturingClientId,
+	} = selected;
+
+	if ( ! name ) {
+		return null;
+	}
+
+	return (
+		<SelectedBlockPopover
+			ref={ ref }
+			clientId={ clientId }
+			rootClientId={ rootClientId }
+			isEmptyDefaultBlock={ isEmptyDefaultBlock }
+			capturingClientId={ capturingClientId }
+			__unstablePopoverSlot={ __unstablePopoverSlot }
+			__unstableContentRef={ __unstableContentRef }
+		/>
+	);
+}
+
+export default forwardRef( UnforwardWrappedBlockPopover );

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -21,11 +21,10 @@ import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
 import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
 
-function UnforwardSelectedBlockTools( {
-	clientId,
-	showEmptyBlockSideInserter,
-	__unstableContentRef,
-}, ref ) {
+function UnforwardSelectedBlockTools(
+	{ clientId, showEmptyBlockSideInserter, __unstableContentRef },
+	ref
+) {
 	const {
 		capturingClientId,
 		isInsertionPointVisible,

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
+import { forwardRef, useRef, useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 
@@ -21,11 +21,11 @@ import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
 import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
 
-export default function SelectedBlockTools( {
+function UnforwardSelectedBlockTools( {
 	clientId,
 	showEmptyBlockSideInserter,
 	__unstableContentRef,
-} ) {
+}, ref ) {
 	const {
 		capturingClientId,
 		isInsertionPointVisible,
@@ -102,6 +102,7 @@ export default function SelectedBlockTools( {
 			>
 				{ shouldShowContextualToolbar && (
 					<BlockContextualToolbar
+						ref={ ref }
 						// If the toolbar is being shown because of being forced
 						// it should focus the toolbar right after the mount.
 						focusOnMount={ isToolbarForced.current }
@@ -128,3 +129,5 @@ export default function SelectedBlockTools( {
 
 	return null;
 }
+
+export default forwardRef( UnforwardSelectedBlockTools );

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -3,6 +3,7 @@
  */
 import { NavigableMenu, Toolbar } from '@wordpress/components';
 import {
+	forwardRef,
 	useState,
 	useRef,
 	useLayoutEffect,
@@ -38,7 +39,7 @@ function focusFirstTabbableIn( container ) {
 	}
 }
 
-function useIsAccessibleToolbar( ref ) {
+function useIsAccessibleToolbar( toolbarRef ) {
 	/*
 	 * By default, we'll assume the starting accessible state of the Toolbar
 	 * is true, as it seems to be the most common case.
@@ -62,7 +63,7 @@ function useIsAccessibleToolbar( ref ) {
 	);
 
 	const determineIsAccessibleToolbar = useCallback( () => {
-		const tabbables = focus.tabbable.find( ref.current );
+		const tabbables = focus.tabbable.find( toolbarRef.current );
 		const onlyToolbarItem = hasOnlyToolbarItem( tabbables );
 		if ( ! onlyToolbarItem ) {
 			deprecated( 'Using custom components as toolbar controls', {
@@ -73,7 +74,7 @@ function useIsAccessibleToolbar( ref ) {
 			} );
 		}
 		setIsAccessibleToolbar( onlyToolbarItem );
-	}, [] );
+	}, [ toolbarRef ] );
 
 	useLayoutEffect( () => {
 		// Toolbar buttons may be rendered asynchronously, so we use
@@ -81,15 +82,18 @@ function useIsAccessibleToolbar( ref ) {
 		const observer = new window.MutationObserver(
 			determineIsAccessibleToolbar
 		);
-		observer.observe( ref.current, { childList: true, subtree: true } );
+		observer.observe( toolbarRef.current, {
+			childList: true,
+			subtree: true,
+		} );
 		return () => observer.disconnect();
-	}, [ isAccessibleToolbar ] );
+	}, [ determineIsAccessibleToolbar, isAccessibleToolbar, toolbarRef ] );
 
 	return isAccessibleToolbar;
 }
 
 function useToolbarFocus(
-	ref,
+	toolbarRef,
 	focusOnMount,
 	isAccessibleToolbar,
 	defaultIndex,
@@ -101,8 +105,8 @@ function useToolbarFocus(
 	const [ initialIndex ] = useState( defaultIndex );
 
 	const focusToolbar = useCallback( () => {
-		focusFirstTabbableIn( ref.current );
-	}, [] );
+		focusFirstTabbableIn( toolbarRef.current );
+	}, [ toolbarRef ] );
 
 	const focusToolbarViaShortcut = () => {
 		if ( shouldUseKeyboardFocusShortcut ) {
@@ -121,7 +125,7 @@ function useToolbarFocus(
 
 	useEffect( () => {
 		// Store ref so we have access on useEffect cleanup: https://legacy.reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing
-		const navigableToolbarRef = ref.current;
+		const navigableToolbarRef = toolbarRef.current;
 		// If initialIndex is passed, we focus on that toolbar item when the
 		// toolbar gets mounted and initial focus is not forced.
 		// We have to wait for the next browser paint because block controls aren't
@@ -150,22 +154,27 @@ function useToolbarFocus(
 			const index = items.findIndex( ( item ) => item.tabIndex === 0 );
 			onIndexChange( index );
 		};
-	}, [ initialIndex, initialFocusOnMount ] );
+	}, [ initialIndex, initialFocusOnMount, toolbarRef, onIndexChange ] );
 }
 
-function NavigableToolbar( {
-	children,
-	focusOnMount,
-	shouldUseKeyboardFocusShortcut = true,
-	__experimentalInitialIndex: initialIndex,
-	__experimentalOnIndexChange: onIndexChange,
-	...props
-} ) {
-	const ref = useRef();
-	const isAccessibleToolbar = useIsAccessibleToolbar( ref );
+function UnforwardNavigableToolbar(
+	{
+		children,
+		focusOnMount,
+		shouldUseKeyboardFocusShortcut = true,
+		__experimentalInitialIndex: initialIndex,
+		__experimentalOnIndexChange: onIndexChange,
+		...props
+	},
+	ref
+) {
+	const maybeRef = useRef();
+	// If a ref was not forwarded, we create one.
+	const toolbarRef = ref || maybeRef;
+	const isAccessibleToolbar = useIsAccessibleToolbar( toolbarRef );
 
 	useToolbarFocus(
-		ref,
+		toolbarRef,
 		focusOnMount,
 		isAccessibleToolbar,
 		initialIndex,
@@ -175,7 +184,11 @@ function NavigableToolbar( {
 
 	if ( isAccessibleToolbar ) {
 		return (
-			<Toolbar label={ props[ 'aria-label' ] } ref={ ref } { ...props }>
+			<Toolbar
+				label={ props[ 'aria-label' ] }
+				ref={ toolbarRef }
+				{ ...props }
+			>
 				{ children }
 			</Toolbar>
 		);
@@ -185,7 +198,7 @@ function NavigableToolbar( {
 		<NavigableMenu
 			orientation="horizontal"
 			role="toolbar"
-			ref={ ref }
+			ref={ toolbarRef }
 			{ ...props }
 		>
 			{ children }
@@ -193,4 +206,4 @@ function NavigableToolbar( {
 	);
 }
 
-export default NavigableToolbar;
+export default forwardRef( UnforwardNavigableToolbar );

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -36,6 +36,7 @@ function hasFocusWithin( container ) {
 
 function focusFirstTabbableIn( container ) {
 	const [ firstTabbable ] = focus.tabbable.find( container );
+
 	if ( firstTabbable ) {
 		firstTabbable.focus( {
 			// When focusing newly mounted toolbars,
@@ -99,15 +100,15 @@ function useIsAccessibleToolbar( toolbarRef ) {
 	return isAccessibleToolbar;
 }
 
-function useToolbarFocus(
+function useToolbarFocus( {
 	toolbarRef,
-	focusEditorOnEscape,
 	focusOnMount,
 	isAccessibleToolbar,
 	defaultIndex,
 	onIndexChange,
-	shouldUseKeyboardFocusShortcut
-) {
+	shouldUseKeyboardFocusShortcut,
+	focusEditorOnEscape,
+} ) {
 	// Make sure we don't use modified versions of this prop.
 	const [ initialFocusOnMount ] = useState( focusOnMount );
 	const [ initialIndex ] = useState( defaultIndex );
@@ -212,15 +213,15 @@ function UnforwardNavigableToolbar(
 	const toolbarRef = ref || maybeRef;
 	const isAccessibleToolbar = useIsAccessibleToolbar( toolbarRef );
 
-	useToolbarFocus(
+	useToolbarFocus( {
 		toolbarRef,
-		focusEditorOnEscape,
 		focusOnMount,
 		isAccessibleToolbar,
-		initialIndex,
+		defaultIndex: initialIndex,
 		onIndexChange,
-		shouldUseKeyboardFocusShortcut
-	);
+		shouldUseKeyboardFocusShortcut,
+		focusEditorOnEscape,
+	} );
 
 	if ( isAccessibleToolbar ) {
 		return (

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -163,7 +163,7 @@ function useToolbarFocus( {
 			const index = items.findIndex( ( item ) => item.tabIndex === 0 );
 			onIndexChange( index );
 		};
-	}, [ initialIndex, initialFocusOnMount, toolbarRef, onIndexChange ] );
+	}, [ initialIndex, initialFocusOnMount, toolbarRef ] );
 
 	const { lastFocus } = useSelect( ( select ) => {
 		const { getLastFocus } = select( blockEditorStore );

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -17,12 +17,17 @@ export default function useTabNav() {
 	const container = useRef();
 	const focusCaptureBeforeRef = useRef();
 	const focusCaptureAfterRef = useRef();
-	const lastFocus = useRef();
+
 	const { hasMultiSelection, getSelectedBlockClientId, getBlockCount } =
 		useSelect( blockEditorStore );
-	const { setNavigationMode } = useDispatch( blockEditorStore );
+	const { setNavigationMode, setLastFocus } = useDispatch( blockEditorStore );
 	const isNavigationMode = useSelect(
 		( select ) => select( blockEditorStore ).isNavigationMode(),
+		[]
+	);
+
+	const lastFocus = useSelect(
+		( select ) => select( blockEditorStore ).getLastFocus(),
 		[]
 	);
 
@@ -158,7 +163,7 @@ export default function useTabNav() {
 		}
 
 		function onFocusOut( event ) {
-			lastFocus.current = event.target;
+			setLastFocus( { ...lastFocus, current: event.target } );
 
 			const { ownerDocument } = node;
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1980,3 +1980,18 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
+
+/**
+ * Action that sets the element that had focus when focus leaves the editor canvas.
+ *
+ * @param {Object} lastFocus The last focused element.
+ *
+ *
+ * @return {Object} Action object.
+ */
+export function setLastFocus( lastFocus = null ) {
+	return {
+		type: 'LAST_FOCUS',
+		lastFocus,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1962,6 +1962,24 @@ export function registeredInserterMediaCategories( state = [], action ) {
 		case 'REGISTER_INSERTER_MEDIA_CATEGORY':
 			return [ ...state, action.category ];
 	}
+
+	return state;
+}
+
+/**
+ * Reducer setting last focused element
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function lastFocus( state = false, action ) {
+	switch ( action.type ) {
+		case 'LAST_FOCUS':
+			return action.lastFocus;
+	}
+
 	return state;
 }
 
@@ -1981,6 +1999,7 @@ const combinedReducers = combineReducers( {
 	settings,
 	preferences,
 	lastBlockAttributesChange,
+	lastFocus,
 	editorMode,
 	hasBlockMovingClientId,
 	highlightedBlock,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3022,3 +3022,14 @@ export const isGroupable = createRegistrySelector(
 			);
 		}
 );
+
+/**
+ * Returns the element of the last element that had focus when focus left the editor canvas.
+ *
+ * @param {Object} state Block editor state.
+ *
+ * @return {Object} Element.
+ */
+export function getLastFocus( state ) {
+	return state.lastFocus;
+}

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -3,6 +3,12 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+test.use( {
+	BlockToolbarUtils: async ( { page, pageUtils }, use ) => {
+		await use( new BlockToolbarUtils( { page, pageUtils } ) );
+	},
+} );
+
 test.describe( 'Block Toolbar', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
@@ -44,6 +50,67 @@ test.describe( 'Block Toolbar', () => {
 			} );
 			expect( scrollTopBefore ).toBe( scrollTopAfter );
 		} );
+
+		test( 'can navigate to the block toolbar and back to block using the keyboard', async ( {
+			BlockToolbarUtils,
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			// Test navigating to block toolbar
+			await editor.insertBlock( { name: 'core/paragraph' } );
+			await page.keyboard.type( 'Paragraph' );
+			await BlockToolbarUtils.focusBlockToolbar();
+			await BlockToolbarUtils.expectLabelToHaveFocus( 'Paragraph' );
+			// // Navigate to Align Text
+			await page.keyboard.press( 'ArrowRight' );
+			await BlockToolbarUtils.expectLabelToHaveFocus( 'Align text' );
+			// // Open the dropdown
+			await page.keyboard.press( 'Enter' );
+			await BlockToolbarUtils.expectLabelToHaveFocus( 'Align text left' );
+			await page.keyboard.press( 'ArrowDown' );
+			await BlockToolbarUtils.expectLabelToHaveFocus(
+				'Align text center'
+			);
+			await page.keyboard.press( 'Escape' );
+			await BlockToolbarUtils.expectLabelToHaveFocus( 'Align text' );
+
+			// Navigate to the Bold item. Testing items via the fills within the block toolbar are especially important
+			await page.keyboard.press( 'ArrowRight' );
+			await BlockToolbarUtils.expectLabelToHaveFocus( 'Bold' );
+
+			await BlockToolbarUtils.focusBlock();
+			await BlockToolbarUtils.expectLabelToHaveFocus(
+				'Block: Paragraph'
+			);
+
+			await BlockToolbarUtils.focusBlockToolbar();
+			await BlockToolbarUtils.expectLabelToHaveFocus( 'Bold' );
+
+			await BlockToolbarUtils.focusBlock();
+
+			// Try selecting text and navigating to block toolbar
+			await pageUtils.pressKeys( 'Shift+ArrowLeft', {
+				times: 4,
+				delay: 50,
+			} );
+			expect(
+				await editor.canvas
+					.locator( ':root' )
+					.evaluate( () => window.getSelection().toString() )
+			).toBe( 'raph' );
+
+			// Go back to the toolbar and apply a formatting option
+			await BlockToolbarUtils.focusBlockToolbar();
+			await BlockToolbarUtils.expectLabelToHaveFocus( 'Bold' );
+			await page.keyboard.press( 'Enter' );
+			// Should focus the selected text again
+			expect(
+				await editor.canvas
+					.locator( ':root' )
+					.evaluate( () => window.getSelection().toString() )
+			).toBe( 'raph' );
+		} );
 	} );
 
 	test( 'should focus with Shift+Tab', async ( {
@@ -61,3 +128,31 @@ test.describe( 'Block Toolbar', () => {
 		).toBeFocused();
 	} );
 } );
+
+class BlockToolbarUtils {
+	constructor( { page, pageUtils } ) {
+		this.page = page;
+		this.pageUtils = pageUtils;
+	}
+
+	async focusBlockToolbar() {
+		await this.pageUtils.pressKeys( 'alt+F10' );
+	}
+
+	async focusBlock() {
+		await this.pageUtils.pressKeys( 'Escape' );
+	}
+
+	async expectLabelToHaveFocus( label ) {
+		const ariaLabel = await this.page.evaluate( () => {
+			const { activeElement } =
+				document.activeElement.contentDocument ?? document;
+			return (
+				activeElement.getAttribute( 'aria-label' ) ||
+				activeElement.innerText
+			);
+		} );
+
+		expect( ariaLabel ).toBe( label );
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds using escape keypress to return from toolbar to editor canvas. Right now the escape keypress on the toolbar causes the blocks to be deselected and loses focus. Escape from a floating element is a very common pattern for returning focus to the canvas -- moreso than `tab`.

## Why?

This is part of the Top Toolbar improvement work. This adds a real feature to Gutenberg that can be expanded upon, and will make it easier to merge https://github.com/WordPress/gutenberg/pull/54513/ instead of reviewing 70 commits...


<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

#### Storing `lastFocus` element when focus leaves the block toolbar
To help make managing focus easier across Gutenberg, anytime focus leaves the editor canvas, the element that previously had focus will be stored. This will help fix focus loss as well, as this PR uses the same methods: https://github.com/WordPress/gutenberg/pull/54443. 

#### Catching Escape Keypress from Block Toolbar
@ajlende and I investigated a lot of ways of catching the escape keypress from the navigable toolbar, and landed with three viable options. The selected method requires forwarding a ref from the editor level down to the navigable toolbar so that the escape unselect shortcut can be blocked and the navigable toolbar event listener will still fire.

Blocking the global escape event shouldn't be necessary, but we have a combination of a few things all combining to create a situation where:
- Because the block toolbar uses `createPortal` to populate the block toolbar fills, we can't rely on the React event bubbling to hit the `onKeyDown` listener for the block toolbar
- Since we can't use the React tree, we use the DOM tree which _should_ handle the event bubbling correctly from a `createPortal` element.
- This bubbles via the React tree, which hits this `unselect` escape keypress before the block toolbar DOM event listener has access to it.

Also, this is better than attaching it to all of the children in the block toolbar because when new items are dynamically rendered into the toolbar (such as via the `bubblesVirtually` slots or the apply/cancel buttons when cropping an image) we can still catch the events. Otherwise, those buttons are added after the mount, and the children don't receive the listener.

### Testing Instructions for Keyboard

- Add blocks of various types
- Use `shift + tab` to move focus to the block toolbar
- Uses `escape` to return focus to the block
- Repeat on different blocks and from different buttons on the block toolbar
- Test with both the floating toolbar and the top toolbar
