### PR TITLE
Fix mismatching link control action buttons visual order and DOM order

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -275,14 +275,14 @@ If passed, children are rendered after the input.
 
 ```jsx
 <LinkControlSearchInput>
-	<div className="block-editor-link-control__search-actions">
+	<HStack justify="right">
 		<Button
 			type="submit"
 			label={ __( 'Submit' ) }
 			icon={ keyboardReturn }
 			className="block-editor-link-control__search-submit"
 		/>
-	</div>
+	</HStack>
 </LinkControlSearchInput>
 ```
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -6,7 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, Spinner, Notice, TextControl } from '@wordpress/components';
+import {
+	Button,
+	Spinner,
+	Notice,
+	TextControl,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
@@ -467,7 +473,13 @@ function LinkControl( {
 			) }
 
 			{ showActions && (
-				<div className="block-editor-link-control__search-actions">
+				<HStack
+					justify="right"
+					className="block-editor-link-control__search-actions"
+				>
+					<Button variant="tertiary" onClick={ handleCancel }>
+						{ __( 'Cancel' ) }
+					</Button>
 					<Button
 						variant="primary"
 						onClick={ isDisabled ? noop : handleSubmit }
@@ -476,10 +488,7 @@ function LinkControl( {
 					>
 						{ __( 'Save' ) }
 					</Button>
-					<Button variant="tertiary" onClick={ handleCancel }>
-						{ __( 'Cancel' ) }
-					</Button>
-				</div>
+				</HStack>
 			) }
 
 			{ renderControlBottom && renderControlBottom() }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -96,12 +96,7 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__search-actions {
-	display: flex;
-	flex-direction: row-reverse; // put "Cancel" on the left but retain DOM order.
-	justify-content: flex-start;
-	gap: $grid-unit-10;
 	padding: $grid-unit-10 $grid-unit-20 $grid-unit-20;
-	order: 20;
 }
 
 .block-editor-link-control__search-results-wrapper {

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -56,7 +56,7 @@
 		}
 
 		.block-editor-link-control__search-actions {
-			padding: 0;
+			padding: $grid-unit-10 0 0;
 		}
 	}
 }

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -17,6 +17,7 @@
 	&.has-siblings {
 		border-top: $border-width solid $gray-900;
 		margin-top: $grid-unit-10;
+		padding-bottom: $grid-unit-10;
 	}
 
 	.block-editor-media-replace-flow__image-url-label {
@@ -55,8 +56,7 @@
 		}
 
 		.block-editor-link-control__search-actions {
-			top: 0; // cancel default top positioning
-			right: 4px;
+			padding: 0;
 		}
 	}
 }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -21,7 +21,6 @@
 		font-size: $default-font-size;
 		padding: 6px 12px;
 
-		&.is-tertiary,
 		&.has-icon {
 			padding: 6px;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/56039

## What?
<!-- In a few words, what is the PR actually doing? -->
First pass at fixing the mismatching visual and DOM order of the 'Cancel' and 'Save' buttons in the link control UI.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For accessibility, visual order and DOM order must always match.
It is important to make all designers and developers aware of this. Pinging all the folks who worked on https://github.com/WordPress/gutenberg/pull/46933
Cc @getdave @draganescu @jameskoster @richtabor @scruffian @jasmussen @joedolson @SaxonF


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Uses the `HStack` component instead of custom CSS rules. This makes these Cancel/Save buttons consistent with all similar button paris in use in the edifor, for example in the:
- block lock modal dialog 
- block removal warning modal dialog
- block rename modal dialog 
- classic block modal dialog 
- all confirm modal dialogs 
- create custom template modal dialog 
- create new page modal dialog 
- create template part modal 
- rename menu item modal dialog 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post, select some text and add a link.
- Select the link in the text. A popover opens. Click the pencil 'Edit' button.
- A new UI opens within the popover, to edit the link.
- Tab through the focusable elements.
- Observe the Cancel button receives focus first.
- Observe the Save button receives focus after the Cancel button.
- Add an Image block.
- Select the image and click 'Replace' in the block toolbar.
- Click the pencil 'Edit' button.
- A new UI opens within the popover, to edit the image URL.
- Tab through the focusable elements.
- Observe the Cancel button receives focus first.
- Observe the Save button receives focus after the Cancel button.

Additionally:
- In the Replace media popover, observe there is no extra padding around the buttons.
- In the Edit link popover, observe the Cancel tertiary button has the default padding for tertiary buttons.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
See above.

## Screenshots or screencast <!-- if applicable -->

Before: 

![before 01](https://github.com/WordPress/gutenberg/assets/1682452/c000c2be-b9c2-4cc5-984f-dcbeec4fadd0)

After:

![after 01](https://github.com/WordPress/gutenberg/assets/1682452/e59f6d38-cb12-455f-a5f8-71a98797ae4e)




