### PR TITLE
Switch tabs after successful upload of fonts

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -6,7 +6,7 @@ import {
 	Modal,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { useContext } from '@wordpress/element';
+import { useState, useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -44,6 +44,7 @@ function FontLibraryModal( {
 	initialTabId = 'installed-fonts',
 } ) {
 	const { collections } = useContext( FontLibraryContext );
+	const [ selectedTab, setSelectedTab ] = useState( initialTabId );
 
 	const tabs = [
 		...DEFAULT_TABS,
@@ -58,7 +59,7 @@ function FontLibraryModal( {
 			className="font-library-modal"
 		>
 			<div className="font-library-modal__tabs">
-				<Tabs initialTabId={ initialTabId }>
+				<Tabs selectedTabId={ selectedTab } onSelect={ setSelectedTab }>
 					<Tabs.TabList>
 						{ tabs.map( ( { id, title } ) => (
 							<Tabs.Tab key={ id } tabId={ id }>
@@ -70,7 +71,13 @@ function FontLibraryModal( {
 						let contents;
 						switch ( id ) {
 							case 'upload-fonts':
-								contents = <UploadFonts />;
+								contents = (
+									<UploadFonts
+										onUpload={ () =>
+											setSelectedTab( 'installed-fonts' )
+										}
+									/>
+								);
 								break;
 							case 'installed-fonts':
 								contents = <InstalledFonts />;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/local-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/local-fonts.js
@@ -27,8 +27,9 @@ import { unlock } from '../../../lock-unlock';
 
 const { ProgressBar } = unlock( componentsPrivateApis );
 
-function LocalFonts() {
-	const { installFont } = useContext( FontLibraryContext );
+function LocalFonts( { onUpload } ) {
+	const { installFont, handleSetLibraryFontSelected } =
+		useContext( FontLibraryContext );
 	const [ notice, setNotice ] = useState( null );
 	const [ isUploading, setIsUploading ] = useState( false );
 	const supportedFormats =
@@ -170,6 +171,10 @@ function LocalFonts() {
 				type: 'success',
 				message: __( 'Fonts were installed successfully.' ),
 			} );
+			handleSetLibraryFontSelected( fontFamilies[ 0 ] );
+			if ( onUpload ) {
+				onUpload();
+			}
 		} catch ( error ) {
 			setNotice( {
 				type: 'error',

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -8,11 +8,11 @@ import { __experimentalSpacer as Spacer } from '@wordpress/components';
  */
 import LocalFonts from './local-fonts';
 
-function UploadFonts() {
+function UploadFonts( { onUpload } ) {
 	return (
 		<>
 			<Spacer margin={ 8 } />
-			<LocalFonts />
+			<LocalFonts onUpload={ onUpload } />
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This change replaces `TabPanel` with `Tabs` component (which is a controlled component), and switches to Library tab (first tab) after successfully uploading the font from "Upload" tab.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Navigate to font library dialog in global styles
2. Switch to "upload" tab and upload a font
3. On successful upload it should automatically switch to "Library" tab.
4. It should not switch tabs in case of errors and show the error message.
5. Also, this fix should not break any of the existing tab behaviour.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![font-upload](https://github.com/WordPress/gutenberg/assets/1935113/02ad925b-da42-4eb2-9486-e642dd05136d)

## References:

Fixes: #54779

Tabs component implementation: #53960

