### PR TITLE
Performance: Add a metric to trace template navigation in the site editor

### DIFF
--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -32,6 +32,7 @@ export interface WPRawPerformanceResults {
 	inserterSearch: number[];
 	inserterHover: number[];
 	listViewOpen: number[];
+	navigate: number[];
 }
 
 export interface WPPerformanceResults {
@@ -65,6 +66,7 @@ export interface WPPerformanceResults {
 	listViewOpen?: number;
 	minListViewOpen?: number;
 	maxListViewOpen?: number;
+	navigate?: number;
 }
 
 /**
@@ -108,6 +110,7 @@ export function curateResults(
 		listViewOpen: average( results.listViewOpen ),
 		minListViewOpen: minimum( results.listViewOpen ),
 		maxListViewOpen: maximum( results.listViewOpen ),
+		navigate: median( results.navigate ),
 	};
 
 	return (


### PR DESCRIPTION
## What?

I've heard some feedback that navigating in the site editor can be slow depending on the theme. In order to improve the situations, I'm adding a new "navigate" metric to the site editor in this PR, that way we're able to track the evolution over time and improve the perceived performance of the site editor.

The new metric tracks the time it takes for the "click event" to execute when navigating from the "Templates" (showing home page) to "Single Posts" template (so we're switching the active template in the view) in the site editor, using the TT13 theme.

This metric is highly dependent on the theme and the content of these templates, the default theme used in performance tests (empty theme) gives numbers that are too small and not very representative. TT13 should give us something more meaningful (granted that it doesn't represent all themes).

## Testing instructions

you should be able to see the number output in the performance job. Once the PR is merged, I'll add the metric to codevitals as well.