### PR TITLE
Site editor: Try lighter menu item color.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -1,5 +1,5 @@
 .edit-site-sidebar-navigation-item.components-item {
-	color: $gray-600;
+	color: $gray-400;
 	// 6px right padding to align with + button
 	padding: $grid-unit-10 6px $grid-unit-10 $grid-unit-20;
 	border: none;


### PR DESCRIPTION
## What?

The previous color, gray 600 had 5.5:1 contrast against the background, more than the AA requires. This new color has 10.38:1 contrast, more than AAA.

## Why?

I think it's worth having the conversation about the role of contrast here, in both the before and after cases here, there is objectively sufficient contrast according to accepted standards. In the latter, the contrast is perceived higher, but this comes at the tradeoff of lower contrast between text and menu items.

## Testing Instructions

Open the site editor and observe the AAA contrast between text and background.

Before:

![before](https://github.com/WordPress/gutenberg/assets/1204802/f220d86d-3a7e-4837-b731-8602541946a7)

After:

![after](https://github.com/WordPress/gutenberg/assets/1204802/18ded95b-a44e-48fa-8af5-53c4b1a11978)

Another option is to swap the colors, so the intro text has AA contrast and the link items has AAA:

![another option](https://github.com/WordPress/gutenberg/assets/1204802/bd8547b4-b1c1-49c0-a41e-72fc56056eff)
