### PR TITLE
Lightbox: Fix "Expand on click" control being disabled unintentionally

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -355,7 +355,8 @@ export default function Image( {
 	const lightboxChecked =
 		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );
 
-	const lightboxToggleDisabled = linkDestination !== 'none';
+	const lightboxToggleDisabled =
+		linkDestination && linkDestination !== 'none';
 
 	const dimensionsControl = (
 		<DimensionsTool


### PR DESCRIPTION
Fixes #56049

## What?

This PR fixes an issue where the Lightbox control ("Expand on click") becomes disabled when an image is inserted in the following two scenarios:

- Insert media from URL
- Insert from media inserter

## Why?

Whether to disable the lightbox toggle is determined by `linkDestination !== 'none`. However, depending on how the image is inserted, this attribute is not necessarily added:

Select an image from the media library after inserting an image block:

```html
<!-- wp:image {"id":1,"linkDestination":"none"} -->
<figure class="wp-block-image">
	<img src="/path/to/image.jpg" alt="" class="wp-image-1"/>
</figure>
<!-- /wp:image -->
```

Enter the URL after inserting the image block:

```html
<!-- wp:image  -->
<figure class="wp-block-image">
	<img src="/path/to/image.jpg" alt=""/>
</figure>
<!-- /wp:image -->
```

Insert images from the media tab of the media inserter:

```html
<!-- wp:image -->
<figure class="wp-block-image">
	<img src="/path/to/image.jpg" alt="" class="wp-image-1"/>
</figure>
<!-- /wp:image -->
```

As you can see, the `linkDestination` attribute may not be applied. In this case, `linkDestination !== 'none'` is true, resulting in the control being unintentionally disabled.

## How?

Added condition that `linkDestination` attribute is not falsy.

## Testing Instructions

- Add images using the following three methods.
  - Select an image from the media library after inserting an image block
  - Enter the URL after inserting the image block
  - Insert images from the media tab of the media inserter
- The "Expand on Click" control should not be disabled.