### PR TITLE
Site editor: Add edit page slug field

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -108,42 +108,49 @@ export default function PageSlug( { postType, postId } ) {
 								onClose={ onClose }
 							/>
 							<VStack spacing={ 5 }>
-								<InputControl
-									__nextHasNoMarginBottom
-									__next40pxDefaultSize
-									label={ __( 'Permalink' ) }
-									hideLabelFromVision
-									value={ forceEmptyField ? '' : recordSlug }
-									autoComplete="off"
-									spellCheck="false"
-									help={ __( 'The last part of the URL.' ) }
-									onChange={ ( newValue ) => {
-										onSlugChange( newValue );
-										// When we delete the field the permalink gets
-										// reverted to the original value.
-										// The forceEmptyField logic allows the user to have
-										// the field temporarily empty while typing.
-										if ( ! newValue ) {
-											if ( ! forceEmptyField ) {
-												setForceEmptyField( true );
+								<form onSubmit={ onClose }>
+									<InputControl
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+										label={ __( 'Permalink' ) }
+										hideLabelFromVision
+										value={
+											forceEmptyField ? '' : recordSlug
+										}
+										autoComplete="off"
+										spellCheck="false"
+										help={ __(
+											'The last part of the URL.'
+										) }
+										onChange={ ( newValue ) => {
+											onSlugChange( newValue );
+											// When we delete the field the permalink gets
+											// reverted to the original value.
+											// The forceEmptyField logic allows the user to have
+											// the field temporarily empty while typing.
+											if ( ! newValue ) {
+												if ( ! forceEmptyField ) {
+													setForceEmptyField( true );
+												}
+												return;
 											}
-											return;
-										}
-										if ( forceEmptyField ) {
-											setForceEmptyField( false );
-										}
-									} }
-									onBlur={ ( event ) => {
-										onSlugChange(
-											cleanForSlug(
-												event.target.value || savedSlug
-											)
-										);
-										if ( forceEmptyField ) {
-											setForceEmptyField( false );
-										}
-									} }
-								/>
+											if ( forceEmptyField ) {
+												setForceEmptyField( false );
+											}
+										} }
+										onBlur={ ( event ) => {
+											onSlugChange(
+												cleanForSlug(
+													event.target.value ||
+														savedSlug
+												)
+											);
+											if ( forceEmptyField ) {
+												setForceEmptyField( false );
+											}
+										} }
+									/>
+								</form>
 							</VStack>
 						</>
 					);

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -37,9 +37,9 @@ function getPostPermalink( record, isEditable ) {
 
 export default function PageSlug( { postType, postId } ) {
 	const { editEntityRecord } = useDispatch( coreStore );
-	const { record, savedSlug } = useSelect(
+	const { record, savedSlug, viewPostLabel } = useSelect(
 		( select ) => {
-			const { getEntityRecord, getEditedEntityRecord } =
+			const { getEntityRecord, getEditedEntityRecord, getPostType } =
 				select( coreStore );
 			const savedRecord = getEntityRecord( 'postType', postType, postId, {
 				_fields: 'slug,generated_slug',
@@ -47,6 +47,7 @@ export default function PageSlug( { postType, postId } ) {
 			return {
 				record: getEditedEntityRecord( 'postType', postType, postId ),
 				savedSlug: savedRecord?.slug || savedRecord?.generated_slug,
+				viewPostLabel: getPostType( postType )?.labels.view_item,
 			};
 		},
 		[ postType, postId ]
@@ -56,13 +57,6 @@ export default function PageSlug( { postType, postId } ) {
 	const isEditable =
 		PERMALINK_POSTNAME_REGEX.test( record?.permalink_template ) &&
 		record?._links?.[ 'wp:action-publish' ];
-	const viewPostLabel = useSelect(
-		( select ) => {
-			const postTypeObject = select( coreStore ).getPostType( postType );
-			return postTypeObject?.labels.view_item;
-		},
-		[ postType ]
-	);
 	const popoverProps = useMemo(
 		() => ( {
 			// Anchor the popover to the middle of the entire row so that it doesn't

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -82,7 +82,7 @@ export default function PageSlug( { postType, postId } ) {
 	);
 	const onSlugChange = ( newValue ) => {
 		editEntityRecord( 'postType', postType, postId, {
-			slug: cleanForSlug( newValue ),
+			slug: newValue,
 		} );
 	};
 	return (
@@ -153,7 +153,10 @@ export default function PageSlug( { postType, postId } ) {
 										} }
 										onBlur={ ( event ) => {
 											onSlugChange(
-												event.target.value || savedSlug
+												cleanForSlug(
+													event.target.value ||
+														savedSlug
+												)
 											);
 											if ( forceEmptyField ) {
 												setForceEmptyField( false );

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -11,7 +11,8 @@ import { useState, useMemo } from '@wordpress/element';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
-	TextControl,
+	__experimentalInputControl as InputControl,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
@@ -108,10 +109,16 @@ export default function PageSlug( { postType, postId } ) {
 								onClose={ onClose }
 							/>
 							<VStack spacing={ 5 }>
-								<TextControl
+								<InputControl
 									__nextHasNoMarginBottom
+									__next40pxDefaultSize
 									label={ __( 'Permalink' ) }
 									hideLabelFromVision
+									prefix={
+										<InputControlPrefixWrapper>
+											/
+										</InputControlPrefixWrapper>
+									}
 									value={ forceEmptyField ? '' : recordSlug }
 									autoComplete="off"
 									spellCheck="false"

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -21,21 +21,21 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 
-/**
- * Internal dependencies
- */
-import useEditedEntityRecord from '../../use-edited-entity-record';
-
 export const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
 
 export default function PageSlug( { postType, postId } ) {
 	const { editEntityRecord } = useDispatch( coreStore );
-	const { record, isLoaded } = useEditedEntityRecord( postType, postId );
-	const savedSlug = useSelect(
-		( select ) =>
-			select( coreStore ).getEntityRecord( 'postType', postType, postId, {
-				_fields: 'slug',
-			} )?.slug,
+	const { record, savedSlug } = useSelect(
+		( select ) => {
+			const { getEntityRecord, getEditedEntityRecord } =
+				select( coreStore );
+			return {
+				record: getEditedEntityRecord( 'postType', postType, postId ),
+				savedSlug: getEntityRecord( 'postType', postType, postId, {
+					_fields: 'slug',
+				} )?.slug,
+			};
+		},
 		[ postType, postId ]
 	);
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -59,7 +59,7 @@ export default function PageSlug( { postType, postId } ) {
 		} ),
 		[ popoverAnchor ]
 	);
-	if ( ! isLoaded ) {
+	if ( ! record ) {
 		return null;
 	}
 	const onSlugChange = ( newValue ) => {

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -87,6 +87,12 @@ export default function PageSlug( { postType, postId } ) {
 				popoverProps={ popoverProps }
 				focusOnMount
 				ref={ setPopoverAnchor }
+				onClose={ () => {
+					if ( forceEmptyField ) {
+						onSlugChange( cleanForSlug( savedSlug ) );
+						setForceEmptyField( false );
+					}
+				} }
 				renderToggle={ ( { onToggle } ) => (
 					<Button
 						className="edit-site-summary-field__trigger"

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -23,7 +23,7 @@ import { store as coreStore } from '@wordpress/core-data';
 
 export const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
 
-function usePostPermalink( record, isEditable ) {
+function getPostPermalink( record, isEditable ) {
 	if ( ! record?.permalink_template ) {
 		return;
 	}
@@ -56,7 +56,6 @@ export default function PageSlug( { postType, postId } ) {
 	const isEditable =
 		PERMALINK_POSTNAME_REGEX.test( record?.permalink_template ) &&
 		record?._links?.[ 'wp:action-publish' ];
-	const permaLink = usePostPermalink( record, isEditable );
 	const viewPostLabel = useSelect(
 		( select ) => {
 			const postTypeObject = select( coreStore ).getPostType( postType );
@@ -80,6 +79,7 @@ export default function PageSlug( { postType, postId } ) {
 	const recordSlug = safeDecodeURIComponent(
 		record?.slug || record?.generated_slug
 	);
+	const permaLink = getPostPermalink( record, isEditable );
 	const onSlugChange = ( newValue ) => {
 		editEntityRecord( 'postType', postType, postId, {
 			slug: newValue,

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -168,7 +168,6 @@ export default function PageSlug( { postType, postId } ) {
 									<ExternalLink
 										className="editor-post-url__link"
 										href={ record.link }
-										target="_blank"
 									>
 										{ permaLink }
 									</ExternalLink>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -12,7 +12,6 @@ import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalInputControl as InputControl,
-	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
@@ -114,11 +113,6 @@ export default function PageSlug( { postType, postId } ) {
 									__next40pxDefaultSize
 									label={ __( 'Permalink' ) }
 									hideLabelFromVision
-									prefix={
-										<InputControlPrefixWrapper>
-											/
-										</InputControlPrefixWrapper>
-									}
 									value={ forceEmptyField ? '' : recordSlug }
 									autoComplete="off"
 									spellCheck="false"

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -1,0 +1,159 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { safeDecodeURIComponent, filterURLForDisplay } from '@wordpress/url';
+import { useState, useMemo } from '@wordpress/element';
+import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import {
+	TextControl,
+	ExternalLink,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Dropdown,
+	Button,
+} from '@wordpress/components';
+import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import useEditedEntityRecord from '../../use-edited-entity-record';
+
+export const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
+
+export default function PageSlug( { postType, postId } ) {
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const { editEntityRecord } = useDispatch( coreStore );
+	const { record, isLoaded } = useEditedEntityRecord( postType, postId );
+	const { record: savedRecord } = useEntityRecord( postType, postId );
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	const isEditable =
+		PERMALINK_POSTNAME_REGEX.test( record?.permalink_template ) &&
+		record?._links?.[ 'wp:action-publish' ];
+	const viewPostLabel = useSelect(
+		( select ) => {
+			const postTypeObject = select( coreStore ).getPostType( postType );
+			return postTypeObject?.labels.view_item;
+		},
+		[ postType ]
+	);
+	const popoverProps = useMemo(
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			'aria-label': __( 'Change slug' ),
+			placement: 'bottom-end',
+		} ),
+		[ popoverAnchor ]
+	);
+	if ( ! isLoaded ) {
+		return null;
+	}
+	const onSlugChange = async ( newValue ) => {
+		try {
+			await editEntityRecord( 'postType', postType, postId, {
+				slug: newValue,
+			} );
+		} catch ( error ) {
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while updating the status' );
+
+			createErrorNotice( errorMessage, {
+				type: 'snackbar',
+			} );
+		}
+	};
+	return (
+		<HStack className="edit-site-summary-field">
+			<Text className="edit-site-summary-field__label">
+				{ __( 'URL' ) }
+			</Text>
+			<Dropdown
+				contentClassName="edit-site-page-panels-edit-slug__dropdown"
+				popoverProps={ popoverProps }
+				focusOnMount
+				ref={ setPopoverAnchor }
+				renderToggle={ ( { onToggle } ) => (
+					<Button
+						className="edit-site-summary-field__trigger"
+						variant="tertiary"
+						onClick={ onToggle }
+					>
+						{ filterURLForDisplay(
+							safeDecodeURIComponent( record.link )
+						) }
+					</Button>
+				) }
+				renderContent={ ( { onClose } ) => {
+					return (
+						<>
+							<InspectorPopoverHeader
+								title={ __( 'URL' ) }
+								onClose={ onClose }
+							/>
+							<VStack spacing={ 5 }>
+								{ isEditable && (
+									<TextControl
+										__nextHasNoMarginBottom
+										label={ __( 'Permalink' ) }
+										value={ safeDecodeURIComponent(
+											record.slug
+										) }
+										autoComplete="off"
+										spellCheck="false"
+										help={
+											<>
+												{ __(
+													'The last part of the URL.'
+												) }{ ' ' }
+												<ExternalLink
+													href={ __(
+														'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
+													) }
+												>
+													{ __( 'Learn more.' ) }
+												</ExternalLink>
+											</>
+										}
+										onChange={ onSlugChange }
+										onBlur={ ( event ) => {
+											if ( ! event.target.value ) {
+												onSlugChange(
+													savedRecord?.slug
+												);
+											}
+										} }
+									/>
+								) }
+								<VStack spacing={ 1 }>
+									<Text
+										size="11"
+										lineHeight={ 1.4 }
+										weight={ 500 }
+										upperCase={ true }
+									>
+										{ viewPostLabel || __( 'View post' ) }
+									</Text>
+									<ExternalLink
+										className="editor-post-url__link"
+										href={ record.link }
+										target="_blank"
+									>
+										{ record.link }
+									</ExternalLink>
+								</VStack>
+							</VStack>
+						</>
+					);
+				} }
+			/>
+		</HStack>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-slug.js
@@ -41,9 +41,7 @@ export default function PageSlug( { postType, postId } ) {
 		( select ) => {
 			const { getEntityRecord, getEditedEntityRecord, getPostType } =
 				select( coreStore );
-			const savedRecord = getEntityRecord( 'postType', postType, postId, {
-				_fields: 'slug,generated_slug',
-			} );
+			const savedRecord = getEntityRecord( 'postType', postType, postId );
 			return {
 				record: getEditedEntityRecord( 'postType', postType, postId ),
 				savedSlug: savedRecord?.slug || savedRecord?.generated_slug,

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-summary.js
@@ -8,6 +8,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import PageStatus from './page-status';
 import PublishDate from './publish-date';
 import EditTemplate from './edit-template';
+import PageSlug from './page-slug';
 
 export default function PageSummary( {
 	status,
@@ -32,6 +33,7 @@ export default function PageSummary( {
 				postType={ postType }
 			/>
 			<EditTemplate />
+			<PageSlug postId={ postId } postType={ postType } />
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -85,3 +85,10 @@
 		min-width: 240px;
 	}
 }
+
+.edit-site-page-panels-edit-slug__dropdown {
+	.components-popover__content {
+		min-width: 320px;
+		padding: $grid-unit-20;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/52632

This PR adds an edit page slug field in site editor, in page summary.


## Testing Instructions
1. In site editor go to different pages
2. Open the page summary and play around with the slug(change, save, etc..)

## Screenshots or screencast <!-- if applicable -->

<img width="346" alt="Screenshot 2023-11-06 at 5 05 22 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/e4b0b7ab-3165-41fe-a57d-498f320a8a7e">

