### PR TITLE
POC: Implement partially synced patterns using the block bindings API

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -42,7 +42,7 @@ Create and save content to reuse across your site. Update the pattern, and the c
 -	**Name:** core/block
 -	**Category:** reusable
 -	**Supports:** ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
--	**Attributes:** ref
+-	**Attributes:** dynamicContent, ref
 
 ## Button
 

--- a/lib/block-supports/pattern.php
+++ b/lib/block-supports/pattern.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Pattern block support flag.
+ *
+ * @package gutenberg
+ */
+
+$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $gutenberg_experiments ) ) {
+	function gutenberg_register_pattern_support( $block_type ) {
+		$pattern_support = property_exists( $block_type, 'supports' ) ? _wp_array_get( $block_type->supports, array( '__experimentalConnections' ), false ) : false;
+
+		if ( $pattern_support ) {
+			if ( ! $block_type->uses_context ) {
+				$block_type->uses_context = array();
+			}
+
+			if ( ! in_array( 'dynamicContent', $block_type->uses_context, true ) ) {
+				$block_type->uses_context[] = 'dynamicContent';
+			}
+		}
+	}
+
+	// Register the block support.
+	WP_Block_Supports::get_instance()->register(
+		'pattern',
+		array(
+			'register_attribute' => 'gutenberg_register_pattern_support',
+		)
+	);
+}

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -101,6 +101,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 		$blocks_attributes_allowlist = array(
 			'core/paragraph' => array( 'content' ),
 			'core/image'     => array( 'url' ),
+			'core/heading' => array( 'content' ),
 		);
 
 		// Whitelist of the block types that support block connections.
@@ -132,9 +133,8 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 				continue;
 			}
 
-			// If the source value is not "meta_fields", skip it because the only supported
-			// connection source is meta (custom fields) for now.
-			if ( 'meta_fields' !== $attribute_value['source'] ) {
+			// Skip if the source value is not "meta_fields" or "pattern_attributes".
+			if ( 'meta_fields' !== $attribute_value['source'] && 'pattern_attributes' !== $attribute_value['source'] ) {
 				continue;
 			}
 
@@ -153,6 +153,10 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 				$block_instance,
 				$attribute_value['value']
 			);
+
+			if ( false === $custom_value ) {
+				continue;
+			}
 
 			$tags  = new WP_HTML_Tag_Processor( $block_content );
 			$found = $tags->next_tag(
@@ -181,5 +185,6 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 
 		return $block_content;
 	}
+
 	add_filter( 'render_block', 'gutenberg_render_block_connections', 10, 3 );
 }

--- a/lib/experimental/connection-sources/index.php
+++ b/lib/experimental/connection-sources/index.php
@@ -12,4 +12,7 @@ return array(
 		// if it doesn't, `get_post_meta()` will just return an empty string.
 		return get_post_meta( $block_instance->context['postId'], $meta_field, true );
 	},
+	'pattern_attributes' => function ( $block_instance, $meta_field ) {
+		return _wp_array_get( $block_instance->context, array( 'dynamicContent', $meta_field ), false );
+	}
 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -256,6 +256,7 @@ require __DIR__ . '/block-supports/duotone.php';
 require __DIR__ . '/block-supports/shadow.php';
 require __DIR__ . '/block-supports/background.php';
 require __DIR__ . '/block-supports/behaviors.php';
+require __DIR__ . '/block-supports/pattern.php';
 
 // Data views.
 require_once __DIR__ . '/experimental/data-views.php';

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { useRegistry } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody, TextControl, SelectControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -55,7 +56,11 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 
 		// Check if the current block is a paragraph or image block.
 		// Currently, only these two blocks are supported.
