### PR TITLE
Better navigation link variations for post types / taxonomies

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Server-side rendering of the `core/navigation-link` block.
+ * Server-side registering and rendering of the `core/navigation-link` block.
  *
  * @package WordPress
  */
@@ -323,12 +323,12 @@ function build_variation_for_navigation_link( $entity, $kind ) {
 }
 
 /**
- * Register a variation for a post type / taxonomy for the navigation link block
+ * Register a variation for a post type / taxonomy for the navigation link block.
  *
  * @param array $variation Variation array from build_variation_for_navigation_link.
  * @return void
  */
-function register_block_core_navigation_link_variation( $variation ) {
+function block_core_navigation_link_register_variation( $variation ) {
 	// Directly set the variations on the registered block type
 	// because there's no server side registration for variations (see #47170).
 	$navigation_block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/navigation-link' );
@@ -393,6 +393,8 @@ function register_block_core_navigation_link() {
 add_action( 'init', 'register_block_core_navigation_link' );
 // Register actions for all post types and taxonomies, to add variations when they are registered.
 // All post types/taxonomies registered before register_block_core_navigation_link, will be handled by that function.
+add_action( 'registered_post_type', 'block_core_navigation_link_register_post_type_variation', 10, 2 );
+add_action( 'registered_taxonomy', 'block_core_navigation_link_register_taxonomy_variation', 10, 3 );
 add_action( 'registered_post_type', 'register_block_core_navigation_link_post_type_variation', 10, 2 );
 add_action( 'registered_taxonomy', 'register_block_core_navigation_link_taxonomy_variation', 10, 3 );
 
@@ -400,14 +402,14 @@ add_action( 'registered_taxonomy', 'register_block_core_navigation_link_taxonomy
  * Register custom post type variations for navigation link on post type registration
  * Handles all post types registered after the block is registered in register_navigation_link_post_type_variations
  *
- * @param string       $post_type The post type name passed from registered_post_type filter.
+ * @param string       $post_type The post type name passed from registered_post_type action hook.
  * @param WP_Post_Type $post_type_object The post type object passed from registered_post_type.
  * @return void
  */
-function register_block_core_navigation_link_post_type_variation( $post_type, $post_type_object ) {
+function block_core_navigation_link_register_post_type_variation( $post_type, $post_type_object ) {
 	if ( $post_type_object->show_in_nav_menus ) {
 		$variation = build_variation_for_navigation_link( $post_type_object, 'post-type' );
-		register_block_core_navigation_link_variation( $variation );
+		block_core_navigation_link_register_variation( $variation );
 	}
 }
 
@@ -420,9 +422,9 @@ function register_block_core_navigation_link_post_type_variation( $post_type, $p
  * @param array        $args Array of taxonomy registration arguments.
  * @return void
  */
-function register_block_core_navigation_link_taxonomy_variation( $taxonomy, $object_type, $args ) {
+function block_core_navigation_link_register_taxonomy_variation( $taxonomy, $object_type, $args ) {
 	if ( isset( $args['show_in_nav_menus'] ) && $args['show_in_nav_menus'] ) {
 		$variation = build_variation_for_navigation_link( (object) $args, 'post-type' );
-		register_block_core_navigation_link_variation( $variation );
+		block_core_navigation_link_register_variation( $variation );
 	}
 }

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -342,6 +342,31 @@ function block_core_navigation_link_register_variation( $variation ) {
 }
 
 /**
+ * Unregister a variation for a post type / taxonomy for the navigation link block.
+ *
+ * @param string $name Name of the post type / taxonomy (which was used as variation name).
+ * @return void
+ */
+function block_core_navigation_link_unregister_variation( $name ) {
+	// Directly get the variations from the registered block type
+	// because there's no server side (un)registration for variations (see #47170).
+	$navigation_block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/navigation-link' );
+	// If the block is not registered (yet), there's no need to remove a variation.
+	if ( ! $navigation_block_type || empty( $navigation_block_type->variations ) ) {
+		return;
+	}
+	// Search for the variation and remove it from the array.
+	foreach ( $navigation_block_type->variations as $i => $variation ) {
+		if ( $variation['name'] === $name ) {
+			unset( $navigation_block_type->variations[ $i ] );
+			break;
+		}
+	}
+	// Reindex array after removing one variation.
+	$navigation_block_type->variations = array_values( $navigation_block_type->variations );
+}
+
+/**
  * Register the navigation link block.
  *
  * @uses render_block_core_navigation()
@@ -395,8 +420,9 @@ add_action( 'init', 'register_block_core_navigation_link' );
 // All post types/taxonomies registered before register_block_core_navigation_link, will be handled by that function.
 add_action( 'registered_post_type', 'block_core_navigation_link_register_post_type_variation', 10, 2 );
 add_action( 'registered_taxonomy', 'block_core_navigation_link_register_taxonomy_variation', 10, 3 );
-add_action( 'registered_post_type', 'register_block_core_navigation_link_post_type_variation', 10, 2 );
-add_action( 'registered_taxonomy', 'register_block_core_navigation_link_taxonomy_variation', 10, 3 );
+// Handle unregistering ofr post types and taxonomies and remove the variations.
+add_action( 'unregistered_post_type', 'block_core_navigation_link_unregister_post_type_variation' );
+add_action( 'unregistered_taxonomy', 'block_core_navigation_link_unregister_taxonomy_variation' );
 
 /**
  * Register custom post type variations for navigation link on post type registration
@@ -427,4 +453,24 @@ function block_core_navigation_link_register_taxonomy_variation( $taxonomy, $obj
 		$variation = build_variation_for_navigation_link( (object) $args, 'post-type' );
 		block_core_navigation_link_register_variation( $variation );
 	}
+}
+
+/**
+ * Unregisters a custom post type variation for navigation link on post type unregistration.
+ *
+ * @param string $post_type The post type name passed from unregistered_post_type action hook.
+ * @return void
+ */
+function block_core_navigation_link_unregister_post_type_variation( $post_type ) {
+	block_core_navigation_link_unregister_variation( $post_type );
+}
+
+/**
+ * Unregisters a custom taxonomy variation for navigation link on taxonomy unregistration.
+ *
+ * @param string $taxonomy The taxonomy name passed from unregistered_taxonomy action hook.
+ * @return void
+ */
+function block_core_navigation_link_unregister_taxonomy_variation( $taxonomy ) {
+	block_core_navigation_link_unregister_variation( $taxonomy );
 }

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -420,7 +420,7 @@ add_action( 'init', 'register_block_core_navigation_link' );
 // All post types/taxonomies registered before register_block_core_navigation_link, will be handled by that function.
 add_action( 'registered_post_type', 'block_core_navigation_link_register_post_type_variation', 10, 2 );
 add_action( 'registered_taxonomy', 'block_core_navigation_link_register_taxonomy_variation', 10, 3 );
-// Handle unregistering ofr post types and taxonomies and remove the variations.
+// Handle unregistering of post types and taxonomies and remove the variations.
 add_action( 'unregistered_post_type', 'block_core_navigation_link_unregister_post_type_variation' );
 add_action( 'unregistered_taxonomy', 'block_core_navigation_link_unregister_taxonomy_variation' );
 

--- a/phpunit/blocks/block-navigation-link-variations-test.php
+++ b/phpunit/blocks/block-navigation-link-variations-test.php
@@ -63,6 +63,8 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 		unregister_post_type( 'private_custom_book' );
 		unregister_taxonomy( 'book_type' );
 		unregister_taxonomy( 'private_book_type' );
+		unregister_post_type( 'temp_custom_book' );
+		unregister_taxonomy( 'temp_book_type' );
 		parent::tear_down();
 	}
 
@@ -112,6 +114,61 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
 		$variation = $this->get_variation_by_name( 'private_book_type', $nav_link_block->variations );
 		$this->assertEmpty( $variation, 'Block variation for private taxonomy exists.' );
+	}
+
+	/**
+	 * @covers ::block_core_navigation_link_unregister_post_type_variation
+	 */
+	public function test_navigation_link_variations_unregister_post_type() {
+		register_post_type(
+			'temp_custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Custom Book',
+				),
+				'public'            => true,
+				'show_in_rest'      => true,
+				'show_in_nav_menus' => true,
+			)
+		);
+
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'temp_custom_book', $nav_link_block->variations );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
+
+		unregister_post_type( 'temp_custom_book' );
+
+		$variation = $this->get_variation_by_name( 'temp_custom_book', $nav_link_block->variations );
+		$this->assertEmpty( $variation, 'Block variation still exists' );
+	}
+
+	/**
+	 * @covers ::block_core_navigation_link_unregister_taxonomy_variation
+	 */
+	public function test_navigation_link_variations_unregister_taxonomy() {
+		register_taxonomy(
+			'temp_book_type',
+			'custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Book Type',
+				),
+				'show_in_nav_menus' => true,
+			)
+		);
+
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'temp_book_type', $nav_link_block->variations );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
+
+		unregister_taxonomy( 'temp_book_type' );
+
+		$variation = $this->get_variation_by_name( 'temp_book_type', $nav_link_block->variations );
+		$this->assertEmpty( $variation, 'Block variation still exists' );
 	}
 
 	/**

--- a/phpunit/blocks/block-navigation-link-variations-test.php
+++ b/phpunit/blocks/block-navigation-link-variations-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Navigation block rendering tests.
+ * Navigation block post type/taxonomies variations tests.
  *
  * @package WordPress
  * @subpackage Blocks
@@ -44,27 +44,27 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::register_block_core_navigation_link_post_type_variation
+	 * @covers ::block_core_navigation_link_register_post_type_variation
 	 */
 	public function test_navigation_link_variations_custom_post_type() {
 		$registry       = WP_Block_Type_Registry::get_instance();
 		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
 		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
 		$variation = $this->get_variation_by_name( 'custom_book', $nav_link_block->variations );
-		$this->assertIsArray( $variation, 'Block variation is not an array' );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
 		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
 		$this->assertEquals( 'Custom Book', $variation['title'], 'Variation title is different than the post type label' );
 	}
 
 	/**
-	 * @covers ::register_block_core_navigation_link_taxonomy_variation
+	 * @covers ::block_core_navigation_link_register_post_type_variation
 	 */
 	public function test_navigation_link_variations_custom_taxonomy() {
 		$registry       = WP_Block_Type_Registry::get_instance();
 		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
 		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
 		$variation = $this->get_variation_by_name( 'book_type', $nav_link_block->variations );
-		$this->assertIsArray( $variation, 'Block variation is not an array' );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
 		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
 		$this->assertEquals( 'Book Type', $variation['title'], 'Variation title is different than the post type label' );
 	}

