### PR TITLE
DataViews: Make used taxonomy private

### DIFF
--- a/lib/experimental/data-views.php
+++ b/lib/experimental/data-views.php
@@ -40,7 +40,7 @@ function _gutenberg_register_data_views_post_type() {
 		'wp_dataviews_type',
 		array( 'wp_dataviews' ),
 		array(
-			'public'            => true,
+			'public'            => false,
 			'hierarchical'      => false,
 			'labels'            => array(
 				'name'          => __( 'Dataview types', 'gutenberg' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes the used taxonomy for views private. Right now is public and there is no need for that. As a side effect is is suggested to create a template for this taxonomy in `site editor`.
