### PR TITLE
DataViews: document `enableSorting` and `enableHiding`

### DIFF
--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -161,6 +161,7 @@ Example:
 			{ value: 2, label: 'User' }
 		]
 		filters: [ 'in' ],
+		enableSorting: false
 	}
 ]
 ```
@@ -171,6 +172,8 @@ Example:
 - `render`: function that renders the field.
 - `elements`: the set of valid values for the field's value.
 - `filters`: what filter operators are available for the user to use over this field. Only `in` available at the moment.
+- `enableSorting`: whether the data can be sorted by the given field. True by default.
+- `enableHiding`: whether the field can be hidden. True by default.
 
 ## Actions
 

--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -145,7 +145,8 @@ Example:
 			return (
 				<time>{ getFormattedDate( item.date ) }</time>
 			);
-		}
+		},
+		enableHiding: false
 	},
 	{
 		id: 'author',


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

Documents two properties of fields that were undocumented: `enableSorting` and `enableHiding`.

