### PR TITLE
Refactor Edit Widgets Document Tools Navigation to own component

### DIFF
--- a/packages/edit-widgets/src/components/header/document-tools/index.js
+++ b/packages/edit-widgets/src/components/header/document-tools/index.js
@@ -3,13 +3,12 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
-import { Button, ToolbarItem, VisuallyHidden } from '@wordpress/components';
+import { Button, ToolbarItem } from '@wordpress/components';
 import {
 	NavigableToolbar,
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { PinnedItems } from '@wordpress/interface';
 import { listView, plus } from '@wordpress/icons';
 import { useCallback, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
@@ -17,10 +16,8 @@ import { useViewportMatch } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import SaveButton from '../../save-button';
 import UndoButton from '../undo-redo/undo';
 import RedoButton from '../undo-redo/redo';
-import MoreMenu from '../../more-menu';
 import useLastSelectedWidgetArea from '../../../hooks/use-last-selected-widget-area';
 import { store as editWidgetsStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
@@ -87,48 +84,46 @@ function DocumentTools( { setListViewToggleElement } ) {
 		fixedToolbarCanBeFocused;
 
 	return (
-					<NavigableToolbar
-						className="edit-widgets-header-toolbar"
-						aria-label={ __( 'Document tools' ) }
-						shouldUseKeyboardFocusShortcut={
-							! blockToolbarCanBeFocused
-						}
-					>
-						<ToolbarItem
-							ref={ inserterButton }
-							as={ Button }
-							className="edit-widgets-header-toolbar__inserter-toggle"
-							variant="primary"
-							isPressed={ isInserterOpen }
-							onMouseDown={ ( event ) => {
-								event.preventDefault();
-							} }
-							onClick={ handleClick }
-							icon={ plus }
-							/* translators: button label text should, if possible, be under 16
+		<NavigableToolbar
+			className="edit-widgets-header-toolbar"
+			aria-label={ __( 'Document tools' ) }
+			shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
+		>
+			<ToolbarItem
+				ref={ inserterButton }
+				as={ Button }
+				className="edit-widgets-header-toolbar__inserter-toggle"
+				variant="primary"
+				isPressed={ isInserterOpen }
+				onMouseDown={ ( event ) => {
+					event.preventDefault();
+				} }
+				onClick={ handleClick }
+				icon={ plus }
+				/* translators: button label text should, if possible, be under 16
 					characters. */
-							label={ _x(
-								'Toggle block inserter',
-								'Generic label for block inserter button'
-							) }
-						/>
-						{ isMediumViewport && (
-							<>
-								<UndoButton />
-								<RedoButton />
-								<ToolbarItem
-									as={ Button }
-									className="edit-widgets-header-toolbar__list-view-toggle"
-									icon={ listView }
-									isPressed={ isListViewOpen }
-									/* translators: button label text should, if possible, be under 16 characters. */
-									label={ __( 'List View' ) }
-									onClick={ toggleListView }
-									ref={ setListViewToggleElement }
-								/>
-							</>
-						) }
-					</NavigableToolbar>
+				label={ _x(
+					'Toggle block inserter',
+					'Generic label for block inserter button'
+				) }
+			/>
+			{ isMediumViewport && (
+				<>
+					<UndoButton />
+					<RedoButton />
+					<ToolbarItem
+						as={ Button }
+						className="edit-widgets-header-toolbar__list-view-toggle"
+						icon={ listView }
+						isPressed={ isListViewOpen }
+						/* translators: button label text should, if possible, be under 16 characters. */
+						label={ __( 'List View' ) }
+						onClick={ toggleListView }
+						ref={ setListViewToggleElement }
+					/>
+				</>
+			) }
+		</NavigableToolbar>
 	);
 }
 

--- a/packages/edit-widgets/src/components/header/document-tools/index.js
+++ b/packages/edit-widgets/src/components/header/document-tools/index.js
@@ -17,18 +17,17 @@ import { useViewportMatch } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import DocumentTools from './document-tools';
-import SaveButton from '../save-button';
-import UndoButton from './undo-redo/undo';
-import RedoButton from './undo-redo/redo';
-import MoreMenu from '../more-menu';
-import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
-import { store as editWidgetsStore } from '../../store';
-import { unlock } from '../../lock-unlock';
+import SaveButton from '../../save-button';
+import UndoButton from '../undo-redo/undo';
+import RedoButton from '../undo-redo/redo';
+import MoreMenu from '../../more-menu';
+import useLastSelectedWidgetArea from '../../../hooks/use-last-selected-widget-area';
+import { store as editWidgetsStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
 
 const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 
-function Header( { setListViewToggleElement } ) {
+function DocumentTools( { setListViewToggleElement } ) {
 	const isMediumViewport = useViewportMatch( 'medium' );
 	const inserterButton = useRef();
 	const widgetAreaClientId = useLastSelectedWidgetArea();
@@ -88,32 +87,49 @@ function Header( { setListViewToggleElement } ) {
 		fixedToolbarCanBeFocused;
 
 	return (
-		<>
-			<div className="edit-widgets-header">
-				<div className="edit-widgets-header__navigable-toolbar-wrapper">
-					{ isMediumViewport && (
-						<h1 className="edit-widgets-header__title">
-							{ __( 'Widgets' ) }
-						</h1>
-					) }
-					{ ! isMediumViewport && (
-						<VisuallyHidden
-							as="h1"
-							className="edit-widgets-header__title"
-						>
-							{ __( 'Widgets' ) }
-						</VisuallyHidden>
-					) }
-					<DocumentTools />
-				</div>
-				<div className="edit-widgets-header__actions">
-					<SaveButton />
-					<PinnedItems.Slot scope="core/edit-widgets" />
-					<MoreMenu />
-				</div>
-			</div>
-		</>
+					<NavigableToolbar
+						className="edit-widgets-header-toolbar"
+						aria-label={ __( 'Document tools' ) }
+						shouldUseKeyboardFocusShortcut={
+							! blockToolbarCanBeFocused
+						}
+					>
+						<ToolbarItem
+							ref={ inserterButton }
+							as={ Button }
+							className="edit-widgets-header-toolbar__inserter-toggle"
+							variant="primary"
+							isPressed={ isInserterOpen }
+							onMouseDown={ ( event ) => {
+								event.preventDefault();
+							} }
+							onClick={ handleClick }
+							icon={ plus }
+							/* translators: button label text should, if possible, be under 16
+					characters. */
+							label={ _x(
+								'Toggle block inserter',
+								'Generic label for block inserter button'
+							) }
+						/>
+						{ isMediumViewport && (
+							<>
+								<UndoButton />
+								<RedoButton />
+								<ToolbarItem
+									as={ Button }
+									className="edit-widgets-header-toolbar__list-view-toggle"
+									icon={ listView }
+									isPressed={ isListViewOpen }
+									/* translators: button label text should, if possible, be under 16 characters. */
+									label={ __( 'List View' ) }
+									onClick={ toggleListView }
+									ref={ setListViewToggleElement }
+								/>
+							</>
+						) }
+					</NavigableToolbar>
 	);
 }
 
-export default Header;
+export default DocumentTools;

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -1,17 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { __, _x } from '@wordpress/i18n';
-import { Button, ToolbarItem, VisuallyHidden } from '@wordpress/components';
-import {
-	NavigableToolbar,
-	store as blockEditorStore,
-	privateApis as blockEditorPrivateApis,
-} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/components';
 import { PinnedItems } from '@wordpress/interface';
-import { listView, plus } from '@wordpress/icons';
-import { useCallback, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 
 /**
@@ -19,73 +11,10 @@ import { useViewportMatch } from '@wordpress/compose';
  */
 import DocumentTools from './document-tools';
 import SaveButton from '../save-button';
-import UndoButton from './undo-redo/undo';
-import RedoButton from './undo-redo/redo';
 import MoreMenu from '../more-menu';
-import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
-import { store as editWidgetsStore } from '../../store';
-import { unlock } from '../../lock-unlock';
-
-const { useShouldContextualToolbarShow } = unlock( blockEditorPrivateApis );
 
 function Header( { setListViewToggleElement } ) {
 	const isMediumViewport = useViewportMatch( 'medium' );
-	const inserterButton = useRef();
-	const widgetAreaClientId = useLastSelectedWidgetArea();
-	const isLastSelectedWidgetAreaOpen = useSelect(
-		( select ) =>
-			select( editWidgetsStore ).getIsWidgetAreaOpen(
-				widgetAreaClientId
-			),
-		[ widgetAreaClientId ]
-	);
-	const { isInserterOpen, isListViewOpen } = useSelect( ( select ) => {
-		const { isInserterOpened, isListViewOpened } =
-			select( editWidgetsStore );
-		return {
-			isInserterOpen: isInserterOpened(),
-			isListViewOpen: isListViewOpened(),
-		};
-	}, [] );
-	const { setIsWidgetAreaOpen, setIsInserterOpened, setIsListViewOpened } =
-		useDispatch( editWidgetsStore );
-	const { selectBlock } = useDispatch( blockEditorStore );
-	const handleClick = () => {
-		if ( isInserterOpen ) {
-			// Focusing the inserter button closes the inserter popover.
-			setIsInserterOpened( false );
-		} else {
-			if ( ! isLastSelectedWidgetAreaOpen ) {
-				// Select the last selected block if hasn't already.
-				selectBlock( widgetAreaClientId );
-				// Open the last selected widget area when opening the inserter.
-				setIsWidgetAreaOpen( widgetAreaClientId, true );
-			}
-			// The DOM updates resulting from selectBlock() and setIsInserterOpened() calls are applied the
-			// same tick and pretty much in a random order. The inserter is closed if any other part of the
-			// app receives focus. If selectBlock() happens to take effect after setIsInserterOpened() then
-			// the inserter is visible for a brief moment and then gets auto-closed due to focus moving to
-			// the selected block.
-			window.requestAnimationFrame( () => setIsInserterOpened( true ) );
-		}
-	};
-
-	const toggleListView = useCallback(
-		() => setIsListViewOpened( ! isListViewOpen ),
-		[ setIsListViewOpened, isListViewOpen ]
-	);
-
-	const {
-		shouldShowContextualToolbar,
-		canFocusHiddenToolbar,
-		fixedToolbarCanBeFocused,
-	} = useShouldContextualToolbarShow();
-	// If there's a block toolbar to be focused, disable the focus shortcut for the document toolbar.
-	// There's a fixed block toolbar when the fixed toolbar option is enabled or when the browser width is less than the large viewport.
-	const blockToolbarCanBeFocused =
-		shouldShowContextualToolbar ||
-		canFocusHiddenToolbar ||
-		fixedToolbarCanBeFocused;
 
 	return (
 		<>
@@ -104,7 +33,9 @@ function Header( { setListViewToggleElement } ) {
 							{ __( 'Widgets' ) }
 						</VisuallyHidden>
 					) }
-					<DocumentTools />
+					<DocumentTools
+						setListViewToggleElement={ setListViewToggleElement }
+					/>
 				</div>
 				<div className="edit-widgets-header__actions">
 					<SaveButton />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Refactoring the widgets editor document tools header navigation to be its own component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This brings it in line with the other site headers. It will also make the work from https://github.com/WordPress/gutenberg/pull/54513/ be much easier to review since it won't include as many changes, and this is a useful refactor for ease of reading and use regardless.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Split the document tools navigation into its own `<DocumentTools />` component. Named that as the aria-label is `Document Tools`.
- Removed all the unused variables and processing work between the files.

## Testing Instructions
There should be no functional changes. All tests should pass. Test the Document Tools area of the Widgets editor header by switching to a theme like TwentyTwenty that uses Widgets. 