### PR TITLE
DataViews: fix spacing issue in top-level bar

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -70,7 +70,7 @@ export default function DataViews( {
 							onChangeView={ onChangeView }
 						/>
 					</HStack>
-					<HStack justify="end">
+					<HStack justify="end" expanded={ false }>
 						<ViewActions
 							fields={ fields }
 							view={ view }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Fixes spacing in the top-level bar. The search & filters now take all the spacing available.

| Before | After |
| --- | --- |
| <img width="1506" alt="Captura de ecrã 2023-11-15, às 16 45 20" src="https://github.com/WordPress/gutenberg/assets/583546/f52538a5-9400-4733-ad11-40cff6303269"> | <img width="1506" alt="Captura de ecrã 2023-11-15, às 16 45 02" src="https://github.com/WordPress/gutenberg/assets/583546/c2971127-f446-474c-9b09-1ec463db6b0a"> |

## Why?

To make space for filters.

## How?

The top-level bar is made of a two `HStack` components and the right one was taking all the horizontal space available at the beginning.

## Testing Instructions

- Enable the "admin views" experiment and visit "Appearance > Editor > Pages". Click on "Manage pages".
- Add as many filters as you can. Select the longer values. Verify the space is taken up as much as possible by the filter components.
