### PR TITLE
Lightbox: Fix button misalignment in gallery image

### DIFF
--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -313,11 +313,21 @@ store(
 						if ( caption ) {
 							const captionComputedStyle =
 								window.getComputedStyle( caption );
-							figureHeight =
-								figureHeight -
-								caption.offsetHeight -
-								parseFloat( captionComputedStyle.marginTop ) -
-								parseFloat( captionComputedStyle.marginBottom );
+							if (
+								! [ 'absolute', 'fixed' ].includes(
+									captionComputedStyle.position
+								)
+							) {
+								figureHeight =
+									figureHeight -
+									caption.offsetHeight -
+									parseFloat(
+										captionComputedStyle.marginTop
+									) -
+									parseFloat(
+										captionComputedStyle.marginBottom
+									);
+							}
 						}
 
 						const buttonOffsetTop = figureHeight - offsetHeight;


### PR DESCRIPTION
Fixes #56058

## What?

This PR fixes an issue where the Lightbox toggle button is misaligned when the image is in a gallery block and has a caption.

### Before 

![before](https://github.com/WordPress/gutenberg/assets/54422211/ddb792aa-7863-477e-a1d5-b22d3616f203)

### After

![after](https://github.com/WordPress/gutenberg/assets/54422211/9fffd04d-bc85-4bc5-b7dd-a7828e9ba922)

## Why?

When positioning the button, the height of the caption is taken into account because if the image has a caption, the figure element will be taller than the image. However, the caption of the image block inside the gallery block has the `position:absolute` style by default, so it does not affect the height of the figure element. As a result, the button's position is shifted up by the height of the caption.

## How?
Does not take into account the height of the caption when the position property of the caption is `absolute` or `fixed`. Although `position:fixed` may be rarely applied, this style also does not affect the height of the figure element.

## Testing Instructions

- Insert an image inside a gallery block.
- Enter a caption for the image and enable Lightbox.
- Focus the image on the front end.
- The lightbox button should be located just at the top right of the image.