--- a/phpunit/blocks/block-navigation-link-variations-test.php
+++ b/phpunit/blocks/block-navigation-link-variations-test.php
@@ -25,6 +25,17 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 				'show_in_nav_menus' => true,
 			)
 		);
+		register_post_type(
+			'private_custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Custom Book',
+				),
+				'public'            => false,
+				'show_in_rest'      => true,
+				'show_in_nav_menus' => false,
+			)
+		);
 		register_taxonomy(
 			'book_type',
 			'custom_book',
@@ -35,11 +46,23 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 				'show_in_nav_menus' => true,
 			)
 		);
+		register_taxonomy(
+			'private_book_type',
+			'private_custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Book Type',
+				),
+				'show_in_nav_menus' => false,
+			)
+		);
 	}
 
 	public function tear_down() {
 		unregister_post_type( 'custom_book' );
+		unregister_post_type( 'private_custom_book' );
 		unregister_taxonomy( 'book_type' );
+		unregister_taxonomy( 'private_book_type' );
 		parent::tear_down();
 	}
 
@@ -59,6 +82,17 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 	/**
 	 * @covers ::block_core_navigation_link_register_post_type_variation
 	 */
+	public function test_navigation_link_variations_private_custom_post_type() {
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'private_custom_book', $nav_link_block->variations );
+		$this->assertEmpty( $variation, 'Block variation for private post type exists.' );
+	}
+
+	/**
+	 * @covers ::block_core_navigation_link_register_taxonomy_variation
+	 */
 	public function test_navigation_link_variations_custom_taxonomy() {
 		$registry       = WP_Block_Type_Registry::get_instance();
 		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
@@ -67,6 +101,17 @@ class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $variation, 'Block variation does not exist' );
 		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
 		$this->assertEquals( 'Book Type', $variation['title'], 'Variation title is different than the post type label' );
