### PR TITLE
Drag and drop: allow dragging to the beginning and end of a document

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -172,7 +172,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	const {
 		__unstableDisableLayoutClassNames,
 		__unstableDisableDropZone,
-		dropZoneElement,
+		__unstableDropZoneElement,
 	} = options;
 	const {
 		clientId,
@@ -214,7 +214,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	);
 
 	const blockDropZoneRef = useBlockDropZone( {
-		dropZoneElement,
+		dropZoneElement: __unstableDropZoneElement,
 		rootClientId: clientId,
 	} );
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -172,7 +172,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	const {
 		__unstableDisableLayoutClassNames,
 		__unstableDisableDropZone,
-		__unstableContentRef,
+		dropZoneElement,
 	} = options;
 	const {
 		clientId,
@@ -214,7 +214,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	);
 
 	const blockDropZoneRef = useBlockDropZone( {
-		dropZoneElement: __unstableContentRef?.current,
+		dropZoneElement,
 		rootClientId: clientId,
 	} );
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -169,8 +169,11 @@ const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md
  */
 export function useInnerBlocksProps( props = {}, options = {} ) {
-	const { __unstableDisableLayoutClassNames, __unstableDisableDropZone } =
-		options;
+	const {
+		__unstableDisableLayoutClassNames,
+		__unstableDisableDropZone,
+		__unstableContentRef,
+	} = options;
 	const {
 		clientId,
 		layout = null,
@@ -211,6 +214,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	);
 
 	const blockDropZoneRef = useBlockDropZone( {
+		dropZoneElement: __unstableContentRef?.current,
 		rootClientId: clientId,
 	} );
 

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -127,7 +127,8 @@ export function getDropTargetPosition(
 
 /**
  * @typedef  {Object} WPBlockDropZoneConfig
- * @property {string} rootClientId The root client id for the block list.
+ * @property {?HTMLElement} dropZoneElement Optional element to be used as the drop zone.
+ * @property {string}       rootClientId    The root client id for the block list.
  */
 
 /**
@@ -136,6 +137,7 @@ export function getDropTargetPosition(
  * @param {WPBlockDropZoneConfig} dropZoneConfig configuration data for the drop zone.
  */
 export default function useBlockDropZone( {
+	dropZoneElement,
 	// An undefined value represents a top-level block. Default to an empty
 	// string for this so that `targetRootClientId` can be easily compared to
 	// values returned by the `getRootBlockClientId` selector, which also uses
@@ -235,6 +237,7 @@ export default function useBlockDropZone( {
 	);
 
 	return useDropZone( {
+		dropZoneElement,
 		isDisabled,
 		onDrop: onBlockDrop,
 		onDragOver( event ) {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -411,7 +411,13 @@ export default function VisualEditor( { styles } ) {
 										: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
 								}
 								layout={ blockListLayout }
-								dropZoneElement={ ref.current }
+								dropZoneElement={
+									// When iframed, pass in the html element of the iframe to
+									// ensure the drop zone extends to the edges of the iframe.
+									isToBeIframed
+										? ref.current?.parentNode
+										: ref.current
+								}
 							/>
 						</RecursionProvider>
 					</BlockCanvas>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -411,7 +411,7 @@ export default function VisualEditor( { styles } ) {
 										: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
 								}
 								layout={ blockListLayout }
-								__unstableContentRef={ ref }
+								dropZoneElement={ ref?.current }
 							/>
 						</RecursionProvider>
 					</BlockCanvas>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -411,6 +411,7 @@ export default function VisualEditor( { styles } ) {
 										: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
 								}
 								layout={ blockListLayout }
+								__unstableContentRef={ ref }
 							/>
 						</RecursionProvider>
 					</BlockCanvas>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -411,7 +411,7 @@ export default function VisualEditor( { styles } ) {
 										: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
 								}
 								layout={ blockListLayout }
-								dropZoneElement={ ref?.current }
+								dropZoneElement={ ref.current }
 							/>
 						</RecursionProvider>
 					</BlockCanvas>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -411,7 +411,7 @@ export default function VisualEditor( { styles } ) {
 										: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
 								}
 								layout={ blockListLayout }
-								dropZoneElement={
+								__unstableDropZoneElement={
 									// When iframed, pass in the html element of the iframe to
 									// ensure the drop zone extends to the edges of the iframe.
 									isToBeIframed

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -134,6 +134,12 @@ export default function SiteEditorCanvas() {
 													isTemplateTypeNavigation,
 											}
 										) }
+										dropZoneElement={
+											// Pass in the html element of the iframe to ensure that
+											// the drop zone extends ot the very edges of the iframe,
+											// even if the template is shorter than the viewport.
+											contentRef.current?.parentNode
+										}
 										layout={ LAYOUT }
 										renderAppender={ showBlockAppender }
 									/>

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -134,7 +134,7 @@ export default function SiteEditorCanvas() {
 													isTemplateTypeNavigation,
 											}
 										) }
-										dropZoneElement={
+										__unstableDropZoneElement={
 											// Pass in the html element of the iframe to ensure that
 											// the drop zone extends ot the very edges of the iframe,
 											// even if the template is shorter than the viewport.

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -136,7 +136,7 @@ export default function SiteEditorCanvas() {
 										) }
 										__unstableDropZoneElement={
 											// Pass in the html element of the iframe to ensure that
-											// the drop zone extends ot the very edges of the iframe,
+											// the drop zone extends to the very edges of the iframe,
 											// even if the template is shorter than the viewport.
 											contentRef.current?.parentNode
 										}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Possible fix for: https://github.com/WordPress/gutenberg/issues/32438 and #55474, implements a potential solution for https://github.com/WordPress/gutenberg/issues/26049

Allow dragging to the top and bottom of the editor canvas, to drag and drop more easily to the beginning or end of the document. This uses a similar approach to that used in the list view in https://github.com/WordPress/gutenberg/pull/50726

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently it's quite fiddly to drag to the beginning and end of the document. One way to resolve this is to pass in a ref to a larger around within which we allow dragging and dropping.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In `useInnerBlocksProps` allow passing in an element to be used as the drop zone area, and use that to allow drag and drop to the top or bottom of the document. This builds on the solution earlier used for the list view in https://github.com/WordPress/gutenberg/pull/50726.
* When iframed, use the parent of the body of the iframe (the `html` element) so that the full area of the iframe is used for the dropzone. This allows drag and drop over the very top area of the post editor (above the post title) to be considered as intending to drag to the beginning of the document, and the very bottom area of the site editor when a short template is used to flag dragging to the end of the document. In other words, if the `body` element is shorter than the full area of the iframe, the full area of the iframe is still used to determine whether a drop target should be considered.

## To-do

* [x] Implement in the site editor
* [x] Tidy up and make the naming consistent

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a short post in the post editor, try dragging blocks to the top and bottom positions — dragging anywhere in the top or bottom of the document should now allow dragging and dropping to the top and bottom of the document, rather than needing to hover over existing blocks in the document.
2. In the site editor, go to edit a template that is shorter than the viewport. Drag a block toward the very bottom of the template — with this PR applied it should be easy to drag to the bottom most position, whereas on `trunk` you can only drag to the last block within the template

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/fb961b7a-5860-4c6a-9441-b47a187f197b

### After

https://github.com/WordPress/gutenberg/assets/14988353/f109d3fd-ea05-4348-86cf-7b797b99fe43