### PR TITLE
Update import/no-extraneous-dependencies lint rule to error for *.native.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -214,7 +214,7 @@ module.exports = {
 				'import/default': 'off',
 				'import/no-extraneous-dependencies': [
 					'error',
-					{ devDependencies: false },
+					{ devDependencies: true },
 				],
 				'import/no-unresolved': 'off',
 				'import/named': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -212,7 +212,10 @@ module.exports = {
 			],
 			rules: {
 				'import/default': 'off',
-				'import/no-extraneous-dependencies': 'off',
+				'import/no-extraneous-dependencies': [
+					'error',
+					{ devDependencies: false },
+				],
 				'import/no-unresolved': 'off',
 				'import/named': 'off',
 				'@wordpress/data-no-store-string-literals': 'off',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
**WIP for testing**

Updates `import/no-extraneous-dependencies` lint rule to error for `*.native.js` files. 

* https://github.com/WordPress/gutenberg/issues/56072

## Why?
Detect cyclic dependencies.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
