### PR TITLE
fix issue #49316

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -68,6 +68,7 @@ export default function PostDateEdit( {
 		displayType,
 		postId
 	);
+	date ??= new Date();
 
 	const postType = useSelect(
 		( select ) =>


### PR DESCRIPTION
Set date to current date when date is undefined

This contribution was made on the Contributors Day at Madrid's WordCamp 2023

## What?
The post date block on the site editor now displays a placeholder with current date instead of 'Post Date' literal. This is the behavior of the post editor too.

## Why?
Fix issue #49316

## How?
Set date to current date when date is undefined

## Testing Instructions
1. Open the site editor for a blog post
2. Add new 'Date' block 
3. The text shown is current date localized

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/35863705/c6411954-b4a8-4054-80fd-926bbe9877d9)
