### PR TITLE
Dataviews: Add a missing icon for the side by side view.

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { page, columns } from '@wordpress/icons';
+import { page, columns, pullRight } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -13,7 +13,7 @@ import { unlock } from '../../lock-unlock';
 const { useLocation } = unlock( routerPrivateApis );
 
 function getDataViewIcon( type ) {
-	const icons = { list: page, grid: columns };
+	const icons = { list: page, grid: columns, 'side-by-side': pullRight };
 	return icons[ type ];
 }
 


### PR DESCRIPTION
Adds a missing icon to the side-by-side view.

## Screenshots
After:
<img width="230" alt="Screenshot 2023-11-07 at 11 38 31" src="https://github.com/WordPress/gutenberg/assets/11271197/c9b286c0-0b6e-459f-9321-692e1ef4ff04">

Before:
<img width="237" alt="Screenshot 2023-11-07 at 11 41 48" src="https://github.com/WordPress/gutenberg/assets/11271197/1a3eb731-b762-4c7c-8f5b-90b00233f75d">
