### PR TITLE
Query: Require queryId for enhanced pagination to prevent PHP notices.

### DIFF
--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -10,14 +10,14 @@
  *
  * @since 6.4.0
  *
- * @param array  $attributes Block attributes.
- * @param string $content    Block default content.
- * @param string $block      Block instance.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      The block instance.
  *
  * @return string Returns the modified output of the query block.
  */
 function render_block_core_query( $attributes, $content, $block ) {
-	if ( $attributes['enhancedPagination'] ) {
+	if ( $attributes['enhancedPagination'] && isset( $attributes['queryId'] ) ) {
 		$p = new WP_HTML_Tag_Processor( $content );
 		if ( $p->next_tag() ) {
 			// Add the necessary directives.
@@ -67,11 +67,14 @@ function render_block_core_query( $attributes, $content, $block ) {
 	if ( ! wp_script_is( $view_asset ) ) {
 		$script_handles = $block->block_type->view_script_handles;
 		// If the script is not needed, and it is still in the `view_script_handles`, remove it.
-		if ( ! $attributes['enhancedPagination'] && in_array( $view_asset, $script_handles, true ) ) {
+		if (
+			( ! $attributes['enhancedPagination'] || ! isset( $attributes['queryId'] ) )
+			&& in_array( $view_asset, $script_handles, true )
+		) {
 			$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_asset ) );
 		}
 		// If the script is needed, but it was previously removed, add it again.
-		if ( $attributes['enhancedPagination'] && ! in_array( $view_asset, $script_handles, true ) ) {
+		if ( $attributes['enhancedPagination'] && isset( $attributes['queryId'] ) && ! in_array( $view_asset, $script_handles, true ) ) {
 			$block->block_type->view_script_handles = array_merge( $script_handles, array( $view_asset ) );
 		}
 	}
@@ -80,11 +83,14 @@ function render_block_core_query( $attributes, $content, $block ) {
 	if ( ! wp_style_is( $style_asset ) ) {
 		$style_handles = $block->block_type->style_handles;
 		// If the styles are not needed, and they are still in the `style_handles`, remove them.
-		if ( ! $attributes['enhancedPagination'] && in_array( $style_asset, $style_handles, true ) ) {
+		if (
+			( ! $attributes['enhancedPagination'] || ! isset( $attributes['queryId'] ) )
+			&& in_array( $style_asset, $style_handles, true )
+		) {
 			$block->block_type->style_handles = array_diff( $style_handles, array( $style_asset ) );
 		}
 		// If the styles are needed, but they were previously removed, add them again.
-		if ( $attributes['enhancedPagination'] && ! in_array( $style_asset, $style_handles, true ) ) {
+		if ( $attributes['enhancedPagination'] && isset( $attributes['queryId'] ) && ! in_array( $style_asset, $style_handles, true ) ) {
 			$block->block_type->style_handles = array_merge( $style_handles, array( $style_asset ) );
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a check to ensure the Query ID is set before rendering enhanced pagination.

Fixes #55719.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without a Query ID the enhanced pagination will throw a notice. The Query ID doesn't include a default so can be unset.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Within `render_block_core_query()` the conditions checking `$attributes['enhancedPagination']` are modified to also check `isset( $attributes['queryId'] )`. If either item is not set then the feature is not enabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Enable debug mode in your wp-config file:
   ```php
   define( 'WP_DEBUG', true );
   define( 'WP_DEBUG_LOG', true );
   define( 'WP_DEBUG_DISPLAY', true );
   ```
2. Download and activate  [peters-sample-theme.zip](https://github.com/WordPress/gutenberg/files/13211136/peters-sample-theme.zip) which contains bad markup in `templates/index.html`
3. Generate some sample posts via WP CLI: `wp post generate`
4. Visit the the front end of the site.
   - on trunk you should see some notices thrown
   - on this branch the notices should not throw
5. Activate the TT2 theme
6. Edit the home page to enable advanced pagination on the query loop
7. Navigate posts, ensure advanced pagination works.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->
