### PR TITLE
Share the editor settings between the post and site editors

### DIFF
--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -120,12 +120,11 @@ _Returns_
 
 ### getSettings
 
-Returns the settings, taking into account active features and permissions.
+Returns the site editor settings.
 
 _Parameters_
 
 -   _state_ `Object`: Global application state.
--   _setIsInserterOpen_ `Function`: Setter for the open state of the global inserter.
 
 _Returns_
 

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -105,7 +105,7 @@ export default function useSiteEditorSettings() {
 			__unstableGetPreference,
 			getCanvasMode,
 			getSettings,
-		} = select( editSiteStore );
+		} = unlock( select( editSiteStore ) );
 		const { getEditedEntityRecord } = select( coreStore );
 		const usedPostType = getEditedPostType();
 		const usedPostId = getEditedPostId();

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -104,8 +104,8 @@ export default function useSiteEditorSettings() {
 			getEditedPostId,
 			__unstableGetPreference,
 			getCanvasMode,
-			getSettingsFromServer,
-		} = unlock( select( editSiteStore ) );
+			getSettings,
+		} = select( editSiteStore );
 		const { getEditedEntityRecord } = select( coreStore );
 		const usedPostType = getEditedPostType();
 		const usedPostId = getEditedPostId();
@@ -123,7 +123,7 @@ export default function useSiteEditorSettings() {
 				'keepCaretInsideBlock'
 			),
 			canvasMode: getCanvasMode(),
