### PR TITLE
DataViews: Add ability to create custom views

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/add-new-view.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/add-new-view.js
@@ -1,0 +1,142 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Modal,
+	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useState } from '@wordpress/element';
+import { plus } from '@wordpress/icons';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import DEFAULT_VIEWS from './default-views';
+import { unlock } from '../../lock-unlock';
+
+const { useHistory, useLocation } = unlock( routerPrivateApis );
+
+function AddNewItemModalContent( { type, setIsAdding } ) {
+	const {
+		params: { path },
+	} = useLocation();
+	const history = useHistory();
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const [ title, setTitle ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+	return (
+		<form
+			onSubmit={ async ( event ) => {
+				event.preventDefault();
+				setIsSaving( true );
+				const { getEntityRecords } = resolveSelect( coreStore );
+				let dataViewTaxonomyId;
+				const dataViewTypeRecords = await getEntityRecords(
+					'taxonomy',
+					'wp_dataviews_type',
+					{ slug: type }
+				);
+				if ( dataViewTypeRecords && dataViewTypeRecords.length > 0 ) {
+					dataViewTaxonomyId = dataViewTypeRecords[ 0 ].id;
+				} else {
+					const record = await saveEntityRecord(
+						'taxonomy',
+						'wp_dataviews_type',
+						{ name: type }
+					);
+					if ( record && record.id ) {
+						dataViewTaxonomyId = record.id;
+					}
+				}
+				const savedRecord = await saveEntityRecord(
+					'postType',
+					'wp_dataviews',
+					{
+						title,
+						status: 'publish',
+						wp_dataviews_type: dataViewTaxonomyId,
+						content: JSON.stringify(
+							DEFAULT_VIEWS[ type ][ 0 ].view
+						),
+					}
+				);
+				history.push( {
+					path,
+					activeView: savedRecord.id,
+					isCustom: 'true',
+				} );
+				setIsSaving( false );
+				setIsAdding( false );
+			} }
+		>
+			<VStack spacing="5">
+				<TextControl
+					__nextHasNoMarginBottom
+					label={ __( 'Name' ) }
+					value={ title }
+					onChange={ setTitle }
+					placeholder={ __( 'My view' ) }
+					className="patterns-create-modal__name-input"
+				/>
+				<HStack justify="right">
+					<Button
+						variant="tertiary"
+						onClick={ () => {
+							setIsAdding( false );
+						} }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+
+					<Button
+						variant="primary"
+						type="submit"
+						aria-disabled={ ! title || isSaving }
+						isBusy={ isSaving }
+					>
+						{ __( 'Create' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
+	);
+}
+
+export default function AddNewItem( { type } ) {
+	const [ isAdding, setIsAdding ] = useState( false );
+	return (
+		<>
+			<SidebarNavigationItem
+				icon={ plus }
+				onClick={ () => {
+					setIsAdding( true );
+				} }
+				className="dataviews__siderbar-content-add-new-item"
+			>
+				{ __( 'New view' ) }
+			</SidebarNavigationItem>
+			{ isAdding && (
+				<Modal
+					title={ __( 'Add new view' ) }
+					onRequestClose={ () => {
+						setIsAdding( false );
+					} }
+					overlayClassName=""
+				>
+					<AddNewItemModalContent
+						type={ type }
+						setIsAdding={ setIsAdding }
+					/>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViewItem from './dataview-item';
+import AddNewItem from './add-new-view';
+
+const EMPTY_ARRAY = [];
+
+function CustomDataViewItem( { dataviewId, isActive } ) {
+	const { dataview } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord } = select( coreStore );
+			return {
+				dataview: getEditedEntityRecord(
+					'postType',
+					'wp_dataviews',
+					dataviewId
+				),
+			};
+		},
+		[ dataviewId ]
+	);
+	const type = useMemo( () => {
+		const viewContent = JSON.parse( dataview.content );
+		return viewContent.type;
+	}, [ dataview.content ] );
+	return (
+		<DataViewItem
+			title={ dataview.title }
+			type={ type }
+			isActive={ isActive }
+			isCustom="true"
+			customViewId={ dataviewId }
+		/>
+	);
+}
+
+export function useCustomDataViews( type ) {
+	const customDataViews = useSelect( ( select ) => {
+		const { getEntityRecords } = select( coreStore );
+		const dataViewTypeRecords = getEntityRecords(
+			'taxonomy',
+			'wp_dataviews_type',
+			{ slug: type }
+		);
+		if ( ! dataViewTypeRecords || dataViewTypeRecords.length === 0 ) {
+			return EMPTY_ARRAY;
+		}
+		const dataViews = getEntityRecords( 'postType', 'wp_dataviews', {
+			wp_dataviews_type: dataViewTypeRecords[ 0 ].id,
+			orderby: 'date',
+			order: 'asc',
+		} );
+		if ( ! dataViews ) {
+			return EMPTY_ARRAY;
+		}
+		return dataViews;
+	} );
+	return customDataViews;
+}
+
+export default function CustomDataViewsList( { type, activeView, isCustom } ) {
+	const customDataViews = useCustomDataViews( type );
+	return (
+		<ItemGroup>
+			{ customDataViews.map( ( customViewRecord ) => {
+				return (
+					<CustomDataViewItem
+						key={ customViewRecord.id }
+						dataviewId={ customViewRecord.id }
+						isActive={
+							isCustom === 'true' &&
+							Number( activeView ) === customViewRecord.id
+						}
+					/>
+				);
+			} ) }
+			<AddNewItem type={ type } />
+		</ItemGroup>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { page, columns } from '@wordpress/icons';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { useLink } from '../routes/link';
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import { unlock } from '../../lock-unlock';
+const { useLocation } = unlock( routerPrivateApis );
+
+function getDataViewIcon( type ) {
+	const icons = { list: page, grid: columns };
+	return icons[ type ];
+}
+
+export default function DataViewItem( {
+	title,
+	slug,
+	customViewId,
+	type,
+	icon,
+	isActive,
+	isCustom,
+} ) {
+	const {
+		params: { path },
+	} = useLocation();
+
+	const iconToUse = icon || getDataViewIcon( type );
+
+	const linkInfo = useLink( {
+		path,
+		activeView: isCustom === 'true' ? customViewId : slug,
+		isCustom,
+	} );
+	return (
+		<SidebarNavigationItem
+			icon={ iconToUse }
+			{ ...linkInfo }
+			aria-current={ isActive ? 'true' : undefined }
+		>
+			{ title }
+		</SidebarNavigationItem>
+	);
+}

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -21,29 +21,35 @@ const DEFAULT_PAGE_BASE = {
 	layout: {},
 };
 
-const DEFAULT_VIEWS = [
-	{
-		title: __( 'All' ),
-		slug: 'all',
-		view: DEFAULT_PAGE_BASE,
-	},
-	{
-		title: __( 'Drafts' ),
-		slug: 'drafts',
-		view: {
-			...DEFAULT_PAGE_BASE,
-			filters: [ { field: 'status', operator: 'in', value: 'draft' } ],
+const DEFAULT_VIEWS = {
+	page: [
+		{
+			title: __( 'All' ),
+			slug: 'all',
+			view: DEFAULT_PAGE_BASE,
 		},
-	},
-	{
-		title: __( 'Trash' ),
-		slug: 'trash',
-		icon: trash,
-		view: {
-			...DEFAULT_PAGE_BASE,
-			filters: [ { field: 'status', operator: 'in', value: 'trash' } ],
+		{
+			title: __( 'Drafts' ),
+			slug: 'drafts',
+			view: {
+				...DEFAULT_PAGE_BASE,
+				filters: [
+					{ field: 'status', operator: 'in', value: 'draft' },
+				],
+			},
 		},
-	},
-];
+		{
+			title: __( 'Trash' ),
+			slug: 'trash',
+			icon: trash,
+			view: {
+				...DEFAULT_PAGE_BASE,
+				filters: [
+					{ field: 'status', operator: 'in', value: 'trash' },
+				],
+			},
+		},
+	],
+};
 
 export default DEFAULT_VIEWS;

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -2,65 +2,56 @@
  * WordPress dependencies
  */
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
-import { page, columns } from '@wordpress/icons';
-import { privateApis as routerPrivateApis } from '@wordpress/router';
 
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import { useLink } from '../routes/link';
-import { default as DEFAULT_VIEWS } from '../page-pages/default-views';
+
+import { default as DEFAULT_VIEWS } from './default-views';
 import { unlock } from '../../lock-unlock';
 const { useLocation } = unlock( routerPrivateApis );
-import SidebarNavigationItem from '../sidebar-navigation-item';
+import DataViewItem from './dataview-item';
+import CustomDataViewsList from './custom-dataviews-list';
 
-function getDataViewIcon( dataview ) {
-	const icons = { list: page, grid: columns };
-	return icons[ dataview.view.type ];
-}
-
-function DataViewItem( { dataview, isActive, icon } ) {
-	const {
-		params: { path },
-	} = useLocation();
-
-	const _icon = icon || getDataViewIcon( dataview );
-
-	const linkInfo = useLink( {
-		path,
-		activeView: dataview.slug,
-	} );
-	return (
-		<SidebarNavigationItem
-			icon={ _icon }
-			{ ...linkInfo }
-			aria-current={ isActive ? 'true' : undefined }
-		>
-			{ dataview.title }
-		</SidebarNavigationItem>
-	);
-}
+const PATH_TO_TYPE = {
+	'/pages': 'page',
+};
 
 export default function DataViewsSidebarContent() {
 	const {
-		params: { path, activeView = 'all' },
+		params: { path, activeView = 'all', isCustom = 'false' },
 	} = useLocation();
-	if ( ! path || path !== '/pages' ) {
+	if ( ! path || ! PATH_TO_TYPE[ path ] ) {
 		return null;
 	}
+	const type = PATH_TO_TYPE[ path ];
 
 	return (
-		<ItemGroup>
-			{ DEFAULT_VIEWS.map( ( dataview ) => {
-				return (
-					<DataViewItem
-						key={ dataview.slug }
-						icon={ dataview.icon }
-						dataview={ dataview }
-						isActive={ dataview.slug === activeView }
-					/>
-				);
-			} ) }
-		</ItemGroup>
+		<>
+			<ItemGroup>
+				{ DEFAULT_VIEWS[ type ].map( ( dataview ) => {
+					return (
+						<DataViewItem
+							key={ dataview.slug }
+							slug={ dataview.slug }
+							title={ dataview.title }
+							icon={ dataview.icon }
+							type={ dataview.view.type }
+							isActive={
+								isCustom === 'false' &&
+								dataview.slug === activeView
+							}
+							isCustom="false"
+						/>
+					);
+				} ) }
+			</ItemGroup>
+			<CustomDataViewsList
+				activeView={ activeView }
+				type={ type }
+				isCustom="true"
+			/>
+		</>
 	);
 }


### PR DESCRIPTION
In this pull request, users can now create their own personalized views, which can be saved and stored in the database. The main focus of this PR is on setting up the necessary mechanisms to add post types and taxonomies, as well as ensuring that the views are correctly referenced and saved to the appropriate entities. However, further UI work will be required in order to distinguish between custom and default views, as well as to enable users to rename or delete their custom views.

## Screenshots

<img width="238" alt="Screenshot 2023-11-01 at 16 59 32" src="https://github.com/WordPress/gutenberg/assets/11271197/930646ad-af93-45fd-ae88-ff6c2262b745">
<img width="237" alt="Screenshot 2023-11-01 at 17 02 40" src="https://github.com/WordPress/gutenberg/assets/11271197/5efed623-1b46-4ba5-ab0a-5ab2b9c47c25">
