### PR TITLE
Fix block rename control shown in "Advanced" for unsupported blocks

### DIFF
--- a/packages/block-editor/src/hooks/block-rename.js
+++ b/packages/block-editor/src/hooks/block-rename.js
@@ -16,7 +16,11 @@ export const withBlockRenameControl = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name, attributes, setAttributes, isSelected } = props;
 
-		const supportsBlockNaming = hasBlockSupport( name, 'renaming', true );
+		const supportsBlockNaming = hasBlockSupport(
+			name,
+			'__experimentalMetadata',
+			false
+		);
 
 		return (
 			<>

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -151,6 +151,12 @@ test.describe( 'Block Renaming', () => {
 			page,
 			pageUtils,
 		} ) => {
+			await pageUtils.pressKeys( 'access+o' );
+
+			const listView = page.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} );
+
 			// Only Group supports renaming.
 			await editor.insertBlock( {
 				name: 'core/paragraph',
@@ -160,11 +166,18 @@ test.describe( 'Block Renaming', () => {
 			// Multiselect via keyboard.
 			await pageUtils.pressKeys( 'primary+a' );
 
+			const listViewParagraphNode = listView.getByRole( 'gridcell', {
+				name: 'Paragraph',
+				exact: true,
+				selected: true,
+			} );
+
+			await expect( listViewParagraphNode ).toBeVisible();
+
 			// Expect the Rename control not to exist at all.
 			await expect(
-				page.getByRole( 'menuitem', {
+				listViewParagraphNode.getByRole( 'menuitem', {
 					name: 'Rename',
-					includeHidden: true, // the option is hidden behind modal
 				} )
 			).toBeHidden();
 		} );

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -145,6 +145,29 @@ test.describe( 'Block Renaming', () => {
 				},
 			] );
 		} );
+
+		test( 'does not allow renaming of blocks that do not support the feature', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			// Only Group supports renaming.
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'First Paragraph' },
+			} );
+
+			// Multiselect via keyboard.
+			await pageUtils.pressKeys( 'primary+a' );
+
+			// Expect the Rename control not to exist at all.
+			await expect(
+				page.getByRole( 'menuitem', {
+					name: 'Rename',
+					includeHidden: true, // the option is hidden behind modal
+				} )
+			).toBeHidden();
+		} );
 	} );
 
 	test.describe( 'Block inspector renaming', () => {
@@ -218,6 +241,41 @@ test.describe( 'Block Renaming', () => {
 					},
 				},
 			] );
+		} );
+
+		test( 'does now allow renaming of blocks that do not support the feature', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			// Only Group supports renaming.
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'First Paragraph' },
+			} );
+
+			// Multiselect via keyboard.
+			await pageUtils.pressKeys( 'primary+a' );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const advancedPanelToggle = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'button', {
+					name: 'Advanced',
+					expanded: false,
+				} );
+
+			await advancedPanelToggle.click();
+
+			// Expect the Rename control not to exist at all.
+			await expect(
+				page.getByRole( 'textbox', {
+					name: 'Block name',
+				} )
+			).toBeHidden();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensures that block rename control is not shown for blocks that do not support the feature

Fixes https://github.com/WordPress/gutenberg/issues/55953

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because only Group supports in 6.4. In `trunk` this is enabled for all blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Gates the feature by the correct supports.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Add some random blocks (not the Group block)
- Click on each in turn and:
    - open block inspector controls
    - toggle `Advanced` panel
    - check you _cannot_ see the rename control
 - Add Group block and verify you _can_ see the rename control.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
