### PR TITLE
DataViews: fix translatable string

### DIFF
--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -5,6 +5,7 @@ import {
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	SelectControl,
 } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 
 export const OPERATOR_IN = 'in';
 
@@ -30,7 +31,11 @@ export default ( { filter, view, onChangeView } ) => {
 					htmlFor={ id }
 					className="dataviews__select-control-prefix"
 				>
-					{ filter.name + ':' }
+					{ sprintf(
+						/* translators: filter name. */
+						__( '%s:' ),
+						filter.name
+					) }
 				</InputControlPrefixWrapper>
 			}
 			options={ filter.elements }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/56001#discussion_r1388164747

## What?

Fixes a translatable string, providing `:` as part of the string.

## Why?

See https://github.com/WordPress/gutenberg/pull/56001#discussion_r1388164747

## How?

Use `sprintf` to format the string.

## Testing Instructions

- Enable the "wp admin" experiment and visit "Appareance > Editor > Manage all pages".
- Verify the existing author & status filter still render their label as expected:

<img width="569" alt="Captura de ecrã 2023-11-13, às 09 59 45" src="https://github.com/WordPress/gutenberg/assets/583546/87b3e9f4-e901-4a88-a7f7-d51f49f63c3a">
