### PR TITLE
Block Editor: Remove expired __experimentalGroup deprecations and prop

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -6,7 +6,6 @@ import {
 	__experimentalToolsPanelContext as ToolsPanelContext,
 } from '@wordpress/components';
 import warning from '@wordpress/warning';
-import deprecated from '@wordpress/deprecated';
 import { useEffect, useContext } from '@wordpress/element';
 
 /**
@@ -18,21 +17,8 @@ import groups from './groups';
 export default function InspectorControlsFill( {
 	children,
 	group = 'default',
-	__experimentalGroup,
 	resetAllFilter,
 } ) {
-	if ( __experimentalGroup ) {
-		deprecated(
-			'`__experimentalGroup` property in `InspectorControlsFill`',
-			{
-				since: '6.2',
-				version: '6.4',
-				alternative: '`group`',
-			}
-		);
-		group = __experimentalGroup;
-	}
-
 	const isDisplayed = useDisplayBlockControls();
 	const Fill = groups[ group ]?.Fill;
 	if ( ! Fill ) {

--- a/packages/block-editor/src/components/inspector-controls/fill.native.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.native.js
@@ -9,7 +9,6 @@ import { View } from 'react-native';
 import { Children } from '@wordpress/element';
 import { BottomSheetConsumer } from '@wordpress/components';
 import warning from '@wordpress/warning';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -21,20 +20,8 @@ import { BlockSettingsButton } from '../block-settings';
 export default function InspectorControlsFill( {
 	children,
 	group = 'default',
-	__experimentalGroup,
 	...props
 } ) {
-	if ( __experimentalGroup ) {
-		deprecated(
-			'`__experimentalGroup` property in `InspectorControlsFill`',
-			{
-				since: '6.2',
-				version: '6.4',
-				alternative: '`group`',
-			}
-		);
-		group = __experimentalGroup;
-	}
 	const isDisplayed = useDisplayBlockControls();
 
 	const Fill = groups[ group ]?.Fill;

--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -7,7 +7,6 @@ import {
 } from '@wordpress/components';
 import { useContext, useMemo } from '@wordpress/element';
 import warning from '@wordpress/warning';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -17,23 +16,11 @@ import BlockSupportSlotContainer from './block-support-slot-container';
 import groups from './groups';
 
 export default function InspectorControlsSlot( {
-	__experimentalGroup,
 	group = 'default',
 	label,
 	fillProps,
 	...props
 } ) {
-	if ( __experimentalGroup ) {
-		deprecated(
-			'`__experimentalGroup` property in `InspectorControlsSlot`',
-			{
-				since: '6.2',
-				version: '6.4',
-				alternative: '`group`',
-			}
-		);
-		group = __experimentalGroup;
-	}
 	const Slot = groups[ group ]?.Slot;
 	const fills = useSlotFills( Slot?.__unstableName );
 

--- a/packages/block-editor/src/components/inspector-controls/slot.native.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.native.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import warning from '@wordpress/warning';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -10,21 +9,9 @@ import deprecated from '@wordpress/deprecated';
 import groups from './groups';
 
 export default function InspectorControlsSlot( {
-	__experimentalGroup,
 	group = 'default',
 	...props
 } ) {
-	if ( __experimentalGroup ) {
-		deprecated(
-			'`__experimentalGroup` property in `InspectorControlsSlot`',
-			{
-				since: '6.2',
-				version: '6.4',
-				alternative: '`group`',
-			}
-		);
-		group = __experimentalGroup;
-	}
 	const Slot = groups[ group ]?.Slot;
 	if ( ! Slot ) {
 		warning( `Unknown InspectorControls group "${ group }" provided.` );

--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -59,7 +59,7 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 					</PanelBody>
 				</InspectorControls>
 			) }
-			<InspectorControls __experimentalGroup="advanced">
+			<InspectorControls group="advanced">
 				<TextControl
 					autoComplete="off"
 					label={ __( 'Name' ) }
@@ -70,7 +70,7 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 						} );
 					} }
 					help={ __(
-						'Affects the "name" atribute of the input element, and is used as a name for the form submission results.'
+						'Affects the "name" attribute of the input element, and is used as a name for the form submission results.'
 					) }
 				/>
 			</InspectorControls>


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/47105#discussion_r1387811569

## What?

Completes the removal of the deprecated `__experimentalGroup` prop from inspector controls fills and slots.

## Why?

`__experimentalGroup` was stabilised into the `group` prop. With the release of WP 6.4, the deprecation of `__experimentalGroup` has expired and can now be removed.

## How?

- Removes `__experimentalGroup` prop and `deprecated()` calls.
- Fixes recent addition using deprecated prop

## Testing Instructions

1. Ensure all the block support controls render appropriately in the inspector controls
2. Confirm there are no further uses of `__experimentalGroup` in code
3. Enable the "Form and input blocks" Gutenberg experiment
4. Edit a post, add a Form block, and select an input block
5. Confirm that a "name" field is displayed under the input block's Advanced panel

