### PR TITLE
DropdownMenuV2: use the `Icon` component to render radio checks

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `Tabs`: Add `focusable` prop to the `Tabs.TabPanel` sub-component ([#55287](https://github.com/WordPress/gutenberg/pull/55287))
 -   `Tabs`: Update sub-components to accept relevant HTML element props ([#55860](https://github.com/WordPress/gutenberg/pull/55860))
+-   `DropdownMenuV2`: Fix radio menu item check icon not rendering correctly in some browsers ([#55964](https://github.com/WordPress/gutenberg/pull/55964))
 
 ### Enhancements
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -99,6 +99,12 @@ export const DropdownMenuCheckboxItem = forwardRef<
 	);
 } );
 
+const radioCheck = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Circle cx={ 12 } cy={ 12 } r={ 3 }></Circle>
+	</SVG>
+);
+
 export const DropdownMenuRadioItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< DropdownMenuRadioItemProps, 'div', false >
@@ -119,14 +125,7 @@ export const DropdownMenuRadioItem = forwardRef<
 				store={ dropdownMenuContext?.store }
 				render={ <Styled.ItemPrefixWrapper /> }
 			>
-				<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-					<Circle
-						cx={ 12 }
-						cy={ 12 }
-						r={ 3 }
-						fill="currentColor"
-					></Circle>
-				</SVG>
+				<Icon icon={ radioCheck } size={ 24 } />
 			</Ariakit.MenuItemCheck>
 			{ children }
 			{ suffix }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the way the experimental version of `DropdownMenu` renders the radio check icon

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the icon is not displayed correctly across all browsers (including MacOS Safari)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By refactoring the code to use the `Icon` component to display the icon:
- it ensures a more coherent approach within `DropdownMenu`, since the `Icon` component is used internally to render the checkbox item's check
- this also fixes the bug, since the `Icon` component sets an explicit size for the underlying SVG element

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open Safari on MacOs
- Load the ["With Radios"](https://wordpress.github.io/gutenberg/?path=/story/components-experimental-dropdownmenu-v2-ariakit--with-radios) Storybook example on Safari
- Verify that, on `trunk`, the radio icon doesn't show
- Apply changes from this PR, and verify that the icon shows correctly

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| ![Screenshot 2023-11-08 at 12 14 56](https://github.com/WordPress/gutenberg/assets/1083581/17fa150c-7907-4535-a079-b8169a58808c) | ![Screenshot 2023-11-08 at 12 15 02](https://github.com/WordPress/gutenberg/assets/1083581/2cc33eb0-e89e-49bf-944b-5d5471698ce2) |
