### PR TITLE
Fix fatal error in WP_Fonts_Resolver::get_settings()

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -200,12 +200,12 @@ class WP_Fonts_Resolver {
 			if ( $set_theme_structure ) {
 				$set_theme_structure = false;
 				$settings            = static::set_tyopgraphy_settings_array_structure( $settings );
-			}
 
-			// Initialize the font families from settings if set and is an array, otherwise default to an empty array.
-			$settings_font_families = ( isset( $settings['typography']['fontFamilies']['theme'] ) && is_array( $settings['typography']['fontFamilies']['theme'] ) )
-				? $settings['typography']['fontFamilies']['theme']
-				: array();
+				// Initialize the font families from settings if set and is an array, otherwise default to an empty array.
+				$settings['typography']['fontFamilies']['theme'] = ( isset( $settings['typography']['fontFamilies']['theme'] ) && is_array( $settings['typography']['fontFamilies']['theme'] ) )
+					? $settings['typography']['fontFamilies']['theme']
+					: array();
+			}
 
 			// Initialize the font families from variation if set and is an array, otherwise default to an empty array.
 			$variation_font_families = ( isset( $variation['settings']['typography']['fontFamilies']['theme'] ) && is_array( $variation['settings']['typography']['fontFamilies']['theme'] ) )
@@ -214,7 +214,7 @@ class WP_Fonts_Resolver {
 
 			// Merge the variation settings with the global settings.
 			$settings['typography']['fontFamilies']['theme'] = array_merge(
-				$settings_font_families,
+				$settings['typography']['fontFamilies']['theme'],
 				$variation_font_families
 			);
 

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -202,9 +202,9 @@ class WP_Fonts_Resolver {
 				$settings            = static::set_tyopgraphy_settings_array_structure( $settings );
 
 				// Initialize the font families from settings if set and is an array, otherwise default to an empty array.
-				$settings['typography']['fontFamilies']['theme'] = ( isset( $settings['typography']['fontFamilies']['theme'] ) && is_array( $settings['typography']['fontFamilies']['theme'] ) )
-					? $settings['typography']['fontFamilies']['theme']
-					: array();
+				if ( ! isset( $settings['typography']['fontFamilies']['theme'] ) || ! is_array( $settings['typography']['fontFamilies']['theme'] ) ) {
+					$settings['typography']['fontFamilies']['theme'] = array();
+				}
 			}
 
 			// Initialize the font families from variation if set and is an array, otherwise default to an empty array.

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -202,10 +202,20 @@ class WP_Fonts_Resolver {
 				$settings            = static::set_tyopgraphy_settings_array_structure( $settings );
 			}
 
+			// Initialize the font families from settings if set and is an array, otherwise default to an empty array.
+			$settings_font_families = ( isset( $settings['typography']['fontFamilies']['theme'] ) && is_array( $settings['typography']['fontFamilies']['theme'] ) )
+				? $settings['typography']['fontFamilies']['theme']
+				: array();
+
+			// Initialize the font families from variation if set and is an array, otherwise default to an empty array
+			$variation_font_families = ( isset( $variation['settings']['typography']['fontFamilies']['theme'] ) && is_array( $variation['settings']['typography']['fontFamilies']['theme'] ) )
+				? $variation['settings']['typography']['fontFamilies']['theme']
+				: array();
+
 			// Merge the variation settings with the global settings.
 			$settings['typography']['fontFamilies']['theme'] = array_merge(
-				$settings['typography']['fontFamilies']['theme'],
-				$variation['settings']['typography']['fontFamilies']['theme']
+				$settings_font_families,
+				$variation_font_families
 			);
 
 			// Make sure there are no duplicates.

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -207,7 +207,7 @@ class WP_Fonts_Resolver {
 				? $settings['typography']['fontFamilies']['theme']
 				: array();
 
-			// Initialize the font families from variation if set and is an array, otherwise default to an empty array
+			// Initialize the font families from variation if set and is an array, otherwise default to an empty array.
 			$variation_font_families = ( isset( $variation['settings']['typography']['fontFamilies']['theme'] ) && is_array( $variation['settings']['typography']['fontFamilies']['theme'] ) )
 				? $variation['settings']['typography']['fontFamilies']['theme']
 				: array();


### PR DESCRIPTION
## What?
This PR aims to fix a PHP fatal error that occurs within `WP_Fonts_Resolver::get_settings()` under certain conditions.
```
PHP Fatal error:  Uncaught TypeError: array_merge(): Argument #1 must be of type array, null given in /lib/experimental/fonts-api/class-wp-fonts-resolver.php:208
```

## Why?
Generally, the code should not trigger PHP fatal errors because certain variables do not match the expected type.

## How?
This PR ensures that the `array_merge()` function inside `WP_Fonts_Resolver::get_settings()` always receives arrays as input parameters.

## Testing instructions.
1. Activate a `Pendant` block theme.
2. Add
```php
define('FONT_LIBRARY_DISABLED', true);
```
to your config file.
3. Edit the src/wp-content/themes/pendant/styles/dark-navy.json file by replacing the following JSON block:
```json
"typography": {
			"fontFamilies": [
				{
					"fontFamily": "Inter, sans-serif",
					"slug": "body-font",
					"name": "Body",
					"fontFace": [
						{
							"fontDisplay": "block",
							"fontFamily": "Inter",
							"fontWeight": "100 500",
							"fontStyle": "normal",
							"fontStretch": "normal",
							"src": [
								"file:./assets/fonts/Inter-Light.ttf"
							]
						},
						{
							"fontDisplay": "block",
							"fontFamily": "Inter",
							"fontWeight": "600 900",
							"fontStyle": "normal",
							"fontStretch": "normal",
							"src": [
								"file:./assets/fonts/Inter-Bold.ttf"
							]
						}
					]
				},
				{
					"fontFamily": "'InterLight', serif",
					"slug": "heading-font",
					"name": "Headings",
					"fontFace": [
						{
							"fontDisplay": "block",
							"fontFamily": "InterLight",
							"fontStyle": "normal",
							"fontStretch": "normal",
							"src": [
								"file:./assets/fonts/Inter-Light.ttf"
							]
						}
					]
				}
			]
		}
	},
```
with
```json
"typography": {
			"fontFamilies": 1
		}
```
4. Make sure you see no
```
Warning: array_merge(): Expected parameter 2 to be an array,
```
error in the admin panel.