### PR TITLE
[Social icons] - Fix that icons without a link are invisible

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -23,10 +23,6 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$rel         = ( isset( $attributes['rel'] ) ) ? $attributes['rel'] : '';
 	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
 
-	// Don't render a link if there is no URL set.
-	if ( ! $url ) {
-		return '';
-	}
 
 	/**
 	 * Prepend emails with `mailto:` if not set.

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -17,12 +17,11 @@
 function render_block_core_social_link( $attributes, $content, $block ) {
 	$open_in_new_tab = isset( $block->context['openInNewTab'] ) ? $block->context['openInNewTab'] : false;
 
-	$service     = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
-	$url         = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label       = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
-	$rel         = ( isset( $attributes['rel'] ) ) ? $attributes['rel'] : '';
-	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
-
+    $service     = (isset($attributes['service'])) ? $attributes['service'] : 'Icon';
+    $url         = (isset($attributes['url'])) ? $attributes['url'] : false;
+    $label       = (isset($attributes['label'])) ? $attributes['label'] : block_core_social_link_get_name($service);
+    $rel         = (isset($attributes['rel'])) ? $attributes['rel'] : '';
+    $show_labels = array_key_exists('showLabels', $block->context) ? $block->context['showLabels'] : false;
 
 	/**
 	 * Prepend emails with `mailto:` if not set.


### PR DESCRIPTION
remove the Don't render if no URL st
now render icons whitout URL

Co authors
@tiniacoleyba
@DaniValero

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #55543.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The problem is about show the social icons whitout link previously edited.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removing the lines about don't render if url is false or empty


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
