### PR TITLE
Disable 'no-conditional-in-test' ESLint rule for Playwright

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -331,6 +331,7 @@ module.exports = {
 						message: 'Prefer page.locator instead.',
 					},
 				],
+				'playwright/no-conditional-in-test': 'off',
 				'@typescript-eslint/await-thenable': 'error',
 				'@typescript-eslint/no-floating-promises': 'error',
 				'@typescript-eslint/no-misused-promises': 'error',


### PR DESCRIPTION
## What?
PR disabled [`no-conditional-in-test`](https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/no-conditional-in-test.md) ESLint rule for Playwright.

## Why?
Most of the warnings I've seen in the code base don't match the intention of this ESLint rule. See https://github.com/WordPress/gutenberg/pull/55915#discussion_r1384410515.

## Testing Instructions
```
npm run lint:js test/e2e/specs/editor
```
