### PR TITLE
DataViews: remove `filter.name`

### DIFF
--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -174,7 +174,6 @@ const field = [
 
 A filter is an object that may contain the following properties:
 
-- `name`: nice looking name for the filter. Field filters may omit it, in which case the field's `header` will be used.
 - `type`: the type of filter. Only `enumeration` is supported at the moment.
 - `elements`: for filters of type `enumeration`, the list of options to show. A one-dimensional array of object with value/label keys, as in `[ { value: 1, label: "Value name" } ]`.
 	- `value`: what's serialized into the view's filters.
@@ -193,9 +192,7 @@ const field = [
 		filters: [
 			'enumeration',
 			{ type: 'enumeration' },
-			{ type: 'enumeration' },
-			{ type: 'enumeration', name: __( 'Author' ) },
-			{ type: 'enumeration', name: __( 'Author' ), elements: authors },
+			{ type: 'enumeration', elements: authors },
 		],
 	}
 ];

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -28,7 +28,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 			if ( 'object' === typeof filter ) {
 				filterIndex[ id ] = {
 					id,
-					name: filter.name || field.header,
+					name: field.header,
 					type: filter.type,
 				};
 			}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Removes `filter.name` prop, as it is no longer used – filters are bound to fields and they take their name from the field itself.

