### PR TITLE
DataViews: simplify filters API

### DIFF
--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -59,21 +59,38 @@ Example:
 - `sort.field`: field used for sorting the dataset.
 - `sort.direction`: the direction to use for sorting, one of `asc` or `desc`.
 - `search`: the text search applied to the dataset.
-- `filters`: the filters applied to the dataset. See filters section.
+- `filters`: the filters applied to the dataset. Each item describes:
+	- `field`: which field this filter is bound to.
+	- `operator`: which type of filter it is. Only `in` available at the moment.
+	- `vaule`: the actual value selected by the user.
 - `visibleFilters`: the `id` of the filters that are visible in the UI.
 - `hiddenFields`: the `id` of the fields that are hidden in the UI.
 - `layout`: ...
 
-Note that it's the consumer's responsibility to provide the data and make sure the dataset corresponds to the view's config (sort, pagination, filters, etc.).
+### View <=> data
 
-Example:
+The view is a representation of the visible state of the dataset. Note, however, that it's the consumer's responsibility to work with the data provider to make sure the user options defined through the view's config (sort, pagination, filters, etc.) are respected.
+
+The following example shows how a view object is used to query the WordPress REST API via the entities abstraction. The same can be done with any other data provider.
 
 ```js
 function MyCustomPageList() { 
 	const [ view, setView ] = useState( {
 		type: 'list',
+		perPage: 5,
 		page: 1,
-		"...": "..."
+		sort: {
+			field: 'date',
+			direction: 'desc',
+		},
+		search: '',
+		filters: [
+			{ field: 'author', operator: 'in', value: 2 },
+			{ field: 'status', operator: 'in', value: 'publish,draft' }
+		],
+		visibleFilters: [ 'author', 'status' ],
+		hiddenFields: [ 'date', 'featured-image' ],
+		layout: {},
 	} );
 
 	const queryArgs = useMemo( () => {
@@ -143,7 +160,7 @@ Example:
 			{ value: 1, label: 'Admin' }
 			{ value: 2, label: 'User' }
 		]
-		filters: [ 'enumeration' ],
+		filters: [ 'in' ],
 	}
 ]
 ```
@@ -153,45 +170,4 @@ Example:
 - `getValue`: function that returns the value of the field.
 - `render`: function that renders the field.
 - `elements`: the set of valid values for the field's value.
