### PR TITLE
Site editor template preview: add E2E test and aria-pressed attribute to template preview toggle

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -114,6 +114,7 @@ export default function EditTemplate() {
 									icon={
 										! isTemplateHidden ? check : undefined
 									}
+									isPressed={ ! isTemplateHidden }
 									onClick={ () => {
 										setPageContentFocusType(
 											isTemplateHidden

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -84,6 +84,11 @@
 	.components-popover__content {
 		min-width: 240px;
 	}
+	.components-button.is-pressed,
+	.components-button.is-pressed:hover {
+		background: inherit;
+		color: inherit;
+	}
 }
 
 .edit-site-page-panels-edit-slug__dropdown {
@@ -92,3 +97,4 @@
 		padding: $grid-unit-20;
 	}
 }
+

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -141,17 +141,36 @@ test.describe( 'Pages', () => {
 		await draftNewPage( page );
 		await editor.openDocumentSettingsSidebar();
 
+		await editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Content',
+			} )
+			.getByRole( 'document', {
+				name: 'Empty block; start writing or type forward slash to choose a block',
+			} )
+			.click();
+
+		// Add some content to the page.
+		await page.keyboard.type( 'Sweet paragraph 1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Sweet paragraph 2' );
+		await editor.saveSiteEditorEntities();
+
 		// Header template area and page content are visible.
 		await expect(
 			editor.canvas.getByRole( 'document', {
 				name: 'Block: header',
 			} )
 		).toBeVisible();
-		await expect(
-			editor.canvas.getByRole( 'document', {
+
+		const paragraphs = editor.canvas
+			.getByRole( 'document', {
 				name: 'Block: Content',
 			} )
-		).toBeVisible();
+			.getByText( 'Sweet paragraph ' );
+
+		await expect( paragraphs.nth( 0 ) ).toBeVisible();
+		await expect( paragraphs.nth( 1 ) ).toBeVisible();
 		await expect(
 			editor.canvas.getByRole( 'document', {
 				name: 'Block: Title',
@@ -185,15 +204,25 @@ test.describe( 'Pages', () => {
 		).toBeHidden();
 
 		// Content block is still visible and wrapped in a container.
-		await expect(
-			editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Group',
-				} )
-				.getByRole( 'document', {
-					name: 'Block: Content',
-				} )
-		).toBeVisible();
+		const paragraphsInGroup = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Group',
+			} )
+			.getByRole( 'document', {
+				name: 'Block: Content',
+			} )
+			.getByText( 'Sweet paragraph ' );
+
+		await expect( paragraphsInGroup.nth( 0 ) ).toBeVisible();
+		await expect( paragraphsInGroup.nth( 1 ) ).toBeVisible();
+		// Check order of paragraphs.
+		// Important to ensure the blocks are rendered as they are in the template.
+		await expect( paragraphsInGroup.nth( 0 ) ).toHaveText(
+			'Sweet paragraph 1'
+		);
+		await expect( paragraphsInGroup.nth( 1 ) ).toHaveText(
+			'Sweet paragraph 2'
+		);
 		await expect(
 			editor.canvas
 				.getByRole( 'document', {
@@ -221,11 +250,8 @@ test.describe( 'Pages', () => {
 				name: 'Block: header',
 			} )
 		).toBeVisible();
-		await expect(
-			editor.canvas.getByRole( 'document', {
-				name: 'Block: Content',
-			} )
-		).toBeVisible();
+		await expect( paragraphs.nth( 0 ) ).toBeVisible();
+		await expect( paragraphs.nth( 1 ) ).toBeVisible();
 		await expect(
 			editor.canvas.getByRole( 'document', {
 				name: 'Block: Title',

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -136,6 +136,103 @@ test.describe( 'Pages', () => {
 			)
 		).toBeVisible();
 	} );
+
+	test( 'toggle template preview', async ( { page, editor } ) => {
+		await draftNewPage( page );
+		await editor.openDocumentSettingsSidebar();
+
+		// Header template area and page content are visible.
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: header',
+			} )
+		).toBeVisible();
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Content',
+			} )
+		).toBeVisible();
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Title',
+			} )
+		).toBeVisible();
+
+		// Toggle template preview to "off".
+		const templateOptionsButton = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Template options' } );
+		await templateOptionsButton.click();
+		const templatePreviewButton = page
+			.getByRole( 'menu', { name: 'Template options' } )
+			.getByRole( 'menuitem', { name: 'Template preview' } );
+
+		await expect( templatePreviewButton ).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		await templatePreviewButton.click();
+		await expect( templatePreviewButton ).toHaveAttribute(
+			'aria-pressed',
+			'false'
+		);
+
+		// Header template area should be hidden.
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: header',
+			} )
+		).toBeHidden();
+
+		// Content block is still visible and wrapped in a container.
+		await expect(
+			editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Group',
+				} )
+				.getByRole( 'document', {
+					name: 'Block: Content',
+				} )
+		).toBeVisible();
+		await expect(
+			editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Group',
+				} )
+				.getByRole( 'document', {
+					name: 'Block: Title',
+				} )
+		).toBeVisible();
+
+		// Remove focus from templateOptionsButton button.
+		await editor.canvas.locator( 'body' ).click();
+
+		// Toggle template preview to "on".
+		await templateOptionsButton.click();
+		await templatePreviewButton.click();
+		await expect( templatePreviewButton ).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+
+		// Header template area and page content are once again visible.
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: header',
+			} )
+		).toBeVisible();
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Content',
+			} )
+		).toBeVisible();
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Title',
+			} )
+		).toBeVisible();
+	} );
+
 	test( 'swap template and reset to default', async ( {
 		admin,
 		page,
@@ -195,6 +292,7 @@ test.describe( 'Pages', () => {
 		await resetButton.click();
 		await expect( templateOptionsButton ).toHaveText( 'Single Entries' );
 	} );
+
 	test( 'swap template options should respect the declared `postTypes`', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -154,7 +154,6 @@ test.describe( 'Pages', () => {
 		await page.keyboard.type( 'Sweet paragraph 1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Sweet paragraph 2' );
-		await editor.saveSiteEditorEntities();
 
 		// Header template area and page content are visible.
 		await expect(


### PR DESCRIPTION
## What?

Add an E2E test for the changes in 

- https://github.com/WordPress/gutenberg/pull/52674

The E2E test intends to cover the following while editing a page in the site editor:

- that template parts are hidden when the preview is toggled 'off' (the button is not "pressed")
- similarly, that they are displayed again when the preview is toggled 'on' the button is "pressed")
- the order of page content elements remains the same between states

Also, we're adding an `aria-pressed` attribute to the "Toggle preview button" to indicate it's state. Currently there's only a visual indicator in the form of an SVG check.

## Why?
Coz there isn't a test.

## Testing Instructions

Run the tests if you like! Or see that they are passing on CI.

A great way to run playwright E2E tests individually or as suites is using the UI tool:

`npx playwright test --ui --headed --config test/e2e/playwright.config.ts`

To check the ARIA attribute:

1. Go to Appearance → Editor → Pages, select or create a page, then edit it.
2. In the Page settings sidebar, click on the Template dropdown and toggle "Show template" and "Hide template"
3. Check that element source to ensure the `aria-pressed` attribute toggles accordingly.
4. There should be no UI regressions.


