### PR TITLE
a11y: Prevent sidebar focus in site editor on small screens

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -116,7 +116,7 @@ export default function Layout() {
 	} );
 	const disableMotion = useReducedMotion();
 	const showSidebar =
-		( isMobileViewport && ! isListPage ) ||
+		( isMobileViewport && canvasMode === 'view' && ! isListPage ) ||
 		( ! isMobileViewport && ( canvasMode === 'view' || ! isEditorPage ) );
 	const showCanvas =
 		( isMobileViewport && isEditorPage && isEditing ) ||
@@ -282,7 +282,7 @@ export default function Layout() {
 							// (https://github.com/WordPress/gutenberg/pull/51558/files#r1231763003),
 							// so we can't remove the element entirely. Using `inert` will make
 							// it inaccessible to screen readers and keyboard navigation.
-							inert={ showSidebar ? undefined : 'inert' }
+							inert={ showSidebar ? undefined : 'true' }
 							animate={ { opacity: showSidebar ? 1 : 0 } }
 							transition={ {
 								type: 'tween',


### PR DESCRIPTION
Fixes #55908

## What?
This PR fixes an issue where focus could be moved to invisible elements in the sidebar of the site editor on small screens.

## Why?
When you do not want the focus to move to the sidebar, it is expected to apply the inert attribute. This attribute is controlled by the showSidebar attribute, but in the case of mobile viewports, the only condition is that it is not a list page (All Templates, All Template Parts, All Pages), and canvas mode was not taken into account.

## How?

Added the condition that canvas mode is view mode.

## Testing Instructions

- Reduce the browser width to 781px or less
- At the same time, monitor the element with the `edit-site-layout__sidebar` class in the developer tools.
- Open the site editor.
- The sidebar will not have the `inert` attribute, and you should be able to move focus properly using the keyboard.
- Open the canvas.
- The `inert` attribute is given to the sidebar, and no invisible focus movement should occur.

> **Warning**
> While writing this pull request, I discovered an issue with screen reader shortcuts in the block editor. This is summarized in #55931.

## Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/54422211/42cd7b41-e0b6-4dcc-a14d-a285c7a75993