### PR TITLE
[Code quality]: Remove obsolete `queryContext`

### DIFF
--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -10,7 +10,6 @@
 	"usesContext": [
 		"queryId",
 		"query",
-		"queryContext",
 		"displayLayout",
 		"templateSlug",
 		"previewPostType",

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -96,7 +96,6 @@ export default function PostTemplateEdit( {
 			// REST API or be handled by custom REST filters like `rest_{$this->post_type}_query`.
 			...restQueryArgs
 		} = {},
-		queryContext = [ { page: 1 } ],
 		templateSlug,
 		previewPostType,
 	},
@@ -104,8 +103,6 @@ export default function PostTemplateEdit( {
 	__unstableLayoutClassNames,
 } ) {
 	const { type: layoutType, columnCount = 3 } = layout || {};
-
-	const [ { page } ] = queryContext;
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
 	const { posts, blocks } = useSelect(
 		( select ) => {
@@ -126,7 +123,7 @@ export default function PostTemplateEdit( {
 					slug: templateSlug.replace( 'category-', '' ),
 				} );
 			const query = {
-				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
+				offset: perPage ? perPage + offset : 0,
 				order,
 				orderby: orderBy,
 			};
@@ -194,7 +191,6 @@ export default function PostTemplateEdit( {
 		},
 		[
 			perPage,
-			page,
 			offset,
 			order,
 			orderBy,

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { EntityProvider } from '@wordpress/core-data';
@@ -127,7 +127,6 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 			hasPageContentFocus: _hasPageContentFocus(),
 		};
 	}, [] );
-	const { setEditedPostContext } = useDispatch( editSiteStore );
 
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
@@ -152,25 +151,8 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 				editedPostType === TEMPLATE_POST_TYPE
 					? editedPost.slug
 					: undefined,
-			queryContext: [
-				context?.queryContext || { page: 1 },
-				( newQueryContext ) =>
-					setEditedPostContext( {
-						...context,
-						queryContext: {
-							...context?.queryContext,
-							...newQueryContext,
-						},
-					} ),
-			],
 		};
-	}, [
-		editedPost.slug,
-		editedPostType,
-		hasPageContentFocus,
-		context,
-		setEditedPostContext,
-	] );
+	}, [ editedPost.slug, editedPostType, hasPageContentFocus, context ] );
 
 	let title;
 	if ( hasLoadedPost ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In [this PR](https://github.com/WordPress/gutenberg/pull/56000#discussion_r1388055379) `queryContext` was mentioned and it seems it's an obsolete context used in the past to have paged results in the editor. For a long time now where Query Pagination was implemented with inner blocks, we don't support this in the editor and always show the first page of the respective query.


## Testing Instructions
1. Every Query Loop instance should work as before.
