### PR TITLE
Block Editor: Optimize BlockListAppender

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -49,10 +49,6 @@ function useAppender( rootClientId, CustomAppender ) {
 				getBlockEditingMode,
 			} = select( blockEditorStore );
 
-			if ( CustomAppender === false ) {
-				return false;
-			}
-
 			if ( ! CustomAppender ) {
 				const selectedBlockClientId = getSelectedBlockClientId();
 				const isParentSelected =
@@ -92,6 +88,26 @@ function BlockListAppender( {
 	renderAppender,
 	className,
 	tagName: TagName = 'div',
+} ) {
+	if ( renderAppender === false ) {
+		return null;
+	}
+
+	return (
+		<BlockListAppenderInner
+			rootClientId={ rootClientId }
+			renderAppender={ renderAppender }
+			className={ className }
+			tagName={ TagName }
+		/>
+	);
+}
+
+function BlockListAppenderInner( {
+	rootClientId,
+	renderAppender,
+	className,
+	tagName: TagName,
 } ) {
 	const appender = useAppender( rootClientId, renderAppender );
 	const isDragOver = useSelect(


### PR DESCRIPTION
## What?
Similar to #56101.

This PR updates the `BlockListAppender` component to render the appender only if the appender component is not specifically set to be `false`. In the case of `false`, we never render it anyway, so with this change we'll not add unnecessary extra store subscriptions. The primary difference is that we're now doing that check outside of the `useSelect` call.

## Why?
This is an effort to minimize unnecessary store subscriptions created per block. See https://github.com/WordPress/gutenberg/pull/54819#issuecomment-1761202859.

Tested using @jsnajdr's debug code (https://github.com/WordPress/gutenberg/commit/c02930390ee76935cc545a708eefe6d9b120f240), the store subscriptions are reduced by almost 1k (~2%) on large text post with 1000 blocks.

## Testing Instructions
* Insert a bunch of blocks.
* Verify the appender still appears when it should, and doesn't appear when not expected to appear.

### Testing Instructions for Keyboard
No specific instructions.

## Screenshots or screencast <!-- if applicable -->

None
