### PR TITLE
Edit Post: Fix pattern modal reopening when making the title empty again

### DIFF
--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -88,7 +88,7 @@ function StartPageOptionsModal( { onClose } ) {
 }
 
 export default function StartPageOptions() {
-	const [ modalState, setModalState ] = useState( 'initial' );
+	const [ isClosed, setIsClosed ] = useState( false );
 	const shouldEnableModal = useSelect( ( select ) => {
 		const { isCleanNewPost } = select( editorStore );
 		const { isEditingTemplate, isFeatureActive } = select( editPostStore );
@@ -100,11 +100,9 @@ export default function StartPageOptions() {
 		);
 	}, [] );
 
-	if ( ! shouldEnableModal || modalState === 'closed' ) {
+	if ( ! shouldEnableModal || isClosed ) {
 		return null;
 	}
 
-	return (
-		<StartPageOptionsModal onClose={ () => setModalState( 'closed' ) } />
-	);
+	return <StartPageOptionsModal onClose={ () => setIsClosed( true ) } />;
 }

--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -3,7 +3,7 @@
  */
 import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useMemo } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	__experimentalBlockPatternsList as BlockPatternsList,
@@ -62,19 +62,11 @@ function PatternSelection( { blockPatterns, onChoosePattern } ) {
 	);
 }
 
-function StartPageOptionsModal() {
-	const [ modalState, setModalState ] = useState( 'initial' );
+function StartPageOptionsModal( { onClose } ) {
 	const startPatterns = useStartPatterns();
 	const hasStartPattern = startPatterns.length > 0;
-	const shouldOpenModal = hasStartPattern && modalState === 'initial';
 
-	useEffect( () => {
-		if ( shouldOpenModal ) {
-			setModalState( 'open' );
-		}
-	}, [ shouldOpenModal ] );
-
-	if ( modalState !== 'open' ) {
+	if ( ! hasStartPattern ) {
 		return null;
 	}
 
@@ -83,12 +75,12 @@ function StartPageOptionsModal() {
 			className="edit-post-start-page-options__modal"
 			title={ __( 'Choose a pattern' ) }
 			isFullScreen
-			onRequestClose={ () => setModalState( 'closed' ) }
+			onRequestClose={ onClose }
 		>
 			<div className="edit-post-start-page-options__modal-content">
 				<PatternSelection
 					blockPatterns={ startPatterns }
-					onChoosePattern={ () => setModalState( 'closed' ) }
+					onChoosePattern={ onClose }
 				/>
 			</div>
 		</Modal>
@@ -96,6 +88,7 @@ function StartPageOptionsModal() {
 }
 
 export default function StartPageOptions() {
+	const [ modalState, setModalState ] = useState( 'initial' );
 	const shouldEnableModal = useSelect( ( select ) => {
 		const { isCleanNewPost } = select( editorStore );
 		const { isEditingTemplate, isFeatureActive } = select( editPostStore );
@@ -107,9 +100,11 @@ export default function StartPageOptions() {
 		);
 	}, [] );
 
-	if ( ! shouldEnableModal ) {
+	if ( ! shouldEnableModal || modalState === 'closed' ) {
 		return null;
 	}
 
-	return <StartPageOptionsModal />;
+	return (
+		<StartPageOptionsModal onClose={ () => setModalState( 'closed' ) } />
+	);
 }


### PR DESCRIPTION
Fixes #55847

## What?
This PR fixes an issue where after closing the pattern modal when opening a new page, if you make the post title empty again, the modal appears again.

https://github.com/WordPress/gutenberg/assets/54422211/647a16ee-d5a7-4e34-81fe-288842d98ff4

## Why?

This modal primarily consists of `StartPageOptions` and a child `StartPageOptionsModal` component. Whether this modal is opened is managed by the child `StartPageOptionsModal` component.

Whether or not child `StartPageOptionsModal` components are rendered is controlled by the `shouldOpenModal` variable. This variable contains the condition whether the post is empty or not (`isCleanNewPost`).

When you enter a post title and then empty the title, the `shouldOpenModal`  variable changes from `false` to `true`, causing the `StartPageOptionsModal` component to be rendered again.

As a result, the `StartPageOptionsModal` component's `modalState` is initialized and the modal is displayed again.

## How?
I decided to manage whether the modal is closed or not using a higher-level component, the `StartPageOptions` component. This PR is related to #53673 which improved performance, but should not impact performance.

## Testing Instructions

- Enable TT4 theme.
- Add a new page.
- A pattern selection modal should appear.
- Close the modal window without selecting a pattern.
- Enter some text in the post title area.
- Delete all that text.
  - This PR: The pattern modal should NOT appear.
  - trunk: The pattern modal should appear.