### PR TITLE
Revert "Dropdown: remove extra white space around toggle"

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Bug fix
-
--   `Dropdown`: remove extra white space around toggle ([#56005](https://github.com/WordPress/gutenberg/pull/56005))
-
 ### Internal
 
 -   Migrate `Divider` from `reakit` to `ariakit` ([#55622](https://github.com/WordPress/gutenberg/pull/55622))

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -1,5 +1,5 @@
 .components-dropdown {
-	display: inline-flex;
+	display: inline-block;
 }
 
 .components-dropdown__content {


### PR DESCRIPTION
Reverts WordPress/gutenberg#56005

See https://github.com/WordPress/gutenberg/pull/56005#issuecomment-1804868252 for more details