### PR TITLE
Update Block Supports docs for spacing default

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -722,10 +722,15 @@ When the block declares support for a specific spacing property, its attributes 
 ```js
 attributes: {
     style: {
-        margin: 'value',
-        padding: {
-            top: 'value',
-        }
+	type: 'object',
+	default: {
+	    spacing: {
+		margin: '2rem',
+		padding: {
+		    top: '2rem'
+		}
+	    }
+	}
     }
 }
 ```


### PR DESCRIPTION
## What?
Fixing the Block Support docs around spacing and nested default attributes.

## Why?
So folks will be able to use the feature properly.

