### PR TITLE
DataViews: remove reset values from filters

### DIFF
--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -180,8 +180,6 @@ A filter is an object that may contain the following properties:
 - `elements`: for filters of type `enumeration`, the list of options to show. A one-dimensional array of object with value/label keys, as in `[ { value: 1, label: "Value name" } ]`.
 	- `value`: what's serialized into the view's filters.
 	- `label`: nice-looking name for users.
-- `resetValue`: for filters of type `enumeration`, this is the value for the reset option. If none is provided, `''` will be used.
-- `resetLabel`: for filters of type `enumeration`, this is the label for the reset option. If none is provided, `All` will be used.
 
 As a convenience, field's filter can provide abbreviated versions for the filter. All of following examples result in the same filter:
 

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -36,8 +36,8 @@ export default function Filters( { fields, view, onChangeView } ) {
 			if ( 'enumeration' === filterIndex[ id ]?.type ) {
 				const elements = [
 					{
-						value: filter.resetValue || '',
-						label: filter.resetLabel || __( 'All' ),
+						value: '',
+						label: __( 'All' ),
 					},
 					...( field.elements || [] ),
 				];

--- a/packages/edit-site/src/components/page-pages/default-views.js
+++ b/packages/edit-site/src/components/page-pages/default-views.js
@@ -4,15 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 
-// DEFAULT_STATUSES is intentionally sorted. Items do not have spaces in between them.
-// The reason for that is to match the default statuses coming from the endpoint
-// (entity request and useEffect to update the view).
-export const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All statuses but 'trash'.
-
 const DEFAULT_PAGE_BASE = {
 	type: 'list',
 	search: '',
-	filters: [ { field: 'status', operator: 'in', value: DEFAULT_STATUSES } ],
+	filters: [],
 	page: 1,
 	perPage: 5,
 	sort: {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -99,7 +99,8 @@ export default function PagePages() {
 		totalPages,
 	} = useEntityRecords( 'postType', 'page', queryArgs );
 
-	const { records: authors } = useEntityRecords( 'root', 'user' );
+	const { records: authors, isResolving: isLoadingAuthors } =
+		useEntityRecords( 'root', 'user' );
 
 	const paginationInfo = useMemo(
 		() => ( {
@@ -244,7 +245,9 @@ export default function PagePages() {
 				fields={ fields }
 				actions={ actions }
 				data={ pages || EMPTY_ARRAY }
-				isLoading={ isLoadingPages || isLoadingStatus }
+				isLoading={
+					isLoadingPages || isLoadingStatus || isLoadingAuthors
+				}
 				view={ view }
 				onChangeView={ onChangeView }
 			/>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -18,7 +18,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import Page from '../page';
 import Link from '../routes/link';
 import { DataViews } from '../dataviews';
-import { DEFAULT_STATUSES, default as DEFAULT_VIEWS } from './default-views';
+import { default as DEFAULT_VIEWS } from './default-views';
 import {
 	useTrashPostAction,
 	postRevisionsAction,
@@ -36,6 +36,10 @@ const defaultConfigPerViewType = {
 		mediaField: 'featured-image',
 	},
 };
+
+// DEFAULT_STATUSES is intentionally sorted. Items do not have spaces in between them.
+// The reason for that is to match the default statuses coming from the endpoint (entity request).
+export const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All statuses but 'trash'.
 
 export default function PagePages() {
 	const {
@@ -61,30 +65,6 @@ export default function PagePages() {
 					.sort()
 					.join();
 	}, [ statuses ] );
-
-	useEffect( () => {
-		// Only update the view if the statuses received from the endpoint
-		// are different from the DEFAULT_STATUSES provided initially.
-		//
-		// The pages endpoint depends on the status endpoint via the status filter.
-		// Initially, this code filters the pages request by DEFAULT_STATUTES,
-		// instead of using the default (publish).
-		// https://developer.wordpress.org/rest-api/reference/pages/#list-pages
-		//
-		// By doing so, it avoids a second request to the pages endpoint
-		// upon receiving the statuses when they are the same (most common scenario).
-		if ( DEFAULT_STATUSES !== defaultStatuses ) {
-			setView( {
-				...view,
-				filters: [
-					...view.filters.filter(
-						( f ) => f.field !== 'status' || f.operator !== 'in'
-					),
-					{ field: 'status', operator: 'in', value: defaultStatuses },
-				],
-			} );
-		}
-	}, [ defaultStatuses ] );
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
@@ -222,7 +202,7 @@ export default function PagePages() {
 				},
 			},
 		],
-		[ defaultStatuses, statuses, authors ]
+		[ statuses, authors ]
 	);
 
 	const trashPostAction = useTrashPostAction();

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -54,8 +54,8 @@ export default function PagePages() {
 			DEFAULT_VIEWS.find( ( { slug } ) => slug === activeView ).view
 		);
 	}, [ path, activeView ] );
-	// Request post statuses to get the proper labels.
-	const { records: statuses } = useEntityRecords( 'root', 'status' );
+	const { records: statuses, isResolving: isLoadingStatus } =
+		useEntityRecords( 'root', 'status' );
 	const defaultStatuses = useMemo( () => {
 		return statuses === null
 			? DEFAULT_STATUSES
@@ -91,7 +91,7 @@ export default function PagePages() {
 			search: view.search,
 			...filters,
 		};
-	}, [ view ] );
+	}, [ view, defaultStatuses ] );
 	const {
 		records: pages,
 		isResolving: isLoadingPages,
@@ -244,7 +244,7 @@ export default function PagePages() {
 				fields={ fields }
 				actions={ actions }
 				data={ pages || EMPTY_ARRAY }
-				isLoading={ isLoadingPages }
+				isLoading={ isLoadingPages || isLoadingStatus }
 				view={ view }
 				onChangeView={ onChangeView }
 			/>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -96,6 +96,12 @@ export default function PagePages() {
 				filters.author = filter.value;
 			}
 		} );
+		// We want to provide a different default item for the status filter
+		// than the REST API provides.
+		if ( ! filters.status || filters.status === '' ) {
+			filters.status = defaultStatuses;
+		}
+
 		return {
 			per_page: view.perPage,
 			page: view.page,
@@ -195,12 +201,7 @@ export default function PagePages() {
 				getValue: ( { item } ) =>
 					statuses?.find( ( { slug } ) => slug === item.status )
 						?.name ?? item.status,
-				filters: [
-					{
-						type: 'enumeration',
-						resetValue: defaultStatuses,
-					},
-				],
+				filters: [ 'enumeration' ],
 				elements:
 					statuses?.map( ( { slug, name } ) => ( {
 						value: slug,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Updates the filters for they to use the same default value (empty string). It's the consumer's responsibility to handle the how that default value is converted to a REST API call.

## Why?

This has a double effect:

- simplifies the filters API
- by providing the same default state for the view, it doesn't depend on data coming from an API – by not updating it programatically we avoid creating undo levels (see [thread](https://github.com/WordPress/gutenberg/pull/55476#discussion_r1367841912))

## How?

It's the consumer responsibility to handle the situation in which no value is selected for the filter. In some cases, this would mean to use the REST API defaults (`author` filter), in some other cases it'd mean to provide different defaults (`status` filter).

## Testing Instructions

- With the "wp-admin" experiment enable, visit "Appareance > Editor > Manage pages".
- If your test site doesn't add/modify the default statuses, verify that there is still only 1 request to the pages endpoint.

