### PR TITLE
Query block enhanced pagination: Detect inner plugin blocks during render

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -63,7 +63,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		wp_reset_postdata(); // Restore original Post Data.
 	}
 
-	if ( $enhanced_pagination ) {
+	if ( $enhanced_pagination && isset( $content ) ) {
 		$p = new WP_HTML_Tag_Processor( $content );
 		if ( $p->next_tag(
 			array(

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -51,7 +51,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		);
 	}
 
-	if ( $enhanced_pagination ) {
+	if ( $enhanced_pagination && isset( $content ) ) {
 		$p = new WP_HTML_Tag_Processor( $content );
 		if ( $p->next_tag(
 			array(

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -38,20 +38,28 @@ export default function EnhancedPaginationModal( {
 	};
 
 	let notice = __(
-		'If you still want to prevent a full page reload, remove that block, then disable "Force page reload" again in the Query Block settings.'
+		'If you still want to prevent full page reloads, remove that block, then disable "Force page reload" again in the Query Block settings.'
 	);
 	if ( hasBlocksFromPlugins ) {
 		notice =
-			__( 'Blocks from plugins are not supported yet.' ) + ' ' + notice;
+			__(
+				'Currently, avoiding full page reloads is not possible when blocks from plugins are present inside the Query block.'
+			) +
+			' ' +
+			notice;
 	} else if ( hasPostContentBlock ) {
 		notice =
-			__( 'The Post Content block is not supported yet.' ) + ' ' + notice;
+			__(
+				'Currently, avoiding full page reloads is not possible when a Content block is present inside the Query block.'
+			) +
+			' ' +
+			notice;
 	}
 
 	return (
 		isOpen && (
 			<Modal
-				title={ __( 'Force page reload has been enabled' ) }
+				title={ __( 'Query block: Force page reload enabled' ) }
 				className="wp-block-query__enhanced-pagination-modal"
 				aria={ {
 					describedby: modalDescriptionId,

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -12,7 +12,7 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useUnsupportedBlocks, useHaveBlocksChanged } from '../utils';
+import { useUnsupportedBlocks } from '../utils';
 
 const modalDescriptionId =
 	'wp-block-query-enhanced-pagination-modal__description';
@@ -23,54 +23,35 @@ export default function EnhancedPaginationModal( {
 	setAttributes,
 } ) {
 	const [ isOpen, setOpen ] = useState( false );
-	const {
-		hasBlocksFromPlugins,
-		hasPostContentBlock,
-		hasPatternOrTemplatePartBlocks,
-		hasUnsupportedBlocks,
-	} = useUnsupportedBlocks( clientId );
-	const haveBlocksChanged = useHaveBlocksChanged( clientId );
+	const { hasBlocksFromPlugins, hasPostContentBlock, hasUnsupportedBlocks } =
+		useUnsupportedBlocks( clientId );
 
 	useEffect( () => {
-		if ( enhancedPagination && haveBlocksChanged && hasUnsupportedBlocks ) {
+		if ( enhancedPagination && hasUnsupportedBlocks ) {
+			setAttributes( { enhancedPagination: false } );
 			setOpen( true );
-			if ( hasBlocksFromPlugins || hasPostContentBlock ) {
-				setAttributes( { enhancedPagination: false } );
-			}
 		}
-	}, [
-		enhancedPagination,
-		haveBlocksChanged,
-		hasUnsupportedBlocks,
-		hasBlocksFromPlugins,
-		hasPostContentBlock,
-		setAttributes,
-	] );
+	}, [ enhancedPagination, hasUnsupportedBlocks, setAttributes ] );
 
 	const closeModal = () => {
 		setOpen( false );
 	};
 
-	let notice = null;
-	let title = __( 'Enhanced pagination has been disabled' );
+	let notice = __(
+		'If you still want to prevent a full page reload, remove that block, then disable "Force page reload" again in the Query Block settings.'
+	);
 	if ( hasBlocksFromPlugins ) {
 		notice =
-			'Blocks from plugins are not supported yet. For the enhanced pagination to work, remove the blocks, then re-enable "Enhanced pagination" in the Query Block settings.';
+			__( 'Blocks from plugins are not supported yet.' ) + ' ' + notice;
 	} else if ( hasPostContentBlock ) {
-		notice = __(
-			'The Post Content block is not supported yet. For the enhanced pagination to work, remove the block, then re-enable "Enhanced pagination" in the Query Block settings.'
-		);
-	} else if ( enhancedPagination && hasPatternOrTemplatePartBlocks ) {
-		title = __( 'Enhanced pagination switched to auto' );
-		notice = __(
-			'Blocks from plugins are not supported yet. Please note that if you add them to the patterns or template parts that are currently inside this Query block, this enhanced pagination will be automatically disabled.'
-		);
+		notice =
+			__( 'The Post Content block is not supported yet.' ) + ' ' + notice;
 	}
 
 	return (
 		isOpen && (
 			<Modal
-				title={ title }
+				title={ __( 'Force page reload has been enabled' ) }
 				className="wp-block-query__enhanced-pagination-modal"
 				aria={ {
 					describedby: modalDescriptionId,
@@ -78,8 +59,6 @@ export default function EnhancedPaginationModal( {
 				role="alertdialog"
 				focusOnMount="firstElement"
 				isDismissible={ false }
-				shouldCloseOnEsc={ true }
-				shouldCloseOnClickOutside={ true }
 				onRequestClose={ closeModal }
 			>
 				<VStack alignment="right" spacing={ 5 }>

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { ToggleControl, ExternalLink } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -14,22 +14,18 @@ export default function EnhancedPaginationControl( {
 	setAttributes,
 	clientId,
 } ) {
-	const { hasBlocksFromPlugins, hasPostContentBlock } =
-		useUnsupportedBlocks( clientId );
+	const { hasUnsupportedBlocks } = useUnsupportedBlocks( clientId );
 
-	const help = enhancedPagination ? (
-		<>
-			{ __(
-				'Browsing between pages will be seamless unless unexpected content is detected.'
-			) }{ ' ' }
-			<ExternalLink href="https://wordpress.org/">
-				{ __( 'Learn more' ) }
-			</ExternalLink>
-			{ '.' }
-		</>
-	) : (
-		__( 'Browsing between pages requires a full page reload.' )
-	);
+	let help = __( 'Browsing between pages requires a full page reload.' );
+	if ( enhancedPagination ) {
+		help = __(
+			"Browsing between pages won't require a full page reload, unless non-compatible blocks are detected."
+		);
+	} else if ( hasUnsupportedBlocks ) {
+		help = __(
+			"Force page reload can't be disabled because there are non-compatible blocks inside the Query block."
+		);
+	}
 
 	return (
 		<>
@@ -37,7 +33,7 @@ export default function EnhancedPaginationControl( {
 				label={ __( 'Force page reload' ) }
 				help={ help }
 				checked={ ! enhancedPagination }
-				disabled={ hasBlocksFromPlugins || hasPostContentBlock }
+				disabled={ hasUnsupportedBlocks }
 				onChange={ ( value ) => {
 					setAttributes( {
 						enhancedPagination: ! value,

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	Notice,
-} from '@wordpress/components';
+import { ToggleControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -43,28 +39,25 @@ export default function EnhancedPaginationControl( {
 		);
 	}
 
+	const label = showAuto
+		? __( 'Enhanced pagination (auto)' )
+		: __( 'Enhanced pagination' );
+
 	return (
 		<>
-			<ToggleGroupControl
-				label={ __( 'Enhanced pagination' ) }
-				value={ !! enhancedPagination }
+			<ToggleControl
+				label={ label }
 				help={ __(
 					'Browsing between pages won’t require a full page reload.'
 				) }
-				onChange={ ( value ) =>
-					setAttributes( { enhancedPagination: value } )
-				}
-				isBlock
-			>
-				<ToggleGroupControlOption
-					value={ false }
-					label={ __( 'Off' ) }
-				/>
-				<ToggleGroupControlOption
-					value={ true }
-					label={ showAuto ? __( 'Auto' ) : __( 'On' ) }
-				/>
-			</ToggleGroupControl>
+				checked={ !! enhancedPagination }
+				disabled={ hasBlocksFromPlugins || hasPostContentBlock }
+				onChange={ ( value ) => {
+					setAttributes( {
+						enhancedPagination: !! value,
+					} );
+				} }
+			/>
 			{ notice && (
 				<Notice
 					status="warning"

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -11,23 +11,23 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	useHasBlocksFromPlugins,
-	useHasPostContentBlock,
-	useHasPatternsOrTemplateParts,
-} from '../../utils';
+import { useUnsupportedBlocks } from '../../utils';
 
 export default function EnhancedPaginationControl( {
 	enhancedPagination,
 	setAttributes,
 	clientId,
 } ) {
-	const hasBlocksFromPlugins = useHasBlocksFromPlugins( clientId );
-	const hasPostContentBlock = useHasPostContentBlock( clientId );
-	const hasSyncedBlocks = useHasPatternsOrTemplateParts( clientId );
+	const {
+		hasBlocksFromPlugins,
+		hasPostContentBlock,
+		hasPatternOrTemplatePartBlocks,
+	} = useUnsupportedBlocks( clientId );
 
 	const showAuto =
-		! hasBlocksFromPlugins && ! hasPostContentBlock && hasSyncedBlocks;
+		! hasBlocksFromPlugins &&
+		! hasPostContentBlock &&
+		hasPatternOrTemplatePartBlocks;
 
 	let notice = null;
 	if ( hasBlocksFromPlugins ) {
@@ -37,7 +37,7 @@ export default function EnhancedPaginationControl( {
 		notice = __(
 			'The Post Content block is not supported yet. For the enhanced pagination to work, remove the block, then re-enable "Enhanced pagination" in the Query Block settings.'
 		);
-	} else if ( enhancedPagination && hasSyncedBlocks ) {
+	} else if ( enhancedPagination && hasPatternOrTemplatePartBlocks ) {
 		notice = __(
 			'Blocks from plugins are not supported yet. Please note that if you add them to the patterns or template parts that are currently inside this Query block, this enhanced pagination will be automatically disabled.'
 		);
@@ -47,7 +47,7 @@ export default function EnhancedPaginationControl( {
 		<>
 			<ToggleGroupControl
 				label={ __( 'Enhanced pagination' ) }
-				value={ enhancedPagination }
+				value={ !! enhancedPagination }
 				help={ __(
 					'Browsing between pages won’t require a full page reload.'
 				) }

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { ToggleControl, Notice } from '@wordpress/components';
+import { ToggleControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -14,59 +14,36 @@ export default function EnhancedPaginationControl( {
 	setAttributes,
 	clientId,
 } ) {
-	const {
-		hasBlocksFromPlugins,
-		hasPostContentBlock,
-		hasPatternOrTemplatePartBlocks,
-	} = useUnsupportedBlocks( clientId );
+	const { hasBlocksFromPlugins, hasPostContentBlock } =
+		useUnsupportedBlocks( clientId );
 
-	const showAuto =
-		! hasBlocksFromPlugins &&
-		! hasPostContentBlock &&
-		hasPatternOrTemplatePartBlocks;
-
-	let notice = null;
-	if ( hasBlocksFromPlugins ) {
-		notice =
-			'Blocks from plugins are not supported yet. For the enhanced pagination to work, remove the blocks, then re-enable "Enhanced pagination" in the Query Block settings.';
-	} else if ( hasPostContentBlock ) {
-		notice = __(
-			'The Post Content block is not supported yet. For the enhanced pagination to work, remove the block, then re-enable "Enhanced pagination" in the Query Block settings.'
-		);
-	} else if ( enhancedPagination && hasPatternOrTemplatePartBlocks ) {
-		notice = __(
-			'Blocks from plugins are not supported yet. Please note that if you add them to the patterns or template parts that are currently inside this Query block, this enhanced pagination will be automatically disabled.'
-		);
-	}
-
-	const label = showAuto
-		? __( 'Enhanced pagination (auto)' )
-		: __( 'Enhanced pagination' );
+	const help = enhancedPagination ? (
+		<>
+			{ __(
+				'Browsing between pages will be seamless unless unexpected content is detected.'
+			) }{ ' ' }
+			<ExternalLink href="https://wordpress.org/">
+				{ __( 'Learn more' ) }
+			</ExternalLink>
+			{ '.' }
+		</>
+	) : (
+		__( 'Browsing between pages requires a full page reload.' )
+	);
 
 	return (
 		<>
 			<ToggleControl
-				label={ label }
-				help={ __(
-					'Browsing between pages won’t require a full page reload.'
-				) }
-				checked={ !! enhancedPagination }
+				label={ __( 'Force page reload' ) }
+				help={ help }
+				checked={ ! enhancedPagination }
 				disabled={ hasBlocksFromPlugins || hasPostContentBlock }
 				onChange={ ( value ) => {
 					setAttributes( {
-						enhancedPagination: !! value,
+						enhancedPagination: ! value,
 					} );
 				} }
 			/>
-			{ notice && (
-				<Notice
-					status="warning"
-					isDismissible={ false }
-					className="wp-block-query__enhanced-pagination-notice"
-				>
-					{ notice }
-				</Notice>
-			) }
 		</>
 	);
 }

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -177,6 +177,7 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 						$p->set_attribute( 'data-wp-navigation-disabled', 'true' );
 					}
 					$content = $p->get_updated_html();
+					$dirty_enhanced_queries[ $block['attrs']['queryId'] ] = null;
 				}
 
 				array_pop( $enhanced_query_stack );

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -92,7 +92,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 	}
 
 	$block_core_query_level -= 1;
-	if ( 0 === $block_core_query_level ) {
+	if ( 0 === $block_core_query_level && $block_core_query_has_plugin_blocks ) {
 		$block_core_query_has_plugin_blocks = false;
 	}
 
@@ -139,9 +139,11 @@ function block_core_query_check_plugin_blocks( $parsed_block, $source_block, $pa
 	global $block_core_query_level, $block_core_query_has_plugin_blocks;
 
 	$block_name = $parsed_block['blockName'];
+
 	if ( 'core/query' === $block_name ) {
 		$block_core_query_level += 1;
 	} elseif (
+		0 < $block_core_query_level &&
 		! $block_core_query_has_plugin_blocks &&
 		isset( $block_name ) &&
 		'core/' !== substr( $block_name, 0, 5 )

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -163,7 +163,9 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 			 */
 			$maybe_disable_enhanced_pagination = function ( $content, $block ) use ( &$enhanced_query_stack, &$dirty_enhanced_queries ) {
 				$has_enhanced_pagination = ! empty( $block['attrs']['enhancedPagination'] );
-				if ( ! $has_enhanced_pagination ) return $content;
+				if ( ! $has_enhanced_pagination ) {
+					return $content;
+				}
 
 				if ( isset( $dirty_enhanced_queries[ $block['attrs']['queryId'] ] ) ) {
 					$p = new WP_HTML_Tag_Processor( $content );

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -150,8 +150,7 @@ function block_core_query_check_plugin_blocks( $parsed_block, $source_block, $pa
 				if ( isset( $with_plugin_blocks[ $block['attrs']['queryId'] ]) ) {
 					$p = new WP_HTML_Tag_Processor( $block_content );
 					if ( $p->next_tag() ) {
-						$p->remove_attribute( 'data-wp-interactive' );
-						$p->remove_attribute( 'data-wp-navigation-id' );
+						$p->set_attribute( 'data-wp-navigation-disabled', 'true' );
 					}
 					$block_content = $p->get_updated_html();
 				}
@@ -160,7 +159,6 @@ function block_core_query_check_plugin_blocks( $parsed_block, $source_block, $pa
 
 				return $block_content;
 			};
-
 			add_filter( 'render_block_core/query', $render_query_block, 999, 3 );
 			$render_cb_registered = true;
 		}

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -180,7 +180,7 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 				return $content;
 			};
 
-			add_filter( 'render_block_core/query', $maybe_disable_enhanced_pagination, 999, 2 );
+			add_filter( 'render_block_core/query', $maybe_disable_enhanced_pagination, 10, 2 );
 			$render_cb_registered = true;
 		}
 	} elseif (
@@ -195,4 +195,4 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 
 	return $parsed_block;
 }
-add_filter( 'render_block_data', 'block_core_query_disable_enhanced_pagination', 999, 1 );
+add_filter( 'render_block_data', 'block_core_query_disable_enhanced_pagination', 10, 1 );

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -195,7 +195,7 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 	} elseif (
 		! empty( $enhanced_query_stack ) &&
 		isset( $block_name ) &&
-		'core/' !== substr( $block_name, 0, 5 )
+		( ! str_starts_with( $block_name, 'core/' ) || 'core/post-content' === $block_name )
 	) {
 		foreach ( $enhanced_query_stack as $query_id ) {
 			$dirty_enhanced_queries[ $query_id ] = true;

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -142,19 +142,26 @@ function block_core_query_check_plugin_blocks( $parsed_block, $source_block, $pa
 			 * That effectively disables the enhanced pagination.
 			 */
 			$render_query_block = function ( $block_content, $block, $instance ) use ( &$current_query_level, &$has_plugin_blocks ) {
+				$has_enhanced_pagination = isset( $block['attrs']['enhancedPagination'] ) && $block['attrs']['enhancedPagination'];
+				$content = $block_content;
+
+				if ( ! $has_enhanced_pagination ) return $content;
+
 				if ( $has_plugin_blocks ) {
 					$p = new WP_HTML_Tag_Processor( $block_content );
 					if ( $p->next_tag() ) {
 						$p->remove_attribute( 'data-wp-interactive' );
 						$p->remove_attribute( 'data-wp-navigation-id' );
 					}
-					return $p->get_updated_html();
+					$content = $p->get_updated_html();
 				}
 
 				$current_query_level -= 1;
 				if ( 0 === $current_query_level && $has_plugin_blocks ) {
 					$has_plugin_blocks = false;
 				}
+
+				return $content;
 			};
 
 			add_filter( 'render_block_core/query', $render_query_block, 999, 3 );

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -151,10 +151,10 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 
 		if ( ! $render_cb_registered ) {
 			/**
-			 * Filter that disables the enhanced pagination feature when a
-			 * plugin block is found inside. It does so by adding an attribute
-			 * called `data-wp-navigation-disabled` which is later handled by
-			 * the front-end logic.
+			 * Filter that disables the enhanced pagination feature during block
+			 * rendering when a plugin block has been found inside. It does so
+			 * by adding an attribute called `data-wp-navigation-disabled` which
+			 * is later handled by the front-end logic.
 			 *
 			 * @param string   $content  The block content.
 			 * @param array    $block    The full block, including name and attributes.

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -163,7 +163,7 @@ function block_core_query_check_plugin_blocks( $parsed_block, $source_block, $pa
 			$render_cb_registered = true;
 		}
 	} elseif (
-		count( $enhanced_query_stack ) > 0 &&
+		! empty( $enhanced_query_stack ) &&
 		isset( $block_name ) &&
 		'core/' !== substr( $block_name, 0, 5 )
 	) {

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -133,7 +133,6 @@ add_action( 'init', 'register_block_core_query' );
  * @since 6.4.0
  *
  * @param array $parsed_block The block being rendered.
- *
  * @return string Returns the parsed block, unmodified.
  */
 function block_core_query_disable_enhanced_pagination( $parsed_block ) {
@@ -160,7 +159,6 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 			 *
 			 * @param string   $content  The block content.
 			 * @param array    $block    The full block, including name and attributes.
-			 *
 			 * @return string Returns the modified output of the query block.
 			 */
 			$render_query_callback = static function ( $content, $block ) use ( &$enhanced_query_stack, &$dirty_enhanced_queries, &$render_query_callback ) {

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -161,7 +161,7 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 			 *
 			 * @return string Returns the modified output of the query block.
 			 */
-			$render_query_callback = static function ( $content, $block ) use ( &$enhanced_query_stack, &$dirty_enhanced_queries ) {
+			$render_query_callback = static function ( $content, $block ) use ( &$enhanced_query_stack, &$dirty_enhanced_queries, &$render_query_callback ) {
 				$has_enhanced_pagination = ! empty( $block['attrs']['enhancedPagination'] );
 				if ( ! $has_enhanced_pagination ) {
 					return $content;
@@ -176,6 +176,10 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 				}
 
 				array_pop( $enhanced_query_stack );
+				if ( empty( $enhanced_query_stack ) ) {
+					remove_filter( 'render_block_core/query', $render_query_callback );
+					$render_query_callback = null;
+				}
 
 				return $content;
 			};

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -363,9 +363,7 @@ export const useUnsupportedBlockList = ( clientId ) => {
 					const blockName = getBlockName( descendantClientId );
 					return (
 						! blockName.startsWith( 'core/' ) ||
-						blockName === 'core/post-content' ||
-						blockName === 'core/template-part' ||
-						blockName === 'core/block'
+						blockName === 'core/post-content'
 					);
 				}
 			);

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -347,22 +347,22 @@ export const usePatterns = ( clientId, name ) => {
 
 /**
  * The object returned by useUnsupportedBlocks with info about the type of
- * unsupported blocks present in the Query block.
+ * unsupported blocks present inside the Query block.
  *
  * @typedef  {Object}  UnsupportedBlocksInfo
  * @property {boolean} hasBlocksFromPlugins True if blocks from plugins are present.
  * @property {boolean} hasPostContentBlock  True if a 'core/post-content' block is present.
- * @property {boolean} hasUnsupportedBlocks True if there are any unsupported blocks (i.e., when bitSum !== 0).
+ * @property {boolean} hasUnsupportedBlocks True if there are any unsupported blocks.
  */
 
 /**
  * Hook that returns an object with information about the unsupported blocks
- * present inside a Query Loop with the given `clientId`. The returned contains
- * props that are true when a certain type of block is present. It also returns
- * a bit sum to be able easily compare when the blocks have changed.
+ * present inside a Query Loop with the given `clientId`. The returned object
+ * contains props that are true when a certain type of unsupported block is
+ * present.
  *
  * @param {string} clientId The block's client ID.
- * @return {UnsupportedBlocksInfo} The object containing all the info.
+ * @return {UnsupportedBlocksInfo} The object containing the information.
  */
 export const useUnsupportedBlocks = ( clientId ) => {
 	return useSelect(

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -352,20 +352,71 @@ export const usePatterns = ( clientId, name ) => {
  * @param {string} clientId The block's client ID.
  * @return {string[]} List of block titles.
  */
-export const useUnsupportedBlockList = ( clientId ) => {
+export const useHasBlocksFromPlugins = ( clientId ) => {
 	return useSelect(
 		( select ) => {
 			const { getClientIdsOfDescendants, getBlockName } =
 				select( blockEditorStore );
+			return (
+				getClientIdsOfDescendants( clientId ).filter(
+					( descendantClientId ) => {
+						const blockName = getBlockName( descendantClientId );
+						return ! blockName.startsWith( 'core/' );
+					}
+				).length > 0
+			);
+		},
+		[ clientId ]
+	);
+};
 
-			return getClientIdsOfDescendants( clientId ).filter(
-				( descendantClientId ) => {
-					const blockName = getBlockName( descendantClientId );
-					return (
-						! blockName.startsWith( 'core/' ) ||
-						blockName === 'core/post-content'
-					);
-				}
+/**
+ * Hook that returns a list of unsupported blocks inside the Query Loop with the
+ * given `clientId`.
+ *
+ * @param {string} clientId The block's client ID.
+ * @return {string[]} List of block titles.
+ */
+export const useHasPostContentBlock = ( clientId ) => {
+	return useSelect(
+		( select ) => {
+			const { getClientIdsOfDescendants, getBlockName } =
+				select( blockEditorStore );
+			return (
+				getClientIdsOfDescendants( clientId ).filter(
+					( descendantClientId ) => {
+						const blockName = getBlockName( descendantClientId );
+						return blockName === 'core/post-content';
+					}
+				).length > 0
+			);
+		},
+		[ clientId ]
+	);
+};
+
+/**
+ * Hook that returns a list of blocks where it's not possible to know if their
+ * inner blocks are supported or not.
+ *
+ * @param {string} clientId The block's client ID.
+ * @return {string[]} List of block titles.
+ */
+export const useHasPatternsOrTemplateParts = ( clientId ) => {
+	return useSelect(
+		( select ) => {
+			const { getClientIdsOfDescendants, getBlockName } =
+				select( blockEditorStore );
+			return (
+				getClientIdsOfDescendants( clientId ).filter(
+					( descendantClientId ) => {
+						const blockName = getBlockName( descendantClientId );
+						return (
+							blockName === 'core/template-part' ||
+							blockName === 'core/block'
+						);
+					}
+				).length > 0
 			);
 		},
 		[ clientId ]

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -36,8 +36,10 @@ store( {
 					if ( isValidLink( ref ) && isValidEvent( event ) ) {
 						event.preventDefault();
 
-						const id = ref.closest( '[data-wp-navigation-id]' )
-							.dataset.wpNavigationId;
+						const {
+							wpNavigationId: id,
+							wpNavigationDisabled: isDisabled,
+						} = ref.closest( '[data-wp-navigation-id]' ).dataset;
 
 						// Don't announce the navigation immediately, wait 400 ms.
 						const timeout = setTimeout( () => {
@@ -46,7 +48,12 @@ store( {
 							context.core.query.animation = 'start';
 						}, 400 );
 
-						await navigate( ref.href );
+						if ( isDisabled ) {
+							window.location.assign( ref.href );
+							await new Promise( () => {} );
+						} else {
+							await navigate( ref.href );
+						}
 
 						// Dismiss loading message if it hasn't been added yet.
 						clearTimeout( timeout );
@@ -70,7 +77,9 @@ store( {
 					}
 				},
 				prefetch: async ( { ref } ) => {
-					if ( isValidLink( ref ) ) {
+					const isDisabled = ref.closest( '[data-wp-navigation-id]' )
+						.dataset.wpNavigationDisabled;
+					if ( isValidLink( ref ) && ! isDisabled ) {
 						await prefetch( ref.href );
 					}
 				},

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -34,7 +34,7 @@ store( {
 			query: {
 				navigate: async ( { event, ref, context } ) => {
 					const isDisabled = ref.closest( '[data-wp-navigation-id]' )
-						.dataset.wpNavigationDisabled;
+						?.dataset.wpNavigationDisabled;
 
 					if (
 						isValidLink( ref ) &&
@@ -78,7 +78,7 @@ store( {
 				},
 				prefetch: async ( { ref } ) => {
 					const isDisabled = ref.closest( '[data-wp-navigation-id]' )
-						.dataset.wpNavigationDisabled;
+						?.dataset.wpNavigationDisabled;
 					if ( isValidLink( ref ) && ! isDisabled ) {
 						await prefetch( ref.href );
 					}

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -53,12 +53,7 @@ store( {
 							context.core.query.animation = 'start';
 						}, 400 );
 
-						if ( isDisabled ) {
-							window.location.assign( ref.href );
-							await new Promise( () => {} );
-						} else {
-							await navigate( ref.href );
-						}
+						await navigate( ref.href );
 
 						// Dismiss loading message if it hasn't been added yet.
 						clearTimeout( timeout );

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -33,13 +33,18 @@ store( {
 		core: {
 			query: {
 				navigate: async ( { event, ref, context } ) => {
-					if ( isValidLink( ref ) && isValidEvent( event ) ) {
+					const isDisabled = ref.closest( '[data-wp-navigation-id]' )
+						.dataset.wpNavigationDisabled;
+
+					if (
+						isValidLink( ref ) &&
+						isValidEvent( event ) &&
+						! isDisabled
+					) {
 						event.preventDefault();
 
-						const {
-							wpNavigationId: id,
-							wpNavigationDisabled: isDisabled,
-						} = ref.closest( '[data-wp-navigation-id]' ).dataset;
+						const id = ref.closest( '[data-wp-navigation-id]' )
+							.dataset.wpNavigationId;
 
 						// Don't announce the navigation immediately, wait 400 ms.
 						const timeout = setTimeout( () => {

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Tests for the Query block rendering.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.0.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RenderQueryBlock extends WP_UnitTestCase {
+
+	private static $post_1;
+	private static $post_2;
+	private static $post_3;
+
+	public function set_up() {
+		parent::set_up();
+
+		self::$post_1 = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_name'    => 'post-1',
+				'post_title'   => 'Post 1',
+				'post_content' => 'Post 1 content',
+				'post_excerpt' => 'Post 1',
+			)
+		);
+
+		self::$post_2 = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_name'    => 'post-2',
+				'post_title'   => 'Post 2',
+				'post_content' => 'Post 2 content',
+				'post_excerpt' => 'Post 2',
+			)
+		);
+	}
+
+	/**
+	 * Tests that the `core/block` block adds the corresponding directives when
+	 * the `enhancedPagination` attribute is set.
+	 */
+	public function test_rendering_query_with_enhanced_pagination() {
+		global $wp_query, $wp_the_query;
+
+		$content = <<<HTML
+		<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
+		<div class="wp-block-query">
+			<!-- wp:post-template {"align":"wide"} -->
+			<!-- /wp:post-template -->
+			<!-- wp:query-pagination -->
+				<!-- wp:query-pagination-previous /-->
+				<!-- wp:query-pagination-next /-->
+			<!-- /wp:query-pagination -->
+		</div>
+		<!-- /wp:query -->
+HTML;
+
+		// Set main query to single post.
+		$wp_query = new WP_Query(
+			array(
+				'posts_per_page' => 1,
+			)
+		);
+
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$p = new WP_HTML_Tag_Processor( $output );
+
+		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
+		$this->assertSame( '{"core":{"query":{"loadingText":"Loading page, please wait.","loadedText":"Page Loaded."}}}', $p->get_attribute( 'data-wp-context' ) );
+		$this->assertSame( 'query-0', $p->get_attribute( 'data-wp-navigation-id' ) );
+		$this->assertSame( true, $p->get_attribute( 'data-wp-interactive' ) );
+
+		$p->next_tag( array( 'class_name' => 'wp-block-post' ) );
+		$this->assertSame( 'post-template-item-' . self::$post_2->ID, $p->get_attribute( 'data-wp-key' ) );
+
+		$p->next_tag( array( 'class_name' => 'wp-block-query-pagination-next' ) );
+		$this->assertSame( 'query-pagination-next', $p->get_attribute( 'data-wp-key' ) );
+		$this->assertSame( 'actions.core.query.navigate', $p->get_attribute( 'data-wp-on--click' ) );
+		$this->assertSame( 'actions.core.query.prefetch', $p->get_attribute( 'data-wp-on--mouseenter' ) );
+		$this->assertSame( 'effects.core.query.prefetch', $p->get_attribute( 'data-wp-effect' ) );
+
+		$p->next_tag( array( 'class_name' => 'screen-reader-text' ) );
+		$this->assertSame( 'polite', $p->get_attribute( 'aria-live' ) );
+		$this->assertSame( 'context.core.query.message', $p->get_attribute( 'data-wp-text' ) );
+
+		$p->next_tag( array( 'class_name' => 'wp-block-query__enhanced-pagination-animation' ) );
+		$this->assertSame( 'selectors.core.query.startAnimation', $p->get_attribute( 'data-wp-class--start-animation' ) );
+		$this->assertSame( 'selectors.core.query.finishAnimation', $p->get_attribute( 'data-wp-class--finish-animation' ) );
+	}
+
+
+
+	/**
+	 * Tests that the `core/block` block adds an extra attribute to disable the
+	 * enhanced pagination in the browser when a plugin block is found inside.
+	 */
+	public function test_rendering_query_with_enhanced_pagination_auto_disabled() {
+		global $wp_query, $wp_the_query;
+
+		$content = <<<HTML
+		<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
+		<div class="wp-block-query">
+			<!-- wp:post-template {"align":"wide"} -->
+				<!-- wp:test/plugin-block /-->
+			<!-- /wp:post-template -->
+			<!-- wp:query-pagination -->
+				<!-- wp:query-pagination-previous /-->
+				<!-- wp:query-pagination-next /-->
+			<!-- /wp:query-pagination -->
+		</div>
+		<!-- /wp:query -->
+HTML;
+
+		// Set main query to single post.
+		$wp_query = new WP_Query(
+			array(
+				'posts_per_page' => 1,
+			)
+		);
+
+		$wp_the_query = $wp_query;
+
+		register_block_type(
+			'test/plugin-block',
+			array(
+				'render_callback' => static function () {
+					return '<div class="wp-block-test/plugin-block">Test</div>';
+				},
+			)
+		);
+
+		$output = do_blocks( $content );
+
+		$p = new WP_HTML_Tag_Processor( $output );
+
+		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
+		$this->assertSame( 'query-0', $p->get_attribute( 'data-wp-navigation-id' ) );
+		$this->assertSame( 'true', $p->get_attribute( 'data-wp-navigation-disabled' ) );
+	}
+}

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -61,8 +61,8 @@ class Tests_Blocks_RenderQueryBlock extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
 		unregister_block_type( 'test/plugin-block' );
+		parent::tear_down();
 	}
 
 	/**

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -136,7 +136,7 @@ HTML;
 	 * Tests that the `core/query` block adds an extra attribute to disable the
 	 * enhanced pagination in the browser when a plugin block is found inside.
 	 */
-	public function test_rendering_query_with_enhanced_pagination_auto_disabled() {
+	public function test_rendering_query_with_enhanced_pagination_auto_disabled_when_plugins_blocks_are_found() {
 		global $wp_query, $wp_the_query;
 
 		$content = <<<HTML
@@ -144,6 +144,41 @@ HTML;
 		<div class="wp-block-query">
 			<!-- wp:post-template {"align":"wide"} -->
 				<!-- wp:test/plugin-block /-->
+			<!-- /wp:post-template -->
+		</div>
+		<!-- /wp:query -->
+HTML;
+
+		// Set main query to single post.
+		$wp_query = new WP_Query(
+			array(
+				'posts_per_page' => 1,
+			)
+		);
+
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$p = new WP_HTML_Tag_Processor( $output );
+
+		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
+		$this->assertSame( 'query-0', $p->get_attribute( 'data-wp-navigation-id' ) );
+		$this->assertSame( 'true', $p->get_attribute( 'data-wp-navigation-disabled' ) );
+	}
+
+	/**
+	 * Tests that the `core/query` block adds an extra attribute to disable the
+	 * enhanced pagination in the browser when a post content block is found inside.
+	 */
+	public function test_rendering_query_with_enhanced_pagination_auto_disabled_when_post_content_block_is_found() {
+		global $wp_query, $wp_the_query;
+
+		$content = <<<HTML
+		<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
+		<div class="wp-block-query">
+			<!-- wp:post-template {"align":"wide"} -->
+				<!-- wp:post-content /-->
 			<!-- /wp:post-template -->
 		</div>
 		<!-- /wp:query -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/55706.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The main problem is explained in the following issue:

- https://github.com/WordPress/gutenberg/issues/55706

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By applying two changes:

- If there is a Pattern or Template Part inside the Query block, switch to "Auto" and inform the user.
- During the rendering, check that all the inner blocks are compatible. If we find one that it's not, disable the enhanced pagination.

I tried to use `ToggleGroupControl` instead of `ToggleControl` because it makes the change to "Auto" much more explicit, but `ToggleGroupControl` has a bug when the value is changed programmatically using `setAttributes()`. Also, `ToggleGroupControl` doesn't have support yet for _disabled_, which is required for this use case.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Add a Query block with some regular core blocks (group, featured image, post title…).
- Make sure that the enhanced pagination can be enabled as previously (no change).
- Enable it.
- Now add a synced Pattern or Template Part somewhere inside the Query block.
- You should see a modal informing that the enhanced pagination has switch to "Auto".
- Check the enhanced pagination setting, you should see a similar message in the Inspector Panel.
- Add another Pattern or Template Part. The modal should not appear again.
- Add a Post Content block.
- A new modal should appear informing you that the enhanced pagination has been disabled.
- Check the enhanced pagination setting, you should see a new message in the Inspector Panel.
- Now the enhanced pagination should not mention "Auto" and instead, be turned off and disabled.
- Remove the Post Content block.
- Check that the enhanced pagination has switched back to "Auto" and that it can be enabled again.
- Now repeat the last process using a block from an external plugin.
- You should see messages similar to the Post Content block.
- Check that adding more blocks don't trigger new modals, unless they are of different types and the settings changes from less restrictive to more restrive.

## Screenshots or screencast

I made a video to explain how the UX works, especially to get feedback from design about the "Auto" mode:

<div>
    <a href="https://www.loom.com/share/311ee1534a1641a786b765b6cbff48bb">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/311ee1534a1641a786b765b6cbff48bb-with-play.gif">
    </a>
  </div>

https://www.loom.com/share/311ee1534a1641a786b765b6cbff48bb

_[Drawings](https://excalidraw.com/#json=LujV45t88k1zcz2ZtIUku,nJNvbjk1uvKz4QlR-fcK_w)_

## Tasks

- [ ] Add PHP unit tests
- [ ] Get feedback on the texts
- [ ] Get feedback on the UX
- [ ] Make sure that we don't need to support `core/pattern`
