### PR TITLE
#55702 - Control dimensions (margin and padding) of the list-item block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -415,7 +415,7 @@ Create a list item. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/
 -	**Name:** core/list-item
 -	**Category:** text
 -	**Parent:** core/list
--	**Supports:** typography (fontSize, lineHeight), ~~className~~
+-	**Supports:** spacing (margin, padding), typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** content, placeholder
 
 ## Login/out

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -22,6 +22,14 @@
 	"supports": {
 		"className": false,
 		"__experimentalSelector": "li",
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/55702.

Introduces the ability to adjust the dimensions (margin and padding) of individual list-item blocks within the Gutenberg editor.

## Why?
This enhancement addresses the need identified in issue [#55702](https://github.com/WordPress/gutenberg/issues/55702). Previously, users were unable to control the spacing around list items, leading to limited styling options and potential layout inconsistencies. By allowing for margin and padding adjustments, this change provides greater flexibility and precision in design.

## How?
Support for dimension controls has been added to the block.json file of the list-item block. This includes the necessary backend changes to enable these features within the block editor's interface.

## Testing Instructions
1. Open a post or page.
2. Insert a "List" block into the content.
3. Add several items to the list to test different spacing scenarios
4. Select the list block and expand the "Dimensions" panel in the block settings sidebar.
5. Adjust the margin and padding values and observe the changes in real-time in the editor.

### Testing Instructions for Keyboard
1. Click on a list element to activate it.
2. Press Tab to cycle through the block's controls until you reach the "Dimensions" panel.
3. Use the Enter key to expand the "Dimensions" options if necessary.
4. With the dimensions panel expanded, use the arrow keys to adjust the margin and padding values.
5. Press Enter to apply the changes and Tab to continue navigating to the next control

## Screenshots or screencast
![image](https://github.com/WordPress/gutenberg/assets/73557314/5110616c-4043-4cbe-91f6-065c11d7c681)