-			settings: getSettingsFromServer(),
+			settings: getSettings(),
 			postType: usedPostType,
 			postId: usedPostId,
 		};

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -4,12 +4,15 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+
 /**
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import inserterMediaCategories from './inserter-media-categories';
+
+const { useBlockEditorSettings } = unlock( editorPrivateApis );
 
 function useArchiveLabel( templateSlug ) {
 	const taxonomyMatches = templateSlug?.match(
@@ -85,40 +88,25 @@ function useArchiveLabel( templateSlug ) {
 
 export default function useSiteEditorSettings() {
 	const { setIsInserterOpened } = useDispatch( editSiteStore );
-	const { storedSettings, canvasMode, templateType, siteSettings } =
-		useSelect(
-			( select ) => {
-				const { canUser, getEntityRecord } = select( coreStore );
-				const { getSettings, getCanvasMode, getEditedPostType } =
-					unlock( select( editSiteStore ) );
-				return {
-					storedSettings: getSettings( setIsInserterOpened ),
-					canvasMode: getCanvasMode(),
-					templateType: getEditedPostType(),
-					siteSettings: canUser( 'read', 'settings' )
-						? getEntityRecord( 'root', 'site' )
-						: undefined,
-				};
-			},
-			[ setIsInserterOpened ]
-		);
-
-	const settingsBlockPatterns =
-		storedSettings.__experimentalAdditionalBlockPatterns ?? // WP 6.0
-		storedSettings.__experimentalBlockPatterns; // WP 5.9
-	const settingsBlockPatternCategories =
-		storedSettings.__experimentalAdditionalBlockPatternCategories ?? // WP 6.0
-		storedSettings.__experimentalBlockPatternCategories; // WP 5.9
-
 	const {
-		restBlockPatterns,
-		restBlockPatternCategories,
 		templateSlug,
-		userPatternCategories,
+		focusMode,
+		isDistractionFree,
+		hasFixedToolbar,
+		keepCaretInsideBlock,
+		canvasMode,
+		settings,
+		postType,
+		postId,
 	} = useSelect( ( select ) => {
-		const { getEditedPostType, getEditedPostId } = select( editSiteStore );
-		const { getEditedEntityRecord, getUserPatternCategories } =
-			select( coreStore );
+		const {
+			getEditedPostType,
+			getEditedPostId,
+			__unstableGetPreference,
+			getCanvasMode,
+			getSettingsFromServer,
+		} = unlock( select( editSiteStore ) );
+		const { getEditedEntityRecord } = select( coreStore );
 		const usedPostType = getEditedPostType();
 		const usedPostId = getEditedPostId();
 		const _record = getEditedEntityRecord(
@@ -127,75 +115,46 @@ export default function useSiteEditorSettings() {
 			usedPostId
 		);
 		return {
-			restBlockPatterns: select( coreStore ).getBlockPatterns(),
-			restBlockPatternCategories:
-				select( coreStore ).getBlockPatternCategories(),
 			templateSlug: _record.slug,
-			userPatternCategories: getUserPatternCategories(),
+			focusMode: !! __unstableGetPreference( 'focusMode' ),
+			isDistractionFree: !! __unstableGetPreference( 'distractionFree' ),
+			hasFixedToolbar: !! __unstableGetPreference( 'fixedToolbar' ),
+			keepCaretInsideBlock: !! __unstableGetPreference(
+				'keepCaretInsideBlock'
+			),
+			canvasMode: getCanvasMode(),
+			settings: getSettingsFromServer(),
+			postType: usedPostType,
+			postId: usedPostId,
 		};
 	}, [] );
 	const archiveLabels = useArchiveLabel( templateSlug );
 
-	const blockPatterns = useMemo(
-		() =>
-			[
-				...( settingsBlockPatterns || [] ),
-				...( restBlockPatterns || [] ),
-			]
-				.filter(
-					( x, index, arr ) =>
-						index === arr.findIndex( ( y ) => x.name === y.name )
-				)
-				.filter( ( { postTypes } ) => {
-					return (
-						! postTypes ||
-						( Array.isArray( postTypes ) &&
-							postTypes.includes( templateType ) )
-					);
-				} ),
-		[ settingsBlockPatterns, restBlockPatterns, templateType ]
-	);
-
-	const blockPatternCategories = useMemo(
-		() =>
-			[
-				...( settingsBlockPatternCategories || [] ),
-				...( restBlockPatternCategories || [] ),
-			].filter(
-				( x, index, arr ) =>
-					index === arr.findIndex( ( y ) => x.name === y.name )
-			),
-		[ settingsBlockPatternCategories, restBlockPatternCategories ]
-	);
-	return useMemo( () => {
-		const {
-			__experimentalAdditionalBlockPatterns,
-			__experimentalAdditionalBlockPatternCategories,
-			focusMode,
-			...restStoredSettings
-		} = storedSettings;
-
+	const defaultEditorSettings = useMemo( () => {
 		return {
-			...restStoredSettings,
-			inserterMediaCategories,
-			__experimentalBlockPatterns: blockPatterns,
-			__experimentalBlockPatternCategories: blockPatternCategories,
-			__experimentalUserPatternCategories: userPatternCategories,
+			...settings,
+
+			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
+			isDistractionFree,
+			hasFixedToolbar,
+			keepCaretInsideBlock,
+
+			// I wonder if they should be set in the post editor too
 			__experimentalArchiveTitleTypeLabel: archiveLabels.archiveTypeLabel,
 			__experimentalArchiveTitleNameLabel: archiveLabels.archiveNameLabel,
-			pageOnFront: siteSettings?.page_on_front,
-			pageForPosts: siteSettings?.page_for_posts,
 		};
 	}, [
-		storedSettings,
-		blockPatterns,
-		blockPatternCategories,
-		userPatternCategories,
+		settings,
+		setIsInserterOpened,
+		focusMode,
+		isDistractionFree,
+		hasFixedToolbar,
+		keepCaretInsideBlock,
 		canvasMode,
 		archiveLabels.archiveTypeLabel,
 		archiveLabels.archiveNameLabel,
-		siteSettings?.page_on_front,
-		siteSettings?.page_for_posts,
 	] );
+
+	return useBlockEditorSettings( defaultEditorSettings, postType, postId );
 }

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -102,10 +103,10 @@ export default function useSiteEditorSettings() {
 		const {
 			getEditedPostType,
 			getEditedPostId,
-			__unstableGetPreference,
 			getCanvasMode,
 			getSettings,
 		} = unlock( select( editSiteStore ) );
+		const { get: getPreference } = select( preferencesStore );
 		const { getEditedEntityRecord } = select( coreStore );
 		const usedPostType = getEditedPostType();
 		const usedPostId = getEditedPostId();
@@ -116,10 +117,17 @@ export default function useSiteEditorSettings() {
 		);
 		return {
 			templateSlug: _record.slug,
-			focusMode: !! __unstableGetPreference( 'focusMode' ),
-			isDistractionFree: !! __unstableGetPreference( 'distractionFree' ),
-			hasFixedToolbar: !! __unstableGetPreference( 'fixedToolbar' ),
-			keepCaretInsideBlock: !! __unstableGetPreference(
+			focusMode: !! getPreference( 'core/edit-site', 'focusMode' ),
+			isDistractionFree: !! getPreference(
+				'core/edit-site',
+				'distractionFree'
+			),
+			hasFixedToolbar: !! getPreference(
+				'core/edit-site',
+				'fixedToolbar'
+			),
+			keepCaretInsideBlock: !! getPreference(
+				'core/edit-site',
 				'keepCaretInsideBlock'
 			),
 			canvasMode: getCanvasMode(),

--- a/packages/edit-site/src/components/global-styles-renderer/index.js
+++ b/packages/edit-site/src/components/global-styles-renderer/index.js
@@ -32,7 +32,7 @@ function useGlobalStylesRenderer() {
 			styles: [ ...nonGlobalStyles, ...styles ],
 			__experimentalFeatures: settings,
 		} );
-	}, [ styles, settings ] );
+	}, [ styles, settings, updateSettings, getSettings ] );
 }
 
 export function GlobalStylesRenderer() {

--- a/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
@@ -24,7 +24,10 @@ export default function DefaultSidebar( {
 	panelClassName,
 } ) {
 	const showIconLabels = useSelect(
-		( select ) => select( editSiteStore ).getSettings().showIconLabels,
+		( select ) =>
+			!! select( editSiteStore ).__unstableGetPreference(
+				'showIconLabels'
+			),
 		[]
 	);
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/default-sidebar.js
@@ -6,11 +6,7 @@ import {
 	ComplementaryAreaMoreMenuItem,
 } from '@wordpress/interface';
 import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { store as editSiteStore } from '../../store';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 export default function DefaultSidebar( {
 	className,
@@ -25,7 +21,8 @@ export default function DefaultSidebar( {
 } ) {
 	const showIconLabels = useSelect(
 		( select ) =>
-			!! select( editSiteStore ).__unstableGetPreference(
+			!! select( preferencesStore ).get(
+				'core/edit-site',
 				'showIconLabels'
 			),
 		[]

--- a/packages/edit-site/src/components/sidebar-edit-mode/plugin-sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/plugin-sidebar/index.js
@@ -3,11 +3,7 @@
  */
 import { ComplementaryArea } from '@wordpress/interface';
 import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { store as editSiteStore } from '../../../store';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Renders a sidebar when activated. The contents within the `PluginSidebar` will appear as content within the sidebar.
