### PR TITLE
Fonts API: Add is_array check before using array_merge

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -202,13 +202,16 @@ class WP_Fonts_Resolver {
 				$settings            = static::set_tyopgraphy_settings_array_structure( $settings );
 			}
 
-			// Merge the variation settings with the global settings.
-			if ( is_array( $settings['typography']['fontFamilies']['theme'] ) && is_array( $variation['settings']['typography']['fontFamilies']['theme'] ) ) {
-				$settings['typography']['fontFamilies']['theme'] = array_merge(
-					$settings['typography']['fontFamilies']['theme'],
-					$variation['settings']['typography']['fontFamilies']['theme']
-				);
+			// Skip if typography.fontFamilies.theme from the global settings and the variation are not arrays.
+			if ( ! is_array( $settings['typography']['fontFamilies']['theme'] ) && ! is_array( $variation['settings']['typography']['fontFamilies']['theme'] ) ) {
+				continue;
 			}
+
+			// Merge the variation settings with the global settings.
+			$settings['typography']['fontFamilies']['theme'] = array_merge(
+				$settings['typography']['fontFamilies']['theme'],
+				$variation['settings']['typography']['fontFamilies']['theme']
+			);
 
 			// Make sure there are no duplicates.
 			$settings['typography']['fontFamilies'] = array_unique( $settings['typography']['fontFamilies'] );

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -203,10 +203,12 @@ class WP_Fonts_Resolver {
 			}
 
 			// Merge the variation settings with the global settings.
-			$settings['typography']['fontFamilies']['theme'] = array_merge(
-				$settings['typography']['fontFamilies']['theme'],
-				$variation['settings']['typography']['fontFamilies']['theme']
-			);
+			if ( is_array( $settings['typography']['fontFamilies']['theme'] ) && is_array( $variation['settings']['typography']['fontFamilies']['theme'] ) ) {
+				$settings['typography']['fontFamilies']['theme'] = array_merge(
+					$settings['typography']['fontFamilies']['theme'],
+					$variation['settings']['typography']['fontFamilies']['theme']
+				);
+			}
 
 			// Make sure there are no duplicates.
 			$settings['typography']['fontFamilies'] = array_unique( $settings['typography']['fontFamilies'] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds an `is_array` check for `$settings['typography']['fontFamilies']['theme']` and `$variation['settings']['typography']['fontFamilies']['theme']` before using `array_merge` on both values.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To prevent potential errors such as `Uncaught TypeError: array_merge(): Argument #1 must be of type array`.

## How?
Checks if both values are arrays, and if not, skips the current variation and moves on to the next one.