### PR TITLE
Fix: Remove unrequired nullish coalescing.

### DIFF
--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -269,8 +269,7 @@ const getVariantVars = ( variants, variant ) => {
 	for ( const variantName of variantNames ) {
 		const key =
 			variantName.charAt( 0 ).toUpperCase() + variantName.slice( 1 );
-		variantVars[ `is${ key }Variant` ] =
-			currentVariant === variantName ?? false;
+		variantVars[ `is${ key }Variant` ] = currentVariant === variantName;
 	}
 
 	return variantVars;


### PR DESCRIPTION
The instruction currentVariant === variantName is either true or false it will never be null or undefined so the nullish coalescing operator is useless. currentVariant === variantName ?? false; is equivalent to currentVariant === variantName;.