### PR TITLE
Pattern: Unlock the private hook outside the component

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -35,6 +35,7 @@ import { useRef, useMemo } from '@wordpress/element';
  */
 import { unlock } from '../lock-unlock';
 
+const { useLayoutClasses } = unlock( blockEditorPrivateApis );
 const fullAlignments = [ 'full', 'wide', 'left', 'right' ];
 
 const useInferredLayout = ( blocks, parentLayout ) => {
@@ -71,7 +72,6 @@ export default function ReusableBlockEdit( {
 	attributes: { ref },
 	__unstableParentLayout: parentLayout,
 } ) {
-	const { useLayoutClasses } = unlock( blockEditorPrivateApis );
 	const hasAlreadyRendered = useHasRecursion( ref );
 	const { record, hasResolved } = useEntityRecord(
 		'postType',


### PR DESCRIPTION
## What?
A micro-optimization moves the private `useLayoutClasses` hook's unlocking outside the component.

## Why?
The private components and hooks can be unlocked at the file level. There's no need to perform the action on each component re-render.

## Testing Instructions
Confirm the Pattern can be inserted as before and there's no error.
