### PR TITLE
DataViews: update 'View' button

### DIFF
--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -275,10 +275,7 @@ function SortMenu( { fields, view, onChangeView } ) {
 	);
 }
 
-function getDataViewIcon( type ) {
-	const icons = { list: blockTable, grid: grid, 'side-by-side': columns };
-	return icons[ type ];
-}
+const VIEW_TYPE_ICONS = { list: blockTable, grid, 'side-by-side': columns };
 
 export default function ViewActions( {
 	fields,
@@ -286,14 +283,17 @@ export default function ViewActions( {
 	onChangeView,
 	supportedLayouts,
 } ) {
-
-	const iconToUse = getDataViewIcon( view.type );
-
 	return (
 		<DropdownMenuV2
 			label={ __( 'Actions' ) }
 			trigger={
-				<Button variant="tertiary" size="compact" icon={ iconToUse }>
+				<Button
+					variant="tertiary"
+					size="compact"
+					icon={
+						VIEW_TYPE_ICONS[ view.type ] || VIEW_TYPE_ICONS.list
+					}
+				>
 					{ __( 'View' ) }
 				</Button>
 			}

--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -10,9 +10,10 @@ import {
 	chevronRightSmall,
 	check,
 	blockTable,
-	chevronDown,
 	arrowUp,
 	arrowDown,
+	grid,
+	columns,
 } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -274,19 +275,26 @@ function SortMenu( { fields, view, onChangeView } ) {
 	);
 }
 
+function getDataViewIcon( type ) {
+	const icons = { list: blockTable, grid: grid, 'side-by-side': columns };
+	return icons[ type ];
+}
+
 export default function ViewActions( {
 	fields,
 	view,
 	onChangeView,
 	supportedLayouts,
 } ) {
+
+	const iconToUse = getDataViewIcon( view.type );
+
 	return (
 		<DropdownMenuV2
 			label={ __( 'Actions' ) }
 			trigger={
-				<Button variant="tertiary" icon={ blockTable }>
+				<Button variant="tertiary" size="compact" icon={ iconToUse }>
 					{ __( 'View' ) }
-					<Icon icon={ chevronDown } />
 				</Button>
 			}
 		>


### PR DESCRIPTION
## What?
Updates the appearance and behavior of the 'View' button in data views to match the designs. The current version appends a chevron that isn't necessary, and the icon is static. It's also too large compared with other buttons in the row.

**Before**


<img width="390" alt="Screenshot 2023-11-15 at 14 44 34" src="https://github.com/WordPress/gutenberg/assets/846565/b7c0e730-2cf4-4f30-bc88-d733e5e0cca7">

**After**

https://github.com/WordPress/gutenberg/assets/846565/a39ec7cc-8fbc-4e5e-b9f6-81bbb5d68c6c

* Chevron removed
* Now uses `compact` size
* Icon changes based on the selected layout


## Testing Instructions
1. In the Site editor navigate to Pages > Manage all pages
2. Observe the View button is now 32px tall (compact size)
3. Change the layout to grid, list, side-by-side and observe the icon updating

### Notes

* To determine the correct icon I copied the implementation in https://github.com/WordPress/gutenberg/blob/1bf654b6c7f794d598fc6980789185924168ee2f/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js#L21. If there's a better way please feel free to take over :)
* We should follow-up to ensure the same icons are applied in the list of views found in the sidebar
* @jasmussen I know you've expressed a desire to change the label from 'View' to avoid confusion with 'views' as a concept. Happy to do that here too if there's a good suggestion. 