### PR TITLE
Patterns: Refactor pattern categories to use existing endpoint to merge in user categories

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -372,6 +372,18 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
+### getPatternCategories
+
+Retrieve the core and user pattern categories.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+
+_Returns_
+
+-   `Array< unknown >`: User patterns category array.
+
 ### getRawEntityRecord
 
 Returns the entity's record object by key, with its attributes mapped to their raw values.

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -44,6 +44,18 @@ _Returns_
 
 -   `boolean | undefined`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
 
+### getAllPatternCategories
+
+Retrieve the core and user pattern categories.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+
+_Returns_
+
+-   `Array< unknown >`: User patterns category array.
+
 ### getAuthors
 
 > **Deprecated** since 11.3. Callers should use `select( 'core' ).getUsers({ who: 'authors' })` instead.
@@ -371,18 +383,6 @@ _Parameters_
 _Returns_
 
 -   `any`: The entity record's save error.
-
-### getPatternCategories
-
-Retrieve the core and user pattern categories.
-
-_Parameters_
-
--   _state_ `State`: Data state.
-
-_Returns_
-
--   `Array< unknown >`: User patterns category array.
 
 ### getRawEntityRecord
 

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -1,0 +1,119 @@
+<?php
+
+class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_Pattern_Categories_Controller {
+	/**
+	 * Retrieves all block pattern categories.
+	 *
+	 * @since 6.0.0
+     * @since 6.5 Added user added categories from wp_pattern_category taxonomy
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		$response   = array();
+        $unique_categories = array();
+		$categories = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
+        $user_categories = get_terms( array(
+			'taxonomy'   => 'wp_pattern_category',
+			'hide_empty' => false,
+		) );
+
+        foreach ( $user_categories as $user_category ) {
+			$prepared_category   = $this->prepare_item_for_response( array( 
+                'name'        => $user_category->slug,
+                'label'       => $user_category->name,
+                'description' => $user_category->description,
+                'id'          => $user_category->term_id,
+            ), $request );
+			$response[]          = $this->prepare_response_for_collection( $prepared_category );
+            $unique_categories[] = $user_category->name;
+		}
+		foreach ( $categories as $category ) {
+            if ( in_array( $category['label'], $unique_categories ) ) {
+                continue;
+            }
+			$prepared_category = $this->prepare_item_for_response( $category, $request );
+			$response[]        = $this->prepare_response_for_collection( $prepared_category );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+    /**
+	 * Prepare a raw block pattern category before it gets output in a REST API response.
+	 *
+	 * @since 6.0.0
+     * @since 6.5 Added `id` field for identifying user categories
+	 *
+	 * @param array           $item    Raw category as registered, before any changes.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$keys   = array( 'name', 'label', 'description', 'id' );
+		$data   = array();
+		foreach ( $keys as $key ) {
+			if ( isset( $item[ $key ] ) && rest_is_field_included( $key, $fields ) ) {
+				$data[ $key ] = $item[ $key ];
+			}
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		return rest_ensure_response( $data );
+	}
+
+    /**
+	 * Retrieves the block pattern category schema, conforming to JSON Schema.
+	 *
+	 * @since 6.0.0
+     * @since 6.5 Added `id` field for identifying user categories
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'block-pattern-category',
+			'type'       => 'object',
+			'properties' => array(
+				'name'        => array(
+					'description' => __( 'The category name.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'label'       => array(
+					'description' => __( 'The category label, in human readable format.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'description' => array(
+					'description' => __( 'The category description, in human readable format.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+                'id' => array(
+					'id' => __( 'An optional category id, currently used to provide id for user wp_pattern_category terms' ),
+					'type'        => 'number',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+			),
+		);
+
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -30,7 +30,7 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
             $unique_categories[] = $user_category->name;
 		}
 		foreach ( $categories as $category ) {
-            if ( in_array( $category['label'], $unique_categories ) ) {
+            if ( in_array( $category['label'], $unique_categories ) || 'query' === $category['name'] ) {
                 continue;
             }
 			$prepared_category = $this->prepare_item_for_response( $category, $request );

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -49,7 +49,7 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 			$unique_categories[] = $user_category->name;
 		}
 		foreach ( $categories as $category ) {
-			if ( in_array( $category['label'], $unique_categories ) || 'query' === $category['name'] ) {
+			if ( in_array( $category['label'], $unique_categories, true ) || 'query' === $category['name'] ) {
 				continue;
 			}
 			$prepared_category = $this->prepare_item_for_response( $category, $request );

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -58,7 +58,7 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 
 		if ( ! isset( $query_args['source'] ) || in_array( 'core', $query_args['source'], true ) ) {
 			foreach ( $categories as $category ) {
-				if ( in_array( $category['label'], $unique_categories, true ) || 'query' === $category['name'] ) {
+				if ( in_array( $category['label'], $unique_categories, true ) ) {
 					continue;
 				}
 				$prepared_category = $this->prepare_item_for_response( $category, $request );

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -40,7 +40,7 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 			)
 		);
 
-		if ( is_array( $query_args['source'] ) && in_array( 'user', $query_args['source'], true ) ) {
+		if ( isset( $query_args['source'] ) && is_array( $query_args['source'] ) && in_array( 'user', $query_args['source'], true ) ) {
 			foreach ( $user_categories as $user_category ) {
 				$prepared_category   = $this->prepare_item_for_response(
 					array(

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -1,38 +1,57 @@
 <?php
+/**
+ * REST API: WP_REST_Block_Pattern_Categories_Controller class
+ *
+ * @package    WordPress
+ * @subpackage REST_API
+ * @since      6.0.0
+ */
 
+/**
+ * Core class used to access block pattern categories via the REST API.
+ *
+ * @since 6.0.0
+ *
+ * @see WP_REST_Controller
+ */
 class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_Pattern_Categories_Controller {
 	/**
 	 * Retrieves all block pattern categories.
 	 *
 	 * @since 6.0.0
-     * @since 6.5 Added user added categories from wp_pattern_category taxonomy
+	 * @since 6.5 Added user added categories from wp_pattern_category taxonomy
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$response   = array();
-        $unique_categories = array();
-		$categories = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
-        $user_categories = get_terms( array(
-			'taxonomy'   => 'wp_pattern_category',
-			'hide_empty' => false,
-		) );
+		$response          = array();
+		$unique_categories = array();
+		$categories        = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
+		$user_categories   = get_terms(
+			array(
+				'taxonomy'   => 'wp_pattern_category',
+				'hide_empty' => false,
+			)
+		);
 
-        foreach ( $user_categories as $user_category ) {
-			$prepared_category   = $this->prepare_item_for_response( array( 
-                'name'        => $user_category->slug,
-                'label'       => $user_category->name,
-                'description' => $user_category->description,
-                'id'          => $user_category->term_id,
-            ), $request );
+		foreach ( $user_categories as $user_category ) {
+			$prepared_category   = $this->prepare_item_for_response(
+				array(
+					'name'        => $user_category->slug,
+					'label'       => $user_category->name,
+					'description' => $user_category->description,
+					'id'          => $user_category->term_id,
+				),
+				$request
+			);
 			$response[]          = $this->prepare_response_for_collection( $prepared_category );
-            $unique_categories[] = $user_category->name;
+			$unique_categories[] = $user_category->name;
 		}
 		foreach ( $categories as $category ) {
-            if ( in_array( $category['label'], $unique_categories ) || 'query' === $category['name'] ) {
-                continue;
-            }
+			if ( in_array( $category['label'], $unique_categories ) || 'query' === $category['name'] ) {
+				continue;
+			}
 			$prepared_category = $this->prepare_item_for_response( $category, $request );
 			$response[]        = $this->prepare_response_for_collection( $prepared_category );
 		}
@@ -40,11 +59,11 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 		return rest_ensure_response( $response );
 	}
 
-    /**
+	/**
 	 * Prepare a raw block pattern category before it gets output in a REST API response.
 	 *
 	 * @since 6.0.0
-     * @since 6.5 Added `id` field for identifying user categories
+	 * @since 6.5 Added `id` field for identifying user categories
 	 *
 	 * @param array           $item    Raw category as registered, before any changes.
 	 * @param WP_REST_Request $request Request object.
@@ -67,11 +86,11 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 		return rest_ensure_response( $data );
 	}
 
-    /**
+	/**
 	 * Retrieves the block pattern category schema, conforming to JSON Schema.
 	 *
 	 * @since 6.0.0
-     * @since 6.5 Added `id` field for identifying user categories
+	 * @since 6.5 Added `id` field for identifying user categories
 	 *
 	 * @return array Item schema data.
 	 */
@@ -103,11 +122,11 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-                'id' => array(
-					'id' => __( 'An optional category id, currently used to provide id for user wp_pattern_category terms' ),
-					'type'        => 'number',
-					'readonly'    => true,
-					'context'     => array( 'view', 'edit', 'embed' ),
+				'id'          => array(
+					'id'       => __( 'An optional category id, currently used to provide id for user wp_pattern_category terms' ),
+					'type'     => 'number',
+					'readonly' => true,
+					'context'  => array( 'view', 'edit', 'embed' ),
 				),
 			),
 		);

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -25,6 +25,11 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
+		$valid_query_args = array(
+			'source' => true,
+		);
+
+		$query_args        = array_intersect_key( $request->get_params(), $valid_query_args );
 		$response          = array();
 		$unique_categories = array();
 		$categories        = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
@@ -35,25 +40,30 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 			)
 		);
 
