### PR TITLE
Small tweaks to CreatePatternModal

### DIFF
--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -113,7 +113,7 @@ export function PostSyncStatusModal() {
 									'Option that makes an individual pattern synchronized'
 								) }
 								help={ __(
-									'Editing the pattern will update it anywhere it is used.'
+									'Sync this pattern across multiple locations.'
 								) }
 								checked={ ! syncType }
 								onChange={ () => {

--- a/packages/patterns/src/components/category-selector.js
+++ b/packages/patterns/src/components/category-selector.js
@@ -61,6 +61,7 @@ export default function CategorySelector( {
 			tokenizeOnBlur
 			__experimentalExpandOnFocus
 			__next40pxDefaultSize
+			__nextHasNoMarginBottom
 		/>
 	);
 }

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -166,12 +166,13 @@ export default function CreatePatternModal( {
 			>
 				<VStack spacing="5">
 					<TextControl
-						__nextHasNoMarginBottom
 						label={ __( 'Name' ) }
 						value={ title }
 						onChange={ setTitle }
 						placeholder={ __( 'My pattern' ) }
 						className="patterns-create-modal__name-input"
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 					<CategorySelector
 						categoryTerms={ categoryTerms }
@@ -184,7 +185,7 @@ export default function CreatePatternModal( {
 							'Option that makes an individual pattern synchronized'
 						) }
 						help={ __(
-							'Editing the pattern will update it anywhere it is used.'
+							'Sync this pattern across multiple locations.'
 						) }
 						checked={ syncType === PATTERN_SYNC_TYPES.full }
 						onChange={ () => {

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -198,6 +198,7 @@ export default function CreatePatternModal( {
 					/>
 					<HStack justify="right">
 						<Button
+							__next40pxDefaultSize
 							variant="tertiary"
 							onClick={ () => {
 								onClose();
@@ -208,6 +209,7 @@ export default function CreatePatternModal( {
 						</Button>
 
 						<Button
+							__next40pxDefaultSize
 							variant="primary"
 							type="submit"
 							aria-disabled={ ! title || isSaving }

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -7,32 +7,27 @@
 	}
 
 	.patterns-menu-items__convert-modal-categories {
-		width: 100%;
 		position: relative;
-		min-height: 40px;
 	}
-	.components-form-token-field__suggestions-list {
+
+	.components-form-token-field__suggestions-list:not(:empty) {
 		position: absolute;
+		border: $border-width solid var(--wp-admin-theme-color);
+		border-bottom-left-radius: $radius-block-ui;
+		border-bottom-right-radius: $radius-block-ui;
+		box-shadow: 0 0 0.5px 0.5px var(--wp-admin-theme-color);
 		box-sizing: border-box;
 		z-index: 1;
 		background-color: $white;
-		// Account for the border width of the token field.
-		width: calc(100% + 2px);
+		width: calc(100% + 2px); // Account for the border width of the token field.
 		left: -1px;
 		min-width: initial;
-		border: 1px solid var(--wp-admin-theme-color);
-		border-top: none;
-		box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
-		border-bottom-left-radius: 2px;
-		border-bottom-right-radius: 2px;
+		max-height: $grid-unit-60 * 2; // Adjust to not cover the save button, showing three items.
 	}
 }
 
 .patterns-create-modal__name-input input[type="text"] {
-	// Match the minimal height of the category selector.
-	min-height: 40px;
-	// Override the default 1px margin-x.
-	margin: 0;
+	margin: 0; // Override the default 1px margin-x.
 }
 
 .patterns-rename-pattern-category-modal__validation-message {

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -189,7 +189,7 @@ export default function ReusableBlockConvertButton( {
 									'Option that makes an individual pattern synchronized'
 								) }
 								help={ __(
-									'Sync this pattern across multiple locations..'
+									'Sync this pattern across multiple locations.'
 								) }
 								checked={ ! syncType }
 								onChange={ () => {

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -183,14 +183,13 @@ export default function ReusableBlockConvertButton( {
 								onChange={ setTitle }
 								placeholder={ __( 'My pattern' ) }
 							/>
-
 							<ToggleControl
 								label={ _x(
 									'Synced',
 									'Option that makes an individual pattern synchronized'
 								) }
 								help={ __(
-									'Editing the pattern will update it anywhere it is used.'
+									'Sync this pattern across multiple locations..'
 								) }
 								checked={ ! syncType }
 								onChange={ () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Should be very little visual changes. 
- Removes the hard-coded 40px styles (and related) to use `__next40pxDefaultSize` instead.
- Use simpler help text for synced (consistent throughout).
- Improve metrics

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a pattern from the theme.
3. Select the group of blocks inserted.
4. Select the block options menu > "Create pattern" item. 
5. See modal.
6. Add a category. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-11-09 at 16 40 31](https://github.com/WordPress/gutenberg/assets/1813435/61e26cab-73e6-4b5f-a604-efa1b0eeb44d)|![CleanShot 2023-11-09 at 16 26 18](https://github.com/WordPress/gutenberg/assets/1813435/4850fe63-4c6b-49a7-988d-89c496d270bd)|



