### PR TITLE
Fix the image link button pressed state.

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -249,6 +249,7 @@ const ImageURLInputUI = ( {
 				aria-expanded={ isOpen }
 				onClick={ openLinkUI }
 				ref={ setPopoverAnchor }
+				isActive={ !! url }
 			/>
 			{ isOpen && (
 				<URLPopover

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `Toolbar`: Remove CSS rule that prevented focus outline to be visible for toolbar buttons in the `:active` state. ([#56123](https://github.com/WordPress/gutenberg/pull/56123)).
+
 ### Internal
 
 -   Migrate `Divider` from `reakit` to `ariakit` ([#55622](https://github.com/WordPress/gutenberg/pull/55622))

--- a/packages/components/src/toolbar/toolbar-button/style.scss
+++ b/packages/components/src/toolbar/toolbar-button/style.scss
@@ -17,11 +17,6 @@
 		bottom: 10px;
 	}
 
-	// Hide focus rectangle on click.
-	&:active::before {
-		display: none;
-	}
-
 	&:not(:disabled).is-pressed[data-subscript]::after {
 		color: $white;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/56078

## What?
<!-- In a few words, what is the PR actually doing? -->
In the Image block and in the Media & Text block, when the image is linked, the Libk bugton in the block toolbar doesn't have a pressed state. As such, there's no visual / semantic / accessible information the image is actually linked.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- The button doesn't convey the linked image state, not visually neither semantically.
- It's inconsistent with the behavior of the text link button.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds the `isActive` prop to the related `ToolbarButton`.
- Removes a CSS rule that prevents the button to show the pressed styling while being clicked.

More details on the CSS rule:
I have the impression the whole content of the toolbar-button stylesheet is a remnant of some previous implementation and it's no lonver in use in the editor. See 

https://github.com/WordPress/gutenberg/blob/5bcb30933846450ed25b3c9d0da39ccc95307b54/packages/components/src/toolbar/toolbar-button/style.scss#L1-L28

All of the rules there are scoped to some kind of `data-subscript` attribute that _I think_ is not used any longer. To my understanding it was meant to display some subscript CSS generated text within the buttons, for headings or maybe the quote block.
Only the following rule wasn't scoped to a `subscript` thing:

```
// Hide focus rectangle on click.
&:active::before {
	display: none;
}
```

This rule hid the pseudo element while the button is being clicked. This is wrong for two reasons, see comments on the here https://github.com/WordPress/gutenberg/issues/56078#issuecomment-1810362312.
- We do want the focus indication to be always visible.
- It prevented the dark `is-pressed` background styling to work while the button is being clicked.

@jasmussen @richtabor when you have a chance, I'd kindly ask you to have a look at the content of [this stylesheet](https://github.com/WordPress/gutenberg/blob/5bcb30933846450ed25b3c9d0da39ccc95307b54/packages/components/src/toolbar/toolbar-button/style.scss#L1-L28). There's a chance it can be removed entirely.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add an image block and add a link to the image.
- Observe that when the image is linked, the Link button in the toolbar:
  - Has the pressed style with a dark background and white icon glyph.
  - Has a `is-pressed` CSS class.
  - Has a `aria-pressed="true"` attribute.
- Test by adding all kinds of links: Internal link through the search, manual link, link to the media file, link to the attachment page.
- Remove the link.
- Observe the button doesn't have the 'pressed' state any longer.
- Add a Media & Text block, Add a link to the image.
- Repeat the steps above. 

**Additionally:**
- See comment https://github.com/WordPress/gutenberg/issues/56078#issuecomment-1810362312
- Add an Embed block, embed this: https://www.youtube.com/watch?v=VeigCZuxnfY and save.
- Select the embed block to make its block toolbar appear.
- Move focus to the toolbar buttons.
- While the buttons show the focus style, click and hold the mouse on the each button.
- Observe that all buttons still show the focus style while they are being clicked.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
