### PR TITLE
Block Editor: Optimize 'Layout' controls

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -151,6 +151,10 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	}, [] );
 	const blockEditingMode = useBlockEditingMode();
 
+	if ( blockEditingMode !== 'default' ) {
+		return null;
+	}
+
 	const layoutBlockSupport = getBlockSupport(
 		blockName,
 		layoutBlockSupportKey,
@@ -270,7 +274,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			{ ! inherit && blockEditingMode === 'default' && layoutType && (
+			{ ! inherit && layoutType && (
 				<layoutType.toolBarControls
 					layout={ usedLayout }
 					onChange={ onChangeLayout }
@@ -331,14 +335,10 @@ export function addAttribute( settings ) {
  */
 export const withInspectorControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const { name: blockName } = props;
-		const supportLayout = hasLayoutBlockSupport( blockName );
+		const supportLayout = hasLayoutBlockSupport( props.name );
 
-		const blockEditingMode = useBlockEditingMode();
 		return [
-			supportLayout && blockEditingMode === 'default' && (
-				<LayoutPanel key="layout" { ...props } />
-			),
+			supportLayout && <LayoutPanel key="layout" { ...props } />,
 			<BlockEdit key="edit" { ...props } />,
 		];
 	},


### PR DESCRIPTION
## What?
Similar to #55753.

A micro-optimization for `layout` controls to avoid calling the `useBlockEditingMode` hook for every block rendered in the editor.

The controls were also calling the hook twice. The second call was redundant.

## Why?
The check is only needed when the block supports Layout settings.

Tested using @jsnajdr's debug code (https://github.com/WordPress/gutenberg/commit/c02930390ee76935cc545a708eefe6d9b120f240), the store subscriptions are reduction by 1000 on large text post - 1000 blocks.

## How?
PR moves block editing mode check inside the `LayoutPanel` component.

## Testing Instructions
1. Open a post or page.
2. Insert a Group block.
3. Confirm that the layout settings are working as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-11-01 at 11 59 38](https://github.com/WordPress/gutenberg/assets/240569/c8b3d426-09eb-4f7e-999d-b1bb91cf73ba)
