### PR TITLE
Docs: Changes imports from `wp.editor` to `wp.blockEditor` for PlainText and RichText

### DIFF
--- a/packages/block-editor/src/components/plain-text/README.md
+++ b/packages/block-editor/src/components/plain-text/README.md
@@ -34,7 +34,7 @@ wp.blocks.registerBlockType( /* ... */, {
 	},
 
 	edit: function( props ) {
-		return React.createElement( wp.editor.PlainText, {
+		return React.createElement( wp.blockEditor.PlainText, {
 			className: props.className,
 			value: props.attributes.content,
 			onChange: function( content ) {
@@ -48,8 +48,8 @@ wp.blocks.registerBlockType( /* ... */, {
 {% ESNext %}
 
 ```js
-const { registerBlockType } = wp.blocks;
-const { PlainText } = wp.editor;
+import { registerBlockType } from '@wordpress/blocks';
+import { PlainText } from '@wordpress/block-editor';
 
 registerBlockType( /* ... */, {
 	// ...

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -94,7 +94,7 @@ wp.blocks.registerBlockType( /* ... */, {
 	},
 
 	edit: function( props ) {
-		return React.createElement( wp.editor.RichText, {
+		return React.createElement( wp.blockEditor.RichText, {
 			tagName: 'h2',
 			className: props.className,
 			value: props.attributes.content,
@@ -105,7 +105,7 @@ wp.blocks.registerBlockType( /* ... */, {
 	},
 
 	save: function( props ) {
-		return React.createElement( wp.editor.RichText.Content, {
+		return React.createElement( wp.blockEditor.RichText.Content, {
 			tagName: 'h2', value: props.attributes.content
 		} );
 	}
@@ -115,8 +115,8 @@ wp.blocks.registerBlockType( /* ... */, {
 {% ESNext %}
 
 ```js
-const { registerBlockType } = wp.blocks;
-const { RichText } = wp.editor;
+import { registerBlockType } from '@wordpress/blocks';
+import { RichText } from '@wordpress/block-editor';
 
 registerBlockType( /* ... */, {
 	// ...
@@ -161,7 +161,7 @@ wp.richText.registerFormatType( /* ... */, {
 	/* ... */
 	edit: function( props ) {
 		return React.createElement(
-			wp.editor.RichTextToolbarButton, {
+			wp.blockEditor.RichTextToolbarButton, {
 				icon: 'editor-code',
 				title: 'My formatting button',
 				onClick: function() { /* ... */ }
@@ -175,8 +175,8 @@ wp.richText.registerFormatType( /* ... */, {
 {% ESNext %}
 
 ```js
-import { registerFormatType } from 'wp-rich-text';
-import { richTextToolbarButton } from 'wp-editor';
+import { registerFormatType } from '@wordpress/rich-text';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
 
 registerFormatType( /* ... */, {
 	/* ... */


### PR DESCRIPTION
## What?
The components `PlainText`and `RichText` are from the `block-editor`, not from the `editor` package.
This PR fixes the code examples in the readme.

Fixes #55831

