### PR TITLE
Performance: measure typing with fixed toolbar

### DIFF
--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -26,6 +26,7 @@ export interface WPRawPerformanceResults {
 	firstContentfulPaint: number[];
 	firstBlock: number[];
 	type: number[];
+	typeWithFixedToolbar: number[];
 	typeContainer: number[];
 	focus: number[];
 	inserterOpen: number[];
@@ -48,6 +49,9 @@ export interface WPPerformanceResults {
 	type?: number;
 	minType?: number;
 	maxType?: number;
+	typeWithFixedToolbar?: number;
+	minTypeWithFixedToolbar?: number;
+	maxTypeWithFixedToolbar?: number;
 	typeContainer?: number;
 	minTypeContainer?: number;
 	maxTypeContainer?: number;
@@ -92,6 +96,9 @@ export function curateResults(
 		type: average( results.type ),
 		minType: minimum( results.type ),
 		maxType: maximum( results.type ),
+		typeWithFixedToolbar: average( results.typeWithFixedToolbar ),
+		minTypeWithFixedToolbar: minimum( results.typeWithFixedToolbar ),
+		maxTypeWithFixedToolbar: maximum( results.typeWithFixedToolbar ),
 		typeContainer: average( results.typeContainer ),
 		minTypeContainer: minimum( results.typeContainer ),
 		maxTypeContainer: maximum( results.typeContainer ),

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -22,6 +22,7 @@ const results = {
 	firstContentfulPaint: [],
 	firstBlock: [],
 	type: [],
+	typeWithFixedToolbar: [],
 	typeContainer: [],
 	focus: [],
 	listViewOpen: [],
@@ -91,6 +92,40 @@ test.describe( 'Post Editor Performance', () => {
 		}
 	} );
 
+	async function type( target, metrics, key ) {
+		// The first character typed triggers a longer time (isTyping change).
+		// It can impact the stability of the metric, so we exclude it. It
+		// probably deserves a dedicated metric itself, though.
+		const samples = 10;
+		const throwaway = 1;
+		const iterations = samples + throwaway;
+
+		// Start tracing.
+		await metrics.startTracing();
+
+		// Type the testing sequence into the empty paragraph.
+		await target.type( 'x'.repeat( iterations ), {
+			delay: BROWSER_IDLE_WAIT,
+			// The extended timeout is needed because the typing is very slow
+			// and the `delay` value itself does not extend it.
+			timeout: iterations * BROWSER_IDLE_WAIT * 2, // 2x the total time to be safe.
+		} );
+
+		// Stop tracing.
+		await metrics.stopTracing();
+
+		// Get the durations.
+		const [ keyDownEvents, keyPressEvents, keyUpEvents ] =
+			metrics.getTypingEventDurations();
+
+		// Save the results.
+		for ( let i = throwaway; i < iterations; i++ ) {
+			results[ key ].push(
+				keyDownEvents[ i ] + keyPressEvents[ i ] + keyUpEvents[ i ]
+			);
+		}
+	}
+
 	test.describe( 'Typing', () => {
 		let draftId = null;
 
@@ -110,37 +145,30 @@ test.describe( 'Post Editor Performance', () => {
 				name: /Empty block/i,
 			} );
 
-			// The first character typed triggers a longer time (isTyping change).
-			// It can impact the stability of the metric, so we exclude it. It
-			// probably deserves a dedicated metric itself, though.
-			const samples = 10;
-			const throwaway = 1;
-			const iterations = samples + throwaway;
+			await type( paragraph, metrics, 'type' );
+		} );
+	} );
 
-			// Start tracing.
-			await metrics.startTracing();
+	test.describe( 'Typing (with fixed toolbar)', () => {
+		let draftId = null;
 
-			// Type the testing sequence into the empty paragraph.
-			await paragraph.type( 'x'.repeat( iterations ), {
-				delay: BROWSER_IDLE_WAIT,
-				// The extended timeout is needed because the typing is very slow
-				// and the `delay` value itself does not extend it.
-				timeout: iterations * BROWSER_IDLE_WAIT * 2, // 2x the total time to be safe.
+		test( 'Setup the test post', async ( { admin, perfUtils, editor } ) => {
+			await admin.createNewPost();
+			await perfUtils.loadBlocksForLargePost();
+			await editor.insertBlock( { name: 'core/paragraph' } );
+			draftId = await perfUtils.saveDraft();
+		} );
+
+		test( 'Run the test', async ( { admin, perfUtils, metrics } ) => {
+			await admin.editPost( draftId );
+			await perfUtils.disableAutosave();
+			const canvas = await perfUtils.getCanvas();
+
+			const paragraph = canvas.getByRole( 'document', {
+				name: /Empty block/i,
 			} );
 
-			// Stop tracing.
-			await metrics.stopTracing();
-
-			// Get the durations.
-			const [ keyDownEvents, keyPressEvents, keyUpEvents ] =
-				metrics.getTypingEventDurations();
-
-			// Save the results.
-			for ( let i = throwaway; i < iterations; i++ ) {
-				results.type.push(
-					keyDownEvents[ i ] + keyPressEvents[ i ] + keyUpEvents[ i ]
-				);
-			}
+			await type( paragraph, metrics, 'typeWithFixedToolbar' );
 		} );
 	} );
 
@@ -166,37 +194,7 @@ test.describe( 'Post Editor Performance', () => {
 				.first();
 			await firstParagraph.click();
 
-			// The first character typed triggers a longer time (isTyping change).
-			// It can impact the stability of the metric, so we exclude it. It
-			// probably deserves a dedicated metric itself, though.
-			const samples = 10;
-			const throwaway = 1;
-			const iterations = samples + throwaway;
-
-			// Start tracing.
-			await metrics.startTracing();
-
-			// Start typing in the middle of the text.
-			await firstParagraph.type( 'x'.repeat( iterations ), {
-				delay: BROWSER_IDLE_WAIT,
-				// The extended timeout is needed because the typing is very slow
-				// and the `delay` value itself does not extend it.
-				timeout: iterations * BROWSER_IDLE_WAIT * 2, // 2x the total time to be safe.
-			} );
-
-			// Stop tracing.
-			await metrics.stopTracing();
-
-			// Get the durations.
-			const [ keyDownEvents, keyPressEvents, keyUpEvents ] =
-				metrics.getTypingEventDurations();
-
-			// Save the results.
-			for ( let i = throwaway; i < iterations; i++ ) {
-				results.typeContainer.push(
-					keyDownEvents[ i ] + keyPressEvents[ i ] + keyUpEvents[ i ]
-				);
-			}
+			await type( firstParagraph, metrics, 'typeContainer' );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds another typing metrics for when the block toolbar is fixed.

Should we add another metric for when the inspector is open? Or should we combine it into one test (both inspector and toolbar fixed)?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The block toolbar is often a source of performance regressions. It's easy to add a button that does a lot of work on render, or runs a bunch of selectors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
