### PR TITLE
Refactor Site Editor Document Tools Navigation to own component

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useRef } from '@wordpress/element';
-import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
-import { store as coreStore } from '@wordpress/core-data';
+import { useViewportMatch } from '@wordpress/compose';
 import {
 	ToolSelector,
 	NavigableToolbar,
@@ -35,58 +34,40 @@ const preventDefault = ( event ) => {
 	event.preventDefault();
 };
 
-export default function DocumentTools( { setListViewToggleElement } ) {
+export default function DocumentTools( {
+	blockEditorMode,
+	isDistractionFree,
+	showIconLabels,
+	setListViewToggleElement,
+	toolbarTransition,
+	toolbarVariants,
+} ) {
 	const inserterButton = useRef();
 	const {
 		isInserterOpen,
 		isListViewOpen,
 		listViewShortcut,
 		isVisualMode,
-		isDistractionFree,
-		blockEditorMode,
-		showIconLabels,
 		hasFixedToolbar,
 	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
-			getEditedPostType,
 			isInserterOpened,
 			isListViewOpened,
 			getEditorMode,
 		} = select( editSiteStore );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
-		const { __unstableGetEditorMode } = select( blockEditorStore );
-
-		const postType = getEditedPostType();
-
-		const {
-			getUnstableBase, // Site index.
-		} = select( coreStore );
 
 		const { get: getPreference } = select( preferencesStore );
 
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
-			templateType: postType,
 			isInserterOpen: isInserterOpened(),
 			isListViewOpen: isListViewOpened(),
 			listViewShortcut: getShortcutRepresentation(
 				'core/edit-site/toggle-list-view'
 			),
 			isVisualMode: getEditorMode() === 'visual',
-			blockEditorMode: __unstableGetEditorMode(),
-			homeUrl: getUnstableBase()?.home,
-			showIconLabels: getPreference(
-				editSiteStore.name,
-				'showIconLabels'
-			),
-			editorCanvasView: unlock(
-				select( editSiteStore )
-			).getEditorCanvasContainerView(),
-			isDistractionFree: getPreference(
-				editSiteStore.name,
-				'distractionFree'
-			),
 			hasFixedToolbar: getPreference(
 				editSiteStore.name,
 				'fixedToolbar'
@@ -100,7 +81,6 @@ export default function DocumentTools( { setListViewToggleElement } ) {
 		setIsListViewOpened,
 	} = useDispatch( editSiteStore );
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
-	const disableMotion = useReducedMotion();
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
@@ -143,19 +123,6 @@ export default function DocumentTools( { setListViewToggleElement } ) {
 	const isZoomedOutViewExperimentEnabled =
 		window?.__experimentalEnableZoomedOutView && isVisualMode;
 	const isZoomedOutView = blockEditorMode === 'zoom-out';
-
-	const toolbarVariants = {
-		isDistractionFree: { y: '-50px' },
-		isDistractionFreeHovering: { y: 0 },
-		view: { y: 0 },
-		edit: { y: 0 },
-	};
-
-	const toolbarTransition = {
-		type: 'tween',
-		duration: disableMotion ? 0 : 0.2,
-		ease: 'easeOut',
-	};
 
 	return (
 		<NavigableToolbar

--- a/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useCallback, useRef } from '@wordpress/element';
@@ -11,15 +6,13 @@ import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	ToolSelector,
-	__experimentalPreviewOptions as PreviewOptions,
 	NavigableToolbar,
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { PinnedItems } from '@wordpress/interface';
 import { _x, __ } from '@wordpress/i18n';
-import { listView, plus, external, chevronUpDown } from '@wordpress/icons';
+import { listView, plus, chevronUpDown } from '@wordpress/icons';
 import {
 	__unstableMotion as motion,
 	Button,
@@ -34,11 +27,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import UndoButton from '../undo-redo/undo';
 import RedoButton from '../undo-redo/redo';
 import { store as editSiteStore } from '../../../store';
-import {
-	useHasEditorCanvasContainer,
-} from '../../editor-canvas-container';
 import { unlock } from '../../../lock-unlock';
-import { FOCUSABLE_ENTITIES } from '../../../utils/constants';
 
 const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 
@@ -47,19 +36,15 @@ const preventDefault = ( event ) => {
 };
 
 export default function DocumentTools( { setListViewToggleElement } ) {
-    const inserterButton = useRef();
+	const inserterButton = useRef();
 	const {
-		deviceType,
-		templateType,
 		isInserterOpen,
 		isListViewOpen,
 		listViewShortcut,
 		isVisualMode,
 		isDistractionFree,
 		blockEditorMode,
-		homeUrl,
 		showIconLabels,
-		editorCanvasView,
 		hasFixedToolbar,
 	} = useSelect( ( select ) => {
 		const {
@@ -148,10 +133,6 @@ export default function DocumentTools( { setListViewToggleElement } ) {
 		canFocusHiddenToolbar ||
 		fixedToolbarCanBeFocused;
 
-	const hasDefaultEditorCanvasView = ! useHasEditorCanvasContainer();
-
-	const isFocusMode = FOCUSABLE_ENTITIES.includes( templateType );
-
 	/* translators: button label text should, if possible, be under 16 characters. */
 	const longLabel = _x(
 		'Toggle block inserter',
@@ -178,110 +159,94 @@ export default function DocumentTools( { setListViewToggleElement } ) {
 
 	return (
 		<NavigableToolbar
-					as={ motion.div }
-					className="edit-site-header-edit-mode__start"
-					aria-label={ __( 'Document tools' ) }
-					shouldUseKeyboardFocusShortcut={
-						! blockToolbarCanBeFocused
-					}
-					variants={ toolbarVariants }
-					transition={ toolbarTransition }
-				>
-					<div className="edit-site-header-edit-mode__toolbar">
-						{ ! isDistractionFree && (
+			as={ motion.div }
+			className="edit-site-header-edit-mode__start"
+			aria-label={ __( 'Document tools' ) }
+			shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
+			variants={ toolbarVariants }
+			transition={ toolbarTransition }
+		>
+			<div className="edit-site-header-edit-mode__toolbar">
+				{ ! isDistractionFree && (
+					<ToolbarItem
+						ref={ inserterButton }
+						as={ Button }
+						className="edit-site-header-edit-mode__inserter-toggle"
+						variant="primary"
+						isPressed={ isInserterOpen }
+						onMouseDown={ preventDefault }
+						onClick={ toggleInserter }
+						disabled={ ! isVisualMode }
+						icon={ plus }
+						label={ showIconLabels ? shortLabel : longLabel }
+						showTooltip={ ! showIconLabels }
+						aria-expanded={ isInserterOpen }
+					/>
+				) }
+				{ isLargeViewport && (
+					<>
+						{ ! hasFixedToolbar && (
 							<ToolbarItem
-								ref={ inserterButton }
-								as={ Button }
-								className="edit-site-header-edit-mode__inserter-toggle"
-								variant="primary"
-								isPressed={ isInserterOpen }
-								onMouseDown={ preventDefault }
-								onClick={ toggleInserter }
-								disabled={ ! isVisualMode }
-								icon={ plus }
-								label={
-									showIconLabels ? shortLabel : longLabel
-								}
+								as={ ToolSelector }
 								showTooltip={ ! showIconLabels }
-								aria-expanded={ isInserterOpen }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+								disabled={ ! isVisualMode }
 							/>
 						) }
-						{ isLargeViewport && (
-							<>
-								{ ! hasFixedToolbar && (
-									<ToolbarItem
-										as={ ToolSelector }
-										showTooltip={ ! showIconLabels }
-										variant={
-											showIconLabels
-												? 'tertiary'
-												: undefined
-										}
-										disabled={ ! isVisualMode }
-									/>
-								) }
-								<ToolbarItem
-									as={ UndoButton }
-									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
-									}
-								/>
-								<ToolbarItem
-									as={ RedoButton }
-									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
-									}
-								/>
-								{ ! isDistractionFree && (
-									<ToolbarItem
-										as={ Button }
-										className="edit-site-header-edit-mode__list-view-toggle"
-										disabled={
-											! isVisualMode || isZoomedOutView
-										}
-										icon={ listView }
-										isPressed={ isListViewOpen }
-										/* translators: button label text should, if possible, be under 16 characters. */
-										label={ __( 'List View' ) }
-										onClick={ toggleListView }
-										ref={ setListViewToggleElement }
-										shortcut={ listViewShortcut }
-										showTooltip={ ! showIconLabels }
-										variant={
-											showIconLabels
-												? 'tertiary'
-												: undefined
-										}
-										aria-expanded={ isListViewOpen }
-									/>
-								) }
-								{ isZoomedOutViewExperimentEnabled &&
-									! isDistractionFree &&
-									! hasFixedToolbar && (
-										<ToolbarItem
-											as={ Button }
-											className="edit-site-header-edit-mode__zoom-out-view-toggle"
-											icon={ chevronUpDown }
-											isPressed={ isZoomedOutView }
-											/* translators: button label text should, if possible, be under 16 characters. */
-											label={ __( 'Zoom-out View' ) }
-											onClick={ () => {
-												setPreviewDeviceType(
-													'Desktop'
-												);
-												__unstableSetEditorMode(
-													isZoomedOutView
-														? 'edit'
-														: 'zoom-out'
-												);
-											} }
-										/>
-									) }
-							</>
+						<ToolbarItem
+							as={ UndoButton }
+							showTooltip={ ! showIconLabels }
+							variant={ showIconLabels ? 'tertiary' : undefined }
+						/>
+						<ToolbarItem
+							as={ RedoButton }
+							showTooltip={ ! showIconLabels }
+							variant={ showIconLabels ? 'tertiary' : undefined }
+						/>
+						{ ! isDistractionFree && (
+							<ToolbarItem
+								as={ Button }
+								className="edit-site-header-edit-mode__list-view-toggle"
+								disabled={ ! isVisualMode || isZoomedOutView }
+								icon={ listView }
+								isPressed={ isListViewOpen }
+								/* translators: button label text should, if possible, be under 16 characters. */
+								label={ __( 'List View' ) }
+								onClick={ toggleListView }
+								ref={ setListViewToggleElement }
+								shortcut={ listViewShortcut }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+								aria-expanded={ isListViewOpen }
+							/>
 						) }
-					</div>
-				</NavigableToolbar>
+						{ isZoomedOutViewExperimentEnabled &&
+							! isDistractionFree &&
+							! hasFixedToolbar && (
+								<ToolbarItem
+									as={ Button }
+									className="edit-site-header-edit-mode__zoom-out-view-toggle"
+									icon={ chevronUpDown }
+									isPressed={ isZoomedOutView }
+									/* translators: button label text should, if possible, be under 16 characters. */
+									label={ __( 'Zoom-out View' ) }
+									onClick={ () => {
+										setPreviewDeviceType( 'Desktop' );
+										__unstableSetEditorMode(
+											isZoomedOutView
+												? 'edit'
+												: 'zoom-out'
+										);
+									} }
+								/>
+							) }
+					</>
+				) }
+			</div>
+		</NavigableToolbar>
 	);
-										}
+}

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -111,7 +111,12 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 		>
 			{ hasDefaultEditorCanvasView && (
 				<DocumentTools
+					blockEditorMode={ blockEditorMode }
+					isDistractionFree={ isDistractionFree }
+					showIconLabels={ showIconLabels }
 					setListViewToggleElement={ setListViewToggleElement }
+					toolbarTransition={ toolbarTransition }
+					toolbarVariants={ toolbarVariants }
 				/>
 			) }
 

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -6,29 +6,22 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useCallback, useRef } from '@wordpress/element';
-import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
+import { useReducedMotion } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import {
-	ToolSelector,
 	__experimentalPreviewOptions as PreviewOptions,
-	NavigableToolbar,
 	store as blockEditorStore,
-	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
-import { _x, __ } from '@wordpress/i18n';
-import { listView, plus, external, chevronUpDown } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
 import {
 	__unstableMotion as motion,
-	Button,
-	ToolbarItem,
 	MenuGroup,
 	MenuItem,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
@@ -36,8 +29,6 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import MoreMenu from './more-menu';
 import SaveButton from '../save-button';
-import UndoButton from './undo-redo/undo';
-import RedoButton from './undo-redo/redo';
 import DocumentActions from './document-actions';
 import DocumentTools from './document-tools';
 import { store as editSiteStore } from '../../store';
@@ -48,36 +39,18 @@ import {
 import { unlock } from '../../lock-unlock';
 import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
-const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
-
-const preventDefault = ( event ) => {
-	event.preventDefault();
-};
-
 export default function HeaderEditMode( { setListViewToggleElement } ) {
-	const inserterButton = useRef();
 	const {
 		deviceType,
 		templateType,
-		isInserterOpen,
-		isListViewOpen,
-		listViewShortcut,
-		isVisualMode,
 		isDistractionFree,
 		blockEditorMode,
 		homeUrl,
 		showIconLabels,
 		editorCanvasView,
-		hasFixedToolbar,
 	} = useSelect( ( select ) => {
-		const {
-			__experimentalGetPreviewDeviceType,
-			getEditedPostType,
-			isInserterOpened,
-			isListViewOpened,
-			getEditorMode,
-		} = select( editSiteStore );
-		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
+		const { __experimentalGetPreviewDeviceType, getEditedPostType } =
+			select( editSiteStore );
 		const { __unstableGetEditorMode } = select( blockEditorStore );
 
 		const postType = getEditedPostType();
@@ -91,12 +64,6 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			templateType: postType,
-			isInserterOpen: isInserterOpened(),
-			isListViewOpen: isListViewOpened(),
-			listViewShortcut: getShortcutRepresentation(
-				'core/edit-site/toggle-list-view'
-			),
-			isVisualMode: getEditorMode() === 'visual',
 			blockEditorMode: __unstableGetEditorMode(),
 			homeUrl: getUnstableBase()?.home,
 			showIconLabels: getPreference(
@@ -110,65 +77,17 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 				editSiteStore.name,
 				'distractionFree'
 			),
-			hasFixedToolbar: getPreference(
-				editSiteStore.name,
-				'fixedToolbar'
-			),
 		};
 	}, [] );
 
-	const {
-		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
-		setIsInserterOpened,
-		setIsListViewOpened,
-	} = useDispatch( editSiteStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { __experimentalSetPreviewDeviceType: setPreviewDeviceType } =
+		useDispatch( editSiteStore );
 	const disableMotion = useReducedMotion();
-
-	const isLargeViewport = useViewportMatch( 'medium' );
-
-	const toggleInserter = useCallback( () => {
-		if ( isInserterOpen ) {
-			// Focusing the inserter button should close the inserter popover.
-			// However, there are some cases it won't close when the focus is lost.
-			// See https://github.com/WordPress/gutenberg/issues/43090 for more details.
-			inserterButton.current.focus();
-			setIsInserterOpened( false );
-		} else {
-			setIsInserterOpened( true );
-		}
-	}, [ isInserterOpen, setIsInserterOpened ] );
-
-	const toggleListView = useCallback(
-		() => setIsListViewOpened( ! isListViewOpen ),
-		[ setIsListViewOpened, isListViewOpen ]
-	);
-
-	const {
-		shouldShowContextualToolbar,
-		canFocusHiddenToolbar,
-		fixedToolbarCanBeFocused,
-	} = useShouldContextualToolbarShow();
-	// If there's a block toolbar to be focused, disable the focus shortcut for the document toolbar.
-	// There's a fixed block toolbar when the fixed toolbar option is enabled or when the browser width is less than the large viewport.
-	const blockToolbarCanBeFocused =
-		shouldShowContextualToolbar ||
-		canFocusHiddenToolbar ||
-		fixedToolbarCanBeFocused;
 
 	const hasDefaultEditorCanvasView = ! useHasEditorCanvasContainer();
 
 	const isFocusMode = FOCUSABLE_ENTITIES.includes( templateType );
 
-	/* translators: button label text should, if possible, be under 16 characters. */
-	const longLabel = _x(
-		'Toggle block inserter',
-		'Generic label for block inserter button'
-	);
-	const shortLabel = ! isInserterOpen ? __( 'Add' ) : __( 'Close' );
-
-	const isZoomedOutViewExperimentEnabled =
-		window?.__experimentalEnableZoomedOutView && isVisualMode;
 	const isZoomedOutView = blockEditorMode === 'zoom-out';
 
 	const toolbarVariants = {
@@ -191,7 +110,9 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 			} ) }
 		>
 			{ hasDefaultEditorCanvasView && (
-				<DocumentTools setListViewToggleElement={ setListViewToggleElement }/>
+				<DocumentTools
+					setListViewToggleElement={ setListViewToggleElement }
+				/>
 			) }
 
 			{ ! isDistractionFree && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Refactoring the site editor document tools header navigation to be its own component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This brings it in line with the other site headers. It will also make the work from https://github.com/WordPress/gutenberg/pull/54513/ be much easier to review since it won't include as many changes, and this is a useful refactor for ease of reading and use regardless.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Split the document tools navigation into its own `<DocumentTools />` component. Named that as the aria-label is `Document Tools`.
- Removed all the unused variables and processing work between the files.
- Cleaned up shared variables by passing them into the `<DocumentTools />` component via props

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
There should be no functional changes. All tests should pass.