### PR TITLE
DropdownMenuV2: prevent default on Escape key presses

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `Tabs`: Add `focusable` prop to the `Tabs.TabPanel` sub-component ([#55287](https://github.com/WordPress/gutenberg/pull/55287))
 -   `Tabs`: Update sub-components to accept relevant HTML element props ([#55860](https://github.com/WordPress/gutenberg/pull/55860))
 -   `DropdownMenuV2`: Fix radio menu item check icon not rendering correctly in some browsers ([#55964](https://github.com/WordPress/gutenberg/pull/55964))
+-   `DropdownMenuV2`: prevent default when pressing Escape key to close menu ([#55962](https://github.com/WordPress/gutenberg/pull/55962))
 
 ### Enhancements
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -113,13 +113,6 @@ The skidding of the popover along the anchor element. Can be set to negative val
 - Required: no
 - Default: `0` for root-level menus, `-8` for nested menus
 
-##### `hideOnEscape`: `boolean | ( ( event: KeyboardEvent | React.KeyboardEvent< Element > ) => boolean )`
-
-Determines whether the menu popover will be hidden when the user presses the Escape key.
-
-- Required: no
-- Default: `( event ) => { event.preventDefault(); return true; }`
-
 ### `DropdownMenuItem`
 
 Used to render a menu item.

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -118,7 +118,7 @@ The skidding of the popover along the anchor element. Can be set to negative val
 Determines whether the menu popover will be hidden when the user presses the Escape key.
 
 - Required: no
-- Default: `true`
+- Default: `( event ) => { event.preventDefault(); return true; }`
 
 ### `DropdownMenuItem`
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -180,7 +180,13 @@ const UnconnectedDropdownMenu = (
 		children,
 		shift,
 		modal = true,
-		hideOnEscape = true,
+		hideOnEscape = ( event ) => {
+			// Pressing Escape can cause unexpected consequences (ie. exiting
+			// full screen mode on MacOs).
+			event.preventDefault();
+			// Returning `true` causes the menu to hide.
+			return true;
+		},
 
 		// From internal components context
 		variant,

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -260,6 +260,17 @@ const UnconnectedDropdownMenu = (
 		[]
 	);
 
+	const wrapperProps = useMemo(
+		() => ( {
+			dir: computedDirection,
+			style: {
+				direction:
+					computedDirection as React.CSSProperties[ 'direction' ],
+			},
+		} ),
+		[ computedDirection ]
+	);
+
 	return (
 		<>
 			{ /* Menu trigger */ }
@@ -292,12 +303,7 @@ const UnconnectedDropdownMenu = (
 				hideOnHoverOutside={ false }
 				data-side={ appliedPlacementSide }
 				variant={ variant }
-				wrapperProps={ {
-					dir: computedDirection,
-					style: {
-						direction: computedDirection,
-					},
-				} }
+				wrapperProps={ wrapperProps }
 				hideOnEscape={ hideOnEscape }
 				unmountOnHide
 			>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -14,6 +14,7 @@ import {
 	useMemo,
 	cloneElement,
 	isValidElement,
+	useCallback,
 } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 import { check, chevronRightSmall } from '@wordpress/icons';
@@ -180,13 +181,6 @@ const UnconnectedDropdownMenu = (
 		children,
 		shift,
 		modal = true,
-		hideOnEscape = ( event ) => {
-			// Pressing Escape can cause unexpected consequences (ie. exiting
-			// full screen mode on MacOs).
-			event.preventDefault();
-			// Returning `true` causes the menu to hide.
-			return true;
-		},
 
 		// From internal components context
 		variant,
@@ -253,6 +247,18 @@ const UnconnectedDropdownMenu = (
 			'For nested DropdownMenus, the `trigger` should always be a `DropdownMenuItem`.'
 		);
 	}
+
+	const hideOnEscape = useCallback(
+		( event: React.KeyboardEvent< Element > ) => {
+			// Pressing Escape can cause unexpected consequences (ie. exiting
+			// full screen mode on MacOs, close parent modals...).
+			event.preventDefault();
+			event.stopPropagation();
+			// Returning `true` causes the menu to hide.
+			return true;
+		},
+		[]
+	);
 
 	return (
 		<>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -253,7 +253,6 @@ const UnconnectedDropdownMenu = (
 			// Pressing Escape can cause unexpected consequences (ie. exiting
 			// full screen mode on MacOs, close parent modals...).
 			event.preventDefault();
-			event.stopPropagation();
 			// Returning `true` causes the menu to hide.
 			return true;
 		},

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -40,6 +40,8 @@ const meta: Meta< typeof DropdownMenu > = {
 	},
 	argTypes: {
 		children: { control: { type: null } },
+		trigger: { control: { type: null } },
+		hideOnEscape: { control: { type: 'boolean' } },
 	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -41,7 +41,6 @@ const meta: Meta< typeof DropdownMenu > = {
 	argTypes: {
 		children: { control: { type: null } },
 		trigger: { control: { type: null } },
-		hideOnEscape: { control: { type: 'boolean' } },
 	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
@@ -496,10 +495,6 @@ export const InsideModal: StoryFn< typeof DropdownMenu > = ( props ) => {
 };
 InsideModal.args = {
 	...Default.args,
-	hideOnEscape: ( e ) => {
-		e.stopPropagation();
-		return true;
-	},
 };
 InsideModal.parameters = {
 	docs: {

--- a/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
@@ -197,32 +197,6 @@ describe( 'DropdownMenu', () => {
 			);
 		} );
 
-		it( 'should not close when pressing the escape key if the `hideOnEscape` prop is set to `false`', async () => {
-			render(
-				<DropdownMenu
-					trigger={ <button>Open dropdown</button> }
-					hideOnEscape={ false }
-				>
-					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-				</DropdownMenu>
-			);
-
-			const trigger = screen.getByRole( 'button', {
-				name: 'Open dropdown',
-			} );
-
-			await click( trigger );
-
-			// Focuses menu on mouse click, focuses first item on keyboard press
-			// Can be changed with a custom useEffect
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
-
-			// Pressing esc will close the menu and move focus to the toggle
-			await press.Escape();
-
-			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
-		} );
-
 		it( 'should close when clicking outside of the content', async () => {
 			render(
 				<DropdownMenu

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -72,7 +72,7 @@ export interface DropdownMenuProps {
 	 * Determines whether the menu popover will be hidden when the user presses
 	 * the Escape key.
 	 *
-	 * @default true
+	 * @default `( event ) => { event.preventDefault(); return true; }`
 	 */
 	hideOnEscape?:
 		| boolean


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR changes the default behaviour of the new experimental `DropdownMenu` component so that the keyboard event related to pressing the `Escape` key is default prevented.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As pointed out in https://github.com/WordPress/gutenberg/pull/55625#issuecomment-1786703818, pressing the `Escape` key to close the dropdown menu can have unintended consequences (like, for example, causing a browser on MacOs to exit full screen mode).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Instead of using a boolean for the `hideOnEscape` prop, we can use a callback function that accepts the `event` object. We can then call `preventDefault()` on it.

Also, note that this PR only changes the default behaviour of the component. Folks wishing to have the keyboard event bubbling up can simply pass a different value for the prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Make sure that, when pressing the Escape key, the dropdown menu still closes correctly
2. Make sure that pressing the event associated to the Escape key pressed when closing the dropdown menu is default prevented:
    - With changes from this PR downloaded on a local machine, run `npm run storybook:dev`
    - Visit the dropdown menu v2 storybook example, and open the example in a new window (ie. [likely this URL](http://localhost:50240/iframe.html?id=components-experimental-dropdownmenu-v2-ariakit--default&viewMode=story))
    - Open the browser dev tools, and in the console type `document.addEventListener('keydown', (e) => console.log(e.key, e.defaultPrevented))`
    - Interact with the dropdown menu. When pressing the Escape key with an open menu, the console output should be `Escape true`. When pressing the escape key when the menu is closed, the console output should be `Escape false`.
3. As an optional test, load the Menu's storybook example on MacOS safari and make the Safari window full screen. Pressing the Escape key while the menu is open should not cause Safari to exit full screen.

