### PR TITLE
Only render block toolbar if blockType has value

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -169,7 +169,7 @@ function UnforwardBlockContextualToolbar(
 	] );
 
 	const isToolbarEnabled =
-		! blockType ||
+		blockType &&
 		hasBlockSupport( blockType, '__experimentalToolbar', true );
 	const hasAnyBlockControls = useHasAnyBlockControls();
 	if (


### PR DESCRIPTION
Previously an undefined block type would still render an empty navigable toolbar. This flips the logic to only render if we have a block type of some kind available.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Don't render the block toolbar if no blockType is available.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There should be no need to render an empty toolbar block div.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check for the existence of a blockType value. `hasBlockSupport( blockType, '__experimentalToolbar', true );` will return `true` since the last parameter gets passed through, even if `blockType = undefined`. So, `hasBlockSupport( undefined, '__experimentalToolbar', true ) === true`, so an empty toolbar will render.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
No functional change from trunk. All e2e tests should pass... we'll see!

## Screenshots or screencast <!-- if applicable -->
