### PR TITLE
test: E2E test setup script creates Android emulator

### DIFF
--- a/packages/react-native-editor/__device-tests__/README.md
+++ b/packages/react-native-editor/__device-tests__/README.md
@@ -4,28 +4,9 @@ The Mobile Gutenberg (MG) project maintains a suite of automated end-to-end (E2E
 
 ## Setup
 
-Before setting up the E2E test environment, the required iOS and Android dependencies must be installed.
-
-> **Note**
-> The required dependencies change overtime. We do our best to update the scripts documented below, but it is best to review the [Appium capabilities](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/__device-tests__/helpers/caps.js) configuration to identify the currently required `deviceName` and `platformVersion` for each of the iOS and Android platforms.
-
-### iOS
-
--   Complete the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide, which covers installing and setting up Xcode.
--   Open [Xcode settings](https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-in-settings) to install the iOS 16.2 simulator runtime.
-
-### Android
-
--   Complete the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide, which covers installing and setting up Android Studio and the Android SDK.
--   Open Android Studio and [create an emulator](https://developer.android.com/studio/run/managing-avds) for a Pixel 3 XL running Android 11.0 with the “Enable Device Frame” option disabled.
-
-### Test Environment
-
-After installing the iOS and Android dependencies, the MG project provides a script to set up the testing environment, verifying necessary dependencies are available.
-
-```shell
-npm run native test:e2e:setup
-```
+1. Complete the [React Native Getting Started](https://reactnative.dev/docs/environment-setup) guide for both iOS and Android, which covers setting up Xcode, Android Studio, the Android SDK.
+1. Open [Xcode settings](https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-in-settings) to install the iOS 16.2 simulator runtime.
+1. `npm run native test:e2e:setup`
 
 ## Running Tests
 

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -24,14 +24,14 @@ function log_error() {
 output=$($APPIUM_CMD driver list --installed --json)
 
 if echo "$output" | grep -q 'uiautomator2'; then
-	log_info "UiAutomator2 is available."
+	log_info "UiAutomator2 available."
 else
 	log_info "UiAutomator2 not found, installing..."
 	$APPIUM_CMD driver install uiautomator2
 fi
 
 if echo "$output" | grep -q 'xcuitest'; then
-	log_info "XCUITest is available."
+	log_info "XCUITest available."
 else
 	log_info "XCUITest not found, installing..."
 	$APPIUM_CMD driver install xcuitest
@@ -54,7 +54,7 @@ function detect_or_create_simulator() {
 	local simulators=$(xcrun simctl list devices -j | jq -r --arg runtime "$runtime_name" '.devices | to_entries[] | select(.key | contains($runtime)) | .value[] | .name + "," + .udid')
 
 	if ! echo "$simulators" | grep -q "$simulator_name"; then
-		log_info "$simulator_name ($runtime_name_display) not available, creating..."
+		log_info "$simulator_name ($runtime_name_display) not found, creating..."
 		xcrun simctl create "$simulator_name" "$simulator_name" "com.apple.CoreSimulator.SimRuntime.$runtime_name" > /dev/null
 		log_success "$simulator_name ($runtime_name_display) created."
 	else
@@ -87,7 +87,7 @@ function detect_or_create_emulator() {
 	local emulator=$(emulator -list-avds | grep "$emulator_id")
 
 	if [[ -z $emulator ]]; then
-		log_info "$emulator_name not available, creating..."
+		log_info "$emulator_name not found, creating..."
 		avdmanager create avd -n "$emulator_id" -k "system-images;android-$runtime_api;google_apis;arm64-v8a" -d "$device_id" > /dev/null
 		log_success "$emulator_name created."
 	else

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -90,4 +90,4 @@ detect_or_create_emulator $ANDROID_DEVICE_NAME
 
 # Mitigate conflicts between development server caches and E2E tests
 npm run clean:runtime > /dev/null
-log_info 'Runtime cache cleaned.'
+log_info 'Runtime cache cleared.'

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -24,14 +24,14 @@ function log_error() {
 output=$($APPIUM_CMD driver list --installed --json)
 
 if echo "$output" | grep -q 'uiautomator2'; then
-	log_info "UiAutomator2 is installed, skipping installation."
+	log_info "UiAutomator2 is available."
 else
 	log_info "UiAutomator2 not found, installing..."
 	$APPIUM_CMD driver install uiautomator2
 fi
 
 if echo "$output" | grep -q 'xcuitest'; then
-	log_info "XCUITest is installed, skipping installation."
+	log_info "XCUITest is available."
 else
 	log_info "XCUITest not found, installing..."
 	$APPIUM_CMD driver install xcuitest

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -69,6 +69,25 @@ IOS_DEVICE_TABLET_NAME=$(jq -r '.ios.local.deviceTabletName' "$CONFIG_FILE")
 detect_or_create_simulator "$IOS_DEVICE_NAME"
 detect_or_create_simulator "$IOS_DEVICE_TABLET_NAME"
 
+function detect_or_create_emulator() {
+	local emulator_name=$1
+	local emulator_id=$(echo "$emulator_name" | sed 's/ /_/g; s/\./_/g')
+	local emulator=$(emulator -list-avds | grep "$emulator_id")
+
+	if [[ -z $emulator ]]; then
+		log_info "$emulator_name not available, creating..."
+		avdmanager create avd -n "$emulator_id" -k "system-images;android-30;google_apis;arm64-v8a" -d "pixel_3_xl" > /dev/null
+		log_success "$emulator_name created."
+	else
+		log_info "$emulator_name available."
+	fi
+}
+
+ANDROID_DEVICE_NAME=$(jq -r '.android.local.deviceName' "$CONFIG_FILE")
+
+# Create the required Android emulators, if they don't exist
+detect_or_create_emulator $ANDROID_DEVICE_NAME
+
 # Mitigate conflicts between development server caches and E2E tests
 npm run clean:runtime > /dev/null
 log_info 'Runtime cache cleaned.'

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -75,6 +75,11 @@ function detect_or_create_emulator() {
 		return
 	fi
 
+	if [[ -z $(command -v avdmanager) ]]; then
+		log_error "avdmanager not found! Please install the Android SDK command-line tools.\n    https://developer.android.com/tools/"
+		exit 1;
+	fi
+
 	local emulator_name=$1
 	local emulator_id=$(echo "$emulator_name" | sed 's/ /_/g; s/\./_/g')
 	local emulator=$(emulator -list-avds | grep "$emulator_id")

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -82,11 +82,13 @@ function detect_or_create_emulator() {
 
 	local emulator_name=$1
 	local emulator_id=$(echo "$emulator_name" | sed 's/ /_/g; s/\./_/g')
+	local device_id=$(echo "$emulator_id" | awk -F '_' '{print tolower($1)"_"tolower($2)"_"tolower($3)}')
+	local runtime_api=$(echo "$emulator_id" | awk -F '_' '{print $NF}')
 	local emulator=$(emulator -list-avds | grep "$emulator_id")
 
 	if [[ -z $emulator ]]; then
 		log_info "$emulator_name not available, creating..."
-		avdmanager create avd -n "$emulator_id" -k "system-images;android-30;google_apis;arm64-v8a" -d "pixel_3_xl" > /dev/null
+		avdmanager create avd -n "$emulator_id" -k "system-images;android-$runtime_api;google_apis;arm64-v8a" -d "$device_id" > /dev/null
 		log_success "$emulator_name created."
 	else
 		log_info "$emulator_name available."

--- a/packages/react-native-editor/bin/test-e2e-setup.sh
+++ b/packages/react-native-editor/bin/test-e2e-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -e
 
 set -o pipefail
 
@@ -70,6 +70,11 @@ detect_or_create_simulator "$IOS_DEVICE_NAME"
 detect_or_create_simulator "$IOS_DEVICE_TABLET_NAME"
 
 function detect_or_create_emulator() {
+	if [[ "${CI}" ]]; then
+		log_info "Detected CI server, skipping Android emulator creation."
+		return
+	fi
+
 	local emulator_name=$1
 	local emulator_id=$(echo "$emulator_name" | sed 's/ /_/g; s/\./_/g')
 	local emulator=$(emulator -list-avds | grep "$emulator_id")


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Expand the E2E test setup script to ensure the required iOS simulators are
available.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to https://github.com/WordPress/gutenberg/issues/55251. Simplify setting
up the E2E test environment by automating the process for creating the required
Android emulators.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Update the E2E test setup script to leverage `avdmanager` to create the required
Android emulators. Remove now unneeded documentation of manual steps.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
**With required emulator unavailable**
1. Delete the Pixel 3 XL via `avdmanager delete avd -n <device-id>`.
2. Run `npm run native test:e2e:setup`
3. Verify the correct Android emulators are created. 

**With required emulator available**
1. Verify the Pixel 3XL emulator is available via `emulator -list-avds`. 
2. Run `npm run native test:e2e:setup`
3. Verify duplicative emulators are not created. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->
n/a
