### PR TITLE
Fix: Use of integer value in a conditional rendering condition on Gradients

### DIFF
--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -257,7 +257,7 @@ export function GradientPicker( {
 						onChange={ onChange }
 					/>
 				) }
-				{ ( gradients.length || clearable ) && (
+				{ ( gradients.length > 0 || clearable ) && (
 					<Component
 						{ ...additionalProps }
 						className={ className }


### PR DESCRIPTION
It's best to steer clear of code snippets like `{(items.length && <ComponentToRender />)}`, as React may output a 0 instead of nothing if the length of the items array is 0. Here it is a more complex condition, but it's still advisable to ensure that the conditions are boolean and not dependent on integers, in order to make the code more future-proof.