### PR TITLE
Fixing the exerpt length issue with AJAX

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -88,11 +88,11 @@ add_action(
 	static function () {
 		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 			add_filter(
-			'editor_excerpt_length',
-			static function () {
-				return 100;
-			},
-			PHP_INT_MAX
+			    'editor_excerpt_length',
+			    static function () {
+				    return 100;
+			    },
+			    PHP_INT_MAX
 			);
 		}
 	}

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -88,11 +88,11 @@ add_action(
 	static function () {
 		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 			add_filter(
-			    'editor_excerpt_length',
-			    static function () {
-				    return 100;
-			    },
-			    PHP_INT_MAX
+				'editor_excerpt_length',
+				static function () {
+					return 100;
+				},
+				PHP_INT_MAX
 			);
 		}
 	}

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -84,15 +84,16 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * Returns 100 because 100 is the max length in the setting.
  */
 add_action(
-	'rest_api_init', 
+	'rest_api_init',
 	static function () {
-	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-		add_filter(
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			add_filter(
 			'editor_excerpt_length',
-			static function ( $value ) {
+			static function () {
 				return 100;
 			},
 			PHP_INT_MAX
-		);
+			);
+		}
 	}
-});
+);

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -83,13 +83,16 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  */
-if ( is_admin() ||
-	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-	add_filter(
-		'excerpt_length',
-		static function () {
-			return 100;
-		},
-		PHP_INT_MAX
-	);
-}
+add_action(
+	'rest_api_init', 
+	static function () {
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		add_filter(
+			'editor_excerpt_length',
+			static function ( $value ) {
+				return 100;
+			},
+			PHP_INT_MAX
+		);
+	}
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR addresses inconsistencies in excerpt length when making AJAX requests versus regular HTTP requests and REST API requests.

Fixes https://github.com/WordPress/gutenberg/issues/53570.

## Why?
In [55400](https://github.com/WordPress/gutenberg/pull/55400), @anton-vlasenko created a patch, which resolved the issue while making the AJAX call, but then it caused the same problem with the REST API call. So, this PR, it aims to make the excerpt length of both the AJAX call, and REST API call consistent, and that to the defined using the "excerpt_length" hook.

## How?
Now it uses the rest_api_init action hook to add the filter only in the REST API context. It checks if REST_REQUEST is defined and set to true, indicating that it's a REST request. If so, it adds the filter for editor_excerpt_length, limiting the excerpt length to 100.

## Testing Instructions
1. Activate a block theme, such as Twenty Twenty-Four.
2. Ensure that Gutenberg is enabled.
3. Create a new POST in the Site Editor. You can use any title. Use the following text as the post's content (just make sure to insert it into a paragraph block): 
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. In euismod diam egestas massa facilisis, in imperdiet mi consequat. Etiam interdum vel tellus laoreet posuere. Aliquam ut sagittis elit. Nullam et orci nisl. Morbi quis vehicula ex, eget luctus odio. Vivamus a tincidunt arcu, id euismod ex. Praesent fringilla velit lorem, sit amet commodo mauris vulputate sodales. Vestibulum tempus, ipsum et ultricies interdum, ligula elit accumsan risus, vel tristique dolor est eu diam. Vivamus pharetra eget erat vel rutrum. Aliquam et ligula quis lorem molestie semper. Aenean convallis tortor nec velit ultricies semper. Maecenas felis erat, cursus nec varius et, auctor eu nulla. Phasellus et nibh imperdiet, placerat erat ut, tristique libero. Nam sed scelerisque enim.
``` 
4. Publish the Post
5. I have bundled the PHP code and JS code required for testing, as a plugin. Simply activate this plugin at first: https://github.com/Rajinsharwar/test-ajax
6. This will enqueue the custom.js file on your frontend. If you open the frontend and open the browser console, you will see the output. (You can open any page in the frontend).

![image](https://github.com/WordPress/gutenberg/assets/68213636/3d8d0dfb-6884-4517-80a7-77bf9253fefa)

7. You will see the output from both the REST API and AJAX together. You will find the length difference.
8. If you open up the plugin folder, in the test-ajax.php, on line 7, modify the excerpt length if you wish. Currently, it's set to 20, and the BUG occurs. 🐞

9. Now, apply the patch, in both the `src/wp-includes/blocks/post-excerpt.php`(WordPress Core) and `build/wp-includes/blocks/post-excerpt.php`(Gutenberg). Generate a new build of the Gutenburg, so that the version gets updated.
10. Now, check the output in the console of the page again. You will see the below output. The post-excerpt length in both cases is now 20. The issue is resolved. ✅

![image](https://github.com/WordPress/gutenberg/assets/68213636/e4e6a33f-d7d2-4abb-93c1-afc898083ac3)

## Screenshots or screencast <!-- if applicable -->
Before:

![image](https://github.com/WordPress/gutenberg/assets/68213636/3d8d0dfb-6884-4517-80a7-77bf9253fefa)

After:

![image](https://github.com/WordPress/gutenberg/assets/68213636/e4e6a33f-d7d2-4abb-93c1-afc898083ac3)