### PR TITLE
Patterns: Add category selectors to the patterns package

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { cloneBlock, createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -21,37 +21,19 @@ import { store as blockEditorStore } from '../../../store';
  * @return {Array} Returns the patterns state. (patterns, categories, onSelect handler)
  */
 const usePatternsState = ( onInsert, rootClientId ) => {
-	const { patternCategories, patterns, userPatternCategories } = useSelect(
+	const { patternCategories, patterns } = useSelect(
 		( select ) => {
 			const { __experimentalGetAllowedPatterns, getSettings } =
 				select( blockEditorStore );
-			const {
-				__experimentalUserPatternCategories,
-				__experimentalBlockPatternCategories,
-			} = getSettings();
+			const { __experimentalBlockPatternCategories } = getSettings();
 			return {
 				patterns: __experimentalGetAllowedPatterns( rootClientId ),
-				userPatternCategories: __experimentalUserPatternCategories,
+
 				patternCategories: __experimentalBlockPatternCategories,
 			};
 		},
 		[ rootClientId ]
 	);
-
-	const allCategories = useMemo( () => {
-		const categories = [ ...patternCategories ];
-		userPatternCategories?.forEach( ( userCategory ) => {
-			if (
-				! categories.find(
-					( existingCategory ) =>
-						existingCategory.name === userCategory.name
-				)
-			) {
-				categories.push( userCategory );
-			}
-		} );
-		return categories;
-	}, [ patternCategories, userPatternCategories ] );
 
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const onClickPattern = useCallback(
@@ -79,7 +61,7 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 		[ createSuccessNotice, onInsert ]
 	);
 
-	return [ patterns, allCategories, onClickPattern ];
+	return [ patterns, patternCategories, onClickPattern ];
 };
 
 export default usePatternsState;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2294,12 +2294,14 @@ const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {
 function getUserPatterns( state ) {
 	const userPatterns =
 		state?.settings?.__experimentalReusableBlocks ?? EMPTY_ARRAY;
-	const userPatternCategories =
-		state?.settings?.__experimentalUserPatternCategories ?? [];
+	const patternCategories =
+		state?.settings?.__experimentalBlockPatternCategories ?? [];
 	const categories = new Map();
-	userPatternCategories.forEach( ( userCategory ) =>
-		categories.set( userCategory.id, userCategory )
-	);
+	patternCategories.forEach( ( category ) => {
+		if ( category.id ) {
+			categories.set( category.id, category );
+		}
+	} );
 	return userPatterns.map( ( userPattern ) => {
 		return {
 			name: `core/block/${ userPattern.id }`,
@@ -2307,7 +2309,7 @@ function getUserPatterns( state ) {
 			title: userPattern.title.raw,
 			categories: userPattern.wp_pattern_category.map( ( catId ) =>
 				categories && categories.get( catId )
-					? categories.get( catId ).slug
+					? categories.get( catId ).name
 					: catId
 			),
 			content: userPattern.content.raw,
@@ -2315,13 +2317,6 @@ function getUserPatterns( state ) {
 		};
 	} );
 }
-
-export const __experimentalUserPatternCategories = createSelector(
-	( state ) => {
-		return state?.settings?.__experimentalUserPatternCategories;
-	},
-	( state ) => [ state.settings.__experimentalUserPatternCategories ]
-);
 
 export const __experimentalGetParsedPattern = createSelector(
 	( state, patternName ) => {
@@ -2344,7 +2339,6 @@ export const __experimentalGetParsedPattern = createSelector(
 	( state ) => [
 		state.settings.__experimentalBlockPatterns,
 		state.settings.__experimentalReusableBlocks,
-		state?.settings?.__experimentalUserPatternCategories,
 	]
 );
 
@@ -2369,7 +2363,6 @@ const getAllAllowedPatterns = createSelector(
 		state.settings.__experimentalBlockPatterns,
 		state.settings.__experimentalReusableBlocks,
 		state.settings.allowedBlockTypes,
-		state?.settings?.__experimentalUserPatternCategories,
 	]
 );
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -9,6 +9,7 @@ import {
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
+import { store as patternsStore } from '@wordpress/patterns';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 import inserterMediaCategories from '../media-categories';
 import { mediaUpload } from '../../utils';
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const EMPTY_BLOCKS_LIST = [];
 
@@ -95,13 +97,11 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		pageOnFront,
 		pageForPosts,
 		postType,
-		userPatternCategories,
 	} = useSelect( ( select ) => {
 		const { canUserUseUnfilteredHTML, getCurrentPostType } =
 			select( editorStore );
 		const isWeb = Platform.OS === 'web';
-		const { canUser, getEntityRecord, getUserPatternCategories } =
-			select( coreStore );
+		const { canUser, getEntityRecord } = select( coreStore );
 
 		const siteSettings = canUser( 'read', 'settings' )
 			? getEntityRecord( 'root', 'site' )
@@ -121,7 +121,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			pageOnFront: siteSettings?.page_on_front,
 			pageForPosts: siteSettings?.page_for_posts,
 			postType: getCurrentPostType(),
-			userPatternCategories: getUserPatternCategories(),
 		};
 	}, [] );
 
@@ -135,8 +134,9 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 	const { restBlockPatterns, restBlockPatternCategories } = useSelect(
 		( select ) => ( {
 			restBlockPatterns: select( coreStore ).getBlockPatterns(),
-			restBlockPatternCategories:
-				select( coreStore ).getBlockPatternCategories(),
+			restBlockPatternCategories: unlock(
+				select( patternsStore )
+			).getPatternCategories(),
 		} ),
 		[]
 	);
@@ -209,7 +209,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
-			__experimentalUserPatternCategories: userPatternCategories,
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, settings ),
 			inserterMediaCategories,
@@ -227,7 +226,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			settings,
 			hasUploadPermissions,
 			reusableBlocks,
-			userPatternCategories,
 			blockPatterns,
 			blockPatternCategories,
 			canUseUnfilteredHTML,

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -32,6 +32,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/a11y": "file:../a11y",
+		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -16,13 +16,13 @@ export const CATEGORY_SLUG = 'wp_pattern_category';
 export default function CategorySelector( {
 	categoryTerms,
 	onChange,
-	categoryMap,
+	patternCategories,
 } ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
 	const suggestions = useMemo( () => {
-		return Array.from( categoryMap.values() )
+		return patternCategories
 			.map( ( category ) => unescapeString( category.label ) )
 			.filter( ( category ) => {
 				if ( search !== '' ) {
@@ -33,7 +33,7 @@ export default function CategorySelector( {
 				return true;
 			} )
 			.sort( ( a, b ) => a.localeCompare( b ) );
-	}, [ search, categoryMap ] );
+	}, [ search, patternCategories ] );
 
 	function handleChange( termNames ) {
 		const uniqueTerms = termNames.reduce( ( terms, newTerm ) => {

--- a/packages/patterns/src/store/index.js
+++ b/packages/patterns/src/store/index.js
@@ -10,6 +10,7 @@ import reducer from './reducer';
 import * as actions from './actions';
 import { STORE_NAME } from './constants';
 import * as selectors from './selectors';
+import * as resolvers from './resolvers';
 import { unlock } from '../lock-unlock';
 
 /**
@@ -21,6 +22,7 @@ import { unlock } from '../lock-unlock';
  */
 export const storeConfig = {
 	reducer,
+	resolvers,
 };
 
 /**

--- a/packages/patterns/src/store/reducer.js
+++ b/packages/patterns/src/store/reducer.js
@@ -14,6 +14,16 @@ export function isEditingPattern( state = {}, action ) {
 	return state;
 }
 
+export function patternCategories( state = [], action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_PATTERN_CATEGORIES':
+			return action.patternCategories;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	isEditingPattern,
+	patternCategories,
 } );

--- a/packages/patterns/src/store/resolvers.js
+++ b/packages/patterns/src/store/resolvers.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+import apiFetch from '@wordpress/api-fetch';
+
+export const getPatternCategories =
+	() =>
+	async ( { dispatch } ) => {
+		const coreCategories = await apiFetch( {
+			path: '/wp/v2/block-patterns/categories',
+		} );
+		const userCategories = await apiFetch( {
+			path: '/wp/v2/wp_pattern_category',
+		} );
+		const mappedUserCategories =
+			userCategories?.map( ( userCategory ) => ( {
+				...userCategory,
+				label: decodeEntities( userCategory.name ),
+				name: userCategory.slug,
+			} ) ) || [];
+		const uniqueCategories = new Map();
+		[ ...mappedUserCategories, ...coreCategories ].forEach(
+			( category ) => {
+				if (
+					! uniqueCategories.has( category.label ) &&
+					// There are two core categories with `Post` label so explicitly remove the one with
+					// the `query` slug to avoid any confusion.
+					category.name !== 'query'
+				) {
+					// We need to store the name separately as this is used as the slug in the
+					// taxonomy and may vary from the label.
+					uniqueCategories.set( category.label, {
+						label: category.label,
+						value: category.label,
+						name: category.name,
+						id: category.id,
+					} );
+				}
+			}
+		);
+		const patternCategories = Array.from( uniqueCategories.values() ).sort(
+			( a, b ) => a.label.localeCompare( b.label )
+		);
+		dispatch( {
+			type: 'RECEIVE_PATTERN_CATEGORIES',
+			patternCategories,
+		} );
+	};

--- a/packages/patterns/src/store/resolvers.js
+++ b/packages/patterns/src/store/resolvers.js
@@ -15,9 +15,10 @@ export const getPatternCategories =
 		} );
 		const mappedUserCategories =
 			userCategories?.map( ( userCategory ) => ( {
-				...userCategory,
 				label: decodeEntities( userCategory.name ),
 				name: userCategory.slug,
+				id: userCategory.id,
+				description: userCategory.description,
 			} ) ) || [];
 		const uniqueCategories = new Map();
 		[ ...mappedUserCategories, ...coreCategories ].forEach(
@@ -28,12 +29,10 @@ export const getPatternCategories =
 					// the `query` slug to avoid any confusion.
 					category.name !== 'query'
 				) {
-					// We need to store the name separately as this is used as the slug in the
-					// taxonomy and may vary from the label.
 					uniqueCategories.set( category.label, {
 						label: category.label,
-						value: category.label,
 						name: category.name,
+						description: category.description,
 						id: category.id,
 					} );
 				}

--- a/packages/patterns/src/store/selectors.js
+++ b/packages/patterns/src/store/selectors.js
@@ -8,3 +8,13 @@
 export function isEditingPattern( state, clientId ) {
 	return state.isEditingPattern[ clientId ];
 }
+
+/**
+ * Retrieve the list of registered block pattern categories.
+ *
+ * @param {Object} state Data state.
+ * @return {Array} Block pattern category list.
+ */
+export function getPatternCategories( state ) {
+	return state.patternCategories;
+}


### PR DESCRIPTION
## What?
Adds a new selector to get all pattern categories to the patterns package as an alternative to https://github.com/WordPress/gutenberg/pull/55822 which combines the categories on the existing pattern categories rest API

## Why?
Currently we combine the core and user pattern categories in a number of different places between post editor and site editor. It would be better to have a single selector that provided the combined categories.

The advantage of this approach is that there are no backwards compat issues with changing API endpoint responses.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

- In the post editor add a new pattern and add a new category
- Make sure the new category now appears in the inserter patterns tab
- Add a new pattern and make sure the new category also appears in the select list dropdown of existing categories

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
