### PR TITLE
Issue Templates: Add default type labels to issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Report a bug with the WordPress block editor or Gutenberg plugin
+labels: ['[Type] Bug']
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Propose an idea for a feature or an enhancement
+labels: [Type] Enhancement
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/New_release.md
+++ b/.github/ISSUE_TEMPLATE/New_release.md
@@ -1,6 +1,7 @@
 ---
 name: Gutenberg Release
 about: A checklist for the Gutenberg plugin release process
+labels: Gutenberg Plugin, [Type] Project Management
 ---
 
 This issue is to provide visibility on the progress of the release process of Gutenberg VERSION_NUMBER and to centralize any conversations about it. The ultimate goal of this issue is to keep the reference of the steps, resources, work, and conversations about this release so it can be helpful for the next contributors releasing a new Gutenberg version.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Automatically add labels to issues based on the issue template used.

* Bug Report:  `[Type] Bug`
* Enhancement: `[Type] Enhancement`
* New Release: `Gutenberg Plugin`, `[Type] Project Management`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I was asking @jordesign about whether adding labels would skip the triage process (it doesn't) and mentioned work automates adding the basic type labels. Jordan thought that sounded appealing. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Editing the issue templates to include `labels` fields

## Testing Instructions

I'm not sure it's possible to test these without a yolo merge/test repo.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
