### PR TITLE
Block Theme Preview: Display the theme name on the activate button

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -42,7 +42,11 @@ export default function SaveButton( {
 				isDirty: dirtyEntityRecords.length > 0,
 				isSaving:
 					dirtyEntityRecords.some( ( record ) =>
-						isSavingEntityRecord( record.kind, record.name, record.key )
+						isSavingEntityRecord(
+							record.kind,
+							record.name,
+							record.key
+						)
 					) || isActivatingTheme,
 				isSaveViewOpen: isSaveViewOpened(),
 				previewingThemeName: previewingTheme?.name?.rendered,

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { displayShortcut } from '@wordpress/keycodes';
 
@@ -11,7 +11,10 @@ import { displayShortcut } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
-import { isPreviewingTheme } from '../../utils/is-previewing-theme';
+import {
+	currentlyPreviewingTheme,
+	isPreviewingTheme,
+} from '../../utils/is-previewing-theme';
 
 export default function SaveButton( {
 	className = 'edit-site-save-button__button',
@@ -21,24 +24,30 @@ export default function SaveButton( {
 	icon,
 	__next40pxDefaultSize = false,
 } ) {
-	const { isDirty, isSaving, isSaveViewOpen } = useSelect( ( select ) => {
-		const {
-			__experimentalGetDirtyEntityRecords,
-			isSavingEntityRecord,
-			isResolving,
-		} = select( coreStore );
-		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-		const { isSaveViewOpened } = select( editSiteStore );
-		const isActivatingTheme = isResolving( 'activateTheme' );
-		return {
-			isDirty: dirtyEntityRecords.length > 0,
-			isSaving:
-				dirtyEntityRecords.some( ( record ) =>
-					isSavingEntityRecord( record.kind, record.name, record.key )
-				) || isActivatingTheme,
-			isSaveViewOpen: isSaveViewOpened(),
-		};
-	}, [] );
+	const { isDirty, isSaving, isSaveViewOpen, previewingThemeName } =
+		useSelect( ( select ) => {
+			const {
+				__experimentalGetDirtyEntityRecords,
+				isSavingEntityRecord,
+				isResolving,
+			} = select( coreStore );
+			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+			const { isSaveViewOpened } = select( editSiteStore );
+			const isActivatingTheme = isResolving( 'activateTheme' );
+			const previewingTheme = select( coreStore ).getTheme(
+				currentlyPreviewingTheme()
+			);
+
+			return {
+				isDirty: dirtyEntityRecords.length > 0,
+				isSaving:
+					dirtyEntityRecords.some( ( record ) =>
+						isSavingEntityRecord( record.kind, record.name, record.key )
+					) || isActivatingTheme,
+				isSaveViewOpen: isSaveViewOpened(),
+				previewingThemeName: previewingTheme?.name?.rendered,
+			};
+		}, [] );
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
 
 	const activateSaveEnabled = isPreviewingTheme() || isDirty;
@@ -47,13 +56,13 @@ export default function SaveButton( {
 	const getLabel = () => {
 		if ( isPreviewingTheme() ) {
 			if ( isSaving ) {
-				return __( 'Activating' );
+				return sprintf( 'Activating %s', previewingThemeName );
 			} else if ( disabled ) {
 				return __( 'Saved' );
 			} else if ( isDirty ) {
-				return __( 'Activate & Save' );
+				return sprintf( 'Activate %s & Save', previewingThemeName );
 			}
-			return __( 'Activate' );
+			return sprintf( 'Activate %s', previewingThemeName );
 		}
 
 		if ( isSaving ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We want to display the name of the previewing theme on the “Activate” button to make it clearer what theme you're previewing.

Note that I keep the text of the “Activate” button on both “Save modal” and “Save panel” unchanged as
* We mentioned the theme name in the description
* The theme name might be too long on the “Save panel”

Does it make sense? Or do we still want to display the theme name there?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Resolve https://github.com/WordPress/gutenberg/issues/52772

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to Appearance > Themes
2. Hover on a block theme
3. Click the ”Live Preview“ button
4. Verify the “Activate” button includes the theme name
5. Go to Edit mode
6. Verify the “Activate” button at the top-right corner includes the theme name as well

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/13596067/143a0d9b-bf24-4f05-a144-a243dbbdb8b9)

![image](https://github.com/WordPress/gutenberg/assets/13596067/5ca7e352-9eba-4697-b888-77cc57335285)


