### PR TITLE
Image block: Add check for lightbox values during image block migration

### DIFF
--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -1047,6 +1047,14 @@ const v8 = {
 		},
 	},
 	migrate( { width, height, ...attributes } ) {
+		// We need to perform a check here because in cases
+		// where attributes are added dynamically to blocks,
+		// block invalidation overrides the isEligible() method
+		// and forces the migration to run, so it's not guaranteed
+		// that `behaviors` or `behaviors.lightbox` will be defined.
+		if ( ! attributes.behaviors?.lightbox ) {
+			return attributes;
+		}
 		const {
 			behaviors: {
 				lightbox: { enabled },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds a check for the `behaviors` and `behaviors.lightbox` attributes during image block migration to prevent the Gutenberg editor from breaking unexpectedly

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/56055
Editing image block attributes dynamically may cause block invalidation and the image's migration logic to run, bypassing the `isEligible()` method, and we need an extra check to ensure the editor doesn't break.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It adds a check in the image block's `deprecated.js`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add the following code to your theme's `functions.php`:

```
add_filter( 'block_type_metadata', 'set_image_auto_centre' );

function set_image_auto_centre( $metadata ) {
  if ( 'core/image' !== $metadata['name'] ) {
    return $metadata;
  }
  $metadata['attributes']['align']['default'] = 'center';

  return $metadata;
}
```
2. Open the WordPress editor and try adding a new post.
3. See that the editor does not break.

## Screenshots or screencast <!-- if applicable -->

Here's a screenshot of the error one receives without the check from this PR:

<img width="892" alt="Screenshot 2023-11-11 at 5 22 52 PM" src="https://github.com/WordPress/gutenberg/assets/5360536/cd0adce5-a143-4a76-bb2e-c7a0a0b16eba">
