### PR TITLE
Background image support: Fix focus loss when resetting background image

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { isBlobURL } from '@wordpress/blob';
 import { getBlockSupport } from '@wordpress/blocks';
+import { focus } from '@wordpress/dom';
 import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	DropZone,
@@ -19,7 +20,7 @@ import {
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Platform, useCallback } from '@wordpress/element';
+import { Platform, useCallback, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
@@ -150,6 +151,8 @@ function BackgroundImagePanelItem( props ) {
 	const { id, title, url } =
 		attributes.style?.background?.backgroundImage || {};
 
+	const replaceContainerRef = useRef();
+
 	const { mediaUpload } = useSelect( ( select ) => {
 		return {
 			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
@@ -253,7 +256,10 @@ function BackgroundImagePanelItem( props ) {
 			resetAllFilter={ resetAllFilter }
 			panelId={ clientId }
 		>
-			<div className="block-editor-hooks__background__inspector-media-replace-container">
+			<div
+				className="block-editor-hooks__background__inspector-media-replace-container"
+				ref={ replaceContainerRef }
+			>
 				<MediaReplaceFlow
 					mediaId={ id }
 					mediaURL={ url }
@@ -271,7 +277,17 @@ function BackgroundImagePanelItem( props ) {
 				>
 					{ hasValue && (
 						<MenuItem
-							onClick={ () => resetBackgroundImage( props ) }
+							onClick={ () => {
+								const [ toggleButton ] = focus.tabbable.find(
+									replaceContainerRef.current
+								);
+								// Focus the toggle button and close the dropdown menu.
+								// This ensures similar behaviour as to selecting an image, where the dropdown is
+								// closed and focus is redirected to the dropdown toggle button.
+								toggleButton?.focus();
+								toggleButton?.click();
+								resetBackgroundImage( props );
+							} }
 						>
 							{ __( 'Reset ' ) }
 						</MenuItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix focus loss when resetting a background image in the background image block support (e.g. in a Group block) when resetting via the main dropdown.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is most noticeable when navigating via keyboard, but the fix in https://github.com/WordPress/gutenberg/pull/55973 that hides the Reset button results in a focus loss when you click the Reset button as the reset button is then no longer rendered once the background image value is cleared. The proposed fix is to deliberately place focus on the toggle button to avoid the focus loss.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a ref to the container for the toggle button
* When resetting the background image, shift focus to the toggle button and click it to close the dropdown — this matches the behaviour that happens when someone uploads or adds an image via the media library

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Add a background image to a Group block
* Go to reset that image via the main dropdown — once reset, the dropdown should close, and focus should be directed to the toggle button
* Test via keyboard
* Test via a few different browsers to make sure this fix doesn't break anything

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

As above, but tab over to the background image toggle and press enter to open the dropdown. After you've added an image, when you hit enter on the Reset option to clear out the value, the dropdown should be closed, and focus should be directed to the toggle button. You should be able to hit enter again to open the dropdown.

## Screenshots or screencast <!-- if applicable -->

### Before

Resetting results in a focus loss with the dropdown still open:

https://github.com/WordPress/gutenberg/assets/14988353/43f9d067-39d3-49d9-a074-5faeaeddb718

### After

Resetting closes the dropdown and shifts focus to the toggle button:

https://github.com/WordPress/gutenberg/assets/14988353/0b43abbf-779e-46d3-9c87-119619c569e6


