### PR TITLE
Background Image Support: Hide the background image reset button when there's no image

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -241,10 +241,12 @@ function BackgroundImagePanelItem( props ) {
 		};
 	}, [] );
 
+	const hasValue = hasBackgroundImageValue( props );
+
 	return (
 		<ToolsPanelItem
 			className="single-column"
-			hasValue={ () => hasBackgroundImageValue( props ) }
+			hasValue={ () => hasValue }
 			label={ __( 'Background image' ) }
 			onDeselect={ () => resetBackgroundImage( props ) }
 			isShownByDefault={ true }
@@ -267,9 +269,13 @@ function BackgroundImagePanelItem( props ) {
 					}
 					variant="secondary"
 				>
-					<MenuItem onClick={ () => resetBackgroundImage( props ) }>
-						{ __( 'Reset ' ) }
-					</MenuItem>
+					{ hasValue && (
+						<MenuItem
+							onClick={ () => resetBackgroundImage( props ) }
+						>
+							{ __( 'Reset ' ) }
+						</MenuItem>
+					) }
 				</MediaReplaceFlow>
 				<DropZone
 					onFilesDrop={ onFilesDrop }


### PR DESCRIPTION
## What?
Fixes #55969

PR hides the "Reset" button for the background image block support panel when there's no image.

## Why?
See #55969

## Testing Instructions
1. Open a post or page.
2. Insert a Group.
3. Set a background image.
4. Confirm the "Reset" button is available.
5. Reset the background image.
6. Confirm that the "Reset" button is displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/c38c8387-2065-4e96-aedd-6565297eece5

