### PR TITLE
Reusable Blocks: Unlock a private hook and a component at the file level

### DIFF
--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -28,6 +28,10 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const { useReusableBlocksRenameHint, ReusableBlocksRenameHint } = unlock(
+	blockEditorPrivateApis
+);
+
 /**
  * Menu control to convert block(s) to reusable block.
  *
@@ -42,9 +46,6 @@ export default function ReusableBlockConvertButton( {
 	rootClientId,
 	onClose,
 } ) {
-	const { useReusableBlocksRenameHint, ReusableBlocksRenameHint } = unlock(
-		blockEditorPrivateApis
-	);
 	const showRenameHint = useReusableBlocksRenameHint();
 	const [ syncType, setSyncType ] = useState( undefined );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );


### PR DESCRIPTION
## What?
Similar to #55800.

A micro-optimization moves the private `useReusableBlocksRenameHint` and `ReusableBlocksRenameHint` unlocking outside the component.

P.S. This is the last occurrence I could find for now.

## Why?
The private components and hooks can be unlocked at the file level. There's no need to perform the action on each component re-render.

## Testing Instructions
IIRC, the component is no longer used by the editors, so confirm that logic is sounds 😅 
