### PR TITLE
Core Data: Move the template lookup to core-data selectors/resolvers

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -161,7 +161,7 @@ _Parameters_
 
 _Returns_
 
--   `string`: The current global styles.
+-   `string`: The default template id for the given query.
 
 ### getEditedEntityRecord
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -150,6 +150,19 @@ _Returns_
 
 -   `undefined< 'edit' >`: Current user object.
 
+### getDefaultTemplateId
+
+Returns the default template use to render a given query.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+-   _query_ `TemplateQuery`: Query.
+
+_Returns_
+
+-   `string`: The current global styles.
+
 ### getEditedEntityRecord
 
 Returns the specified entity record, merged with its edits.
@@ -643,6 +656,19 @@ _Parameters_
 -   _edits_ `Object`: The edits.
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.
+
+_Returns_
+
+-   `Object`: Action object.
+
+### receiveDefaultTemplateId
+
+Returns an action object used to set the template for a given query.
+
+_Parameters_
+
+-   _query_ `Object`: The lookup query.
+-   _templateId_ `string`: The resolved template id.
 
 _Returns_
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -205,6 +205,19 @@ _Returns_
 
 -   `Object`: Action object.
 
+### receiveDefaultTemplateId
+
+Returns an action object used to set the template for a given query.
+
+_Parameters_
+
+-   _query_ `Object`: The lookup query.
+-   _templateId_ `string`: The resolved template id.
+
+_Returns_
+
+-   `Object`: Action object.
+
 ### receiveEntityRecords
 
 Returns an action object used in signalling that entity records have been received.
@@ -443,6 +456,19 @@ _Parameters_
 _Returns_
 
 -   `undefined< 'edit' >`: Current user object.
+
+### getDefaultTemplateId
+
+Returns the default template use to render a given query.
+
+_Parameters_
+
+-   _state_ `State`: Data state.
+-   _query_ `TemplateQuery`: Query.
+
+_Returns_
+
+-   `string`: The current global styles.
 
 ### getEditedEntityRecord
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -468,7 +468,7 @@ _Parameters_
 
 _Returns_
 
--   `string`: The current global styles.
+-   `string`: The default template id for the given query.
 
 ### getEditedEntityRecord
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -908,3 +908,19 @@ export function receiveNavigationFallbackId( fallbackId ) {
 		fallbackId,
 	};
 }
+
+/**
+ * Returns an action object used to set the template for a given query.
+ *
+ * @param {Object} query      The lookup query.
+ * @param {string} templateId The resolved template id.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveDefaultTemplateId( query, templateId ) {
+	return {
+		type: 'RECEIVE_DEFAULT_TEMPLATE',
+		query,
+		templateId,
+	};
+}

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -572,6 +572,26 @@ export function themeGlobalStyleRevisions( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Reducer managing the template lookup per query.
+ *
+ * @param {Record<string, string>} state  Current state.
+ * @param {Object}                 action Dispatched action.
+ *
+ * @return {Record<string, string>} Updated state.
+ */
+export function defaultTemplates( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_DEFAULT_TEMPLATE':
+			return {
+				...state,
+				[ JSON.stringify( action.query ) ]: action.templateId,
+			};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	terms,
 	users,
@@ -592,4 +612,5 @@ export default combineReducers( {
 	blockPatternCategories,
 	userPatternCategories,
 	navigationFallbackId,
+	defaultTemplates,
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -707,3 +707,14 @@ export const getNavigationFallbackId =
 			] );
 		}
 	};
+
+export const getDefaultTemplateId =
+	( query ) =>
+	async ( { dispatch } ) => {
+		const template = await apiFetch( {
+			path: addQueryArgs( '/wp/v2/templates/lookup', query ),
+		} );
+		if ( template ) {
+			dispatch.receiveDefaultTemplateId( query, template.id );
+		}
+	};

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1365,7 +1365,7 @@ export function getCurrentThemeGlobalStylesRevisions(
  * @param state Data state.
  * @param query Query.
  *
- * @return The current global styles.
+ * @return The default template id for the given query.
  */
 export function getDefaultTemplateId(
 	state: State,

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -46,6 +46,7 @@ export interface State {
 	users: UserState;
 	navigationFallbackId: EntityRecordKey;
 	userPatternCategories: Array< UserPatternCategory >;
+	defaultTemplates: Record< string, string >;
 }
 
 type EntityRecordKey = string | number;
@@ -80,6 +81,12 @@ interface UserState {
 	queries: Record< string, EntityRecordKey[] >;
 	byId: Record< EntityRecordKey, ET.User< 'edit' > >;
 }
+
+type TemplateQuery = {
+	slug?: string;
+	is_custom?: boolean;
+	ignore_empty?: boolean;
+};
 
 export interface UserPatternCategory {
 	id: number;
@@ -1350,4 +1357,19 @@ export function getCurrentThemeGlobalStylesRevisions(
 	}
 
 	return state.themeGlobalStyleRevisions[ currentGlobalStylesId ];
+}
+
+/**
+ * Returns the default template use to render a given query.
+ *
+ * @param state Data state.
+ * @param query Query.
+ *
+ * @return The current global styles.
+ */
+export function getDefaultTemplateId(
+	state: State,
+	query: TemplateQuery
+): string {
+	return state.defaultTemplates[ JSON.stringify( query ) ];
 }

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -266,12 +266,22 @@ export const setPage =
 	( page ) =>
 	async ( { dispatch, registry } ) => {
 		let template;
-		const getDefaultTemplate = async ( slug ) =>
-			apiFetch( {
-				path: addQueryArgs( '/wp/v2/templates/lookup', {
+		const getDefaultTemplate = async ( slug ) => {
+			const templateId = await registry
+				.resolveSelect( coreStore )
+				.getDefaultTemplateId( {
 					slug: `page-${ slug }`,
-				} ),
-			} );
+				} );
+			return templateId
+				? await registry
+						.resolveSelect( coreStore )
+						.getEntityRecord(
+							'postType',
+							TEMPLATE_POST_TYPE,
+							templateId
+						)
+				: undefined;
+		};
 
 		if ( page.path ) {
 			template = await registry


### PR DESCRIPTION
## What?

Extracted from #55844 

This PR adds `getDefaultTemplateId` selectors to core-data to avoid the adhoc apiFetch calls. The main reason I'm doing this PR is because I want to deprecate the `setPage` action in the site editor because it does too much and replace it with a React hook like done in #55844 

## Testing Instructions

1- Test navigation between different sections of the site editor (pages, single pages...)
2- Test starter templates.
