### PR TITLE
Block Editor: Optimize 'anchor' inspector controls

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -126,18 +126,17 @@ function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
 export const withInspectorControl = createHigherOrderComponent(
 	( BlockEdit ) => {
 		return ( props ) => {
-			const hasAnchor = hasBlockSupport( props.name, 'anchor' );
-
 			return (
 				<>
 					<BlockEdit { ...props } />
-					{ hasAnchor && props.isSelected && (
-						<BlockEditAnchorControl
-							blockName={ props.name }
-							attributes={ props.attributes }
-							setAttributes={ props.setAttributes }
-						/>
-					) }
+					{ props.isSelected &&
+						hasBlockSupport( props.name, 'anchor' ) && (
+							<BlockEditAnchorControl
+								blockName={ props.name }
+								attributes={ props.attributes }
+								setAttributes={ props.setAttributes }
+							/>
+						) }
 				</>
 			);
 		};


### PR DESCRIPTION
## What?
This is similar to #55345.

A micro-optimization for `anchor` inspector controls to avoid calling `useBlockEditingMode` for every block rendered in the editor and only render control when a block is selected.

## Why?
This control is only needed when editing a block.

## How?
I tried to keep the changes to a minimum. PR extracts essential logic for the field into a separate component, only rendered when the block supports an `anchor` and is selected.

## Testing Instructions
1. Open a post or page.
2. Add a paragraph or a heading block.
3. Navigate to Advanced settings in the sidebar.
4. Change the "HTML Anchor".
5. The setting should work as before.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-10-31 at 11 48 54](https://github.com/WordPress/gutenberg/assets/240569/094f1eed-4776-4cb3-9f6b-547bbab0460e)
