### PR TITLE
Resizeable box (for resizing cover block) should use after block popover slot

### DIFF
--- a/packages/block-editor/src/components/resizable-box-popover/index.js
+++ b/packages/block-editor/src/components/resizable-box-popover/index.js
@@ -17,7 +17,7 @@ export default function ResizableBoxPopover( {
 		<BlockPopover
 			clientId={ clientId }
 			__unstableCoverTarget
-			__unstablePopoverSlot="block-toolbar"
+			__unstablePopoverSlot="__unstable-block-tools-after"
 			shift={ false }
 			{ ...props }
 		>


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
Change the slot name used for the resize handles on the cover block resizer.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The block-popover slot is reserved for block-toolbar like popovers, such as the captions popover. Popovers that are not block tools should use the `__unstable-block-tools-after` slot. This is important for when the Top Toolbar is within the header DOM, as these resize tools should not be within that. Regardless, these tools should be using the `__unstable-block-tools-after` slot.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Change the slot used by the resizer to the `__unstable-block-tools-after`

## Testing Instructions

There should be no functional change from `trunk`.
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a cover block
- Resize it using the circle handles on the bottom and right sides
- Should resize as on `trunk`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
