### PR TITLE
Add context for translators to any unclear usage of "synced"

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -55,14 +55,17 @@ export function PatternsFilter( {
 
 	const patternSyncMenuOptions = useMemo(
 		() => [
+			// translators: Button label, when clicked it shows "All patterns".
 			{ value: SYNC_TYPES.all, label: __( 'All' ) },
 			{
 				value: SYNC_TYPES.full,
+				// translators: Button label, when clicked it shows all "Synced patterns".
 				label: __( 'Synced' ),
 				disabled: shouldDisableSyncFilter,
 			},
 			{
 				value: SYNC_TYPES.unsynced,
+				// translators: Button label, when click it shows all "Not synced patterns".
 				label: __( 'Not synced' ),
 				disabled: shouldDisableSyncFilter,
 			},

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -9,7 +9,7 @@ import {
 	MenuItemsChoice,
 	ExternalLink,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { useMemo, createInterpolateElement } from '@wordpress/element';
 
@@ -55,18 +55,24 @@ export function PatternsFilter( {
 
 	const patternSyncMenuOptions = useMemo(
 		() => [
-			// translators: Button label, when clicked it shows "All patterns".
-			{ value: SYNC_TYPES.all, label: __( 'All' ) },
+			{
+				value: SYNC_TYPES.all,
+				label: _x( 'All', 'Option that shows all patterns' ),
+			},
 			{
 				value: SYNC_TYPES.full,
-				// translators: Button label, when clicked it shows all "Synced patterns".
-				label: __( 'Synced' ),
+				label: _x(
+					'Synced',
+					'Option that shows all synchronized patterns'
+				),
 				disabled: shouldDisableSyncFilter,
 			},
 			{
 				value: SYNC_TYPES.unsynced,
-				// translators: Button label, when click it shows all "Not synced patterns".
-				label: __( 'Not synced' ),
+				label: _x(
+					'Not synced',
+					'Option that shows all patterns that are not synchronized'
+				),
 				disabled: shouldDisableSyncFilter,
 			},
 		],

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -12,7 +12,7 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, _x, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useAsyncList, useViewportMatch } from '@wordpress/compose';
@@ -33,12 +33,15 @@ import Pagination from './pagination';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const SYNC_FILTERS = {
-	// translators: Button label, when clicked it shows "All patterns".
-	all: __( 'All' ),
-	// translators: Button label, when clicked it shows all "Synced patterns".
-	[ PATTERN_SYNC_TYPES.full ]: __( 'Synced' ),
-	// translators: Button label, when click it shows all "Not synced patterns".
-	[ PATTERN_SYNC_TYPES.unsynced ]: __( 'Not synced' ),
+	all: _x( 'All', 'Option that shows all patterns' ),
+	[ PATTERN_SYNC_TYPES.full ]: _x(
+		'Synced',
+		'Option that shows all synchronized patterns'
+	),
+	[ PATTERN_SYNC_TYPES.unsynced ]: _x(
+		'Not synced',
+		'Option that shows all patterns that are not synchronized'
+	),
 };
 
 const SYNC_DESCRIPTIONS = {

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -33,8 +33,11 @@ import Pagination from './pagination';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const SYNC_FILTERS = {
+	// translators: Button label, when clicked it shows "All patterns".
 	all: __( 'All' ),
+	// translators: Button label, when clicked it shows all "Synced patterns".
 	[ PATTERN_SYNC_TYPES.full ]: __( 'Synced' ),
+	// translators: Button label, when click it shows all "Not synced patterns".
 	[ PATTERN_SYNC_TYPES.unsynced ]: __( 'Not synced' ),
 };
 

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -109,7 +109,7 @@ export function PostSyncStatusModal() {
 						<VStack spacing="5">
 							<ReusableBlocksRenameHint />
 							<ToggleControl
-								// translators: Toggle button label, when active makes an individual pattern "Synced".
+								// translators: Button label, when active makes an individual pattern "Synced".
 								label={ __( 'Synced' ) }
 								help={ __(
 									'Editing the pattern will update it anywhere it is used.'

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -109,6 +109,7 @@ export function PostSyncStatusModal() {
 						<VStack spacing="5">
 							<ReusableBlocksRenameHint />
 							<ToggleControl
+								// translators: Toggle button label, when active makes an individual pattern "Synced".
 								label={ __( 'Synced' ) }
 								help={ __(
 									'Editing the pattern will update it anywhere it is used.'

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	PanelRow,
 	Modal,
@@ -109,8 +109,10 @@ export function PostSyncStatusModal() {
 						<VStack spacing="5">
 							<ReusableBlocksRenameHint />
 							<ToggleControl
-								// translators: Button label, when active makes an individual pattern "Synced".
-								label={ __( 'Synced' ) }
+								label={ _x(
+									'Synced',
+									'Option that makes an individual pattern synchronized'
+								) }
 								help={ __(
 									'Editing the pattern will update it anywhere it is used.'
 								) }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -179,7 +179,7 @@ export default function CreatePatternModal( {
 						categoryMap={ categoryMap }
 					/>
 					<ToggleControl
-						// translators: Toggle button label, when active makes an individual pattern "Synced".
+						// translators: Button label, when active makes an individual pattern "Synced".
 						label={ __( 'Synced' ) }
 						help={ __(
 							'Editing the pattern will update it anywhere it is used.'

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -179,6 +179,7 @@ export default function CreatePatternModal( {
 						categoryMap={ categoryMap }
 					/>
 					<ToggleControl
+						// translators: Toggle button label, when active makes an individual pattern "Synced".
 						label={ __( 'Synced' ) }
 						help={ __(
 							'Editing the pattern will update it anywhere it is used.'

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -9,7 +9,7 @@ import {
 	__experimentalVStack as VStack,
 	ToggleControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -179,8 +179,10 @@ export default function CreatePatternModal( {
 						categoryMap={ categoryMap }
 					/>
 					<ToggleControl
-						// translators: Button label, when active makes an individual pattern "Synced".
-						label={ __( 'Synced' ) }
+						label={ _x(
+							'Synced',
+							'Option that makes an individual pattern synchronized'
+						) }
 						help={ __(
 							'Editing the pattern will update it anywhere it is used.'
 						) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -18,7 +18,7 @@ import {
 } from '@wordpress/components';
 import { symbol } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -185,8 +185,10 @@ export default function ReusableBlockConvertButton( {
 							/>
 
 							<ToggleControl
-								// translators: Button label, when active makes an individual pattern "Synced".
-								label={ __( 'Synced' ) }
+								label={ _x(
+									'Synced',
+									'Option that makes an individual pattern synchronized'
+								) }
 								help={ __(
 									'Editing the pattern will update it anywhere it is used.'
 								) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -185,6 +185,7 @@ export default function ReusableBlockConvertButton( {
 							/>
 
 							<ToggleControl
+								// translators: Toggle button label, when active makes an individual pattern "Synced".
 								label={ __( 'Synced' ) }
 								help={ __(
 									'Editing the pattern will update it anywhere it is used.'

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -185,7 +185,7 @@ export default function ReusableBlockConvertButton( {
 							/>
 
 							<ToggleControl
-								// translators: Toggle button label, when active makes an individual pattern "Synced".
+								// translators: Button label, when active makes an individual pattern "Synced".
 								label={ __( 'Synced' ) }
 								help={ __(
 									'Editing the pattern will update it anywhere it is used.'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #55783

As mentioned in that issue, it's unclear if the word "synced" is singular or plural and this can result in incorrect translations.

## How?
Add a translator comment explaining each usage of the word 'synced'.