### PR TITLE
Fix: 404 Link on git workflow docs.

### DIFF
--- a/docs/contributors/code/git-workflow.md
+++ b/docs/contributors/code/git-workflow.md
@@ -23,7 +23,7 @@ See the [repository management document](/docs/contributors/repository-managemen
 
 ## Git Workflow Walkthrough
 
-The workflow for code and documentation is the same, since both are managed in GitHub. You can watch a [video walk-through of contributing documentation](https://wordpress.tv/2020/09/02/marcus-kazmierczak-contribute-developer-documentation-to-gutenberg/) and the accompanying [slides for contributing to Gutenberg](https://mkaz.blog/wordpress/contribute-documentation-to-gutenberg/).
+The workflow for code and documentation is the same, since both are managed in GitHub. You can watch a [video walk-through of contributing documentation](https://wordpress.tv/2020/09/02/marcus-kazmierczak-contribute-developer-documentation-to-gutenberg/) and the accompanying [tutorial for contributing to Gutenberg](https://mkaz.blog/wordpress/contribute-developer-documentation-to-gutenberg/).
 
 Here is a visual overview of the Git workflow:
 


### PR DESCRIPTION
Fixes a link that points to a 404 page.

## Testing Instructions
Verify this link works https://mkaz.blog/wordpress/contribute-developer-documentation-to-gutenberg/
While this link does not work https://mkaz.blog/wordpress/contribute-documentation-to-gutenberg/.

