### PR TITLE
Performance: Start logging site editor metrics in codevitals

### DIFF
--- a/bin/log-performance-results.js
+++ b/bin/log-performance-results.js
@@ -14,6 +14,10 @@ const resultsFiles = [
 		metricsPrefix: '',
 	},
 	{
+		file: 'site-editor.performance-results.json',
+		metricsPrefix: 'site-editor-',
+	},
+	{
 		file: 'front-end-block-theme.performance-results.json',
 		metricsPrefix: 'block-theme-',
 	},


### PR DESCRIPTION
This is a tiny PR that allows us to track site editor metrics in codevitals.run 
We have metrics there for some time, let's start seeing how they evolve over time.