+	}
+
+	/**
+	 * @covers ::block_core_navigation_link_register_taxonomy_variation
+	 */
+	public function test_navigation_link_variations_private_custom_taxonomy() {
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		$this->assertNotEmpty( $nav_link_block->variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'private_book_type', $nav_link_block->variations );
+		$this->assertEmpty( $variation, 'Block variation for private taxonomy exists.' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a follow up to #54801
It adds the following things: 
- Adds handling of unregistering post types / taxonomies and their variations.
- Adds unit tests for private post types / taxonomies (those with `show_in_nav_menus` set to false)
- Fixes some code documentation
- Fixes: Renames functions to be in line with the naming conventions for block php files and also consistency in this file itself

Since the original PR was just merged into trunk and not released yet, I think renaming those functions is not a breaking change.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
#54801 worked, but I missed some minor errors in code documentation and function naming.
Also @obache [pointed out](https://github.com/WordPress/gutenberg/issues/49678#issuecomment-1809353433) that unregistering of post types/taxonomies was not handled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Similar to registering the variations, it hooks into `unregistered_post_type` and `unregistered_taxonomy` to unregister the variations. Since there is no server-side API for (un)registering variations, this is done directly by searching through the variations array of the registered block type - not ideal, but I see no other way atm. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
#### Testing unregistering

##### Post Type
1. Register a custom post type ([example code from developer.wordpress.org](https://developer.wordpress.org/plugins/post-types/registering-custom-post-types/)).
```php
add_action('init', function () {
    register_post_type(
        'wporg_product',
        array(
            'labels'      => array(
                'name'          => __('Products', 'textdomain'),
                'singular_name' => __('Product', 'textdomain'),
                'item_link' => __('Product Link', 'textdomain')
            ),
            'public'      => true,
            'has_archive' => true,
            'show_in_rest' => true,
            'show_in_nav_menus' => true
        )
    );
}, 11);
```
Important: Set the item_link label or the block variation is called Post Link.
Important: change add_action priority to something higher than 10 (eg 11) - when using something lower it already works in trunk.
2. Unregister the custom post type after the navigation link block is registered and the variation is created: 
```php
add_action('init', function () {
    unregister_post_type('wporg_product');
}, 100);
```
3. Go into site-editor and add a navigation block
4. try to search for a block named like the custom taxonomy (eg "Product Link").
5. Block variation should not be available

##### Taxonomy
1. Register a custom taxonomy ([example code from developer.wordpress.org](https://developer.wordpress.org/plugins/taxonomies/working-with-custom-taxonomies/#step-2-creating-a-new-plugin)) 
```php
add_action('init', function() {
	 $args   = array(
		 'labels'            => array(
		     'link_item'         => __( 'Course' ),
	         ),
		 'show_in_nav_menus' => true
	 );
	 register_taxonomy( 'course', [ 'post' ], $args );
});
```
Important: Set the item_link label or the block variation is called Post Link.
Important: change add_action priority to something higher than 10 (eg 11) - when using something lower it already works in trunk.
2. Unregister the custom taxonomy after the navigation link block is registered and the variation is created: 
```php
add_action('init', function () {
    unregister_taxonomy('course');
}, 100);
```
3. Go into site-editor and add a navigation block
4. try to search for a block named like the custom taxonomy (eg "Course Link").
6. Block variation should not be available

### Automated testing

Run `npm run test:unit:php:base -- --filter Block_Navigation_Link_Variations_Test`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
