### PR TITLE
Tabs: Fix flaky unit tests

### DIFF
--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -524,6 +524,12 @@ describe( 'Tabs', () => {
 				await screen.findByRole( 'tab', { name: 'Alpha' } )
 			).toHaveFocus();
 
+			await waitFor( () =>
+				expect(
+					screen.getByRole( 'tab', { name: 'Beta' } )
+				).toHaveAttribute( 'tabindex', '-1' )
+			);
+
 			// Because all other tabs should have `tabindex=-1`, pressing Tab
 			// should NOT move the focus to the next tab, which is Beta.
 			// Instead, focus should go to the currently selected tabpanel (alpha).
@@ -847,6 +853,13 @@ describe( 'Tabs', () => {
 				// onSelect should not be called since the disabled tab is
 				// highlighted, but not selected.
 				await user.keyboard( '[Tab]' );
+
+				await waitFor( () =>
+					expect(
+						screen.getByRole( 'tab', { name: 'Alpha' } )
+					).toHaveFocus()
+				);
+
 				await user.keyboard( '[ArrowLeft]' );
 				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -524,6 +524,9 @@ describe( 'Tabs', () => {
 				await screen.findByRole( 'tab', { name: 'Alpha' } )
 			).toHaveFocus();
 
+			// This assertion ensures the component has had time to fully
+			// render, preventing flakiness.
+			// see https://github.com/WordPress/gutenberg/pull/55950
 			await waitFor( () =>
 				expect(
 					screen.getByRole( 'tab', { name: 'Beta' } )
@@ -854,6 +857,9 @@ describe( 'Tabs', () => {
 				// highlighted, but not selected.
 				await user.keyboard( '[Tab]' );
 
+				// This assertion ensures focus has time to move to the first
+				// tab before the test proceeds, preventing flakiness.
+				// see https://github.com/WordPress/gutenberg/pull/55950
 				await waitFor( () =>
 					expect(
 						screen.getByRole( 'tab', { name: 'Alpha' } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix two flaky unit tests that were first mentioned in https://github.com/WordPress/gutenberg/pull/55287#discussion_r1383823103

## Why?
Because no one likes a flaky test.

## How?
Two tests had issues, and were solved by ensuring the component had time to fully update before proceeding.

**Tabs › Uncontrolled mode › Disabled tab › should disable the tab when `disabled` is `true`**

While debugging, I noticed that `tabindex=-1` on inactive tests wasn't always being applied in time in the testing environment. This allowed the next tab in line to receive focus, triggering a failure. The new assertion waits for this property to be present before proceeding, ensuring an accurate test. I'd prefer we didn't need an assertion for this type of under-the-hood detail,  but I'll take it over flakiness.

**Tabs › Tab Activation › should not focus the next tab when the Tab key is pressed**

This test relies on pressing the [Tab] key, followed by the [ArrowLeft] key, and then checking that the proper tab has focus. The focus check was happening too quickly sometimes, and new focus hadn't been applied yet. The new assertion waits for and checks the focused element after the [Tab] key, ensuring the new focus is applied before [LeftArrow] is pressed.

Between different testing runs I ran the full unit test suite about 100 times without any failures.

## Testing Instructions
note: I didn't encounter the flakiness when running the tests individually, though I maybe just didn't try enough. I just ran the full suite instead and recommend testing this PR the same way. 

- After the test finishes, re-run with `Enter/Return`.
- Repeat approximately 372 times. Or, you know... just a bunch.
- Confirm that anti-flaky status has been achieved.
