### PR TITLE
Server directive processing: Process only root blocks

### DIFF
--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -43,8 +43,7 @@ function gutenberg_interactivity_mark_inner_blocks( $parsed_block, $source_block
 						'data-wp-text'    => 'gutenberg_interactivity_process_wp_text',
 					);
 
-					$tags = new WP_Directive_Processor( $block_content );
-
+					$tags               = new WP_Directive_Processor( $block_content );
 					$tags               = gutenberg_interactivity_process_directives( $tags, 'data-wp-', $directives );
 					$render_block_data -= 1;
 					return $tags->get_updated_html();

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -23,7 +23,7 @@ function gutenberg_interactivity_process_directives_in_root_blocks( $block_conte
 
 	if ( WP_Directive_Processor::is_root_block( $block ) ) {
 
-		if ( $do_block_calls === 1 ) {
+		if ( 1 === $do_block_calls ) {
 			$directives = array(
 				'data-wp-bind'    => 'gutenberg_interactivity_process_wp_bind',
 				'data-wp-context' => 'gutenberg_interactivity_process_wp_context',

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -8,8 +8,9 @@
  */
 
 /**
- * Mark the inner blocks with a temporary property so we can discard them later,
- * and process only the root blocks.
+ * Process the Interactivity API directives using the root blocks of the
+ * outermost rendering, ignoring the root blocks of inner blocks like Patterns,
+ * Template Parts or Content.
  *
  * @param array $parsed_block The parsed block.
  * @param array $source_block The source block.
@@ -17,7 +18,7 @@
  *
  * @return array The parsed block.
  */
-function gutenberg_interactivity_mark_inner_blocks( $parsed_block, $source_block, $parent_block ) {
+function gutenberg_interactivity_process_directives( $parsed_block, $source_block, $parent_block ) {
 	static $is_inside_root_block              = false;
 	static $process_directives_in_root_blocks = null;
 
@@ -43,7 +44,7 @@ function gutenberg_interactivity_mark_inner_blocks( $parsed_block, $source_block
 				);
 
 				$tags                 = new WP_Directive_Processor( $block_content );
-				$tags                 = gutenberg_interactivity_process_directives( $tags, 'data-wp-', $directives );
+				$tags                 = gutenberg_interactivity_process_rendered_html( $tags, 'data-wp-', $directives );
 				$is_inside_root_block = false;
 				return $tags->get_updated_html();
 
@@ -61,11 +62,12 @@ function gutenberg_interactivity_mark_inner_blocks( $parsed_block, $source_block
 
 	return $parsed_block;
 }
-add_filter( 'render_block_data', 'gutenberg_interactivity_mark_inner_blocks', 10, 3 );
+add_filter( 'render_block_data', 'gutenberg_interactivity_process_directives', 10, 3 );
 
 
 /**
- * Process directives.
+ * Traverses the HTML searching for Interactivity API directives and processing
+ * them.
  *
  * @param WP_Directive_Processor $tags An instance of the WP_Directive_Processor.
  * @param string                 $prefix Attribute prefix.
@@ -74,7 +76,7 @@ add_filter( 'render_block_data', 'gutenberg_interactivity_mark_inner_blocks', 10
  * @return WP_Directive_Processor The modified instance of the
  * WP_Directive_Processor.
  */
-function gutenberg_interactivity_process_directives( $tags, $prefix, $directives ) {
+function gutenberg_interactivity_process_rendered_html( $tags, $prefix, $directives ) {
 	$context   = new WP_Directive_Context();
 	$tag_stack = array();
 

--- a/packages/e2e-tests/plugins/interactive-blocks.php
+++ b/packages/e2e-tests/plugins/interactive-blocks.php
@@ -39,8 +39,8 @@ add_action(
 		// HTML is not correct or malformed.
 		if ( 'true' === $_GET['disable_directives_ssr'] ) {
 			remove_filter(
-				'render_block',
-				'gutenberg_interactivity_process_directives_in_root_blocks'
+				'render_block_data',
+				'gutenberg_interactivity_process_directives'
 			);
 		}
 	}

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -93,15 +93,11 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 			)
 		);
 
-		// Reset root blocks counter.
-		WP_Directive_Processor::$root_blocks = array();
-
 		$providers = $this->data_only_root_blocks_are_processed();
 		foreach ( $providers as $provider ) {
 			do_blocks( $provider['page_content'] );
 			$this->assertSame( $provider['root_blocks'], count( WP_Directive_Processor::$root_blocks ) );
-			// Reset root blocks counter.
-			WP_Directive_Processor::$root_blocks = array();
+
 		}
 	}
 
@@ -136,19 +132,12 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 				'<!-- /wp:quote -->',
 			),
 			array(
-				'root_blocks'  => 3,
+				'root_blocks'  => 2,
 				'page_content' =>
 				'<!-- wp:paragraph -->' .
 					'<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>' .
 				'<!-- /wp:paragraph -->' .
-				'<!-- wp:pattern {"slug":"core/interactivity-pattern"} /-->' .
-				'<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->' .
-				'	<div class="wp-block-group alignfull"' .
-					'style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">' .
-					'<!-- wp:paragraph -->' .
-						'<p>Test</p>' .
-					'<!-- /wp:paragraph --></div>' .
-				'<!-- /wp:group -->',
+				'<!-- wp:pattern {"slug":"core/interactivity-pattern"} /-->',
 			),
 		);
 	}

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -28,10 +28,10 @@ function gutenberg_test_process_directives_helper_increment( $store ) {
 }
 
 /**
- * Tests for the gutenberg_interactivity_process_directives function.
+ * Tests for the gutenberg_interactivity_process_rendered_html function.
  *
  * @group  interactivity-api
- * @covers gutenberg_interactivity_process_directives
+ * @covers gutenberg_interactivity_process_rendered_html
  */
 class Tests_Process_Directives extends WP_UnitTestCase {
 	public function test_correctly_call_attribute_directive_processor_on_closing_tag() {
@@ -60,7 +60,7 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 
 		$markup = '<div>Example: <div foo-test="abc"><img><span>This is a test></span><div>Here is a nested div</div></div></div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
-		gutenberg_interactivity_process_directives( $tags, 'foo-', $directives );
+		gutenberg_interactivity_process_rendered_html( $tags, 'foo-', $directives );
 	}
 
 	public function test_directives_with_double_hyphen_processed_correctly() {
@@ -74,7 +74,7 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 
 		$markup = '<div foo-test--value="abc"></div>';
 		$tags   = new WP_HTML_Tag_Processor( $markup );
-		gutenberg_interactivity_process_directives( $tags, 'foo-', $directives );
+		gutenberg_interactivity_process_rendered_html( $tags, 'foo-', $directives );
 	}
 
 	public function test_interactivity_process_directives_in_root_blocks() {

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -78,11 +78,12 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 	}
 
 	public function test_interactivity_process_directives_in_root_blocks() {
-		$pattern_content = '<!-- wp:paragraph -->' .
-		'<p>Pattern Content Block 1</p>' .
+		$pattern_content =
+		'<!-- wp:paragraph -->' .
+			'<p>Pattern Content Block 1</p>' .
 		'<!-- /wp:paragraph -->' .
 		'<!-- wp:paragraph -->' .
-		'<p>Pattern Content Block 2</p>' .
+			'<p>Pattern Content Block 2</p>' .
 		'<!-- /wp:paragraph -->';
 		register_block_pattern(
 			'core/interactivity-pattern',
@@ -97,7 +98,6 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 
 		$providers = $this->data_only_root_blocks_are_processed();
 		foreach ( $providers as $provider ) {
-
 			do_blocks( $provider['page_content'] );
 			$this->assertSame( $provider['root_blocks'], count( WP_Directive_Processor::$root_blocks ) );
 			// Reset root blocks counter.
@@ -114,9 +114,8 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 
 		return array(
 			array(
-				'root_blocks'         => 2,
-				'is_root_block_calls' => 4,
-				'page_content'        =>
+				'root_blocks'  => 2,
+				'page_content' =>
 				'<!-- wp:quote -->' .
 					'<blockquote class="wp-block-quote">
 						<!-- wp:paragraph -->' .
@@ -129,17 +128,16 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 				'<!-- wp:quote -->' .
 					'<blockquote class="wp-block-quote">
 						<!-- wp:paragraph -->' .
-							'<p>The XYZ Doohickey Company was founded in 1971, and has been providing' .
-							'quality doohickeys to the public ever since. Located in Gotham City, XYZ employs' .
-							'over 2,000 people and does all kinds of awesome things for the Gotham community.</p>' .
+						'<p>The XYZ Doohickey Company was founded in 1971, and has been providing' .
+						'quality doohickeys to the public ever since. Located in Gotham City, XYZ employs' .
+						'over 2,000 people and does all kinds of awesome things for the Gotham community.</p>' .
 						'<!-- /wp:paragraph -->
 					</blockquote>' .
 				'<!-- /wp:quote -->',
 			),
 			array(
-				'root_blocks'         => 3,
-				'is_root_block_calls' => 6,
-				'page_content'        =>
+				'root_blocks'  => 3,
+				'page_content' =>
 				'<!-- wp:paragraph -->' .
 					'<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>' .
 				'<!-- /wp:paragraph -->' .

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -80,12 +80,10 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 	public function test_interactivity_process_directives_in_root_blocks() {
 		// Reset root blocks counter.
 		WP_Directive_Processor::$root_blocks = array();
-		$provider                            = $this->data_only_root_blocks_are_processed();
-		foreach ( $provider as $provider ) {
-			$parsed_blocks = parse_blocks( $provider['page_content'] );
-			foreach ( $parsed_blocks as $parsed_block ) {
-				render_block( $parsed_block );
-			}
+
+		$providers = $this->data_only_root_blocks_are_processed();
+		foreach ( $providers as $provider ) {
+			do_blocks( $provider['page_content'] );
 			$this->assertSame( $provider['root_blocks'], count( WP_Directive_Processor::$root_blocks ) );
 			// Reset root blocks counter.
 			WP_Directive_Processor::$root_blocks = array();
@@ -167,6 +165,20 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 					'<p>Deeply Nested</p>' .
 					'<!-- /wp:paragraph --></div>' .
 					'<!-- /wp:group -->',
+			),
+			array(
+				'root_blocks'  => 3,
+				'page_content' => '<!-- wp:paragraph -->' .
+				'<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>' .
+				'<!-- /wp:paragraph -->' .
+				'<!-- wp:block {"ref":215} /-->' .
+				'<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->' .
+				'<div class="wp-block-group alignfull"' .
+				'style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">' .
+				'<!-- wp:paragraph -->' .
+				'<p>Test</p>' .
+				'<!-- /wp:paragraph --></div>' .
+				'<!-- /wp:group -->',
 			),
 		);
 	}

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -78,11 +78,26 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 	}
 
 	public function test_interactivity_process_directives_in_root_blocks() {
+		$pattern_content = '<!-- wp:paragraph -->' .
+		'<p>Pattern Content Block 1</p>' .
+		'<!-- /wp:paragraph -->' .
+		'<!-- wp:paragraph -->' .
+		'<p>Pattern Content Block 2</p>' .
+		'<!-- /wp:paragraph -->';
+		register_block_pattern(
+			'core/interactivity-pattern',
+			array(
+				'title'   => 'Interactivity Pattern',
+				'content' => $pattern_content,
+			)
+		);
+
 		// Reset root blocks counter.
 		WP_Directive_Processor::$root_blocks = array();
 
 		$providers = $this->data_only_root_blocks_are_processed();
 		foreach ( $providers as $provider ) {
+
 			do_blocks( $provider['page_content'] );
 			$this->assertSame( $provider['root_blocks'], count( WP_Directive_Processor::$root_blocks ) );
 			// Reset root blocks counter.
@@ -99,85 +114,42 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 
 		return array(
 			array(
-				'root_blocks'  => 2,
-				'page_content' => '<!-- wp:quote -->' .
-					'<blockquote class="wp-block-quote"><!-- wp:paragraph -->' .
-					'<p>The XYZ Doohickey Company was founded in 1971, and has been providing' .
-					'quality doohickeys to the public ever since. Located in Gotham City, XYZ employs' .
-					'over 2,000 people and does all kinds of awesome things for the Gotham community.</p>' .
-					'<!-- /wp:paragraph --></blockquote>' .
-					'<!-- /wp:quote -->' .
-					'<!-- wp:quote -->' .
-					'<blockquote class="wp-block-quote"><!-- wp:paragraph -->' .
-					'<p>The XYZ Doohickey Company was founded in 1971, and has been providing' .
-					'quality doohickeys to the public ever since. Located in Gotham City, XYZ employs' .
-					'over 2,000 people and does all kinds of awesome things for the Gotham community.</p>' .
-					'<!-- /wp:paragraph --></blockquote>' .
-					'<!-- /wp:quote -->',
+				'root_blocks'         => 2,
+				'is_root_block_calls' => 4,
+				'page_content'        =>
+				'<!-- wp:quote -->' .
+					'<blockquote class="wp-block-quote">
+						<!-- wp:paragraph -->' .
+						'<p>The XYZ Doohickey Company was founded in 1971, and has been providing' .
+						'quality doohickeys to the public ever since. Located in Gotham City, XYZ employs' .
+						'over 2,000 people and does all kinds of awesome things for the Gotham community.</p>' .
+						'<!-- /wp:paragraph -->
+					</blockquote>' .
+				'<!-- /wp:quote -->' .
+				'<!-- wp:quote -->' .
+					'<blockquote class="wp-block-quote">
+						<!-- wp:paragraph -->' .
+							'<p>The XYZ Doohickey Company was founded in 1971, and has been providing' .
+							'quality doohickeys to the public ever since. Located in Gotham City, XYZ employs' .
+							'over 2,000 people and does all kinds of awesome things for the Gotham community.</p>' .
+						'<!-- /wp:paragraph -->
+					</blockquote>' .
+				'<!-- /wp:quote -->',
 			),
 			array(
-				'root_blocks'  => 1,
-				'page_content' => '' .
-					'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->' .
-					'<div class="wp-block-group"><!-- wp:image {"width":"216px","height":"auto","sizeSlug":"large"} -->' .
-					'<figure class="wp-block-image size-large is-resized"><img src="#" alt="" style="width:216px;height:auto"/></figure>' .
-					'<!-- /wp:image -->' .
-					'<!-- wp:paragraph -->' .
-					'<p>As a new WordPress user, you should go to <a href="#">your dashboard</a>to delete this page and' .
-					'create new pages for your content. Have fun!</p>' .
-					'<!-- /wp:paragraph -->' .
-					'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->' .
-					'<div class="wp-block-group"><!-- wp:paragraph -->' .
-					'<p>Deeply Nested</p>' .
-					'<!-- /wp:paragraph --></div>' .
-					'<!-- /wp:group --></div>' .
-					'<!-- /wp:group -->',
-			),
-			array(
-				'root_blocks'  => 6,
-				'page_content' => '<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->' .
-					'<div class="wp-block-group"><!-- wp:paragraph -->' .
-					'<p>Deeply Nested</p>' .
-					'<!-- /wp:paragraph --></div>' .
-					'<!-- /wp:group -->' .
-					'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->' .
-					'<div class="wp-block-group"><!-- wp:paragraph -->' .
-					'<p>Deeply Nested</p>' .
-					'<!-- /wp:paragraph --></div>' .
-					'<!-- /wp:group -->' .
-					'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->' .
-					'<div class="wp-block-group"><!-- wp:paragraph -->' .
-					'<p>Deeply Nested</p>' .
-					'<!-- /wp:paragraph --></div>' .
-					'<!-- /wp:group -->' .
-					'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->' .
-					'<div class="wp-block-group"><!-- wp:paragraph -->' .
-					'<p>Deeply Nested</p>' .
-					'<!-- /wp:paragraph --></div>' .
-					'<!-- /wp:group -->' .
-					'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->' .
-					'<div class="wp-block-group"><!-- wp:paragraph -->' .
-					'<p>Deeply Nested</p>' .
-					'<!-- /wp:paragraph --></div>' .
-					'<!-- /wp:group -->' .
-					'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->' .
-					'<div class="wp-block-group"><!-- wp:paragraph -->' .
-					'<p>Deeply Nested</p>' .
-					'<!-- /wp:paragraph --></div>' .
-					'<!-- /wp:group -->',
-			),
-			array(
-				'root_blocks'  => 3,
-				'page_content' => '<!-- wp:paragraph -->' .
-				'<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>' .
-				'<!-- /wp:paragraph -->' .
-				'<!-- wp:block {"ref":215} /-->' .
-				'<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->' .
-				'<div class="wp-block-group alignfull"' .
-				'style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">' .
+				'root_blocks'         => 3,
+				'is_root_block_calls' => 6,
+				'page_content'        =>
 				'<!-- wp:paragraph -->' .
-				'<p>Test</p>' .
-				'<!-- /wp:paragraph --></div>' .
+					'<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>' .
+				'<!-- /wp:paragraph -->' .
+				'<!-- wp:pattern {"slug":"core/interactivity-pattern"} /-->' .
+				'<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->' .
+				'	<div class="wp-block-group alignfull"' .
+					'style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">' .
+					'<!-- wp:paragraph -->' .
+						'<p>Test</p>' .
+					'<!-- /wp:paragraph --></div>' .
 				'<!-- /wp:group -->',
 			),
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Co-authored with @luisherranz 

## What?
<!-- In a few words, what is the PR actually doing? -->
Create a "root blocks" identifier, so the Interactivity API will only process the directives of these ones. 
When we process the directives in PHP of a block that contains inner blocks, we already have the entire HTML, so, in order to prevent the function to run on a inner block render, we need a function to retrieve only the root blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Unit tests are included in the PR

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2023-10-31 at 18 35 20](https://github.com/WordPress/gutenberg/assets/37012961/84f59998-8cca-4578-bdfb-8210ff6b22da)
