### PR TITLE
Global Styles: Don't show "Apply Styles Globally" button in non-block based themes

### DIFF
--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -17,8 +17,9 @@ import {
 	hasBlockSupport,
 } from '@wordpress/blocks';
 import { useContext, useMemo, useCallback } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -391,6 +392,10 @@ function PushChangesToGlobalStylesControl( {
 const withPushChangesToGlobalStyles = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const blockEditingMode = useBlockEditingMode();
+		const isBlockBasedTheme = useSelect(
+			( select ) => select( coreStore ).getCurrentTheme()?.is_block_theme,
+			[]
+		);
 		const supportsStyles = SUPPORTED_STYLES.some( ( feature ) =>
 			hasBlockSupport( props.name, feature )
 		);
@@ -398,11 +403,13 @@ const withPushChangesToGlobalStyles = createHigherOrderComponent(
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ blockEditingMode === 'default' && supportsStyles && (
-					<InspectorAdvancedControls>
-						<PushChangesToGlobalStylesControl { ...props } />
-					</InspectorAdvancedControls>
-				) }
+				{ blockEditingMode === 'default' &&
+					supportsStyles &&
+					isBlockBasedTheme && (
+						<InspectorAdvancedControls>
+							<PushChangesToGlobalStylesControl { ...props } />
+						</InspectorAdvancedControls>
+					) }
 			</>
 		);
 	}


### PR DESCRIPTION
Fixes #56007

## What?

This PR will prevent the "Apply Styles Globally" button from being displayed in hybrid themes that support block template parts.

![hybrid-theme](https://github.com/WordPress/gutenberg/assets/54422211/4390bf68-a330-463b-ac00-5ff150e5f425)

## Why?
This is because non-block-based themes do not support global styles UI and there is no way to reset global styles once applied.

## How?

Checks if the current theme is a block theme when the button is rendered.

## Testing Instructions

- Access `http://localhost:8888/wp-admin`.
- Block Theme:
  - Activate Twenty Twenty-Four
  - Access Appearance > Editor
  - Select the block and open the Advanced panel
  - There should be "Apply Styles Globally" button
- Non-block-based theme:
  - Activate Emptyhybrid theme
  - Access Appearance > Template Parts
  - Select the block and open the Advanced panel
  - There should be no "Apply Styles Globally" button