### PR TITLE
Add more statuses to default page views

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -38,6 +38,36 @@ const DEFAULT_VIEWS = {
 			},
 		},
 		{
+			title: __( 'Pending' ),
+			slug: 'pending',
+			view: {
+				...DEFAULT_PAGE_BASE,
+				filters: [
+					{ field: 'status', operator: 'in', value: 'pending' },
+				],
+			},
+		},
+		{
+			title: __( 'Scheduled' ),
+			slug: 'scheduled',
+			view: {
+				...DEFAULT_PAGE_BASE,
+				filters: [
+					{ field: 'status', operator: 'in', value: 'future' },
+				],
+			},
+		},
+		{
+			title: __( 'Private' ),
+			slug: 'private',
+			view: {
+				...DEFAULT_PAGE_BASE,
+				filters: [
+					{ field: 'status', operator: 'in', value: 'private' },
+				],
+			},
+		},
+		{
 			title: __( 'Trash' ),
 			slug: 'trash',
 			icon: trash,


### PR DESCRIPTION
## What?
Adds views for managing Private, Scheduled, and Pending pages. 

## Why?
Drafts and Trash are surfaced, it seems reasonable to include other statuses, they're particularly useful on busier sites. 

## Testing Instructions
1. In the Site editor navigate to Pages > Manage all pages
2. Observe the new view options in the side bar
3. Ensure they all return the pages as expected

| Before | After |
| --- | --- |
| <img width="356" alt="Screenshot 2023-11-15 at 15 20 36" src="https://github.com/WordPress/gutenberg/assets/846565/2bb15df0-f7a4-4dfd-ac83-5293edeb7c22"> | <img width="810" alt="Screenshot 2023-11-15 at 15 41 30" src="https://github.com/WordPress/gutenberg/assets/846565/8020da9b-44e4-46d2-874b-98ab29fe953c"> |

