### PR TITLE
DataViews: update field API to generate filters based on type

### DIFF
--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -154,11 +154,11 @@ Example:
 				<a href="...">{ item.author }</a>
 			);
 		},
+		type: 'enumeration',
 		elements: [
 			{ value: 1, label: 'Admin' }
 			{ value: 2, label: 'User' }
 		]
-		filters: [ 'in' ],
 		enableSorting: false
 	}
 ]
@@ -169,7 +169,7 @@ Example:
 -   `getValue`: function that returns the value of the field.
 -   `render`: function that renders the field.
 -   `elements`: the set of valid values for the field's value.
--   `filters`: what filter operators are available for the user to use over this field. Only `in` available at the moment.
+-   `type`: the type of the field. Used to generate the proper filters. Only `enumeration` available at the moment.
 -   `enableSorting`: whether the data can be sorted by the given field. True by default.
 -   `enableHiding`: whether the field can be hidden. True by default.
 

--- a/packages/edit-site/src/components/dataviews/add-filter.js
+++ b/packages/edit-site/src/components/dataviews/add-filter.js
@@ -22,28 +22,27 @@ const {
 	DropdownMenuItemV2,
 } = unlock( componentsPrivateApis );
 
-const VALID_OPERATORS = [ OPERATOR_IN ];
+const ENUMERATION_TYPE = 'enumeration'; // TODO: merge with the one in filters.js
 
 export default function AddFilter( { fields, view, onChangeView } ) {
 	const filters = [];
 	fields.forEach( ( field ) => {
-		if ( ! field.filters ) {
+		if ( ! field.type ) {
 			return;
 		}
 
-		field.filters.forEach( ( filter ) => {
-			if ( VALID_OPERATORS.some( ( operator ) => operator === filter ) ) {
+		switch ( field.type ) {
+			case ENUMERATION_TYPE:
 				filters.push( {
 					field: field.id,
 					name: field.header,
-					operator: filter,
 					elements: field.elements || [],
 					isVisible: view.filters.some(
-						( f ) => f.field === field.id && f.operator === filter
+						( f ) =>
+							f.field === field.id && f.operator === OPERATOR_IN
 					),
 				} );
-			}
-		} );
+		}
 	} );
 
 	if ( filters.length === 0 ) {
@@ -92,7 +91,7 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 											...currentView.filters,
 											{
 												field: filter.field,
-												operator: 'in',
+												operator: OPERATOR_IN,
 												value: element.value,
 											},
 										],

--- a/packages/edit-site/src/components/dataviews/add-filter.js
+++ b/packages/edit-site/src/components/dataviews/add-filter.js
@@ -22,7 +22,8 @@ const {
 	DropdownMenuItemV2,
 } = unlock( componentsPrivateApis );
 
-const ENUMERATION_TYPE = 'enumeration'; // TODO: merge with the one in filters.js
+// TODO: find a place where these constants can be shared across components.
+const ENUMERATION_TYPE = 'enumeration';
 
 export default function AddFilter( { fields, view, onChangeView } ) {
 	const filters = [];

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -10,21 +10,22 @@ import { default as InFilter, OPERATOR_IN } from './in-filter';
 import AddFilter from './add-filter';
 import ResetFilters from './reset-filters';
 
-const VALID_OPERATORS = [ OPERATOR_IN ];
+const ENUMERATION_TYPE = 'enumeration';
 
 export default function Filters( { fields, view, onChangeView } ) {
 	const filters = [];
 	fields.forEach( ( field ) => {
-		if ( ! field.filters ) {
+		if ( ! field.type ) {
 			return;
 		}
 
-		field.filters.forEach( ( filter ) => {
-			if ( VALID_OPERATORS.some( ( operator ) => operator === filter ) ) {
+		switch ( field.type ) {
+			case ENUMERATION_TYPE:
 				filters.push( {
 					field: field.id,
+					operator: OPERATOR_IN,
 					name: field.header,
-					operator: filter,
+					type: field.type,
 					elements: [
 						{
 							value: '',
@@ -36,8 +37,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 						( f ) => f.field === field.id && f.operator === filter
 					),
 				} );
-			}
-		} );
+		}
 	} );
 
 	const filterComponents = filters?.map( ( filter ) => {

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -23,9 +23,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 			case ENUMERATION_TYPE:
 				filters.push( {
 					field: field.id,
-					operator: OPERATOR_IN,
 					name: field.header,
-					type: field.type,
 					elements: [
 						{
 							value: '',
@@ -34,29 +32,26 @@ export default function Filters( { fields, view, onChangeView } ) {
 						...( field.elements || [] ),
 					],
 					isVisible: view.filters.some(
-						( f ) => f.field === field.id && f.operator === filter
+						( f ) =>
+							f.field === field.id && f.operator === OPERATOR_IN
 					),
 				} );
 		}
 	} );
 
-	const filterComponents = filters?.map( ( filter ) => {
+	const filterComponents = filters.map( ( filter ) => {
 		if ( ! filter.isVisible ) {
 			return null;
 		}
 
-		if ( OPERATOR_IN === filter.operator ) {
-			return (
-				<InFilter
-					key={ filter.field + '.' + filter.operator }
-					filter={ filter }
-					view={ view }
-					onChangeView={ onChangeView }
-				/>
-			);
-		}
-
-		return null;
+		return (
+			<InFilter
+				key={ filter.field + '.' + filter.operator }
+				filter={ filter }
+				view={ view }
+				onChangeView={ onChangeView }
+			/>
+		);
 	} );
 
 	filterComponents.push(

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
+// TODO: find a place where these constants can be shared across components.
 export const OPERATOR_IN = 'in';
 
 export default ( { filter, view, onChangeView } ) => {

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -52,6 +52,11 @@ const sortingItemsInfo = {
 	desc: { icon: arrowDown, label: __( 'Sort descending' ) },
 };
 const sortIcons = { asc: chevronUp, desc: chevronDown };
+
+// TODO: find a place where these constants can be shared across components.
+const ENUMERATION_TYPE = 'enumeration';
+const OPERATOR_IN = 'in';
+
 function HeaderMenu( { dataView, header } ) {
 	if ( header.isPlaceholder ) {
 		return null;
@@ -68,7 +73,7 @@ function HeaderMenu( { dataView, header } ) {
 	const sortedDirection = header.column.getIsSorted();
 
 	let filter;
-	if ( header.column.columnDef.type === 'enumeration' ) {
+	if ( header.column.columnDef.type === ENUMERATION_TYPE ) {
 		filter = {
 			field: header.column.columnDef.id,
 			elements: [
@@ -197,7 +202,8 @@ function HeaderMenu( { dataView, header } ) {
 														return (
 															field !==
 																filter.field ||
-															operator !== 'in'
+															operator !==
+																OPERATOR_IN
 														);
 													}
 												);

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -68,12 +68,7 @@ function HeaderMenu( { dataView, header } ) {
 	const sortedDirection = header.column.getIsSorted();
 
 	let filter;
-	if (
-		header.column.columnDef.filters?.length > 0 &&
-		header.column.columnDef.filters.some(
-			( f ) => 'string' === typeof f && f === 'in'
-		)
-	) {
+	if ( header.column.columnDef.type === 'enumeration' ) {
 		filter = {
 			field: header.column.columnDef.id,
 			elements: [

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -227,7 +227,7 @@ export default function PagePages() {
 						</a>
 					);
 				},
-				filters: [ 'in' ],
+				type: 'enumeration',
 				elements:
 					authors?.map( ( { id, name } ) => ( {
 						value: id,
@@ -240,7 +240,7 @@ export default function PagePages() {
 				getValue: ( { item } ) =>
 					STATUSES.find( ( { value } ) => value === item.status )
 						?.label ?? item.status,
-				filters: [ 'in' ],
+				type: 'enumeration',
 				elements: STATUSES,
 				enableSorting: false,
 			},


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/pull/55917#discussion_r1386210818

## What?

This PR updates the field API to generate the filters based on the field `type` – and it removes the existing `filters` prop.

```js
{
  id: 'author',
  type: 'enumeration', // In the future, add support for 'date', 'time', 'boolean', 'string', etc.
  elements: [ ... ]
}
```

## Why 

Follow-up on conversations about filters. This is what I see:

- The mapping field <=> filter is 1:1. Both visually and logically: there won't be two UI controls for the same field with different filters, there will be only one. As a result, there's only one filter per field in the query as well.
- We can generate the filters based on the field type, which will also be used for other things (edit, etc.).
- Some fields may not support all the operations of its default filter, so we need to configure the filter. For example: `type: enumeration`. By default, we may offer `IN` and `NOT_IN` operators but some fields may want to disable support for `NOT_IN`. In the [current design](https://github.com/WordPress/gutenberg/issues/55100#issuecomment-1798325397), disabling one of the operators would mean the UI won't show the "settings" submenu:

<img width="1238" alt="Filter settings" src="https://github.com/WordPress/gutenberg/assets/846565/84f2fe33-6be5-4a1d-a4db-d57e142eee4c">

- The same for the `type: date`. By default, we may offer `BEFORE`, `AFTER`, and `PRESET_RANGE` ("today", "this week", "last month", etc.) operators. See [conversation](https://github.com/WordPress/gutenberg/issues/55100#issuecomment-1798325397)). Some fields may not support all of that, or may want different preset ranges available ("this hour", "last hour", "today" instead of "last mont", "last year"), depending on the frequency of the data. Not design for this, but the same rationale could apply here.

## How

So far, providing the field `type` is enough.

However, we need to plan to configure the filters in upcoming PRs (adding `NOT_IN` operator, adding `DATE` filter, etc.). This is how it could work (this is not to implement in this PR, but I wanted to share the direction):

```js
// The author filter gets the default UI component.
{
  id: 'author',
  type: 'enumeration',
  elements: [ ... ]
},

// The status filter only gets IN operators in the UI component.
{
  id: 'status',
  type: 'enumeration',
  elements: [ ... ],
  operators: {
    notIn: false
  }
},

// The date filter gets the default experience.
{
  id: 'date',
  type: 'date'
}

// In a different dataset the date field wants:
// - different preset ranges
// - disables the `after` operator, so the date UI control would allow the user to pick one date (`before`) but not a range
{
  id: 'date',
  type: 'date',
  operators: {
    presetRanges: [ 'today', 'yesterday, 'this-week', 'last-week' ],
    after: false
  }
}
```

## Testing Instructions

- Enable the "wp admin" views experiment and visit "Appareance > Editor > Manage all pages".
- Verify the filters (top-level and columns) still work as expected.
