### PR TITLE
Template Part block: Use `_build_block_template_result_from_post`

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -43,10 +43,10 @@ function render_block_core_template_part( $attributes ) {
 		if ( $template_part_post ) {
 			// A published post might already exist if this template part was customized elsewhere
 			// or if it's part of a customized template.
-			$content    = $template_part_post->post_content;
-			$area_terms = get_the_terms( $template_part_post, 'wp_template_part_area' );
-			if ( ! is_wp_error( $area_terms ) && false !== $area_terms ) {
-				$area = $area_terms[0]->name;
+			$block_template = _build_block_template_result_from_post( $template_part_post );
+			$content        = $block_template->content;
+			if ( isset( $block_template->area ) ) {
+				$area = $block_template->area;
 			}
 			/**
 			 * Fires when a block template part is loaded from a template post stored in the database.


### PR DESCRIPTION
## What?
In the Template Part block's `render` method, use `_build_block_template_result_from_post()` to build a `WP_Block_Template` object instead of doing the same "post-processing" in a manual way.

## Why?
In https://github.com/WordPress/wordpress-develop/pull/5523, we're extending Block Hooks, which previously only worked for unmodified templates, template parts, and patterns to also work with _modified_ ones. To that end, we're adding logic to `_build_block_template_result_from_post()` to conditionally insert hooked blocks, which is generally used to build a `WP_Block_Template` object from a template or pattern DB post object for the purpose of rendering it on the frontend or viewing it in the editor.

However, the Template Part block's `render` method isn't currently using that method; instead, it's using some lower-level "post-processing" of the DB post object. As a consequence, hooked blocks won't be inserted into Template Part blocks if the template part they're rendering has user modifications, unless the Template Part block code is updated to accommodate for them.

## How?
There are two options to make sure that hooked blocks are also inserted into modified template parts:
- Duplicate the insertion logic into the Template Part block's `render` method, or
- Use `_build_block_template_result_from_post` in the Template Part block's `render` method.

This PR implements the latter, which has the advantage that it won't duplicate hooked blocks insertion (in the worst case scenario resulting in the same block being inserted twice, if not properly guarded by conditionals). Furthermore, it makes it easier to implement hooked blocks insertion separately (in `_build_block_template_result_from_post` in Core, or alternatively via a filter in Gutenberg) and will simply start working once that has been implemented.

Note that this PR is somewhat comparable to #52892, which did something similar for the _un_modified template part code path, using the `get_block_file_template` function.

## Testing Instructions
Verify that template parts are still working as before. Check both the frontend and the editor.

## Follow-up

In the long run, it would probably be best if the Template Part block used a high-level function such as [`get_block_template`](https://developer.wordpress.org/reference/functions/get_block_template/) to fetch the template part it's supposed to render from either the DB or the theme file instead of duplicating that logic (in order to avoid e.g. the logic getting out of sync). The major obstacle seems to be the presence of the three actions fired by the Template Part block during rendering, introduced by #36884. However, we might be able to accommodate for that by moving those actions over to the respective helper functions in `block-template-utils.php`.

In order for https://github.com/WordPress/wordpress-develop/pull/5523 not to get blocked, I'd like to tackle that separately, though. I'll file an issue for that once this PR is merged.

---

_h/t @artemiomorales who discovered that we need to update the Template Part block to accommodate for hooked blocks insertion during a pair programming session today._