### PR TITLE
Pattern: fix regression error in post type templates

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -20,7 +20,7 @@ const PatternEdit = ( { attributes, clientId } ) => {
 	);
 
 	const currentThemeStylesheet = useSelect(
-		( select ) => select( coreStore ).getCurrentTheme().stylesheet
+		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet
 	);
 
 	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #55846

When loading the editor, the `getCurrentTheme()` is returning `undefined`, which breaks the editor when the post type contains a pattern. So this PR fixes it.

I'd appreciate it if it could be merged before WP 6.4 is released, otherwise, we'll have users facing this issue on their sites.

It seems it started to happen after this PR: https://github.com/WordPress/gutenberg/pull/53423. cc @pbking, in case you have the opportunity to check it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We have some post types in Sensei LMS which contains a template with patterns. It happens at least for the Course, Lesson and Email post types. This is one related issue: https://github.com/Automattic/sensei/issues/7262 in Sensei repository.

Notice that it can happen with any post type that has a template with a pattern.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I just added a optional chain operator to make sure it won't break when the current theme is not ready for use in the editor yet.

I didn't investigate deeper if it could have other related issues, but this small fix fixes the mentioned use case specifically.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Create a new post type with a template by using the following snippet:
    ```php
    add_action( 'init', function() {
	    register_post_type(
		    'my-test',
		    [
			    'public'       => true,
			    'show_in_rest' => true,
			    'template'     => [
				    [
					    'core/pattern',
					    [ 'slug' => 'core/simple-header-with-dark-background' ],
				    ],
			    ]
		    ]
	    );
    } );
    ```
2. Create a new post of this new post type.
3. See that no errors happen in the editor or in the browser console.

## Screenshots or screencast <!-- if applicable -->

The error before the fix:

![Screenshot 2023-11-01 at 11 48 33](https://github.com/WordPress/gutenberg/assets/876340/4d202131-4e51-4fe3-be82-5a6ad04a714f)