### PR TITLE
Page spec: merging create page and toggle preview tests

### DIFF
--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -111,9 +111,7 @@ async function testToggleTemplatePreview( editor, page ) {
 		} )
 	).toBeHidden();
 
-	// Check order of paragraphs.
-	// Important to ensure the blocks are rendered as they are in the template.
-
+	// Content blocks are wrapped in a Group block by default.
 	await expect(
 		editor.canvas
 			.getByRole( 'document', {
@@ -123,6 +121,7 @@ async function testToggleTemplatePreview( editor, page ) {
 				name: 'Block: Content',
 			} )
 	).toBeVisible();
+
 	// Ensure order is preserved between toggling.
 	await page
 		.locator(
@@ -254,8 +253,10 @@ test.describe( 'Pages', () => {
 		await addPageContent( editor, page );
 
 		// Run assertions
+		/* eslint-disable playwright/expect-expect */
 		await testCreatePage( editor, page );
 		await testToggleTemplatePreview( editor, page );
+		/* eslint-enable playwright/expect-expect */
 	} );
 
 	test( 'swap template and reset to default', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
Follow up to https://github.com/WordPress/gutenberg/pull/56096

This PR merges the create page and toggle preview tests because they rely on the same page content to work.

It also speeds up the test suite a little because we don't have to reload the page. 

The PR also changes the test to check for consistent block order between toggling template preview.

#56096 was testing the presence and order of paragraph blocks, but since they're contained in a single post content block it didn't achieve it's purpose: to test that template changes, e.g., changing the order of post title and post content blocks, are reflected when template preview is toggled to "off".

## Testing Instructions

Run the tests using the sweet playwright UI tool!!

`npm run test:e2e:playwright -- --ui --headed`