### PR TITLE
DataViews: reset pagination upon filter change

### DIFF
--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -34,6 +34,7 @@ export default ( { filter, view, onChangeView } ) => {
 
 				onChangeView( ( currentView ) => ( {
 					...currentView,
+					page: 1,
 					filters: cleanEmptyObject( {
 						...currentView.filters,
 						[ filter.id ]: value,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

Fixes https://github.com/WordPress/gutenberg/issues/55756 It resets pagination upon a change in a filter. See issue for instructions on how to reproduce.
