### PR TITLE
SiteEditor: Optimize BackToPageNotification component

### DIFF
--- a/packages/edit-site/src/components/page-content-focus-manager/back-to-page-notification.js
+++ b/packages/edit-site/src/components/page-content-focus-manager/back-to-page-notification.js
@@ -25,27 +25,19 @@ export default function BackToPageNotification() {
  * switches from focusing on editing page content to editing a template.
  */
 export function useBackToPageNotification() {
-	const { isPage, hasPageContentFocus } = useSelect(
-		( select ) => ( {
-			isPage: select( editSiteStore ).isPage(),
-			hasPageContentFocus: select( editSiteStore ).hasPageContentFocus(),
-		} ),
+	const hasPageContentFocus = useSelect(
+		( select ) => select( editSiteStore ).hasPageContentFocus(),
 		[]
 	);
+	const { isPage } = useSelect( editSiteStore );
 
 	const alreadySeen = useRef( false );
-	const prevHasPageContentFocus = useRef( false );
 
 	const { createInfoNotice } = useDispatch( noticesStore );
 	const { setHasPageContentFocus } = useDispatch( editSiteStore );
 
 	useEffect( () => {
-		if (
-			! alreadySeen.current &&
-			isPage &&
-			prevHasPageContentFocus.current &&
-			! hasPageContentFocus
-		) {
+		if ( isPage() && ! alreadySeen.current && ! hasPageContentFocus ) {
 			createInfoNotice( __( 'You are editing a template.' ), {
 				isDismissible: true,
 				type: 'snackbar',
@@ -58,11 +50,9 @@ export function useBackToPageNotification() {
 			} );
 			alreadySeen.current = true;
 		}
-		prevHasPageContentFocus.current = hasPageContentFocus;
 	}, [
 		alreadySeen,
 		isPage,
-		prevHasPageContentFocus,
 		hasPageContentFocus,
 		createInfoNotice,
 		setHasPageContentFocus,

--- a/packages/edit-site/src/components/page-content-focus-manager/back-to-page-notification.js
+++ b/packages/edit-site/src/components/page-content-focus-manager/back-to-page-notification.js
@@ -51,7 +51,6 @@ export function useBackToPageNotification() {
 			alreadySeen.current = true;
 		}
 	}, [
-		alreadySeen,
 		isPage,
 		hasPageContentFocus,
 		createInfoNotice,


### PR DESCRIPTION
Extracted from #56000 

## What?

This is just a small optimization to `BackToPageNotification` to avoid re-rendering that component when the isPage selector changes its value. Basically, we only want to trigger this notice when the "mode" changes.

This also fixes a small hidden bug where the notice don't show up if the component remounts at the wrong moment.

## Testing Instructions

- Open a page in the site editor
- Switch to the "template editing" mode
- You should see the snacker saying that you're editing the template.