-		foreach ( $user_categories as $user_category ) {
-			$prepared_category   = $this->prepare_item_for_response(
-				array(
-					'name'        => $user_category->slug,
-					'label'       => $user_category->name,
-					'description' => $user_category->description,
-					'id'          => $user_category->term_id,
-				),
-				$request
-			);
-			$response[]          = $this->prepare_response_for_collection( $prepared_category );
-			$unique_categories[] = $user_category->name;
-		}
-		foreach ( $categories as $category ) {
-			if ( in_array( $category['label'], $unique_categories, true ) || 'query' === $category['name'] ) {
-				continue;
+		if ( is_array( $query_args['source'] ) && in_array( 'user', $query_args['source'], true ) ) {
+			foreach ( $user_categories as $user_category ) {
+				$prepared_category   = $this->prepare_item_for_response(
+					array(
+						'name'        => $user_category->slug,
+						'label'       => $user_category->name,
+						'description' => $user_category->description,
+						'id'          => $user_category->term_id,
+					),
+					$request
+				);
+				$response[]          = $this->prepare_response_for_collection( $prepared_category );
+				$unique_categories[] = $user_category->name;
 			}
-			$prepared_category = $this->prepare_item_for_response( $category, $request );
-			$response[]        = $this->prepare_response_for_collection( $prepared_category );
+		}
+
+		if ( ! isset( $query_args['source'] ) || in_array( 'core', $query_args['source'], true ) ) {
+			foreach ( $categories as $category ) {
+				if ( in_array( $category['label'], $unique_categories, true ) || 'query' === $category['name'] ) {
+					continue;
+				}
+				$prepared_category = $this->prepare_item_for_response( $category, $request );
+				$response[]        = $this->prepare_response_for_collection( $prepared_category );
+			}
 		}
 
 		return rest_ensure_response( $response );
@@ -71,12 +81,17 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$fields = $this->get_fields_for_response( $request );
-		$keys   = array( 'name', 'label', 'description', 'id' );
+		$keys   = array( 'name', 'label', 'description' );
 		$data   = array();
 		foreach ( $keys as $key ) {
 			if ( isset( $item[ $key ] ) && rest_is_field_included( $key, $fields ) ) {
 				$data[ $key ] = $item[ $key ];
 			}
+		}
+
+		// For backwards compatibility we only want to include the id if the field is explicitly requested.
+		if ( rest_is_field_included( 'id', $fields ) && isset( $item['id'] ) ) {
+			$data['id'] = $item['id'];
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -123,10 +138,10 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'id'          => array(
-					'id'       => __( 'An optional category id, currently used to provide id for user wp_pattern_category terms' ),
-					'type'     => 'number',
-					'readonly' => true,
-					'context'  => array( 'view', 'edit', 'embed' ),
+					'description' => __( 'An optional category id, currently used to provide id for user wp_pattern_category terms' ),
+					'type'        => 'number',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 			),
 		);
@@ -134,5 +149,33 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
+	}
+
+	/**
+	 * Retrieves the search parameters for the block pattern categories.
+	 *
+	 * @since 6.5.0 Added  to request.
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		$query_params['source'] = array(
+			'description' => __( 'Limit result set to comments assigned to specific sources, `core` or `user`' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'string',
+			),
+		);
+
+		/**
+		 * Filter collection parameters for the block pattern categories controller.
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param array $query_params JSON Schema-formatted collection parameters.
+		 */
+		return apply_filters( 'rest_pattern_directory_collection_params', $query_params );
 	}
 }

