### PR TITLE
Iframe: Bubble events from html element instead of body element to fix drag chip positioning

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -73,12 +73,13 @@ function bubbleEvent( event, Constructor, frame ) {
  * @param {Document} iframeDocument Document to attach listeners to.
  */
 function useBubbleEvents( iframeDocument ) {
-	return useRefEffect( ( body ) => {
+	return useRefEffect( () => {
 		const { defaultView } = iframeDocument;
 		if ( ! defaultView ) {
 			return;
 		}
 		const { frameElement } = defaultView;
+		const html = iframeDocument.documentElement;
 		const eventTypes = [ 'dragover', 'mousemove' ];
 		const handlers = {};
 		for ( const name of eventTypes ) {
@@ -88,12 +89,12 @@ function useBubbleEvents( iframeDocument ) {
 				const Constructor = window[ constructorName ];
 				bubbleEvent( event, Constructor, frameElement );
 			};
-			body.addEventListener( name, handlers[ name ] );
+			html.addEventListener( name, handlers[ name ] );
 		}
 
 		return () => {
 			for ( const name of eventTypes ) {
-				body.removeEventListener( name, handlers[ name ] );
+				html.removeEventListener( name, handlers[ name ] );
 			}
 		};
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/33683 and #32438, unblocks #56070

Update the `Iframe` component's event bubbling to be attached to the `html` element instead of the `body` element, to ensure that drag events are correctly bubbled even if the body element does not completely fill up an `iframe`. A good example is in the post title wrapper in the post editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the drag chip position gets "stuck" over the top area of the editor canvas when it is iframed.

This is because in the post editor, the post title wrapper uses a top margin. As it is the first "real" element within the body of the iframe, due to margin collapse, the top margin is applied to the body element so the `body` doesn't sit flush at the top of the iframe. As a result, the event bubbling of the iframe does not fire in the top area of the iframe, as there is no `body` element there to capture and then bubble events.

Here is a screenshot of how the `body` element does not sit flush to the top within the iframe:

<img width="1276" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/6bc9aabd-c6d1-400c-be30-54fc126657ab">

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The solution is to attach the event bubbling to the `html` element instead of the `body` element, as the `html` element will always fill the entirety of the iframe.

While we could address the margin issue with the `body` element for the case of the post editor, I think a safer solution is to always bubble from the `html` element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the post editor, before applying this PR, try dragging a block from the list view to the top area of the editor iframe, and notice that the drag chip (the icon following the mouse cursor) gets stuck above the post title.
2. With this PR applied, the drag chip position should follow the mouse cursor wherever the mouse goes over the top area of the iframe.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/9f287131-9b8f-4a58-be03-f46b58aba348

### After

https://github.com/WordPress/gutenberg/assets/14988353/87efe580-177e-4be6-81c8-733ea12a9ab5