-- `filters`: what filters are available for the user to use. See filters section.
-
-## Filters
-
-Filters describe the conditions a record should match to be listed as part of the dataset. Filters are provided per field.
-
-```js
-const field = [
-	{
-		id: 'author',
-		filters: [ 'enumeration' ],
-	}
-];
-
-<DataViews
-	fields={ fields }
-/>
-```
-
-A filter is an object that may contain the following properties:
-
-- `type`: the type of filter. Only `enumeration` is supported at the moment.
-- `elements`: for filters of type `enumeration`, the list of options to show. A one-dimensional array of object with value/label keys, as in `[ { value: 1, label: "Value name" } ]`.
-	- `value`: what's serialized into the view's filters.
-	- `label`: nice-looking name for users.
-
-As a convenience, field's filter can provide abbreviated versions for the filter. All of following examples result in the same filter:
-
-```js
-const field = [
-	{
-		id: 'author',
-		header: __( 'Author' ),
-		elements: authors,
-		filters: [
-			'enumeration',
-			{ type: 'enumeration' },
-			{ type: 'enumeration', elements: authors },
-		],
-	}
-];
-```
+- `filters`: what filter operators are available for the user to use over this field. Only `in` available at the moment.

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -6,67 +6,55 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import InFilter from './in-filter';
+import { default as InFilter, OPERATOR_IN } from './in-filter';
+const VALID_OPERATORS = [ OPERATOR_IN ];
 
 export default function Filters( { fields, view, onChangeView } ) {
-	const filterIndex = {};
+	const filtersRegistered = [];
 	fields.forEach( ( field ) => {
 		if ( ! field.filters ) {
 			return;
 		}
 
 		field.filters.forEach( ( filter ) => {
-			const id = field.id;
-			if ( 'string' === typeof filter ) {
-				filterIndex[ id ] = {
-					id,
+			if ( VALID_OPERATORS.some( ( operator ) => operator === filter ) ) {
+				filtersRegistered.push( {
+					field: field.id,
 					name: field.header,
-					type: filter,
-				};
-			}
-
-			if ( 'object' === typeof filter ) {
-				filterIndex[ id ] = {
-					id,
-					name: field.header,
-					type: filter.type,
-				};
-			}
-
-			if ( 'enumeration' === filterIndex[ id ]?.type ) {
-				const elements = [
-					{
-						value: '',
-						label: __( 'All' ),
-					},
-					...( field.elements || [] ),
-				];
-				filterIndex[ id ] = {
-					...filterIndex[ id ],
-					elements,
-				};
+					operator: filter,
+					elements: [
+						{
+							value: '',
+							label: __( 'All' ),
+						},
+						...( field.elements || [] ),
+					],
+				} );
 			}
 		} );
 	} );
 
-	return view.visibleFilters?.map( ( filterName ) => {
-		const filter = filterIndex[ filterName ];
+	return view.visibleFilters?.map( ( fieldName ) => {
+		const visibleFiltersForField = filtersRegistered.filter(
+			( f ) => f.field === fieldName
+		);
 
-		if ( ! filter ) {
+		if ( visibleFiltersForField.length === 0 ) {
 			return null;
 		}
 
-		if ( filter.type === 'enumeration' ) {
-			return (
-				<InFilter
-					key={ filterName }
-					filter={ filter }
-					view={ view }
-					onChangeView={ onChangeView }
-				/>
-			);
-		}
-
-		return null;
+		return visibleFiltersForField.map( ( filter ) => {
+			if ( OPERATOR_IN === filter.operator ) {
+				return (
+					<InFilter
+						key={ fieldName }
+						filter={ visibleFiltersForField[ 0 ] }
+						view={ view }
+						onChangeView={ onChangeView }
+					/>
+				);
+			}
+			return null;
+		} );
 	} );
 }

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -6,11 +6,11 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 
-const OPERATOR_IN = 'in';
+export const OPERATOR_IN = 'in';
 
 export default ( { filter, view, onChangeView } ) => {
 	const valueFound = view.filters.find(
-		( f ) => f.field === filter.id && f.operator === OPERATOR_IN
+		( f ) => f.field === filter.field && f.operator === OPERATOR_IN
 	);
 
 	const activeValue =
@@ -32,11 +32,12 @@ export default ( { filter, view, onChangeView } ) => {
 			options={ filter.elements }
 			onChange={ ( value ) => {
 				const filters = view.filters.filter(
-					( f ) => f.field !== filter.id || f.operator !== OPERATOR_IN
+					( f ) =>
+						f.field !== filter.field || f.operator !== OPERATOR_IN
 				);
 				if ( value !== '' ) {
 					filters.push( {
-						field: filter.id,
+						field: filter.field,
 						operator: OPERATOR_IN,
 						value,
 					} );

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -72,13 +72,11 @@ function HeaderMenu( { dataView, header } ) {
 	if (
 		header.column.columnDef.filters?.length > 0 &&
 		header.column.columnDef.filters.some(
-			( f ) =>
-				( 'string' === typeof f && f === 'enumeration' ) ||
-				( 'object' === typeof f && f.type === 'enumeration' )
+			( f ) => 'string' === typeof f && f === 'in'
 		)
 	) {
 		filter = {
-			id: header.column.columnDef.id,
+			field: header.column.columnDef.id,
 			elements: [
 				{
 					value: '',
@@ -149,7 +147,7 @@ function HeaderMenu( { dataView, header } ) {
 				{ isFilterable && (
 					<DropdownMenuGroupV2>
 						<DropdownSubMenuV2
-							key={ filter.id }
+							key={ filter.field }
 							trigger={
 								<DropdownSubMenuTriggerV2
 									prefix={ <Icon icon={ funnel } /> }
@@ -169,7 +167,7 @@ function HeaderMenu( { dataView, header } ) {
 									( f ) =>
 										Object.keys( f )[ 0 ].split(
 											':'
-										)[ 0 ] === filter.id
+										)[ 0 ] === filter.field
 								);
 
 								// Set the empty item as active if the filter is not set.
@@ -204,7 +202,7 @@ function HeaderMenu( { dataView, header } ) {
 															)[ 0 ].split( ':' );
 														return (
 															field !==
-																filter.id ||
+																filter.field ||
 															operator !== 'in'
 														);
 													}
@@ -218,8 +216,8 @@ function HeaderMenu( { dataView, header } ) {
 												dataView.setColumnFilters( [
 													...otherFilters,
 													{
-														[ filter.id + ':in' ]:
-															element.value,
+														[ filter.field +
+														':in' ]: element.value,
 													},
 												] );
 											}

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -231,7 +231,7 @@ export default function PagePages() {
 						</a>
 					);
 				},
-				filters: [ 'enumeration' ],
+				filters: [ 'in' ],
 				elements:
 					authors?.map( ( { id, name } ) => ( {
 						value: id,
@@ -244,7 +244,7 @@ export default function PagePages() {
 				getValue: ( { item } ) =>
 					statuses?.find( ( { slug } ) => slug === item.status )
 						?.name ?? item.status,
-				filters: [ 'enumeration' ],
+				filters: [ 'in' ],
 				elements:
 					statuses?.map( ( { slug, name } ) => ( {
 						value: slug,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Update filters API to:

- only take a string in the field registration (objects no longer necessary)
- use the same shape internally as the one used by the view https://github.com/WordPress/gutenberg/pull/55735
  - use `field` instead of `id` as key to identify the filter
  - use `operator` instead of `type` as key
  - use `in` instead of `enumeration` for the operator
- update docs

## Testing Instructions

- Enable the wp-admin experiment and visit "Appearance > Editor > Manage all pages".
- Verify the filters still work as expected.
