### PR TITLE
Tooltip: Don't render buttons tooltip when show button text labels is enabled

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -19,6 +19,7 @@ export default function PreviewOptions( {
 	deviceType,
 	setDeviceType,
 	label,
+	showIconLabels,
 } ) {
 	const isMobile = useViewportMatch( 'small', '<' );
 	if ( isMobile ) return null;
@@ -35,6 +36,7 @@ export default function PreviewOptions( {
 		disabled: ! isEnabled,
 		__experimentalIsFocusable: ! isEnabled,
 		children: viewLabel,
+		showTooltip: ! showIconLabels,
 	};
 	const menuProps = {
 		'aria-label': __( 'View options' ),

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -15,22 +15,27 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editPostStore } from '../../store';
 
 export default function DevicePreview() {
-	const { hasActiveMetaboxes, isPostSaveable, isViewable, deviceType } =
-		useSelect( ( select ) => {
-			const { getEditedPostAttribute } = select( editorStore );
-			const { getPostType } = select( coreStore );
-			const postType = getPostType( getEditedPostAttribute( 'type' ) );
+	const {
+		hasActiveMetaboxes,
+		isPostSaveable,
+		isViewable,
+		deviceType,
+		showIconLabels,
+	} = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( editorStore );
+		const { getPostType } = select( coreStore );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
-			return {
-				hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
-				isPostSaveable: select( editorStore ).isEditedPostSaveable(),
-				isViewable: postType?.viewable ?? false,
-				deviceType:
-					select(
-						editPostStore
-					).__experimentalGetPreviewDeviceType(),
-			};
-		}, [] );
+		return {
+			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
+			isPostSaveable: select( editorStore ).isEditedPostSaveable(),
+			isViewable: postType?.viewable ?? false,
+			deviceType:
+				select( editPostStore ).__experimentalGetPreviewDeviceType(),
+			showIconLabels:
+				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
+		};
+	}, [] );
 	const { __experimentalSetPreviewDeviceType: setPreviewDeviceType } =
 		useDispatch( editPostStore );
 
@@ -41,6 +46,7 @@ export default function DevicePreview() {
 			deviceType={ deviceType }
 			setDeviceType={ setPreviewDeviceType }
 			label={ __( 'Preview' ) }
+			showIconLabels={ showIconLabels }
 		>
 			{ ( { onClose } ) =>
 				isViewable && (

--- a/packages/edit-post/src/components/view-link/index.js
+++ b/packages/edit-post/src/components/view-link/index.js
@@ -8,18 +8,28 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
-export default function ViewLink() {
-	const { permalink, isPublished, label } = useSelect( ( select ) => {
-		// Grab post type to retrieve the view_item label.
-		const postTypeSlug = select( editorStore ).getCurrentPostType();
-		const postType = select( coreStore ).getPostType( postTypeSlug );
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../store';
 
-		return {
-			permalink: select( editorStore ).getPermalink(),
-			isPublished: select( editorStore ).isCurrentPostPublished(),
-			label: postType?.labels.view_item,
-		};
-	}, [] );
+export default function ViewLink() {
+	const { permalink, isPublished, label, showIconLabels } = useSelect(
+		( select ) => {
+			// Grab post type to retrieve the view_item label.
+			const postTypeSlug = select( editorStore ).getCurrentPostType();
+			const postType = select( coreStore ).getPostType( postTypeSlug );
+
+			return {
+				permalink: select( editorStore ).getPermalink(),
+				isPublished: select( editorStore ).isCurrentPostPublished(),
+				label: postType?.labels.view_item,
+				showIconLabels:
+					select( editPostStore ).isFeatureActive( 'showIconLabels' ),
+			};
+		},
+		[]
+	);
 
 	// Only render the view button if the post is published and has a permalink.
 	if ( ! isPublished || ! permalink ) {
@@ -32,6 +42,7 @@ export default function ViewLink() {
 			label={ label || __( 'View post' ) }
 			href={ permalink }
 			target="_blank"
+			showTooltip={ ! showIconLabels }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -229,6 +229,7 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 							isEnabled={
 								! isFocusMode && hasDefaultEditorCanvasView
 							}
+							showIconLabels={ showIconLabels }
 						>
 							{ ( { onClose } ) => (
 								<MenuGroup>

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -98,7 +98,7 @@ export default function SaveButton( {
 			 * Displaying the keyboard shortcut conditionally makes the tooltip
 			 * itself show conditionally. This would trigger a full-rerendering
 			 * of the button that we want to avoid. By setting `showTooltip`,
-			 & the tooltip is always rendered even when there's no keyboard shortcut.
+			 * the tooltip is always rendered even when there's no keyboard shortcut.
 			 */
 			showTooltip={ showTooltip }
 			icon={ icon }

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -156,7 +156,7 @@ export default function PostSavedState( {
 			 * Displaying the keyboard shortcut conditionally makes the tooltip
 			 * itself show conditionally. This would trigger a full-rerendering
 			 * of the button that we want to avoid. By setting `showTooltip`,
-			 & the tooltip is always rendered even when there's no keyboard shortcut.
+			 * the tooltip is always rendered even when there's no keyboard shortcut.
 			 */
 			showTooltip
 			variant="tertiary"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/55815

## What?
<!-- In a few words, what is the PR actually doing? -->
Buttons that already show visible text don't need a tooltiip that just repeats the visible text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Unnecessarily clutters the UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use the `showTooltip` prop based on the `showIconLabels` preference.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a draft post.
- Use the Tab key to move focus to the Preview icon button.
- Observe the button still displays its tooltip.
- Go to Options > Preferences, and enable 'Show button text labels'.
- Move focus to the Preview button again.
- Observe the button does not display a tooltip.
- Publish the post.
- Repeat the test on the 'View Post' button.
- Go to the Site editor.
- Test the View button by repeating the steps above.

Note: the 'Save/Saved' button does have the same problem but for now we have to force its tooltip to always render [as explained in this comment](https://github.com/WordPress/gutenberg/issues/55815#issuecomment-1792327348).


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