-		if ( ! [ 'core/paragraph', 'core/image' ].includes( props.name ) ) {
+		if (
+			! [ 'core/paragraph', 'core/image', 'core/heading' ].includes(
+				props.name
+			)
+		) {
 			return <BlockEdit { ...props } />;
 		}
 
@@ -65,6 +70,41 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 		let attributeName;
 		if ( props.name === 'core/paragraph' ) attributeName = 'content';
 		if ( props.name === 'core/image' ) attributeName = 'url';
+		if ( props.name === 'core/heading' ) attributeName = 'content';
+
+		const connectionSource =
+			props.attributes?.connections?.attributes?.[ attributeName ]
+				?.source || '';
+		const connectionValue =
+			props.attributes?.connections?.attributes?.[ attributeName ]
+				?.value || '';
+
+		function updateConnections( source, value ) {
+			if ( value === '' ) {
+				props.setAttributes( {
+					connections: undefined,
+					placeholder: undefined,
+				} );
+			} else {
+				props.setAttributes( {
+					connections: {
+						attributes: {
+							// The attributeName will be either `content` or `url`.
+							[ attributeName ]: {
+								// Source will be variable, could be post_meta, user_meta, term_meta, etc.
+								// Could even be a custom source like a social media attribute.
+								source,
+								value,
+							},
+						},
+					},
+					placeholder: sprintf(
+						'This content will be replaced on the frontend by the value of "%s" custom field.',
+						value
+					),
+				} );
+			}
+		}
 
 		if ( hasCustomFieldsSupport && props.isSelected ) {
 			return (
@@ -76,42 +116,40 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 								title={ __( 'Connections' ) }
 								initialOpen={ true }
 							>
+								<SelectControl
+									label={ __( 'Source' ) }
+									value={ connectionSource }
+									options={ [
+										{
+											label: __( 'None' ),
+											value: '',
+										},
+										{
+											label: __( 'Meta fields' ),
+											value: 'meta_fields',
+										},
+										{
+											label: __( 'Pattern attributes' ),
+											value: 'pattern_attributes',
+										},
+									] }
+									onChange={ ( nextSource ) => {
+										updateConnections(
+											nextSource,
+											connectionValue
+										);
+									} }
+								/>
 								<TextControl
 									__nextHasNoMarginBottom
 									autoComplete="off"
 									label={ __( 'Custom field meta_key' ) }
-									value={
-										props.attributes?.connections
-											?.attributes?.[ attributeName ]
-											?.value || ''
-									}
+									value={ connectionValue }
 									onChange={ ( nextValue ) => {
-										if ( nextValue === '' ) {
-											props.setAttributes( {
-												connections: undefined,
-												[ attributeName ]: undefined,
-												placeholder: undefined,
-											} );
-										} else {
-											props.setAttributes( {
-												connections: {
-													attributes: {
-														// The attributeName will be either `content` or `url`.
-														[ attributeName ]: {
-															// Source will be variable, could be post_meta, user_meta, term_meta, etc.
-															// Could even be a custom source like a social media attribute.
-															source: 'meta_fields',
-															value: nextValue,
-														},
-													},
-												},
-												[ attributeName ]: undefined,
-												placeholder: sprintf(
-													'This content will be replaced on the frontend by the value of "%s" custom field.',
-													nextValue
-												),
-											} );
-										}
+										updateConnections(
+											connectionSource,
+											nextValue
+										);
 									} }
 								/>
 							</PanelBody>
@@ -125,6 +163,30 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 	};
 }, 'withInspectorControl' );
 
