### PR TITLE
Fix: Add missing defaultStatuses on PagePages.

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -204,7 +204,7 @@ export default function PagePages() {
 				},
 			},
 		],
-		[ statuses, authors ]
+		[ defaultStatuses, statuses, authors ]
 	);
 
 	const trashPostAction = useTrashPostAction();


### PR DESCRIPTION
Adds a missing dependency on the useMemo of packages/edit-site/src/components/page-pages/index.js.