### PR TITLE
DataViews: add labels to "in-filters"

### DIFF
--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -5,11 +5,10 @@ import {
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	SelectControl,
 } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
 
 export const OPERATOR_IN = 'in';
 
-export default function InFilter( { filter, view, onChangeView } ) {
+export default ( { filter, view, onChangeView } ) => {
 	const valueFound = view.filters.find(
 		( f ) => f.field === filter.field && f.operator === OPERATOR_IN
 	);
@@ -19,7 +18,7 @@ export default function InFilter( { filter, view, onChangeView } ) {
 			? ''
 			: valueFound.value;
 
-	const id = useInstanceId( InFilter, 'dataviews__filters-in' );
+	const id = `dataviews__filters-in-${ filter.field }`;
 
 	return (
 		<SelectControl
@@ -56,4 +55,4 @@ export default function InFilter( { filter, view, onChangeView } ) {
 			} }
 		/>
 	);
-}
+};

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -5,10 +5,11 @@ import {
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	SelectControl,
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 
 export const OPERATOR_IN = 'in';
 
-export default ( { filter, view, onChangeView } ) => {
+export default function InFilter( { filter, view, onChangeView } ) {
 	const valueFound = view.filters.find(
 		( f ) => f.field === filter.field && f.operator === OPERATOR_IN
 	);
@@ -18,12 +19,16 @@ export default ( { filter, view, onChangeView } ) => {
 			? ''
 			: valueFound.value;
 
+	const id = useInstanceId( InFilter, 'dataviews__filters-in' );
+
 	return (
 		<SelectControl
+			id={ id }
 			value={ activeValue }
 			prefix={
 				<InputControlPrefixWrapper
-					as="span"
+					as="label"
+					htmlFor={ id }
 					className="dataviews__select-control-prefix"
 				>
 					{ filter.name + ':' }
@@ -51,4 +56,4 @@ export default ( { filter, view, onChangeView } ) => {
 			} }
 		/>
 	);
-};
+}


### PR DESCRIPTION
## What?
This patch ensures that "in-filter" inputs have accessible names.

It is an alternative approach to that explored by #55977, tackling the issue closer to the problem. Given the likely short-term lifecycle of the filter implementation, this is more economical alternative to #55963.

## Why?
All user inputs should have an [accessible name](https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name). This is currently lacking in data view filters.

## How?
The visible label is updated to use a `<label>` element, and semantically linked to the select input with a `for`/`id` combination.

The alternative of setting `label`/`hideLabelFromVision` props on the parent `<SelectControl>` was considered, but this approach has the benefit of physically associating the label with the control as well as semantically, so clicking on it will focus the input.

## Testing Instructions
Nothing should visually change.

Using developer tools, a screen reader, or similar, confirm that the filter inputs have accessible names, derived from the visible labels.

![Data views filters, with developer tools information below illustrating the relationship between a label and an input, circled in red.](https://github.com/WordPress/gutenberg/assets/159848/f05560d1-3638-4311-9b69-b309f73b38ab)