### PR TITLE
DataViews: fix status filter upon switching the default views from the sidebar

### DIFF
--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -9,10 +9,13 @@ import {
 const OPERATOR_IN = 'in';
 
 export default ( { filter, view, onChangeView } ) => {
-	const activeValue = view.filters.find(
+	let activeValue = view.filters.find(
 		( f ) => f.field === filter.id && f.operator === OPERATOR_IN
 	)?.value;
 
+	if ( ! activeValue ) {
+		activeValue = '';
+	}
 	return (
 		<SelectControl
 			value={ activeValue }

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -9,13 +9,15 @@ import {
 const OPERATOR_IN = 'in';
 
 export default ( { filter, view, onChangeView } ) => {
-	let activeValue = view.filters.find(
+	const valueFound = view.filters.find(
 		( f ) => f.field === filter.id && f.operator === OPERATOR_IN
-	)?.value;
+	);
 
-	if ( ! activeValue ) {
-		activeValue = '';
-	}
+	const activeValue =
+		! valueFound || ! valueFound.hasOwnProperty( 'value' )
+			? ''
+			: valueFound.value;
+
 	return (
 		<SelectControl
 			value={ activeValue }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/55839

## What?

Fixes an issue by which the "All" view in the sidebar doesn't update the status filter.

This is how it should behave:

https://github.com/WordPress/gutenberg/assets/583546/4c17fe9d-c9c6-4b99-ac18-159da99387ab

## Testing Instructions

- With the "wp-admin" experiment enabled, visit "Appearance > Site editor > Manage all pages".
- In the sidebar select the "Drafts" view.
- Then, select the "All" view again.

At all points, the status filter should reflect the selected view.
