### PR TITLE
Block Editor: Optimize 'duotone' controls

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -102,6 +102,7 @@ function DuotonePanel( { attributes, setAttributes, name } ) {
 	const style = attributes?.style;
 	const duotoneStyle = style?.color?.duotone;
 	const settings = useBlockSettings( name );
+	const blockEditingMode = useBlockEditingMode();
 
 	const duotonePalette = useMultiOriginPresets( {
 		presetSetting: 'color.duotone',
@@ -121,6 +122,10 @@ function DuotonePanel( { attributes, setAttributes, name } ) {
 		( colorPalette?.length === 0 && disableCustomColors );
 
 	if ( duotonePalette?.length === 0 && disableCustomDuotone ) {
+		return null;
+	}
+
+	if ( blockEditingMode !== 'default' ) {
 		return null;
 	}
 
@@ -219,17 +224,13 @@ const withDuotoneControls = createHigherOrderComponent(
 			'filter.duotone'
 		);
 
-		const blockEditingMode = useBlockEditingMode();
-
 		// CAUTION: code added before this line will be executed
 		// for all blocks, not just those that support duotone. Code added
 		// above this line should be carefully evaluated for its impact on
 		// performance.
 		return (
 			<>
-				{ hasDuotoneSupport && blockEditingMode === 'default' && (
-					<DuotonePanel { ...props } />
-				) }
+				{ hasDuotoneSupport && <DuotonePanel { ...props } /> }
 				<BlockEdit { ...props } />
 			</>
 		);


### PR DESCRIPTION
## What?
Similar to #55692

A micro-optimization for `duotone` controls to avoid calling the `useBlockEditingMode` hook for every block rendered in the editor.

## Why?
The check is only needed if the block supports the Duotone filters.

## How?
This is a straightforward change. PR moves block editing mode check inside the `DuotonePanel` component.

## Testing Instructions
1. Open a post or page.
2. Insert an Image block.
3. Confirm that Duotone controls work as before.
