### PR TITLE
"Detach" text change in template options

### DIFF
--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -26,7 +26,7 @@ export default function ConvertToRegularBlocks( { clientId, onClose } ) {
 				onClose();
 			} }
 		>
-			{ __( 'Detach blocks from template part' ) }
+			{ __( 'Detach' ) }
 		</MenuItem>
 	);
 }

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -211,9 +211,7 @@ test.describe( 'Template Part', () => {
 
 		// Detach the paragraph from the header template part.
 		await editor.selectBlocks( templatePartWithParagraph );
-		await editor.clickBlockOptionsMenuItem(
-			'Detach blocks from template part'
-		);
+		await editor.clickBlockOptionsMenuItem( 'Detach' );
 
 		// There should be a paragraph but no header template part.
 		await expect( paragraph ).toBeVisible();


### PR DESCRIPTION
Fixes #55601
Change in the text of the template options, previously "Detach blocks from template part" appeared, now "Detach" appears.

Made with love from WordCamp Madrid 2023 - Contributor Day

![Captura de pantalla 2023-11-05 131157](https://github.com/WordPress/gutenberg/assets/99050272/2ed53196-2679-4a18-b51c-e69572475809)
