### PR TITLE
Site Editor: Don't use 'useEntityRecord' to only dispatch actions

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
@@ -3,7 +3,8 @@
  */
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEntityRecord } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ export default function ResetDefaultTemplate( { onClick } ) {
 	const currentTemplateSlug = useCurrentTemplateSlug();
 	const isPostsPage = useIsPostsPage();
 	const { postType, postId } = useEditedPostContext();
-	const entity = useEntityRecord( 'postType', postType, postId );
+	const { editEntityRecord } = useDispatch( coreStore );
 	// The default template in a post is indicated by an empty string.
 	if ( ! currentTemplateSlug || isPostsPage ) {
 		return null;
@@ -27,7 +28,13 @@ export default function ResetDefaultTemplate( { onClick } ) {
 		<MenuGroup>
 			<MenuItem
 				onClick={ async () => {
-					entity.edit( { template: '' }, { undoIgnore: true } );
+					editEntityRecord(
+						'postType',
+						postType,
+						postId,
+						{ template: '' },
+						{ undoIgnore: true }
+					);
 					onClick();
 				} }
 			>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/swap-template-button.js
@@ -6,7 +6,8 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { MenuItem, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEntityRecord } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { parse } from '@wordpress/blocks';
 import { useAsyncList } from '@wordpress/compose';
 
@@ -22,12 +23,18 @@ export default function SwapTemplateButton( { onClick } ) {
 		setShowModal( false );
 	}, [] );
 	const { postType, postId } = useEditedPostContext();
-	const entitiy = useEntityRecord( 'postType', postType, postId );
+	const { editEntityRecord } = useDispatch( coreStore );
 	if ( ! availableTemplates?.length ) {
 		return null;
 	}
 	const onTemplateSelect = async ( template ) => {
-		entitiy.edit( { template: template.name }, { undoIgnore: true } );
+		editEntityRecord(
+			'postType',
+			postType,
+			postId,
+			{ template: template.name },
+			{ undoIgnore: true }
+		);
 		onClose(); // Close the template suggestions modal first.
 		onClick();
 	};


### PR DESCRIPTION
## What?
A micro-optimization for the `SwapTemplateButton` and `ResetDefaultTemplate` components. PR replaces the `useEntityRecord` hook usage with the `editEntityRecord` action.

## Why?
A selected entity by `useEntityRecord` was used during rendering but only to dispatch an edit action. This means components don't have to re-render when the entity is updated; instead, we can dispatch edit action directly.

There's no reason to listen to the store subscription when a component doesn't act upon the data change.

## Testing Instructions
1. Open a page in the Site Editor.
2. Confirm that the "Swap template" and "Use default template" actions work as before. See #51477 for detailed testing instructions.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-11-13 at 13 36 50](https://github.com/WordPress/gutenberg/assets/240569/11b0b54f-f330-4d3f-9aae-ea52b7df4e21)
