### PR TITLE
Fix: Filter duotone link on block-supports documentation.

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -232,7 +232,7 @@ When the block declares support for `color.background`, the attributes definitio
 
 _**Note:** Deprecated since WordPress 6.3._
 
-This property has been replaced by [`filter.duotone`](#filter-duotone).
+This property has been replaced by [`filter.duotone`](#filterduotone).
 
 ### color.gradients
 


### PR DESCRIPTION
Fixes an anchor link to the filter duotone section.

## Testing Instructions
Verify this link works and links to the duotone filter https://github.com/WordPress/gutenberg/blob/ecfe5ebe02df6162a73f28b8139079250778b088/docs/reference-guides/block-api/block-supports.md#filterduotone
While this link does not work https://github.com/WordPress/gutenberg/blob/ecfe5ebe02df6162a73f28b8139079250778b088/docs/reference-guides/block-api/block-supports.md#filter-duotone

