### PR TITLE
Update custom data view button

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
@@ -61,6 +61,8 @@ function CustomDataViewItem( { dataviewId, isActive } ) {
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
 					toggleProps={ {
+						size: 'small',
+						className: 'edit-site-sidebar-navigation-screen-dataviews__ellipsis-button',
 						style: {
 							color: 'inherit',
 						},

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -6,3 +6,7 @@
 		text-transform: uppercase;
 	}
 }
+
+.edit-site-sidebar-navigation-screen-dataviews__ellipsis-button {
+	display: flex;
+}


### PR DESCRIPTION
## What?
Update the custom data view button to ensure the footprint matches regular data view buttons.

## How?
Use the `small` Button variant.

## Testing Instructions
1. Navigate to the Manage Pages view in the Site Editor
2. Create a custom view
3. Ensure the custom view button has the same height (40px) as regular view buttons

### Before
<img width="357" alt="Screenshot 2023-11-09 at 14 58 31" src="https://github.com/WordPress/gutenberg/assets/846565/08c89697-987b-4224-98b3-0653373e92cd">

Note the custom data view button is much taller due to the regular size ellipsis button.

### After
<img width="356" alt="Screenshot 2023-11-09 at 15 06 29" src="https://github.com/WordPress/gutenberg/assets/846565/e540a528-5130-400a-9170-6922cf532bbc">