### PR TITLE
DataViews: list all users in author filter

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -94,9 +94,7 @@ export default function PagePages() {
 		totalPages,
 	} = useEntityRecords( 'postType', 'page', queryArgs );
 
-	const { records: authors } = useEntityRecords( 'root', 'user', {
-		has_published_posts: [ 'page' ],
-	} );
+	const { records: authors } = useEntityRecords( 'root', 'user' );
 
 	const paginationInfo = useMemo(
 		() => ( {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow up to https://github.com/WordPress/gutenberg/pull/55455#discussion_r1367478553

## What?

This PR lists all users in the authors component. Before it only listed the ones with published posts.

## Why?

Since we now list pages that may not be published yet (draft, scheduled), some authors were not listed in the component.

## Testing Instructions

- Create a new user and make it create a draft page. Do not publish it.
- With the "wp-admin" experiment enabled, go to "Appearance > Editor > Pages > Manage all pages".
- Verify that the draft page is listed and that the user is also present in the "Authors" filter (it wasn't before this PR).
