### PR TITLE
Update Labels in Block Inserter (block patterns tab)

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -21,12 +21,12 @@ export const SYNC_TYPES = {
 
 export const allPatternsCategory = {
 	name: 'allPatterns',
-	label: __( 'All Patterns' ),
+	label: __( 'All' ),
 };
 
 export const myPatternsCategory = {
 	name: 'myPatterns',
-	label: __( 'My Patterns' ),
+	label: __( 'My patterns' ),
 };
 
 export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -21,12 +21,12 @@ export const SYNC_TYPES = {
 
 export const allPatternsCategory = {
 	name: 'allPatterns',
-	label: __( 'All patterns' ),
+	label: __( 'All Patterns' ),
 };
 
 export const myPatternsCategory = {
 	name: 'myPatterns',
-	label: __( 'My patterns' ),
+	label: __( 'My Patterns' ),
 };
 
 export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {


### PR DESCRIPTION
In the Patterns tab of the Block Inserter I have amended the labels for 'My patterns' and 'All patterns' to 'My Patterns' and 'All Patterns' (title case). I believe this is a more consistent approach, also I see further down we have 'Call to Action' pattern category which is title case.

<img width="1436" alt="Screenshot 2566-11-09 at 14 23 30" src="https://github.com/WordPress/gutenberg/assets/38789408/a8933508-7886-4128-99fd-49a2190036c4">

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adding title case for two labels

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A more professional, consistent edit
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the block inserter and view the 'Patterns' tab.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


