### PR TITLE
[Block Post Date] - Render a default real date in Site Editor, same as in Post Editor.

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -62,13 +62,13 @@ export default function PostDateEdit( {
 		'site',
 		'time_format'
 	);
-	const [ date, setDate ] = useEntityProp(
+	const [ postTypeDate, setDate ] = useEntityProp(
 		'postType',
 		postTypeSlug,
 		displayType,
 		postId
 	);
-	date ??= new Date();
+	const date = postTypeDate || new Date();
 
 	const postType = useSelect(
 		( select ) =>

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -68,6 +68,7 @@ export default function PostDateEdit( {
 		displayType,
 		postId
 	);
+	date ??= new Date();
 
 	const postType = useSelect(
 		( select ) =>


### PR DESCRIPTION
Set date to current date when date is undefined

This contribution was made on the Contributors Day at Madrid's WordCamp 2023

## What?
The post date block on the site editor now displays a placeholder with current date instead of 'Post Date' literal. This is the behavior of the post editor too.

## Why?
Fixes #49316.

## How?
Set date to current date when date is undefined

## Testing Instructions
Open the site editor for a blog post
Add new 'Date' block
The text shown is current date localized

## Screenshots or screencast
![image](https://github.com/WordPress/gutenberg/assets/35863705/5259c393-75de-4a26-8f74-a1ba216a37ac)

