### PR TITLE
Give nice unique names to block controls HOCs

### DIFF
--- a/docs/reference-guides/filters/block-filters.md
+++ b/docs/reference-guides/filters/block-filters.md
@@ -187,7 +187,7 @@ const { createHigherOrderComponent } = wp.compose;
 const { InspectorControls } = wp.blockEditor;
 const { PanelBody } = wp.components;
 
-const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
+const withMyPluginControls = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
 		return (
 			<>
@@ -198,12 +198,12 @@ const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
 			</>
 		);
 	};
-}, 'withInspectorControl' );
+}, 'withMyPluginControls' );
 
 wp.hooks.addFilter(
 	'editor.BlockEdit',
 	'my-plugin/with-inspector-controls',
-	withInspectorControls
+	withMyPluginControls
 );
 ```
 
@@ -212,7 +212,7 @@ wp.hooks.addFilter(
 ```js
 var el = React.createElement;
 
-var withInspectorControls = wp.compose.createHigherOrderComponent( function (
+var withMyPluginControls = wp.compose.createHigherOrderComponent( function (
 	BlockEdit
 ) {
 	return function ( props ) {
@@ -227,12 +227,12 @@ var withInspectorControls = wp.compose.createHigherOrderComponent( function (
 			)
 		);
 	};
-}, 'withInspectorControls' );
+}, 'withMyPluginControls' );
 
 wp.hooks.addFilter(
 	'editor.BlockEdit',
 	'my-plugin/with-inspector-controls',
-	withInspectorControls
+	withMyPluginControls
 );
 ```
 
@@ -245,7 +245,7 @@ To mitigate this, consider whether any work you perform can be altered to run on
 For example, if you are adding components that only need to render when the block is _selected_, then you can use the block's "selected" state (`props.isSelected`) to conditionalize your rendering.
 
 ```js
-const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
+const withMyPluginControls = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
 		return (
 			<>
@@ -258,7 +258,7 @@ const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
 			</>
 		);
 	};
