### PR TITLE
DataViews: update 'All pages' sidebar heading

### DIFF
--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -60,7 +60,6 @@ function SidebarScreens() {
 				<NavigatorScreen path="/pages">
 					<SidebarNavigationScreen
 						title={ __( 'Pages' ) }
-						description={ __( 'Manage your pages.' ) }
 						backPath="/page"
 						content={ <DataViewsSidebarContent /> }
 					/>

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -59,7 +59,7 @@ function SidebarScreens() {
 			{ window?.__experimentalAdminViews && (
 				<NavigatorScreen path="/pages">
 					<SidebarNavigationScreen
-						title={ __( 'All Pages' ) }
+						title={ __( 'Pages' ) }
 						description={ __( 'Manage your pages.' ) }
 						backPath="/page"
 						content={ <DataViewsSidebarContent /> }


### PR DESCRIPTION
## What?
Updates the heading in the page management sidebar.

## Why?
"**All** pages" might be a bit too specific, given it's now possible to view a subset of pages in this view (e.g. Trash). The equivalent view in wp-admin is also titled "Pages".

**Before**
<img width="356" alt="Screenshot 2023-11-15 at 15 20 36" src="https://github.com/WordPress/gutenberg/assets/846565/04be9fd3-d832-4c0d-aaf9-883af579dba2">

**After**
<img width="358" alt="Screenshot 2023-11-15 at 15 24 59" src="https://github.com/WordPress/gutenberg/assets/846565/9fa5a6f5-07cf-459f-9fd8-55568654ca59">

I appreciate this duplicates the heading of the panel parent, so an alternative could be "Manage pages":

<img width="358" alt="Screenshot 2023-11-15 at 15 26 52" src="https://github.com/WordPress/gutenberg/assets/846565/654d2572-f8d1-47a0-ab7d-c36fcba43967">

## Testing Instructions
1. In the Site editor navigate to Pages > Manage all pages
2. Observe the new heading
