### PR TITLE
Details: fix multiselect in Chrome

### DIFF
--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -24,10 +24,13 @@ const TEMPLATE = [
 function DetailsEdit( { attributes, setAttributes, clientId } ) {
 	const { showContent, summary } = attributes;
 	const blockProps = useBlockProps();
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		template: TEMPLATE,
-		__experimentalCaptureToolbars: true,
-	} );
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			template: TEMPLATE,
+			__experimentalCaptureToolbars: true,
+		}
+	);
 
 	// Check if either the block or the inner blocks are selected.
 	const hasSelection = useSelect(
@@ -58,10 +61,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<details
-				{ ...innerBlocksProps }
-				open={ hasSelection || showContent }
-			>
+			<details { ...blockProps } open={ hasSelection || showContent }>
 				<summary onClick={ ( event ) => event.preventDefault() }>
 					<RichText
 						aria-label={ __( 'Write summary' ) }
@@ -75,7 +75,13 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 						multiline={ false }
 					/>
 				</summary>
-				{ innerBlocksProps.children }
+				{
+					// In Chrome, the details content needs a wrapper div for
+					// multiselection to work. Chrome internally uses HTML slots
+					// so this might be an issues when making everything
+					// `contenteditable`.
+				 }
+				<div { ...innerBlocksProps } />
 			</details>
 		</>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #55671.

Unfortunately this seems to be a bug in Chrome. In Safari and Firefox it's working correctly. Here's a simple reproducible case: https://codepen.io/iseulde/pen/poGRjYK

A simple workaround is to wrap all the details content in a div.

Tbh, I'm not sure why we didn't save the content in a div from the start, it would add a lot more styling options on the front-end as well. Right now you can't pad and colour all contents for example. **Should we add the div in the save function as well?**

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
