### PR TITLE
SiteEditor: Refactor disable non page content blocks

### DIFF
--- a/packages/edit-site/src/components/page-content-focus-manager/disable-non-page-content-blocks.js
+++ b/packages/edit-site/src/components/page-content-focus-manager/disable-non-page-content-blocks.js
@@ -1,9 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
-import { addFilter, removeFilter } from '@wordpress/hooks';
-import { useBlockEditingMode } from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	useBlockEditingMode,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -11,42 +13,47 @@ import { useEffect } from '@wordpress/element';
  */
 import { PAGE_CONTENT_BLOCK_TYPES } from '../../utils/constants';
 
+function DisableBlock( { clientId } ) {
+	const isDescendentOfQueryLoop = useSelect(
+		( select ) => {
+			const { getBlockParentsByBlockName } = select( blockEditorStore );
+			return (
+				getBlockParentsByBlockName( clientId, 'core/query' ).length !==
+				0
+			);
+		},
+		[ clientId ]
+	);
+	const mode = isDescendentOfQueryLoop ? undefined : 'contentOnly';
+	const { setBlockEditingMode, unsetBlockEditingMode } =
+		useDispatch( blockEditorStore );
+	useEffect( () => {
+		if ( mode ) {
+			setBlockEditingMode( clientId, mode );
+		}
+		return () => {
+			if ( mode ) {
+				unsetBlockEditingMode( clientId );
+			}
+		};
+	}, [ clientId, mode, setBlockEditingMode, unsetBlockEditingMode ] );
+}
+
 /**
  * Component that when rendered, makes it so that the site editor allows only
  * page content to be edited.
  */
 export default function DisableNonPageContentBlocks() {
-	useDisableNonPageContentBlocks();
-	return null;
-}
-
-/**
- * Disables non-content blocks using the `useBlockEditingMode` hook.
- */
-export function useDisableNonPageContentBlocks() {
 	useBlockEditingMode( 'disabled' );
-	useEffect( () => {
-		addFilter(
-			'editor.BlockEdit',
-			'core/edit-site/disable-non-content-blocks',
-			withDisableNonPageContentBlocks
+	const clientIds = useSelect( ( select ) => {
+		const { __experimentalGetGlobalBlocksByName } =
+			select( blockEditorStore );
+		return __experimentalGetGlobalBlocksByName(
+			Object.keys( PAGE_CONTENT_BLOCK_TYPES )
 		);
-		return () =>
-			removeFilter(
-				'editor.BlockEdit',
-				'core/edit-site/disable-non-content-blocks'
-			);
 	}, [] );
-}
 
-const withDisableNonPageContentBlocks = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const isDescendentOfQueryLoop = props.context.queryId !== undefined;
-		const isPageContent =
-			PAGE_CONTENT_BLOCK_TYPES[ props.name ] && ! isDescendentOfQueryLoop;
-		const mode = isPageContent ? 'contentOnly' : undefined;
-		useBlockEditingMode( mode );
-		return <BlockEdit { ...props } />;
-	},
-	'withDisableNonPageContentBlocks'
-);
+	return clientIds.map( ( clientId ) => {
+		return <DisableBlock key={ clientId } clientId={ clientId } />;
+	} );
+}

--- a/packages/edit-site/src/components/page-content-focus-manager/disable-non-page-content-blocks.js
+++ b/packages/edit-site/src/components/page-content-focus-manager/disable-non-page-content-blocks.js
@@ -30,12 +30,10 @@ function DisableBlock( { clientId } ) {
 	useEffect( () => {
 		if ( mode ) {
 			setBlockEditingMode( clientId, mode );
-		}
-		return () => {
-			if ( mode ) {
+			return () => {
 				unsetBlockEditingMode( clientId );
-			}
-		};
+			};
+		}
 	}, [ clientId, mode, setBlockEditingMode, unsetBlockEditingMode ] );
 }
 


### PR DESCRIPTION
Extracted from #56000 

## What?

This PR refactors the `DisableNonPageContentBlocks` component to make it a bit more resilient to component remounts and also probably slightly more performant. The previous code used to filter all blocks rendered in the site editor to inject the right mode (lock/unlock content editing). 

In #56000 this broke because the component was being remounted which caused the filters to not run consistently. In the current PR, I avoid `editor.BlockEdit` filters entirely and I just fetch the exact blocks that I want to lock/unlock and apply the logic.

## Testing Instructions

1- Open the site editor
2- Ensure that if you open a page in the site editor: only "content" blocks are editable until you switch to template mode.