### PR TITLE
Site Editor: Update edited entity sync logic

### DIFF
--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -222,6 +222,8 @@ _Returns_
 
 ### addTemplate
 
+> **Deprecated**
+
 Action that adds a new template and sets it as the current template.
 
 _Parameters_

--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -276,6 +276,7 @@ _Parameters_
 
 -   _postType_ `string`: The entity's post type.
 -   _postId_ `string`: The entity's ID.
+-   _context_ `Object`: The entity's context.
 
 _Returns_
 
@@ -365,15 +366,9 @@ _Returns_
 
 ### setPage
 
+> **Deprecated**
+
 Resolves the template for a page and displays both. If no path is given, attempts to use the postId to generate a path like `?p=${ postId }`.
-
-_Parameters_
-
--   _page_ `Object`: The page object.
--   _page.type_ `string`: The page type.
--   _page.slug_ `string`: The page slug.
--   _page.path_ `string`: The page path.
--   _page.context_ `Object`: The page context.
 
 _Returns_
 
@@ -382,11 +377,6 @@ _Returns_
 ### setTemplate
 
 Action that sets a template, optionally fetching it from REST API.
-
-_Parameters_
-
--   _templateId_ `number`: The template ID.
--   _templateSlug_ `string`: The template slug.
 
 _Returns_
 

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -61,7 +61,6 @@ import {
 } from './utils';
 import AddCustomGenericTemplateModalContent from './add-custom-generic-template-modal-content';
 import TemplateActionsLoadingScreen from './template-actions-loading-screen';
