### PR TITLE
Fix flaky 'Switch to Draft' action in Preview e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -161,6 +161,7 @@ test.describe( 'Preview', () => {
 		await editor.canvas
 			.locator( 'role=textbox[name="Add title"i]' )
 			.type( 'Lorem' );
+		await editor.openDocumentSettingsSidebar();
 
 		// Open the preview page.
 		const previewPage = await editor.openPreviewPage( editorPage );


### PR DESCRIPTION
## What?
I noticed [this failure](https://github.com/WordPress/gutenberg/actions/runs/6720276265/job/18265107292?pr=52285#step:7:20) while re-running e2e tests for #52285.

The 'Switch to Draft' draft action will fail when do document settings sidebar is closed. This update ensures sidebar is open for this test case.

## Testing Instructions
CI checks should be green.

## Screenshots or screencast <!-- if applicable -->
[failure-screencast.webm](https://github.com/WordPress/gutenberg/assets/240569/fd7510e2-1c80-4c1b-9316-b9fda025e27e)
