### PR TITLE
Rename `TextFilter` to `Search`

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -14,7 +14,7 @@ import ViewList from './view-list';
 import Pagination from './pagination';
 import ViewActions from './view-actions';
 import Filters from './filters';
-import TextFilter from './text-filter';
+import Search from './search';
 import { ViewGrid } from './view-grid';
 
 export default function DataViews( {
@@ -41,7 +41,7 @@ export default function DataViews( {
 				<HStack>
 					<HStack justify="start">
 						{ search && (
-							<TextFilter
+							<Search
 								label={ searchLabel }
 								view={ view }
 								onChangeView={ onChangeView }

--- a/packages/edit-site/src/components/dataviews/search.js
+++ b/packages/edit-site/src/components/dataviews/search.js
@@ -10,7 +10,7 @@ import { SearchControl } from '@wordpress/components';
  */
 import useDebouncedInput from '../../utils/use-debounced-input';
 
-export default function TextFilter( { label, view, onChangeView } ) {
+export default function Search( { label, view, onChangeView } ) {
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput(
 		view.search
 	);


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow up to https://github.com/WordPress/gutenberg/pull/55722

## What?

This PR renames the `TextFilter` UI component to `Search`.

## Why?

The search UI component no longer behaves like a filter.

## Testing Instructions

- Activate the "wp-admin" experiment.
- Navigate to "Appearance > Editor > Pages > Manage all pages".
- Verify search still works as expected.
