### PR TITLE
Block Quick Navigation: truncate text

### DIFF
--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -6,6 +6,8 @@ import {
 	Button,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	__experimentalTruncate as Truncate,
+	FlexBlock,
 	FlexItem,
 } from '@wordpress/components';
 import {
@@ -73,8 +75,12 @@ function BlockQuickNavigationItem( { clientId } ) {
 			onClick={ () => selectBlock( clientId ) }
 		>
 			<HStack justify="flex-start">
-				<BlockIcon icon={ icon } />
-				<FlexItem>{ name }</FlexItem>
+				<FlexItem>
+					<BlockIcon icon={ icon } />
+				</FlexItem>
+				<FlexBlock style={ { textAlign: 'left' } }>
+					<Truncate>{ name }</Truncate>
+				</FlexBlock>
 			</HStack>
 		</Button>
 	);

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -5,8 +5,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
+	Flex,
 	FlexBlock,
 	FlexItem,
 } from '@wordpress/components';
@@ -74,14 +74,14 @@ function BlockQuickNavigationItem( { clientId } ) {
 			isPressed={ isSelected }
 			onClick={ () => selectBlock( clientId ) }
 		>
-			<HStack justify="flex-start">
+			<Flex>
 				<FlexItem>
 					<BlockIcon icon={ icon } />
 				</FlexItem>
 				<FlexBlock style={ { textAlign: 'left' } }>
 					<Truncate>{ name }</Truncate>
 				</FlexBlock>
-			</HStack>
+			</Flex>
 		</Button>
 	);
 }


### PR DESCRIPTION
## What?

This PR solves the following two problems that occur when the button text of the `BlockQuickNavigation` component is long.

- Icon is pushed to the left
- Text overflows

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/b697ee7e-16eb-4dc5-bf2b-87dadcfe44c8) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/11fec64a-70a0-4a21-80a2-c9ba43b4430c) | 

For example, this is the list displayed in the sidebar content panel when `templateLock` mode is `contentOnly`. For heading blocks, this problem is easier to reproduce because the text is displayed instead of the block name.

## How?

Similar to the list view, I prevent text wrapping through the `Truncate` component. At the same time, I restructured the button contents with `Flex` / `FlexBlock` / `FlexItem` so that the icon width is the same regardless of the text length.

The only concern was that I needed some CSS to left-align the button text. This component doesn't have a stylesheet, so I added inline styles.

## Testing Instructions

Paste the markup below into your code editor. This markup has a heading block with long text in a group that has `templateLock:contentOnly` set.

```html
<!-- wp:group {"templateLock": "contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading -->
<h2 class="wp-block-heading">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</h2>
<!-- /wp:heading -->
<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

- Select this group block.
- Check the content panel in the block sidebar.