### PR TITLE
DataViews: remove unnecessary `sortingFn` prop from field description

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -213,7 +213,6 @@ export default function PagePages() {
 					);
 				},
 				maxWidth: 400,
-				sortingFn: 'alphanumeric',
 				enableHiding: false,
 			},
 			{


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Removes the `sortingFn` prop from the `title` field description.

## Why?

It's not used anywhere.

## Testing Instructions

- Enable the "wp admin" views experiment and visit "Appareance > Editor > Manage all pages".
- Verify that sorting by `title` still works as before.
