### PR TITLE
Trash Data View: Use trash icon

### DIFF
--- a/packages/edit-site/src/components/page-pages/default-views.js
+++ b/packages/edit-site/src/components/page-pages/default-views.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { trash } from '@wordpress/icons';
 
 // DEFAULT_STATUSES is intentionally sorted. Items do not have spaces in between them.
 // The reason for that is to match the default statuses coming from the endpoint
@@ -46,6 +47,7 @@ const DEFAULT_VIEWS = [
 	{
 		title: __( 'Trash' ),
 		slug: 'trash',
+		icon: trash,
 		view: {
 			...DEFAULT_PAGE_BASE,
 			filters: {

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -19,12 +19,12 @@ function getDataViewIcon( dataview ) {
 	return icons[ dataview.view.type ];
 }
 
-function DataViewItem( { dataview, isActive } ) {
+function DataViewItem( { dataview, isActive, icon } ) {
 	const {
 		params: { path },
 	} = useLocation();
 
-	const icon = getDataViewIcon( dataview );
+	const _icon = icon || getDataViewIcon( dataview );
 
 	const linkInfo = useLink( {
 		path,
@@ -32,7 +32,7 @@ function DataViewItem( { dataview, isActive } ) {
 	} );
 	return (
 		<SidebarNavigationItem
-			icon={ icon }
+			icon={ _icon }
 			{ ...linkInfo }
 			aria-current={ isActive ? 'true' : undefined }
 		>
@@ -55,6 +55,7 @@ export default function DataViewsSidebarContent() {
 				return (
 					<DataViewItem
 						key={ dataview.slug }
+						icon={ dataview.icon }
 						dataview={ dataview }
 						isActive={ dataview.slug === activeView }
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/55764

## Screenshots or screencast <!-- if applicable -->

<img width="358" alt="Screenshot 2023-11-01 at 12 38 14" src="https://github.com/WordPress/gutenberg/assets/846565/f6d7af86-69d7-4f62-a46b-5dc9d00d431e">

