### PR TITLE
Global styles revisions: add route for single styles revisions

### DIFF
--- a/lib/compat/wordpress-6.4/rest-api.php
+++ b/lib/compat/wordpress-6.4/rest-api.php
@@ -19,11 +19,3 @@ function gutenberg_register_rest_block_patterns_routes() {
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns_routes' );
 
-/**
- * Registers the Global Styles Revisions REST API routes.
- */
-function gutenberg_register_global_styles_revisions_endpoints() {
-	$global_styles_revisions_controller = new Gutenberg_REST_Global_Styles_Revisions_Controller_6_4();
-	$global_styles_revisions_controller->register_routes();
-}
-add_action( 'rest_api_init', 'gutenberg_register_global_styles_revisions_endpoints' );

--- a/lib/compat/wordpress-6.4/rest-api.php
+++ b/lib/compat/wordpress-6.4/rest-api.php
@@ -18,4 +18,3 @@ function gutenberg_register_rest_block_patterns_routes() {
 	$block_patterns->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_block_patterns_routes' );
-

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Global_Styles_Revisions_Controller class, inspired by WP_REST_Revisions_Controller.
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 6.3.0
+ */
+
+/**
+ * Core class used to access global styles revisions via the REST API.
+ *
+ * @since 6.3.0
+ *
+ * @see WP_REST_Controller
+ */
+class Gutenberg_REST_Global_Styles_Revisions_Controller_6_5 extends Gutenberg_REST_Global_Styles_Revisions_Controller_6_4 {
+	/**
+	 * Registers the controller's routes.
+	 *
+	 * @since 6.3.0
+	 * @since 6.5.0 Adds route to fetch individual global styles revisions.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->parent_base . '/(?P<parent>[\d]+)/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'parent' => array(
+						'description' => __( 'The ID for the parent of the global styles revision.' ),
+						'type'        => 'integer',
+					),
+					'id'     => array(
+						'description' => __( 'Unique identifier for the global styles revision.' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		parent::register_routes();
+	}
+
+	/**
+	 * Retrieves one global styles revision from the collection.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+		$parent = $this->get_parent( $request['parent'] );
+		if ( is_wp_error( $parent ) ) {
+			return $parent;
+		}
+
+		$revision = $this->get_revision( $request['id'] );
+		if ( is_wp_error( $revision ) ) {
+			return $revision;
+		}
+
+		$response = $this->prepare_item_for_response( $revision, $request );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Get the global styles revision, if the ID is valid.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param int $id Supplied ID.
+	 * @return WP_Post|WP_Error Revision post object if ID is valid, WP_Error otherwise.
+	 */
+	protected function get_revision( $id ) {
+		$error = new WP_Error(
+			'rest_post_invalid_id',
+			__( 'Invalid revision ID.' ),
+			array( 'status' => 404 )
+		);
+
+		if ( (int) $id <= 0 ) {
+			return $error;
+		}
+
+		$revision = get_post( (int) $id );
+		if ( empty( $revision ) || empty( $revision->ID ) || 'revision' !== $revision->post_type ) {
+			return $error;
+		}
+
+		return $revision;
+	}
+}

--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * PHP and WordPress configuration compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Registers the Global Styles Revisions REST API routes.
+ */
+function gutenberg_register_global_styles_revisions_endpoints() {
+	$global_styles_revisions_controller = new Gutenberg_REST_Global_Styles_Revisions_Controller_6_5();
+	$global_styles_revisions_controller->register_routes();
+}
+
+add_action( 'rest_api_init', 'gutenberg_register_global_styles_revisions_endpoints' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -56,6 +56,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.4/rest-api.php';
 	require_once __DIR__ . '/compat/wordpress-6.4/theme-previews.php';
 
+	// WordPress 6.5 compat.
+	require_once __DIR__ . '/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php';
+	require_once __DIR__ . '/compat/wordpress-6.5/rest-api.php';
+
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';
 	require_once __DIR__ . '/rest-api.php';

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -242,6 +242,11 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 			$routes,
 			'Global style revisions based on the given parentID route does not exist.'
 		);
+		$this->assertArrayHasKey(
+			'/wp/v2/global-styles/(?P<parent>[\d]+)/revisions/(?P<id>[\d]+)',
+			$routes,
+			'Single global style revisions based on the given parentID and revision ID route does not exist.'
+		);
 	}
 
 	/**
@@ -299,6 +304,20 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	}
 
 	/**
+	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_item
+	 */
+	public function test_get_item() {
+		wp_set_current_user( self::$admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions/' . $this->revision_1_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Response status is 200.' );
+		$this->check_get_revision_response( $data, $this->revision_1 );
+	}
+
+	/**
 	 * @ticket 58524
 	 *
 	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_item_schema
@@ -320,18 +339,12 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 		$this->assertArrayHasKey( 'modified', $properties, 'Schema properties array has "modified" key.' );
 		$this->assertArrayHasKey( 'modified_gmt', $properties, 'Schema properties array has "modified_gmt" key.' );
 	}
+
 	/**
 	 * @doesNotPerformAssertions
 	 */
 	public function test_context_param() {
 		// Controller does not implement test_context_param().
-	}
-
-	/**
-	 * @doesNotPerformAssertions
-	 */
-	public function test_get_item() {
-		// Controller does not implement get_item().
 	}
 
 	/**

--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -304,6 +304,8 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	}
 
 	/**
+	 * @ticket 59810
+	 *
 	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_item
 	 */
 	public function test_get_item() {
@@ -315,6 +317,22 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 
 		$this->assertSame( 200, $response->get_status(), 'Response status is 200.' );
 		$this->check_get_revision_response( $data, $this->revision_1 );
+	}
+
+	/**
+	 * @ticket 59810
+	 *
+	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_revision
+	 */
+	public function test_get_item_invalid_revision_id_should_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$expected_error  = 'rest_post_invalid_id';
+		$expected_status = 404;
+		$request         = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions/20000001' );
+		$response        = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( $expected_error, $response, $expected_status );
 	}
 
 	/**


### PR DESCRIPTION
Tracking: 

- https://github.com/WordPress/gutenberg/issues/55776


Core sync PR:

- https://github.com/WordPress/wordpress-develop/pull/5622

## What?
Adding route for single global styles revisions: `/wp/v2/global-styles/${ parentId }/revisions/${ revisionsId }`

## Why?

To make global styles revisions compatible with the [proposed Core Data revisions API](https://github.com/WordPress/gutenberg/pull/54046), that is, so that we can fetch single revisions via `getRevision()`.




## Testing Instructions

Run the tests!

```
npm run test:unit:php:base -- --filter Gutenberg_REST_Global_Styles_Revisions_Controller_Test
```