### PR TITLE
DataViews: show actions label

### DIFF
--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -31,7 +31,7 @@
 	td,
 	th {
 		padding: $grid-unit-15;
-		[data-field-id="actions"] {
+		&[data-field-id="actions"] {
 			text-align: right;
 		}
 	}

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -28,7 +28,6 @@ import {
 	Button,
 	Icon,
 	privateApis as componentsPrivateApis,
-	VisuallyHidden,
 } from '@wordpress/components';
 import { useMemo, Children, Fragment } from '@wordpress/element';
 
@@ -267,7 +266,7 @@ function ViewList( {
 		} );
 		if ( actions?.length ) {
 			_columns.push( {
-				header: <VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>,
+				header: __( 'Actions' ),
 				id: 'actions',
 				cell: ( props ) => {
 					return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/55848#issuecomment-1794896115

> * Actions column should have a heading.
>  * Iirc there's an a11y requirement that the actions column (possible all columns in fact) not be empty, so for templates with no actions perhaps just display a `–`.

> <img width="1338" alt="Templates" src="https://github.com/WordPress/gutenberg/assets/846565/933b687c-9c07-4977-b08d-c4a5ad06501a">


This PR right now just shows the `actions` label. I started with the intention of showing `–` if no actions are available, but it seems a bit confusing to me and would appreciate some more feedback. I think users might expect this to be an action(ex. remove row or something..). 


