### PR TITLE
Site Editor: Fix the 'Slug' display for draft pages

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -46,7 +46,9 @@ function getPageDetails( page ) {
 			label: __( 'Slug' ),
 			value: (
 				<Truncate numberOfLines={ 1 }>
-					{ safeDecodeURIComponent( page.slug ) }
+					{ safeDecodeURIComponent(
+						page.slug || page.generated_slug
+					) }
 				</Truncate>
 			),
 		},


### PR DESCRIPTION
## What?
PR fixes a bug where the `slug` wasn't displayed for draft pages in the details area.

## How?
Use `record.generated_slug` as a fallback. This matches the behavior of the `editor` package permalink selectors. Ref: https://core.trac.wordpress.org/ticket/45017.

## Testing Instructions
1. Open the Site Editor.
2. Navigate to Pages.
3. Open a draft page.
4. Confirm that the `slug` is correctly displayed in the "Details" sidebar.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-11-01 at 21 11 48](https://github.com/WordPress/gutenberg/assets/240569/52aed01f-4c7b-44d6-85dd-949fabc2c240)
