### PR TITLE
Form Blocks: Capitalize title and end the description with a period

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -287,7 +287,7 @@ A form. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/blo
 -	**Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** action, email, method, submissionMethod
 
-## Input field
+## Input Field
 
 The basic building block for forms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form-input))
 
@@ -309,7 +309,7 @@ Provide a notification message after the form has been submitted. ([Source](http
 -	**Supports:** 
 -	**Attributes:** type
 
-## Form submit button
+## Form Submit Button
 
 A submission button for forms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/form-submit-button))
 

--- a/packages/block-library/src/form-input/block.json
+++ b/packages/block-library/src/form-input/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"__experimental": true,
 	"name": "core/form-input",
-	"title": "Input field",
+	"title": "Input Field",
 	"category": "common",
 	"parent": [ "core/form" ],
 	"description": "The basic building block for forms.",

--- a/packages/block-library/src/form-input/variations.js
+++ b/packages/block-library/src/form-input/variations.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 const variations = [
 	{
 		name: 'text',
-		title: __( 'Text input' ),
+		title: __( 'Text Input' ),
 		icon: 'edit-page',
 		description: __( 'A generic text input.' ),
 		attributes: { type: 'text' },
@@ -17,7 +17,7 @@ const variations = [
 	},
 	{
 		name: 'textarea',
-		title: __( 'Textarea input' ),
+		title: __( 'Textarea Input' ),
 		icon: 'testimonial',
 		description: __(
 			'A textarea input to allow entering multiple lines of text.'
@@ -29,7 +29,7 @@ const variations = [
 	},
 	{
 		name: 'checkbox',
-		title: __( 'Checkbox input' ),
+		title: __( 'Checkbox Input' ),
 		description: __( 'A simple checkbox input.' ),
 		icon: 'forms',
 		attributes: { type: 'checkbox', inlineLabel: true },
@@ -39,7 +39,7 @@ const variations = [
 	},
 	{
 		name: 'email',
-		title: __( 'Email input' ),
+		title: __( 'Email Input' ),
 		icon: 'email',
 		description: __( 'Used for email addresses.' ),
 		attributes: { type: 'email' },
@@ -49,7 +49,7 @@ const variations = [
 	},
 	{
 		name: 'url',
-		title: __( 'URL input' ),
+		title: __( 'URL Input' ),
 		icon: 'admin-site',
 		description: __( 'Used for URLs.' ),
 		attributes: { type: 'url' },
@@ -59,7 +59,7 @@ const variations = [
 	},
 	{
 		name: 'tel',
-		title: __( 'Telephone input' ),
+		title: __( 'Telephone Input' ),
 		icon: 'phone',
 		description: __( 'Used for phone numbers.' ),
 		attributes: { type: 'tel' },
@@ -69,7 +69,7 @@ const variations = [
 	},
 	{
 		name: 'number',
-		title: __( 'Number input' ),
+		title: __( 'Number Input' ),
 		icon: 'edit-page',
 		description: __( 'A numeric input.' ),
 		attributes: { type: 'number' },

--- a/packages/block-library/src/form-submission-notification/variations.js
+++ b/packages/block-library/src/form-submission-notification/variations.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 const variations = [
 	{
 		name: 'form-submission-success',
-		title: __( 'Form submission success' ),
-		description: __( 'Success message for form submissions' ),
+		title: __( 'Form Submission Success' ),
+		description: __( 'Success message for form submissions.' ),
 		attributes: {
 			type: 'success',
 		},
@@ -31,8 +31,8 @@ const variations = [
 	},
 	{
 		name: 'form-submission-error',
-		title: __( 'Form submission error' ),
-		description: __( 'Error/failure message for form submissions' ),
+		title: __( 'Form Submission Error' ),
+		description: __( 'Error/failure message for form submissions.' ),
 		attributes: {
 			type: 'error',
 		},

--- a/packages/block-library/src/form-submit-button/block.json
+++ b/packages/block-library/src/form-submit-button/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"__experimental": true,
 	"name": "core/form-submit-button",
-	"title": "Form submit button",
+	"title": "Form Submit Button",
 	"category": "common",
 	"icon": "button",
 	"parent": [ "core/form" ],


### PR DESCRIPTION
## What?

This PR makes the following two changes:

- Unify block titles from title case to capital case
- End a description with a period

## Why?

This is because both rules are used in almost every other core block.

## Testing Instructions

There is no impact on the code.
