### PR TITLE
DataViews: update filter component

### DIFF
--- a/packages/edit-site/src/components/dataviews/add-filter.js
+++ b/packages/edit-site/src/components/dataviews/add-filter.js
@@ -54,10 +54,10 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 				<Button
 					disabled={ filters.length === view.filters?.length }
 					__experimentalIsFocusable
-					icon={ plus }
 					variant="tertiary"
 					size="compact"
 				>
+					<Icon icon={ plus } style={ { flexShrink: 0 } } />
 					{ __( 'Add filter' ) }
 				</Button>
 			}

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { default as InFilter } from './in-filter';
@@ -23,13 +18,8 @@ export default function Filters( { fields, view, onChangeView } ) {
 				filters.push( {
 					field: field.id,
 					name: field.header,
-					elements: [
-						{
-							value: '',
-							label: __( 'All' ),
-						},
-						...( field.elements || [] ),
-					],
+					operator: filter,
+					elements: field.elements || [],
 					isVisible: view.filters.some(
 						( f ) =>
 							f.field === field.id && f.operator === OPERATOR_IN

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -18,7 +18,6 @@ export default function Filters( { fields, view, onChangeView } ) {
 				filters.push( {
 					field: field.id,
 					name: field.header,
-					operator: filter,
 					elements: field.elements || [],
 					isVisible: view.filters.some(
 						( f ) =>

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -16,10 +16,10 @@ import { OPERATOR_IN } from './constants';
 import { unlock } from '../../lock-unlock';
 
 const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
+	DropdownMenuV2Ariakit: DropdownMenu,
+	DropdownMenuItemV2Ariakit: DropdownMenuItem,
+	DropdownMenuCheckboxItemV2Ariakit: DropdownMenuCheckboxItem,
+	DropdownMenuSeparatorV2Ariakit: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
 export default ( { filter, view, onChangeView } ) => {
@@ -51,7 +51,7 @@ export default ( { filter, view, onChangeView } ) => {
 						key={ element.value }
 						value={ element.value }
 						checked={ activeElement?.value === element.value }
-						onSelect={ () =>
+						onChange={ () =>
 							onChangeView( ( currentView ) => ( {
 								...currentView,
 								page: 1,

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -16,10 +16,10 @@ import { OPERATOR_IN } from './constants';
 import { unlock } from '../../lock-unlock';
 
 const {
-	DropdownMenuV2,
-	DropdownMenuItemV2,
-	DropdownMenuCheckboxItemV2,
-	DropdownMenuSeparatorV2,
+	DropdownMenuV2: DropdownMenu,
+	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
+	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
 export default ( { filter, view, onChangeView } ) => {
@@ -29,7 +29,7 @@ export default ( { filter, view, onChangeView } ) => {
 	);
 
 	return (
-		<DropdownMenuV2
+		<DropdownMenu
 			key={ filter.field }
 			trigger={
 				<Button variant="tertiary" size="compact" label={ filter.name }>
@@ -47,7 +47,7 @@ export default ( { filter, view, onChangeView } ) => {
 		>
 			{ filter.elements.map( ( element ) => {
 				return (
-					<DropdownMenuCheckboxItemV2
+					<DropdownMenuCheckboxItem
 						key={ element.value }
 						value={ element.value }
 						checked={ activeElement?.value === element.value }
@@ -73,11 +73,11 @@ export default ( { filter, view, onChangeView } ) => {
 						}
 					>
 						{ element.label }
-					</DropdownMenuCheckboxItemV2>
+					</DropdownMenuCheckboxItem>
 				);
 			} ) }
-			<DropdownMenuSeparatorV2 />
-			<DropdownMenuItemV2
+			<DropdownMenuSeparator />
+			<DropdownMenuItem
 				key="remove-filter"
 				onSelect={ () =>
 					onChangeView( ( currentView ) => ( {
@@ -92,7 +92,7 @@ export default ( { filter, view, onChangeView } ) => {
 				}
 			>
 				{ __( 'Reset' ) }
-			</DropdownMenuItemV2>
-		</DropdownMenuV2>
+			</DropdownMenuItem>
+		</DropdownMenu>
 	);
 };

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -28,9 +28,8 @@ export default ( { filter, view, onChangeView } ) => {
 	return (
 		<DropdownMenuV2
 			key={ filter.field }
-			label={ filter.name }
 			trigger={
-				<Button variant="tertiary" size="compact">
+				<Button variant="tertiary" size="compact" label={ filter.name }>
 					{ activeElement !== undefined
 						? sprintf(
 								/* translators: 1: Filter name. 2: filter value. e.g.: "Author is Admin". */

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -6,7 +6,7 @@ import {
 	privateApis as componentsPrivateApis,
 	Icon,
 } from '@wordpress/components';
-import { check, chevronDown } from '@wordpress/icons';
+import { chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -15,9 +15,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { OPERATOR_IN } from './constants';
 import { unlock } from '../../lock-unlock';
 
-const { DropdownMenuV2, DropdownMenuItemV2, DropdownMenuSeparatorV2 } = unlock(
-	componentsPrivateApis
-);
+const {
+	DropdownMenuV2,
+	DropdownMenuItemV2,
+	DropdownMenuCheckboxItemV2,
+	DropdownMenuSeparatorV2,
+} = unlock( componentsPrivateApis );
 
 export default ( { filter, view, onChangeView } ) => {
 	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
@@ -44,13 +47,10 @@ export default ( { filter, view, onChangeView } ) => {
 		>
 			{ filter.elements.map( ( element ) => {
 				return (
-					<DropdownMenuItemV2
+					<DropdownMenuCheckboxItemV2
 						key={ element.value }
-						suffix={
-							activeElement?.value === element.value && (
-								<Icon icon={ check } />
-							)
-						}
+						value={ element.value }
+						checked={ activeElement?.value === element.value }
 						onSelect={ () =>
 							onChangeView( ( currentView ) => ( {
 								...currentView,
@@ -71,10 +71,9 @@ export default ( { filter, view, onChangeView } ) => {
 								],
 							} ) )
 						}
-						role="menuitemcheckbox"
 					>
 						{ element.label }
-					</DropdownMenuItemV2>
+					</DropdownMenuCheckboxItemV2>
 				);
 			} ) }
 			<DropdownMenuSeparatorV2 />

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -16,10 +16,10 @@ import { OPERATOR_IN } from './constants';
 import { unlock } from '../../lock-unlock';
 
 const {
-	DropdownMenuV2Ariakit: DropdownMenu,
-	DropdownMenuItemV2Ariakit: DropdownMenuItem,
-	DropdownMenuCheckboxItemV2Ariakit: DropdownMenuCheckboxItem,
-	DropdownMenuSeparatorV2Ariakit: DropdownMenuSeparator,
+	DropdownMenuV2: DropdownMenu,
+	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
+	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
 export default ( { filter, view, onChangeView } ) => {
@@ -51,7 +51,7 @@ export default ( { filter, view, onChangeView } ) => {
 						key={ element.value }
 						value={ element.value }
 						checked={ activeElement?.value === element.value }
-						onChange={ () =>
+						onSelect={ () =>
 							onChangeView( ( currentView ) => ( {
 								...currentView,
 								page: 1,

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -93,7 +93,7 @@ export default ( { filter, view, onChangeView } ) => {
 					} ) )
 				}
 			>
-				{ __( 'Remove' ) }
+				{ __( 'Reset' ) }
 			</DropdownMenuItemV2>
 		</DropdownMenuV2>
 	);

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -41,7 +41,7 @@ export default ( { filter, view, onChangeView } ) => {
 								activeElement.label
 						  )
 						: filter.name }
-					<Icon icon={ chevronDown } />
+					<Icon icon={ chevronDown } style={ { flexShrink: 0 } } />
 				</Button>
 			}
 		>

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -17,9 +17,7 @@ import { unlock } from '../../lock-unlock';
 
 const {
 	DropdownMenuV2: DropdownMenu,
-	DropdownMenuItemV2: DropdownMenuItem,
 	DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
 export default ( { filter, view, onChangeView } ) => {
@@ -76,23 +74,6 @@ export default ( { filter, view, onChangeView } ) => {
 					</DropdownMenuCheckboxItem>
 				);
 			} ) }
-			<DropdownMenuSeparator />
-			<DropdownMenuItem
-				key="remove-filter"
-				onSelect={ () =>
-					onChangeView( ( currentView ) => ( {
-						...currentView,
-						page: 1,
-						filters: [
-							...view.filters.filter(
-								( f ) => f.field !== filter.field
-							),
-						],
-					} ) )
-				}
-			>
-				{ __( 'Reset' ) }
-			</DropdownMenuItem>
 		</DropdownMenu>
 	);
 };

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -73,13 +73,7 @@ function HeaderMenu( { dataView, header } ) {
 	if ( header.column.columnDef.type === ENUMERATION_TYPE ) {
 		filter = {
 			field: header.column.columnDef.id,
-			elements: [
-				{
-					value: '',
-					label: __( 'All' ),
-				},
-				...( header.column.columnDef.elements || [] ),
-			],
+			elements: header.column.columnDef.elements || [],
 		};
 	}
 	const isFilterable = !! filter;
@@ -166,11 +160,6 @@ function HeaderMenu( { dataView, header } ) {
 										)[ 0 ] === filter.field
 								);
 
-								// Set the empty item as active if the filter is not set.
-								if ( ! columnFilter && element.value === '' ) {
-									isActive = true;
-								}
-
 								if ( columnFilter ) {
 									const value =
 										Object.values( columnFilter )[ 0 ];
@@ -205,25 +194,44 @@ function HeaderMenu( { dataView, header } ) {
 													}
 												);
 
-											if ( element.value === '' ) {
-												dataView.setColumnFilters(
-													otherFilters
-												);
-											} else {
-												dataView.setColumnFilters( [
-													...otherFilters,
-													{
-														[ filter.field +
-														':in' ]: element.value,
-													},
-												] );
-											}
+											dataView.setColumnFilters( [
+												...otherFilters,
+												{
+													[ filter.field + ':in' ]:
+														isActive
+															? undefined
+															: element.value,
+												},
+											] );
 										} }
 									>
 										{ element.label }
 									</DropdownMenuItemV2>
 								);
 							} ) }
+							<DropdownMenuSeparatorV2 />
+							<DropdownMenuItemV2
+								key="remove-filter"
+								onSelect={ () => {
+									const otherFilters = dataView
+										.getState()
+										.columnFilters?.filter( ( f ) => {
+											const [ field, operator ] =
+												Object.keys( f )[ 0 ].split(
+													':'
+												);
+											return (
+												field !== filter.field ||
+												operator !== 'in'
+											);
+										} );
+									dataView.setColumnFilters( [
+										...otherFilters,
+									] );
+								} }
+							>
+								{ __( 'Remove' ) }
+							</DropdownMenuItemV2>
 						</DropdownSubMenuV2>
 					</DropdownMenuGroupV2>
 				) }

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -209,29 +209,6 @@ function HeaderMenu( { dataView, header } ) {
 									</DropdownMenuItemV2>
 								);
 							} ) }
-							<DropdownMenuSeparatorV2 />
-							<DropdownMenuItemV2
-								key="remove-filter"
-								onSelect={ () => {
-									const otherFilters = dataView
-										.getState()
-										.columnFilters?.filter( ( f ) => {
-											const [ field, operator ] =
-												Object.keys( f )[ 0 ].split(
-													':'
-												);
-											return (
-												field !== filter.field ||
-												operator !== 'in'
-											);
-										} );
-									dataView.setColumnFilters( [
-										...otherFilters,
-									] );
-								} }
-							>
-								{ __( 'Remove' ) }
-							</DropdownMenuItemV2>
 						</DropdownSubMenuV2>
 					</DropdownMenuGroupV2>
 				) }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/55100

## What?

Updates the filter component to use a `Dropdown` instead of a `SelectControl`.

https://github.com/WordPress/gutenberg/assets/583546/bc27888f-63f3-4a48-a828-d1fb9d50d677

## Why?

Implement the design mockups.

## How?

Updates the `InFilter` component to use a Dropdown.

## Testing Instructions

- Enable the "admin views" experiment and visit "Appareance > Editor > Pages". Click on "Manage all pages".
- View and interact with the filters.

## Follow-ups

- Add "not in" operation.
- Multiselection.
- Allow removing the filter individually. 
- Update to use ariakit components.
