### PR TITLE
Playwright Utils: Fix 'clickBlockOptionsMenuItem' helper

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/click-block-options-menu-item.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/click-block-options-menu-item.ts
@@ -12,8 +12,7 @@ import type { Editor } from './index';
 export async function clickBlockOptionsMenuItem( this: Editor, label: string ) {
 	await this.clickBlockToolbarButton( 'Options' );
 	await this.page
-		.locator(
-			`role=menu[name="Options"i] >> role=menuitem[name="${ label }"i]`
-		)
+		.getByRole( 'menu', { name: 'Options' } )
+		.getByRole( 'menuitem', { name: label } )
 		.click();
 }


### PR DESCRIPTION
## What?
PR fixes a bug where the `editor.clickBlockOptionsMenuItem` helper failed for menu items displaying keyboard shortcodes.

## Why?
The helper should work with any menu item in the Options dropdown.

## How?
Switch to `page.getByRole()`, which uses case-insensitive and substring matching for labels by [default](https://playwright.dev/docs/api/class-page#page-get-by-role-option-name).

## Testing Instructions
The following e2e test case will fail on the trunk:

```js
/**
 * WordPress dependencies
 */
const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );

test.describe( 'clickBlockOptionsMenuItem', () => {
	test.beforeEach( async ( { admin } ) => {
		await admin.createNewPost();
	} );

	test( 'should delete a block via options menu', async ( {
		editor,
		page,
	} ) => {
		await editor.canvas
			.getByRole( 'button', { name: 'Add default block' } )
			.click();
		await page.keyboard.type( 'Hey!' );

		await editor.clickBlockOptionsMenuItem( 'Delete' );
		await expect(
			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
		).toBeHidden();
	} );
} );
```
