### PR TITLE
Query Loop - Add accessibility markup at the end of the loop in all cases.

### DIFF
--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -44,7 +44,11 @@ function render_block_core_query( $attributes, $content, $block ) {
 			$block->block_type->supports['interactivity'] = true;
 
 			// Add a div to announce messages using `aria-live`.
-			$last_div_position = strripos( $content, '</div>' );
+			$html_tag = 'div';
+			if ( ! empty( $attributes['tagName'] ) ) {
+				$html_tag = esc_attr( $attributes['tagName'] );
+			}
+			$last_tag_position = strripos( $content, '</' . $html_tag . '>' );
 			$content           = substr_replace(
 				$content,
 				'<div
@@ -57,7 +61,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 					data-wp-class--start-animation="selectors.core.query.startAnimation"
 					data-wp-class--finish-animation="selectors.core.query.finishAnimation"
 				></div>',
-				$last_div_position,
+				$last_tag_position,
 				0
 			);
 		}

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -131,6 +131,44 @@ HTML;
 		$this->assertSame( 'true', $p->get_attribute( 'data-wp-navigation-disabled' ) );
 	}
 
+
+	/**
+	 * Tests that the `core/query` last tag is rendered with the tagName attribute
+	 * if is defined, having a div as default.
+	 */
+	public function test_enhanced_query_markup_rendering_at_bottom_on_custom_html_element_tags() {
+		global $wp_query, $wp_the_query;
+
+		$content = <<<HTML
+		<!-- wp:query {"queryId":0,"query":{"inherit":true},"tagName":"aside","enhancedPagination":true} -->
+		<aside class="wp-block-query">
+			<!-- wp:post-template {"align":"wide"} -->
+				<!-- wp:test/plugin-block /-->
+			<!-- /wp:post-template -->
+		</aside>
+		<!-- /wp:query -->
+HTML;
+
+		// Set main query to single post.
+		$wp_query = new WP_Query(
+			array(
+				'posts_per_page' => 1,
+			)
+		);
+
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$aside_closing_tag    = '</aside>';
+		$pos                  = strrpos( $output, $aside_closing_tag );
+		$last_closing_tag_pos = strrpos( $output, '>', -( strlen( $output ) - $pos ) );
+		$last_opening_tag_pos = strrpos( $output, '<', -( strlen( $output ) - $last_closing_tag_pos ) );
+		$previous_tag         = substr( $output, $last_opening_tag_pos, $last_closing_tag_pos - $last_opening_tag_pos + 1 );
+
+		$this->assertSame( '</div>', $previous_tag );
+	}
+
 	/**
 	 * Tests that the `core/query` block adds an extra attribute to disable the
 	 * enhanced pagination in the browser when a post content block is found inside.

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -145,8 +145,10 @@ HTML;
 			<!-- wp:post-template {"align":"wide"} -->
 				<!-- wp:test/plugin-block /-->
 			<!-- /wp:post-template -->
+			<span>Helper to get last HTML Tag</span>
 		</aside>
 		<!-- /wp:query -->
+
 HTML;
 
 		// Set main query to single post.
@@ -160,13 +162,16 @@ HTML;
 
 		$output = do_blocks( $content );
 
-		$aside_closing_tag    = '</aside>';
-		$pos                  = strrpos( $output, $aside_closing_tag );
-		$last_closing_tag_pos = strrpos( $output, '>', -( strlen( $output ) - $pos ) );
-		$last_opening_tag_pos = strrpos( $output, '<', -( strlen( $output ) - $last_closing_tag_pos ) );
-		$previous_tag         = substr( $output, $last_opening_tag_pos, $last_closing_tag_pos - $last_opening_tag_pos + 1 );
+		$p = new WP_HTML_Tag_Processor( $output );
 
-		$this->assertSame( '</div>', $previous_tag );
+		$p->next_tag( 'span' );
+
+		// Test that there is a div added just after the last tag inside the aside.
+		$this->assertSame( $p->next_tag(), true );
+		// Test that that div is the accesibility one.
+		$this->assertSame( 'screen-reader-text', $p->get_attribute( 'class' ) );
+		$this->assertSame( 'context.core.query.message', $p->get_attribute( 'data-wp-text' ) );
+		$this->assertSame( 'polite', $p->get_attribute( 'aria-live' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As the enhanced query loop is adding accessibility tags at the end of the markup. It was searching for a div tag.
The query loop can have also aside, section, a different tag than just a div. So, with this PR, the markup is added at the end of the query loop always.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1) Add a query loop with pagination, more than 3 posts, 3 posts per page in configuration. Disable force reload.
2) Set the query loop HTML element as a non default tag (section, aside, etc).
3)At the frontend, check that 
```
<div
	class="wp-block-query__enhanced-pagination-animation"
	data-wp-class--start-animation="selectors.core.query.startAnimation"
	data-wp-class--finish-animation="selectors.core.query.finishAnimation"
></div>
```

is at the end of the query loop markup.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Before:
![Screenshot 2023-11-06 at 14 02 58](https://github.com/WordPress/gutenberg/assets/37012961/52444af0-9294-42ef-b014-5ba3cc622cd0)

After:
![Screenshot 2023-11-06 at 14 02 40](https://github.com/WordPress/gutenberg/assets/37012961/5157dc26-600b-4e55-bcf7-fb424cae8b0c)
