### PR TITLE
More settings tip: add explicit font size.

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/style.scss
+++ b/packages/block-editor/src/components/inspector-controls-tabs/style.scss
@@ -15,13 +15,14 @@
 }
 
 .block-editor-inspector-controls-tabs__hint {
-	align-items: top;
+	align-items: flex-start;
 	background: $gray-100;
 	border-radius: $radius-block-ui;
 	color: $gray-900;
 	display: flex;
 	flex-direction: row;
 	margin: $grid-unit-20;
+	font-size: $default-font-size;
 }
 
 .block-editor-inspector-controls-tabs__hint-content {


### PR DESCRIPTION
## What?

In certain embedded contexts, CSS bleeds into the more-settings tip, causing the font size to be inherited and perhaps larger. In this screenshot, it's from a Gutenberg embedded in P2 context, where it inherits a 16px font size:

![fix this, it might need an explicit font size](https://github.com/WordPress/gutenberg/assets/1204802/d3028c8a-9501-4c26-b8ce-4b1d4721a221)

Here's the offending "inherit" for the font size:

![Screenshot 2023-11-03 at 10 32 56](https://github.com/WordPress/gutenberg/assets/1204802/0aea5af3-3353-4e7f-be39-d0b1702b7f28)

This PR explicitly adds a font size so that it should maintain as it should:

![Screenshot 2023-11-03 at 10 37 10](https://github.com/WordPress/gutenberg/assets/1204802/7b834583-f296-43db-aec1-0b863d98bd62)

The PR also fixes an issue where incorrect CSS was present.

## Testing Instructions

This one is hard to test without faking it, but in a new env where the notice isn't dismissed, add this CSS:

```
.p2-editor {
	font-size: 16px;
}
```

Then add "p2-editor" as a class to any parent, such as the `body` element of the editor.

You should still see the correct 13px font size on the notice.
