### PR TITLE
useEntityRecord: Do not trigger REST API requests when disabled

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -113,4 +113,38 @@ describe( 'useEntityRecord', () => {
 		expect( widget.editedRecord ).toEqual( { hello: 'foo', id: 1 } );
 		expect( widget.edits ).toEqual( { hello: 'foo' } );
 	} );
+
+	it( 'does not resolve entity record when disabled via options', async () => {
+		// Provide response
+		triggerFetch.mockImplementation( () => TEST_RECORD );
+
+		let data;
+		const TestComponent = () => {
+			data = useEntityRecord( 'root', 'widget', 2, {
+				options: { enabled: false },
+			} );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		expect( data ).toEqual( {
+			edit: expect.any( Function ),
+			editedRecord: {},
+			hasEdits: false,
+			edits: {},
+			record: null,
+			save: expect.any( Function ),
+		} );
+
+		// Fetch request should have been issued
+		await waitFor( () =>
+			expect( triggerFetch ).not.toHaveBeenCalledWith( {
+				path: '/wp/v2/widgets/2?context=edit',
+			} )
+		);
+	} );
 } );

--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -23,6 +23,7 @@ describe( 'useEntityRecord', () => {
 	beforeEach( () => {
 		registry = createRegistry();
 		registry.register( coreDataStore );
+		triggerFetch.mockReset();
 	} );
 
 	const TEST_RECORD = { id: 1, hello: 'world' };
@@ -140,7 +141,10 @@ describe( 'useEntityRecord', () => {
 			save: expect.any( Function ),
 		} );
 
-		// Fetch request should have been issued
+		// Fetch request should have been issued.
+		await waitFor( () => {
+			expect( triggerFetch ).not.toHaveBeenCalled();
+		} );
 		await waitFor( () =>
 			expect( triggerFetch ).not.toHaveBeenCalledWith( {
 				path: '/wp/v2/widgets/2?context=edit',

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -56,6 +56,8 @@ export interface Options {
 	enabled: boolean;
 }
 
+const EMPTY_OBJECT = {};
+
 /**
  * Resolves the specified entity record.
  *
@@ -167,24 +169,34 @@ export default function useEntityRecord< RecordType >(
 	);
 
 	const { editedRecord, hasEdits, edits } = useSelect(
-		( select ) => ( {
-			editedRecord: select( coreStore ).getEditedEntityRecord(
-				kind,
-				name,
-				recordId
-			),
-			hasEdits: select( coreStore ).hasEditsForEntityRecord(
-				kind,
-				name,
-				recordId
-			),
-			edits: select( coreStore ).getEntityRecordNonTransientEdits(
-				kind,
-				name,
-				recordId
-			),
-		} ),
-		[ kind, name, recordId ]
+		( select ) => {
+			if ( ! options.enabled ) {
+				return {
+					editedRecord: EMPTY_OBJECT,
+					hasEdits: false,
+					edits: EMPTY_OBJECT,
+				};
+			}
+
+			return {
+				editedRecord: select( coreStore ).getEditedEntityRecord(
+					kind,
+					name,
+					recordId
+				),
+				hasEdits: select( coreStore ).hasEditsForEntityRecord(
+					kind,
+					name,
+					recordId
+				),
+				edits: select( coreStore ).getEntityRecordNonTransientEdits(
+					kind,
+					name,
+					recordId
+				),
+			};
+		},
+		[ kind, name, recordId, options.enabled ]
 	);
 
 	const { data: record, ...querySelectRest } = useQuerySelect(


### PR DESCRIPTION
## What?
A regression after #39595.

The `useEntityRecord` hook shouldn't call resolves and trigger REST API requests when `options.enabled` is set to `false`.

## Why?
PR fixes a regression.

## Testing Instructions
```
npm run test:unit -- packages/core-data/src/hooks/test/use-entity-record.js
```