### PR TITLE
PostCSS style transformation: fail gracefully instead of throwing an error

### DIFF
--- a/packages/block-editor/src/utils/test/transform-styles.js
+++ b/packages/block-editor/src/utils/test/transform-styles.js
@@ -4,6 +4,28 @@
 import transformStyles from '../transform-styles';
 
 describe( 'transformStyles', () => {
+	it( 'should not throw error in case of invalid css', () => {
+		const run = () =>
+			transformStyles(
+				[
+					{
+						css: 'h1 { color: red; }', // valid CSS
+					},
+					{
+						css: 'h1 { color: red;', // invalid CSS
+					},
+				],
+				'.my-namespace'
+			);
+
+		expect( run ).not.toThrow();
+
+		const [ validCSS, invalidCSS ] = run();
+
+		expect( validCSS ).toBe( '.my-namespace h1 { color: red; }' );
+		expect( invalidCSS ).toBe( null );
+	} );
+
 	describe( 'selector wrap', () => {
 		it( 'should wrap regular selectors', () => {
 			const input = `h1 { color: red; }`;

--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -33,7 +33,13 @@ const transformStyles = ( styles, wrapperSelector = '' ) => {
 				].filter( Boolean )
 			).process( css, {} ).css; // use sync PostCSS API
 		} catch ( error ) {
-			if ( ! ( error instanceof CssSyntaxError ) ) {
+			if ( error instanceof CssSyntaxError ) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'wp.blockEditor.transformStyles Failed to transform CSS.',
+					error.message + '\n' + error.showSourceCode( false )
+				);
+			} else {
 				// eslint-disable-next-line no-console
 				console.warn(
 					'wp.blockEditor.transformStyles Failed to transform CSS.',


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/56082.

## What?

https://github.com/WordPress/gutenberg/pull/49521 introduces a regression in which invalid CSS throws an error. This PR fixes the problem by letting the transformation fail gracefully.

## Why?

https://github.com/WordPress/gutenberg/pull/49521 changed the internal CSS transformer to fix a couple of issues, but invalid CSS handling was not exhaustively tested.

## How?

I'm wrapping the transformation function with a try-catch block and returning null in case it fails to parse the CSS.

## Testing Instructions

Follow the instructions in https://github.com/WordPress/gutenberg/issues/56082.