### PR TITLE
Update: Code quality: Use for each instead of map.

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.tsx
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.tsx
@@ -66,7 +66,7 @@ function createSlotRegistry(): SlotFillBubblesVirtuallyContext {
 		const slotFills = fills.get( name );
 		if ( slotFills ) {
 			// Force update fills.
-			slotFills.map( ( fill ) => fill.current.rerender() );
+			slotFills.forEach( ( fill ) => fill.current.rerender() );
 		}
 	};
 


### PR DESCRIPTION
We were not mapping an array to another array we were just applying an operation on each element of the array so in that case forEach should be used instead of map.