### PR TITLE
DropdownMenu: remove extra vertical space around the toggle button

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Bug Fix
 
+-   `DropdownMenu`: remove extra vertical space around the toggle button ([#56136](https://github.com/WordPress/gutenberg/pull/56136)).
 -   Package should not depend on `@ariakit/test`, that package is only needed for testing ([#56091](https://github.com/WordPress/gutenberg/pull/56091)).
 
 ## 25.11.0 (2023-11-02)

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -1,3 +1,7 @@
+.components-dropdown-menu__toggle {
+	vertical-align: top;
+}
+
 .components-dropdown-menu__menu {
 	width: 100%;
 	font-family: $default-font;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Supersedes #56005

This PR tweaks the vertical alignment of the menu toggle for the `DropdownMenu` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These changes prevent some unwanted vertical space from being added under the dropdown menu toggle, as initially flagged in https://github.com/WordPress/gutenberg/pull/56002#discussion_r1388152765

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`DropdownMenu` internally uses the `Dropdown` component. Since we established that [it would be risky to tweak the `display` property of the `Dropdown` wrapper element](https://github.com/WordPress/gutenberg/pull/56005#issuecomment-1805286017), we opted for removing the unwanted vertical space by setting the `vertical-align` CSS property in the `DropdownMenu` component.

As also noted elsewhere, this PR will only remove such vertical space on the `DropdownMenu` component. Consumers of `Dropdown` will have to provide a similar "fix" directly when using the component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Checkout `trunk`
- Apply this patch: 
```diff
diff --git a/packages/components/src/dropdown-menu/stories/index.story.tsx b/packages/components/src/dropdown-menu/stories/index.story.tsx
index d4b856380d..f36d3194db 100644
--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -67,6 +67,9 @@ Default.args = {
 			onClick: () => console.log( 'down!' ),
 		},
 	],
+	toggleProps: {
+		size: 'small',
+	},
 };
 
 export const WithChildren = Template.bind( {} );

```
- Visit the `DropdownMenu` storybook example. Inspect the dropdown menu's toggle, and notice how, while the `button` element is 24px tall, the surrounding `div` (with classname `.components-dropdown-menu`) has a height of 27px.
- Apply the changes from this PR
- Reload the same Storybook example. The `div` wrapping the toggle should now have the same height as the toggle (24px)
