### PR TITLE
Lightbox: Fix close button position.

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -372,7 +372,7 @@
 
 @keyframes lightbox-zoom-in {
 	0% {
-		transform: translate(calc(-50vw + var(--wp--lightbox-initial-left-position) + (var(--wp--lightbox-scrollbar-width) / 2)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
+		transform: translate(calc((-100vw + var(--wp--lightbox-scrollbar-width)) / 2 + var(--wp--lightbox-initial-left-position)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
 	}
 	100% {
 		transform: translate(-50%, -50%) scale(1, 1);
@@ -389,6 +389,6 @@
 	}
 	100% {
 		visibility: hidden;
-		transform: translate(calc(-50vw + var(--wp--lightbox-initial-left-position) + (var(--wp--lightbox-scrollbar-width) / 2)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
+		transform: translate(calc((-100vw + var(--wp--lightbox-scrollbar-width)) / 2 + var(--wp--lightbox-initial-left-position)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -215,7 +215,7 @@
 	left: 0;
 	z-index: 100000;
 	overflow: hidden;
-	width: 100vw;
+	width: 100%;
 	height: 100vh;
 	box-sizing: border-box;
 	visibility: hidden;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -372,7 +372,7 @@
 
 @keyframes lightbox-zoom-in {
 	0% {
-		transform: translate(calc(-50vw + var(--wp--lightbox-initial-left-position)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
+		transform: translate(calc(-50vw + var(--wp--lightbox-initial-left-position) + (var(--wp--lightbox-scrollbar-width) / 2)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
 	}
 	100% {
 		transform: translate(-50%, -50%) scale(1, 1);
@@ -389,6 +389,6 @@
 	}
 	100% {
 		visibility: hidden;
-		transform: translate(calc(-50vw + var(--wp--lightbox-initial-left-position)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
+		transform: translate(calc(-50vw + var(--wp--lightbox-initial-left-position) + (var(--wp--lightbox-scrollbar-width) / 2)), calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));
 	}
 }

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -569,7 +569,7 @@ function setStyles( context, ref ) {
 			--wp--lightbox-image-height: ${ lightboxImgHeight }px;
 			--wp--lightbox-scale: ${ containerScale };
 			--wp--lightbox-scrollbar-width: ${
-				window.innerWidth - document.body.clientWidth
+				window.innerWidth - document.documentElement.clientWidth
 			}px;
 		}
 	`;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -568,6 +568,9 @@ function setStyles( context, ref ) {
 			--wp--lightbox-image-width: ${ lightboxImgWidth }px;
 			--wp--lightbox-image-height: ${ lightboxImgHeight }px;
 			--wp--lightbox-scale: ${ containerScale };
+			--wp--lightbox-scrollbar-width: ${
+				window.innerWidth - document.body.clientWidth
+			}px;
 		}
 	`;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Changed the position of close button to be calculated from the inside of the scroll bar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fix #56052.

This problem is more noticeable in Chrome on Windows because of the wider scrollbars, but the same problem occurs when the scrollbars are displayed on a Mac.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change width of `.wp-lightbox-overlay` to `100%` . 
Because `.wp-lightbox-overlay` is a child element of `body`, 100% is the size of 100vw minus the width of the scrollbar.

> However, when the lightbox is closed, there is a slight unnatural shift, so a different approach is needed.

Within `keyframes` `100%` is not computed. Instead `100vw - $scrollbar-width` is used.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add Image block and activate lightbox.
2. Check lightbox view.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![screenshot  chrome on windows](https://github.com/WordPress/gutenberg/assets/1908815/d42c6558-0d74-4861-a3da-f0c61bce5824)

