### PR TITLE
Data: Fix ESLint warnings for the 'useSelect' hook

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -197,6 +197,9 @@ function useMappingSelect( suspense, mapSelect, deps ) {
 		() => Store( registry, suspense ),
 		[ registry, suspense ]
 	);
+
+	// These are "pass-through" dependencies from the parent hook,
+	// and the parent should catch any hook rule violations.
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const selector = useCallback( mapSelect, deps );
 	const { subscribe, getValue } = store( selector, isAsync );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -193,7 +193,11 @@ function useStaticSelect( storeName ) {
 function useMappingSelect( suspense, mapSelect, deps ) {
 	const registry = useRegistry();
 	const isAsync = useAsyncMode();
-	const store = useMemo( () => Store( registry, suspense ), [ registry ] );
+	const store = useMemo(
+		() => Store( registry, suspense ),
+		[ registry, suspense ]
+	);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const selector = useCallback( mapSelect, deps );
 	const { subscribe, getValue } = store( selector, isAsync );
 	const result = useSyncExternalStore( subscribe, getValue, getValue );


### PR DESCRIPTION
## What?
PR fixes `react-hooks/exhaustive-deps` warnings for the `useSelect` hook.

## Why?
I had to patch the hooks a few times last week for debugging and noticed the ESLint warnings that can be easily fixed.

## How?
* The `suspense` is a boolean that won't change during the runtime. It's safe to pass it to the dependency array.
* Disable warning for `selector` callback warnings, as arguments come from the main hook and will adhere to the same rules.

## Testing Instructions
CI checks should be green.
