### PR TITLE
Move "Manage patterns" below "Detach pattern"

### DIFF
--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -64,9 +64,6 @@ function PatternsManageButton( { clientId } ) {
 
 	return (
 		<>
-			<MenuItem href={ managePatternsUrl }>
-				{ __( 'Manage patterns' ) }
-			</MenuItem>
 			{ canRemove && (
 				<MenuItem
 					onClick={ () => convertSyncedPatternToStatic( clientId ) }
@@ -76,6 +73,9 @@ function PatternsManageButton( { clientId } ) {
 						: __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
+			<MenuItem href={ managePatternsUrl }>
+				{ __( 'Manage patterns' ) }
+			</MenuItem>
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Moves the "Detach pattern" menu item to the same location as "Create pattern" as they are inversely related.  Also, "Manage patterns" only renders as a menu item when you've selected a pattern, it should be appended—not prepended—to the pattern controls. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a theme pattern. 
3. Select the block options > Create pattern option. 
4. Complete the modal to create a pattern. 
5. Select the block options menu. 
6. See "Detach pattern" where "Create pattern" was, and "Manage patterns" below.

## Screenshots or screencast <!-- if applicable -->

#### For reference, here are the menu items as seen when selected on a block:

![CleanShot 2023-11-09 at 17 00 51](https://github.com/WordPress/gutenberg/assets/1813435/66e8c39d-0b46-4a81-8248-abf91ce3185a)

#### And here's when you've created a pattern: 

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-11-09 at 16 58 17](https://github.com/WordPress/gutenberg/assets/1813435/afaaa6f2-0f71-4f17-9082-f45019af2d0a)|![CleanShot 2023-11-09 at 16 58 47](https://github.com/WordPress/gutenberg/assets/1813435/d4d5df4a-ea57-468e-960f-cda50ae9e13c)|



