### PR TITLE
DataViews: Update author and title fields in template's list

### DIFF
--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -152,7 +152,7 @@ export function useAddedBy( postType, postId ) {
  * @param {Object} props
  * @param {string} props.imageUrl
  */
-function AvatarImage( { imageUrl } ) {
+export function AvatarImage( { imageUrl } ) {
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 
 	return (

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -7,6 +7,7 @@ import removeAccents from 'remove-accents';
  * WordPress dependencies
  */
 import {
+	Icon,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
@@ -78,11 +79,15 @@ function TemplateTitle( { item } ) {
 }
 
 function AuthorField( { item } ) {
-	const { text, type, imageUrl } = useAddedBy( item.type, item.id );
+	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
 	return (
 		<HStack alignment="left">
-			{ type === 'user' && imageUrl && (
+			{ imageUrl ? (
 				<AvatarImage imageUrl={ imageUrl } />
+			) : (
+				<div className="edit-site-list-added-by__icon">
+					<Icon icon={ icon } />
+				</div>
 			) }
 			<span>{ text }</span>
 		</HStack>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/55848#issuecomment-1794896115

This PR handles:
1. Author cell can be simplified to just display the name, including a gravatar for user-generated templates.
2. The 'customized' note can move to beneath the title.


## Screenshots or screencast <!-- if applicable -->
<img width="1095" alt="Screenshot 2023-11-16 at 10 34 48 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/5cdb5ad2-5949-4b13-b927-d2e3176ba74b">

