### PR TITLE
Templates: Update filter to call all of the individual methods

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
@@ -37,10 +37,6 @@ function injectThemeAttributeInBlockTemplateContent(
 }
 
 function preparePatterns( patterns, template, currentThemeStylesheet ) {
-	// Filter out duplicates.
-	const filterOutDuplicatesByName = ( currentItem, index, items ) =>
-		index === items.findIndex( ( item ) => currentItem.name === item.name );
-
 	// Filter out core/directory patterns not included in theme.json.
 	const filterOutExcludedPatternSources = ( pattern ) =>
 		! EXCLUDED_PATTERN_SOURCES.includes( pattern.source );
@@ -51,9 +47,8 @@ function preparePatterns( patterns, template, currentThemeStylesheet ) {
 
 	return patterns
 		.filter(
-			( pattern, index, items ) =>
+			( pattern ) =>
 				filterOutExcludedPatternSources( pattern ) &&
-				filterOutDuplicatesByName( pattern, index, items ) &&
 				filterCompatiblePatterns( pattern )
 		)
 		.map( ( pattern ) => ( {

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
@@ -51,9 +51,10 @@ function preparePatterns( patterns, template, currentThemeStylesheet ) {
 
 	return patterns
 		.filter(
-			filterOutExcludedPatternSources &&
-				filterOutDuplicatesByName &&
-				filterCompatiblePatterns
+			( pattern, index, items ) =>
+				filterOutExcludedPatternSources( pattern ) &&
+				filterOutDuplicatesByName( pattern, index, items ) &&
+				filterCompatiblePatterns( pattern )
 		)
 		.map( ( pattern ) => ( {
 			...pattern,

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/hooks.js
@@ -37,6 +37,10 @@ function injectThemeAttributeInBlockTemplateContent(
 }
 
 function preparePatterns( patterns, template, currentThemeStylesheet ) {
+	// Filter out duplicates.
+	const filterOutDuplicatesByName = ( currentItem, index, items ) =>
+		index === items.findIndex( ( item ) => currentItem.name === item.name );
+
 	// Filter out core/directory patterns not included in theme.json.
 	const filterOutExcludedPatternSources = ( pattern ) =>
 		! EXCLUDED_PATTERN_SOURCES.includes( pattern.source );
@@ -47,8 +51,9 @@ function preparePatterns( patterns, template, currentThemeStylesheet ) {
 
 	return patterns
 		.filter(
-			( pattern ) =>
+			( pattern, index, items ) =>
 				filterOutExcludedPatternSources( pattern ) &&
+				filterOutDuplicatesByName( pattern, index, items ) &&
 				filterCompatiblePatterns( pattern )
 		)
 		.map( ( pattern ) => ( {


### PR DESCRIPTION
## What?
Updates the pattern array filter in the site editor template panel hook to call all of the filter methods.

## Why?
As [noted here](https://github.com/WordPress/gutenberg/pull/55877/files#r1386926483), because multiple methods are called this needs to be done within a function, otherwise only the last method is actually being called with the existing syntax.

This didn't show as a bug as in this instance the last filter method is the critical one so with the TT4 templates example this still resulted in the correct list of templates being returned.

## How?
Adds a function call to the array.filter call, and executes each of the filter methods in within this function.

## Testing Instructions
1. Open the Site Editor and go to the template inspector.
2. You should see a button that allows you to replace your current template
3. This button should open a modal allowing you to select a different template
4. When you select a different template, the contents of your old template should be replaced with the one you selected and the entity should be dirty.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/107534/391a3c24-4b5d-4754-b51b-4c99851097b2

