### PR TITLE
Patterns: change pattern category taxonomy public param to false

### DIFF
--- a/lib/compat/wordpress-6.4/block-patterns.php
+++ b/lib/compat/wordpress-6.4/block-patterns.php
@@ -16,7 +16,7 @@
  */
 function gutenberg_register_taxonomy_patterns() {
 	$args = array(
-		'public'             => true,
+		'public'             => false,
 		'publicly_queryable' => false,
 		'hierarchical'       => false,
 		'labels'             => array(


### PR DESCRIPTION
## What?
Sets the pattern categories taxonomy `public` param to `false` instead of true

## Why?
It was [suggested here](https://core.trac.wordpress.org/ticket/59569) that this would be a better setting for this taxonomy as it only needs to be accessed in admin, not the frontend.

## How?
Changes the param from true to false

## Testing Instructions
Log in as Admin, Editor, and Author users and make sure that each of these can add new and existing categories to patterns in the post editor and the site editor patterns library.

