### PR TITLE
DataViews: add control to reset all filters at once

### DIFF
--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -50,7 +50,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 				if ( OPERATOR_IN === filter.operator ) {
 					return (
 						<InFilter
-							key={ fieldName }
+							key={ fieldName + '.' + filter.operator }
 							filter={ visibleFiltersForField[ 0 ] }
 							view={ view }
 							onChangeView={ onChangeView }
@@ -64,7 +64,11 @@ export default function Filters( { fields, view, onChangeView } ) {
 
 	if ( visibleFilters.length > 0 ) {
 		visibleFilters.push(
-			<ResetFilters view={ view } onChangeView={ onChangeView } />
+			<ResetFilters
+				key="reset-filters"
+				view={ view }
+				onChangeView={ onChangeView }
+			/>
 		);
 	}
 

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -36,29 +36,31 @@ export default function Filters( { fields, view, onChangeView } ) {
 		} );
 	} );
 
-	const visibleFilters = view.visibleFilters?.map( ( fieldName ) => {
-		const visibleFiltersForField = filtersRegistered.filter(
-			( f ) => f.field === fieldName
-		);
+	const visibleFilters = view.visibleFilters
+		?.map( ( fieldName ) => {
+			const visibleFiltersForField = filtersRegistered.filter(
+				( f ) => f.field === fieldName
+			);
 
-		if ( visibleFiltersForField.length === 0 ) {
-			return null;
-		}
-
-		return visibleFiltersForField.map( ( filter ) => {
-			if ( OPERATOR_IN === filter.operator ) {
-				return (
-					<InFilter
-						key={ fieldName }
-						filter={ visibleFiltersForField[ 0 ] }
-						view={ view }
-						onChangeView={ onChangeView }
-					/>
-				);
+			if ( visibleFiltersForField.length === 0 ) {
+				return null;
 			}
-			return null;
-		} );
-	} ).filter( Boolean );
+
+			return visibleFiltersForField.map( ( filter ) => {
+				if ( OPERATOR_IN === filter.operator ) {
+					return (
+						<InFilter
+							key={ fieldName }
+							filter={ visibleFiltersForField[ 0 ] }
+							view={ view }
+							onChangeView={ onChangeView }
+						/>
+					);
+				}
+				return null;
+			} );
+		} )
+		.filter( Boolean );
 
 	if ( visibleFilters.length > 0 ) {
 		visibleFilters.push( <ResetFilters onChangeView={ onChangeView } /> );

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -7,6 +7,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { default as InFilter, OPERATOR_IN } from './in-filter';
+import ResetFilters from './reset-filters';
+
 const VALID_OPERATORS = [ OPERATOR_IN ];
 
 export default function Filters( { fields, view, onChangeView } ) {
@@ -34,7 +36,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 		} );
 	} );
 
-	return view.visibleFilters?.map( ( fieldName ) => {
+	const visibleFilters = view.visibleFilters?.map( ( fieldName ) => {
 		const visibleFiltersForField = filtersRegistered.filter(
 			( f ) => f.field === fieldName
 		);
@@ -56,5 +58,11 @@ export default function Filters( { fields, view, onChangeView } ) {
 			}
 			return null;
 		} );
-	} );
+	} ).filter( Boolean );
+
+	if ( visibleFilters.length > 0 ) {
+		visibleFilters.push( <ResetFilters onChangeView={ onChangeView } /> );
+	}
+
+	return visibleFilters;
 }

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -62,7 +62,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 		} )
 		.filter( Boolean );
 
-	if ( visibleFilters.length > 0 ) {
+	if ( visibleFilters?.length > 0 ) {
 		visibleFilters.push(
 			<ResetFilters
 				key="reset-filters"

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -63,7 +63,9 @@ export default function Filters( { fields, view, onChangeView } ) {
 		.filter( Boolean );
 
 	if ( visibleFilters.length > 0 ) {
-		visibleFilters.push( <ResetFilters onChangeView={ onChangeView } /> );
+		visibleFilters.push(
+			<ResetFilters view={ view } onChangeView={ onChangeView } />
+		);
 	}
 
 	return visibleFilters;

--- a/packages/edit-site/src/components/dataviews/reset-filters.js
+++ b/packages/edit-site/src/components/dataviews/reset-filters.js
@@ -1,22 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { BaseControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default ( { onChangeView } ) => {
 	return (
-		<Button
-			variant="tertiary"
-			onClick={ () => {
-				onChangeView( ( currentView ) => ( {
-					...currentView,
-					page: 1,
-					filters: [],
-				} ) );
-			} }
-		>
-			{ __( 'Reset filters' ) }
-		</Button>
+		<BaseControl>
+			<Button
+				variant="tertiary"
+				onClick={ () => {
+					onChangeView( ( currentView ) => ( {
+						...currentView,
+						page: 1,
+						filters: [],
+					} ) );
+				} }
+			>
+				{ __( 'Reset filters' ) }
+			</Button>
+		</BaseControl>
 	);
 };

--- a/packages/edit-site/src/components/dataviews/reset-filters.js
+++ b/packages/edit-site/src/components/dataviews/reset-filters.js
@@ -13,6 +13,7 @@ export default ( { onChangeView } ) => {
 					onChangeView( ( currentView ) => ( {
 						...currentView,
 						page: 1,
+						search: '',
 						filters: [],
 					} ) );
 				} }

--- a/packages/edit-site/src/components/dataviews/reset-filters.js
+++ b/packages/edit-site/src/components/dataviews/reset-filters.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default ( { onChangeView } ) => {
+	return (
+		<Button
+			variant="tertiary"
+			onClick={ () => {
+				onChangeView( ( currentView ) => ( {
+					...currentView,
+					page: 1,
+					filters: [],
+				} ) );
+			} }
+		>
+			{ __( 'Reset filters' ) }
+		</Button>
+	);
+};

--- a/packages/edit-site/src/components/dataviews/reset-filters.js
+++ b/packages/edit-site/src/components/dataviews/reset-filters.js
@@ -4,10 +4,11 @@
 import { BaseControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default ( { onChangeView } ) => {
+export default ( { view, onChangeView } ) => {
 	return (
 		<BaseControl>
 			<Button
+				disabled={ view.search === '' && view.filters?.length === 0 }
 				variant="tertiary"
 				onClick={ () => {
 					onChangeView( ( currentView ) => ( {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Adds a new control `ResetFilters` to reset all filters at once.

## Why?

As per [the designs](https://github.com/WordPress/gutenberg/pull/55508#issuecomment-1794996453):

<img width="479" alt="Screenshot 2023-11-06 at 14 46 56" src="https://github.com/WordPress/gutenberg/assets/846565/fd3966e3-70c9-4142-b108-902057fc40f3">

## Testing Instructions

- Enable "new wp admin" experiment and visit "Appearance > Editor > Manage all pages".
- Use the filters (top-level, column, sidebar / search, author, status) and reset them via the new button.
- Verify that the reset button is disabled if no filters are active.

https://github.com/WordPress/gutenberg/assets/583546/26ed8eb7-a31d-4f2a-8e16-4e176b71514a

