### PR TITLE
Fix: LinkControl on widgets editor does not show font page and post page indication

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -32,28 +32,36 @@ export default function WidgetAreasBlockEditorProvider( {
 	...props
 } ) {
 	const mediaPermissions = useResourcePermissions( 'media' );
-	const { reusableBlocks, isFixedToolbarActive, keepCaretInsideBlock } =
-		useSelect(
-			( select ) => ( {
-				widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
-				widgets: select( editWidgetsStore ).getWidgets(),
-				reusableBlocks: ALLOW_REUSABLE_BLOCKS
-					? select( coreStore ).getEntityRecords(
-							'postType',
-							'wp_block'
-					  )
-					: [],
-				isFixedToolbarActive: !! select( preferencesStore ).get(
-					'core/edit-widgets',
-					'fixedToolbar'
-				),
-				keepCaretInsideBlock: !! select( preferencesStore ).get(
-					'core/edit-widgets',
-					'keepCaretInsideBlock'
-				),
-			} ),
-			[]
-		);
+	const {
+		reusableBlocks,
+		isFixedToolbarActive,
+		keepCaretInsideBlock,
+		pageOnFront,
+		pageForPosts,
+	} = useSelect( ( select ) => {
+		const { canUser, getEntityRecord, getEntityRecords } =
+			select( coreStore );
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEntityRecord( 'root', 'site' )
+			: undefined;
+		return {
+			widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
+			widgets: select( editWidgetsStore ).getWidgets(),
+			reusableBlocks: ALLOW_REUSABLE_BLOCKS
+				? getEntityRecords( 'postType', 'wp_block' )
+				: [],
+			isFixedToolbarActive: !! select( preferencesStore ).get(
+				'core/edit-widgets',
+				'fixedToolbar'
+			),
+			keepCaretInsideBlock: !! select( preferencesStore ).get(
+				'core/edit-widgets',
+				'keepCaretInsideBlock'
+			),
+			pageOnFront: siteSettings?.page_on_front,
+			pageForPosts: siteSettings?.page_for_posts,
+		};
+	}, [] );
 	const { setIsInserterOpened } = useDispatch( editWidgetsStore );
 
 	const settings = useMemo( () => {
@@ -75,6 +83,8 @@ export default function WidgetAreasBlockEditorProvider( {
 			mediaUpload: mediaUploadBlockEditor,
 			templateLock: 'all',
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
+			pageOnFront,
+			pageForPosts,
 		};
 	}, [
 		blockEditorSettings,
@@ -83,6 +93,8 @@ export default function WidgetAreasBlockEditorProvider( {
 		mediaPermissions.canCreate,
 		reusableBlocks,
 		setIsInserterOpened,
+		pageOnFront,
+		pageForPosts,
 	] );
 
 	const widgetAreaId = useLastSelectedWidgetArea();


### PR DESCRIPTION
LinkControl part of the block editor has a UI to show when a page is the front page of a site or the blog page. It is working well on the post editor but it is not working at all on the site editor because some missing block editor settings are missing there. This PR fixes the issue.

cc: @MaggieCabrera as this is a follow-up to a task we previously worked on.

## Testing
Go to the new widgets editor (theme-supporting widgets is required, I used 2011).
Add a link e.g.: in a paragraph or button to the front page of a site (select one on reading settings if you have not one yet). Verify the UI correctly shows it is the front page.
Add a link e.g.: in a paragraph or button to the blog page of a site (select one on reading settings if you have not one yet). Verify the UI correctly shows it is the blog page.



## Screenshots
### Before
<img width="243" alt="Screenshot 2023-10-30 at 10 32 20" src="https://github.com/WordPress/gutenberg/assets/11271197/13e706ed-1be1-43ca-9bbc-9fd9ee8359e3">

### After

<img width="240" alt="Screenshot 2023-10-30 at 10 32 28" src="https://github.com/WordPress/gutenberg/assets/11271197/14963302-8ee4-442c-bdb4-999ec94819c0">
