### PR TITLE
Update components to use __next40pxDefaultSize

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -59,6 +59,7 @@ function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
 	const textControl = (
 		<TextControl
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 			className="html-anchor-control"
 			label={ __( 'HTML anchor' ) }
 			help={

--- a/packages/block-editor/src/hooks/block-rename-ui.js
+++ b/packages/block-editor/src/hooks/block-rename-ui.js
@@ -92,6 +92,7 @@ function RenameModal( { blockName, originalBlockName, onClose, onSave } ) {
 				<VStack spacing="3">
 					<TextControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						value={ editedBlockName }
 						label={ __( 'Block name' ) }
 						hideLabelFromVision={ true }
@@ -130,6 +131,7 @@ function BlockRenameControl( props ) {
 			<InspectorControls group="advanced">
 				<TextControl
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'Block name' ) }
 					value={ customName || '' }
 					onChange={ onChange }

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -49,6 +49,7 @@ function CustomClassNameControls( { attributes, setAttributes } ) {
 		<InspectorControls group="advanced">
 			<TextControl
 				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 				autoComplete="off"
 				label={ __( 'Additional CSS class(es)' ) }
 				value={ attributes.className || '' }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -149,10 +149,11 @@ export default function ReusableBlockEdit( {
 			<InspectorControls>
 				<PanelBody>
 					<TextControl
-						__nextHasNoMarginBottom
 						label={ __( 'Name' ) }
 						value={ title }
 						onChange={ setTitle }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/comments/edit/comments-inspector-controls.js
+++ b/packages/block-library/src/comments/edit/comments-inspector-controls.js
@@ -22,6 +22,7 @@ export default function CommentsInspectorControls( {
 			<InspectorControls group="advanced">
 				<SelectControl
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'HTML element' ) }
 					options={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -319,6 +319,7 @@ export default function CoverInspectorControls( {
 			<InspectorControls group="advanced">
 				<SelectControl
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'HTML element' ) }
 					options={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -52,6 +52,7 @@ function GroupEditControls( { tagName, onSelectTagName } ) {
 		<InspectorControls group="advanced">
 			<SelectControl
 				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 				label={ __( 'HTML element' ) }
 				options={ [
 					{ label: __( 'Default (<div>)' ), value: 'div' },

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -131,6 +131,7 @@ export default function QueryContent( {
 			<InspectorControls group="advanced">
 				<SelectControl
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'HTML element' ) }
 					options={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -95,6 +95,7 @@ export function TemplatePartAdvancedControls( {
 			) }
 			<SelectControl
 				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 				label={ __( 'HTML element' ) }
 				options={ [
 					{

--- a/packages/editor/src/components/page-attributes/order.js
+++ b/packages/editor/src/components/page-attributes/order.js
@@ -39,6 +39,7 @@ function PageAttributesOrder() {
 		<Flex>
 			<FlexBlock>
 				<NumberControl
+					__next40pxDefaultSize
 					label={ __( 'Order' ) }
 					value={ value }
 					onChange={ setUpdatedOrder }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Another round towards https://github.com/WordPress/gutenberg/issues/46734.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Check out each of the inspectors for the block files below. 
2. Check out the page post type "Order" control. 
3. Check out the block rename modal input.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-11-09 at 17 20 20](https://github.com/WordPress/gutenberg/assets/1813435/d0ff2e59-c5f4-431e-8f53-4136d39e12b0)
![CleanShot 2023-11-09 at 17 17 18](https://github.com/WordPress/gutenberg/assets/1813435/b0accdbe-dd9b-4c10-a10f-8d96d13edb4e)
![CleanShot 2023-11-09 at 17 15 42](https://github.com/WordPress/gutenberg/assets/1813435/3abba370-4ee3-4e71-a032-dd108c8fafb4)
![CleanShot 2023-11-09 at 17 15 11](https://github.com/WordPress/gutenberg/assets/1813435/6f69fea2-9c3c-4705-a14d-ec6bd9f59c2b)
