### PR TITLE
Global Style Revisions: ensure consistent back button behavior

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -32,7 +32,7 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 );
 
 function ScreenRevisions() {
-	const { goBack } = useNavigator();
+	const { goTo } = useNavigator();
 	const { user: userConfig, setUserConfig } =
 		useContext( GlobalStylesContext );
 	const { blocks, editorCanvasContainerView } = useSelect( ( select ) => {
@@ -58,13 +58,13 @@ function ScreenRevisions() {
 
 	useEffect( () => {
 		if ( editorCanvasContainerView !== 'global-styles-revisions' ) {
-			goBack();
+			goTo( '/' ); // Return global styles main panel.
 			setEditorCanvasContainerView( editorCanvasContainerView );
 		}
 	}, [ editorCanvasContainerView ] );
 
 	const onCloseRevisions = () => {
-		goBack();
+		goTo( '/' ); // Return global styles main panel.
 	};
 
 	const restoreRevision = ( revision ) => {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -58,7 +58,7 @@ function ScreenRevisions() {
 
 	useEffect( () => {
 		if ( editorCanvasContainerView !== 'global-styles-revisions' ) {
-			goTo( '/' ); // Return global styles main panel.
+			goTo( '/' ); // Return to global styles main panel.
 			setEditorCanvasContainerView( editorCanvasContainerView );
 		}
 	}, [ editorCanvasContainerView ] );

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -64,7 +64,7 @@ function ScreenRevisions() {
 	}, [ editorCanvasContainerView ] );
 
 	const onCloseRevisions = () => {
-		goTo( '/' ); // Return global styles main panel.
+		goTo( '/' ); // Return to global styles main panel.
 	};
 
 	const restoreRevision = ( revision ) => {


### PR DESCRIPTION
## What?

Returns the user to the editor and main global styles panel after a global styles revision is applied.

### Before

https://github.com/WordPress/gutenberg/assets/6458278/691a0ee1-dcd5-45c4-9a63-f3eba0eed1dc


### After

https://github.com/WordPress/gutenberg/assets/6458278/2db5f6af-f7a8-46f3-bd95-ac3596ef452a


## Why?
After applying a revision, `goBack()` is called however the behaviour is inconsistent depending on the previous action.

When applying a revision the route should switch to the global styles panel. 


## How?
Using `goTo( '/' )`, which will return the user to the global styles main panel.

## Testing Instructions
1. Open the site editor. Make sure you have a few styles revisions in reserve, if not change your site's styles and save the template.
2. Open the style revisions panel, then select and apply a revision
3. Observe that the page navigates to the editor and the global styles revisions panel
4. Now select a site style (Browse styles from the global styles panel), and then head back to revisions
5. Apply another revision
6. Once again, observe that the page navigates to the editor and the global styles revisions panel.