+const createEditFunctionWithPatternSource = () =>
+	createHigherOrderComponent(
+		( BlockEdit ) =>
+			( { attributes, ...props } ) => {
+				const registry = useRegistry();
+				const sourceAttributes =
+					registry._selectAttributes?.( {
+						clientId: props.clientId,
+						name: props.name,
+						attributes,
+					} ) ?? attributes;
+
+				return (
+					<BlockEdit { ...props } attributes={ sourceAttributes } />
+				);
+			}
+	);
+
+function shimAttributeSource( settings ) {
+	settings.edit = createEditFunctionWithPatternSource()( settings.edit );
+
+	return settings;
+}
+
 if ( window.__experimentalConnections ) {
 	addFilter(
 		'blocks.registerBlockType',
@@ -135,5 +197,10 @@ if ( window.__experimentalConnections ) {
 		'editor.BlockEdit',
 		'core/connections/with-inspector-control',
 		withInspectorControl
+	);
+	addFilter(
+		'blocks.registerBlockType',
+		'core/pattern/shimAttributeSource',
+		shimAttributeSource
 	);
 }

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -8,6 +8,9 @@
 	"keywords": [ "reusable" ],
 	"textdomain": "default",
 	"attributes": {
+		"dynamicContent": {
+			"type": "object"
+		},
 		"ref": {
 			"type": "number"
 		}

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -41,6 +41,21 @@ function render_block_core_block( $attributes ) {
 
 	$seen_refs[ $attributes['ref'] ] = true;
 
+	$filter_block_context = static function( $context ) use ( $attributes ) {
+		if ( isset( $attributes['dynamicContent'] ) && $attributes['dynamicContent'] ) {
+			$context['dynamicContent'] = $attributes['dynamicContent'];
+		}
+
+		return $context;
+	};
+
+	/**
+	 * We set the `dynamicContent` context through the `render_block_context`
+	 * filter so that it is available when a pattern's inner blocks are
+	 * rendering via do_blocks given it only receives the inner content.
+	 */
+	add_filter( 'render_block_context', $filter_block_context, 1 );
+
 	// Handle embeds for reusable blocks.
 	global $wp_embed;
 	$content = $wp_embed->run_shortcode( $reusable_block->post_content );
@@ -48,6 +63,9 @@ function render_block_core_block( $attributes ) {
 
 	$content = do_blocks( $content );
 	unset( $seen_refs[ $attributes['ref'] ] );
+
+	remove_filter( 'render_block_context', $filter_block_context, 1 );
+
 	return $content;
 }
 

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -14,7 +14,7 @@
 		"content": {
 			"type": "string",
 			"source": "html",
-			"selector": "h1,h2,h3,h4,h5,h6",
+			"selector": "h2",
 			"default": "",
 			"__experimentalRole": "content"
 		},
@@ -63,7 +63,8 @@
 			}
 		},
 		"__unstablePasteTextInline": true,
-		"__experimentalSlashInserter": true
+		"__experimentalSlashInserter": true,
+		"__experimentalConnections": true
 	},
 	"editorStyle": "wp-block-heading-editor",
 	"style": "wp-block-heading"


### PR DESCRIPTION
Props to @kevin940726 and @aaronrobertshaw for their work on this.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See #53705

Implements partially synced patterns using some of the available parts of the block bindings API.

The PR is a technical prototype, with the user experience still requiring lots of development.

## Why?
See more of the rationale for block bindings in https://github.com/WordPress/gutenberg/issues/54536.

## How?
This uses the system implemented in https://github.com/WordPress/gutenberg/pull/53241 to declare connections (which will probably be renamed to bindings) on the blocks within a pattern (when the user is designing the pattern).

Users can insert these patterns into a post, and when editing a 'connected' attribute of a block, the values are saved to the pattern block instance in a `dynamicContent` attribute instead of to the block being edited. This allows multiple instances of the same synced pattern to have different content.

The PR also opts partially synced patterns into using the HTML API to dynamically replace block values in PHP.

## Testing Instructions
Watch the video for a walkthrough.
Prerequisite: Enable the 'Connections' experiment

1. Create a Pattern (Edit Site > Patterns > Use the '+' button to create a synced pattern
2. Add a heading and a paragraph to the pattern, and give them some default text
3. For both the heading and the paragraph, use the block inspector to change the heading and paragraph connections to a source of 'Pattern attributes' and add a unique value for the 'key' (using preferably kebab case or camel case).
4. Save the pattern
5. Switch to editing a post and insert the pattern twice
6. Update the text in the two instances of the patterns, and note that they can be made distinct, unlike synced patterns that don't have connections.
7. Preview the post, your changes should be reflected in the frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/677833/a5fda6b4-19f3-4a9b-a0b7-18bdbdbe5d82

