### PR TITLE
ListViewBlock: Combine 'useSelect' hooks

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -69,17 +69,17 @@ function ListViewBlock( {
 	const blockTitle =
 		blockInformation?.name || blockInformation?.title || __( 'Untitled' );
 
-	const block = useSelect(
-		( select ) => select( blockEditorStore ).getBlock( clientId ),
-		[ clientId ]
-	);
-	const blockName = useSelect(
-		( select ) => select( blockEditorStore ).getBlockName( clientId ),
-		[ clientId ]
-	);
-	const blockEditingMode = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlockEditingMode( clientId ),
+	const { block, blockName, blockEditingMode } = useSelect(
+		( select ) => {
+			const { getBlock, getBlockName, getBlockEditingMode } =
+				select( blockEditorStore );
+
+			return {
+				block: getBlock( clientId ),
+				blockName: getBlockName( clientId ),
+				blockEditingMode: getBlockEditingMode( clientId ),
+			};
+		},
 		[ clientId ]
 	);
 


### PR DESCRIPTION
## What?
PR combines multiple `useSelect` hook calls into a single one for the `ListViewBlock` component.

## Why?
All hooks have the same dependency and are selected from the same store. There's no need to create 3 store subscriptions. The store subscription numbers can add up when working with large posts. See https://github.com/WordPress/gutenberg/pull/54819#issuecomment-1761202859.

## Testing Instructions
There's no functionality change. Smoke-test the list view and confirm CI checks are passing.
