### PR TITLE
Register post terms variations on taxonomy registration

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -85,17 +85,22 @@ function build_variation_for_post_terms( $taxonomy ) {
 }
 
 /**
- * Register a variation for a taxonomy for the post-terms block.
+ * Registers a variation for a taxonomy for the post-terms block.
+ *
+ * @since 6.X.Y
  *
  * @param array $variation Variation array from build_variation_for_post_terms.
- * @return void
  */
 function block_core_post_terms_register_variation( $variation ) {
-	// Directly set the variations on the registered block type
-	// because there's no server side registration for variations (see #47170).
+	/*
+	 * Directly set the variations on the registered block type
+	 * because there's no server side registration for variations (see #47170).
+	 */
 	$navigation_block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/post-terms' );
-	// If the block is not registered yet, bail early.
-	// Variation will be registered in register_block_core_post_terms then.
+	/*
+	 * If the block is not registered yet, bail early.
+	 * Variation will be registered in register_block_core_post_terms then.
+	 */
 	if ( ! $navigation_block_type ) {
 		return;
 	}
@@ -107,14 +112,17 @@ function block_core_post_terms_register_variation( $variation ) {
 }
 
 /**
- * Unregister a variation for a taxonomy for the post-terms block.
+ * Unregisters a variation for a taxonomy for the post-terms block.
+ *
+ * @since 6.X.Y
  *
  * @param string $name Name of the taxonomy (which was used as variation name).
- * @return void
  */
 function block_core_post_terms_unregister_variation( $name ) {
-	// Directly get the variations from the registered block type
-	// because there's no server side (un)registration for variations (see #47170).
+	/*
+	 * Directly get the variations from the registered block type
+	 * because there's no server side (un)registration for variations (see #47170).
+	 */
 	$navigation_block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/post-terms' );
 	// If the block is not registered (yet), there's no need to remove a variation.
 	if ( ! $navigation_block_type || empty( $navigation_block_type->variations ) ) {
@@ -135,12 +143,16 @@ function block_core_post_terms_unregister_variation( $name ) {
 /**
  * Returns an array of variations for the post-terms block.
  *
+ * @since 6.5.0
+ *
  * @return array
  */
 function build_post_term_block_variations() {
-	// This will only handle taxonomies registered until this point (init on priority 9).
-	// See action hooks below for other taxonomies.
-	// See https://github.com/WordPress/gutenberg/issues/52569 for details.
+	/*
+	 * This will only handle taxonomies registered until this point (init on priority 9).
+	 * See action hooks below for other taxonomies.
+	 * See https://github.com/WordPress/gutenberg/issues/52569 for details.
+	 */
 	$taxonomies = get_taxonomies(
 		array(
 			'publicly_queryable' => true,
@@ -149,9 +161,10 @@ function build_post_term_block_variations() {
 		'objects'
 	);
 
-	// Split the available taxonomies to `built_in` and custom ones,
-	// in order to prioritize the `built_in` taxonomies at the
-	// search results.
+	/* Split the available taxonomies to `built_in` and custom ones,
+	 * in order to prioritize the `built_in` taxonomies at the
+	 * search results.
+	 */
 	$built_ins         = array();
 	$custom_variations = array();
 
@@ -185,14 +198,18 @@ function register_block_core_post_terms() {
 	);
 }
 add_action( 'init', 'register_block_core_post_terms' );
-// Register actions for all taxonomies, to add variations when they are registered.
-// All taxonomies registered before register_block_core_post_terms, will be handled by that function.
+/*
+ * Register actions for all taxonomies, to add variations when they are registered.
+ * All taxonomies registered before register_block_core_post_terms, will be handled by that function.
+ */
 add_action( 'registered_taxonomy', 'block_core_post_terms_register_taxonomy_variation', 10, 3 );
 add_action( 'unregistered_taxonomy', 'block_core_post_terms_unregister_taxonomy_variation', 10, 3 );
 
 /**
- * Register a custom taxonomy variation for post terms on taxonomy registration
+ * Registers a custom taxonomy variation for the post-terms block on taxonomy registration
  * Handles all taxonomies registered after the block is registered in register_block_core_post_terms
+ *
+ * @since 6.X.Y
  *
  * @param string       $taxonomy Taxonomy slug.
  * @param array|string $object_type Object type or array of object types.
@@ -210,8 +227,9 @@ function block_core_post_terms_register_taxonomy_variation( $taxonomy, $object_t
 /**
  * Unregisters a custom taxonomy variation for post terms block on taxonomy unregistration.
  *
+ * @since 6.X.Y
+ *
  * @param string $taxonomy The taxonomy name passed from unregistered_taxonomy action hook.
- * @return void
  */
 function block_core_post_terms_unregister_taxonomy_variation( $taxonomy ) {
 	block_core_post_terms_unregister_variation( $taxonomy );

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -149,7 +149,7 @@ add_action( 'registered_taxonomy', 'register_block_core_post_terms_taxonomy_vari
  * @return void
  */
 function register_block_core_post_terms_taxonomy_variation( $taxonomy, $object_type, $args ) {
-	if ( isset( $args['show_in_nav_menus'] ) && $args['show_in_nav_menus'] ) {
+	if ( isset( $args['publicly_queryable'] ) && $args['publicly_queryable'] ) {
 		$variation = block_core_post_terms_build_variation_for_post_terms( (object) $args );
 		// Directly set the variations on the registered block type
 		// because there's no server side registration for variations (see #47170).

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Server-side rendering of the `core/post-terms` block.
+ * Server-side registering and rendering of the `core/post-terms` block.
  *
  * @package WordPress
  */
@@ -59,11 +59,38 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 }
 
 /**
- * Returns the available variations for the `core/post-terms` block.
+ * Returns a post terms variation
  *
- * @return array The available variations for the block.
+ * @param WP_Taxonomy|stdClass $taxonomy taxonomy entity.
+ *
+ * @return array
  */
-function build_post_term_block_variations() {
+function block_core_post_terms_build_variation_for_post_terms( $taxonomy ) {
+	$variation = array(
+		'name'        => $taxonomy->name,
+		'title'       => $taxonomy->label,
+		'description' => sprintf(
+			/* translators: %s: taxonomy's label */
+			__( 'Display a list of assigned terms from the taxonomy: %s' ),
+			$taxonomy->label
+		),
+		'attributes'  => array(
+			'term' => $taxonomy->name,
+		),
+		'isActive'    => array( 'term' ),
+		'scope'       => array( 'inserter', 'transform' ),
+	);
+
+	return $variation;
+}
+
+/**
+ * Registers the `core/post-terms` block on the server.
+ */
+function register_block_core_post_terms() {
+	// This will only handle taxonomies registered until this point (init on priority 9).
+	// See action hooks below for other taxonomies.
+	// See https://github.com/WordPress/gutenberg/issues/52569 for details.
 	$taxonomies = get_taxonomies(
 		array(
 			'publicly_queryable' => true,
@@ -80,20 +107,7 @@ function build_post_term_block_variations() {
 
 	// Create and register the eligible taxonomies variations.
 	foreach ( $taxonomies as $taxonomy ) {
-		$variation = array(
-			'name'        => $taxonomy->name,
-			'title'       => $taxonomy->label,
-			'description' => sprintf(
-				/* translators: %s: taxonomy's label */
-				__( 'Display a list of assigned terms from the taxonomy: %s' ),
-				$taxonomy->label
-			),
-			'attributes'  => array(
-				'term' => $taxonomy->name,
-			),
-			'isActive'    => array( 'term' ),
-			'scope'       => array( 'inserter', 'transform' ),
-		);
+		$variation = block_core_post_terms_build_variation_for_post_terms( $taxonomy );
 		// Set the category variation as the default one.
 		if ( 'category' === $taxonomy->name ) {
 			$variation['isDefault'] = true;
@@ -121,3 +135,31 @@ function register_block_core_post_terms() {
 	);
 }
 add_action( 'init', 'register_block_core_post_terms' );
+// Register actions for all taxonomies, to add variations when they are registered.
+// All taxonomies registered before register_block_core_post_terms, will be handled by that function.
+add_action( 'registered_taxonomy', 'register_block_core_post_terms_taxonomy_variation', 10, 3 );
+
+/**
+ * Register a custom taxonomy variation for post terms on taxonomy registration
+ * Handles all taxonomies registered after the block is registered in register_block_core_post_terms
+ *
+ * @param string       $taxonomy Taxonomy slug.
+ * @param array|string $object_type Object type or array of object types.
+ * @param array        $args Array of taxonomy registration arguments.
+ * @return void
+ */
+function register_block_core_post_terms_taxonomy_variation( $taxonomy, $object_type, $args ) {
+	if ( isset( $args['show_in_nav_menus'] ) && $args['show_in_nav_menus'] ) {
+		$variation = block_core_post_terms_build_variation_for_post_terms( (object) $args );
+		// Directly set the variations on the registered block type
+		// because there's no server side registration for variations (see #47170).
+		$post_terms_block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/post-terms' );
+		// If the block is not registered yet, bail early.
+		// Variation will be registered in register_block_core_post_terms then.
+		if ( ! $post_terms_block_type ) {
+			return;
+		}
+
+		$post_terms_block_type->variations[] = $variation;
+	}
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -127,6 +127,7 @@
 				<element value="build_template_part_block_instance_variations"/>
 				<element value="build_template_part_block_variations"/>
 				<element value="build_variation_for_navigation_link"/>
+				<element value="build_variation_for_post_terms"/>
 				<element value="classnames_for_block_core_search"/>
 				<element value="comments_block_form_defaults"/>
 				<element value="enqueue_legacy_post_comments_block_styles"/>

--- a/phpunit/blocks/block-post-terms-variations-test.php
+++ b/phpunit/blocks/block-post-terms-variations-test.php
@@ -18,9 +18,11 @@ class Block_Post_Terms_Variations_Test extends WP_UnitTestCase {
 			'book_type',
 			array( 'post' ),
 			array(
-				'labels' => array(
+				'labels'             => array(
 					'name' => 'Book Type',
 				),
+				'publicly_queryable' => true,
+				'show_in_rest'       => true,
 			)
 		);
 
@@ -75,9 +77,11 @@ class Block_Post_Terms_Variations_Test extends WP_UnitTestCase {
 			'temp_book_type',
 			'custom_book',
 			array(
-				'labels' => array(
+				'labels'             => array(
 					'name' => 'Book Type',
 				),
+				'publicly_queryable' => true,
+				'show_in_rest'       => true,
 			)
 		);
 

--- a/phpunit/blocks/block-post-terms-variations-test.php
+++ b/phpunit/blocks/block-post-terms-variations-test.php
@@ -23,10 +23,22 @@ class Block_Post_Terms_Variations_Test extends WP_UnitTestCase {
 				),
 			)
 		);
+
+		register_taxonomy(
+			'private_book_type',
+			array( 'post' ),
+			array(
+				'labels'             => array(
+					'name' => 'Book Type',
+				),
+				'publicly_queryable' => false,
+			)
+		);
 	}
 
 	public function tear_down() {
 		unregister_taxonomy( 'book_type' );
+		unregister_taxonomy( 'private_book_type' );
 		parent::tear_down();
 	}
 
@@ -41,6 +53,17 @@ class Block_Post_Terms_Variations_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $variation, 'Block variation is not an array' );
 		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
 		$this->assertEquals( 'Book Type', $variation['title'], 'Variation title is different than the taxonomy label' );
+	}
+
+	/**
+	 * @covers ::register_block_core_post_terms_variation
+	 */
+	public function test_post_terms_variations_custom_private_taxonomy() {
+		$registry         = WP_Block_Type_Registry::get_instance();
+		$post_terms_block = $registry->get_registered( 'core/post-terms' );
+		$this->assertNotEmpty( $post_terms_block->variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'private_book_type', $post_terms_block->variations );
+		$this->assertEmpty( $variation, 'Block variation for private taxonomy exists.' );
 	}
 
 	/**

--- a/phpunit/blocks/block-post-terms-variations-test.php
+++ b/phpunit/blocks/block-post-terms-variations-test.php
@@ -39,24 +39,25 @@ class Block_Post_Terms_Variations_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		unregister_taxonomy( 'book_type' );
 		unregister_taxonomy( 'private_book_type' );
+		unregister_taxonomy( 'temp_book_type' );
 		parent::tear_down();
 	}
 
 	/**
-	 * @covers ::register_block_core_post_terms_variation
+	 * @covers ::block_core_post_terms_register_taxonomy_variation
 	 */
 	public function test_post_terms_variations_custom_taxonomy() {
 		$registry         = WP_Block_Type_Registry::get_instance();
 		$post_terms_block = $registry->get_registered( 'core/post-terms' );
 		$this->assertNotEmpty( $post_terms_block->variations, 'Block has no variations' );
 		$variation = $this->get_variation_by_name( 'book_type', $post_terms_block->variations );
-		$this->assertIsArray( $variation, 'Block variation is not an array' );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
 		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
 		$this->assertEquals( 'Book Type', $variation['title'], 'Variation title is different than the taxonomy label' );
 	}
 
 	/**
-	 * @covers ::register_block_core_post_terms_variation
+	 * @covers ::block_core_post_terms_register_taxonomy_variation
 	 */
 	public function test_post_terms_variations_custom_private_taxonomy() {
 		$registry         = WP_Block_Type_Registry::get_instance();
@@ -64,6 +65,32 @@ class Block_Post_Terms_Variations_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $post_terms_block->variations, 'Block has no variations' );
 		$variation = $this->get_variation_by_name( 'private_book_type', $post_terms_block->variations );
 		$this->assertEmpty( $variation, 'Block variation for private taxonomy exists.' );
+	}
+
+	/**
+	 * @covers ::block_core_post_terms_unregister_taxonomy_variation
+	 */
+	public function test_post_terms_variations_unregister_taxonomy() {
+		register_taxonomy(
+			'temp_book_type',
+			'custom_book',
+			array(
+				'labels' => array(
+					'name' => 'Book Type',
+				),
+			)
+		);
+
+		$registry         = WP_Block_Type_Registry::get_instance();
+		$post_terms_block = $registry->get_registered( 'core/post-terms' );
+		$this->assertNotEmpty( $post_terms_block->variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'temp_book_type', $post_terms_block->variations );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
+
+		unregister_taxonomy( 'temp_book_type' );
+
+		$variation = $this->get_variation_by_name( 'temp_book_type', $post_terms_block->variations );
+		$this->assertEmpty( $variation, 'Block variation still exists' );
 	}
 
 	/**

--- a/phpunit/blocks/block-post-terms-variations-test.php
+++ b/phpunit/blocks/block-post-terms-variations-test.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Post Terms block variations tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Post Terms block variations for taxonomies.
+ *
+ * @group blocks
+ */
+class Block_Post_Terms_Variations_Test extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+		register_taxonomy(
+			'book_type',
+			array( 'post' ),
+			array(
+				'labels' => array(
+					'name' => 'Book Type',
+				),
+			)
+		);
+	}
+
+	public function tear_down() {
+		unregister_taxonomy( 'book_type' );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::register_block_core_post_terms_variation
+	 */
+	public function test_post_terms_variations_custom_taxonomy() {
+		$registry         = WP_Block_Type_Registry::get_instance();
+		$post_terms_block = $registry->get_registered( 'core/post-terms' );
+		$this->assertNotEmpty( $post_terms_block->variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'book_type', $post_terms_block->variations );
+		$this->assertIsArray( $variation, 'Block variation is not an array' );
+		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
+		$this->assertEquals( 'Book Type', $variation['title'], 'Variation title is different than the taxonomy label' );
+	}
+
+	/**
+	 * Get a variation by its name from an array of variations.
+	 *
+	 * @param string $variation_name The name (= slug) of the variation.
+	 * @param array  $variations An array of variations.
+	 * @return array|null The found variation or null.
+	 */
+	private function get_variation_by_name( $variation_name, $variations ) {
+		$found_variation = null;
+		foreach ( $variations as $variation ) {
+			if ( $variation['name'] === $variation_name ) {
+				$found_variation = $variation;
+			}
+		}
+
+		return $found_variation;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This solves the issue from #52569 where custom taxonomies registered after `init` priority 10 are not taken into account for the post-terms blocks variations.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/52569 - server side function runs too early to make sure it gets all custom taxonomies/post types by plugins, themes etc..

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Similar to #54801 (which does the same thing for the navigation link block)
Variations for all taxonomies registered until `register_block_core_post_terms` (at init priority 10) are registered directly in here. For all taxonomies registered after that, actions are added to `registered_taxonomy`, which will register variations during taxonomy registration.

We can't use the second approach for all taxonomies, because some of them (eg builtin ones) are registered before the post terms block is registered, therefore variations can't yet be added.

I'm directly adding the variation on the WP_Block_Type object from WP_Block_Type_Registry, because there's no API for registering variations in PHP (yet).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
### Manual testing
#### Taxonomy
1. Register a custom taxonomy ([example code from developer.wordpress.org](https://developer.wordpress.org/plugins/taxonomies/working-with-custom-taxonomies/#step-2-creating-a-new-plugin)) 
```php
add_action('init', function() {
	 $args   = array(
		 'labels'            => array(
		     'name'         => __( 'Courses' ),
	         ),
	 );
	 register_taxonomy( 'course', [ 'post' ], $args );
});
```
Important: Set the name/label or the block variation is called Post Link.
Important: change add_action priority to something higher than 10 (eg 11) - when using something lower it already works in trunk.
3. Go into site- or post-editor (for the post type post)
4. try to search for a block named like the custom taxonomy (eg "Courses").
5. Block is available

### Automated testing

Run `npm run test:unit:php:base -- --filter Block_Post_Terms_Variations_Test`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
