### PR TITLE
Rename Unforward to Unforwarded and export the named const

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -32,7 +32,7 @@ import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 import { useHasAnyBlockControls } from '../block-controls/use-has-block-controls';
 
-function UnforwardBlockContextualToolbar(
+function UnforwardedBlockContextualToolbar(
 	{ focusOnMount, isFixed, ...props },
 	ref
 ) {
@@ -226,4 +226,8 @@ function UnforwardBlockContextualToolbar(
 	);
 }
 
-export default forwardRef( UnforwardBlockContextualToolbar );
+export const BlockContextualToolbar = forwardRef(
+	UnforwardedBlockContextualToolbar
+);
+
+export default BlockContextualToolbar;

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -21,7 +21,7 @@ import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
 import { useShouldContextualToolbarShow } from '../../utils/use-should-contextual-toolbar-show';
 
-function UnforwardSelectedBlockTools(
+function UnforwardedSelectedBlockTools(
 	{ clientId, showEmptyBlockSideInserter, __unstableContentRef },
 	ref
 ) {
@@ -129,4 +129,6 @@ function UnforwardSelectedBlockTools(
 	return null;
 }
 
-export default forwardRef( UnforwardSelectedBlockTools );
+export const SelectedBlockTools = forwardRef( UnforwardedSelectedBlockTools );
+
+export default SelectedBlockTools;

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -196,7 +196,7 @@ function useToolbarFocus( {
 	}, [ focusEditorOnEscape, lastFocus, toolbarRef ] );
 }
 
-function UnforwardNavigableToolbar(
+function UnforwardedNavigableToolbar(
 	{
 		children,
 		focusOnMount,
@@ -247,4 +247,6 @@ function UnforwardNavigableToolbar(
 	);
 }
 
-export default forwardRef( UnforwardNavigableToolbar );
+export const NavigableToolbar = forwardRef( UnforwardedNavigableToolbar );
+
+export default NavigableToolbar;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Updating naming from Unforward to Unforward_ed_ as suggested by @draganescu: https://github.com/WordPress/gutenberg/pull/55712#pullrequestreview-1710609524

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Codebase consistency. I misread the others, thinking it was supposed to be Unforward to be consistent. I also added the named constant export to be more consistent with the structure elsewhere.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changed from `Unforward` to `Unforwarded`
Added the named const and export it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
No functional changes from trunk. Test that keyboard interactions on the block toolbar (shift/shift+tab, alt + f10, escape) all work as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
