### PR TITLE
Rich text: highlight format: gracefully handle old span format

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -135,23 +135,5 @@ export const textColor = {
 		style: 'style',
 		class: 'class',
 	},
-	/*
-	 * Since this format relies on the <mark> tag, it's important to
-	 * prevent the default yellow background color applied by most
-	 * browsers. The solution is to detect when this format is used with a
-	 * text color but no background color, and in such cases to override
-	 * the default styling with a transparent background.
-	 *
-	 * @see https://github.com/WordPress/gutenberg/pull/35516
-	 */
-	__unstableFilterAttributeValue( key, value ) {
-		if ( key !== 'style' ) return value;
-		// We should not add a background-color if it's already set.
-		if ( value && value.includes( 'background-color' ) ) return value;
-		const addedCSS = [ 'background-color', transparentValue ].join( ':' );
-		// Prepend `addedCSS` to avoid a double `;;` as any the existing CSS
-		// rules will already include a `;`.
-		return value ? [ addedCSS, value ].join( ';' ) : addedCSS;
-	},
 	edit: TextColorEdit,
 };

--- a/packages/format-library/src/text-color/index.native.js
+++ b/packages/format-library/src/text-color/index.native.js
@@ -26,7 +26,6 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
  * Internal dependencies
  */
 import { getActiveColors } from './inline.js';
-import { transparentValue } from './index.js';
 import { default as InlineColorUI } from './inline';
 import styles from './style.scss';
 
@@ -182,27 +181,6 @@ export const textColor = {
 	attributes: {
 		style: 'style',
 		class: 'class',
-	},
-	/*
-	 * Since this format relies on the <mark> tag, it's important to
-	 * prevent the default yellow background color applied by most
-	 * browsers. The solution is to detect when this format is used with a
-	 * text color but no background color, and in such cases to override
-	 * the default styling with a transparent background.
-	 *
-	 * @see https://github.com/WordPress/gutenberg/pull/35516
-	 */
-	__unstableFilterAttributeValue( key, value ) {
-		if ( key !== 'style' ) return value;
-		// We need to remove the extra spaces within the styles on mobile
-		const newValue = value?.replace( / /g, '' );
-		// We should not add a background-color if it's already set
-		if ( newValue && newValue.includes( 'background-color' ) )
-			return newValue;
-		const addedCSS = [ 'background-color', transparentValue ].join( ':' );
-		// Prepend `addedCSS` to avoid a double `;;` as any the existing CSS
-		// rules will already include a `;`.
-		return newValue ? [ addedCSS, newValue ].join( ';' ) : addedCSS;
 	},
 	edit: TextColorEdit,
 };

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -89,21 +89,6 @@ export function useRichText( {
 	if ( ! record.current ) {
 		hadSelectionUpdate.current = isSelected;
 		setRecordFromProps();
-		// Sometimes formats are added programmatically and we need to make
-		// sure it's persisted to the block store / markup. If these formats
-		// are not applied, they could cause inconsistencies between the data
-		// in the visual editor and the frontend. Right now, it's only relevant
-		// to the `core/text-color` format, which is applied at runtime in
-		// certain circunstances. See the `__unstableFilterAttributeValue`
-		// function in `packages/format-library/src/text-color/index.js`.
-		// @todo find a less-hacky way of solving this.
-
-		const hasRelevantInitFormat =
-			record.current?.formats[ 0 ]?.[ 0 ]?.type === 'core/text-color';
-
-		if ( hasRelevantInitFormat ) {
-			handleChangesUponInit( record.current );
-		}
 	} else if (
 		selectionStart !== record.current.start ||
 		selectionEnd !== record.current.end
@@ -147,29 +132,6 @@ export function useRichText( {
 		// We batch both calls to only attempt to rerender once.
 		registry.batch( () => {
 			onSelectionChange( start, end );
-			onChange( _value.current, {
-				__unstableFormats: formats,
-				__unstableText: text,
-			} );
-		} );
-		forceRender();
-	}
-
-	function handleChangesUponInit( newRecord ) {
-		record.current = newRecord;
-
-		_value.current = toHTMLString( {
-			value: __unstableBeforeSerialize
-				? {
-						...newRecord,
-						formats: __unstableBeforeSerialize( newRecord ),
-				  }
-				: newRecord,
-		} );
-
-		const { formats, text } = newRecord;
-
-		registry.batch( () => {
 			onChange( _value.current, {
 				__unstableFormats: formats,
 				__unstableText: text,

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -70,14 +70,6 @@ function toFormat( { tagName, attributes } ) {
 
 		registeredAttributes[ key ] = _attributes[ name ];
 
-		if ( formatType.__unstableFilterAttributeValue ) {
-			registeredAttributes[ key ] =
-				formatType.__unstableFilterAttributeValue(
-					key,
-					registeredAttributes[ key ]
-				);
-		}
-
 		// delete the attribute and what's left is considered
 		// to be unregistered.
 		delete _attributes[ name ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Since #52423, rich text no longer forcefully “upgrades” a tag name of a format if it doesn’t match the tag name declared by the format type. This allows us to remove all the logic (introduced in #35516) for adding a background color when a highlight format still uses the old span markup, because we will now leave the span in place. It also allows us to remove the logic that dirties the editor for this upgrade.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The reasoning behind this is not only simplicity, but also leaving existing markup alone. It's needed for #43204, which relies on `create` not modifying existing markup.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

#52423 made a change that allows existing tag names to be preserved.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a post with the following old highlight markup

```html
<!-- wp:paragraph -->
<p><span class="has-inline-color has-vivid-purple-color">text</span></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><span class="has-inline-color" style="color:gold">text</span></p>
<!-- /wp:paragraph -->
```

Ensure that the the text in the editor is correctly coloured. Also ensure that when putting the caret in the text, the highlight button in the rich text dropdown is active. This means the format is properly recognised as a highlight.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
