### PR TITLE
DataViews: add delete and restore actions

### DIFF
--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -133,14 +133,10 @@ export function useRestorePostAction() {
 				return status === 'trash';
 			},
 			async perform( post ) {
+				await editEntityRecord( 'postType', post.type, post.id, {
+					status: 'draft',
+				} );
 				try {
-					await editEntityRecord(
-						'postType',
-						post.type,
-						post.id,
-						{ status: 'draft' },
-						{ throwOnError: true }
-					);
 					await saveEditedEntityRecord(
 						'postType',
 						post.type,

--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { external, trash } from '@wordpress/icons';
+import { external, trash, backup } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -64,6 +64,118 @@ export function useTrashPostAction() {
 			},
 		} ),
 		[ createSuccessNotice, createErrorNotice, deleteEntityRecord ]
+	);
+}
+
+export function usePermanentlyDeletePostAction() {
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+	const { deleteEntityRecord } = useDispatch( coreStore );
+
+	return useMemo(
+		() => ( {
+			id: 'permanently-delete',
+			label: __( 'Permanently delete' ),
+			isPrimary: true,
+			icon: trash,
+			isEligible( { status } ) {
+				return status === 'trash';
+			},
+			async perform( post ) {
+				try {
+					await deleteEntityRecord(
+						'postType',
+						post.type,
+						post.id,
+						{ force: true },
+						{ throwOnError: true }
+					);
+					createSuccessNotice(
+						sprintf(
+							/* translators: The posts's title. */
+							__( '"%s" permanently deleted.' ),
+							decodeEntities( post.title.rendered )
+						),
+						{
+							type: 'snackbar',
+							id: 'edit-site-post-permanently-deleted',
+						}
+					);
+				} catch ( error ) {
+					const errorMessage =
+						error.message && error.code !== 'unknown_error'
+							? error.message
+							: __(
+									'An error occurred while permanently deleting the post.'
+							  );
+
+					createErrorNotice( errorMessage, { type: 'snackbar' } );
+				}
+			},
+		} ),
+		[ createSuccessNotice, createErrorNotice, deleteEntityRecord ]
+	);
+}
+
+export function useRestorePostAction() {
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+	const { editEntityRecord, saveEditedEntityRecord } =
+		useDispatch( coreStore );
+
+	return useMemo(
+		() => ( {
+			id: 'restore',
+			label: __( 'Restore' ),
+			isPrimary: true,
+			icon: backup,
+			isEligible( { status } ) {
+				return status === 'trash';
+			},
+			async perform( post ) {
+				try {
+					await editEntityRecord(
+						'postType',
+						post.type,
+						post.id,
+						{ status: 'draft' },
+						{ throwOnError: true }
+					);
+					await saveEditedEntityRecord(
+						'postType',
+						post.type,
+						post.id,
+						{ throwOnError: true }
+					);
+					createSuccessNotice(
+						sprintf(
+							/* translators: The posts's title. */
+							__( '"%s" has been restored.' ),
+							decodeEntities( post.title.rendered )
+						),
+						{
+							type: 'snackbar',
+							id: 'edit-site-post-restored',
+						}
+					);
+				} catch ( error ) {
+					const errorMessage =
+						error.message && error.code !== 'unknown_error'
+							? error.message
+							: __(
+									'An error occurred while restoring the post.'
+							  );
+
+					createErrorNotice( errorMessage, { type: 'snackbar' } );
+				}
+			},
+		} ),
+		[
+			createSuccessNotice,
+			createErrorNotice,
+			editEntityRecord,
+			saveEditedEntityRecord,
+		]
 	);
 }
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -21,6 +21,8 @@ import { DataViews } from '../dataviews';
 import { DEFAULT_STATUSES, default as DEFAULT_VIEWS } from './default-views';
 import {
 	useTrashPostAction,
+	usePermanentlyDeletePostAction,
+	useRestorePostAction,
 	postRevisionsAction,
 	viewPostAction,
 	useEditPostAction,
@@ -216,15 +218,24 @@ export default function PagePages() {
 	);
 
 	const trashPostAction = useTrashPostAction();
+	const permanentlyDeletePostAction = usePermanentlyDeletePostAction();
+	const restorePostAction = useRestorePostAction();
 	const editPostAction = useEditPostAction();
 	const actions = useMemo(
 		() => [
 			viewPostAction,
 			trashPostAction,
+			permanentlyDeletePostAction,
+			restorePostAction,
 			editPostAction,
 			postRevisionsAction,
 		],
-		[ trashPostAction, editPostAction ]
+		[
+			trashPostAction,
+			permanentlyDeletePostAction,
+			restorePostAction,
+			editPostAction,
+		]
 	);
 	const onChangeView = useCallback(
 		( viewUpdater ) => {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -225,8 +225,8 @@ export default function PagePages() {
 		() => [
 			viewPostAction,
 			trashPostAction,
-			permanentlyDeletePostAction,
 			restorePostAction,
+			permanentlyDeletePostAction,
 			editPostAction,
 			postRevisionsAction,
 		],


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/55765

Adds the permanently delete and restore actions.

## Screenshot
<img width="1000" alt="Screenshot 2023-11-01 at 18 29 22" src="https://github.com/WordPress/gutenberg/assets/11271197/103e5029-bd38-4367-a3cc-33af491be5ed">
