### PR TITLE
Font Library: Fix font installation failure

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
@@ -351,7 +351,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	 *
 	 * @return bool Whether the font directory exists.
 	 */
-	public function has_upload_directory() {
+	private function has_upload_directory() {
 		$upload_dir = WP_Font_Library::get_fonts_dir();
 		return is_dir( $upload_dir );
 	}

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
@@ -345,6 +345,18 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Checks whether the font directory exists or not.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return bool Whether the font directory exists.
+	 */
+	public function has_upload_directory() {
+		$upload_dir = WP_Font_Library::get_fonts_dir();
+		return is_dir( $upload_dir );
+	}
+
+	/**
 	 * Checks whether the user has write permissions to the temp and fonts directories.
 	 *
 	 * @since 6.5.0
@@ -418,12 +430,29 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 			$response_status = 400;
 		}
 
-		if ( $this->needs_write_permission( $fonts_to_install ) && ! $this->has_write_permission() ) {
-			$errors[]        = new WP_Error(
-				'cannot_write_fonts_folder',
-				__( 'Error: WordPress does not have permission to write the fonts folder on your server.', 'gutenberg' )
-			);
-			$response_status = 500;
+		if ( $this->needs_write_permission( $fonts_to_install ) ) {
+			$upload_dir = WP_Font_Library::get_fonts_dir();
+			if ( ! $this->has_upload_directory() ) {
+				if ( ! wp_mkdir_p( $upload_dir ) ) {
+					$errors[] = new WP_Error(
+						'cannot_create_fonts_folder',
+						sprintf(
+							/* translators: %s: Directory path. */
+							__( 'Error: Unable to create directory %s.', 'gutenberg' ),
+							esc_html( $upload_dir )
+						)
+					);
+					$response_status = 500;
+				}
+			}
+
+			if ( $this->has_upload_directory() && ! $this->has_write_permission() ) {
+				$errors[]        = new WP_Error(
+					'cannot_write_fonts_folder',
+					__( 'Error: WordPress does not have permission to write the fonts folder on your server.', 'gutenberg' )
+				);
+				$response_status = 500;
+			}
 		}
 
 		if ( ! empty( $errors ) ) {


### PR DESCRIPTION
Fixes #55879

## What?
This PR fixes an issue where local fonts or Google fonts installation fails.

## Why?
When I traced the cause, I found that it was caused by #54829. The error also occurs because `has_write_permission()` is `false` at this location.

https://github.com/WordPress/gutenberg/blob/43c5e2ad1cb3b65c948d6f08e58de63e4b85a379/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php#L421

The `has_write_permission()` method checks whether the font directory (`/path-to/wp-content/fonts`) is writable.
However, if you have never installed any fonts, the `fonts` directory does not exist and is considered unwritable.

Before the change in #54829, [`wp_upload_dir()['basedir']` (`/path/to/wp-content/uploads`) was checked](https://github.com/WordPress/gutenberg/pull/54829/files?diff=unified&w=0#diff-048d4d07825b1ee72d1b1049e3199789cb4b04bd53984284a7734de6e47682fcL327) to see if it was writable, which is not the actual directory where the fonts would be written. In most cases the `uploads` directory will be writable, so the `has_write_permission()` method will return true and the font will be installed _unintentionally_.

## How?

Originally, I think we should install the font after all checks below have passed.

- Does the `fonts` directory exist?
- If the `fonts` directory does not exist, try to create it and check whether the directory was created successfully
- Is the `fonts` directory writable?

I reflected all these conditions in the logic.

## Testing Instructions

### Pattern 1

- If the `/path/to/wp-content/fonts` directory exists, please delete it.
- Try installing the font.
- The `fonts` directory will be created and the font installation should be successful.

### Pattern 2

- Delete `/path/to/wp-content/fonts` directory.
- Make the `/path-to/wp-content` directory non-writable with the following command: `chmod a-w /path/to/wp-content`
- Try installing the font.
- The installation should fail and return a 500 error (`cannot_create_fonts_folder`).

### Pattern 3

- Make the `/path/to/wp-content` directory writable again with the following command: `chmod 755 /path/to/wp-content`
- Create `path/to/wp-content/fonts` dorectory
- Make the `/path-to/wp-content/fonts` directory non-writable with the following command: `chmod a-w /path/to/wp-content/fonts`
- Try installing the font.
- The installation should fail and return a 500 error (`cannot_write_fonts_folder`).