@@ -77,7 +73,8 @@ import { store as editSiteStore } from '../../../store';
 export default function PluginSidebarEditSite( { className, ...props } ) {
 	const showIconLabels = useSelect(
 		( select ) =>
-			!! select( editSiteStore ).__unstableGetPreference(
+			!! select( preferencesStore ).get(
+				'core/edit-site',
 				'showIconLabels'
 			),
 		[]

--- a/packages/edit-site/src/components/sidebar-edit-mode/plugin-sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/plugin-sidebar/index.js
@@ -76,7 +76,10 @@ import { store as editSiteStore } from '../../../store';
  */
 export default function PluginSidebarEditSite( { className, ...props } ) {
 	const showIconLabels = useSelect(
-		( select ) => select( editSiteStore ).getSettings().showIconLabels,
+		( select ) =>
+			!! select( editSiteStore ).__unstableGetPreference(
+				'showIconLabels'
+			),
 		[]
 	);
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -63,7 +63,7 @@ function SidebarNavigationScreenGlobalStylesContent() {
 		const { getSettings } = unlock( select( editSiteStore ) );
 
 		return {
-			storedSettings: getSettings( false ),
+			storedSettings: getSettings(),
 		};
 	}, [] );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/navigation-menu-editor.js
@@ -20,7 +20,7 @@ export default function NavigationMenuEditor( { navigationMenuId } ) {
 		const { getSettings } = unlock( select( editSiteStore ) );
 
 		return {
-			storedSettings: getSettings( false ),
+			storedSettings: getSettings(),
 		};
 	}, [] );
 

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -10,10 +10,6 @@ import {
 import { dispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { createRoot } from '@wordpress/element';
-import {
-	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
-	__experimentalFetchUrlData as fetchUrlData,
-} from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -38,12 +34,6 @@ import App from './components/app';
 export function initializeEditor( id, settings ) {
 	const target = document.getElementById( id );
 	const root = createRoot( target );
-
-	// This might not be needed anymore.
-	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>
-		fetchLinkSuggestions( search, searchOptions, settings );
-	// This might not be needed anymore.
-	settings.__experimentalFetchRichUrlData = fetchUrlData;
 
 	dispatch( blocksStore ).reapplyBlockTypeFilters();
 	const coreBlocks = __experimentalGetCoreBlocks().filter(

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -39,8 +39,10 @@ export function initializeEditor( id, settings ) {
 	const target = document.getElementById( id );
 	const root = createRoot( target );
 
+	// This might not be needed anymore.
 	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>
 		fetchLinkSuggestions( search, searchOptions, settings );
+	// This might not be needed anymore.
 	settings.__experimentalFetchRichUrlData = fetchUrlData;
 
 	dispatch( blocksStore ).reapplyBlockTypeFilters();

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -31,11 +31,14 @@ import {
  */
 export function toggleFeature( featureName ) {
 	return function ( { registry } ) {
-		deprecated( "select( 'core/edit-site' ).toggleFeature( featureName )", {
-			since: '6.0',
-			alternative:
-				"select( 'core/preferences').toggle( 'core/edit-site', featureName )",
-		} );
+		deprecated(
+			"dispatch( 'core/edit-site' ).toggleFeature( featureName )",
+			{
+				since: '6.0',
+				alternative:
+					"dispatch( 'core/preferences').toggle( 'core/edit-site', featureName )",
+			}
+		);
 
 		registry
 			.dispatch( preferencesStore )

--- a/packages/edit-site/src/store/private-selectors.js
+++ b/packages/edit-site/src/store/private-selectors.js
@@ -41,7 +41,3 @@ export function getEditorCanvasContainerView( state ) {
 export function getPageContentFocusType( state ) {
 	return hasPageContentFocus( state ) ? state.pageContentFocusType : null;
 }
-
-export function getSettingsFromServer( state ) {
-	return state.settings;
-}

--- a/packages/edit-site/src/store/private-selectors.js
+++ b/packages/edit-site/src/store/private-selectors.js
@@ -41,3 +41,7 @@ export function getEditorCanvasContainerView( state ) {
 export function getPageContentFocusType( state ) {
 	return hasPageContentFocus( state ) ? state.pageContentFocusType : null;
 }
+
+export function getSettingsFromServer( state ) {
+	return state.settings;
+}

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -33,7 +33,10 @@ export const isFeatureActive = createRegistrySelector(
 			alternative: `select( 'core/preferences' ).get`,
 		} );
 
-		return select( preferencesStore ).get( 'core/edit-site', featureName );
+		return !! select( preferencesStore ).get(
+			'core/edit-site',
+			featureName
+		);
 	}
 );
 
@@ -67,6 +70,13 @@ export const getCanUserCreateMedia = createRegistrySelector(
  * @return {Array} The available reusable blocks.
  */
 export const getReusableBlocks = createRegistrySelector( ( select ) => () => {
+	deprecated(
+		"select( 'core/core' ).getEntityRecords( 'postType', 'wp_block' )",
+		{
+			since: '6.5',
+			version: '6.8',
+		}
+	);
 	const isWeb = Platform.OS === 'web';
 	return isWeb
 		? select( coreDataStore ).getEntityRecords( 'postType', 'wp_block', {

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -1,15 +1,9 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
 import { store as coreDataStore } from '@wordpress/core-data';
 import { createRegistrySelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
-import { uploadMedia } from '@wordpress/media-utils';
 import { Platform } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -18,10 +12,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { getFilteredTemplatePartBlocks } from './utils';
-import {
-	TEMPLATE_POST_TYPE,
-	TEMPLATE_PART_POST_TYPE,
-} from '../utils/constants';
+import { TEMPLATE_PART_POST_TYPE } from '../utils/constants';
 /**
  * @typedef {'template'|'template_type'} TemplateType Template type.
  */
@@ -97,67 +88,16 @@ export const getReusableBlocks = createRegistrySelector( ( select ) => () => {
 } );
 
 /**
- * Returns the settings, taking into account active features and permissions.
+ * Returns the site editor settings.
  *
- * @param {Object}   state             Global application state.
- * @param {Function} setIsInserterOpen Setter for the open state of the global inserter.
+ * @param {Object} state Global application state.
  *
  * @return {Object} Settings.
  */
-export const getSettings = createSelector(
-	( state, setIsInserterOpen ) => {
-		const settings = {
-			...state.settings,
-			outlineMode: true,
-			focusMode: !! __unstableGetPreference( state, 'focusMode' ),
-			isDistractionFree: !! __unstableGetPreference(
-				state,
-				'distractionFree'
-			),
-			hasFixedToolbar: !! __unstableGetPreference(
-				state,
-				'fixedToolbar'
-			),
-			keepCaretInsideBlock: !! __unstableGetPreference(
-				state,
-				'keepCaretInsideBlock'
-			),
-			showIconLabels: !! __unstableGetPreference(
-				state,
-				'showIconLabels'
-			),
-			__experimentalSetIsInserterOpened: setIsInserterOpen,
-			__experimentalReusableBlocks: getReusableBlocks( state ),
-			__experimentalPreferPatternsOnRoot:
-				TEMPLATE_POST_TYPE === getEditedPostType( state ),
-		};
-
-		const canUserCreateMedia = getCanUserCreateMedia( state );
-		if ( ! canUserCreateMedia ) {
-			return settings;
-		}
-
-		settings.mediaUpload = ( { onError, ...rest } ) => {
-			uploadMedia( {
-				wpAllowedMimeTypes: state.settings.allowedMimeTypes,
-				onError: ( { message } ) => onError( message ),
-				...rest,
-			} );
-		};
-		return settings;
-	},
-	( state ) => [
-		getCanUserCreateMedia( state ),
-		state.settings,
-		__unstableGetPreference( state, 'focusMode' ),
-		__unstableGetPreference( state, 'distractionFree' ),
-		__unstableGetPreference( state, 'fixedToolbar' ),
-		__unstableGetPreference( state, 'keepCaretInsideBlock' ),
-		__unstableGetPreference( state, 'showIconLabels' ),
-		getReusableBlocks( state ),
-		getEditedPostType( state ),
-	]
-);
+export function getSettings( state ) {
+	// It is important that we don't inject anything into these settings locally.
+	return state.settings;
+}
 
 /**
  * @deprecated

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -94,6 +94,8 @@ export const getReusableBlocks = createRegistrySelector( ( select ) => () => {
  */
 export function getSettings( state ) {
 	// It is important that we don't inject anything into these settings locally.
+	// The reason for this is that we have an effect in place that calls setSettings based on the previous value of getSettings.
+	// If we add computed settings here, we'll be adding these computed settings to the state which is very unexpected.
 	return state.settings;
 }
 

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -18,20 +18,6 @@ import { TEMPLATE_PART_POST_TYPE } from '../utils/constants';
  */
 
 /**
- * Helper for getting a preference from the preferences store.
- *
- * This is only present so that `getSettings` doesn't need to be made a
- * registry selector.
- *
- * It's unstable because the selector needs to be exported and so part of the
- * public API to work.
- */
-export const __unstableGetPreference = createRegistrySelector(
-	( select ) => ( state, name ) =>
-		select( preferencesStore ).get( 'core/edit-site', name )
-);
-
-/**
  * Returns whether the given feature is enabled or not.
  *
  * @deprecated
@@ -40,14 +26,16 @@ export const __unstableGetPreference = createRegistrySelector(
  *
  * @return {boolean} Is active.
  */
-export function isFeatureActive( state, featureName ) {
-	deprecated( `select( 'core/edit-site' ).isFeatureActive`, {
-		since: '6.0',
-		alternative: `select( 'core/preferences' ).get`,
-	} );
+export const isFeatureActive = createRegistrySelector(
+	( select ) => ( _, featureName ) => {
+		deprecated( `select( 'core/edit-site' ).isFeatureActive`, {
+			since: '6.0',
+			alternative: `select( 'core/preferences' ).get`,
+		} );
 
-	return !! __unstableGetPreference( state, featureName );
-}
+		return select( preferencesStore ).get( 'core/edit-site', featureName );
+	}
+);
 
 /**
  * Returns the current editing canvas device type.
@@ -257,9 +245,9 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
  *
  * @return {string} Editing mode.
  */
-export function getEditorMode( state ) {
-	return __unstableGetPreference( state, 'editorMode' );
-}
+export const getEditorMode = createRegistrySelector( ( select ) => () => {
+	return select( preferencesStore ).get( 'core/edit-site', 'editorMode' );
+} );
 
 /**
  * @deprecated

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -47,21 +47,27 @@ describe( 'actions', () => {
 		it( 'should toggle a feature flag', () => {
 			const registry = createRegistryWithStores();
 
-			// Should default to false.
+			// Should start as undefined.
 			expect(
-				registry.select( editSiteStore ).isFeatureActive( 'name' )
-			).toBe( false );
+				registry
+					.select( preferencesStore )
+					.get( 'core/edit-site', 'name' )
+			).toBe( undefined );
 
 			// Toggle on.
 			registry.dispatch( editSiteStore ).toggleFeature( 'name' );
 			expect(
-				registry.select( editSiteStore ).isFeatureActive( 'name' )
+				registry
+					.select( preferencesStore )
+					.get( 'core/edit-site', 'name' )
 			).toBe( true );
 
 			// Toggle off again.
 			registry.dispatch( editSiteStore ).toggleFeature( 'name' );
 			expect(
-				registry.select( editSiteStore ).isFeatureActive( 'name' )
+				registry
+					.select( preferencesStore )
+					.get( 'core/edit-site', 'name' )
 			).toBe( false );
 
 			// Expect a deprecation warning.

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -10,7 +10,6 @@ import {
 	getCanUserCreateMedia,
 	getEditedPostType,
 	getEditedPostId,
-	getReusableBlocks,
 	isInserterOpened,
 	isListViewOpened,
 	isPage,
@@ -19,12 +18,8 @@ import {
 
 describe( 'selectors', () => {
 	const canUser = jest.fn( () => true );
-	const getEntityRecords = jest.fn( () => [] );
 	getCanUserCreateMedia.registry = {
 		select: jest.fn( () => ( { canUser } ) ),
-	};
-	getReusableBlocks.registry = {
-		select: jest.fn( () => ( { getEntityRecords } ) ),
 	};
 
 	describe( 'getCanUserCreateMedia', () => {
@@ -34,22 +29,6 @@ describe( 'selectors', () => {
 				getCanUserCreateMedia.registry.select
 			).toHaveBeenCalledWith( coreDataStore );
 			expect( canUser ).toHaveBeenCalledWith( 'create', 'media' );
-		} );
-	} );
-
-	describe( 'getReusableBlocks', () => {
-		it( "selects `getEntityRecords( 'postType', 'wp_block' )` from the core store", () => {
-			expect( getReusableBlocks() ).toEqual( [] );
-			expect( getReusableBlocks.registry.select ).toHaveBeenCalledWith(
-				coreDataStore
-			);
-			expect( getEntityRecords ).toHaveBeenCalledWith(
-				'postType',
-				'wp_block',
-				{
-					per_page: -1,
-				}
-			);
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -8,7 +8,6 @@ import { store as coreDataStore } from '@wordpress/core-data';
  */
 import {
 	getCanUserCreateMedia,
-	getSettings,
 	getEditedPostType,
 	getEditedPostId,
 	getReusableBlocks,
@@ -56,61 +55,6 @@ describe( 'selectors', () => {
 					per_page: -1,
 				}
 			);
-		} );
-	} );
-
-	describe( 'getSettings', () => {
-		it( "returns the settings when the user can't create media", () => {
-			canUser.mockReturnValueOnce( false );
-			canUser.mockReturnValueOnce( false );
-			get.mockImplementation( ( scope, name ) => {
-				if ( name === 'focusMode' ) return false;
-				if ( name === 'fixedToolbar' ) return false;
-			} );
-			const state = {
-				settings: {},
-				preferences: {},
-				editedPost: { postType: 'wp_template' },
-			};
-			const setInserterOpened = () => {};
-			expect( getSettings( state, setInserterOpened ) ).toEqual( {
-				outlineMode: true,
-				focusMode: false,
-				hasFixedToolbar: false,
-				isDistractionFree: false,
-				keepCaretInsideBlock: false,
-				showIconLabels: false,
-				__experimentalSetIsInserterOpened: setInserterOpened,
-				__experimentalReusableBlocks: [],
-				__experimentalPreferPatternsOnRoot: true,
-			} );
-		} );
-
-		it( 'returns the extended settings when the user can create media', () => {
-			get.mockImplementation( ( scope, name ) => {
-				if ( name === 'focusMode' ) return true;
-				if ( name === 'fixedToolbar' ) return true;
-			} );
-
-			const state = {
-				settings: { key: 'value' },
-				editedPost: { postType: 'wp_template_part' },
-			};
-			const setInserterOpened = () => {};
-
-			expect( getSettings( state, setInserterOpened ) ).toEqual( {
-				outlineMode: true,
-				key: 'value',
-				focusMode: true,
-				hasFixedToolbar: true,
-				isDistractionFree: false,
-				keepCaretInsideBlock: false,
-				showIconLabels: false,
-				__experimentalSetIsInserterOpened: setInserterOpened,
-				__experimentalReusableBlocks: [],
-				mediaUpload: expect.any( Function ),
-				__experimentalPreferPatternsOnRoot: false,
-			} );
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -13,7 +13,6 @@ import {
 	getReusableBlocks,
 	isInserterOpened,
 	isListViewOpened,
-	__unstableGetPreference,
 	isPage,
 	hasPageContentFocus,
 } from '../selectors';
@@ -21,15 +20,11 @@ import {
 describe( 'selectors', () => {
 	const canUser = jest.fn( () => true );
 	const getEntityRecords = jest.fn( () => [] );
-	const get = jest.fn();
 	getCanUserCreateMedia.registry = {
 		select: jest.fn( () => ( { canUser } ) ),
 	};
 	getReusableBlocks.registry = {
 		select: jest.fn( () => ( { getEntityRecords } ) ),
-	};
-	__unstableGetPreference.registry = {
-		select: jest.fn( () => ( { get } ) ),
 	};
 
 	describe( 'getCanUserCreateMedia', () => {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -40,21 +40,14 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			}
 			return { postId: post.id, postType: post.type };
 		}, [ post.id, post.type ] );
-		const { editorSettings, selection, isReady } = useSelect(
-			( select ) => {
-				const {
-					getEditorSettings,
-					getEditorSelection,
-					__unstableIsEditorReady,
-				} = select( editorStore );
-				return {
-					editorSettings: getEditorSettings(),
-					isReady: __unstableIsEditorReady(),
-					selection: getEditorSelection(),
-				};
-			},
-			[]
-		);
+		const { selection, isReady } = useSelect( ( select ) => {
+			const { getEditorSelection, __unstableIsEditorReady } =
+				select( editorStore );
+			return {
+				isReady: __unstableIsEditorReady(),
+				selection: getEditorSelection(),
+			};
+		}, [] );
 		const { id, type } = __unstableTemplate ?? post;
 		const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 			'postType',
@@ -62,8 +55,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			{ id }
 		);
 		const blockEditorSettings = useBlockEditorSettings(
-			editorSettings,
-			!! __unstableTemplate
+			settings,
+			type,
+			id
 		);
 		const {
 			updatePostLock,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -40,14 +40,21 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			}
 			return { postId: post.id, postType: post.type };
 		}, [ post.id, post.type ] );
-		const { selection, isReady } = useSelect( ( select ) => {
-			const { getEditorSelection, __unstableIsEditorReady } =
-				select( editorStore );
-			return {
-				isReady: __unstableIsEditorReady(),
-				selection: getEditorSelection(),
-			};
-		}, [] );
+		const { editorSettings, selection, isReady } = useSelect(
+			( select ) => {
+				const {
+					getEditorSettings,
+					getEditorSelection,
+					__unstableIsEditorReady,
+				} = select( editorStore );
+				return {
+					editorSettings: getEditorSettings(),
+					isReady: __unstableIsEditorReady(),
+					selection: getEditorSelection(),
+				};
+			},
+			[]
+		);
 		const { id, type } = __unstableTemplate ?? post;
 		const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 			'postType',
@@ -55,7 +62,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			{ id }
 		);
 		const blockEditorSettings = useBlockEditorSettings(
-			settings,
+			editorSettings,
 			type,
 			id
 		);

--- a/packages/editor/src/components/provider/use-block-editor-settings.native.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.native.js
@@ -13,8 +13,8 @@ import { store as editorStore } from '../../store';
 
 const EMPTY_BLOCKS_LIST = [];
 
-function useNativeBlockEditorSettings( settings, hasTemplate ) {
-	const editorSettings = useBlockEditorSettings( settings, hasTemplate );
+function useNativeBlockEditorSettings( settings, postType, postId ) {
+	const editorSettings = useBlockEditorSettings( settings, postType, postId );
 	const supportReusableBlock = settings.capabilities?.reusableBlock === true;
 
 	const { reusableBlocks, isTitleSelected } = useSelect(

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -4,9 +4,13 @@
 import { ExperimentalEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
 import { EntitiesSavedStatesExtensible } from './components/entities-saved-states';
+import useBlockEditorSettings from './components/provider/use-block-editor-settings';
 
 export const privateApis = {};
 lock( privateApis, {
 	ExperimentalEditorProvider,
 	EntitiesSavedStatesExtensible,
+
+	// This is a temporary private API while we're updating the site editor to use EditorProvider.
+	useBlockEditorSettings,
 } );


### PR DESCRIPTION
Related #52632

## What?

The post editor and the site editor both pass down settings from the server to the block editor, they also augment these settings with some wordpress specific settings like: mediaUpload, fetchLinkSuggestions, mediaCategories...

Overtime, we found ourselves with a lot of duplication between these two editors and also in the site editor we had three different ways of providing these settings:

 - Some of them are injected in the `index.js` file (like fetchLinkSuggestions)
 - Some of them are injected in the `getSettings` selector of the edit-site store
 - Some of them are injected in the `useSiteEditorSettings` hook.

So the goal of this PR is multiple:

 - Share the logic to provide the WP settings to the block editor between post and site editor. (The later goal here is to be able to use `EditorProvider` directly in the site editor in order to be able to reuse components form the editor package as well)
 - Clarify where settings are provider in the site editor: All of the site editor specific settings are injected in `useSiteEditorSettings`, the rest is just common between post and site editor.

**Note**

 - There's a lot of code that we can probably remove now, I'm going to try to do these removals in this PR as well and maybe some deprecations in case of impact on public APIs.

## Testing Instructions

Overall, this PR shouldn't have a big impact but it's important to test well. There are some very subtle but small changes that we may need to check, I'll try to add inline comments to the PR where I can.