### PR TITLE
Fix: Don't register dataviews postype and taxonomy if experiment is disabled.

### DIFF
--- a/lib/experimental/data-views.php
+++ b/lib/experimental/data-views.php
@@ -9,6 +9,10 @@
  * Registers the `wp_dataviews` post type and the `wp_dataviews_type` taxonomy.
  */
 function _gutenberg_register_data_views_post_type() {
+	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	if ( empty( $gutenberg_experiments ) || ! array_key_exists( 'gutenberg-dataviews', $gutenberg_experiments ) ) {
+		return;
+	}
 	register_post_type(
 		'wp_dataviews',
 		array(


### PR DESCRIPTION
This pull request addresses the problem of dataviews posttype and taxonomy being registered even when the experiment is not enabled. 

## Testing
To test the fix, you can temporarily change 'show_ui' to true on the post type and taxonomy. Then, verify that the dataviews menu item appears when the dataviews experiment is enabled and disappears when it is disabled.