### PR TITLE
Update Link Control labels to use gray-900

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -61,6 +61,10 @@ $preview-image-height: 140px;
 .block-editor-link-control__field {
 	margin: $grid-unit-20; // allow margin collapse for vertical spacing.
 
+	.components-base-control__label {
+		color: $gray-900;
+	}
+
 	input[type="text"],
 	// Specificity overide of URLInput defaults.
 	&.block-editor-url-input input[type="text"].block-editor-url-input__input {
@@ -419,6 +423,10 @@ $preview-image-height: 140px;
 
 	.components-base-control__field {
 		display: flex; // don't allow label to wrap under checkbox.
+
+		.components-checkbox-control__label {
+			color: $gray-900;
+		}
 	}
 
 	// Cancel left margin inherited from WP Admin Forms CSS.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update Link Control labels to use correct gray color ($gray-900)

Fixes #54589

PR in WordCamp Madrid 2023 Contributor Day with @Albert-Sirvelia @AlexBrea

## Why?
Labels in Link Control are not using the correct gray color ($gray-900).

## How?
Modifying the style.scss of the Link Control component and changing the color of the labels

## Testing Instructions
1. Open a post or page. 
2. Insert a link
3. Edit link and open advance settings

## Screenshots or screencast

![Link Control](https://github.com/WordPress/gutenberg/assets/47475754/91c32c12-d599-4303-a22e-18c5aea1180a)
