### PR TITLE
Font Library: create fonts dir if a font face needs to use the file system

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -394,7 +394,7 @@ class WP_Font_Family {
 				continue;
 			}
 
-			// If the font face require to use the filesystem, create the fonts dir if it doesn't exist.
+			// If the font face requires the use of the filesystem, create the fonts dir if it doesn't exist.
 			if ( ! empty( $font_face['downloadFromUrl'] ) && ! empty( $font_face['uploadedFile'] ) ) {
 				wp_mkdir_p( WP_Font_Library::get_fonts_dir() );
 			}

--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -394,7 +394,7 @@ class WP_Font_Family {
 				continue;
 			}
 
-			// If the font face require to use the filesystem, create the fonts dir if it doesn't exist
+			// If the font face require to use the filesystem, create the fonts dir if it doesn't exist.
 			if ( ! empty( $font_face['downloadFromUrl'] ) && ! empty( $font_face['uploadedFile'] ) ) {
 				@wp_mkdir_p( WP_Font_Library::get_fonts_dir() );
 			}

--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -394,6 +394,11 @@ class WP_Font_Family {
 				continue;
 			}
 
+			// If the font face require to use the filesystem, create the fonts dir if it doesn't exist
+			if ( ! empty( $font_face['downloadFromUrl'] ) && ! empty( $font_face['uploadedFile'] ) ) {
+				@wp_mkdir_p( WP_Font_Library::get_fonts_dir() );
+			}
+
 			// If installing google fonts, download the font face assets.
 			if ( ! empty( $font_face['downloadFromUrl'] ) ) {
 				$new_font_face = $this->download_font_face_assets( $new_font_face );

--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -396,7 +396,7 @@ class WP_Font_Family {
 
 			// If the font face require to use the filesystem, create the fonts dir if it doesn't exist.
 			if ( ! empty( $font_face['downloadFromUrl'] ) && ! empty( $font_face['uploadedFile'] ) ) {
-				@wp_mkdir_p( WP_Font_Library::get_fonts_dir() );
+				wp_mkdir_p( WP_Font_Library::get_fonts_dir() );
 			}
 
 			// If installing google fonts, download the font face assets.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Font Library: create fonts dir if a font face needs to use the filesystem

## Why?
Because if the fonts directory is not created the writing of the fonts files can fail on certain servers.

## How?
create fonts dir if a font face needs to use the filesystem

## Testing Instructions
- Navigate to the font library.
- Try to install a font from Google Fonts collection.
- Check that is working as expected.


