### PR TITLE
Global styles revisions: load unsaved revision item into the revisions preview

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -45,7 +45,6 @@ function ScreenRevisions() {
 	}, [] );
 	const { revisions, isLoading, hasUnsavedChanges } =
 		useGlobalStylesRevisions();
-	const [ selectedRevisionId, setSelectedRevisionId ] = useState();
 	const [ globalStylesRevision, setGlobalStylesRevision ] =
 		useState( userConfig );
 	const [
@@ -79,7 +78,6 @@ function ScreenRevisions() {
 			settings: revision?.settings || {},
 			id: revision?.id,
 		} );
-		setSelectedRevisionId( revision?.id );
 	};
 
 	useEffect( () => {
@@ -91,8 +89,10 @@ function ScreenRevisions() {
 
 	const firstRevision = revisions[ 0 ];
 	const shouldSelectFirstItem =
+		!! firstRevision?.id &&
 		! selectedRevisionMatchesEditorStyles &&
-		( ! selectedRevisionId || 'unsaved' === selectedRevisionId );
+		( ! globalStylesRevision?.id ||
+			'unsaved' === globalStylesRevision?.id );
 
 	useEffect( () => {
 		/*
@@ -133,7 +133,7 @@ function ScreenRevisions() {
 					<div className="edit-site-global-styles-screen-revisions">
 						<RevisionsButtons
 							onChange={ selectRevision }
-							selectedRevisionId={ selectedRevisionId }
+							selectedRevisionId={ globalStylesRevision?.id }
 							userRevisions={ revisions }
 						/>
 						{ isLoadButtonEnabled && (

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -96,8 +96,8 @@ function ScreenRevisions() {
 
 	useEffect( () => {
 		/*
-		 * Ensure that the first item is selected loaded into the preview pane
-		 * where no revision is selected and the selected styles don't match the current editor styles.
+		 * Ensure that the first item is selected and loaded into the preview pane
+		 * when no revision is selected and the selected styles don't match the current editor styles.
 		 * This is required in case editor styles are changed outside the revisions panel,
 		 * e.g., via the reset styles function of useGlobalStylesReset().
 		 * See: https://github.com/WordPress/gutenberg/issues/55866

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -59,33 +59,6 @@ function ScreenRevisions() {
 		globalStylesRevision,
 		userConfig
 	);
-	const shouldSelectFirstItem =
-		! selectedRevisionMatchesEditorStyles &&
-		( ! selectedRevisionId || 'unsaved' === selectedRevisionId );
-
-	useEffect( () => {
-		if ( editorCanvasContainerView !== 'global-styles-revisions' ) {
-			goTo( '/' ); // Return to global styles main panel.
-			setEditorCanvasContainerView( editorCanvasContainerView );
-			return;
-		}
-
-		/*
-			Ensure that the first item is selected where no revision is selected
-			and the selected styles don't match the current editor styles.
-			This is required in case editor styles are changed outside the revisions panel,
-			e.g., via the reset styles function of useGlobalStylesReset().
-			See: https://github.com/WordPress/gutenberg/issues/55866
-		*/
-		if ( shouldSelectFirstItem ) {
-			setGlobalStylesRevision( revisions[ 0 ] );
-		}
-	}, [
-		editorCanvasContainerView,
-		shouldSelectFirstItem,
-		revisions[ 0 ],
-		setGlobalStylesRevision,
-	] );
 
 	const onCloseRevisions = () => {
 		goTo( '/' ); // Return to global styles main panel.
@@ -108,6 +81,31 @@ function ScreenRevisions() {
 		} );
 		setSelectedRevisionId( revision?.id );
 	};
+
+	useEffect( () => {
+		if ( editorCanvasContainerView !== 'global-styles-revisions' ) {
+			goTo( '/' ); // Return to global styles main panel.
+			setEditorCanvasContainerView( editorCanvasContainerView );
+		}
+	}, [ editorCanvasContainerView ] );
+
+	const firstRevision = revisions[ 0 ];
+	const shouldSelectFirstItem =
+		! selectedRevisionMatchesEditorStyles &&
+		( ! selectedRevisionId || 'unsaved' === selectedRevisionId );
+
+	useEffect( () => {
+		/*
+		 * Ensure that the first item is selected loaded into the preview pane
+		 * where no revision is selected and the selected styles don't match the current editor styles.
+		 * This is required in case editor styles are changed outside the revisions panel,
+		 * e.g., via the reset styles function of useGlobalStylesReset().
+		 * See: https://github.com/WordPress/gutenberg/issues/55866
+		 */
+		if ( shouldSelectFirstItem ) {
+			selectRevision( firstRevision );
+		}
+	}, [ shouldSelectFirstItem, firstRevision, selectRevision ] );
 
 	// Only display load button if there is a revision to load and it is different from the current editor styles.
 	const isLoadButtonEnabled =


### PR DESCRIPTION
## What?
Resolves: https://github.com/WordPress/gutenberg/issues/55866

### Before

https://github.com/WordPress/gutenberg/assets/6458278/bd2bb4f8-3771-4cfe-8d65-f9ee0e29178e

### After

https://github.com/WordPress/gutenberg/assets/6458278/3e6a1374-6047-4359-b66b-5d8c2917b0bd


## Why?

External changes to global styles in the editor, e.g., via the reset styles function of `useGlobalStylesReset()`, will create a new "unsaved" entry in the revisions list and replace the first item in the list. 

However the styles aren't loaded in the preview.

## How?
Always load the first style object into the revisions preview:

- the user hasn't selected any revision in the list, or
- the selected item is an unsaved revision, which the first one anyway, and
- the selected styles don't match the current editor styles
- added extra doc comments for context

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

1. Navigate to Appearance -> Editor
2. Select a different style under Styles and Save (this creates a revision)
3. Open the revisions panel, check that the topmost, saved revision item is selected
4. Click on the Revisions symbol (a clock) and select Reset to defaults
5. A new unsaved changes revision item is created. Observe that the reset styles are loaded into the preview.
6. Select another revision and hit "Apply", now select the first item in the revisions list (the unsaved changes)
7. Click on the Revisions symbol (a clock) and select Reset to defaults (repeat step 4). Observe that the reset styles are loaded into the preview.
