### PR TITLE
Migrating `PatternTransformationsMenu`

### DIFF
--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -108,13 +108,16 @@ function BlockPattern( { pattern, onSelect } ) {
 	return (
 		<div className={ `${ baseClassName }-list__list-item` }>
 			<CompositeItem
-				role="option"
-				as="div"
-				aria-label={ pattern.title }
-				aria-describedby={
-					pattern.description ? descriptionId : undefined
+				render={
+					<div
+						role="option"
+						aria-label={ pattern.title }
+						aria-describedby={
+							pattern.description ? descriptionId : undefined
+						}
+						className={ `${ baseClassName }-list__item` }
+					/>
 				}
-				className={ `${ baseClassName }-list__item` }
 				onClick={ () => onSelect( pattern.transformedBlocks ) }
 			>
 				<BlockPreview

--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -11,9 +11,7 @@ import {
 	MenuItem,
 	Popover,
 	VisuallyHidden,
-	__unstableComposite as Composite,
-	__unstableUseCompositeState as useCompositeState,
-	__unstableCompositeItem as CompositeItem,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 
 /**
@@ -21,6 +19,13 @@ import {
  */
 import BlockPreview from '../block-preview';
 import useTransformedPatterns from './use-transformed-patterns';
+import { unlock } from '../../lock-unlock';
+
+const {
+	CompositeV2: Composite,
+	CompositeItemV2: CompositeItem,
+	useCompositeStoreV2: useCompositeStore,
+} = unlock( componentsPrivateApis );
 
 function PatternTransformationsMenu( {
 	blocks,
@@ -73,10 +78,10 @@ function PreviewPatternsPopover( { patterns, onSelect } ) {
 }
 
 function BlockPatternsList( { patterns, onSelect } ) {
-	const composite = useCompositeState();
+	const composite = useCompositeStore();
 	return (
 		<Composite
-			{ ...composite }
+			store={ composite }
 			role="listbox"
 			className="block-editor-block-switcher__preview-patterns-container"
 			aria-label={ __( 'Patterns list' ) }
@@ -86,14 +91,13 @@ function BlockPatternsList( { patterns, onSelect } ) {
 					key={ pattern.name }
 					pattern={ pattern }
 					onSelect={ onSelect }
-					composite={ composite }
 				/>
 			) ) }
 		</Composite>
 	);
 }
 
-function BlockPattern( { pattern, onSelect, composite } ) {
+function BlockPattern( { pattern, onSelect } ) {
 	// TODO check pattern/preview width...
 	const baseClassName =
 		'block-editor-block-switcher__preview-patterns-container';
@@ -106,7 +110,6 @@ function BlockPattern( { pattern, onSelect, composite } ) {
 			<CompositeItem
 				role="option"
 				as="div"
-				{ ...composite }
 				aria-label={ pattern.title }
 				aria-describedby={
 					pattern.description ? descriptionId : undefined


### PR DESCRIPTION
## What?

This PR updates [`PatternTransformationsMenu`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js) in `@wordpress/block-editor` to use the updated `Composite` implementation from #54225.


## Why?

In #54225, an updated implementation of `Composite` was added to `@wordpress/components`. As per #55224, all consumers of `Composite` need to migrate from the old version to the new version.


## How?

 - Removes `__unstableComposite` imports from `@wordpress/components`
 - Adds private `Composite*` exports from `@wordpress/components`
 - Refactors `BlockPatternsList` and `BlockPattern` to use updated `Composite` components


## Testing Instructions

1. Using the _Twenty Twenty-Three_ theme, add/edit a post/page, and insert a Heading block.
2. Click the Block switcher button in the block toolbar.
3. In the dropdown menu that opens, select the (first) 'Patterns' menu item.
4. A popover should open on the right to show the preview of the available pattern(s).
5. You should see a 'Heading' pattern that comes from the Patterns directory.
6. There should be no visible differences.


### Before and after

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/f4414221-6d0b-4eac-8f19-e54342a1ba85" alt="" width="45%">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/550736e1-004e-42ea-88c9-972835c4feee" alt="" width="45%">
</p>


### Testing Instructions for Keyboard

1. Opening the same block switcher menu, select the same 'Patterns' menu item.
   - Note, the implementation is odd, so needs <kbd>return</kbd>/<kbd>space</kbd> rather than an arrow key.
2. The first available pattern should be focused.
3. If there are multiple patterns available, they should be accessible with arrow keys.