### PR TITLE
[PoC] Explore options for adding partial syncing of blocks with innerBlock content

### DIFF
--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -57,9 +57,12 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 		// Check if the current block is a paragraph or image block.
 		// Currently, only these two blocks are supported.
 		if (
-			! [ 'core/paragraph', 'core/image', 'core/heading' ].includes(
-				props.name
-			)
+			! [
+				'core/paragraph',
+				'core/image',
+				'core/heading',
+				'core/list',
+			].includes( props.name )
 		) {
 			return <BlockEdit { ...props } />;
 		}
@@ -71,6 +74,7 @@ const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) => {
 		if ( props.name === 'core/paragraph' ) attributeName = 'content';
 		if ( props.name === 'core/image' ) attributeName = 'url';
 		if ( props.name === 'core/heading' ) attributeName = 'content';
+		if ( props.name === 'core/list' ) attributeName = 'innerBlocks';
 
 		const connectionSource =
 			props.attributes?.connections?.attributes?.[ attributeName ]

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -36,6 +36,7 @@
 		}
 	},
 	"supports": {
+		"__experimentalConnections": true,
 		"anchor": true,
 		"className": false,
 		"typography": {

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -125,6 +125,43 @@ function IndentUI( { clientId } ) {
 
 export default function Edit( { attributes, setAttributes, clientId, style } ) {
 	const { ordered, type, reversed, start } = attributes;
+
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
+	const { patternParentAttributes } = useSelect( ( select ) => {
+		const { getBlockParentsByBlockName, getBlockAttributes } =
+			select( blockEditorStore );
+		const parent = getBlockParentsByBlockName(
+			clientId,
+			'core/block'
+		)?.[ 0 ];
+		return {
+			patternParent: parent,
+			patternParentAttributes: getBlockAttributes( parent ),
+		};
+	} );
+
+	useEffect( () => {
+		if (
+			Array.isArray( patternParentAttributes?.dynamicContent?.myList )
+		) {
+			const patternInstanceInnerBlocks =
+				patternParentAttributes?.dynamicContent?.myList.map(
+					( block ) => {
+						return createBlock(
+							block.name,
+							block.attributes,
+							block.innerBlocks
+						);
+					}
+				);
+			replaceInnerBlocks( clientId, patternInstanceInnerBlocks );
+		}
+	}, [
+		clientId,
+		patternParentAttributes?.dynamicContent?.myList,
+		replaceInnerBlocks,
+	] );
+
 	const blockProps = useBlockProps( {
 		style: {
 			...( Platform.isNative && style ),


### PR DESCRIPTION
## What?
Currently a hard-coded PoC to investigate how feasible it is to serialise innerBlock pattern changes into the parent patterns attributes

## Why?
Some work has been done already to allow the [partial syncing of pattern content by connecting block attributes](https://github.com/WordPress/gutenberg/pull/55807), and this may form the basis of any MVP for [partial syncing of patterns](https://github.com/WordPress/gutenberg/issues/53705), but we need to investigate in advance if the approach of storing the instance specific content in the parent pattern block attributes scales to also storing changes to innerBlock content to allow partial syncing of columns, groups, galleries, etc.

## How?
Stores a serialised representation of the inner blocks in the parent pattern attributes and update the given block innerblocks with these blocks when loaded.

This is very early stage and is currently just hardcoded in the List block edit method and content needs to be manually pasted into parent pattern attributes.  The idea is to use the hard coding to better understand how the flows might work and then this can be abstracted out into the likes of the innerBlocksProps so it can be automatically applied across blocks.

## Testing Instructions
Not easily tested yet, more details coming soon ...

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/b615b391-03d4-4578-b0f1-493df7e39164



