### PR TITLE
Fix flaky 'Meta boxes' e2e tests

### DIFF
--- a/test/e2e/specs/editor/plugins/meta-boxes.spec.js
+++ b/test/e2e/specs/editor/plugins/meta-boxes.spec.js
@@ -61,9 +61,17 @@ test.describe( 'Meta boxes', () => {
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${ postId }` );
 
-		await expect(
-			page.locator( '.wp-block-latest-posts > li' )
-		).toContainText( [ 'A published post', 'Dynamic block test' ] );
+		await expect
+			.poll( async () => {
+				const posts = await page
+					.locator(
+						'.entry-content .wp-block-latest-posts__post-title'
+					)
+					.allTextContents();
+
+				return posts.sort();
+			} )
+			.toEqual( [ 'A published post', 'Dynamic block test' ] );
 	} );
 
 	test( 'Should render the excerpt in meta based on post content if no explicit excerpt exists', async ( {

--- a/test/e2e/specs/editor/plugins/meta-boxes.spec.js
+++ b/test/e2e/specs/editor/plugins/meta-boxes.spec.js
@@ -61,17 +61,9 @@ test.describe( 'Meta boxes', () => {
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${ postId }` );
 
-		await expect
-			.poll( async () => {
-				const posts = await page
-					.locator(
-						'.entry-content .wp-block-latest-posts__post-title'
-					)
-					.allTextContents();
-
-				return posts.sort();
-			} )
-			.toEqual( [ 'A published post', 'Dynamic block test' ] );
+		await expect(
+			page.locator( '.entry-content .wp-block-latest-posts__post-title' )
+		).toContainText( [ 'Dynamic block test', 'A published post' ] );
 	} );
 
 	test( 'Should render the excerpt in meta based on post content if no explicit excerpt exists', async ( {


### PR DESCRIPTION
## What?
PR fixes flaky `Should render dynamic blocks when the meta box uses the excerpt for front end rendering` e2e tests.

Props to @noahtallen for spotting the issue - https://github.com/WordPress/gutenberg/pull/55915#discussion_r1391150150.

## How?
~~Updates assertion to sort post titles. The test doesn't care about the order, only that titles are rendered.~~

Update the locator scope to only match the Latest Post list in the content and swap the order of the post items.

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/editor/plugins/meta-boxes.spec.js
```
