### PR TITLE
Move document tools motion to header-edit-mode layout level

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
@@ -12,11 +12,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { _x, __ } from '@wordpress/i18n';
 import { listView, plus, chevronUpDown } from '@wordpress/icons';
-import {
-	__unstableMotion as motion,
-	Button,
-	ToolbarItem,
-} from '@wordpress/components';
+import { Button, ToolbarItem } from '@wordpress/components';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as preferencesStore } from '@wordpress/preferences';
 
@@ -39,8 +35,6 @@ export default function DocumentTools( {
 	isDistractionFree,
 	showIconLabels,
 	setListViewToggleElement,
-	toolbarTransition,
-	toolbarVariants,
 } ) {
 	const inserterButton = useRef();
 	const {
@@ -125,103 +119,92 @@ export default function DocumentTools( {
 	const isZoomedOutView = blockEditorMode === 'zoom-out';
 
 	return (
-		<motion.div
-			variants={ toolbarVariants }
-			transition={ toolbarTransition }
+		<NavigableToolbar
+			className="edit-site-header-edit-mode__start"
+			aria-label={ __( 'Document tools' ) }
+			shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
 		>
-			<NavigableToolbar
-				className="edit-site-header-edit-mode__start"
-				aria-label={ __( 'Document tools' ) }
-				shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
-			>
-				<div className="edit-site-header-edit-mode__toolbar">
-					{ ! isDistractionFree && (
+			<div className="edit-site-header-edit-mode__toolbar">
+				{ ! isDistractionFree && (
+					<ToolbarItem
+						ref={ inserterButton }
+						as={ Button }
+						className="edit-site-header-edit-mode__inserter-toggle"
+						variant="primary"
+						isPressed={ isInserterOpen }
+						onMouseDown={ preventDefault }
+						onClick={ toggleInserter }
+						disabled={ ! isVisualMode }
+						icon={ plus }
+						label={ showIconLabels ? shortLabel : longLabel }
+						showTooltip={ ! showIconLabels }
+						aria-expanded={ isInserterOpen }
+					/>
+				) }
+				{ isLargeViewport && (
+					<>
+						{ ! hasFixedToolbar && (
+							<ToolbarItem
+								as={ ToolSelector }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+								disabled={ ! isVisualMode }
+							/>
+						) }
 						<ToolbarItem
-							ref={ inserterButton }
-							as={ Button }
-							className="edit-site-header-edit-mode__inserter-toggle"
-							variant="primary"
-							isPressed={ isInserterOpen }
-							onMouseDown={ preventDefault }
-							onClick={ toggleInserter }
-							disabled={ ! isVisualMode }
-							icon={ plus }
-							label={ showIconLabels ? shortLabel : longLabel }
+							as={ UndoButton }
 							showTooltip={ ! showIconLabels }
-							aria-expanded={ isInserterOpen }
+							variant={ showIconLabels ? 'tertiary' : undefined }
 						/>
-					) }
-					{ isLargeViewport && (
-						<>
-							{ ! hasFixedToolbar && (
-								<ToolbarItem
-									as={ ToolSelector }
-									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
-									}
-									disabled={ ! isVisualMode }
-								/>
-							) }
+						<ToolbarItem
+							as={ RedoButton }
+							showTooltip={ ! showIconLabels }
+							variant={ showIconLabels ? 'tertiary' : undefined }
+						/>
+						{ ! isDistractionFree && (
 							<ToolbarItem
-								as={ UndoButton }
+								as={ Button }
+								className="edit-site-header-edit-mode__list-view-toggle"
+								disabled={ ! isVisualMode || isZoomedOutView }
+								icon={ listView }
+								isPressed={ isListViewOpen }
+								/* translators: button label text should, if possible, be under 16 characters. */
+								label={ __( 'List View' ) }
+								onClick={ toggleListView }
+								ref={ setListViewToggleElement }
+								shortcut={ listViewShortcut }
 								showTooltip={ ! showIconLabels }
 								variant={
 									showIconLabels ? 'tertiary' : undefined
 								}
+								aria-expanded={ isListViewOpen }
 							/>
-							<ToolbarItem
-								as={ RedoButton }
-								showTooltip={ ! showIconLabels }
-								variant={
-									showIconLabels ? 'tertiary' : undefined
-								}
-							/>
-							{ ! isDistractionFree && (
+						) }
+						{ isZoomedOutViewExperimentEnabled &&
+							! isDistractionFree &&
+							! hasFixedToolbar && (
 								<ToolbarItem
 									as={ Button }
-									className="edit-site-header-edit-mode__list-view-toggle"
-									disabled={
-										! isVisualMode || isZoomedOutView
-									}
-									icon={ listView }
-									isPressed={ isListViewOpen }
+									className="edit-site-header-edit-mode__zoom-out-view-toggle"
+									icon={ chevronUpDown }
+									isPressed={ isZoomedOutView }
 									/* translators: button label text should, if possible, be under 16 characters. */
-									label={ __( 'List View' ) }
-									onClick={ toggleListView }
-									ref={ setListViewToggleElement }
-									shortcut={ listViewShortcut }
-									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
-									}
-									aria-expanded={ isListViewOpen }
+									label={ __( 'Zoom-out View' ) }
+									onClick={ () => {
+										setPreviewDeviceType( 'Desktop' );
+										__unstableSetEditorMode(
+											isZoomedOutView
+												? 'edit'
+												: 'zoom-out'
+										);
+									} }
 								/>
 							) }
-							{ isZoomedOutViewExperimentEnabled &&
-								! isDistractionFree &&
-								! hasFixedToolbar && (
-									<ToolbarItem
-										as={ Button }
-										className="edit-site-header-edit-mode__zoom-out-view-toggle"
-										icon={ chevronUpDown }
-										isPressed={ isZoomedOutView }
-										/* translators: button label text should, if possible, be under 16 characters. */
-										label={ __( 'Zoom-out View' ) }
-										onClick={ () => {
-											setPreviewDeviceType( 'Desktop' );
-											__unstableSetEditorMode(
-												isZoomedOutView
-													? 'edit'
-													: 'zoom-out'
-											);
-										} }
-									/>
-								) }
-						</>
-					) }
-				</div>
-			</NavigableToolbar>
-		</motion.div>
+					</>
+				) }
+			</div>
+		</NavigableToolbar>
 	);
 }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -110,14 +110,17 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 			} ) }
 		>
 			{ hasDefaultEditorCanvasView && (
-				<DocumentTools
-					blockEditorMode={ blockEditorMode }
-					isDistractionFree={ isDistractionFree }
-					showIconLabels={ showIconLabels }
-					setListViewToggleElement={ setListViewToggleElement }
-					toolbarTransition={ toolbarTransition }
-					toolbarVariants={ toolbarVariants }
-				/>
+				<motion.div
+					variants={ toolbarVariants }
+					transition={ toolbarTransition }
+				>
+					<DocumentTools
+						blockEditorMode={ blockEditorMode }
+						isDistractionFree={ isDistractionFree }
+						showIconLabels={ showIconLabels }
+						setListViewToggleElement={ setListViewToggleElement }
+					/>
+				</motion.div>
 			) }
 
 			{ ! isDistractionFree && (


### PR DESCRIPTION
Fixed in https://github.com/WordPress/gutenberg/pull/55678 by @t-hamano. Thanks for the research and fix!
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Moving the motion div up to the layout level for the edit site header keeps the navigation document tools and the animation of it separated. Now all the animations are in the edit-site-header rather than being passed into the document tools navigation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fewer props passed. Animation of header logic stays in one file, so it's easier to reason about. The navigation has no need to know about how it's animated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Move the animation div up a level.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Open the site editor.
Click on the editor pane.
Check there are no console errors.
Header animation should match `trunk`