### PR TITLE
Edit Post: Use a single 'useSelect' hook for getting selectors

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -18,7 +18,6 @@ import { createBlock } from '@wordpress/blocks';
 import { store as editPostStore } from '../../store';
 
 function KeyboardShortcuts() {
-	const { getBlockSelectionStart } = useSelect( blockEditorStore );
 	const { getEditorMode, isEditorSidebarOpened, isListViewOpened } =
 		useSelect( editPostStore );
 	const isModeToggleDisabled = useSelect( ( select ) => {
@@ -38,8 +37,12 @@ function KeyboardShortcuts() {
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
 
 	const { replaceBlocks } = useDispatch( blockEditorStore );
-	const { getBlockName, getSelectedBlockClientId, getBlockAttributes } =
-		useSelect( blockEditorStore );
+	const {
+		getBlockName,
+		getSelectedBlockClientId,
+		getBlockAttributes,
+		getBlockSelectionStart,
+	} = useSelect( blockEditorStore );
 
 	const handleTextLevelShortcut = ( event, level ) => {
 		event.preventDefault();


### PR DESCRIPTION
## What?
PR combines two `useSelect` hooks for getting `block-editor` store selectors into one.

## Why?
Just a minor code quality improvement.

## Testing Instructions
No changes to the behavior. Confirm CI checks are green.
