### PR TITLE
Fix: 404 link in get-started-with-create-block docs.

### DIFF
--- a/docs/getting-started/devenv/get-started-with-create-block.md
+++ b/docs/getting-started/devenv/get-started-with-create-block.md
@@ -1,6 +1,6 @@
 # Get started with create-block
 
-Custom blocks for the Block Editor in WordPress are typically registered using plugins and are defined through a specific set of files. The [`@wordpress/create-block`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/) package is an officially supported tool to scaffold the structure of files needed to create and register a block. It generates all the necessary code to start a project and integrates a modern JavaScript build setup (using [`wp-scripts`](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts.md)) with no configuration required. 
+Custom blocks for the Block Editor in WordPress are typically registered using plugins and are defined through a specific set of files. The [`@wordpress/create-block`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/) package is an officially supported tool to scaffold the structure of files needed to create and register a block. It generates all the necessary code to start a project and integrates a modern JavaScript build setup (using [`wp-scripts`](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts/)) with no configuration required. 
 
 The package is designed to help developers quickly set up a block development environment following WordPress best practices.
 


### PR DESCRIPTION
Fixes a link that points to a 404 page.

## Testing Instructions
Verify this link works https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts/
While this link does not work https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts.md.

