### PR TITLE
Patterns: use existing download function for JSON downloads to fix non-ASCII encoding

### DIFF
--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import downloadjs from 'downloadjs';
 import { paramCase as kebabCase } from 'change-case';
 
 /**
@@ -51,6 +50,32 @@ import {
 import { store as editSiteStore } from '../../store';
 import { useLink } from '../routes/link';
 import { unlock } from '../../lock-unlock';
+
+/**
+ * Downloads a file.
+ *
+ * @param {string} fileName    File Name.
+ * @param {string} content     File Content.
+ * @param {string} contentType File mime type.
+ */
+function download( fileName, content, contentType ) {
+	const file = new window.Blob( [ content ], { type: contentType } );
+
+	// IE11 can't use the click to download technique
+	// we use a specific IE11 technique instead.
+	if ( window.navigator.msSaveOrOpenBlob ) {
+		window.navigator.msSaveOrOpenBlob( file, fileName );
+	} else {
+		const a = document.createElement( 'a' );
+		a.href = URL.createObjectURL( file );
+		a.download = fileName;
+
+		a.style.display = 'none';
+		document.body.appendChild( a );
+		a.click();
+		document.body.removeChild( a );
+	}
+}
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
@@ -118,9 +143,9 @@ function GridItem( { categoryId, item, ...props } ) {
 			syncStatus: item.patternBlock.wp_pattern_sync_status,
 		};
 
-		return downloadjs(
-			JSON.stringify( json, null, 2 ),
+		return download(
 			`${ kebabCase( item.title || item.name ) }.json`,
+			JSON.stringify( json, null, 2 ),
 			'application/json'
 		);
 	};

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -53,6 +53,7 @@ import { unlock } from '../../lock-unlock';
 
 /**
  * Downloads a file.
+ * Also used in packages/list-reusable-blocks/src/utils/file.js.
  *
  * @param {string} fileName    File Name.
  * @param {string} content     File Content.

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -61,21 +61,13 @@ import { unlock } from '../../lock-unlock';
  */
 function download( fileName, content, contentType ) {
 	const file = new window.Blob( [ content ], { type: contentType } );
-
-	// IE11 can't use the click to download technique
-	// we use a specific IE11 technique instead.
-	if ( window.navigator.msSaveOrOpenBlob ) {
-		window.navigator.msSaveOrOpenBlob( file, fileName );
-	} else {
-		const a = document.createElement( 'a' );
-		a.href = URL.createObjectURL( file );
-		a.download = fileName;
-
-		a.style.display = 'none';
-		document.body.appendChild( a );
-		a.click();
-		document.body.removeChild( a );
-	}
+	const a = document.createElement( 'a' );
+	a.href = URL.createObjectURL( file );
+	a.download = fileName;
+	a.style.display = 'none';
+	document.body.appendChild( a );
+	a.click();
+	document.body.removeChild( a );
 }
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );


### PR DESCRIPTION
## What?
Maybe resolves https://github.com/WordPress/gutenberg/issues/55746

Patterns that contain non-ASCII characters are corrupted on download.

## Why?
The downloadjs module patterns is using seems to have a non-resolved bug where it [cannot properly encode non-ASCII characters](https://github.com/rndme/download/issues/56).

## How?
Use the same, [internal function](https://github.com/WordPress/gutenberg/blob/f4389b9851256d1f02b513d8379ee544e446af98/packages/list-reusable-blocks/src/utils/file.js#L8-L8) as the reusable blocks. 

We're downloading only JSON so we don't need any special functionality I gather?

## Testing Instructions
Create a new pattern with the following content: 

```html
<!-- wp:paragraph -->
<p>This is a pattern containing non-ASCII characters 文字出版社 ~=[]()%+{}@;’#!$_&amp;- éè ;∞¥₤€ ワードプレス We hopè you find it inform@tiv€ Thank You!</p>
<!-- /wp:paragraph -->
```

Save the pattern.

Export the pattern.

Re-import the pattern.

Import should work!

### Before
```json
{
  "__file": "wp_block",
  "title": "Non ASCII",
  "content": "<!-- wp:paragraph -->\n<p>This is a pattern containing non-ASCII characters �W�H> ~=[]()%+{}@;#!$_&amp;- �� ;��� ����� We hop� you find it inform@tiv� Thank You!</p>\n<!-- /wp:paragraph -->",
  "syncStatus": ""
}
```

### After

```json
{
  "__file": "wp_block",
  "title": "Non ASCII",
  "content": "<!-- wp:paragraph -->\n<p>This is a pattern containing non-ASCII characters 文字出版社 ~=[]()%+{}@;’#!$_&amp;- éè ;∞¥₤€ ワードプレス We hopè you find it inform@tiv€ Thank You!</p>\n<!-- /wp:paragraph -->",
  "syncStatus": ""
}
```
