### PR TITLE
DropdownMenu V2 tweaks

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -32,6 +32,7 @@
 -   `Tabs`: Update sub-components to accept relevant HTML element props ([#55860](https://github.com/WordPress/gutenberg/pull/55860))
 -   `DropdownMenuV2`: Fix radio menu item check icon not rendering correctly in some browsers ([#55964](https://github.com/WordPress/gutenberg/pull/55964))
 -   `DropdownMenuV2`: prevent default when pressing Escape key to close menu ([#55962](https://github.com/WordPress/gutenberg/pull/55962))
+-   `DropdownMenuV2`: Design tweaks ([#56041](https://github.com/WordPress/gutenberg/pull/56041))
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
-### Enhancements 
+### Enhancements
 
 -   `Button`: Add focus rings to focusable disabled buttons ([#56383](https://github.com/WordPress/gutenberg/pull/56383)).
 
 ### Experimental
 
 -   `Tabs`: Memoize and expose the component context ([#56224](https://github.com/WordPress/gutenberg/pull/56224)).
+-   `DropdownMenuV2`: Design tweaks ([#56041](https://github.com/WordPress/gutenberg/pull/56041))
 
 ### Internal
 
@@ -32,7 +33,6 @@
 -   `Tabs`: Update sub-components to accept relevant HTML element props ([#55860](https://github.com/WordPress/gutenberg/pull/55860))
 -   `DropdownMenuV2`: Fix radio menu item check icon not rendering correctly in some browsers ([#55964](https://github.com/WordPress/gutenberg/pull/55964))
 -   `DropdownMenuV2`: prevent default when pressing Escape key to close menu ([#55962](https://github.com/WordPress/gutenberg/pull/55962))
--   `DropdownMenuV2`: Design tweaks ([#56041](https://github.com/WordPress/gutenberg/pull/56041))
 
 ### Enhancements
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -284,6 +284,34 @@ Event handler called when the checked radio menu item changes.
 
 - Required: no
 
+### `DropdownMenuItemLabel`
+
+Used to render the menu item's label.
+
+#### Props
+
+The component accepts the following props:
+
+##### `children`: `React.ReactNode`
+
+The label contents.
+
+- Required: yes
+
+### `DropdownMenuItemHelpText`
+
+Used to render the menu item's help text.
+
+#### Props
+
+The component accepts the following props:
+
+##### `children`: `React.ReactNode`
+
+The help text contents.
+
+- Required: yes
+
 ### `DropdownMenuGroup`
 
 Used to group menu items.

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -298,20 +298,6 @@ The contents of the group.
 
 - Required: yes
 
-### `DropdownMenuGroupLabel`
-
-Used to render a group label.
-
-#### Props
-
-The component accepts the following props:
-
-##### `children`: `React.ReactNode`
-
-The contents of the group.
-
-- Required: yes
-
 ### `DropdownMenuSeparatorProps`
 
 Used to render a visual separator.

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -15,10 +15,6 @@ import {
 	cloneElement,
 	isValidElement,
 	useCallback,
-	useState,
-	useEffect,
-	useRef,
-	useId,
 } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 import { check, chevronRightSmall } from '@wordpress/icons';
@@ -52,16 +48,7 @@ export const DropdownMenuItem = forwardRef<
 	{ prefix, suffix, children, hideOnClick = true, ...props },
 	ref
 ) {
-	const id = useId();
 	const dropdownMenuContext = useContext( DropdownMenuContext );
-
-	const { registerHasPrefix, unregisterHasPrefix } =
-		dropdownMenuContext ?? {};
-	const hasPrefix = !! prefix;
-	useEffect( () => {
-		registerHasPrefix?.( id, hasPrefix );
-		return () => unregisterHasPrefix?.( id );
-	}, [ id, registerHasPrefix, unregisterHasPrefix, hasPrefix ] );
 
 	return (
 		<Styled.DropdownMenuItem
@@ -69,9 +56,6 @@ export const DropdownMenuItem = forwardRef<
 			{ ...props }
 			hideOnClick={ hideOnClick }
 			store={ dropdownMenuContext?.store }
-			shouldIndent={
-				! hasPrefix && ( dropdownMenuContext?.shouldIndent ?? false )
-			}
 		>
 			{ prefix && (
 				<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
@@ -95,16 +79,7 @@ export const DropdownMenuCheckboxItem = forwardRef<
 	{ suffix, children, hideOnClick = false, ...props },
 	ref
 ) {
-	const id = useId();
 	const dropdownMenuContext = useContext( DropdownMenuContext );
-
-	const { registerHasPrefix, unregisterHasPrefix } =
-		dropdownMenuContext ?? {};
-	useEffect( () => {
-		// Check items always have a prefix (the check icon).
-		registerHasPrefix?.( id, true );
-		return () => unregisterHasPrefix?.( id );
-	}, [ id, registerHasPrefix, unregisterHasPrefix ] );
 
 	return (
 		<Styled.DropdownMenuCheckboxItem
@@ -144,16 +119,7 @@ export const DropdownMenuRadioItem = forwardRef<
 	{ suffix, children, hideOnClick = false, ...props },
 	ref
 ) {
-	const id = useId();
 	const dropdownMenuContext = useContext( DropdownMenuContext );
-
-	const { registerHasPrefix, unregisterHasPrefix } =
-		dropdownMenuContext ?? {};
-	useEffect( () => {
-		// Radio items always have a prefix (the check icon).
-		registerHasPrefix?.( id, true );
-		return () => unregisterHasPrefix?.( id );
-	}, [ id, registerHasPrefix, unregisterHasPrefix ] );
 
 	return (
 		<Styled.DropdownMenuRadioItem
@@ -258,50 +224,9 @@ const UnconnectedDropdownMenu = (
 		rtl: computedDirection === 'rtl',
 	} );
 
-	const [ shouldIndent, setShouldIndent ] = useState( false );
-
-	const updateShouldIndent = useCallback( () => {
-		let atLeastOnePrefix = false;
-		for ( const value of hasPrefixMap.current.values() ) {
-			atLeastOnePrefix ||= value;
-		}
-
-		setShouldIndent( atLeastOnePrefix );
-	}, [] );
-
-	const hasPrefixMap = useRef( new Map< string, boolean >() );
-
-	const registerHasPrefix = useCallback(
-		( id: string, hasPrefix: boolean ) => {
-			hasPrefixMap.current.set( id, hasPrefix );
-			updateShouldIndent();
-		},
-		[ updateShouldIndent ]
-	);
-
-	const unregisterHasPrefix = useCallback(
-		( id: string ) => {
-			hasPrefixMap.current.delete( id );
-			updateShouldIndent();
-		},
-		[ updateShouldIndent ]
-	);
-
 	const contextValue = useMemo(
-		() => ( {
-			store: dropdownMenuStore,
-			variant,
-			shouldIndent,
-			registerHasPrefix,
-			unregisterHasPrefix,
-		} ),
-		[
-			dropdownMenuStore,
-			variant,
-			shouldIndent,
-			registerHasPrefix,
-			unregisterHasPrefix,
-		]
+		() => ( { store: dropdownMenuStore, variant } ),
+		[ dropdownMenuStore, variant ]
 	);
 
 	// Extract the side from the applied placement — useful for animations.

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -30,7 +30,6 @@ import type {
 	DropdownMenuContext as DropdownMenuContextType,
 	DropdownMenuProps,
 	DropdownMenuGroupProps,
-	DropdownMenuGroupLabelProps,
 	DropdownMenuItemProps,
 	DropdownMenuCheckboxItemProps,
 	DropdownMenuRadioItemProps,
@@ -152,20 +151,6 @@ export const DropdownMenuGroup = forwardRef<
 	const dropdownMenuContext = useContext( DropdownMenuContext );
 	return (
 		<Styled.DropdownMenuGroup
-			ref={ ref }
-			{ ...props }
-			store={ dropdownMenuContext?.store }
-		/>
-	);
-} );
-
-export const DropdownMenuGroupLabel = forwardRef<
-	HTMLDivElement,
-	WordPressComponentProps< DropdownMenuGroupLabelProps, 'div', false >
->( function DropdownMenuGroupLabel( props, ref ) {
-	const dropdownMenuContext = useContext( DropdownMenuContext );
-	return (
-		<Styled.DropdownMenuGroupLabel
 			ref={ ref }
 			{ ...props }
 			store={ dropdownMenuContext?.store }

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -15,6 +15,10 @@ import {
 	cloneElement,
 	isValidElement,
 	useCallback,
+	useState,
+	useEffect,
+	useRef,
+	useId,
 } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 import { check, chevronRightSmall } from '@wordpress/icons';
@@ -48,7 +52,16 @@ export const DropdownMenuItem = forwardRef<
 	{ prefix, suffix, children, hideOnClick = true, ...props },
 	ref
 ) {
+	const id = useId();
 	const dropdownMenuContext = useContext( DropdownMenuContext );
+
+	const { registerHasPrefix, unregisterHasPrefix } =
+		dropdownMenuContext ?? {};
+	const hasPrefix = !! prefix;
+	useEffect( () => {
+		registerHasPrefix?.( id, hasPrefix );
+		return () => unregisterHasPrefix?.( id );
+	}, [ id, registerHasPrefix, unregisterHasPrefix, hasPrefix ] );
 
 	return (
 		<Styled.DropdownMenuItem
@@ -56,6 +69,9 @@ export const DropdownMenuItem = forwardRef<
 			{ ...props }
 			hideOnClick={ hideOnClick }
 			store={ dropdownMenuContext?.store }
+			shouldIndent={
+				! hasPrefix && ( dropdownMenuContext?.shouldIndent ?? false )
+			}
 		>
 			{ prefix && (
 				<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
@@ -79,7 +95,16 @@ export const DropdownMenuCheckboxItem = forwardRef<
 	{ suffix, children, hideOnClick = false, ...props },
 	ref
 ) {
+	const id = useId();
 	const dropdownMenuContext = useContext( DropdownMenuContext );
+
+	const { registerHasPrefix, unregisterHasPrefix } =
+		dropdownMenuContext ?? {};
+	useEffect( () => {
+		// Check items always have a prefix (the check icon).
+		registerHasPrefix?.( id, true );
+		return () => unregisterHasPrefix?.( id );
+	}, [ id, registerHasPrefix, unregisterHasPrefix ] );
 
 	return (
 		<Styled.DropdownMenuCheckboxItem
@@ -119,7 +144,16 @@ export const DropdownMenuRadioItem = forwardRef<
 	{ suffix, children, hideOnClick = false, ...props },
 	ref
 ) {
+	const id = useId();
 	const dropdownMenuContext = useContext( DropdownMenuContext );
+
+	const { registerHasPrefix, unregisterHasPrefix } =
+		dropdownMenuContext ?? {};
+	useEffect( () => {
+		// Radio items always have a prefix (the check icon).
+		registerHasPrefix?.( id, true );
+		return () => unregisterHasPrefix?.( id );
+	}, [ id, registerHasPrefix, unregisterHasPrefix ] );
 
 	return (
 		<Styled.DropdownMenuRadioItem
@@ -224,9 +258,50 @@ const UnconnectedDropdownMenu = (
 		rtl: computedDirection === 'rtl',
 	} );
 
+	const [ shouldIndent, setShouldIndent ] = useState( false );
+
+	const updateShouldIndent = useCallback( () => {
+		let atLeastOnePrefix = false;
+		for ( const value of hasPrefixMap.current.values() ) {
+			atLeastOnePrefix ||= value;
+		}
+
+		setShouldIndent( atLeastOnePrefix );
+	}, [] );
+
+	const hasPrefixMap = useRef( new Map< string, boolean >() );
+
+	const registerHasPrefix = useCallback(
+		( id: string, hasPrefix: boolean ) => {
+			hasPrefixMap.current.set( id, hasPrefix );
+			updateShouldIndent();
+		},
+		[ updateShouldIndent ]
+	);
+
+	const unregisterHasPrefix = useCallback(
+		( id: string ) => {
+			hasPrefixMap.current.delete( id );
+			updateShouldIndent();
+		},
+		[ updateShouldIndent ]
+	);
+
 	const contextValue = useMemo(
-		() => ( { store: dropdownMenuStore, variant } ),
-		[ dropdownMenuStore, variant ]
+		() => ( {
+			store: dropdownMenuStore,
+			variant,
+			shouldIndent,
+			registerHasPrefix,
+			unregisterHasPrefix,
+		} ),
+		[
+			dropdownMenuStore,
+			variant,
+			shouldIndent,
+			registerHasPrefix,
+			unregisterHasPrefix,
+		]
 	);
 
 	// Extract the side from the applied placement — useful for animations.

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -296,7 +296,9 @@ const UnconnectedDropdownMenu = (
 				{ ...otherProps }
 				modal={ modal }
 				store={ dropdownMenuStore }
-				gutter={ gutter ?? ( dropdownMenuStore.parent ? 16 : 8 ) }
+				// Nested menus overlap by 8px
+				gutter={ gutter ?? ( dropdownMenuStore.parent ? 0 : 8 ) }
+				// Nested menus have their items aligned horizontally
 				shift={ shift ?? ( dropdownMenuStore.parent ? -8 : 0 ) }
 				hideOnHoverOutside={ false }
 				data-side={ appliedPlacementSide }

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -62,12 +62,16 @@ export const DropdownMenuItem = forwardRef<
 			) }
 
 			<Styled.DropdownMenuItemContentWrapper>
-				{ children }
-			</Styled.DropdownMenuItemContentWrapper>
+				<Styled.DropdownMenuItemChildrenWrapper>
+					{ children }
+				</Styled.DropdownMenuItemChildrenWrapper>
 
-			{ suffix && (
-				<Styled.ItemSuffixWrapper>{ suffix }</Styled.ItemSuffixWrapper>
-			) }
+				{ suffix && (
+					<Styled.ItemSuffixWrapper>
+						{ suffix }
+					</Styled.ItemSuffixWrapper>
+				) }
+			</Styled.DropdownMenuItemContentWrapper>
 		</Styled.DropdownMenuItem>
 	);
 } );
@@ -96,12 +100,16 @@ export const DropdownMenuCheckboxItem = forwardRef<
 			</Ariakit.MenuItemCheck>
 
 			<Styled.DropdownMenuItemContentWrapper>
-				{ children }
-			</Styled.DropdownMenuItemContentWrapper>
+				<Styled.DropdownMenuItemChildrenWrapper>
+					{ children }
+				</Styled.DropdownMenuItemChildrenWrapper>
 
-			{ suffix && (
-				<Styled.ItemSuffixWrapper>{ suffix }</Styled.ItemSuffixWrapper>
-			) }
+				{ suffix && (
+					<Styled.ItemSuffixWrapper>
+						{ suffix }
+					</Styled.ItemSuffixWrapper>
+				) }
+			</Styled.DropdownMenuItemContentWrapper>
 		</Styled.DropdownMenuCheckboxItem>
 	);
 } );
@@ -136,10 +144,16 @@ export const DropdownMenuRadioItem = forwardRef<
 			</Ariakit.MenuItemCheck>
 
 			<Styled.DropdownMenuItemContentWrapper>
-				{ children }
-			</Styled.DropdownMenuItemContentWrapper>
+				<Styled.DropdownMenuItemChildrenWrapper>
+					{ children }
+				</Styled.DropdownMenuItemChildrenWrapper>
 
-			{ suffix }
+				{ suffix && (
+					<Styled.ItemSuffixWrapper>
+						{ suffix }
+					</Styled.ItemSuffixWrapper>
+				) }
+			</Styled.DropdownMenuItemContentWrapper>
 		</Styled.DropdownMenuRadioItem>
 	);
 } );

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -276,12 +276,15 @@ const UnconnectedDropdownMenu = (
 					dropdownMenuStore.parent
 						? cloneElement( trigger, {
 								// Add submenu arrow, unless a `suffix` is explicitly specified
-								suffix: trigger.props.suffix ?? (
-									<Styled.SubmenuChevronIcon
-										aria-hidden="true"
-										icon={ chevronRightSmall }
-										size={ 24 }
-									/>
+								suffix: (
+									<>
+										{ trigger.props.suffix }
+										<Styled.SubmenuChevronIcon
+											aria-hidden="true"
+											icon={ chevronRightSmall }
+											size={ 24 }
+										/>
+									</>
 								),
 						  } )
 						: trigger

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -61,7 +61,11 @@ export const DropdownMenuItem = forwardRef<
 			{ prefix && (
 				<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
 			) }
-			{ children }
+
+			<Styled.DropdownMenuItemContentWrapper>
+				{ children }
+			</Styled.DropdownMenuItemContentWrapper>
+
 			{ suffix && (
 				<Styled.ItemSuffixWrapper>{ suffix }</Styled.ItemSuffixWrapper>
 			) }
@@ -92,7 +96,10 @@ export const DropdownMenuCheckboxItem = forwardRef<
 				<Icon icon={ check } size={ 24 } />
 			</Ariakit.MenuItemCheck>
 
-			{ children }
+			<Styled.DropdownMenuItemContentWrapper>
+				{ children }
+			</Styled.DropdownMenuItemContentWrapper>
+
 			{ suffix && (
 				<Styled.ItemSuffixWrapper>{ suffix }</Styled.ItemSuffixWrapper>
 			) }
@@ -128,7 +135,11 @@ export const DropdownMenuRadioItem = forwardRef<
 			>
 				<Icon icon={ radioCheck } size={ 24 } />
 			</Ariakit.MenuItemCheck>
-			{ children }
+
+			<Styled.DropdownMenuItemContentWrapper>
+				{ children }
+			</Styled.DropdownMenuItemContentWrapper>
+
 			{ suffix }
 		</Styled.DropdownMenuRadioItem>
 	);
@@ -329,6 +340,19 @@ export const DropdownMenuSeparator = forwardRef<
 			{ ...props }
 			store={ dropdownMenuContext?.store }
 			variant={ dropdownMenuContext?.variant }
+		/>
+	);
+} );
+
+export const DropdownMenuItemHelpText = forwardRef<
+	HTMLHRElement,
+	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
+>( function DropdownMenuItemHelpText( props, ref ) {
+	return (
+		<Styled.DropdownMenuItemHelpText
+			numberOfLines={ 2 }
+			ref={ ref }
+			{ ...props }
 		/>
 	);
 } );

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -347,8 +347,21 @@ export const DropdownMenuSeparator = forwardRef<
 	);
 } );
 
+export const DropdownMenuItemLabel = forwardRef<
+	HTMLSpanElement,
+	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
+>( function DropdownMenuItemLabel( props, ref ) {
+	return (
+		<Styled.DropdownMenuItemLabel
+			numberOfLines={ 1 }
+			ref={ ref }
+			{ ...props }
+		/>
+	);
+} );
+
 export const DropdownMenuItemHelpText = forwardRef<
-	HTMLHRElement,
+	HTMLSpanElement,
 	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
 >( function DropdownMenuItemHelpText( props, ref ) {
 	return (

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -57,9 +57,7 @@ export const DropdownMenuItem = forwardRef<
 			hideOnClick={ hideOnClick }
 			store={ dropdownMenuContext?.store }
 		>
-			{ prefix && (
-				<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
-			) }
+			<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
 
 			<Styled.DropdownMenuItemContentWrapper>
 				<Styled.DropdownMenuItemChildrenWrapper>
@@ -297,6 +295,7 @@ const UnconnectedDropdownMenu = (
 											aria-hidden="true"
 											icon={ chevronRightSmall }
 											size={ 24 }
+											preserveAspectRatio="xMidYMid slice"
 										/>
 									</>
 								),

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -54,6 +54,7 @@ export const DropdownMenuItem = forwardRef<
 		<Styled.DropdownMenuItem
 			ref={ ref }
 			{ ...props }
+			accessibleWhenDisabled
 			hideOnClick={ hideOnClick }
 			store={ dropdownMenuContext?.store }
 		>
@@ -87,6 +88,7 @@ export const DropdownMenuCheckboxItem = forwardRef<
 		<Styled.DropdownMenuCheckboxItem
 			ref={ ref }
 			{ ...props }
+			accessibleWhenDisabled
 			hideOnClick={ hideOnClick }
 			store={ dropdownMenuContext?.store }
 		>
@@ -131,6 +133,7 @@ export const DropdownMenuRadioItem = forwardRef<
 		<Styled.DropdownMenuRadioItem
 			ref={ ref }
 			{ ...props }
+			accessibleWhenDisabled
 			hideOnClick={ hideOnClick }
 			store={ dropdownMenuContext?.store }
 		>

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -316,10 +316,12 @@ const UnconnectedDropdownMenu = (
 				{ ...otherProps }
 				modal={ modal }
 				store={ dropdownMenuStore }
-				// Nested menus overlap by 8px
+				// Root menu has an 8px distance from its trigger,
+				// otherwise 0 (which causes the submenu to slightly overlap)
 				gutter={ gutter ?? ( dropdownMenuStore.parent ? 0 : 8 ) }
-				// Nested menus have their items aligned horizontally
-				shift={ shift ?? ( dropdownMenuStore.parent ? -8 : 0 ) }
+				// Align nested menu by the same (but opposite) amount
+				// as the menu container's padding.
+				shift={ shift ?? ( dropdownMenuStore.parent ? -4 : 0 ) }
 				hideOnHoverOutside={ false }
 				data-side={ appliedPlacementSide }
 				variant={ variant }

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -95,6 +95,8 @@ export const DropdownMenuCheckboxItem = forwardRef<
 			<Ariakit.MenuItemCheck
 				store={ dropdownMenuContext?.store }
 				render={ <Styled.ItemPrefixWrapper /> }
+				// Override some ariakit inline styles
+				style={ { width: 'auto', height: 'auto' } }
 			>
 				<Icon icon={ check } size={ 24 } />
 			</Ariakit.MenuItemCheck>
@@ -140,6 +142,8 @@ export const DropdownMenuRadioItem = forwardRef<
 			<Ariakit.MenuItemCheck
 				store={ dropdownMenuContext?.store }
 				render={ <Styled.ItemPrefixWrapper /> }
+				// Override some ariakit inline styles
+				style={ { width: 'auto', height: 'auto' } }
 			>
 				<Icon icon={ radioCheck } size={ 24 } />
 			</Ariakit.MenuItemCheck>

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
-import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 
 /**
@@ -14,13 +13,12 @@ import { useState, useMemo, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { COLORS, useCx } from '../../utils';
+import { useCx } from '../../utils';
 import {
 	DropdownMenu,
 	DropdownMenuItem,
 	DropdownMenuCheckboxItem,
 	DropdownMenuGroup,
-	DropdownMenuGroupLabel,
 	DropdownMenuSeparator,
 	DropdownMenuContext,
 	DropdownMenuRadioItem,
@@ -89,7 +87,6 @@ export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 		<DropdownMenuItem disabled>Disabled item</DropdownMenuItem>
 		<DropdownMenuSeparator />
 		<DropdownMenuGroup>
-			<DropdownMenuGroupLabel>Prefix and suffix</DropdownMenuGroupLabel>
 			<DropdownMenuItem
 				prefix={ <Icon icon={ wordpress } size={ 24 } /> }
 			>
@@ -158,9 +155,6 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 	return (
 		<DropdownMenu { ...props }>
 			<DropdownMenuGroup>
-				<DropdownMenuGroupLabel>
-					Individual, uncontrolled checkboxes
-				</DropdownMenuGroupLabel>
 				<DropdownMenuCheckboxItem
 					name="checkbox-individual-uncontrolled-a"
 					value="a"
@@ -183,9 +177,6 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
 			<DropdownMenuGroup>
-				<DropdownMenuGroupLabel>
-					Individual, controlled checkboxes
-				</DropdownMenuGroupLabel>
 				<DropdownMenuCheckboxItem
 					name="checkbox-individual-controlled-a"
 					value="a"
@@ -211,9 +202,6 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
 			<DropdownMenuGroup>
-				<DropdownMenuGroupLabel>
-					Multiple, uncontrolled checkboxes
-				</DropdownMenuGroupLabel>
 				<DropdownMenuCheckboxItem
 					name="checkbox-multiple-uncontrolled"
 					value="a"
@@ -236,9 +224,6 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
 			<DropdownMenuGroup>
-				<DropdownMenuGroupLabel>
-					Multiple, controlled checkboxes
-				</DropdownMenuGroupLabel>
 				<DropdownMenuCheckboxItem
 					name="checkbox-multiple-controlled"
 					value="a"
@@ -278,9 +263,6 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 	return (
 		<DropdownMenu { ...props }>
 			<DropdownMenuGroup>
-				<DropdownMenuGroupLabel>
-					Uncontrolled radios
-				</DropdownMenuGroupLabel>
 				<DropdownMenuRadioItem name="radio-uncontrolled" value="one">
 					Radio item 1
 					<DropdownMenuItemHelpText>
@@ -300,9 +282,6 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
 			<DropdownMenuGroup>
-				<DropdownMenuGroupLabel>
-					Controlled radios
-				</DropdownMenuGroupLabel>
 				<DropdownMenuRadioItem
 					name="radio-controlled"
 					value="one"

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -123,11 +123,7 @@ export const WithSubmenu: StoryFn< typeof DropdownMenu > = ( props ) => (
 				</DropdownMenuItem>
 			}
 		>
-			<DropdownMenuItem
-				prefix={ <Icon icon={ wordpress } size={ 24 } /> }
-			>
-				Level 2 item
-			</DropdownMenuItem>
+			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
 			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
 			<DropdownMenu
 				trigger={ <DropdownMenuItem>Submenu trigger</DropdownMenuItem> }

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -117,7 +117,11 @@ export const WithSubmenu: StoryFn< typeof DropdownMenu > = ( props ) => (
 	<DropdownMenu { ...props }>
 		<DropdownMenuItem>Level 1 item</DropdownMenuItem>
 		<DropdownMenu
-			trigger={ <DropdownMenuItem>Submenu trigger</DropdownMenuItem> }
+			trigger={
+				<DropdownMenuItem suffix="Suffix">
+					Submenu trigger
+				</DropdownMenuItem>
+			}
 		>
 			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
 			<DropdownMenuItem>Level 2 item</DropdownMenuItem>

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -393,7 +393,13 @@ const Slot = () => {
 		[ dropdownMenuContext ]
 	);
 
-	return <ExampleSlotFill.Slot fillProps={ fillProps } bubblesVirtually />;
+	return (
+		<ExampleSlotFill.Slot
+			fillProps={ fillProps }
+			bubblesVirtually
+			style={ { display: 'contents' } }
+		/>
+	);
 };
 
 type ForwardedContextTuple< P = {} > = [

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -24,6 +24,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuContext,
 	DropdownMenuRadioItem,
+	DropdownMenuItemHelpText,
 } from '..';
 import Icon from '../../icon';
 import Button from '../../button';
@@ -65,35 +66,25 @@ const meta: Meta< typeof DropdownMenu > = {
 };
 export default meta;
 
-const ItemHelpText = styled.span`
-	font-size: 12px;
-	color: ${ COLORS.gray[ '700' ] };
-
-	/* when the immediate parent item is hovered / focused */
-	[data-active-item] > * > &,
-	/* when the parent item is a submenu trigger and the submenu is open */
-	[aria-expanded='true'] > &,
-	/* when the parent item is disabled */
-	[aria-disabled='true'] > & {
-		color: inherit;
-	}
-`;
-
 export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 	<DropdownMenu { ...props }>
-		<DropdownMenuItem>Default item</DropdownMenuItem>
+		<DropdownMenuItem>Label</DropdownMenuItem>
+		<DropdownMenuItem>
+			<span>Label</span>
+			<DropdownMenuItemHelpText>Help text</DropdownMenuItemHelpText>
+		</DropdownMenuItem>
+		<DropdownMenuItem>
+			Label
+			<DropdownMenuItemHelpText>
+				Help text is automatically truncated when there are more than
+				two lines of text.
+			</DropdownMenuItemHelpText>
+		</DropdownMenuItem>
 		<DropdownMenuItem hideOnClick={ false }>
-			<div
-				style={ {
-					display: 'inline-flex',
-					flexDirection: 'column',
-				} }
-			>
-				Other item
-				<ItemHelpText>
-					Won&apos;t close the menu when clicked
-				</ItemHelpText>
-			</div>
+			Label
+			<DropdownMenuItemHelpText>
+				This item doesn&apos;t close the menu on click
+			</DropdownMenuItemHelpText>
 		</DropdownMenuItem>
 		<DropdownMenuItem disabled>Disabled item</DropdownMenuItem>
 		<DropdownMenuSeparator />
@@ -174,14 +165,20 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					name="checkbox-individual-uncontrolled-a"
 					value="a"
 				>
-					Checkbox item A (initially unchecked)
+					Checkbox item A
+					<DropdownMenuItemHelpText>
+						Uncontrolled
+					</DropdownMenuItemHelpText>
 				</DropdownMenuCheckboxItem>
 				<DropdownMenuCheckboxItem
 					name="checkbox-individual-uncontrolled-b"
 					value="b"
 					defaultChecked
 				>
-					Checkbox item B (initially checked)
+					Checkbox item B
+					<DropdownMenuItemHelpText>
+						Uncontrolled, initially checked
+					</DropdownMenuItemHelpText>
 				</DropdownMenuCheckboxItem>
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
@@ -196,6 +193,9 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					onChange={ ( e ) => setAChecked( e.target.checked ) }
 				>
 					Checkbox item A
+					<DropdownMenuItemHelpText>
+						Controlled
+					</DropdownMenuItemHelpText>
 				</DropdownMenuCheckboxItem>
 				<DropdownMenuCheckboxItem
 					name="checkbox-individual-controlled-b"
@@ -203,7 +203,10 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ isBChecked }
 					onChange={ ( e ) => setBChecked( e.target.checked ) }
 				>
-					Checkbox item B (initially checked)
+					Checkbox item B
+					<DropdownMenuItemHelpText>
+						Controlled, initially checked
+					</DropdownMenuItemHelpText>
 				</DropdownMenuCheckboxItem>
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
@@ -215,14 +218,20 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					name="checkbox-multiple-uncontrolled"
 					value="a"
 				>
-					Checkbox item A (initially unchecked)
+					Checkbox item A
+					<DropdownMenuItemHelpText>
+						Uncontrolled, multiple selection
+					</DropdownMenuItemHelpText>
 				</DropdownMenuCheckboxItem>
 				<DropdownMenuCheckboxItem
 					name="checkbox-multiple-uncontrolled"
 					value="b"
 					defaultChecked
 				>
-					Checkbox item B (initially checked)
+					Checkbox item B
+					<DropdownMenuItemHelpText>
+						Uncontrolled, multiple selection, initially checked
+					</DropdownMenuItemHelpText>
 				</DropdownMenuCheckboxItem>
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
@@ -236,7 +245,10 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ multipleCheckboxesValue.includes( 'a' ) }
 					onChange={ onMultipleCheckboxesCheckedChange }
 				>
-					Checkbox item A (initially unchecked)
+					Checkbox item A
+					<DropdownMenuItemHelpText>
+						Controlled, multiple selection
+					</DropdownMenuItemHelpText>
 				</DropdownMenuCheckboxItem>
 				<DropdownMenuCheckboxItem
 					name="checkbox-multiple-controlled"
@@ -244,7 +256,10 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ multipleCheckboxesValue.includes( 'b' ) }
 					onChange={ onMultipleCheckboxesCheckedChange }
 				>
-					Checkbox item B (initially checked)
+					Checkbox item B
+					<DropdownMenuItemHelpText>
+						Controlled, multiple selection, initially checked
+					</DropdownMenuItemHelpText>
 				</DropdownMenuCheckboxItem>
 			</DropdownMenuGroup>
 		</DropdownMenu>
@@ -268,13 +283,19 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 				</DropdownMenuGroupLabel>
 				<DropdownMenuRadioItem name="radio-uncontrolled" value="one">
 					Radio item 1
+					<DropdownMenuItemHelpText>
+						Uncontrolled
+					</DropdownMenuItemHelpText>
 				</DropdownMenuRadioItem>
 				<DropdownMenuRadioItem
 					name="radio-uncontrolled"
 					value="two"
 					defaultChecked
 				>
-					Radio item 2 (initially checked)
+					Radio item 2
+					<DropdownMenuItemHelpText>
+						Uncontrolled, initially checked
+					</DropdownMenuItemHelpText>
 				</DropdownMenuRadioItem>
 			</DropdownMenuGroup>
 			<DropdownMenuSeparator />
@@ -289,6 +310,9 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 					onChange={ onRadioChange }
 				>
 					Radio item 1
+					<DropdownMenuItemHelpText>
+						Controlled
+					</DropdownMenuItemHelpText>
 				</DropdownMenuRadioItem>
 				<DropdownMenuRadioItem
 					name="radio-controlled"
@@ -296,7 +320,10 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ radioValue === 'two' }
 					onChange={ onRadioChange }
 				>
-					Radio item 2 (initially checked)
+					Radio item 2
+					<DropdownMenuItemHelpText>
+						Controlled, initially checked
+					</DropdownMenuItemHelpText>
 				</DropdownMenuRadioItem>
 			</DropdownMenuGroup>
 		</DropdownMenu>

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -123,7 +123,11 @@ export const WithSubmenu: StoryFn< typeof DropdownMenu > = ( props ) => (
 				</DropdownMenuItem>
 			}
 		>
-			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
+			<DropdownMenuItem
+				prefix={ <Icon icon={ wordpress } size={ 24 } /> }
+			>
+				Level 2 item
+			</DropdownMenuItem>
 			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
 			<DropdownMenu
 				trigger={ <DropdownMenuItem>Submenu trigger</DropdownMenuItem> }

--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -7,7 +7,7 @@ import { css } from '@emotion/react';
 /**
  * WordPress dependencies
  */
-import { wordpress } from '@wordpress/icons';
+import { customLink, formatCapitalize } from '@wordpress/icons';
 import { useState, useMemo, useContext } from '@wordpress/element';
 
 /**
@@ -22,6 +22,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuContext,
 	DropdownMenuRadioItem,
+	DropdownMenuItemLabel,
 	DropdownMenuItemHelpText,
 } from '..';
 import Icon from '../../icon';
@@ -36,6 +37,20 @@ const meta: Meta< typeof DropdownMenu > = {
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 		DropdownMenuItem,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuCheckboxItem,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuGroup,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuSeparator,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuContext,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuRadioItem,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuItemLabel,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		DropdownMenuItemHelpText,
 	},
 	argTypes: {
 		children: { control: { type: null } },
@@ -66,20 +81,22 @@ export default meta;
 
 export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 	<DropdownMenu { ...props }>
-		<DropdownMenuItem>Label</DropdownMenuItem>
 		<DropdownMenuItem>
-			<span>Label</span>
+			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
+		</DropdownMenuItem>
+		<DropdownMenuItem>
+			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
 			<DropdownMenuItemHelpText>Help text</DropdownMenuItemHelpText>
 		</DropdownMenuItem>
 		<DropdownMenuItem>
-			Label
+			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
 			<DropdownMenuItemHelpText>
-				Help text is automatically truncated when there are more than
-				two lines of text.
+				The menu item help text is automatically truncated when there
+				are more than two lines of text
 			</DropdownMenuItemHelpText>
 		</DropdownMenuItem>
 		<DropdownMenuItem hideOnClick={ false }>
-			Label
+			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
 			<DropdownMenuItemHelpText>
 				This item doesn&apos;t close the menu on click
 			</DropdownMenuItemHelpText>
@@ -88,19 +105,22 @@ export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 		<DropdownMenuSeparator />
 		<DropdownMenuGroup>
 			<DropdownMenuItem
-				prefix={ <Icon icon={ wordpress } size={ 24 } /> }
+				prefix={ <Icon icon={ customLink } size={ 24 } /> }
 			>
-				With prefix
+				<DropdownMenuItemLabel>With prefix</DropdownMenuItemLabel>
 			</DropdownMenuItem>
-			<DropdownMenuItem suffix={ <span>⌘S</span> }>
-				With suffix
-			</DropdownMenuItem>
+			<DropdownMenuItem suffix={ '⌘S' }>With suffix</DropdownMenuItem>
 			<DropdownMenuItem
 				disabled
-				prefix={ <Icon icon={ wordpress } size={ 24 } /> }
-				suffix={ <span>⌥⌘T</span> }
+				prefix={ <Icon icon={ formatCapitalize } size={ 24 } /> }
+				suffix="⌥⌘T"
 			>
-				Disabled with prefix and suffix
+				<DropdownMenuItemLabel>
+					Disabled with prefix and suffix
+				</DropdownMenuItemLabel>
+				<DropdownMenuItemHelpText>
+					And help text
+				</DropdownMenuItemHelpText>
 			</DropdownMenuItem>
 		</DropdownMenuGroup>
 	</DropdownMenu>
@@ -119,17 +139,33 @@ export const WithSubmenu: StoryFn< typeof DropdownMenu > = ( props ) => (
 		<DropdownMenu
 			trigger={
 				<DropdownMenuItem suffix="Suffix">
-					Submenu trigger
+					<DropdownMenuItemLabel>
+						Submenu trigger item with a long label
+					</DropdownMenuItemLabel>
 				</DropdownMenuItem>
 			}
 		>
-			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
-			<DropdownMenuItem>Level 2 item</DropdownMenuItem>
+			<DropdownMenuItem>
+				<DropdownMenuItemLabel>Level 2 item</DropdownMenuItemLabel>
+			</DropdownMenuItem>
+			<DropdownMenuItem>
+				<DropdownMenuItemLabel>Level 2 item</DropdownMenuItemLabel>
+			</DropdownMenuItem>
 			<DropdownMenu
-				trigger={ <DropdownMenuItem>Submenu trigger</DropdownMenuItem> }
+				trigger={
+					<DropdownMenuItem>
+						<DropdownMenuItemLabel>
+							Submenu trigger
+						</DropdownMenuItemLabel>
+					</DropdownMenuItem>
+				}
 			>
-				<DropdownMenuItem>Level 3 item</DropdownMenuItem>
-				<DropdownMenuItem>Level 3 item</DropdownMenuItem>
+				<DropdownMenuItem>
+					<DropdownMenuItemLabel>Level 3 item</DropdownMenuItemLabel>
+				</DropdownMenuItem>
+				<DropdownMenuItem>
+					<DropdownMenuItemLabel>Level 3 item</DropdownMenuItemLabel>
+				</DropdownMenuItem>
 			</DropdownMenu>
 		</DropdownMenu>
 	</DropdownMenu>
@@ -162,8 +198,11 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 				<DropdownMenuCheckboxItem
 					name="checkbox-individual-uncontrolled-a"
 					value="a"
+					suffix="⌥⌘T"
 				>
-					Checkbox item A
+					<DropdownMenuItemLabel>
+						Checkbox item A
+					</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Uncontrolled
 					</DropdownMenuItemHelpText>
@@ -173,7 +212,9 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					value="b"
 					defaultChecked
 				>
-					Checkbox item B
+					<DropdownMenuItemLabel>
+						Checkbox item B
+					</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Uncontrolled, initially checked
 					</DropdownMenuItemHelpText>
@@ -187,7 +228,9 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ isAChecked }
 					onChange={ ( e ) => setAChecked( e.target.checked ) }
 				>
-					Checkbox item A
+					<DropdownMenuItemLabel>
+						Checkbox item A
+					</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Controlled
 					</DropdownMenuItemHelpText>
@@ -198,7 +241,9 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ isBChecked }
 					onChange={ ( e ) => setBChecked( e.target.checked ) }
 				>
-					Checkbox item B
+					<DropdownMenuItemLabel>
+						Checkbox item B
+					</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Controlled, initially checked
 					</DropdownMenuItemHelpText>
@@ -210,7 +255,9 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					name="checkbox-multiple-uncontrolled"
 					value="a"
 				>
-					Checkbox item A
+					<DropdownMenuItemLabel>
+						Checkbox item A
+					</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Uncontrolled, multiple selection
 					</DropdownMenuItemHelpText>
@@ -220,7 +267,9 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					value="b"
 					defaultChecked
 				>
-					Checkbox item B
+					<DropdownMenuItemLabel>
+						Checkbox item B
+					</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Uncontrolled, multiple selection, initially checked
 					</DropdownMenuItemHelpText>
@@ -234,7 +283,9 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ multipleCheckboxesValue.includes( 'a' ) }
 					onChange={ onMultipleCheckboxesCheckedChange }
 				>
-					Checkbox item A
+					<DropdownMenuItemLabel>
+						Checkbox item A
+					</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Controlled, multiple selection
 					</DropdownMenuItemHelpText>
@@ -245,7 +296,9 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ multipleCheckboxesValue.includes( 'b' ) }
 					onChange={ onMultipleCheckboxesCheckedChange }
 				>
-					Checkbox item B
+					<DropdownMenuItemLabel>
+						Checkbox item B
+					</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Controlled, multiple selection, initially checked
 					</DropdownMenuItemHelpText>
@@ -268,7 +321,7 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 		<DropdownMenu { ...props }>
 			<DropdownMenuGroup>
 				<DropdownMenuRadioItem name="radio-uncontrolled" value="one">
-					Radio item 1
+					<DropdownMenuItemLabel>Radio item 1</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Uncontrolled
 					</DropdownMenuItemHelpText>
@@ -278,7 +331,7 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 					value="two"
 					defaultChecked
 				>
-					Radio item 2
+					<DropdownMenuItemLabel>Radio item 2</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Uncontrolled, initially checked
 					</DropdownMenuItemHelpText>
@@ -292,7 +345,7 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ radioValue === 'one' }
 					onChange={ onRadioChange }
 				>
-					Radio item 1
+					<DropdownMenuItemLabel>Radio item 1</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Controlled
 					</DropdownMenuItemHelpText>
@@ -303,7 +356,7 @@ export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
 					checked={ radioValue === 'two' }
 					onChange={ onRadioChange }
 				>
-					Radio item 2
+					<DropdownMenuItemLabel>Radio item 2</DropdownMenuItemLabel>
 					<DropdownMenuItemHelpText>
 						Controlled, initially checked
 					</DropdownMenuItemHelpText>
@@ -337,13 +390,17 @@ export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
 					onClick={ () => setOuterModalOpen( true ) }
 					hideOnClick={ false }
 				>
-					Open outer modal
+					<DropdownMenuItemLabel>
+						Open outer modal
+					</DropdownMenuItemLabel>
 				</DropdownMenuItem>
 				<DropdownMenuItem
 					onClick={ () => setInnerModalOpen( true ) }
 					hideOnClick={ false }
 				>
-					Open inner modal
+					<DropdownMenuItemLabel>
+						Open inner modal
+					</DropdownMenuItemLabel>
 				</DropdownMenuItem>
 				{ isInnerModalOpen && (
 					<Modal
@@ -430,18 +487,32 @@ export const WithSlotFill: StoryFn< typeof DropdownMenu > = ( props ) => {
 	return (
 		<SlotFillProvider>
 			<DropdownMenu { ...props }>
-				<DropdownMenuItem>Item</DropdownMenuItem>
+				<DropdownMenuItem>
+					<DropdownMenuItemLabel>Item</DropdownMenuItemLabel>
+				</DropdownMenuItem>
 				<Slot />
 			</DropdownMenu>
 
 			<Fill>
-				<DropdownMenuItem>Item from fill</DropdownMenuItem>
+				<DropdownMenuItem>
+					<DropdownMenuItemLabel>
+						Item from fill
+					</DropdownMenuItemLabel>
+				</DropdownMenuItem>
 				<DropdownMenu
 					trigger={
-						<DropdownMenuItem>Submenu from fill</DropdownMenuItem>
+						<DropdownMenuItem>
+							<DropdownMenuItemLabel>
+								Submenu from fill
+							</DropdownMenuItemLabel>
+						</DropdownMenuItem>
 					}
 				>
-					<DropdownMenuItem>Submenu item from fill</DropdownMenuItem>
+					<DropdownMenuItem>
+						<DropdownMenuItemLabel>
+							Submenu item from fill
+						</DropdownMenuItemLabel>
+					</DropdownMenuItem>
 				</DropdownMenu>
 			</Fill>
 		</SlotFillProvider>
@@ -457,15 +528,28 @@ const toolbarVariantContextValue = {
 	},
 };
 export const ToolbarVariant: StoryFn< typeof DropdownMenu > = ( props ) => (
+	// TODO: add toolbar
 	<ContextSystemProvider value={ toolbarVariantContextValue }>
 		<DropdownMenu { ...props }>
-			<DropdownMenuItem>Level 1 item</DropdownMenuItem>
-			<DropdownMenuItem>Level 1 item</DropdownMenuItem>
+			<DropdownMenuItem>
+				<DropdownMenuItemLabel>Level 1 item</DropdownMenuItemLabel>
+			</DropdownMenuItem>
+			<DropdownMenuItem>
+				<DropdownMenuItemLabel>Level 1 item</DropdownMenuItemLabel>
+			</DropdownMenuItem>
 			<DropdownMenuSeparator />
 			<DropdownMenu
-				trigger={ <DropdownMenuItem>Submenu trigger</DropdownMenuItem> }
+				trigger={
+					<DropdownMenuItem>
+						<DropdownMenuItemLabel>
+							Submenu trigger
+						</DropdownMenuItemLabel>
+					</DropdownMenuItem>
+				}
 			>
-				<DropdownMenuItem>Level 2 item</DropdownMenuItem>
+				<DropdownMenuItem>
+					<DropdownMenuItemLabel>Level 2 item</DropdownMenuItemLabel>
+				</DropdownMenuItem>
 			</DropdownMenu>
 		</DropdownMenu>
 	</ContextSystemProvider>
@@ -488,17 +572,31 @@ export const InsideModal: StoryFn< typeof DropdownMenu > = ( props ) => {
 			{ isModalOpen && (
 				<Modal onRequestClose={ () => setModalOpen( false ) }>
 					<DropdownMenu { ...props }>
-						<DropdownMenuItem>Level 1 item</DropdownMenuItem>
-						<DropdownMenuItem>Level 1 item</DropdownMenuItem>
+						<DropdownMenuItem>
+							<DropdownMenuItemLabel>
+								Level 1 item
+							</DropdownMenuItemLabel>
+						</DropdownMenuItem>
+						<DropdownMenuItem>
+							<DropdownMenuItemLabel>
+								Level 1 item
+							</DropdownMenuItemLabel>
+						</DropdownMenuItem>
 						<DropdownMenuSeparator />
 						<DropdownMenu
 							trigger={
 								<DropdownMenuItem>
-									Submenu trigger
+									<DropdownMenuItemLabel>
+										Submenu trigger
+									</DropdownMenuItemLabel>
 								</DropdownMenuItem>
 							}
 						>
-							<DropdownMenuItem>Level 2 item</DropdownMenuItem>
+							<DropdownMenuItem>
+								<DropdownMenuItemLabel>
+									Level 2 item
+								</DropdownMenuItemLabel>
+							</DropdownMenuItem>
 						</DropdownMenu>
 					</DropdownMenu>
 					<Button onClick={ () => setModalOpen( false ) }>

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -72,6 +72,10 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 	/* TODO: is there a way to read the sass variable? */
 	z-index: 1000000;
 
+	display: grid;
+	grid-template-columns: minmax( 0, max-content ) 1fr;
+	grid-template-rows: auto;
+
 	min-width: 220px;
 	max-height: var( --popover-available-height );
 	padding: ${ CONTENT_WRAPPER_PADDING };
@@ -112,6 +116,9 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 `;
 
 const itemPrefix = css`
+	/* Always occupy the first column, even when auto-collapsing /*
+	grid-column: 1;
+
 	/* !important is to override some inline styles set by Ariakit */
 	width: ${ ITEM_PREFIX_WIDTH } !important;
 	/* !important is to override some inline styles set by Ariakit */
@@ -131,6 +138,7 @@ const itemPrefix = css`
 `;
 
 const itemSuffix = css`
+	flex: 0;
 	width: max-content;
 	display: inline-flex;
 	align-items: center;
@@ -179,17 +187,31 @@ export const ItemSuffixWrapper = styled.span`
 
 const baseItem = css`
 	all: unset;
+
+	position: relative;
+
+	/* Occupy the width of all grid columns (ie. full width) */
+	grid-column: 1 / -1;
+
+	/*
+	 * Define a grid layout which inherits the same columns configuration
+	 * from the parent layout (ie. subgrid).
+	 */
+	display: grid;
+	grid-template-columns: subgrid;
+	align-items: center;
+
 	font-size: ${ font( 'default.fontSize' ) };
 	font-family: inherit;
 	font-weight: normal;
 	line-height: 20px;
+
 	color: ${ COLORS.gray[ 900 ] };
 	border-radius: ${ CONFIG.radiusBlockUi };
-	display: flex;
-	align-items: center;
+
 	padding: ${ space( 2 ) } ${ ITEM_PADDING_INLINE_END } ${ space( 2 ) }
 		${ ITEM_PADDING_INLINE_START };
-	position: relative;
+
 	user-select: none;
 	outline: none;
 
@@ -231,10 +253,6 @@ const baseItem = css`
 	svg {
 		fill: currentColor;
 	}
-
-	&:not( :has( ${ ItemPrefixWrapper } ) ) {
-		padding-inline-start: ${ ITEM_PREFIX_WIDTH };
-	}
 `;
 
 export const DropdownMenuItem = styled( Ariakit.MenuItem )`
@@ -250,16 +268,33 @@ export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio )`
 `;
 
 export const DropdownMenuItemContentWrapper = styled.div`
+	/*
+	 * Always occupy the second column, since the first column
+	 * is taken by the prefix wrapper (when displayed).
+	 */
+	grid-column: 2;
+
+	display: flex;
+`;
+
+export const DropdownMenuItemChildrenWrapper = styled.div`
+	flex: 1;
 	display: inline-flex;
 	flex-direction: column;
 	pointer-events: none;
 `;
 
-export const DropdownMenuGroup = styled( Ariakit.MenuGroup )``;
+export const DropdownMenuGroup = styled( Ariakit.MenuGroup )`
+	/* Ignore this element when calculating the layout. Useful for subgrid */
+	display: contents;
+`;
 
 export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )<
 	Pick< DropdownMenuContext, 'variant' >
 >`
+	/* Occupy the width of all grid columns (ie. full width) */
+	grid-column: 1 / -1;
+
 	border: none;
 	height: ${ CONFIG.borderWidth };
 	/* TODO: doesn't match border color from variables */

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -12,6 +12,7 @@ import styled from '@emotion/styled';
 import { COLORS, font, rtl, CONFIG } from '../utils';
 import { space } from '../utils/space';
 import Icon from '../icon';
+import { Truncate } from '../truncate';
 import type { DropdownMenuContext } from './types';
 
 const ANIMATION_PARAMS = {
@@ -248,6 +249,12 @@ export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio )`
 	${ baseItem }
 `;
 
+export const DropdownMenuItemContentWrapper = styled.div`
+	display: inline-flex;
+	flex-direction: column;
+	pointer-events: none;
+`;
+
 export const DropdownMenuGroup = styled( Ariakit.MenuGroup )``;
 
 export const DropdownMenuGroupLabel = styled( Ariakit.MenuGroupLabel )`
@@ -295,3 +302,19 @@ export const SubmenuChevronIcon = styled( Icon )`
 		}
 	) }
 `;
+
+export const DropdownMenuItemHelpText = styled( Truncate )`
+	font-size: 12px;
+	color: ${ COLORS.gray[ '700' ] };
+`;
+
+// /* when the immediate parent item is hovered / focused */
+// [data-active-item] > ${ DropdownMenuItem }[data-active-item] > &,
+// [data-active-item] > ${ DropdownMenuRadioItem }[data-active-item] > &,
+// [data-active-item] > ${ DropdownMenuCheckboxItem }[data-active-item] > &,
+// /* when the parent item is a submenu trigger and the submenu is open */
+// [aria-expanded='true'] > &,
+// /* when the parent item is disabled */
+// [aria-disabled='true'] > & {
+// 	color: inherit;
+// }

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -231,14 +231,18 @@ const baseItem = css`
 	svg {
 		fill: currentColor;
 	}
-
-	&:not( :has( ${ ItemPrefixWrapper } ) ) {
-		padding-inline-start: ${ ITEM_PREFIX_WIDTH };
-	}
 `;
 
-export const DropdownMenuItem = styled( Ariakit.MenuItem )`
+export const DropdownMenuItem = styled( Ariakit.MenuItem )< {
+	shouldIndent?: boolean;
+} >`
 	${ baseItem }
+
+	${ ( props ) =>
+		props.shouldIndent &&
+		`
+		padding-inline-start: ${ ITEM_PREFIX_WIDTH };
+		` }
 `;
 
 export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox )`

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -311,6 +311,12 @@ export const SubmenuChevronIcon = styled( Icon )`
 	) };
 `;
 
+export const DropdownMenuItemLabel = styled( Truncate )`
+	font-size: ${ font( 'default.fontSize' ) };
+	line-height: 20px;
+	color: inherit;
+`;
+
 export const DropdownMenuItemHelpText = styled( Truncate )`
 	font-size: ${ font( 'helpText.fontSize' ) };
 	line-height: 16px;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -257,24 +257,6 @@ export const DropdownMenuItemContentWrapper = styled.div`
 
 export const DropdownMenuGroup = styled( Ariakit.MenuGroup )``;
 
-export const DropdownMenuGroupLabel = styled( Ariakit.MenuGroupLabel )`
-	box-sizing: border-box;
-	display: flex;
-	align-items: center;
-	min-height: ${ space( 8 ) };
-
-	padding: ${ space( 2 ) } ${ ITEM_PADDING_INLINE_END } ${ space( 2 ) }
-		${ ITEM_PREFIX_WIDTH };
-	/* TODO: color doesn't match available UI variables */
-	color: ${ COLORS.gray[ 700 ] };
-
-	/* TODO: font size doesn't match available ones via "font" utils */
-	font-size: 11px;
-	line-height: 1.4;
-	font-weight: 500;
-	text-transform: uppercase;
-`;
-
 export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )<
 	Pick< DropdownMenuContext, 'variant' >
 >`

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -22,12 +22,15 @@ const ANIMATION_PARAMS = {
 };
 
 const CONTENT_WRAPPER_PADDING = space( 2 );
-const ITEM_PREFIX_WIDTH = space( 7 );
-const ITEM_PADDING_INLINE_START = space( 2 );
-const ITEM_PADDING_INLINE_END = space( 2.5 );
+const ITEM_PADDING_BLOCK = space( 2 );
+const ITEM_PADDING_INLINE = space( 3 );
 
-// TODO: should bring this into the config, and make themeable
-const DEFAULT_BORDER_COLOR = COLORS.ui.borderDisabled;
+// TODO:
+// - those values are different from saved variables?
+// - should bring this into the config, and make themeable
+// - border color and divider color are different?
+const DEFAULT_BORDER_COLOR = COLORS.gray[ 300 ];
+const DIVIDER_COLOR = COLORS.gray[ 200 ];
 const TOOLBAR_VARIANT_BORDER_COLOR = COLORS.gray[ '900' ];
 const DEFAULT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ DEFAULT_BORDER_COLOR }, ${ CONFIG.popoverShadow }`;
 const TOOLBAR_VARIANT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ TOOLBAR_VARIANT_BORDER_COLOR }`;
@@ -76,7 +79,9 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 	grid-template-columns: minmax( 0, max-content ) 1fr;
 	grid-template-rows: auto;
 
-	min-width: 220px;
+	box-sizing: border-box;
+	min-width: 160px;
+	max-width: 320px;
 	max-height: var( --popover-available-height );
 	padding: ${ CONTENT_WRAPPER_PADDING };
 
@@ -115,80 +120,12 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 	}
 `;
 
-const itemPrefix = css`
-	/* Always occupy the first column, even when auto-collapsing /*
-	grid-column: 1;
-
-	/* !important is to override some inline styles set by Ariakit */
-	width: ${ ITEM_PREFIX_WIDTH } !important;
-	/* !important is to override some inline styles set by Ariakit */
-	height: auto !important;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	/* Prefixes don't get affected by the item's inline start padding */
-	margin-inline-start: calc( -1 * ${ ITEM_PADDING_INLINE_START } );
-	/*
-		Negative margin allows the suffix to be as tall as the whole item
-		(incl. padding) before increasing the items' height. This can be useful,
-		e.g., when using icons that are bigger than 20x20 px
-	*/
-	margin-top: ${ space( -2 ) };
-	margin-bottom: ${ space( -2 ) };
-`;
-
-const itemSuffix = css`
-	flex: 0;
-	width: max-content;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	/* Push prefix to the inline-end of the item */
-	margin-inline-start: auto;
-	/* Minimum space between the item's content and suffix */
-	padding-inline-start: ${ space( 6 ) };
-	/*
-		Negative margin allows the suffix to be as tall as the whole item
-		(incl. padding) before increasing the items' height. This can be useful,
-		e.g., when using icons that are bigger than 20x20 px
-	*/
-	margin-top: ${ space( -2 ) };
-	margin-bottom: ${ space( -2 ) };
-
-	/*
-		Override color in normal conditions, but inherit the item's color
-	  for altered conditions.
-
-		TODO:
-		  - For now, used opacity like for disabled item, which makes it work
-			  regardless of the theme
-		  - how do we translate this for themes? Should we have a new variable
-		for "secondary" text?
-	*/
-	opacity: 0.6;
-
-	/* when the parent item is hovered / focused */
-	[data-active-item] > &,
-	/* when the parent item is a submenu trigger and the submenu is open */
-	[aria-expanded='true'] > &,
-	/* when the parent item is disabled */
-	[aria-disabled='true'] > & {
-		opacity: 1;
-	}
-`;
-
-export const ItemPrefixWrapper = styled.span`
-	${ itemPrefix }
-`;
-
-export const ItemSuffixWrapper = styled.span`
-	${ itemSuffix }
-`;
-
 const baseItem = css`
 	all: unset;
 
 	position: relative;
+	min-height: ${ space( 10 ) };
+	box-sizing: border-box;
 
 	/* Occupy the width of all grid columns (ie. full width) */
 	grid-column: 1 / -1;
@@ -209,26 +146,21 @@ const baseItem = css`
 	color: ${ COLORS.gray[ 900 ] };
 	border-radius: ${ CONFIG.radiusBlockUi };
 
-	padding: ${ space( 2 ) } ${ ITEM_PADDING_INLINE_END } ${ space( 2 ) }
-		${ ITEM_PADDING_INLINE_START };
+	padding-block: ${ ITEM_PADDING_BLOCK };
+	padding-inline: ${ ITEM_PADDING_INLINE };
 
 	user-select: none;
 	outline: none;
 
 	&[aria-disabled='true'] {
-		/*
-		TODO:
-			- we need a disabled color in the Theme variables
-			- design specs use opacity instead of setting a new text color
-	*/
-		opacity: 0.5;
+		color: ${ COLORS.ui.textDisabled };
 		pointer-events: none;
 	}
 
 	/* Hover */
-	&[data-active-item] {
-		/* TODO: reconcile with global focus styles */
-		background-color: ${ COLORS.gray[ '100' ] };
+	&[data-active-item]:not( [data-focus-visible] ) {
+		background-color: ${ COLORS.theme.accent };
+		color: ${ COLORS.white };
 	}
 
 	/* Keyboard focus (focus-visible) */
@@ -247,7 +179,8 @@ const baseItem = css`
 
 	/* When the item is the trigger of an open submenu */
 	${ DropdownMenu }:not(:focus) &:not(:focus)[aria-expanded="true"] {
-		/* TODO: should we style submenu triggers any different? */
+		background-color: ${ COLORS.gray[ 100 ] };
+		color: ${ COLORS.gray[ 900 ] };
 	}
 
 	svg {
@@ -256,15 +189,44 @@ const baseItem = css`
 `;
 
 export const DropdownMenuItem = styled( Ariakit.MenuItem )`
-	${ baseItem }
+	${ baseItem };
 `;
 
 export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox )`
-	${ baseItem }
+	${ baseItem };
 `;
 
 export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio )`
-	${ baseItem }
+	${ baseItem };
+`;
+
+export const ItemPrefixWrapper = styled.span`
+	/* Always occupy the first column, even when auto-collapsing */
+	grid-column: 1;
+
+	&:not( :empty ) {
+		margin-inline-end: ${ space( 2 ) };
+	}
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	/* Override inline styles applied by ariakit */
+	width: auto !important;
+	height: auto !important;
+
+	color: ${ COLORS.gray[ '700' ] };
+
+	/*
+	* When the parent menu item is active, except when it's a non-focused/hovered
+	* submenu trigger (in that case, color should not be inherited)
+	*/
+	[data-active-item]:not( [data-focus-visible] ) > &,
+	/* When the parent menu item is disabled */
+	[aria-disabled='true'] > & {
+		color: inherit;
+	}
 `;
 
 export const DropdownMenuItemContentWrapper = styled.div`
@@ -275,13 +237,41 @@ export const DropdownMenuItemContentWrapper = styled.div`
 	grid-column: 2;
 
 	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: ${ space( 3 ) };
+
+	pointer-events: none;
 `;
 
 export const DropdownMenuItemChildrenWrapper = styled.div`
 	flex: 1;
+
 	display: inline-flex;
 	flex-direction: column;
-	pointer-events: none;
+	gap: ${ space( 1 ) };
+`;
+
+export const ItemSuffixWrapper = styled.span`
+	flex: 0;
+	width: max-content;
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: ${ space( 3 ) };
+
+	color: ${ COLORS.gray[ '700' ] };
+
+	/*
+	 * When the parent menu item is active, except when it's a non-focused/hovered
+	 * submenu trigger (in that case, color should not be inherited)
+	 */
+	[data-active-item]:not( [data-focus-visible] ) *:not(${ DropdownMenu }) &,
+	/* When the parent menu item is disabled */
+	[aria-disabled='true'] *:not(${ DropdownMenu }) & {
+		color: inherit;
+	}
 `;
 
 export const DropdownMenuGroup = styled( Ariakit.MenuGroup )`
@@ -297,41 +287,37 @@ export const DropdownMenuSeparator = styled( Ariakit.MenuSeparator )<
 
 	border: none;
 	height: ${ CONFIG.borderWidth };
-	/* TODO: doesn't match border color from variables */
 	background-color: ${ ( props ) =>
 		props.variant === 'toolbar'
 			? TOOLBAR_VARIANT_BORDER_COLOR
-			: DEFAULT_BORDER_COLOR };
-	/* Negative horizontal margin to make separator go from side to side */
-	margin: ${ space( 2 ) } calc( -1 * ${ CONTENT_WRAPPER_PADDING } );
+			: DIVIDER_COLOR };
+	/* Align with menu items' content */
+	margin-block: ${ space( 2 ) };
+	margin-inline: ${ ITEM_PADDING_INLINE };
 
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 `;
 
 export const SubmenuChevronIcon = styled( Icon )`
+	width: ${ space( 1.5 ) };
 	${ rtl(
 		{
-			transform: `scaleX(1) translateX(${ space( 2 ) })`,
+			transform: `scaleX(1)`,
 		},
 		{
-			transform: `scaleX(-1) translateX(${ space( 2 ) })`,
+			transform: `scaleX(-1)`,
 		}
-	) }
+	) };
 `;
 
 export const DropdownMenuItemHelpText = styled( Truncate )`
-	font-size: 12px;
+	font-size: ${ font( 'helpText.fontSize' ) };
+	line-height: 16px;
 	color: ${ COLORS.gray[ '700' ] };
-`;
 
-// /* when the immediate parent item is hovered / focused */
-// [data-active-item] > ${ DropdownMenuItem }[data-active-item] > &,
-// [data-active-item] > ${ DropdownMenuRadioItem }[data-active-item] > &,
-// [data-active-item] > ${ DropdownMenuCheckboxItem }[data-active-item] > &,
-// /* when the parent item is a submenu trigger and the submenu is open */
-// [aria-expanded='true'] > &,
-// /* when the parent item is disabled */
-// [aria-disabled='true'] > & {
-// 	color: inherit;
-// }
+	[data-active-item]:not( [data-focus-visible] ) *:not( ${ DropdownMenu } ) &,
+	[aria-disabled='true'] *:not( ${ DropdownMenu } ) & {
+		color: inherit;
+	}
+`;

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -231,18 +231,14 @@ const baseItem = css`
 	svg {
 		fill: currentColor;
 	}
+
+	&:not( :has( ${ ItemPrefixWrapper } ) ) {
+		padding-inline-start: ${ ITEM_PREFIX_WIDTH };
+	}
 `;
 
-export const DropdownMenuItem = styled( Ariakit.MenuItem )< {
-	shouldIndent?: boolean;
-} >`
+export const DropdownMenuItem = styled( Ariakit.MenuItem )`
 	${ baseItem }
-
-	${ ( props ) =>
-		props.shouldIndent &&
-		`
-		padding-inline-start: ${ ITEM_PREFIX_WIDTH };
-		` }
 `;
 
 export const DropdownMenuCheckboxItem = styled( Ariakit.MenuItemCheckbox )`

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -154,7 +154,7 @@ const baseItem = css`
 
 	&[aria-disabled='true'] {
 		color: ${ COLORS.ui.textDisabled };
-		pointer-events: none;
+		cursor: not-allowed;
 	}
 
 	/* Hover */

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -158,7 +158,9 @@ const baseItem = css`
 	}
 
 	/* Hover */
-	&[data-active-item]:not( [data-focus-visible] ) {
+	&[data-active-item]:not( [data-focus-visible] ):not(
+			[aria-disabled='true']
+		) {
 		background-color: ${ COLORS.theme.accent };
 		color: ${ COLORS.white };
 	}

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -220,10 +220,6 @@ export const ItemPrefixWrapper = styled.span`
 	align-items: center;
 	justify-content: center;
 
-	/* Override inline styles applied by ariakit */
-	width: auto !important;
-	height: auto !important;
-
 	color: ${ COLORS.gray[ '700' ] };
 
 	/*

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -21,7 +21,7 @@ const ANIMATION_PARAMS = {
 	EASING: 'cubic-bezier( 0.16, 1, 0.3, 1 )',
 };
 
-const CONTENT_WRAPPER_PADDING = space( 2 );
+const CONTENT_WRAPPER_PADDING = space( 1 );
 const ITEM_PADDING_BLOCK = space( 2 );
 const ITEM_PADDING_INLINE = space( 3 );
 
@@ -86,7 +86,7 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 	padding: ${ CONTENT_WRAPPER_PADDING };
 
 	background-color: ${ COLORS.ui.background };
-	border-radius: ${ CONFIG.radiusBlockUi };
+	border-radius: 4px;
 	${ ( props ) => css`
 		box-shadow: ${ props.variant === 'toolbar'
 			? TOOLBAR_VARIANT_BOX_SHADOW

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -149,6 +149,12 @@ const baseItem = css`
 	padding-block: ${ ITEM_PADDING_BLOCK };
 	padding-inline: ${ ITEM_PADDING_INLINE };
 
+	/*
+	 * Make sure that, when an item is scrolled into view (eg. while using the
+	 * keyboard to move focus), the whole item comes into view
+	 */
+	scroll-margin: ${ CONTENT_WRAPPER_PADDING };
+
 	user-select: none;
 	outline: none;
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
@@ -16,7 +16,6 @@ import {
 	DropdownMenu,
 	DropdownMenuCheckboxItem,
 	DropdownMenuItem,
-	DropdownMenuGroupLabel,
 	DropdownMenuRadioItem,
 	DropdownMenuSeparator,
 	DropdownMenuGroup,
@@ -452,9 +451,6 @@ describe( 'DropdownMenu', () => {
 				return (
 					<DropdownMenu trigger={ <button>Open dropdown</button> }>
 						<DropdownMenuGroup>
-							<DropdownMenuGroupLabel>
-								Radio group label
-							</DropdownMenuGroupLabel>
 							<DropdownMenuRadioItem
 								name="radio-test"
 								value="radio-one"
@@ -532,9 +528,6 @@ describe( 'DropdownMenu', () => {
 			render(
 				<DropdownMenu trigger={ <button>Open dropdown</button> }>
 					<DropdownMenuGroup>
-						<DropdownMenuGroupLabel>
-							Radio group label
-						</DropdownMenuGroupLabel>
 						<DropdownMenuRadioItem
 							name="radio-test"
 							value="radio-one"

--- a/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
@@ -984,7 +984,7 @@ describe( 'DropdownMenu', () => {
 			// The contents of the suffix are rendered after the item's children
 			expect(
 				screen.getByRole( 'menuitemradio', {
-					name: 'Radio item oneRadio suffix',
+					name: 'Radio item one Radio suffix',
 				} )
 			).toBeInTheDocument();
 		} );

--- a/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/test/index.tsx
@@ -133,8 +133,9 @@ describe( 'DropdownMenu', () => {
 			await press.ArrowDown();
 
 			// DropdownMenu open, focus is on the first focusable item
+			// (disabled items are still focusable and accessible)
 			expect(
-				screen.getByRole( 'menuitem', { name: 'Second item' } )
+				screen.getByRole( 'menuitem', { name: 'First item' } )
 			).toHaveFocus();
 		} );
 
@@ -162,8 +163,9 @@ describe( 'DropdownMenu', () => {
 			await press.Space();
 
 			// DropdownMenu open, focus is on the first focusable item
+			// (disabled items are still focusable and accessible
 			expect(
-				screen.getByRole( 'menuitem', { name: 'Second item' } )
+				screen.getByRole( 'menuitem', { name: 'First item' } )
 			).toHaveFocus();
 		} );
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -88,13 +88,6 @@ export interface DropdownMenuGroupProps {
 	children: React.ReactNode;
 }
 
-export interface DropdownMenuGroupLabelProps {
-	/**
-	 * The contents of the dropdown menu group label.
-	 */
-	children: React.ReactNode;
-}
-
 export interface DropdownMenuItemProps {
 	/**
 	 * The contents of the menu item.

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -14,20 +14,6 @@ export interface DropdownMenuContext {
 	 * The variant used by the underlying menu popover.
 	 */
 	variant?: 'toolbar';
-	/**
-	 * Whether items in this menu should be indented, ie. they should show
-	 * extra white space even when they don't have a prefix.
-	 */
-	shouldIndent: boolean;
-	/**
-	 * Function used by menu items to let the parent dropdown menu know
-	 * whether they are rendering a prefix or not.
-	 */
-	registerHasPrefix: ( itemId: string, hasPrefix: boolean ) => void;
-	/**
-	 * Function used by menu items to unregister a previously set entry.
-	 */
-	unregisterHasPrefix: ( itemId: string ) => void;
 }
 
 export interface DropdownMenuProps {

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -14,6 +14,20 @@ export interface DropdownMenuContext {
 	 * The variant used by the underlying menu popover.
 	 */
 	variant?: 'toolbar';
+	/**
+	 * Whether items in this menu should be indented, ie. they should show
+	 * extra white space even when they don't have a prefix.
+	 */
+	shouldIndent: boolean;
+	/**
+	 * Function used by menu items to let the parent dropdown menu know
+	 * whether they are rendering a prefix or not.
+	 */
+	registerHasPrefix: ( itemId: string, hasPrefix: boolean ) => void;
+	/**
+	 * Function used by menu items to unregister a previously set entry.
+	 */
+	unregisterHasPrefix: ( itemId: string ) => void;
 }
 
 export interface DropdownMenuProps {

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -32,7 +32,6 @@ import {
 import {
 	DropdownMenu as DropdownMenuV2Ariakit,
 	DropdownMenuGroup as DropdownMenuGroupV2Ariakit,
-	DropdownMenuGroupLabel as DropdownMenuGroupLabelV2Ariakit,
 	DropdownMenuItem as DropdownMenuItemV2Ariakit,
 	DropdownMenuCheckboxItem as DropdownMenuCheckboxItemV2Ariakit,
 	DropdownMenuRadioItem as DropdownMenuRadioItemV2Ariakit,
@@ -74,7 +73,6 @@ lock( privateApis, {
 	Theme,
 	DropdownMenuV2Ariakit,
 	DropdownMenuGroupV2Ariakit,
-	DropdownMenuGroupLabelV2Ariakit,
 	DropdownMenuItemV2Ariakit,
 	DropdownMenuCheckboxItemV2Ariakit,
 	DropdownMenuRadioItemV2Ariakit,

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -36,6 +36,8 @@ import {
 	DropdownMenuCheckboxItem as DropdownMenuCheckboxItemV2Ariakit,
 	DropdownMenuRadioItem as DropdownMenuRadioItemV2Ariakit,
 	DropdownMenuSeparator as DropdownMenuSeparatorV2Ariakit,
+	DropdownMenuItemLabel as DropdownMenuItemLabelV2Ariakit,
+	DropdownMenuItemHelpText as DropdownMenuItemHelpTextV2Ariakit,
 } from './dropdown-menu-v2-ariakit';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
@@ -77,4 +79,6 @@ lock( privateApis, {
 	DropdownMenuCheckboxItemV2Ariakit,
 	DropdownMenuRadioItemV2Ariakit,
 	DropdownMenuSeparatorV2Ariakit,
+	DropdownMenuItemLabelV2Ariakit,
+	DropdownMenuItemHelpTextV2Ariakit,
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #55933

This PR includes a series of tweaks to the experimental new version of `DropdownMenu`, based on the specs shared in #55933.

Main tweaks:
- Removed group label component (not needed)
- Added new subcomponents for menu item label and help text (mostly needed because of text truncation behavior)
- Added auto-indentation of menu items based on the presence, in the same popover, of at least one item with a prefix
- Tweaks to spacing, typography, colors, hovered/focused/disabled states...

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The design spec brings a coherent look with the rest of the components library, and addresses a few complex scenarios when dealing with some combinations of menu items and their contents.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The most complex bits in the implementation:
- CSS grid and subgrid were used to implement the auto-indent functionality
- The Label and Help text subcomponent use the `Truncate` component under the hood

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the "DropdownMenu v2 ariakit" Storybook examples, make sure that the component follows the design specs

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1083581/398c4224-83f2-4219-b14b-3d739630c75c




