### PR TITLE
Improve tooltip for parent blocks on the block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -74,7 +74,7 @@ export default function BlockParentSelector() {
 				onClick={ () => selectBlock( firstParentClientId ) }
 				label={ sprintf(
 					/* translators: %s: Name of the block's parent. */
-					__( 'Select %s' ),
+					__( 'Select parent %s' ),
 					blockInformation?.title
 				) }
 				showTooltip

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -74,7 +74,7 @@ export default function BlockParentSelector() {
 				onClick={ () => selectBlock( firstParentClientId ) }
 				label={ sprintf(
 					/* translators: %s: Name of the block's parent. */
-					__( 'Select parent %s' ),
+					__( 'Select parent block: %s' ),
 					blockInformation?.title
 				) }
 				showTooltip

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -53,7 +53,7 @@ async function createAndSelectBlock() {
 	);
 	await userEvent.click(
 		screen.getByRole( 'button', {
-			name: 'Select Cover',
+			name: 'Select parent block: Cover',
 		} )
 	);
 }

--- a/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
@@ -350,7 +350,7 @@ describe( 'Pattern blocks', () => {
 		expect( reusableBlockWithParagraph ).toBeTruthy();
 
 		// Convert back to regular blocks.
-		await clickBlockToolbarButton( 'Select Edited block' );
+		await clickBlockToolbarButton( 'Select parent block: Edited block' );
 		await clickBlockToolbarButton( 'Options' );
 		await clickMenuItem( 'Detach' );
 		await page.waitForXPath( selector, {

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -354,7 +354,7 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
-		await editor.clickBlockToolbarButton( 'Select List' );
+		await editor.clickBlockToolbarButton( 'Select parent block: List' );
 		await editor.transformBlockTo( 'core/paragraph' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -397,7 +397,7 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
-		await editor.clickBlockToolbarButton( 'Select List' );
+		await editor.clickBlockToolbarButton( 'Select parent block: List' );
 		await editor.transformBlockTo( 'core/quote' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -674,7 +674,7 @@ test.describe( 'List (@firefox)', () => {
 
 	test( 'should change the base list type', async ( { editor } ) => {
 		await editor.insertBlock( { name: 'core/list' } );
-		await editor.clickBlockToolbarButton( 'Select List' );
+		await editor.clickBlockToolbarButton( 'Select parent block: List' );
 		await editor.clickBlockToolbarButton( 'Ordered' );
 		await expect.poll( editor.getEditedPostContent ).toBe(
 			`<!-- wp:list {"ordered":true} -->
@@ -694,7 +694,7 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.press( 'Enter' );
 		await editor.clickBlockToolbarButton( 'Indent' );
 		await page.keyboard.type( '1' );
-		await editor.clickBlockToolbarButton( 'Select List' );
+		await editor.clickBlockToolbarButton( 'Select parent block: List' );
 		await editor.clickBlockToolbarButton( 'Ordered' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -1232,7 +1232,7 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.type( '2' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '3' );
-		await editor.clickBlockToolbarButton( 'Select List' );
+		await editor.clickBlockToolbarButton( 'Select parent block: List' );
 		await editor.clickBlockToolbarButton( 'Ordered' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -1264,7 +1264,7 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.type( 'b' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'c' );
-		await editor.clickBlockToolbarButton( 'Select List' );
+		await editor.clickBlockToolbarButton( 'Select parent block: List' );
 		await editor.clickBlockToolbarButton( 'Unordered' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -130,13 +130,17 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await blockListBox.getByRole( 'option', { name: 'List' } ).click();
 		// Select the list wrapper and then parent block.
 		await page.keyboard.press( 'ArrowUp' );
-		await editor.clickBlockToolbarButton( 'Select Allowed Blocks Dynamic' );
+		await editor.clickBlockToolbarButton(
+			'Select parent block: Allowed Blocks Dynamic'
+		);
 
 		// Insert the image.
 		await blockAppender.click();
 		await blockListBox.getByRole( 'option', { name: 'Image' } ).click();
 
-		await editor.clickBlockToolbarButton( 'Select Allowed Blocks Dynamic' );
+		await editor.clickBlockToolbarButton(
+			'Select parent block: Allowed Blocks Dynamic'
+		);
 		await blockAppender.click();
 
 		// It should display a different allowed block list.
@@ -147,7 +151,9 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 
 		await blockListBox.getByRole( 'option', { name: 'Gallery' } ).click();
 
-		await editor.clickBlockToolbarButton( 'Select Allowed Blocks Dynamic' );
+		await editor.clickBlockToolbarButton(
+			'Select parent block: Allowed Blocks Dynamic'
+		);
 		await blockAppender.click();
 
 		// It should display a different allowed block list.

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -201,7 +201,7 @@ class ToolbarRovingTabindexUtils {
 		await this.page.keyboard.press( 'ArrowRight' );
 		await this.expectLabelToHaveFocus( currentBlockLabel );
 		await this.pageUtils.pressKeys( 'shift+Tab' );
-		await this.expectLabelToHaveFocus( 'Select Group' );
+		await this.expectLabelToHaveFocus( 'Select parent block: Group' );
 		await this.page.keyboard.press( 'ArrowRight' );
 		await this.expectLabelToHaveFocus( currentBlockTitle );
 	}

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -59,7 +59,7 @@ test.describe( 'Toolbar roving tabindex', () => {
 		await page.keyboard.type( 'List' );
 		await ToolbarRovingTabindexUtils.testBlockToolbarKeyboardNavigation(
 			'List text',
-			'Select List'
+			'Select parent block: List'
 		);
 		await page.click( `role=button[name="Select parent block: List"i]` );
 		await ToolbarRovingTabindexUtils.wrapCurrentBlockWithGroup( 'List' );

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -61,7 +61,7 @@ test.describe( 'Toolbar roving tabindex', () => {
 			'List text',
 			'Select List'
 		);
-		await page.click( `role=button[name="Select List"i]` );
+		await page.click( `role=button[name="Select parent block: List"i]` );
 		await ToolbarRovingTabindexUtils.wrapCurrentBlockWithGroup( 'List' );
 		await ToolbarRovingTabindexUtils.testGroupKeyboardNavigation(
 			'Block: List',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improves the tooltip to make clear we are going to select the parent of the current block

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Having a tooltip that just says "Select Group" can be confusing for new users who are still not used to the editor's UI. There's no way to know the relationship the icon we are clicking has with the current block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changed the string

## Screenshots or screencast <!-- if applicable -->

Before

<img width="914" alt="Screenshot 2023-11-15 at 12 58 49" src="https://github.com/WordPress/gutenberg/assets/3593343/44bee449-87a5-4d57-81ec-fbbd3d8b00ec">

After


<img width="908" alt="Screenshot 2023-11-15 at 16 21 41" src="https://github.com/WordPress/gutenberg/assets/3593343/a716188e-e4f9-4ea6-8552-ac2b1466a2dc">
