### PR TITLE
Read More block: reduce text decoration specificity

### DIFF
--- a/packages/block-library/src/read-more/style.scss
+++ b/packages/block-library/src/read-more/style.scss
@@ -1,7 +1,7 @@
 .wp-block-read-more {
 	display: block;
 	width: fit-content;
-	&:not([style*="text-decoration"]) {
+	&:where(:not([style*="text-decoration"])) {
 		text-decoration: none;
 
 		&:focus,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/56036

> The read more block is always a link, but it can not be styled as a link using theme.json. Not without using the "CSS" field and force overriding the current block CSS.

This PR reduces the specificity of the css selectors to allow overriding from theme.json.

## Testing Instructions
1. Add text decoration styles to Read More block through theme.json
2. Observe that the take precedence over the block's styles
3. Ensure existing Read More blocks have the styles they were expected to have, regarding the text decoration.
