### PR TITLE
Block Editor: Optimize 'Block Hooks' inspector controls

### DIFF
--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -238,14 +238,15 @@ function BlockHooksControl( props ) {
 export const withBlockHooksControls = createHigherOrderComponent(
 	( BlockEdit ) => {
 		return ( props ) => {
-			const blockEdit = <BlockEdit key="edit" { ...props } />;
 			return (
 				<>
-					{ blockEdit }
-					<BlockHooksControl
-						blockName={ props.name }
-						clientId={ props.clientId }
-					/>
+					<BlockEdit key="edit" { ...props } />
+					{ props.isSelected && (
+						<BlockHooksControl
+							blockName={ props.name }
+							clientId={ props.clientId }
+						/>
+					) }
 				</>
 			);
 		};


### PR DESCRIPTION
## What?
Similar to #55721.

PR updates the `withBlockHooksControls` filter to render the "Block Hooks" inspector controls when a block is selected. It is only needed when editing a block.

## Why?
This is an effort to minimize unnecessary store subscriptions created per block. See https://github.com/WordPress/gutenberg/pull/54819#issuecomment-1761202859.

Tested using @jsnajdr's debug code (https://github.com/WordPress/gutenberg/commit/c02930390ee76935cc545a708eefe6d9b120f240), the store subscriptions are reduced by 2-3k on large text post - 1000 blocks.

## Testing Instructions
1. Install and activate the Like Button block by @ockham - [like-button.zip](https://github.com/ockham/like-button/releases/download/v0.5.0/like-button.zip).
2. Open the Site Editor.
3. Navigate to the Template with comments - Single Post(s).
4. Select the Comment Template block.
5. Confirm that "Plugins" controls are rendered in the sidebar as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2023-11-14 at 11 42 48](https://github.com/WordPress/gutenberg/assets/240569/a30c6c40-58c4-40dc-8139-d8c86ecf76f8)
