### PR TITLE
DataViews: make items per page an even number

### DIFF
--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -86,7 +86,7 @@ function ViewTypeMenu( { view, onChangeView } ) {
 	);
 }
 
-const PAGE_SIZE_VALUES = [ 6, 20, 50 ];
+const PAGE_SIZE_VALUES = [ 20, 50, 100 ];
 function PageSizeMenu( { view, onChangeView } ) {
 	return (
 		<DropdownSubMenuV2

--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -86,7 +86,7 @@ function ViewTypeMenu( { view, onChangeView } ) {
 	);
 }
 
-const PAGE_SIZE_VALUES = [ 5, 20, 50 ];
+const PAGE_SIZE_VALUES = [ 6, 20, 50 ];
 function PageSizeMenu( { view, onChangeView } ) {
 	return (
 		<DropdownSubMenuV2

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -9,7 +9,7 @@ const DEFAULT_PAGE_BASE = {
 	search: '',
 	filters: [],
 	page: 1,
-	perPage: 6,
+	perPage: 20,
 	sort: {
 		field: 'date',
 		direction: 'desc',

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -9,7 +9,7 @@ const DEFAULT_PAGE_BASE = {
 	search: '',
 	filters: [],
 	page: 1,
-	perPage: 5,
+	perPage: 6,
 	sort: {
 		field: 'date',
 		direction: 'desc',


### PR DESCRIPTION
## What?

Having 5 items as the minimum items per page doesn't work well with the grid view.

In a scenario with more than 5 items we end up with the following (note how the 6th space in the grid is empty, inducing to believe there is no more records, yet the pagination says otherwise):

<img width="1197" alt="Captura de ecrã 2023-11-06, às 17 44 39" src="https://github.com/WordPress/gutenberg/assets/583546/99f781c3-1b72-48f7-9d7b-e01b6b91418e">

## Why?

To bring clarity to the grid view.

## How?

By setting the minimum to 20, see conversation https://github.com/WordPress/gutenberg/pull/55906#issuecomment-1796808442

~By setting the minimum to 6. I've also tested with 10 as minimum, but that forces scrolling, which has its own issues https://github.com/WordPress/gutenberg/issues/55905 I'm not really opinionated on the specific number, though.~

