### PR TITLE
Global Styles: Make search more responsive for block type list

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -159,7 +159,7 @@ const MemoizedBlockList = memo( BlockList );
 
 function ScreenBlockList() {
 	const [ filterValue, setFilterValue ] = useState( '' );
-	const defferedFilterValue = useDeferredValue( filterValue );
+	const deferredFilterValue = useDeferredValue( filterValue );
 
 	return (
 		<>
@@ -177,7 +177,7 @@ function ScreenBlockList() {
 				label={ __( 'Search for blocks' ) }
 				placeholder={ __( 'Search' ) }
 			/>
-			<MemoizedBlockList filterValue={ defferedFilterValue } />
+			<MemoizedBlockList filterValue={ deferredFilterValue } />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -9,7 +9,14 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	useEffect,
+	useRef,
+	useDeferredValue,
+	memo,
+} from '@wordpress/element';
 import {
 	BlockIcon,
 	privateApis as blockEditorPrivateApis,
@@ -99,9 +106,8 @@ function BlockMenuItem( { block } ) {
 	);
 }
 
-function ScreenBlockList() {
+function BlockList( { filterValue } ) {
 	const sortedBlockTypes = useSortedBlockTypes();
-	const [ filterValue, setFilterValue ] = useState( '' );
 	const debouncedSpeak = useDebounce( speak, 500 );
 	const isMatchingSearchTerm = useSelect(
 		( select ) => select( blocksStore ).isMatchingSearchTerm,
@@ -141,6 +147,27 @@ function ScreenBlockList() {
 	}, [ filterValue, debouncedSpeak ] );
 
 	return (
+		<div
+			ref={ blockTypesListRef }
+			className="edit-site-block-types-item-list"
+		>
+			{ filteredBlockTypes.map( ( block ) => (
+				<BlockMenuItem
+					block={ block }
+					key={ 'menu-itemblock-' + block.name }
+				/>
+			) ) }
+		</div>
+	);
+}
+
+const MemoizedBlockList = memo( BlockList );
+
+function ScreenBlockList() {
+	const [ filterValue, setFilterValue ] = useState( '' );
+	const defferedFilterValue = useDeferredValue( filterValue );
+
+	return (
 		<>
 			<ScreenHeader
 				title={ __( 'Blocks' ) }
@@ -156,17 +183,7 @@ function ScreenBlockList() {
 				label={ __( 'Search for blocks' ) }
 				placeholder={ __( 'Search' ) }
 			/>
-			<div
-				ref={ blockTypesListRef }
-				className="edit-site-block-types-item-list"
-			>
-				{ filteredBlockTypes.map( ( block ) => (
-					<BlockMenuItem
-						block={ block }
-						key={ 'menu-itemblock-' + block.name }
-					/>
-				) ) }
-			</div>
+			<MemoizedBlockList filterValue={ defferedFilterValue } />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -109,10 +109,8 @@ function BlockMenuItem( { block } ) {
 function BlockList( { filterValue } ) {
 	const sortedBlockTypes = useSortedBlockTypes();
 	const debouncedSpeak = useDebounce( speak, 500 );
-	const isMatchingSearchTerm = useSelect(
-		( select ) => select( blocksStore ).isMatchingSearchTerm,
-		[]
-	);
+	const { isMatchingSearchTerm } = useSelect( blocksStore );
+
 	const filteredBlockTypes = useMemo( () => {
 		if ( ! filterValue ) {
 			return sortedBlockTypes;

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -11,7 +11,6 @@ import {
 import { useSelect } from '@wordpress/data';
 import {
 	useState,
-	useMemo,
 	useEffect,
 	useRef,
 	useDeferredValue,
@@ -111,14 +110,11 @@ function BlockList( { filterValue } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 	const { isMatchingSearchTerm } = useSelect( blocksStore );
 
-	const filteredBlockTypes = useMemo( () => {
-		if ( ! filterValue ) {
-			return sortedBlockTypes;
-		}
-		return sortedBlockTypes.filter( ( blockType ) =>
-			isMatchingSearchTerm( blockType, filterValue )
-		);
-	}, [ filterValue, sortedBlockTypes, isMatchingSearchTerm ] );
+	const filteredBlockTypes = ! filterValue
+		? sortedBlockTypes
+		: sortedBlockTypes.filter( ( blockType ) =>
+				isMatchingSearchTerm( blockType, filterValue )
+		  );
 
 	const blockTypesListRef = useRef();
 


### PR DESCRIPTION
## What?
PR improves perceived performance when searching for a block in the Global Styles block types list.

The screencasts below are without CPU throttling, but the difference is more visible when it's enabled.

## Why?
Searching for a block type was sluggish.

## How?
See: https://react.dev/reference/react/useDeferredValue#deferring-re-rendering-for-a-part-of-the-ui

## Testing Instructions
1. Open the Site Editor.
2. Open the Global Styles sidebar and navigate to the blocks screen.
3. Type the block name in search.
4. The input field should be more responsive.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/a984ee6e-23a6-47e9-894b-bf3aa16db442


https://github.com/WordPress/gutenberg/assets/240569/7826e3fc-0487-4d92-b6a1-99b7997cab63

