### PR TITLE
Image block: don't show pointer cursor on linked image in the editor

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -36,13 +36,6 @@
 	.components-button {
 		transition: none;
 	}
-
-	// When the Image block is linked,
-	// it's wrapped with a disabled <a /> tag.
-	// Restore cursor style so it doesn't appear 'clickable'.
-	> a {
-		cursor: default;
-	}
 }
 
 
@@ -68,6 +61,13 @@ figure.wp-block-image:not(.wp-block) {
 		top: 50%;
 		left: 50%;
 		transform: translate(-50%, -50%);
+	}
+
+	// When the Image block is linked,
+	// it's wrapped with a disabled <a /> tag.
+	// Restore cursor style so it doesn't appear 'clickable'.
+	> a {
+		cursor: default;
 	}
 }
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -36,6 +36,13 @@
 	.components-button {
 		transition: none;
 	}
+
+	// When the Image block is linked,
+	// it's wrapped with a disabled <a /> tag.
+	// Restore cursor style so it doesn't appear 'clickable'.
+	> a {
+		cursor: default;
+	}
 }
 
 


### PR DESCRIPTION
## What?

In this PR we set the cursor style to "default", so it doesn't appear 'clickable'.

### Before
https://github.com/WordPress/gutenberg/assets/6458278/3a79b1b5-b57c-427f-b041-c692ecdda5b0

### After
https://github.com/WordPress/gutenberg/assets/6458278/94630532-0393-46c1-a958-ca9ea5768bf4

## Why?

Since https://github.com/WordPress/gutenberg/pull/55470, when an Image block is linked it's wrapped with a disabled <a /> tag

This created a small regression in the editor: the cursor shows the "pointer" style.


## Testing Instructions

Add an image to a post. Add a link to that image.

Ensure the pointer cursor doesn't appear when you hover over the linked image.

This applies to the editor only, so publish the page and check in the frontend that a pointer cursor appears on the linked image.

Here is some test block code!

```html
<!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
<figure class="wp-block-image size-large"><a href="https://openverse.org/en-gb/image/47e4e857-07ef-4a97-b6ca-94126a3c4246"><img src="https://live.staticflickr.com/2774/4399421398_87191e276a_b.jpg" alt=""/></a></figure>
<!-- /wp:image -->
```

Check with a gallery as well

```html
<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
<figure class="wp-block-image size-large"><a href="https://openverse.org/en-gb/image/16d7f334-fe66-40d7-a9bb-0423bcf4f98f"><img src="https://live.staticflickr.com/4119/4823972210_5cd94b7337_b.jpg" alt=""/></a></figure>
<!-- /wp:image -->

<!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
<figure class="wp-block-image size-large"><a href="https://openverse.org/en-gb/image/47e4e857-07ef-4a97-b6ca-94126a3c4246"><img src="https://live.staticflickr.com/2774/4399421398_87191e276a_b.jpg" alt=""/></a></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->
```