### PR TITLE
Move clientId key to BlockContextualToolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -195,6 +195,9 @@ function UnforwardedBlockContextualToolbar(
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }
 			variant={ isFixed ? 'unstyled' : undefined }
+			// Resets the index whenever the active block changes so
+			// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+			key={ selectedBlockClientId }
 			{ ...props }
 		>
 			{ ! isCollapsed && <BlockToolbar hideDragHandle={ isFixed } /> }

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -111,9 +111,6 @@ function UnforwardedSelectedBlockTools(
 						__experimentalOnIndexChange={ ( index ) => {
 							initialToolbarItemIndexRef.current = index;
 						} }
-						// Resets the index whenever the active block changes so
-						// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-						key={ clientId }
 					/>
 				) }
 				{ shouldShowBreadcrumb && (


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Moves the `key` from the `<SelectedBlockTools />` to the `<BlockContextualToolbar />`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There is a bug where the `<BlockContextualToolbar />` loses its connection to the selected block and cannot be focused.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The client id was set as a key on the `<SelectedBlockTools />`, which helped keep the block to block toolbar connection. This benefit wasn't applied to the `<BlockContextualToolbar />`, so fixed toolbars didn't get this bug fix. By moving this key down a level to the `<BlockContextualToolbar />` component, all the versions of the toolbar get this bug fix.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Have an image (no caption) and a paragraph block on a post
- Click the image block
- Click the Add Caption button
- Click the Paragraph
- Press alt + f10 (fn + option + f10 on mac)
- Focus should be in the Block Toolbar

Repeat the test for all versions of the toolbar - top toolbar, fixed toolbar (smaller screens), and floating popover toolbar. You can also verify on trunk that the above flow is broken for the top toolbar and fixed toolbar.
