### PR TITLE
Fix fatal error in WP_Fonts_Resolver::get_settings()

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -200,11 +200,6 @@ class WP_Fonts_Resolver {
 			if ( $set_theme_structure ) {
 				$set_theme_structure = false;
 				$settings            = static::set_tyopgraphy_settings_array_structure( $settings );
-
-				// Initialize the font families from settings if set and is an array, otherwise default to an empty array.
-				if ( ! isset( $settings['typography']['fontFamilies']['theme'] ) || ! is_array( $settings['typography']['fontFamilies']['theme'] ) ) {
-					$settings['typography']['fontFamilies']['theme'] = array();
-				}
 			}
 
 			// Initialize the font families from variation if set and is an array, otherwise default to an empty array.
@@ -219,7 +214,12 @@ class WP_Fonts_Resolver {
 			);
 
 			// Make sure there are no duplicates.
-			$settings['typography']['fontFamilies'] = array_unique( $settings['typography']['fontFamilies'] );
+			$settings['typography']['fontFamilies'] = array_unique( $settings['typography']['fontFamilies'], SORT_REGULAR );
+
+			// The font families from settings might become null after running the `array_unique`.
+			if ( ! isset( $settings['typography']['fontFamilies']['theme'] ) || ! is_array( $settings['typography']['fontFamilies']['theme'] ) ) {
+				$settings['typography']['fontFamilies']['theme'] = array();
+			}
 		}
 
 		return $settings;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR aims to fix a PHP fatal error that occurs within WP_Fonts_Resolver::get_settings() under certain conditions.

```
PHP Fatal error:  Uncaught TypeError: array_merge(): Argument #1 must be of type array, null given in /lib/experimental/fonts-api/class-wp-fonts-resolver.php:208
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Generally, the code should not trigger PHP fatal errors because certain variables do not match the expected type.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR ensures that the `$settings['typography']['fontFamilies']['theme']` won't become `null` after the `array_unique()`function inside WP_Fonts_Resolver::get_settings()

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Activate the [ueno](https://wordpress.com/theme/ueno) theme
2. Go to the post editor
3. Ensure you won't see the error of the `array_merge`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
