### PR TITLE
DataViews: add new page size option

### DIFF
--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -95,7 +95,7 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 	);
 }
 
-const PAGE_SIZE_VALUES = [ 20, 50, 100 ];
+const PAGE_SIZE_VALUES = [ 10, 20, 50, 100 ];
 function PageSizeMenu( { view, onChangeView } ) {
 	return (
 		<DropdownSubMenuV2


### PR DESCRIPTION
Part of 

## What?

Adds a new page size option: `10`.

## Why?

It's smaller than the default `20`, it helps in some use cases (inspecting a smaller set of items, etc.), and it works well across all layouts (table, grid, side-by-side).

## How?

Add the new option to the list of options available.

## Testing Instructions

- Enable the "admin views" experiment and visit "Appareance > Editor > Manage all pages".
- Go to "View actions > Page size" (top-right button) and verify that `20` is the default but you can switch to 10.

<img width="438" alt="Captura de ecrã 2023-11-14, às 12 09 24" src="https://github.com/WordPress/gutenberg/assets/583546/daaed792-4005-47d8-8ddb-cc954e98fcf5">
