### PR TITLE
Missing block: use raw source for originalContent

### DIFF
--- a/packages/block-library/src/missing/block.json
+++ b/packages/block-library/src/missing/block.json
@@ -15,7 +15,7 @@
 		},
 		"originalContent": {
 			"type": "string",
-			"source": "html"
+			"source": "raw"
 		}
 	},
 	"supports": {

--- a/test/integration/fixtures/blocks/core__form-input.json
+++ b/test/integration/fixtures/blocks/core__form-input.json
@@ -5,7 +5,7 @@
 		"attributes": {
 			"originalName": "core/form-input",
 			"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>",
-			"originalContent": "<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required=\"\" aria-required=\"true\"></label>\n<!-- /wp:form-input -->"
+			"originalContent": "<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__form-input.serialized.html
+++ b/test/integration/fixtures/blocks/core__form-input.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:form-input {"label":"Name","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Name</span><input class="wp-block-form-input" type="text" name="Name" required="" aria-required="true"></label>
+<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Name</span><input class="wp-block-form-input" type="text" name="Name" required aria-required="true"/></label>
 <!-- /wp:form-input -->

--- a/test/integration/fixtures/blocks/core__form.json
+++ b/test/integration/fixtures/blocks/core__form.json
@@ -5,7 +5,7 @@
 		"attributes": {
 			"originalName": "core/form",
 			"originalUndelimitedContent": "<form>\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>\n<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>\n</form>",
-			"originalContent": "<!-- wp:form -->\n<form>\n<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required=\"\" aria-required=\"true\"></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"email\",\"label\":\"Email\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required=\"\" aria-required=\"true\"></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"url\",\"label\":\"Website\"} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"textarea\",\"label\":\"Comment\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required=\"\" aria-required=\"true\"></textarea></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"submit\",\"label\":\"Submit\"} -->\n<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>\n<!-- /wp:form-input -->\n</form>\n<!-- /wp:form -->"
+			"originalContent": "<!-- wp:form -->\n<form>\n<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"email\",\"label\":\"Email\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"url\",\"label\":\"Website\"} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"textarea\",\"label\":\"Comment\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"submit\",\"label\":\"Submit\"} -->\n<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>\n<!-- /wp:form-input -->\n</form>\n<!-- /wp:form -->"
 		},
 		"innerBlocks": [
 			{
@@ -14,7 +14,7 @@
 				"attributes": {
 					"originalName": "core/form-input",
 					"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>",
-					"originalContent": "<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required=\"\" aria-required=\"true\"></label>\n<!-- /wp:form-input -->"
+					"originalContent": "<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->"
 				},
 				"innerBlocks": []
 			},
@@ -24,7 +24,7 @@
 				"attributes": {
 					"originalName": "core/form-input",
 					"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>",
-					"originalContent": "<!-- wp:form-input {\"type\":\"email\",\"label\":\"Email\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required=\"\" aria-required=\"true\"></label>\n<!-- /wp:form-input -->"
+					"originalContent": "<!-- wp:form-input {\"type\":\"email\",\"label\":\"Email\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->"
 				},
 				"innerBlocks": []
 			},
@@ -34,7 +34,7 @@
 				"attributes": {
 					"originalName": "core/form-input",
 					"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>",
-					"originalContent": "<!-- wp:form-input {\"type\":\"url\",\"label\":\"Website\"} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"></label>\n<!-- /wp:form-input -->"
+					"originalContent": "<!-- wp:form-input {\"type\":\"url\",\"label\":\"Website\"} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>\n<!-- /wp:form-input -->"
 				},
 				"innerBlocks": []
 			},
@@ -44,7 +44,7 @@
 				"attributes": {
 					"originalName": "core/form-input",
 					"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>",
-					"originalContent": "<!-- wp:form-input {\"type\":\"textarea\",\"label\":\"Comment\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required=\"\" aria-required=\"true\"></textarea></label>\n<!-- /wp:form-input -->"
+					"originalContent": "<!-- wp:form-input {\"type\":\"textarea\",\"label\":\"Comment\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>\n<!-- /wp:form-input -->"
 				},
 				"innerBlocks": []
 			},

--- a/test/integration/fixtures/blocks/core__form.serialized.html
+++ b/test/integration/fixtures/blocks/core__form.serialized.html
@@ -1,16 +1,16 @@
 <!-- wp:form -->
 <form>
 <!-- wp:form-input {"label":"Name","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Name</span><input class="wp-block-form-input" type="text" name="Name" required="" aria-required="true"></label>
+<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Name</span><input class="wp-block-form-input" type="text" name="Name" required aria-required="true"/></label>
 <!-- /wp:form-input -->
 <!-- wp:form-input {"type":"email","label":"Email","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Email</span><input class="wp-block-form-input" type="email" name="Email" required="" aria-required="true"></label>
+<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Email</span><input class="wp-block-form-input" type="email" name="Email" required aria-required="true"/></label>
 <!-- /wp:form-input -->
 <!-- wp:form-input {"type":"url","label":"Website"} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Website</span><input class="wp-block-form-input" type="url" name="Website" aria-required="false"></label>
+<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Website</span><input class="wp-block-form-input" type="url" name="Website" aria-required="false"/></label>
 <!-- /wp:form-input -->
 <!-- wp:form-input {"type":"textarea","label":"Comment","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Comment</span><textarea class="wp-block-form-input" name="Comment" required="" aria-required="true"></textarea></label>
+<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Comment</span><textarea class="wp-block-form-input" name="Comment" required aria-required="true"></textarea></label>
 <!-- /wp:form-input -->
 <!-- wp:form-input {"type":"submit","label":"Submit"} -->
 <div class="wp-block-buttons"><div class="wp-block-button"><button class="wp-block-button__link wp-element-button">Submit</button></div></div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The `raw` source is meant exactly for the raw, original, unmodified content, while `html` may be modifying the content (`innerHTML` converts a lot of characters to HTML entities). See #27268 for the HTML block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`originalContent` means that the content shouldn't be modified.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
