### PR TITLE
Rich text: remove OBJECT_REPLACEMENT_CHARACTER and deprecated getTextContent

### DIFF
--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -34,7 +34,6 @@ import {
 	getActiveFormat,
 	getActiveFormats,
 	insert,
-	getTextContent,
 	isEmpty,
 	create,
 	toHTMLString,
@@ -478,14 +477,14 @@ export class RichText extends Component {
 
 		if ( triggeredOption ) {
 			const record = this.getRecord();
-			const text = getTextContent( record );
+			const { text, start } = record;
 			// Only respond to the trigger if the selection is on the start of text or line
 			// or if the character before is a space.
 			const useTrigger =
 				text.length === 0 ||
-				record.start === 0 ||
-				text.charAt( record.start - 1 ) === '\n' ||
-				text.charAt( record.start - 1 ) === ' ';
+				start === 0 ||
+				text.charAt( start - 1 ) === '\n' ||
+				text.charAt( start - 1 ) === ' ';
 
 			if ( useTrigger && triggeredOption.onClick ) {
 				triggeredOption.onClick();

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Internal
 
+-   `Autocomplete`: use the `text` property instead of `getTextContent` on rich
+    text value.
 -   Migrate `Divider` from `reakit` to `ariakit` ([#55622](https://github.com/WordPress/gutenberg/pull/55622))
 -   Migrate `DisclosureContent` from `reakit` to `ariakit` and TypeScript ([#55639](https://github.com/WordPress/gutenberg/pull/55639))
 -   Migrate `RadioGroup` from `reakit` to `ariakit` and TypeScript ([#55580](https://github.com/WordPress/gutenberg/pull/55580))

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -15,13 +15,7 @@ import {
 } from '@wordpress/element';
 import { __, _n } from '@wordpress/i18n';
 import { useInstanceId, useMergeRefs, useRefEffect } from '@wordpress/compose';
-import {
-	create,
-	slice,
-	insert,
-	isCollapsed,
-	getTextContent,
-} from '@wordpress/rich-text';
+import { create, slice, insert, isCollapsed } from '@wordpress/rich-text';
 import { speak } from '@wordpress/a11y';
 import { isAppleOS } from '@wordpress/keycodes';
 
@@ -253,7 +247,7 @@ export function useAutocomplete( {
 	// is a potential bottleneck for the editor type metric.
 	const textContent = useMemo( () => {
 		if ( isCollapsed( record ) ) {
-			return getTextContent( slice( record, 0 ) );
+			return slice( record, 0 ).text;
 		}
 		return '';
 	}, [ record ] );
@@ -329,9 +323,11 @@ export function useAutocomplete( {
 			return;
 		}
 
-		const textAfterSelection = getTextContent(
-			slice( record, undefined, getTextContent( record ).length )
-		);
+		const textAfterSelection = slice(
+			record,
+			undefined,
+			record.text.length
+		).text;
 
 		if (
 			allowContext &&

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, useDispatch } from '@wordpress/data';
-import { create, getTextContent } from '@wordpress/rich-text';
+import { create } from '@wordpress/rich-text';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -128,11 +128,9 @@ export const DocumentOutline = ( {
 						>
 							{ item.isEmpty
 								? emptyHeadingContent
-								: getTextContent(
-										create( {
-											html: item.attributes.content,
-										} )
-								  ) }
+								: create( {
+										html: item.attributes.content,
+								  } ).text }
 							{ isIncorrectLevel && incorrectLevelContent }
 							{ item.level === 1 &&
 								hasMultipleH1 &&

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import {
-	getTextContent,
 	applyFormat,
 	removeFormat,
 	slice,
@@ -41,7 +40,7 @@ function Edit( {
 	const [ addingLink, setAddingLink ] = useState( false );
 
 	function addLink() {
-		const text = getTextContent( slice( value ) );
+		const { text } = slice( value );
 
 		if ( text && isURL( text ) && isValidHref( text ) ) {
 			onChange(

--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -13,7 +13,6 @@ import { RichTextToolbarButton } from '@wordpress/block-editor';
 import {
 	applyFormat,
 	getActiveFormat,
-	getTextContent,
 	isCollapsed,
 	removeFormat,
 	slice,
@@ -56,7 +55,7 @@ export const link = {
 
 			addLink() {
 				const { value, onChange } = this.props;
-				const text = getTextContent( slice( value ) );
+				const { text } = slice( value );
 
 				if ( text && isURL( text ) && isValidHref( text ) ) {
 					const newValue = applyFormat( value, {

--- a/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
+++ b/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
@@ -15,7 +15,6 @@ import {
 	insert,
 	isCollapsed,
 	applyFormat,
-	getTextContent,
 	slice,
 } from '@wordpress/rich-text';
 import { external, textColor } from '@wordpress/icons';
@@ -38,7 +37,7 @@ const LinkSettingsScreen = ( {
 	activeAttributes,
 	isVisible,
 } ) => {
-	const [ text, setText ] = useState( getTextContent( slice( value ) ) );
+	const [ text, setText ] = useState( slice( value ).text );
 	const [ opensInNewWindow, setOpensInNewWindows ] = useState(
 		activeAttributes.target === '_blank'
 	);
@@ -111,7 +110,7 @@ const LinkSettingsScreen = ( {
 				linkText.length
 			);
 			newAttributes = insert( value, toInsert );
-		} else if ( text !== getTextContent( slice( value ) ) ) {
+		} else if ( text !== slice( value ).text ) {
 			// Edit text in selected link.
 			const toInsert = applyFormat(
 				create( { text } ),

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -220,6 +220,8 @@ _Returns_
 
 ### getTextContent
 
+> **Deprecated** Use the text property instead.
+
 Get the textual content of a Rich Text value. This is similar to `Element.textContent`.
 
 _Parameters_

--- a/packages/rich-text/src/component/use-copy-handler.js
+++ b/packages/rich-text/src/component/use-copy-handler.js
@@ -10,7 +10,6 @@ import { useRefEffect } from '@wordpress/compose';
 import { toHTMLString } from '../to-html-string';
 import { isCollapsed } from '../is-collapsed';
 import { slice } from '../slice';
-import { getTextContent } from '../get-text-content';
 
 export function useCopyHandler( props ) {
 	const propsRef = useRef( props );
@@ -27,7 +26,7 @@ export function useCopyHandler( props ) {
 			}
 
 			const selectedRecord = slice( record.current );
-			const plainText = getTextContent( selectedRecord );
+			const plainText = selectedRecord.text;
 			const html = toHTMLString( { value: selectedRecord } );
 			event.clipboardData.setData( 'text/plain', plainText );
 			event.clipboardData.setData( 'text/html', html );

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -9,7 +9,7 @@ import { select } from '@wordpress/data';
 import { store as richTextStore } from './store';
 import { createElement } from './create-element';
 import { mergePair } from './concat';
-import { OBJECT_REPLACEMENT_CHARACTER, ZWNBSP } from './special-characters';
+import { ZWNBSP } from './special-characters';
 
 /** @typedef {import('./types').RichTextValue} RichTextValue */
 
@@ -283,16 +283,13 @@ export function collapseWhiteSpace( string ) {
 }
 
 /**
- * Removes reserved characters used by rich-text (zero width non breaking spaces added by `toTree` and object replacement characters).
+ * Removes reserved characters used by rich-text (zero width non breaking spaces
+ * added by `toTree`).
  *
  * @param {string} string
  */
 export function removeReservedCharacters( string ) {
-	// with the global flag, note that we should create a new regex each time OR reset lastIndex state.
-	return string.replace(
-		new RegExp( `[${ ZWNBSP }${ OBJECT_REPLACEMENT_CHARACTER }]`, 'gu' ),
-		''
-	);
+	return string.replaceAll( ZWNBSP, '' );
 }
 
 /**
@@ -365,7 +362,7 @@ function createFromElement( { element, range, isEditableTree } ) {
 						},
 					},
 				],
-				text: OBJECT_REPLACEMENT_CHARACTER,
+				text: ' ',
 			};
 			accumulateSelection( accumulator, node, range, value );
 			mergePair( accumulator, value );
@@ -396,7 +393,7 @@ function createFromElement( { element, range, isEditableTree } ) {
 						innerHTML: node.innerHTML,
 					},
 				],
-				text: OBJECT_REPLACEMENT_CHARACTER,
+				text: ' ',
 			} );
 			continue;
 		}
@@ -418,7 +415,7 @@ function createFromElement( { element, range, isEditableTree } ) {
 				mergePair( accumulator, {
 					formats: [ , ],
 					replacements: [ format ],
-					text: OBJECT_REPLACEMENT_CHARACTER,
+					text: ' ',
 				} );
 			}
 		} else {

--- a/packages/rich-text/src/get-active-object.js
+++ b/packages/rich-text/src/get-active-object.js
@@ -9,7 +9,7 @@
  * @return {RichTextFormat|void} Active object, or undefined.
  */
 export function getActiveObject( { start, end, replacements } ) {
-	if ( start + 1 !== end || replacements[ start ] ) {
+	if ( start + 1 !== end || ! replacements[ start ] ) {
 		return;
 	}
 

--- a/packages/rich-text/src/get-active-object.js
+++ b/packages/rich-text/src/get-active-object.js
@@ -1,9 +1,3 @@
-/**
- * Internal dependencies
- */
-
-import { OBJECT_REPLACEMENT_CHARACTER } from './special-characters';
-
 /** @typedef {import('./types').RichTextValue} RichTextValue */
 /** @typedef {import('./types').RichTextFormat} RichTextFormat */
 
@@ -14,8 +8,8 @@ import { OBJECT_REPLACEMENT_CHARACTER } from './special-characters';
  *
  * @return {RichTextFormat|void} Active object, or undefined.
  */
-export function getActiveObject( { start, end, replacements, text } ) {
-	if ( start + 1 !== end || text[ start ] !== OBJECT_REPLACEMENT_CHARACTER ) {
+export function getActiveObject( { start, end, replacements } ) {
+	if ( start + 1 !== end || replacements[ start ] ) {
 		return;
 	}
 

--- a/packages/rich-text/src/get-text-content.js
+++ b/packages/rich-text/src/get-text-content.js
@@ -1,18 +1,15 @@
-/**
- * Internal dependencies
- */
-import { OBJECT_REPLACEMENT_CHARACTER } from './special-characters';
-
 /** @typedef {import('./types').RichTextValue} RichTextValue */
 
 /**
  * Get the textual content of a Rich Text value. This is similar to
  * `Element.textContent`.
  *
+ * @deprecated Use the text property instead.
+ *
  * @param {RichTextValue} value Value to use.
  *
  * @return {string} The text content.
  */
 export function getTextContent( { text } ) {
-	return text.replace( OBJECT_REPLACEMENT_CHARACTER, '' );
+	return text;
 }

--- a/packages/rich-text/src/insert-object.js
+++ b/packages/rich-text/src/insert-object.js
@@ -3,7 +3,6 @@
  */
 
 import { insert } from './insert';
-import { OBJECT_REPLACEMENT_CHARACTER } from './special-characters';
 
 /** @typedef {import('./types').RichTextValue} RichTextValue */
 /** @typedef {import('./types').RichTextFormat} RichTextFormat */
@@ -24,7 +23,7 @@ export function insertObject( value, formatToInsert, startIndex, endIndex ) {
 	const valueToInsert = {
 		formats: [ , ],
 		replacements: [ formatToInsert ],
-		text: OBJECT_REPLACEMENT_CHARACTER,
+		text: ' ',
 	};
 
 	return insert( value, valueToInsert, startIndex, endIndex );

--- a/packages/rich-text/src/special-characters.js
+++ b/packages/rich-text/src/special-characters.js
@@ -1,9 +1,4 @@
 /**
- * Object replacement character, used as a placeholder for objects.
- */
-export const OBJECT_REPLACEMENT_CHARACTER = '\ufffc';
-
-/**
  * Zero width non-breaking space, used as padding in the editable DOM tree when
  * it is empty otherwise.
  */

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -215,23 +215,6 @@ exports[`recordToDom should handle selection before br 1`] = `
 </body>
 `;
 
-exports[`recordToDom should ignore manually added object replacement character 1`] = `
-<body>
-  test
-</body>
-`;
-
-exports[`recordToDom should ignore manually added object replacement character with formatting 1`] = `
-<body>
-  <em
-    data-rich-text-format-boundary="true"
-  >
-    hi
-  </em>
-  
-</body>
-`;
-
 exports[`recordToDom should not error with overlapping formats (1) 1`] = `
 <body>
   <a

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { create, removeReservedCharacters } from '../create';
-import { OBJECT_REPLACEMENT_CHARACTER, ZWNBSP } from '../special-characters';
+import { ZWNBSP } from '../special-characters';
 import { createElement } from '../create-element';
 import { registerFormatType } from '../register-format-type';
 import { unregisterFormatType } from '../unregister-format-type';
@@ -105,22 +105,9 @@ describe( 'create', () => {
 	} );
 
 	it( 'removeReservedCharacters should remove all reserved characters', () => {
-		expect(
-			removeReservedCharacters( `${ OBJECT_REPLACEMENT_CHARACTER }` )
-		).toEqual( '' );
 		expect( removeReservedCharacters( `${ ZWNBSP }` ) ).toEqual( '' );
-		expect(
-			removeReservedCharacters(
-				`${ OBJECT_REPLACEMENT_CHARACTER }c${ OBJECT_REPLACEMENT_CHARACTER }at${ OBJECT_REPLACEMENT_CHARACTER }`
-			)
-		).toEqual( 'cat' );
 		expect(
 			removeReservedCharacters( `${ ZWNBSP }b${ ZWNBSP }at${ ZWNBSP }` )
 		).toEqual( 'bat' );
-		expect(
-			removeReservedCharacters(
-				`te${ OBJECT_REPLACEMENT_CHARACTER }st${ ZWNBSP }${ ZWNBSP }`
-			)
-		).toEqual( 'test' );
 	} );
 } );

--- a/packages/rich-text/src/test/get-active-object.js
+++ b/packages/rich-text/src/test/get-active-object.js
@@ -3,13 +3,12 @@
  */
 
 import { getActiveObject } from '../get-active-object';
-import { OBJECT_REPLACEMENT_CHARACTER } from '../special-characters';
 
 describe( 'getActiveObject', () => {
 	it( 'should return object if selected', () => {
 		const record = {
 			replacements: [ { type: 'img' } ],
-			text: OBJECT_REPLACEMENT_CHARACTER,
+			text: ' ',
 			start: 0,
 			end: 1,
 		};
@@ -20,7 +19,7 @@ describe( 'getActiveObject', () => {
 	it( 'should return nothing if nothing is selected', () => {
 		const record = {
 			replacements: [ { type: 'img' } ],
-			text: OBJECT_REPLACEMENT_CHARACTER,
+			text: ' ',
 			start: 0,
 			end: 0,
 		};

--- a/packages/rich-text/src/test/get-active-object.js
+++ b/packages/rich-text/src/test/get-active-object.js
@@ -26,15 +26,4 @@ describe( 'getActiveObject', () => {
 
 		expect( getActiveObject( record ) ).toBe( undefined );
 	} );
-
-	it( 'should return nothing if te selection is not an object', () => {
-		const record = {
-			replacements: [ { type: 'em' } ],
-			text: 'a',
-			start: 0,
-			end: 1,
-		};
-
-		expect( getActiveObject( record ) ).toBe( undefined );
-	} );
 } );

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -224,7 +224,7 @@ export const spec = [
 			end: 0,
 			formats: [ , ],
 			replacements: [ img ],
-			text: '\ufffc',
+			text: ' ',
 		},
 	},
 	{
@@ -243,7 +243,7 @@ export const spec = [
 			end: 1,
 			formats: [ [ em ] ],
 			replacements: [ img ],
-			text: '\ufffc',
+			text: ' ',
 		},
 	},
 	{
@@ -262,7 +262,7 @@ export const spec = [
 			end: 5,
 			formats: [ , , [ em ], [ em ], [ em ] ],
 			replacements: [ , , , , img ],
-			text: 'test\ufffc',
+			text: 'test ',
 		},
 	},
 	{
@@ -281,7 +281,7 @@ export const spec = [
 			end: 5,
 			formats: [ [ em ], [ em ], [ em ], , , ],
 			replacements: [ img, , , , , ],
-			text: '\ufffctest',
+			text: ' test',
 		},
 	},
 	{
@@ -482,7 +482,7 @@ export const spec = [
 					type: 'script',
 				},
 			],
-			text: '\ufffc',
+			text: ' ',
 		},
 	},
 	{
@@ -508,7 +508,7 @@ export const spec = [
 					type: 'img',
 				},
 			],
-			text: '\ufffc',
+			text: ' ',
 		},
 	},
 ];

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ZWNBSP, OBJECT_REPLACEMENT_CHARACTER } from '../../special-characters';
+import { ZWNBSP } from '../../special-characters';
 
 export function getSparseArrayLength( array ) {
 	return array.reduce( ( accumulator ) => accumulator + 1, 0 );
@@ -30,46 +30,6 @@ export const spec = [
 			formats: [],
 			replacements: [],
 			text: '',
-		},
-	},
-	{
-		description:
-			'should ignore manually added object replacement character',
-		html: `test${ OBJECT_REPLACEMENT_CHARACTER }`,
-		createRange: ( element ) => ( {
-			startOffset: 0,
-			startContainer: element,
-			endOffset: 1,
-			endContainer: element,
-		} ),
-		startPath: [ 0, 0 ],
-		endPath: [ 0, 4 ],
-		record: {
-			start: 0,
-			end: 4,
-			formats: [ , , , , ],
-			replacements: [ , , , , ],
-			text: 'test',
-		},
-	},
-	{
-		description:
-			'should ignore manually added object replacement character with formatting',
-		html: `<em>h${ OBJECT_REPLACEMENT_CHARACTER }i</em>`,
-		createRange: ( element ) => ( {
-			startOffset: 0,
-			startContainer: element,
-			endOffset: 1,
-			endContainer: element,
-		} ),
-		startPath: [ 0, 0, 0 ],
-		endPath: [ 0, 0, 2 ],
-		record: {
-			start: 0,
-			end: 2,
-			formats: [ [ em ], [ em ] ],
-			replacements: [ , , ],
-			text: 'hi',
 		},
 	},
 	{
@@ -719,7 +679,7 @@ export const specWithRegistration = [
 					innerHTML: 'a',
 				},
 			],
-			text: OBJECT_REPLACEMENT_CHARACTER,
+			text: ' ',
 		},
 	},
 ];

--- a/packages/rich-text/src/test/insert-object.js
+++ b/packages/rich-text/src/test/insert-object.js
@@ -8,7 +8,6 @@ import deepFreeze from 'deep-freeze';
  */
 import { insertObject } from '../insert-object';
 import { getSparseArrayLength } from './helpers';
-import { OBJECT_REPLACEMENT_CHARACTER } from '../special-characters';
 
 describe( 'insert', () => {
 	const obj = { type: 'obj' };
@@ -25,7 +24,7 @@ describe( 'insert', () => {
 		const expected = {
 			formats: [ , , , [ em ], , , , , , , ],
 			replacements: [ , , obj, , , , , , , , ],
-			text: `on${ OBJECT_REPLACEMENT_CHARACTER }o three`,
+			text: `on o three`,
 			start: 3,
 			end: 3,
 		};

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -4,7 +4,7 @@
 
 import { getActiveFormats } from './get-active-formats';
 import { getFormatType } from './get-format-type';
-import { OBJECT_REPLACEMENT_CHARACTER, ZWNBSP } from './special-characters';
+import { ZWNBSP } from './special-characters';
 
 function restoreOnAttributes( attributes, isEditableTree ) {
 	if ( isEditableTree ) {
@@ -220,9 +220,9 @@ export function toTree( {
 			}
 		}
 
-		if ( character === OBJECT_REPLACEMENT_CHARACTER ) {
-			const replacement = replacements[ i ];
-			if ( ! replacement ) continue;
+		const replacement = replacements[ i ];
+
+		if ( replacement ) {
 			const { type, attributes, innerHTML } = replacement;
 			const formatType = getFormatType( type );
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove the use of `OBJECT_REPLACEMENT_CHARACTER` in rich text values, use a space character instead, and deprecated `getTextContent`. The only reason `getTextContent` exists to to remove this character.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Removes the risk of this special character leaking out of rich text, which is currently stored in the `text` property. People using rich text values can now safely use the `text` property, which for a long has been mistakenly and temptingly used for the wrong purpose, to get text content out of a rich text value.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We can simply use the space character and check if there's a replacement object at the same index. A space is a good choice here:

Imagine I have `a<img>b`. The text content of this will be `a b`, which is good cause you wouldn't want a search for `ab` to match anything.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