-import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
@@ -165,7 +164,6 @@ export default function NewTemplate( {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
-	const { setTemplate } = unlock( useDispatch( editSiteStore ) );
 
 	const { homeUrl } = useSelect( ( select ) => {
 		const {
@@ -207,9 +205,6 @@ export default function NewTemplate( {
 				},
 				{ throwOnError: true }
 			);
-
-			// Set template before navigating away to avoid initial stale value.
-			setTemplate( newTemplate.id, newTemplate.slug );
 
 			// Navigate to the created template editor.
 			history.push( {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -147,7 +147,7 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 
 		return {
 			...( hasPageContentFocus ? context : nonPostFields ),
-			// Ideally this context should be removed. However, it is currently by the query block.
+			// Ideally this context should be removed. However, it is currently used by the Query Loop block.
 			templateSlug:
 				editedPostType === 'wp_template' ? editedPost.slug : undefined,
 			queryContext: [

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -144,8 +144,12 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 		: __( 'Block Library' );
 	const blockContext = useMemo( () => {
 		const { postType, postId, ...nonPostFields } = context ?? {};
+
 		return {
 			...( hasPageContentFocus ? context : nonPostFields ),
+			// Ideally this context should be removed. However, it is currently by the query block.
+			templateSlug:
+				editedPostType === 'wp_template' ? editedPost.slug : undefined,
 			queryContext: [
 				context?.queryContext || { page: 1 },
 				( newQueryContext ) =>
@@ -158,7 +162,13 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 					} ),
 			],
 		};
-	}, [ hasPageContentFocus, context, setEditedPostContext ] );
+	}, [
+		editedPost.slug,
+		editedPostType,
+		hasPageContentFocus,
+		context,
+		setEditedPostContext,
+	] );
 
 	let title;
 	if ( hasLoadedPost ) {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -149,7 +149,9 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 			...( hasPageContentFocus ? context : nonPostFields ),
 			// Ideally this context should be removed. However, it is currently used by the Query Loop block.
 			templateSlug:
-				editedPostType === 'wp_template' ? editedPost.slug : undefined,
+				editedPostType === TEMPLATE_POST_TYPE
+					? editedPost.slug
+					: undefined,
 			queryContext: [
 				context?.queryContext || { page: 1 },
 				( newQueryContext ) =>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecord } from '@wordpress/core-data';
@@ -14,14 +13,12 @@ import {
 	useEditedPostContext,
 	useIsPostsPage,
 } from './hooks';
-import { store as editSiteStore } from '../../../store';
 
 export default function ResetDefaultTemplate( { onClick } ) {
 	const currentTemplateSlug = useCurrentTemplateSlug();
 	const isPostsPage = useIsPostsPage();
 	const { postType, postId } = useEditedPostContext();
 	const entity = useEntityRecord( 'postType', postType, postId );
-	const { setPage } = useDispatch( editSiteStore );
 	// The default template in a post is indicated by an empty string.
 	if ( ! currentTemplateSlug || isPostsPage ) {
 		return null;
@@ -32,9 +29,6 @@ export default function ResetDefaultTemplate( { onClick } ) {
 				onClick={ async () => {
 					entity.edit( { template: '' }, { undoIgnore: true } );
 					onClick();
-					await setPage( {
-						context: { postType, postId },
-					} );
 				} }
 			>
 				{ __( 'Use default template' ) }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
 import { useMemo, useState, useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
@@ -14,7 +13,6 @@ import { useAsyncList } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../../store';
 import { useAvailableTemplates, useEditedPostContext } from './hooks';
 
 export default function SwapTemplateButton( { onClick } ) {
@@ -25,15 +23,11 @@ export default function SwapTemplateButton( { onClick } ) {
 	}, [] );
 	const { postType, postId } = useEditedPostContext();
 	const entitiy = useEntityRecord( 'postType', postType, postId );
-	const { setPage } = useDispatch( editSiteStore );
 	if ( ! availableTemplates?.length ) {
 		return null;
 	}
 	const onTemplateSelect = async ( template ) => {
 		entitiy.edit( { template: template.name }, { undoIgnore: true } );
-		await setPage( {
-			context: { postType, postId },
-		} );
 		onClose(); // Close the template suggestions modal first.
 		onClick();
 	};

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/page-details.js
@@ -105,26 +105,13 @@ export default function PageDetails( { id } ) {
 	const { record } = useEntityRecord( 'postType', 'page', id );
 	const { parentTitle, templateTitle, isPostsPage } = useSelect(
 		( select ) => {
-			const { getEditedPostContext } = unlock( select( editSiteStore ) );
-			const postContext = getEditedPostContext();
-			const templates = select( coreStore ).getEntityRecords(
+			const { getEditedPostId } = unlock( select( editSiteStore ) );
+			const template = select( coreStore ).getEntityRecord(
 				'postType',
 				TEMPLATE_POST_TYPE,
-				{ per_page: -1 }
+				getEditedPostId()
 			);
-			// Template title.
-			const templateSlug =
-				// Checks that the post type matches the current theme's post type, otherwise
-				// the templateSlug returns 'home'.
-				postContext?.postType === 'page'
-					? postContext?.templateSlug
-					: null;
-			const _templateTitle =
-				templates && templateSlug
-					? templates.find(
-							( template ) => template.slug === templateSlug
-					  )?.title?.rendered
-					: null;
+			const _templateTitle = template?.title?.rendered;
 
 			// Parent page title.
 			const _parentTitle = record?.parent

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -79,7 +79,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 					}
 				}
 
-				// If the no template is assigned, use the default template.
+				// If no template is assigned, use the default template.
 				return getDefaultTemplateId( {
 					slug: `${ postTypeToResolve }-${ editedEntity?.slug }`,
 				} );

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -104,8 +104,6 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 		[ homepageId, isRequestingSite, url, postId, postType ]
 	);
 
-	// todo add template slug in context.
-
 	const context = useMemo( () => {
 		if ( postTypesWithoutParentTemplate.includes( postType ) ) {
 			return {};

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -11,14 +11,20 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+	PATTERN_TYPES,
+} from '../../utils/constants';
 
 const { useLocation } = unlock( routerPrivateApis );
 
 const postTypesWithoutParentTemplate = [
-	'wp_template',
-	'wp_template_part',
-	'wp_block',
-	'wp_navigation',
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+	NAVIGATION_POST_TYPE,
+	PATTERN_TYPES,
 ];
 
 function useResolveEditedEntityAndContext( { postId, postType } ) {
@@ -69,7 +75,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				if ( currentTemplateSlug ) {
 					const currentTemplate = getEntityRecords(
 						'postType',
-						'wp_template',
+						TEMPLATE_POST_TYPE,
 						{
 							per_page: -1,
 						}
@@ -127,7 +133,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 	if ( ( postType && postId ) || homepageId || ! isRequestingSite ) {
 		return {
 			isReady: resolvedTemplateId !== undefined,
-			postType: 'wp_template',
+			postType: TEMPLATE_POST_TYPE,
 			postId: resolvedTemplateId,
 			context,
 		};

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -24,7 +24,7 @@ const postTypesWithoutParentTemplate = [
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 	NAVIGATION_POST_TYPE,
-	PATTERN_TYPES,
+	PATTERN_TYPES.user,
 ];
 
 function useResolveEditedEntityAndContext( { postId, postType } ) {

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -79,11 +79,19 @@ export function setTemplate() {
  *
  * @param {Object} template The template.
  *
+ * @deprecated
+ *
  * @return {Object} Action object used to set the current template.
  */
 export const addTemplate =
 	( template ) =>
 	async ( { dispatch, registry } ) => {
+		deprecated( "dispatch( 'core/edit-site' ).addTemplate", {
+			since: '6.5',
+			version: '6.8',
+			hint: 'use saveEntityRecord directly',
+		} );
+
 		const newTemplate = await registry
 			.dispatch( coreStore )
 			.saveEntityRecord( 'postType', TEMPLATE_POST_TYPE, template );

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -60,33 +60,19 @@ export function __experimentalSetPreviewDeviceType( deviceType ) {
 /**
  * Action that sets a template, optionally fetching it from REST API.
  *
- * @param {number} templateId   The template ID.
- * @param {string} templateSlug The template slug.
  * @return {Object} Action object.
  */
-export const setTemplate =
-	( templateId, templateSlug ) =>
-	async ( { dispatch, registry } ) => {
-		if ( ! templateSlug ) {
-			try {
-				const template = await registry
-					.resolveSelect( coreStore )
-					.getEntityRecord(
-						'postType',
-						TEMPLATE_POST_TYPE,
-						templateId
-					);
-				templateSlug = template?.slug;
-			} catch ( error ) {}
-		}
+export function setTemplate() {
+	deprecated( "dispatch( 'core/edit-site' ).setTemplate", {
+		since: '6.5',
+		version: '6.8',
+		hint: 'The setTemplate is not needed anymore, the correct entity is resolved from the URL automatically.',
+	} );
 
-		dispatch( {
-			type: 'SET_EDITED_POST',
-			postType: TEMPLATE_POST_TYPE,
-			id: templateId,
-			context: { templateSlug },
-		} );
+	return {
+		type: 'NOTHING',
 	};
+}
 
 /**
  * Action that adds a new template and sets it as the current template.
@@ -211,14 +197,16 @@ export function setNavigationMenu( navigationMenuId ) {
  *
  * @param {string} postType The entity's post type.
  * @param {string} postId   The entity's ID.
+ * @param {Object} context  The entity's context.
  *
  * @return {Object} Action object.
  */
-export function setEditedEntity( postType, postId ) {
+export function setEditedEntity( postType, postId, context ) {
 	return {
 		type: 'SET_EDITED_POST',
 		postType,
 		id: postId,
+		context,
 	};
 }
 
@@ -254,85 +242,19 @@ export function setEditedPostContext( context ) {
  * Resolves the template for a page and displays both. If no path is given, attempts
  * to use the postId to generate a path like `?p=${ postId }`.
  *
- * @param {Object} page         The page object.
- * @param {string} page.type    The page type.
- * @param {string} page.slug    The page slug.
- * @param {string} page.path    The page path.
- * @param {Object} page.context The page context.
+ * @deprecated
  *
  * @return {number} The resolved template ID for the page route.
  */
-export const setPage =
-	( page ) =>
-	async ( { dispatch, registry } ) => {
-		let template;
-		const getDefaultTemplate = async ( slug ) => {
-			const templateId = await registry
-				.resolveSelect( coreStore )
-				.getDefaultTemplateId( {
-					slug: `page-${ slug }`,
-				} );
-			return templateId
-				? await registry
-						.resolveSelect( coreStore )
-						.getEntityRecord(
-							'postType',
-							TEMPLATE_POST_TYPE,
-							templateId
-						)
-				: undefined;
-		};
+export function setPage() {
+	deprecated( "dispatch( 'core/edit-site' ).setPage", {
+		since: '6.5',
+		version: '6.8',
+		hint: 'The setPage is not needed anymore, the correct entity is resolved from the URL automatically.',
+	} );
 
-		if ( page.path ) {
-			template = await registry
-				.resolveSelect( coreStore )
-				.__experimentalGetTemplateForLink( page.path );
-		} else {
-			const editedEntity = await registry
-				.resolveSelect( coreStore )
-				.getEditedEntityRecord(
-					'postType',
-					page.context?.postType || 'post',
-					page.context?.postId
-				);
-			const currentTemplateSlug = editedEntity?.template;
-			if ( currentTemplateSlug ) {
-				const currentTemplate = (
-					await registry
-						.resolveSelect( coreStore )
-						.getEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
-							per_page: -1,
-						} )
-				)?.find( ( { slug } ) => slug === currentTemplateSlug );
-				if ( currentTemplate ) {
-					template = currentTemplate;
-				} else {
-					// If a page has a `template` set and is not included in the list
-					// of the current theme's templates, query for current theme's default template.
-					template = await getDefaultTemplate( editedEntity?.slug );
-				}
-			} else {
-				// Page's `template` is empty, that indicates we need to use the default template for the page.
-				template = await getDefaultTemplate( editedEntity?.slug );
-			}
-		}
-
-		if ( ! template ) {
-			return;
-		}
-
-		dispatch( {
-			type: 'SET_EDITED_POST',
-			postType: TEMPLATE_POST_TYPE,
-			id: template.id,
-			context: {
-				...page.context,
-				templateSlug: template.slug,
-			},
-		} );
-
-		return template.id;
-	};
+	return { type: 'NOTHING' };
+}
 
 /**
  * Action that sets the active navigation panel menu.

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -104,7 +104,6 @@ export const addTemplate =
 			type: 'SET_EDITED_POST',
 			postType: TEMPLATE_POST_TYPE,
 			id: newTemplate.id,
-			context: { templateSlug: newTemplate.slug },
 		} );
 	};
 

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -69,49 +69,6 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'setTemplate', () => {
-		const ID = 1;
-		const SLUG = 'archive';
-
-		it( 'should set the template when slug is provided', async () => {
-			const registry = createRegistryWithStores();
-
-			await registry.dispatch( editSiteStore ).setTemplate( ID, SLUG );
-
-			const select = registry.select( editSiteStore );
-			expect( select.getEditedPostId() ).toBe( ID );
-			expect( select.getEditedPostContext().templateSlug ).toBe( SLUG );
-		} );
-
-		it( 'should set the template by fetching the template slug', async () => {
-			const registry = createRegistryWithStores();
-
-			apiFetch.setFetchHandler( async ( options ) => {
-				const { method = 'GET', path } = options;
-				if ( method === 'GET' ) {
-					if ( path.startsWith( '/wp/v2/types' ) ) {
-						return ENTITY_TYPES;
-					}
-
-					if ( path.startsWith( `/wp/v2/templates/${ ID }` ) ) {
-						return { id: ID, slug: SLUG };
-					}
-				}
-
-				throw {
-					code: 'unknown_path',
-					message: `Unknown path: ${ method } ${ path }`,
-				};
-			} );
-
-			await registry.dispatch( editSiteStore ).setTemplate( ID );
-
-			const select = registry.select( editSiteStore );
-			expect( select.getEditedPostId() ).toBe( ID );
-			expect( select.getEditedPostContext().templateSlug ).toBe( SLUG );
-		} );
-	} );
-
 	describe( 'addTemplate', () => {
 		it( 'should issue a REST request to create the template and then set it', async () => {
 			const registry = createRegistryWithStores();
@@ -159,45 +116,6 @@ describe( 'actions', () => {
 			const select = registry.select( editSiteStore );
 			expect( select.getEditedPostId() ).toBe( ID );
 			expect( select.getEditedPostType() ).toBe( 'wp_template_part' );
-		} );
-	} );
-
-	describe( 'setPage', () => {
-		it( 'should find the template and then set the page', async () => {
-			const registry = createRegistryWithStores();
-
-			const ID = 'emptytheme//single';
-			const SLUG = 'single';
-
-			apiFetch.setFetchHandler( async ( options ) => {
-				const { method = 'GET', path, url } = options;
-
-				// Called with url arg in `__experimentalGetTemplateForLink`
-				if ( url ) {
-					return { data: { id: ID, slug: SLUG } };
-				}
-
-				if ( method === 'GET' ) {
-					if ( path.startsWith( '/wp/v2/types' ) ) {
-						return ENTITY_TYPES;
-					}
-
-					if ( path.startsWith( `/wp/v2/templates/${ ID }` ) ) {
-						return { id: ID, slug: SLUG };
-					}
-				}
-
-				throw {
-					code: 'unknown_path',
-					message: `Unknown path: ${ method } ${ path }`,
-				};
-			} );
-
-			await registry.dispatch( editSiteStore ).setPage( { path: '/' } );
-
-			const select = registry.select( editSiteStore );
-			expect( select.getEditedPostId() ).toBe( 'emptytheme//single' );
-			expect( select.getEditedPostType() ).toBe( 'wp_template' );
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -102,7 +102,6 @@ describe( 'actions', () => {
 
 			const select = registry.select( editSiteStore );
 			expect( select.getEditedPostId() ).toBe( ID );
-			expect( select.getEditedPostContext().templateSlug ).toBe( SLUG );
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { createRegistry } from '@wordpress/data';
@@ -14,18 +13,6 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { store as editSiteStore } from '..';
 import { setHasPageContentFocus } from '../actions';
-
-const ENTITY_TYPES = {
-	wp_template: {
-		description: 'Templates to include in your theme.',
-		hierarchical: false,
-		name: 'Templates',
-		rest_base: 'templates',
-		rest_namespace: 'wp/v2',
-		slug: 'wp_template',
-		taxonomies: [],
-	},
-};
 
 function createRegistryWithStores() {
 	// create a registry
@@ -66,42 +53,6 @@ describe( 'actions', () => {
 
 			// Expect a deprecation warning.
 			expect( console ).toHaveWarned();
-		} );
-	} );
-
-	describe( 'addTemplate', () => {
-		it( 'should issue a REST request to create the template and then set it', async () => {
-			const registry = createRegistryWithStores();
-
-			const ID = 1;
-			const SLUG = 'index';
-
-			apiFetch.setFetchHandler( async ( options ) => {
-				const { method = 'GET', path, data } = options;
-
-				if ( method === 'GET' && path.startsWith( '/wp/v2/types' ) ) {
-					return ENTITY_TYPES;
-				}
-
-				if (
-					method === 'POST' &&
-					path.startsWith( '/wp/v2/templates' )
-				) {
-					return { id: ID, slug: data.slug };
-				}
-
-				throw {
-					code: 'unknown_path',
-					message: `Unknown path: ${ method } ${ path }`,
-				};
-			} );
-
-			await registry
-				.dispatch( editSiteStore )
-				.addTemplate( { slug: SLUG } );
-
-			const select = registry.select( editSiteStore );
-			expect( select.getEditedPostId() ).toBe( ID );
 		} );
 	} );
 


### PR DESCRIPTION
## What?

In several places in the site editor, we're forced to call `setPage` manually to force the recomputing of the active template after the user make some changes. The reason is that the active template was not being computed reactively.  This PR updates the sync logic so that any change to the entities that might affect the active template actually triggers the template resolution code.

## Testing Instructions

Navigate the site editor and ensure that the correct template/page/pattern is shown in all situations in the frame.
