### PR TITLE
Pattern: process embeds

### DIFF
--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -48,7 +48,12 @@ function render_block_core_pattern( $attributes ) {
 		$content = gutenberg_serialize_blocks( $blocks );
 	}
 
-	return do_blocks( $content );
+	$content = do_blocks( $content );
+
+	global $wp_embed;
+	$content = $wp_embed->autoembed( $content );
+
+	return $content;
 }
 
 add_action( 'init', 'register_block_core_pattern' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Process `embed` blocks inside a pattern file so that the media is embedded rather than just outputting a URL.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Gutenberg lets you create patterns that include embed blocks. When the pattern is included in a template **file** the embed in the editor properly embeds and shows the embedded item. When the front-end is viewed the embed is not processed and instead it just shows a URL.

The front-end should display what Gutenberg does.

Additionally, this works for template-parts, and for patterns included by template-parts, just not for patterns included by templates.

This addresses #46556

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The PHP `render_callback` function for the `core/pattern` block now uses [WP_Embed::autoembed](https://developer.wordpress.org/reference/classes/wp_embed/autoembed/) to expand any autoembeds. I've copied how [template-parts does the same thing](https://github.com/WordPress/gutenberg/blob/16bb053a7ae6b957b65463f3ea77c08173de2a2b/packages/block-library/src/template-part/index.php#L150-L152), but template-parts does a lot of other stuff in addition, I don't think they are needed for embed purposes but maybe they should be applied too?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a pattern file to emptytheme (or your active theme)
2. In the pattern file, add an embed block
3. Add the pattern to an HTML template (not through the Site Editor)
4. Load the page - on trunk the embed URL is displayed, but not embedded and vice versa on this branch

Here's a git diff to emptytheme you can use to do steps 1-3: [test.patch](https://github.com/WordPress/gutenberg/files/13301192/test.patch) Download it to the root of your gb and then `git apply test.patch`



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

Editor | Frontend Before | Frontend After
-----|-----------------|--------------
<img width="1450" alt="Screenshot 2023-11-08 at 20 33 08" src="https://github.com/WordPress/gutenberg/assets/93301/ad4001d2-4b19-4de6-bffe-0f7089506a2a"> | <img width="1459" alt="Screenshot 2023-11-08 at 20 34 30" src="https://github.com/WordPress/gutenberg/assets/93301/b52d2c24-d141-46f4-aa3a-798d4b02188c"> |<img width="1459" alt="Screenshot 2023-11-08 at 20 33 46" src="https://github.com/WordPress/gutenberg/assets/93301/93b8897f-d5d5-407d-b4d8-e34646620a81">