--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -19,7 +19,7 @@ function gutenberg_register_global_styles_revisions_endpoints() {
 }
 add_action( 'rest_api_init', 'gutenberg_register_global_styles_revisions_endpoints' );
 
-/** 
+/**
  * Registers the block pattern categories REST API routes.
  */
 function gutenberg_register_rest_block_pattern_categories_routes() {

--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -17,5 +17,13 @@ function gutenberg_register_global_styles_revisions_endpoints() {
 	$global_styles_revisions_controller = new Gutenberg_REST_Global_Styles_Revisions_Controller_6_5();
 	$global_styles_revisions_controller->register_routes();
 }
-
 add_action( 'rest_api_init', 'gutenberg_register_global_styles_revisions_endpoints' );
+
+/** 
+ * Registers the block pattern categories REST API routes.
+ */
+function gutenberg_register_rest_block_pattern_categories_routes() {
+	$block_patterns = new Gutenberg_REST_Block_Pattern_Categories_Controller();
+	$block_patterns->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_block_pattern_categories_routes' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -58,6 +58,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 6.5 compat.
 	require_once __DIR__ . '/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php';
+	require __DIR__ . '/compat/wordpress-6.5/class-gutenberg-rest-block-pattern-categories-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.5/rest-api.php';
 
 	// Plugin specific code.

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { cloneBlock, createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -21,37 +21,18 @@ import { store as blockEditorStore } from '../../../store';
  * @return {Array} Returns the patterns state. (patterns, categories, onSelect handler)
  */
 const usePatternsState = ( onInsert, rootClientId ) => {
-	const { patternCategories, patterns, userPatternCategories } = useSelect(
+	const { patternCategories, patterns } = useSelect(
 		( select ) => {
 			const { __experimentalGetAllowedPatterns, getSettings } =
 				select( blockEditorStore );
-			const {
-				__experimentalUserPatternCategories,
-				__experimentalBlockPatternCategories,
-			} = getSettings();
+			const { __experimentalBlockPatternCategories } = getSettings();
 			return {
 				patterns: __experimentalGetAllowedPatterns( rootClientId ),
-				userPatternCategories: __experimentalUserPatternCategories,
 				patternCategories: __experimentalBlockPatternCategories,
 			};
 		},
 		[ rootClientId ]
 	);
-
-	const allCategories = useMemo( () => {
-		const categories = [ ...patternCategories ];
-		userPatternCategories?.forEach( ( userCategory ) => {
-			if (
-				! categories.find(
-					( existingCategory ) =>
-						existingCategory.name === userCategory.name
-				)
-			) {
-				categories.push( userCategory );
-			}
-		} );
-		return categories;
-	}, [ patternCategories, userPatternCategories ] );
 
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const onClickPattern = useCallback(
@@ -79,7 +60,7 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 		[ createSuccessNotice, onInsert ]
 	);
 
-	return [ patterns, allCategories, onClickPattern ];
+	return [ patterns, patternCategories, onClickPattern ];
 };
 
 export default usePatternsState;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2330,7 +2330,7 @@ export const __experimentalGetParsedPattern = createSelector(
 	( state ) => [
 		state.settings.__experimentalBlockPatterns,
 		state.settings.__experimentalReusableBlocks,
-		state?.settings?.__experimentalUserPatternCategories,
+		state.settings.__experimentalBlockPatternCategories,
 	]
 );
 
@@ -2355,7 +2355,7 @@ const getAllAllowedPatterns = createSelector(
 		state.settings.__experimentalBlockPatterns,
 		state.settings.__experimentalReusableBlocks,
 		state.settings.allowedBlockTypes,
-		state?.settings?.__experimentalUserPatternCategories,
+		state.settings.__experimentalBlockPatternCategories,
 	]
 );
 
@@ -2382,6 +2382,7 @@ export const __experimentalGetAllowedPatterns = createSelector(
 	( state, rootClientId ) => [
 		state.settings.__experimentalBlockPatterns,
 		state.settings.__experimentalReusableBlocks,
+		state.settings.__experimentalBlockPatternCategories,
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
 		state.blockListSettings[ rootClientId ],

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2277,12 +2277,15 @@ const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {
 function getUserPatterns( state ) {
 	const userPatterns =
 		state?.settings?.__experimentalReusableBlocks ?? EMPTY_ARRAY;
-	const userPatternCategories =
-		state?.settings?.__experimentalUserPatternCategories ?? [];
+	const patternCategories =
+		state?.settings?.__experimentalBlockPatternCategories ?? [];
 	const categories = new Map();
-	userPatternCategories.forEach( ( userCategory ) =>
-		categories.set( userCategory.id, userCategory )
-	);
+	patternCategories.forEach( ( category ) => {
+		if ( category.id ) {
+			categories.set( category.id, category );
+		}
+	} );
+
 	return userPatterns.map( ( userPattern ) => {
 		return {
 			name: `core/block/${ userPattern.id }`,
@@ -2290,7 +2293,7 @@ function getUserPatterns( state ) {
 			title: userPattern.title.raw,
 			categories: userPattern.wp_pattern_category.map( ( catId ) =>
 				categories && categories.get( catId )
-					? categories.get( catId ).slug
+					? categories.get( catId ).name
 					: catId
 			),
 			content: userPattern.content.raw,

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -679,6 +679,18 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
+### getPatternCategories
+
+Retrieve the core and user pattern categories.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+
+_Returns_
+
+-   `Array< unknown >`: User patterns category array.
+
 ### getRawEntityRecord
 
 Returns the entity's record object by key, with its attributes mapped to their raw values.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -351,6 +351,18 @@ _Returns_
 
 -   `boolean | undefined`: Whether or not the user can edit, or `undefined` if the OPTIONS request is still being made.
 
+### getAllPatternCategories
+
+Retrieve the core and user pattern categories.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+
+_Returns_
+
+-   `Array< unknown >`: User patterns category array.
+
 ### getAuthors
 
 > **Deprecated** since 11.3. Callers should use `select( 'core' ).getUsers({ who: 'authors' })` instead.
@@ -678,18 +690,6 @@ _Parameters_
 _Returns_
 
 -   `any`: The entity record's save error.
-
-### getPatternCategories
-
-Retrieve the core and user pattern categories.
-
-_Parameters_
-
--   _state_ `State`: Data state.
-
-_Returns_
-
--   `Array< unknown >`: User patterns category array.
 
 ### getRawEntityRecord
 

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -543,6 +543,14 @@ export function userPatternCategories( state = [], action ) {
 	return state;
 }
 
+export function patternCategories( state = [], action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_PATTERN_CATEGORIES':
+			return action.patternCategories;
+	}
+	return state;
+}
+
 export function navigationFallbackId( state = null, action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_NAVIGATION_FALLBACK_ID':
@@ -611,6 +619,7 @@ export default combineReducers( {
 	blockPatterns,
 	blockPatternCategories,
 	userPatternCategories,
+	patternCategories,
 	navigationFallbackId,
 	defaultTemplates,
 } );

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -543,10 +543,10 @@ export function userPatternCategories( state = [], action ) {
 	return state;
 }
 
-export function patternCategories( state = [], action ) {
+export function allPatternCategories( state = [], action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_PATTERN_CATEGORIES':
-			return action.patternCategories;
+		case 'RECEIVE_ALL_PATTERN_CATEGORIES':
+			return action.allPatternCategories;
 	}
 	return state;
 }
@@ -619,7 +619,7 @@ export default combineReducers( {
 	blockPatterns,
 	blockPatternCategories,
 	userPatternCategories,
-	patternCategories,
+	allPatternCategories,
 	navigationFallbackId,
 	defaultTemplates,
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -668,6 +668,21 @@ export const getUserPatternCategories =
 		} );
 	};
 
+export const getPatternCategories =
+	() =>
+	async ( { dispatch } ) => {
+		const patternCategories = await apiFetch( {
+			path: addQueryArgs( '/wp/v2/block-patterns/categories', {
+				_fields: 'name,label,description, id',
+				source: [ 'core', 'user' ],
+			} ),
+		} );
+		dispatch( {
+			type: 'RECEIVE_PATTERN_CATEGORIES',
+			patternCategories,
+		} );
+	};
+
 export const getNavigationFallbackId =
 	() =>
 	async ( { dispatch, select } ) => {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -668,18 +668,18 @@ export const getUserPatternCategories =
 		} );
 	};
 
-export const getPatternCategories =
+export const getAllPatternCategories =
 	() =>
 	async ( { dispatch } ) => {
-		const patternCategories = await apiFetch( {
+		const allPatternCategories = await apiFetch( {
 			path: addQueryArgs( '/wp/v2/block-patterns/categories', {
 				_fields: 'name,label,description, id',
 				source: [ 'core', 'user' ],
 			} ),
 		} );
 		dispatch( {
-			type: 'RECEIVE_PATTERN_CATEGORIES',
-			patternCategories,
+			type: 'RECEIVE_ALL_PATTERN_CATEGORIES',
+			allPatternCategories,
 		} );
 	};
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -47,7 +47,7 @@ export interface State {
 	navigationFallbackId: EntityRecordKey;
 	userPatternCategories: Array< UserPatternCategory >;
 	defaultTemplates: Record< string, string >;
-	patternCategories: Array< unknown >;
+	allPatternCategories: Array< unknown >;
 }
 
 type EntityRecordKey = string | number;
@@ -1348,8 +1348,8 @@ export function getUserPatternCategories(
  * @return User patterns category array.
  */
 
-export function getPatternCategories( state: State ): Array< unknown > {
-	return state.patternCategories;
+export function getAllPatternCategories( state: State ): Array< unknown > {
+	return state.allPatternCategories;
 }
 
 /**

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -47,6 +47,7 @@ export interface State {
 	navigationFallbackId: EntityRecordKey;
 	userPatternCategories: Array< UserPatternCategory >;
 	defaultTemplates: Record< string, string >;
+	patternCategories: Array< unknown >;
 }
 
 type EntityRecordKey = string | number;
@@ -1337,6 +1338,18 @@ export function getUserPatternCategories(
 	state: State
 ): Array< UserPatternCategory > {
 	return state.userPatternCategories;
+}
+
+/**
+ * Retrieve the core and user pattern categories.
+ *
+ * @param state Data state.
+ *
+ * @return User patterns category array.
+ */
+
+export function getPatternCategories( state: State ): Array< unknown > {
+	return state.patternCategories;
 }
 
 /**

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -42,7 +42,7 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 
 			// Prevent the need to refresh the page to get up-to-date categories
 			// and pattern categorization.
-			invalidateResolution( 'getUserPatternCategories' );
+			invalidateResolution( 'getBlockPatternCategories' );
 			invalidateResolution( 'getEntityRecords', [
 				'postType',
 				PATTERN_TYPES.user,

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -42,7 +42,7 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 
 			// Prevent the need to refresh the page to get up-to-date categories
 			// and pattern categorization.
-			invalidateResolution( 'getPatternCategories' );
+			invalidateResolution( 'getAllPatternCategories' );
 			invalidateResolution( 'getEntityRecords', [
 				'postType',
 				PATTERN_TYPES.user,

--- a/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/delete-category-menu-item.js
@@ -42,7 +42,7 @@ export default function DeleteCategoryMenuItem( { category, onClose } ) {
 
 			// Prevent the need to refresh the page to get up-to-date categories
 			// and pattern categorization.
-			invalidateResolution( 'getBlockPatternCategories' );
+			invalidateResolution( 'getPatternCategories' );
 			invalidateResolution( 'getEntityRecords', [
 				'postType',
 				PATTERN_TYPES.user,

--- a/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-category-menu-item.js
@@ -39,12 +39,10 @@ export default function RenameCategoryMenuItem( { category, onClose } ) {
 }
 
 function RenameModal( { category, onClose } ) {
-	// User created pattern categories have their properties updated when
-	// retrieved via `getUserPatternCategories`. The rename modal expects an
-	// object that will match the pattern category entity.
+	// The rename modal expects an object that will match the pattern category entity.
 	const normalizedCategory = {
 		id: category.id,
-		slug: category.slug,
+		slug: category.name,
 		name: category.label,
 	};
 

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -266,7 +266,7 @@ const selectUserPatterns = createSelector(
 			PATTERN_TYPES.user,
 			{ per_page: -1 },
 		] ),
-		select( coreStore ).getUserPatternCategories(),
+		select( coreStore ).getAllPatternCategories(),
 	]
 );
 

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -211,7 +211,7 @@ const patternBlockToPattern = ( patternBlock, categories ) => ( {
 
 const selectUserPatterns = createSelector(
 	( select, syncStatus, search = '' ) => {
-		const { getEntityRecords, getIsResolving, getPatternCategories } =
+		const { getEntityRecords, getIsResolving, getAllPatternCategories } =
 			select( coreStore );
 
 		const query = { per_page: -1 };
@@ -220,7 +220,7 @@ const selectUserPatterns = createSelector(
 			PATTERN_TYPES.user,
 			query
 		);
-		const patternCategories = getPatternCategories();
+		const patternCategories = getAllPatternCategories();
 		const categories = new Map();
 		patternCategories.forEach( ( category ) => {
 			if ( category.id ) {

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -192,7 +192,7 @@ const patternBlockToPattern = ( patternBlock, categories ) => ( {
 		categories: patternBlock.wp_pattern_category.map(
 			( patternCategoryId ) =>
 				categories && categories.get( patternCategoryId )
-					? categories.get( patternCategoryId ).slug
+					? categories.get( patternCategoryId ).name
 					: patternCategoryId
 		),
 	} ),
@@ -211,7 +211,7 @@ const patternBlockToPattern = ( patternBlock, categories ) => ( {
 
 const selectUserPatterns = createSelector(
 	( select, syncStatus, search = '' ) => {
-		const { getEntityRecords, getIsResolving, getUserPatternCategories } =
+		const { getEntityRecords, getIsResolving, getPatternCategories } =
 			select( coreStore );
 
 		const query = { per_page: -1 };
@@ -220,11 +220,13 @@ const selectUserPatterns = createSelector(
 			PATTERN_TYPES.user,
 			query
 		);
-		const userPatternCategories = getUserPatternCategories();
+		const patternCategories = getPatternCategories();
 		const categories = new Map();
-		userPatternCategories.forEach( ( userCategory ) =>
-			categories.set( userCategory.id, userCategory )
-		);
+		patternCategories.forEach( ( category ) => {
+			if ( category.id ) {
+				categories.set( category.id, category );
+			}
+		} );
 		let patterns = records
 			? records.map( ( record ) =>
 					patternBlockToPattern( record, categories )
@@ -249,11 +251,10 @@ const selectUserPatterns = createSelector(
 			// to be in the category.
 			hasCategory: () => true,
 		} );
-
 		return {
 			patterns,
 			isResolving,
-			categories: userPatternCategories,
+			categories: patternCategories,
 		};
 	},
 	( select ) => [

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
@@ -163,7 +163,7 @@ export default function PatternCategories( { post } ) {
 			const newTerm = await saveEntityRecord( 'taxonomy', slug, term, {
 				throwOnError: true,
 			} );
-			invalidateResolution( 'getBlockPatternCategories' );
+			invalidateResolution( 'getPatternCategories' );
 			return unescapeTerm( newTerm );
 		} catch ( error ) {
 			if ( error.code !== 'term_exists' ) {

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
@@ -163,7 +163,7 @@ export default function PatternCategories( { post } ) {
 			const newTerm = await saveEntityRecord( 'taxonomy', slug, term, {
 				throwOnError: true,
 			} );
-			invalidateResolution( 'getPatternCategories' );
+			invalidateResolution( 'getAllPatternCategories' );
 			return unescapeTerm( newTerm );
 		} catch ( error ) {
 			if ( error.code !== 'term_exists' ) {

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/pattern-categories.js
@@ -163,7 +163,7 @@ export default function PatternCategories( { post } ) {
 			const newTerm = await saveEntityRecord( 'taxonomy', slug, term, {
 				throwOnError: true,
 			} );
-			invalidateResolution( 'getUserPatternCategories' );
+			invalidateResolution( 'getBlockPatternCategories' );
 			return unescapeTerm( newTerm );
 		} catch ( error ) {
 			if ( error.code !== 'term_exists' ) {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -106,7 +106,7 @@ export default function usePatternDetails( postType, postId ) {
 		if ( record.wp_pattern_category?.length > 0 ) {
 			const patternCategoriesMap = new Map();
 			patternCategories.forEach( ( userCategory ) =>
-				patternCategories.set( userCategory.id, userCategory )
+				patternCategoriesMap.set( userCategory.id, userCategory )
 			);
 
 			const categories = record.wp_pattern_category

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -42,11 +42,12 @@ export default function usePatternDetails( postType, postId ) {
 		[]
 	);
 	const { currentTheme, patternCategories } = useSelect( ( select ) => {
-		const { getCurrentTheme, getPatternCategories } = select( coreStore );
+		const { getCurrentTheme, getAllPatternCategories } =
+			select( coreStore );
 
 		return {
 			currentTheme: getCurrentTheme(),
-			patternCategories: getPatternCategories(),
+			patternCategories: getAllPatternCategories(),
 		};
 	}, [] );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pattern/use-pattern-details.js
@@ -41,13 +41,12 @@ export default function usePatternDetails( postType, postId ) {
 			select( editorStore ).__experimentalGetDefaultTemplatePartAreas(),
 		[]
 	);
-	const { currentTheme, userPatternCategories } = useSelect( ( select ) => {
-		const { getCurrentTheme, getUserPatternCategories } =
-			select( coreStore );
+	const { currentTheme, patternCategories } = useSelect( ( select ) => {
+		const { getCurrentTheme, getPatternCategories } = select( coreStore );
 
 		return {
 			currentTheme: getCurrentTheme(),
-			userPatternCategories: getUserPatternCategories(),
+			patternCategories: getPatternCategories(),
 		};
 	}, [] );
 
@@ -105,14 +104,16 @@ export default function usePatternDetails( postType, postId ) {
 			} );
 		}
 		if ( record.wp_pattern_category?.length > 0 ) {
-			const patternCategories = new Map();
-			userPatternCategories.forEach( ( userCategory ) =>
+			const patternCategoriesMap = new Map();
+			patternCategories.forEach( ( userCategory ) =>
 				patternCategories.set( userCategory.id, userCategory )
 			);
 
 			const categories = record.wp_pattern_category
-				.filter( ( category ) => patternCategories.get( category ) )
-				.map( ( category ) => patternCategories.get( category ).label );
+				.filter( ( category ) => patternCategoriesMap.get( category ) )
+				.map(
+					( category ) => patternCategoriesMap.get( category ).label
+				);
 
 			details.push( {
 				label: __( 'Categories' ),

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-default-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-default-pattern-categories.js
@@ -22,7 +22,7 @@ export default function useDefaultPatternCategories() {
 	} );
 
 	const restBlockPatternCategories = useSelect( ( select ) =>
-		select( coreStore ).getBlockPatternCategories()
+		select( coreStore ).getPatternCategories()
 	);
 
 	return [

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-default-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-default-pattern-categories.js
@@ -22,7 +22,7 @@ export default function useDefaultPatternCategories() {
 	} );
 
 	const restBlockPatternCategories = useSelect( ( select ) =>
-		select( coreStore ).getPatternCategories()
+		select( coreStore ).getAllPatternCategories()
 	);
 
 	return [

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
@@ -24,8 +24,7 @@ export default function usePatternCategories() {
 		label: __( 'Uncategorized' ),
 	} );
 	const themePatterns = useThemePatterns();
-	const { patterns: userPatterns, categories: userPatternCategories } =
-		usePatterns( PATTERN_TYPES.user );
+	const { patterns: userPatterns } = usePatterns( PATTERN_TYPES.user );
 
 	const patternCategories = useMemo( () => {
 		const categoryMap = {};
@@ -33,11 +32,6 @@ export default function usePatternCategories() {
 
 		// Create a map for easier counting of patterns in categories.
 		defaultCategories.forEach( ( category ) => {
-			if ( ! categoryMap[ category.name ] ) {
-				categoryMap[ category.name ] = { ...category, count: 0 };
-			}
-		} );
-		userPatternCategories.forEach( ( category ) => {
 			if ( ! categoryMap[ category.name ] ) {
 				categoryMap[ category.name ] = { ...category, count: 0 };
 			}
@@ -70,18 +64,16 @@ export default function usePatternCategories() {
 		} );
 
 		// Filter categories so we only have those containing patterns.
-		[ ...defaultCategories, ...userPatternCategories ].forEach(
-			( category ) => {
-				if (
-					categoryMap[ category.name ].count &&
-					! categoriesWithCounts.find(
-						( cat ) => cat.name === category.name
-					)
-				) {
-					categoriesWithCounts.push( categoryMap[ category.name ] );
-				}
+		[ ...defaultCategories ].forEach( ( category ) => {
+			if (
+				categoryMap[ category.name ].count &&
+				! categoriesWithCounts.find(
+					( cat ) => cat.name === category.name
+				)
+			) {
+				categoriesWithCounts.push( categoryMap[ category.name ] );
 			}
-		);
+		} );
 		const sortedCategories = categoriesWithCounts.sort( ( a, b ) =>
 			a.label.localeCompare( b.label )
 		);
@@ -100,12 +92,7 @@ export default function usePatternCategories() {
 		} );
 
 		return sortedCategories;
-	}, [
-		defaultCategories,
-		themePatterns,
-		userPatternCategories,
-		userPatterns,
-	] );
+	}, [ defaultCategories, themePatterns, userPatterns ] );
 
 	return { patternCategories, hasPatterns: !! patternCategories.length };
 }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -142,7 +142,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		( select ) => ( {
 			restBlockPatterns: select( coreStore ).getBlockPatterns(),
 			restBlockPatternCategories:
-				select( coreStore ).getPatternCategories(),
+				select( coreStore ).getAllPatternCategories(),
 		} ),
 		[]
 	);

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -97,7 +97,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		userCanCreatePages,
 		pageOnFront,
 		pageForPosts,
-		userPatternCategories,
 	} = useSelect(
 		( select ) => {
 			const isWeb = Platform.OS === 'web';
@@ -105,7 +104,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				canUser,
 				getRawEntityRecord,
 				getEntityRecord,
-				getUserPatternCategories,
 				getEntityRecords,
 			} = select( coreStore );
 
@@ -128,7 +126,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				userCanCreatePages: canUser( 'create', 'pages' ),
 				pageOnFront: siteSettings?.page_on_front,
 				pageForPosts: siteSettings?.page_for_posts,
-				userPatternCategories: getUserPatternCategories(),
 			};
 		},
 		[ postType, postId ]
@@ -145,7 +142,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		( select ) => ( {
 			restBlockPatterns: select( coreStore ).getBlockPatterns(),
 			restBlockPatternCategories:
-				select( coreStore ).getBlockPatternCategories(),
+				select( coreStore ).getPatternCategories(),
 		} ),
 		[]
 	);
@@ -218,7 +215,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
-			__experimentalUserPatternCategories: userPatternCategories,
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, settings ),
 			inserterMediaCategories,
@@ -242,7 +238,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			settings,
 			hasUploadPermissions,
 			reusableBlocks,
-			userPatternCategories,
 			blockPatterns,
 			blockPatternCategories,
 			canUseUnfilteredHTML,

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -16,13 +16,13 @@ export const CATEGORY_SLUG = 'wp_pattern_category';
 export default function CategorySelector( {
 	categoryTerms,
 	onChange,
-	categoryMap,
+	categories,
 } ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
 	const suggestions = useMemo( () => {
-		return Array.from( categoryMap.values() )
+		return categories
 			.map( ( category ) => unescapeString( category.label ) )
 			.filter( ( category ) => {
 				if ( search !== '' ) {
@@ -33,7 +33,7 @@ export default function CategorySelector( {
 				return true;
 			} )
 			.sort( ( a, b ) => a.localeCompare( b ) );
-	}, [ search, categoryMap ] );
+	}, [ search, categories ] );
 
 	function handleChange( termNames ) {
 		const uniqueTerms = termNames.reduce( ( terms, newTerm ) => {

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -49,9 +49,9 @@ export default function CreatePatternModal( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const patternCategories = useSelect( ( select ) => {
-		const { getBlockPatternCategories } = select( coreStore );
+		const { getPatternCategories } = select( coreStore );
 
-		return getBlockPatternCategories();
+		return getPatternCategories();
 	} );
 
 	async function onCreate( patternTitle, sync ) {
@@ -110,7 +110,7 @@ export default function CreatePatternModal( {
 				termData,
 				{ throwOnError: true }
 			);
-			invalidateResolution( 'getBlockPatternCategories' );
+			invalidateResolution( 'getPatternCategories' );
 			return newTerm.id;
 		} catch ( error ) {
 			if ( error.code !== 'term_exists' ) {

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -49,9 +49,9 @@ export default function CreatePatternModal( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const patternCategories = useSelect( ( select ) => {
-		const { getPatternCategories } = select( coreStore );
+		const { getAllPatternCategories } = select( coreStore );
 
-		return getPatternCategories();
+		return getAllPatternCategories();
 	} );
 
 	async function onCreate( patternTitle, sync ) {
@@ -110,7 +110,7 @@ export default function CreatePatternModal( {
 				termData,
 				{ throwOnError: true }
 			);
-			invalidateResolution( 'getPatternCategories' );
+			invalidateResolution( 'getAllPatternCategories' );
 			return newTerm.id;
 		} catch ( error ) {
 			if ( error.code !== 'term_exists' ) {

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -10,7 +10,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { useState, useMemo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
@@ -48,41 +48,11 @@ export default function CreatePatternModal( {
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
-	const { corePatternCategories, userPatternCategories } = useSelect(
-		( select ) => {
-			const { getUserPatternCategories, getBlockPatternCategories } =
-				select( coreStore );
+	const patternCategories = useSelect( ( select ) => {
+		const { getBlockPatternCategories } = select( coreStore );
 
-			return {
-				corePatternCategories: getBlockPatternCategories(),
-				userPatternCategories: getUserPatternCategories(),
-			};
-		}
-	);
-
-	const categoryMap = useMemo( () => {
-		// Merge the user and core pattern categories and remove any duplicates.
-		const uniqueCategories = new Map();
-		[ ...userPatternCategories, ...corePatternCategories ].forEach(
-			( category ) => {
-				if (
-					! uniqueCategories.has( category.label ) &&
-					// There are two core categories with `Post` label so explicitly remove the one with
-					// the `query` slug to avoid any confusion.
-					category.name !== 'query'
-				) {
-					// We need to store the name separately as this is used as the slug in the
-					// taxonomy and may vary from the label.
-					uniqueCategories.set( category.label, {
-						label: category.label,
-						value: category.label,
-						name: category.name,
-					} );
-				}
-			}
-		);
-		return uniqueCategories;
-	}, [ userPatternCategories, corePatternCategories ] );
+		return getBlockPatternCategories();
+	} );
 
 	async function onCreate( patternTitle, sync ) {
 		if ( ! title || isSaving ) {
@@ -128,7 +98,9 @@ export default function CreatePatternModal( {
 		try {
 			// We need to match any existing term to the correct slug to prevent duplicates, eg.
 			// the core `Headers` category uses the singular `header` as the slug.
-			const existingTerm = categoryMap.get( term );
+			const existingTerm = patternCategories.find(
+				( category ) => category.label === term
+			);
 			const termData = existingTerm
 				? { name: existingTerm.label, slug: existingTerm.name }
 				: { name: term };
@@ -138,7 +110,7 @@ export default function CreatePatternModal( {
 				termData,
 				{ throwOnError: true }
 			);
-			invalidateResolution( 'getUserPatternCategories' );
+			invalidateResolution( 'getBlockPatternCategories' );
 			return newTerm.id;
 		} catch ( error ) {
 			if ( error.code !== 'term_exists' ) {
@@ -176,7 +148,7 @@ export default function CreatePatternModal( {
 					<CategorySelector
 						categoryTerms={ categoryTerms }
 						onChange={ setCategoryTerms }
-						categoryMap={ categoryMap }
+						categories={ patternCategories }
 					/>
 					<ToggleControl
 						label={ _x(

--- a/packages/patterns/src/components/duplicate-pattern-modal.js
+++ b/packages/patterns/src/components/duplicate-pattern-modal.js
@@ -36,9 +36,9 @@ export default function DuplicatePatternModal( {
 } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const categories = useSelect( ( select ) => {
-		const { getPatternCategories } = select( coreStore );
+		const { getAllPatternCategories } = select( coreStore );
 
-		return getPatternCategories();
+		return getAllPatternCategories();
 	} );
 
 	if ( ! pattern ) {

--- a/packages/patterns/src/components/duplicate-pattern-modal.js
+++ b/packages/patterns/src/components/duplicate-pattern-modal.js
@@ -15,14 +15,14 @@ import { PATTERN_SYNC_TYPES } from '../constants';
 function getTermLabels( pattern, categories ) {
 	// Theme patterns don't have an id and rely on core pattern categories.
 	if ( ! pattern.id ) {
-		return categories.core
+		return categories
 			?.filter( ( category ) =>
 				pattern.categories.includes( category.name )
 			)
 			.map( ( category ) => category.label );
 	}
 
-	return categories.user
+	return categories
 		?.filter( ( category ) =>
 			pattern.wp_pattern_category.includes( category.id )
 		)
@@ -36,13 +36,9 @@ export default function DuplicatePatternModal( {
 } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const categories = useSelect( ( select ) => {
-		const { getUserPatternCategories, getBlockPatternCategories } =
-			select( coreStore );
+		const { getPatternCategories } = select( coreStore );
 
-		return {
-			core: getBlockPatternCategories(),
-			user: getUserPatternCategories(),
-		};
+		return getPatternCategories();
 	} );
 
 	if ( ! pattern ) {

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -101,7 +101,7 @@ export default function RenamePatternCategoryModal( {
 				}
 			);
 
-			invalidateResolution( 'getBlockPatternCategories' );
+			invalidateResolution( 'getPatternCategories' );
 			onSuccess?.( savedRecord );
 			onClose();
 

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -101,7 +101,7 @@ export default function RenamePatternCategoryModal( {
 				}
 			);
 
-			invalidateResolution( 'getUserPatternCategories' );
+			invalidateResolution( 'getBlockPatternCategories' );
 			onSuccess?.( savedRecord );
 			onClose();
 

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -101,7 +101,7 @@ export default function RenamePatternCategoryModal( {
 				}
 			);
 
-			invalidateResolution( 'getPatternCategories' );
+			invalidateResolution( 'getAllPatternCategories' );
 			onSuccess?.( savedRecord );
 			onClose();
 


### PR DESCRIPTION
## What?
Merges the user and theme pattern categories in the `/v2/block-patterns/categories` endpoint instead of merging them in multiple places in the UI

## Why?
Currently, the merging of these categories is duplicated in the block and site editor. It would be better to handle this in a single place, and it makes sense to do it on the API endpoint.

## How?
In order to maintain backwards compat with the existing selectors a new resolver and selector is added for `getAllPatternCategories` and the endpoint has been modified to only return the user categories and additional fields if explicitly specified in the request.

There is a corresponding PR to port the changes to the API endpoint to core [here](https://github.com/WordPress/wordpress-develop/pull/5621).

## Testing Instructions

- Add some patterns in the block editor, and assign some to existing theme/core pattern categories and some to new custom categories
- Make sure that the patterns appear under the theme/core categories in the inserter `Patterns` tab, and that the new custom categories also appear in the `Patterns` tab with the correct patterns listed
- When adding a new pattern make sure that the theme/core and custom categories appear in the category select list
- In the site editor make sure all the categories appear in the Patterns section, with the patterns listed under the correct categories
- Try adding a new pattern from the site editor `+` option at top of navigation and make sure new categories appear in the left category panel after adding
- Try renaming a custom category with overflow menu at top right of Patterns section when category selected, and make sure the change is reflected everywhere without having to refresh.