-}, 'withInspectorControl' );
+}, 'withMyPluginControls' );
 ```
 
 #### `editor.BlockListBlock`

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -98,8 +98,8 @@ export function addAttribute( settings ) {
 			...settings.attributes,
 			align: {
 				type: 'string',
-				// Allow for '' since it is used by updateAlignment function
-				// in withToolbarControls for special cases with defined default values.
+				// Allow for '' since it is used by the `updateAlignment` function
+				// in toolbar controls for special cases with defined default values.
 				enum: [ ...ALL_ALIGNMENTS, '' ],
 			},
 		};
@@ -115,7 +115,7 @@ function BlockEditAlignmentToolbarControls( {
 } ) {
 	// Compute the block valid alignments by taking into account,
 	// if the theme supports wide alignments or not and the layout's
-	// availble alignments. We do that for conditionally rendering
+	// available alignments. We do that for conditionally rendering
 	// Slot.
 	const blockAllowedAlignments = getValidAlignments(
 		getBlockSupport( blockName, 'align' ),
@@ -160,7 +160,7 @@ function BlockEditAlignmentToolbarControls( {
  *
  * @return {Function} Wrapped component.
  */
-export const withToolbarControls = createHigherOrderComponent(
+export const withAlignmentControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const hasAlignmentSupport = hasBlockSupport(
 			props.name,
@@ -181,7 +181,7 @@ export const withToolbarControls = createHigherOrderComponent(
 			</>
 		);
 	},
-	'withToolbarControls'
+	'withAlignmentControls'
 );
 
 function BlockListBlockWithDataAlign( { block: BlockListBlock, props } ) {
@@ -257,7 +257,7 @@ export function addAssignedAlign( props, blockType, attributes ) {
 
 addFilter(
 	'blocks.registerBlockType',
-	'core/align/addAttribute',
+	'core/editor/align/addAttribute',
 	addAttribute
 );
 addFilter(
@@ -268,10 +268,10 @@ addFilter(
 addFilter(
 	'editor.BlockEdit',
 	'core/editor/align/with-toolbar-controls',
-	withToolbarControls
+	withAlignmentControls
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',
-	'core/align/addAssignedAlign',
+	'core/editor/align/addAssignedAlign',
 	addAssignedAlign
 );

--- a/packages/block-editor/src/hooks/align.native.js
+++ b/packages/block-editor/src/hooks/align.native.js
@@ -36,8 +36,8 @@ addFilter(
 				...settings.attributes,
 				align: {
 					type: 'string',
-					// Allow for '' since it is used by updateAlignment function
-					// in withToolbarControls for special cases with defined default values.
+					// Allow for '' since it is used by the `updateAlignment` function
+					// in toolbar controls for special cases with defined default values.
 					enum: [ ...ALIGNMENTS, '' ],
 				},
 			};

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -123,26 +123,23 @@ function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
  *
  * @return {Component} Wrapped component.
  */
-export const withInspectorControl = createHigherOrderComponent(
-	( BlockEdit ) => {
-		return ( props ) => {
-			return (
-				<>
-					<BlockEdit { ...props } />
-					{ props.isSelected &&
-						hasBlockSupport( props.name, 'anchor' ) && (
-							<BlockEditAnchorControl
-								blockName={ props.name }
-								attributes={ props.attributes }
-								setAttributes={ props.setAttributes }
-							/>
-						) }
-				</>
-			);
-		};
-	},
-	'withInspectorControl'
-);
+export const withAnchorControls = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		return (
+			<>
+				<BlockEdit { ...props } />
+				{ props.isSelected &&
+					hasBlockSupport( props.name, 'anchor' ) && (
+						<BlockEditAnchorControl
+							blockName={ props.name }
+							attributes={ props.attributes }
+							setAttributes={ props.setAttributes }
+						/>
+					) }
+			</>
+		);
+	};
+}, 'withAnchorControls' );
 
 /**
  * Override props assigned to save component to inject anchor ID, if block
@@ -166,11 +163,11 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 addFilter( 'blocks.registerBlockType', 'core/anchor/attribute', addAttribute );
 addFilter(
 	'editor.BlockEdit',
-	'core/editor/anchor/with-inspector-control',
-	withInspectorControl
+	'core/editor/anchor/with-inspector-controls',
+	withAnchorControls
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',
-	'core/anchor/save-props',
+	'core/editor/anchor/save-props',
 	addSaveProps
 );

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -235,23 +235,26 @@ function BlockHooksControl( props ) {
 	);
 }
 
-export const withBlockHooks = createHigherOrderComponent( ( BlockEdit ) => {
-	return ( props ) => {
-		const blockEdit = <BlockEdit key="edit" { ...props } />;
-		return (
-			<>
-				{ blockEdit }
-				<BlockHooksControl
-					blockName={ props.name }
-					clientId={ props.clientId }
-				/>
-			</>
-		);
-	};
-}, 'withBlockHooks' );
+export const withBlockHooksControls = createHigherOrderComponent(
+	( BlockEdit ) => {
+		return ( props ) => {
+			const blockEdit = <BlockEdit key="edit" { ...props } />;
+			return (
+				<>
+					{ blockEdit }
+					<BlockHooksControl
+						blockName={ props.name }
+						clientId={ props.clientId }
+					/>
+				</>
+			);
+		};
+	},
+	'withBlockHooksControls'
+);
 
 addFilter(
 	'editor.BlockEdit',
-	'core/block-hooks/with-inspector-control',
-	withBlockHooks
+	'core/editor/block-hooks/with-inspector-controls',
+	withBlockHooksControls
 );

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -187,7 +187,7 @@ function BlockRenameControl( props ) {
 	);
 }
 
-export const withBlockRenameControl = createHigherOrderComponent(
+export const withBlockRenameControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { clientId, name, attributes, setAttributes, isSelected } = props;
 
@@ -216,11 +216,11 @@ export const withBlockRenameControl = createHigherOrderComponent(
 			</>
 		);
 	},
-	'withToolbarControls'
+	'withBlockRenameControls'
 );
 
 addFilter(
 	'editor.BlockEdit',
-	'core/block-rename-ui/with-block-rename-control',
-	withBlockRenameControl
+	'core/block-rename-ui/with-block-rename-controls',
+	withBlockRenameControls
 );

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -37,7 +37,7 @@ function StopEditingAsBlocksOnOutsideSelect( {
 	return null;
 }
 
-export const withBlockControls = createHigherOrderComponent(
+export const withContentLockControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { getBlockListSettings, getSettings } =
 			useSelect( blockEditorStore );
@@ -155,11 +155,11 @@ export const withBlockControls = createHigherOrderComponent(
 			</>
 		);
 	},
-	'withToolbarControls'
+	'withContentLockControls'
 );
 
 addFilter(
 	'editor.BlockEdit',
 	'core/content-lock-ui/with-block-controls',
-	withBlockControls
+	withContentLockControls
 );

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -72,7 +72,7 @@ function CustomClassNameControls( { attributes, setAttributes } ) {
  *
  * @return {Component} Wrapped component.
  */
-export const withInspectorControl = createHigherOrderComponent(
+export const withCustomClassNameControls = createHigherOrderComponent(
 	( BlockEdit ) => {
 		return ( props ) => {
 			const hasCustomClassName = hasBlockSupport(
@@ -94,7 +94,7 @@ export const withInspectorControl = createHigherOrderComponent(
 			);
 		};
 	},
-	'withInspectorControl'
+	'withCustomClassNameControls'
 );
 
 /**
@@ -163,17 +163,17 @@ export function addTransforms( result, source, index, results ) {
 
 addFilter(
 	'blocks.registerBlockType',
-	'core/custom-class-name/attribute',
+	'core/editor/custom-class-name/attribute',
 	addAttribute
 );
 addFilter(
 	'editor.BlockEdit',
-	'core/editor/custom-class-name/with-inspector-control',
-	withInspectorControl
+	'core/editor/custom-class-name/with-inspector-controls',
+	withCustomClassNameControls
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',
-	'core/custom-class-name/save-props',
+	'core/editor/custom-class-name/save-props',
 	addSaveProps
 );
 

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -44,7 +44,7 @@ function addAttribute( settings ) {
  *
  * @return {Component} Wrapped component.
  */
-const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
+const withCustomFieldsControls = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
 		const blockEditingMode = useBlockEditingMode();
 		const hasCustomFieldsSupport = hasBlockSupport(
@@ -123,17 +123,17 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 
 		return <BlockEdit { ...props } />;
 	};
-}, 'withInspectorControl' );
+}, 'withCustomFieldsControls' );
 
 if ( window.__experimentalConnections ) {
 	addFilter(
 		'blocks.registerBlockType',
-		'core/connections/attribute',
+		'core/editor/connections/attribute',
 		addAttribute
 	);
 	addFilter(
 		'editor.BlockEdit',
-		'core/connections/with-inspector-control',
-		withInspectorControl
+		'core/editor/connections/with-inspector-controls',
+		withCustomFieldsControls
 	);
 }

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -333,7 +333,7 @@ export function addAttribute( settings ) {
  *
  * @return {Function} Wrapped component.
  */
-export const withInspectorControls = createHigherOrderComponent(
+export const withLayoutControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const supportLayout = hasLayoutBlockSupport( props.name );
 
@@ -342,7 +342,7 @@ export const withInspectorControls = createHigherOrderComponent(
 			<BlockEdit key="edit" { ...props } />,
 		];
 	},
-	'withInspectorControls'
+	'withLayoutControls'
 );
 
 /**
@@ -501,5 +501,5 @@ addFilter(
 addFilter(
 	'editor.BlockEdit',
 	'core/editor/layout/with-inspector-controls',
-	withInspectorControls
+	withLayoutControls
 );

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -329,7 +329,7 @@ export function PositionPanel( props ) {
  *
  * @return {Function} Wrapped component.
  */
-export const withInspectorControls = createHigherOrderComponent(
+export const withPositionControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name: blockName } = props;
 		const positionSupport = hasBlockSupport(
@@ -346,7 +346,7 @@ export const withInspectorControls = createHigherOrderComponent(
 			<BlockEdit key="edit" { ...props } />,
 		];
 	},
-	'withInspectorControls'
+	'withPositionControls'
 );
 
 /**
@@ -413,5 +413,5 @@ addFilter(
 addFilter(
 	'editor.BlockEdit',
 	'core/editor/position/with-inspector-controls',
-	withInspectorControls
+	withPositionControls
 );

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -354,7 +354,7 @@ export function addEditProps( settings ) {
  *
  * @return {Function} Wrapped component.
  */
-export const withBlockControls = createHigherOrderComponent(
+export const withBlockStyleControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		if ( ! hasStyleSupport( props.name ) ) {
 			return <BlockEdit key="edit" { ...props } />;
@@ -378,7 +378,7 @@ export const withBlockControls = createHigherOrderComponent(
 			</>
 		);
 	},
-	'withToolbarControls'
+	'withBlockStyleControls'
 );
 
 // Defines which element types are supported, including their hover styles or
@@ -537,7 +537,7 @@ addFilter(
 addFilter(
 	'editor.BlockEdit',
 	'core/style/with-block-controls',
-	withBlockControls
+	withBlockStyleControls
 );
 
 addFilter(

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -22,7 +22,7 @@ import BlockEdit from '../../components/block-edit';
 import BlockEditorProvider from '../../components/provider';
 import {
 	getValidAlignments,
-	withToolbarControls,
+	withAlignmentControls,
 	withDataAlign,
 	addAssignedAlign,
 } from '../align';
@@ -157,7 +157,7 @@ describe( 'align', () => {
 		} );
 	} );
 
-	describe( 'withToolbarControls', () => {
+	describe( 'withAlignControls', () => {
 		const componentProps = {
 			name: 'core/foo',
 			attributes: {},
@@ -167,7 +167,7 @@ describe( 'align', () => {
 		it( 'should do nothing if no valid alignments', () => {
 			registerBlockType( 'core/foo', blockSettings );
 
-			const EnhancedComponent = withToolbarControls(
+			const EnhancedComponent = withAlignmentControls(
 				( { wrapperProps } ) => <div { ...wrapperProps } />
 			);
 
@@ -197,7 +197,7 @@ describe( 'align', () => {
 				},
 			} );
 
-			const EnhancedComponent = withToolbarControls(
+			const EnhancedComponent = withAlignmentControls(
 				( { wrapperProps } ) => <div { ...wrapperProps } />
 			);
 


### PR DESCRIPTION
Fixes an aesthetic/devex issue where the HOCs that add block controls have undifferentiated names like `withToolbarControls` or `withInspectorControls`:

<img width="478" alt="Screenshot 2023-11-02 at 10 19 20" src="https://github.com/WordPress/gutenberg/assets/664258/2619c584-d1e6-42f6-a585-52cdecc4598c">

This PR modifies the HOC names to be specific, like `withPositionControls` or `withAlignmentControls`. The HOCs that add styles and attributes (like `withPositionStyles`) already use a similar convention.

I'm also unifying the names to consistently use plural (controls, not control) and unifying the convention for hook names (the `core/editor/...` prefix).

The result looks like this in the React devtools:

<img width="613" alt="Screenshot 2023-11-02 at 9 52 13" src="https://github.com/WordPress/gutenberg/assets/664258/708708ba-48bf-425f-9299-27a0ce9c8d5c">

**How to test:**
There should be no behavior change at all, we're just renaming variables, basically.