### PR TITLE
Add layout classes to legacy Group inner container

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -869,10 +869,27 @@ function gutenberg_restore_group_inner_container( $block_content, $block ) {
 	$processor      = new WP_HTML_Tag_Processor( $block_content );
 
 	if ( $processor->next_tag( array( 'class_name' => 'wp-block-group' ) ) ) {
-		foreach ( $processor->class_list() as $class_name ) {
-			if ( str_contains( $class_name, 'layout' ) ) {
-				array_push( $layout_classes, $class_name );
-				$processor->remove_class( $class_name );
+		if ( method_exists( $processor, 'class_list' ) ) {
+			foreach ( $processor->class_list() as $class_name ) {
+				if ( str_contains( $class_name, 'layout' ) ) {
+					array_push( $layout_classes, $class_name );
+					$processor->remove_class( $class_name );
+				}
+			}
+		} else {
+			/**
+			* The class_list method was only added in 6.4 so this needs a temporary fallback.
+			* This fallback should be removed when the minimum supported version is 6.4.
+			*/
+			$classes = $processor->get_attribute( 'class' );
+			if ( $classes ) {
+				$classes = explode( ' ', $classes );
+				foreach ( $classes as $class_name ) {
+					if ( str_contains( $class_name, 'layout' ) ) {
+						array_push( $layout_classes, $class_name );
+						$processor->remove_class( $class_name );
+					}
+				}
 			}
 		}
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -870,20 +870,19 @@ function gutenberg_restore_group_inner_container( $block_content, $block ) {
 
 	if ( $processor->next_tag( array( 'class_name' => 'wp-block-group' ) ) ) {
 		foreach ( $processor->class_list() as $class_name ) {
-			if (str_contains( $class_name, 'layout' ) ) {
+			if ( str_contains( $class_name, 'layout' ) ) {
 				array_push( $layout_classes, $class_name );
-				$what = $processor->remove_class( $class_name );
-			}			
+				$processor->remove_class( $class_name );
+			}
 		}
 	}
 
 	$content_without_layout_classes = $processor->get_updated_html();
-
-	$replace_regex   = sprintf(
+	$replace_regex                  = sprintf(
 		'/(^\s*<%1$s\b[^>]*wp-block-group[^>]*>)(.*)(<\/%1$s>\s*$)/ms',
 		preg_quote( $tag_name, '/' )
 	);
-	$updated_content = preg_replace_callback(
+	$updated_content                = preg_replace_callback(
 		$replace_regex,
 		static function ( $matches ) {
 			return $matches[1] . '<div class="wp-block-group__inner-container">' . $matches[2] . '</div>' . $matches[3];
@@ -897,7 +896,7 @@ function gutenberg_restore_group_inner_container( $block_content, $block ) {
 			foreach ( $layout_classes as $class_name ) {
 				$processor->add_class( $class_name );
 			}
-		}		
+		}
 		$updated_content = $processor->get_updated_html();
 	}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -866,7 +866,7 @@ function gutenberg_restore_group_inner_container( $block_content, $block ) {
 	}
 
 	$layout_classes = array();
-	$processor = new WP_HTML_Tag_Processor( $block_content );
+	$processor      = new WP_HTML_Tag_Processor( $block_content );
 
 	if ( $processor->next_tag( array( 'class_name' => 'wp-block-group' ) ) ) {
 		foreach ( $processor->class_list() as $class_name ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -865,6 +865,10 @@ function gutenberg_restore_group_inner_container( $block_content, $block ) {
 		return $block_content;
 	}
 
+	/**
+	 * This filter runs after the layout classnames have been added to the block, so they
+	 * have to be removed from the outer wrapper and then added to the inner.
+	*/
 	$layout_classes = array();
 	$processor      = new WP_HTML_Tag_Processor( $block_content );
 
@@ -907,6 +911,7 @@ function gutenberg_restore_group_inner_container( $block_content, $block ) {
 		$content_without_layout_classes
 	);
 
+	// Add layout classes to inner wrapper.
 	if ( ! empty( $layout_classes ) ) {
 		$processor = new WP_HTML_Tag_Processor( $updated_content );
 		if ( $processor->next_tag( array( 'class_name' => 'wp-block-group__inner-container' ) ) ) {

--- a/packages/block-editor/src/components/button-block-appender/content.scss
+++ b/packages/block-editor/src/components/button-block-appender/content.scss
@@ -39,8 +39,8 @@
 	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > &,
 	.is-layout-flow.block-editor-block-list__block:not(.is-selected) > &,
 	// Legacy groups have an inner container so need to be targeted separately
-	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > .wp-block-group__inner-container > &,
-	.is-layout-flow.block-editor-block-list__block:not(.is-selected) > .wp-block-group__inner-container > & {
+	.block-editor-block-list__block:not(.is-selected) > .is-layout-constrained.wp-block-group__inner-container > &,
+	.block-editor-block-list__block:not(.is-selected) > .is-layout-flow.wp-block-group__inner-container > & {
 		pointer-events: none;
 
 		&::after {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -71,13 +71,7 @@ function GroupEditControls( { tagName, onSelectTagName } ) {
 	);
 }
 
-function GroupEdit( {
-	attributes,
-	name,
-	setAttributes,
-	clientId,
-	__unstableLayoutClassNames: layoutClassNames,
-} ) {
+function GroupEdit( { attributes, name, setAttributes, clientId } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
 		( select ) => {
 			const { getBlock, getSettings } = select( blockEditorStore );
@@ -103,9 +97,8 @@ function GroupEdit( {
 		themeSupportsLayout || type === 'flex' || type === 'grid';
 
 	// Hooks.
-	const blockProps = useBlockProps( {
-		className: ! layoutSupportEnabled ? layoutClassNames : null,
-	} );
+	const blockProps = useBlockProps();
+
 	const [ showPlaceholder, setShowPlaceholder ] = useShouldShowPlaceHolder( {
 		attributes,
 		usedLayoutType: type,
@@ -134,7 +127,6 @@ function GroupEdit( {
 			templateLock,
 			allowedBlocks,
 			renderAppender,
-			__unstableDisableLayoutClassNames: ! layoutSupportEnabled,
 		}
 	);
 

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -464,4 +464,92 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Check that gutenberg_restore_group_inner_container() restores the legacy inner container on the Group block.
+	 *
+	 * @dataProvider data_restore_group_inner_container
+	 *
+	 * @covers ::gutenberg_restore_group_inner_container
+	 *
+	 * @param array  $args            Dataset to test.
+	 * @param string $expected_output The expected output.
+	 */
+	public function test_restore_group_inner_container( $args, $expected_output ) {
+		$actual_output = gutenberg_restore_group_inner_container( $args['block_content'], $args['block'] );
+		$this->assertEquals( $expected_output, $actual_output );
+	}
+
+	/**
+	 * Data provider for test_restore_group_inner_container.
+	 *
+	 * @return array
+	 */
+	public function data_restore_group_inner_container() {
+		return array(
+			'group block with existing inner container'    => array(
+				'args'            => array(
+					'block_content' => '<div class="wp-block-group"><div class="wp-block-group__inner-container"></div></div>',
+					'block'         => array(
+						'blockName'    => 'core/group',
+						'attrs'        => array(
+							'layout' => array(
+								'type' => 'default',
+							),
+						),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<div class="wp-block-group"><div class="wp-block-group__inner-container"></div></div>',
+						'innerContent' => array(
+							'<div class="wp-block-group"><div class="wp-block-group__inner-container">',
+							' ',
+							' </div></div>',
+						),
+					),
+				),
+				'expected_output' => '<div class="wp-block-group"><div class="wp-block-group__inner-container"></div></div>',
+			),
+			'group block with no existing inner container' => array(
+				'args'            => array(
+					'block_content' => '<div class="wp-block-group"></div>',
+					'block'         => array(
+						'blockName'    => 'core/group',
+						'attrs'        => array(
+							'layout' => array(
+								'type' => 'default',
+							),
+						),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<div class="wp-block-group"></div>',
+						'innerContent' => array(
+							'<div class="wp-block-group">',
+							' ',
+							' </div>',
+						),
+					),
+				),
+				'expected_output' => '<div class="wp-block-group"><div class="wp-block-group__inner-container"></div></div>',
+			),
+			'group block with layout classnames'           => array(
+				'args'            => array(
+					'block_content' => '<div class="wp-block-group is-layout-constrained wp-block-group-is-layout-constrained"></div>',
+					'block'         => array(
+						'blockName'    => 'core/group',
+						'attrs'        => array(
+							'layout' => array(
+								'type' => 'default',
+							),
+						),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<div class="wp-block-group"></div>',
+						'innerContent' => array(
+							'<div class="wp-block-group">',
+							' ',
+							' </div>',
+						),
+					),
+				),
+				'expected_output' => '<div class="wp-block-group"><div class="wp-block-group__inner-container is-layout-constrained wp-block-group-is-layout-constrained"></div></div>',
+			),
+		);
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #47386; alternative to #47451.

If appearance tools are enabled on a classic theme but no theme.json exists, an inner container is added to Group blocks, but layout classes are still added to the outer container. 

Currently the filter that adds the inner container runs after the layout filter, but even if we switch their running order, the [block inner content ](https://github.com/WordPress/gutenberg/blob/fix/block-gap-in-classic/lib/block-supports/layout.php#L791) doesn't seem to change, so the layout classes never get added to the inner container.

This PR uses the HTML tag processor to remove the layout classes from the outer container and add them to the inner container, within the filter where that container gets added.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add theme support for appearance tools to a classic theme;
2. Check that block spacing works correctly on Group blocks in both editor and front end;
3. Check that nothing breaks when appearance tools are disabled.

Note that this PR changes the position of the layout classnames whether appearance tools are enabled or not. The core styles applied to the default layout classnames don't appear to have any impact but this could potentially be a breaking change for themes that might have attached their own CSS to the layout classnames. I guess we could possibly put these changes behind a check that appearance tools are enabled. Thoughts?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
