### PR TITLE
Block Editor: Optimize layout style renderer subscription

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -442,12 +442,12 @@ function BlockWithChildLayoutStyles( { block: BlockListBlock, props } ) {
 
 	let css = '';
 	if ( selfStretch === 'fixed' && flexSize ) {
-		css += `${ selector } {
+		css = `${ selector } {
 				flex-basis: ${ flexSize };
 				box-sizing: border-box;
 			}`;
 	} else if ( selfStretch === 'fill' ) {
-		css += `${ selector } {
+		css = `${ selector } {
 				flex-grow: 1;
 			}`;
 	}

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -436,7 +436,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 );
 
 function BlockWithChildLayoutStyles( { block: BlockListBlock, props } ) {
-	const { style: { layout = {} } = {} } = props.attributes;
+	const layout = props.attributes.style?.layout ?? {};
 	const { selfStretch, flexSize } = layout;
 
 	const id = useInstanceId( BlockListBlock );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -481,7 +481,7 @@ function BlockWithChildLayoutStyles( { block: BlockListBlock, props } ) {
  */
 export const withChildLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const { style: { layout = {} } = {} } = props.attributes;
+		const layout = props.attributes.style?.layout ?? {};
 		const { selfStretch, flexSize } = layout;
 		const hasChildLayout = selfStretch || flexSize;
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -345,7 +345,7 @@ export const withLayoutControls = createHigherOrderComponent(
 	'withLayoutControls'
 );
 
-function BlockListWithLayoutStyles( { block: BlockListBlock, props } ) {
+function BlockWithLayoutStyles( { block: BlockListBlock, props } ) {
 	const { name, attributes } = props;
 	const disableLayoutStyles = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
@@ -423,16 +423,13 @@ export const withLayoutStyles = createHigherOrderComponent(
 		}
 
 		return (
-			<BlockListWithLayoutStyles
-				block={ BlockListBlock }
-				props={ props }
-			/>
+			<BlockWithLayoutStyles block={ BlockListBlock } props={ props } />
 		);
 	},
 	'withLayoutStyles'
 );
 
-function BlockListWithChildLayoutStyles( { block: BlockListBlock, props } ) {
+function BlockWithChildLayoutStyles( { block: BlockListBlock, props } ) {
 	const { style: { layout = {} } = {} } = props.attributes;
 	const { selfStretch, flexSize } = layout;
 	const disableLayoutStyles = useSelect( ( select ) => {
@@ -493,7 +490,7 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 		}
 
 		return (
-			<BlockListWithChildLayoutStyles
+			<BlockWithChildLayoutStyles
 				block={ BlockListBlock }
 				props={ props }
 			/>


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/55754#pullrequestreview-1707861987.
Similar to #55449.

PR moves most of the logic from `withLayoutStyles` and `withChildLayoutStyles` into separate components, which are only rendered when a block supports layout.

Tested using @jsnajdr's debug code (https://github.com/WordPress/gutenberg/commit/c02930390ee76935cc545a708eefe6d9b120f240), the store subscriptions are reduced by 4000 on large text post - 1000 blocks, i.e., four subscription per-block.

## Why?
See https://github.com/WordPress/gutenberg/pull/54819#issuecomment-1761202859.

## Testing Instructions
1. Open a post or page.
2. Insert Row or Stack blocks, add child block, and test various layout settings.
3. Confirm they work as before.

### Testing Instructions for Keyboard
Same.
