### PR TITLE
Dropdown: remove extra white space around toggle

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fix
+
+-   `Dropdown`: remove extra white space around toggle ([#56005](https://github.com/WordPress/gutenberg/pull/56005))
+
 ### Internal
 
 -   Migrate `Divider` from `reakit` to `ariakit` ([#55622](https://github.com/WordPress/gutenberg/pull/55622))

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -1,5 +1,5 @@
 .components-dropdown {
-	display: inline-block;
+	display: inline-flex;
 }
 
 .components-dropdown__content {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A tweak to the `Dropdown` component to make sure that there isn't extra white space rendered around the toggle button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As flagged in https://github.com/WordPress/gutenberg/pull/56002#discussion_r1388152765, sometimes there could be extra space around the dropdown toggle

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By changing `Dropdown`'s `display` style from `inline-block` to `inline-flex`. Using flexbox, in fact, automatically removes such white space around a wrapper's children.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In the `DropdownMenu` example, add `toggleProps: { size: 'small' }` prop to the default example
- Make sure that the `DropdownMenu` wrapper element around the toggle (the one with class `components-dropdown components-dropdown-menu`) is exactly 24x24 px (with the same changes applied to `trunk`, the wrapper would be 27px tall instead of 24)

Additionally, smoke test usages of `Dropdown` and `DropdownMenu` across the editor and make sure that the components look and behave as expected.