### PR TITLE
Fix formatting issue in the "Get started with create-block" doc

### DIFF
--- a/docs/getting-started/devenv/get-started-with-create-block.md
+++ b/docs/getting-started/devenv/get-started-with-create-block.md
@@ -57,7 +57,7 @@ See the `wp-scripts` [package documentation](https://developer.wordpress.org/blo
 
 ### Interactive mode
 
-For developers who prefer a more guided experience, the `create-block package` provides an interactive mode. Instead of manually specifying all options upfront, like the `slug` in the above example, this mode will prompt you for inputs step-by-step.
+For developers who prefer a more guided experience, the `create-block` package provides an interactive mode. Instead of manually specifying all options upfront, like the `slug` in the above example, this mode will prompt you for inputs step-by-step.
 
 To use this mode, run the command:
 


### PR DESCRIPTION
Just a minor fix to formatting. "package" should not have been included in the inline code formatting. 