### PR TITLE
test: E2E test setup script creates iOS simulators

### DIFF
--- a/packages/react-native-editor/__device-tests__/README.md
+++ b/packages/react-native-editor/__device-tests__/README.md
@@ -4,7 +4,7 @@ The Mobile Gutenberg (MG) project maintains a suite of automated end-to-end (E2E
 
 ## Setup
 
-Before setting up Appium, the required iOS and Android dependencies must be installed.
+Before setting up the E2E test environment, the required iOS and Android dependencies must be installed.
 
 > **Note**
 > The required dependencies change overtime. We do our best to update the scripts documented below, but it is best to review the [Appium capabilities](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/__device-tests__/helpers/caps.js) configuration to identify the currently required `deviceName` and `platformVersion` for each of the iOS and Android platforms.
@@ -13,18 +13,15 @@ Before setting up Appium, the required iOS and Android dependencies must be inst
 
 -   Complete the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide, which covers installing and setting up Xcode.
 -   Open [Xcode settings](https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-in-settings) to install the iOS 16.2 simulator runtime.
--   Create the required simulators by running the follow scripts in your shell:
-    -   `xcrun simctl create "iPhone 14" "iPhone 14" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"`
-    -   `xcrun simctl create "iPad (10th generation)" "iPad (10th generation)" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"`
 
 ### Android
 
 -   Complete the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide, which covers installing and setting up Android Studio and the Android SDK.
 -   Open Android Studio and [create an emulator](https://developer.android.com/studio/run/managing-avds) for a Pixel 3 XL running Android 11.0 with the “Enable Device Frame” option disabled.
 
-### Appium
+### Test Environment
 
-The MG project provides a script to set up the testing environment, installing the necessary Appium dependencies.
+After installing the iOS and Android dependencies, the MG project provides a script to set up the testing environment, verifying necessary dependencies are available.
 
 ```shell
 npm run native test:e2e:setup

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -42,11 +42,11 @@ function detect_or_create_simulator() {
 	local simulators=$(xcrun simctl list devices -j | jq -r --arg runtime "$runtime_name" '.devices | to_entries[] | select(.key | contains($runtime)) | .value[] | .name + "," + .udid')
 
 	if ! echo "$simulators" | grep -q "$simulator_name"; then
-		echo "[info] $simulator_name simulator running $runtime_name_display not found, creating..."
+		echo "[info] $simulator_name ($runtime_name_display) not available, creating..."
 		xcrun simctl create "$simulator_name" "$simulator_name" "com.apple.CoreSimulator.SimRuntime.$runtime_name" > /dev/null
-		echo "[info] $simulator_name simulator running $runtime_name_display created."
+		echo "[info] $simulator_name ($runtime_name_display) created."
 	else
-		echo "[info] $simulator_name simulator running $runtime_name_display found."
+		echo "[info] $simulator_name ($runtime_name_display) available."
 	fi
 }
 

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -28,6 +28,13 @@ fi
 CONFIG_FILE="$(pwd)/__device-tests__/helpers/device-config.json"
 IOS_PLATFORM_VERSION=$(jq -r '.ios.local.platformVersion' "$CONFIG_FILE")
 
+# Throw an error if the required iOS runtime is not installed
+if ! xcrun simctl list runtimes -j | jq -r --arg version "$IOS_PLATFORM_VERSION" '.runtimes | to_entries[] | select(.value.version | contains($version))' > /dev/null; then
+	echo "[error] iOS $IOS_PLATFORM_VERSION runtime not found! Please install the iOS $IOS_PLATFORM_VERSION runtime using Xcode."
+	echo "        https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-in-settings"
+	exit 1;
+fi
+
 function detect_or_create_simulator() {
 	local simulator_name=$1
 	local runtime_name_display=$(echo "iOS $IOS_PLATFORM_VERSION")

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -25,6 +25,31 @@ else
 	$APPIUM_CMD driver install xcuitest
 fi
 
+CONFIG_FILE="$(pwd)/__device-tests__/helpers/device-config.json"
+IOS_PLATFORM_VERSION=$(jq -r '.ios.local.platformVersion' "$CONFIG_FILE")
+
+function detect_or_create_simulator() {
+	local simulator_name=$1
+	local runtime_name_display=$(echo "iOS $IOS_PLATFORM_VERSION")
+	local runtime_name=$(echo "$runtime_name_display" | sed 's/ /-/g; s/\./-/g')
+	local simulators=$(xcrun simctl list devices -j | jq -r --arg runtime "$runtime_name" '.devices | to_entries[] | select(.key | contains($runtime)) | .value[] | .name + "," + .udid')
+
+	if ! echo "$simulators" | grep -q "$simulator_name"; then
+		echo "[info] $simulator_name simulator running $runtime_name_display not found, creating..."
+		xcrun simctl create "$simulator_name" "$simulator_name" "com.apple.CoreSimulator.SimRuntime.$runtime_name" > /dev/null
+		echo "[info] $simulator_name simulator running $runtime_name_display created."
+	else
+		echo "[info] $simulator_name simulator running $runtime_name_display found."
+	fi
+}
+
+IOS_DEVICE_NAME=$(jq -r '.ios.local.deviceName' "$CONFIG_FILE")
+IOS_DEVICE_TABLET_NAME=$(jq -r '.ios.local.deviceTabletName' "$CONFIG_FILE")
+
+# Create the required iOS simulators, if they don't exist
+detect_or_create_simulator "$IOS_DEVICE_NAME"
+detect_or_create_simulator "$IOS_DEVICE_TABLET_NAME"
+
 # Mitigate conflicts between development server caches and E2E tests
 npm run clean:runtime > /dev/null
 echo '[info] Runtime cache cleaned.'

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -10,15 +10,15 @@ else
 fi
 
 function log_info() {
-	printf "[info] $1\n"
+	printf "ℹ️  $1\n"
 }
 
 function log_success {
-	printf "[success] $1\n"
+	printf "✅ $1\n"
 }
 
 function log_error() {
-	printf "[error] $1\n"
+	printf "❌ $1\n"
 }
 
 output=$($APPIUM_CMD driver list --installed --json)
@@ -42,7 +42,7 @@ IOS_PLATFORM_VERSION=$(jq -r '.ios.local.platformVersion' "$CONFIG_FILE")
 
 # Throw an error if the required iOS runtime is not installed
 if ! xcrun simctl list runtimes -j | jq -r --arg version "$IOS_PLATFORM_VERSION" '.runtimes | to_entries[] | select(.value.version | contains($version))' > /dev/null; then
-	log_error "iOS $IOS_PLATFORM_VERSION runtime not found! Please install the iOS $IOS_PLATFORM_VERSION runtime using Xcode.\n         https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-in-settings"
+	log_error "iOS $IOS_PLATFORM_VERSION runtime not found! Please install the iOS $IOS_PLATFORM_VERSION runtime using Xcode.\n    https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-in-settings"
 	exit 1;
 fi
 

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -41,7 +41,8 @@ CONFIG_FILE="$(pwd)/__device-tests__/helpers/device-config.json"
 IOS_PLATFORM_VERSION=$(jq -r '.ios.local.platformVersion' "$CONFIG_FILE")
 
 # Throw an error if the required iOS runtime is not installed
-if ! xcrun simctl list runtimes -j | jq -r --arg version "$IOS_PLATFORM_VERSION" '.runtimes | to_entries[] | select(.value.version | contains($version))' > /dev/null; then
+IOS_RUNTIME_INSTALLED=$(xcrun simctl list runtimes -j | jq -r --arg version "$IOS_PLATFORM_VERSION" '.runtimes | to_entries[] | select(.value.version | contains($version))')
+if [[ -z $IOS_RUNTIME_INSTALLED ]]; then
 	log_error "iOS $IOS_PLATFORM_VERSION runtime not found! Please install the iOS $IOS_PLATFORM_VERSION runtime using Xcode.\n    https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-in-settings"
 	exit 1;
 fi

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -3,26 +3,26 @@
 set -o pipefail
 
 if command -v appium >/dev/null 2>&1; then
-    APPIUM_CMD="appium"
+	APPIUM_CMD="appium"
 else
-    # Use relative path to access the locally installed appium
-    APPIUM_CMD="../../../node_modules/.bin/appium"
+	# Use relative path to access the locally installed appium
+	APPIUM_CMD="../../../node_modules/.bin/appium"
 fi
 
 output=$($APPIUM_CMD driver list --installed --json)
 
 if echo "$output" | grep -q 'uiautomator2'; then
-    echo '[info] UiAutomator2 is installed, skipping installation.'
+	echo '[info] UiAutomator2 is installed, skipping installation.'
 else
-    echo '[info] UiAutomator2 not found, installing...'
-    $APPIUM_CMD driver install uiautomator2
+	echo '[info] UiAutomator2 not found, installing...'
+	$APPIUM_CMD driver install uiautomator2
 fi
 
 if echo "$output" | grep -q 'xcuitest'; then
-    echo '[info] XCUITest is installed, skipping installation.'
+	echo '[info] XCUITest is installed, skipping installation.'
 else
-    echo '[info] XCUITest not found, installing...'
-    $APPIUM_CMD driver install xcuitest
+	echo '[info] XCUITest not found, installing...'
+	$APPIUM_CMD driver install xcuitest
 fi
 
 # Mitigate conflicts between development server caches and E2E tests


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Expand the E2E test setup script to ensure the required iOS simulators are
available.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to https://github.com/WordPress/gutenberg/issues/55251. Simplify setting
up the E2E test environment by automating the process for creating the required
iOS simulators.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Convert spaces to tabs to match project
- E2E test script detects or creates iOS simulators
- E2E setup script throws error if required iOS runtime unavailable
- Update E2E test environment setup documentation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
**With required simulators unavailable**
1. Delete the iPhone 14 and iPad (10th generation) simulators via `xcrun simctl delete <device-id>`. 
2. Run `npm run native test:e2e:setup`
3. Verify the correct iOS simulators are created. 

**With required simulators available**
1. Verity the iPhone 14 and iPad (10th generation) simulators are available via `xcrun simctl list devices`. 
2. Run `npm run native test:e2e:setup`
3. Verify duplicative simulators are not created. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
