### PR TITLE
Template Part: Add fallback to the current theme when not provided

### DIFF
--- a/packages/block-library/src/navigation/use-template-part-area-label.js
+++ b/packages/block-library/src/navigation/use-template-part-area-label.js
@@ -45,14 +45,16 @@ export default function useTemplatePartAreaLabel( clientId ) {
 					'core/editor'
 				).__experimentalGetDefaultTemplatePartAreas();
 			/* eslint-enable @wordpress/data-no-store-string-literals */
-			const { getEditedEntityRecord } = select( coreStore );
+			const { getCurrentTheme, getEditedEntityRecord } =
+				select( coreStore );
 
 			for ( const templatePartClientId of parentTemplatePartClientIds ) {
 				const templatePartBlock = getBlock( templatePartClientId );
 
 				// The 'area' usually isn't stored on the block, but instead
 				// on the entity.
-				const { theme, slug } = templatePartBlock.attributes;
+				const { theme = getCurrentTheme()?.stylesheet, slug } =
+					templatePartBlock.attributes;
 				const templatePartEntityId = createTemplatePartId(
 					theme,
 					slug

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -20,7 +20,8 @@ const PatternEdit = ( { attributes, clientId } ) => {
 	);
 
 	const currentThemeStylesheet = useSelect(
-		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet
+		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
+		[]
 	);
 
 	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -35,7 +35,11 @@ export default function TemplatePartEdit( {
 	setAttributes,
 	clientId,
 } ) {
-	const { slug, theme, tagName, layout = {} } = attributes;
+	const currentTheme = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
+		[]
+	);
+	const { slug, theme = currentTheme, tagName, layout = {} } = attributes;
 	const templatePartId = createTemplatePartId( theme, slug );
 	const hasAlreadyRendered = useHasRecursion( templatePartId );
 	const [ isTemplatePartSelectionOpen, setIsTemplatePartSelectionOpen ] =

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -32,10 +32,11 @@ export const settings = {
 			return;
 		}
 
-		const entity = select( coreDataStore ).getEntityRecord(
+		const { getCurrentTheme, getEntityRecord } = select( coreDataStore );
+		const entity = getEntityRecord(
 			'postType',
 			'wp_template_part',
-			theme + '//' + slug
+			( theme || getCurrentTheme()?.stylesheet ) + '//' + slug
 		);
 		if ( ! entity ) {
 			return;

--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -35,10 +35,12 @@ export function enhanceTemplatePartVariations( settings, name ) {
 			// Find a matching variation from the created template part
 			// by checking the entity's `area` property.
 			if ( ! slug ) return false;
-			const entity = select( coreDataStore ).getEntityRecord(
+			const { getCurrentTheme, getEntityRecord } =
+				select( coreDataStore );
+			const entity = getEntityRecord(
 				'postType',
 				'wp_template_part',
-				`${ theme }//${ slug }`
+				`${ theme || getCurrentTheme()?.stylesheet }//${ slug }`
 			);
 
 			if ( entity?.slug ) {

--- a/packages/edit-site/src/hooks/template-part-edit.js
+++ b/packages/edit-site/src/hooks/template-part-edit.js
@@ -24,11 +24,13 @@ function EditTemplatePartMenuItem( { attributes } ) {
 	const { params } = useLocation();
 	const templatePart = useSelect(
 		( select ) => {
-			return select( coreStore ).getEntityRecord(
+			const { getCurrentTheme, getEntityRecord } = select( coreStore );
+
+			return getEntityRecord(
 				'postType',
 				TEMPLATE_PART_POST_TYPE,
 				// Ideally this should be an official public API.
-				`${ theme }//${ slug }`
+				`${ theme || getCurrentTheme()?.stylesheet }//${ slug }`
 			);
 		},
 		[ theme, slug ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to https://github.com/WordPress/gutenberg/pull/55217 and https://github.com/WordPress/wordpress-develop/pull/5455.
Similar to https://github.com/WordPress/gutenberg/pull/53423, https://github.com/WordPress/gutenberg/pull/55858.

I'm looking at adding the fallback for the current theme in places where template parts are loaded from the server without preprocessing through `_inject_theme_attribute_in_template_part_block` to work correctly in all cases in the editor. It's an alternative to https://core.trac.wordpress.org/ticket/59583 where we were trying to inject the default theme attribute into the template part blocks serialized in HTML stored for templates and patterns.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I'm seeking ways to the whole logic to the client to bring back the performance improvements we measured for the homepage in the Twenty Twenty-Four theme during the WordPress 6.4 release cycle. It was an accidental discovery caused by the regression introduced in https://core.trac.wordpress.org/changeset/56805 where `_inject_theme_attribute_in_template_part_block` was conditionally removed from processing in block patterns.

If the approach seems reasonable and also solid enough, we might give it another try to remove (this time purposefully) the same processing on the server slightly improving the performance in certain scenarios. /cc @felixarntz 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The default theme gets always provided as a fallback with the core data store by calling: `getCurrentTheme()?.stylesheet`. This way, that information doesn't need to come from the server with the REST API response containing HTML for templates and patterns.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

To test the changes I applied the following patch to WordPress Core when using https://github.com/WordPress/wordpress-develop:

```diff
diff --git a/src/wp-includes/block-template-utils.php b/src/wp-includes/block-template-utils.php
index a4e54432d2..d6a381a9e2 100644
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -547,7 +547,7 @@ function _build_block_template_result_from_file( $template_file, $template_type
 		$template->area = $template_file['area'];
 	}
 
-	$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
+	$before_block_visitor = null;
 	$after_block_visitor  = null;
 	$hooked_blocks        = get_hooked_blocks();
 	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
diff --git a/src/wp-includes/blocks.php b/src/wp-includes/blocks.php
index 1dc1e66230..a043ffe116 100644
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -788,8 +788,6 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks prepended to it.
 	 */
 	return function ( &$block, &$parent_block = null, $prev = null ) use ( $hooked_blocks, $context ) {
-		_inject_theme_attribute_in_template_part_block( $block );
-
 		$markup = '';
 
 		if ( $parent_block && ! $prev ) {
diff --git a/src/wp-includes/class-wp-block-patterns-registry.php b/src/wp-includes/class-wp-block-patterns-registry.php
index a11bac06be..8eb1611f23 100644
--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -165,7 +165,7 @@ final class WP_Block_Patterns_Registry {
 	private function prepare_content( $pattern, $hooked_blocks ) {
 		$content = $pattern['content'];
 
-		$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
+		$before_block_visitor = null;
 		$after_block_visitor  = null;
 		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $pattern );
```

It might also be as simple as removing the body of `_inject_theme_attribute_in_template_part_block` to ensure it doesn't apply the modifications to template parts serialized in HTML.

With that in place:

1. Navigate to the website with the Twenty Twenty-Four theme active. Bonus points for testing with other themes that have Template Parts blocks included in templates and patterns without the theme attribute defined.
2. I ensured that all template parts load correctly on the front end for the homepage, single page, archive page, etc.
3. I ensured that all templates and template parts load correctly in the site editor.
4. I also made sure that there were no errors logged on the Browsers Console.