### PR TITLE
DataViews: Fix pagination on manual input

### DIFF
--- a/packages/edit-site/src/components/dataviews/pagination.js
+++ b/packages/edit-site/src/components/dataviews/pagination.js
@@ -83,16 +83,17 @@ function Pagination( {
 										min={ 1 }
 										max={ totalPages }
 										onChange={ ( value ) => {
+											const _value = +value;
 											if (
-												! value ||
-												value < 1 ||
-												value > totalPages
+												! _value ||
+												_value < 1 ||
+												_value > totalPages
 											) {
 												return;
 											}
 											onChangeView( {
 												...view,
-												page: value,
+												page: _value,
 											} );
 										} }
 										step="1"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/55937

When manually entering a page number in the pagination control, an invalid page number incorrectly enables the previous pagination controls, allowing the user to "access" pages below 1.

## Testing Instructions
1. Navigate to the pagination control, and enter a page number out of range (e.g. 0).
2. Note that the value will reset to a number within range (e.g. 1), but that the "First page" and "Previous page" buttons will be disabled.

