### PR TITLE
Form Input Block: Replace deprecated `__experimentalGroup` prop with `group` prop

### DIFF
--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -59,7 +59,7 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 					</PanelBody>
 				</InspectorControls>
 			) }
-			<InspectorControls __experimentalGroup="advanced">
+			<InspectorControls group="advanced">
 				<TextControl
 					autoComplete="off"
 					label={ __( 'Name' ) }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Change the deprecated properties of the `InspectorControl` in the Form component to recommended properties and correct the following logs.

```
index.js:77 `__experimentalGroup` property in `InspectorControlsFill` in the Form Input Fiield Block deprecated since version 6.2 and will be removed in version 6.4. Please use `group` instead.
```

## Testing Instructions

- Enable "Form and input blocks" from the Gutenberg > Experiments menu.
- Insert a Form block.
- Select one of the field blocks.
- There should still be a "Name" setting in the Advanced section of the block sidebar.