### PR TITLE
Stay in the selected inspector tab when switching blocks

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -11,6 +11,7 @@ import SettingsTab from './settings-tab';
 import StylesTab from './styles-tab';
 import InspectorControls from '../inspector-controls';
 import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
+import useLastSelectedInspectorControlTab from './use-last-selected-inspector-control-tab';
 
 export default function InspectorControlsTabs( {
 	blockName,
@@ -18,19 +19,25 @@ export default function InspectorControlsTabs( {
 	hasBlockStyles,
 	tabs,
 } ) {
+	const [ lastSelectedTab, setLastSelectedTab ] =
+		useLastSelectedInspectorControlTab( tabs );
+
 	// The tabs panel will mount before fills are rendered to the list view
 	// slot. This means the list view tab isn't initially included in the
 	// available tabs so the panel defaults selection to the settings tab
 	// which at the time is the first tab. This check allows blocks known to
 	// include the list view tab to set it as the tab selected by default.
-	const initialTabName = ! useIsListViewTabDisabled( blockName )
-		? TAB_LIST_VIEW.name
-		: undefined;
+	const hasListTab = ! useIsListViewTabDisabled( blockName );
+
+	const initialTabName =
+		lastSelectedTab ?? ( hasListTab ? TAB_LIST_VIEW.name : undefined );
+
 	return (
 		<TabPanel
 			className="block-editor-block-inspector__tabs"
 			tabs={ tabs }
 			initialTabName={ initialTabName }
+			onSelect={ setLastSelectedTab }
 			key={ clientId }
 		>
 			{ ( tab ) => {

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-last-selected-inspector-control-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-last-selected-inspector-control-tab.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { TAB_LIST_VIEW } from './utils';
+
+const SETTINGS_KEY = 'lastSelectedInspectorControlTab';
+
+export default function useLastSelectedInspectorControlTab( tabs ) {
+	const lastTab = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return settings[ SETTINGS_KEY ];
+	} );
+
+	const { updateSettings } = useDispatch( blockEditorStore );
+
+	const setLastSelectedTab = useCallback(
+		( tabName ) => {
+			if ( TAB_LIST_VIEW.name === tabName ) {
+				return;
+			}
+			updateSettings( {
+				[ SETTINGS_KEY ]: tabName,
+			} );
+		},
+		[ updateSettings ]
+	);
+
+	const selectedBlockHasTab = !! tabs?.find(
+		( { name } ) => lastTab === name
+	);
+
+	return [ selectedBlockHasTab ? lastTab : undefined, setLastSelectedTab ];
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #51104 

## What?
- In the sidebar inspector, keep track of the tab (Settings/Styles) the user selects
- When selecting a new block, open the last selected tab by default

## Why?

When building a template, it's common to go back and forth between blocks to adjust the same settings, like margins or other spacing. Having to navigate to the controls again and again is a source of friction. 

## How?
- Introduce a hook, `useLastSelectedInspectorControlTab`
- Stores the last selected tab in the settings state of the block editor store
- Hook this up to the `TabPanel`'s `initialTabName` and `onSelect` props.  

## Testing Instructions
- Open a template for editing in the site editor that contains multiple blocks
- Select a block, open the sidebar inspector, and select the Styles tab
- Select another block, and check that the Styles tab remains open
- Select a block that doesn't have a Styles tab, and make sure a default tab is still selected (Settings/List)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Changes shouldn't affect keyboard navigation


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/176949/6b899b2c-e833-45f0-b9ab-82d923c5f338



