### PR TITLE
[Block Library - Image]: Try Image compression

### DIFF
--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -19,3 +19,91 @@ function gutenberg_register_global_styles_revisions_endpoints() {
 }
 
 add_action( 'rest_api_init', 'gutenberg_register_global_styles_revisions_endpoints' );
+
+
+/**
+ * Updates REST API response for the attachments and adds extra properties.
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Post          $post    The original attachment post.
+ * @return WP_REST_Response $response Updated response object.
+ */
+function gutenberg_modify_rest_attachments_response( $response, $post ) {
+	$uncompressed_media_id = get_post_meta( $post->ID, '_wp_uncompressed_media_id', true );
+	if ( $uncompressed_media_id ) {
+		$response->data['uncompressed_source_url'] = wp_get_attachment_url( $uncompressed_media_id );
+	}
+	// There is a cached value for the file size, but it seems that it's
+	// not reliable (@see https://core.trac.wordpress.org/ticket/57459).
+	$response->data['filesize'] = filesize( get_attached_file( $post->ID ) );
+	return $response;
+}
+add_filter( 'rest_prepare_attachment', 'gutenberg_modify_rest_attachments_response', 10, 2 );
+
+
+/**
+ * Fires after a single attachment is completely created or updated via the REST API.
+ *
+ * @param WP_Post         $attachment Inserted or updated attachment object.
+ * @param WP_REST_Request $request    Request object.
+ * @param bool            $creating   True when creating an attachment, false when updating.
+ */
+function gutenberg_rest_after_insert_attachment_update_meta( $attachment, $request, $creating ) {
+	if ( ! $creating ) {
+		return;
+	}
+	$_wp_compression_factor = $request->get_param( '_wp_compression_factor' );
+	if ( $_wp_compression_factor ) {
+		update_post_meta( $attachment->ID, '_wp_compression_factor', $_wp_compression_factor );
+	}
+	$_wp_uncompressed_media_id = $request->get_param( '_wp_uncompressed_media_id' );
+	if ( $_wp_uncompressed_media_id ) {
+		update_post_meta( $attachment->ID, '_wp_uncompressed_media_id', $_wp_uncompressed_media_id );
+	}
+}
+add_action( 'rest_after_insert_attachment', 'gutenberg_rest_after_insert_attachment_update_meta', 10, 3 );
+
+
+// TODO: probably we should delete all compressed versions when the original is deleted.
+// function gutenberg_pre_delete_attachment() {
+// }
+// add_action( 'pre_delete_attachment', 'gutenberg_pre_delete_attachment', 10, 3 );.
+
+
+/**
+ * Registers additional post meta for the attachment post type.
+ *
+ * @return void
+ */
+function gutenberg_register_attachment_post_meta() {
+	// TODO: could we do this with a `parent` relationship?
+	register_post_meta(
+		'attachment',
+		'_wp_uncompressed_media_id',
+		array(
+			'type'         => 'number',
+			'description'  => __( 'Id of the linked uncompressed attachment.', 'gutenberg' ),
+			'show_in_rest' => array(
+				'schema' => array(
+					'type' => 'number',
+				),
+			),
+			'single'       => true,
+		)
+	);
+	register_post_meta(
+		'attachment',
+		'_wp_compression_factor',
+		array(
+			'type'         => 'number',
+			'description'  => __( 'Compression factor of attachment.', 'gutenberg' ),
+			'show_in_rest' => array(
+				'schema' => array(
+					'type' => 'number',
+				),
+			),
+			'single'       => true,
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_attachment_post_meta' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21050,6 +21050,11 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
 		},
+		"node_modules/blueimp-canvas-to-blob": {
+			"version": "3.29.0",
+			"resolved": "https://registry.npmjs.org/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.29.0.tgz",
+			"integrity": "sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg=="
+		},
 		"node_modules/bn.js": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -22785,6 +22790,15 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"dependencies": {
 				"ms": "2.0.0"
+			}
+		},
+		"node_modules/compressorjs": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/compressorjs/-/compressorjs-1.2.1.tgz",
+			"integrity": "sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==",
+			"dependencies": {
+				"blueimp-canvas-to-blob": "^3.29.0",
+				"is-blob": "^2.1.0"
 			}
 		},
 		"node_modules/compute-scroll-into-view": {
@@ -31418,6 +31432,17 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-blob": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+			"integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-boolean-object": {
@@ -54612,6 +54637,7 @@
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
+				"compressorjs": "^1.2.1",
 				"deepmerge": "^4.3.0",
 				"diff": "^4.0.2",
 				"dom-scroll-into-view": "^1.2.1",
@@ -69939,6 +69965,7 @@
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
+				"compressorjs": "^1.2.1",
 				"deepmerge": "^4.3.0",
 				"diff": "^4.0.2",
 				"dom-scroll-into-view": "^1.2.1",
@@ -73241,6 +73268,11 @@
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
 		},
+		"blueimp-canvas-to-blob": {
+			"version": "3.29.0",
+			"resolved": "https://registry.npmjs.org/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.29.0.tgz",
+			"integrity": "sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg=="
+		},
 		"bn.js": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -74619,6 +74651,15 @@
 						"ms": "2.0.0"
 					}
 				}
+			}
+		},
+		"compressorjs": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/compressorjs/-/compressorjs-1.2.1.tgz",
+			"integrity": "sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==",
+			"requires": {
+				"blueimp-canvas-to-blob": "^3.29.0",
+				"is-blob": "^2.1.0"
 			}
 		},
 		"compute-scroll-into-view": {
@@ -81221,6 +81262,11 @@
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
+		},
+		"is-blob": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+			"integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw=="
 		},
 		"is-boolean-object": {
 			"version": "1.1.2",

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -326,6 +326,10 @@ Undocumented declaration.
 
 Undocumented declaration.
 
+### CompressMedia
+
+Undocumented declaration.
+
 ### ContrastChecker
 
 _Related_

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -67,6 +67,7 @@
 		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
+		"compressorjs": "^1.2.1",
 		"deepmerge": "^4.3.0",
 		"diff": "^4.0.2",
 		"dom-scroll-into-view": "^1.2.1",

--- a/packages/block-editor/src/components/compress-media/index.js
+++ b/packages/block-editor/src/components/compress-media/index.js
@@ -1,0 +1,369 @@
+/**
+ * External dependencies
+ */
+import Compressor from 'compressorjs';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useState,
+	useEffect,
+	useRef,
+	useLayoutEffect,
+} from '@wordpress/element';
+import { isBlobURL } from '@wordpress/blob';
+import {
+	Modal,
+	Button,
+	RangeControl,
+	FlexItem,
+	BaseControl,
+	__experimentalText as Text,
+	__experimentalUnitControl as UnitControl,
+	__experimentalHeading as Heading,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { percent } from '@wordpress/icons';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+// TODO: move the hook to a different file.. Could be done in a follow up, or extracted before.
+import useDebouncedInput from '../inserter/hooks/use-debounced-input';
+import { store as blockEditorStore } from '../../store';
+
+const EMPTY_ARRAY = [];
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+// Helper function to convert bytes to human readable format.
+function humanReadableFileSize( fileSize ) {
+	if ( ! fileSize ) return;
+	const units = [ 'B', 'kB', 'MB', 'GB' ];
+	const unitExponent = Math.floor( Math.log( fileSize ) / Math.log( 1024 ) );
+	return `${ ( fileSize / Math.pow( 1024, unitExponent ) ).toFixed( 2 ) }${
+		units[ unitExponent ]
+	}`;
+}
+
+// TODO: probably make private..
+export default function CompressMedia( { image, onUploadImage } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	if ( ! image ) {
+		return null;
+	}
+	return (
+		<>
+			{ /* TODO: probably make the whole row a Button  */ }
+			<VStack>
+				<Heading level={ 2 }>{ __( 'Compress image' ) }</Heading>
+				<HStack
+					justify="space-between"
+					className="compress-image_container"
+				>
+					<HStack justify="flex-start">
+						<img
+							className="compress-image__thumbnail"
+							alt={ image.alt_text }
+							src={ image.source_url }
+						/>
+						<Text limit={ 10 } truncate>
+							{ image.title?.rendered || image.title }
+						</Text>
+					</HStack>
+					<HStack justify="flex-end">
+						<span>{ humanReadableFileSize( image.filesize ) }</span>
+						<Button
+							label={ __( 'Compress attachments' ) }
+							onClick={ () => setIsModalOpen( true ) }
+							// TODO: create a new icon for this..
+							icon={ percent }
+						/>
+					</HStack>
+				</HStack>
+			</VStack>
+			{ isModalOpen && (
+				<CompressMediaModal
+					image={ image }
+					onClose={ () => setIsModalOpen( false ) }
+					onUploadImage={ onUploadImage }
+				/>
+			) }
+		</>
+	);
+}
+
+function CompressMediaModal( { image, onClose, onUploadImage } ) {
+	const [ uncompressedMediaBlob, setUncompressedMediaBlob ] =
+		useState( null );
+	// We need to fetch the uncompressed media blob to be able to compress it.
+	const uncompressedSourceUrl =
+		image?.uncompressed_source_url || image?.source_url;
+	useEffect( () => {
+		if ( ! uncompressedSourceUrl ) {
+			return;
+		}
+		window
+			.fetch( uncompressedSourceUrl )
+			.then( ( result ) => result.blob() )
+			.then( setUncompressedMediaBlob );
+	}, [ uncompressedSourceUrl ] );
+	// TODO: get from preferences and default to 82 or something..
+	// TODO: store number in post meta and make proper conversions where needed..
+	const [ quality, setQuality, debouncedQuality ] = useDebouncedInput(
+		`${ image.meta?._wp_compression_factor || 80 }%`
+	);
+	const [ isUploading, setIsUploading ] = useState( false );
+	const [ currentTempConversion, setCurrentTempConversion ] =
+		useState( null );
+	// TODO: handle the existing conversions...
+	// Init temp conversions maybe with existing converted images...
+	const tempConversions = useRef( new Map() );
+	const mediaUpload = useSelect(
+		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
+		[]
+	);
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	// We are using an effect to update the current compressed media
+	// because we debounce the quality input to avoid many unneeded.
+	// compressions. The media compression happens client side and we
+	// upload the compressed version.
+	useEffect( () => {
+		if ( ! uncompressedMediaBlob ) {
+			return;
+		}
+		const _quality = parseInt( debouncedQuality );
+		if ( tempConversions.current.has( _quality ) ) {
+			setCurrentTempConversion( tempConversions.current.get( _quality ) );
+			return;
+		}
+		// TODO: there is no check right now for existing uploaded compressed versions.
+		// We should either have these info and avoid uploading an image with the same
+		// compression factor, or try to handle it PHP before inserting the attachment.
+		// If we go the PHP route, it's connected with the question about what to do with
+		// the rest attachment fields like title, caption, etc..
+		new Compressor( uncompressedMediaBlob, {
+			quality: _quality / 100,
+			// The compression process is asynchronous, which means the
+			// `result` can be accessed in the `success` hook function.
+			success( result ) {
+				const formData = new FormData();
+				formData.append( 'file', result, result.name );
+				setCurrentTempConversion( result );
+				tempConversions.current.set( _quality, result );
+			},
+			error( error ) {
+				createErrorNotice( error?.message, { type: 'snackbar' } );
+			},
+		} );
+	}, [ createErrorNotice, debouncedQuality, uncompressedMediaBlob ] );
+	async function uploadImage() {
+		if ( ! currentTempConversion ) {
+			return;
+		}
+		// TODO: How to handle the original image's data?
+		// Should we copy some values like now(title, caption, etc..) from it
+		// and keep them decoupled in that aspect?
+		// If we want to sync these data it should prabably be done in REST layer
+		// when preparing the response..
+		setIsUploading( true );
+		mediaUpload( {
+			filesList: [ currentTempConversion ],
+			additionalData: {
+				// TODO: check if we can ever have the `raw` value. Probably not in `view` context,
+				// but check the original request in Image block.
+				title: image.title?.raw || image.title?.rendered || '',
+				alt_text: image.alt_text,
+				caption: image.caption?.raw || image.caption?.rendered || '',
+				description:
+					image.description?.raw || image.description?.rendered || '',
+				_wp_compression_factor: parseInt( quality ) || 0,
+				_wp_uncompressed_media_id:
+					image.meta._wp_uncompressed_media_id || image.id || 0,
+				// TODO: ideally we should pass the meta values in the REST API
+				// and not handle the update in gutenberg_rest_after_insert_attachment_update_meta.
+				// meta: {
+				// 	_wp_compression_factor: parseInt( quality ) || 0,
+				// 	_wp_uncompressed_media_id:
+				// 		image.meta._wp_uncompressed_media_id || image.id || 0,
+				// },
+			},
+			onFileChange( [ img ] ) {
+				if ( isBlobURL( img?.url ) ) {
+					return;
+				}
+				onUploadImage( img );
+				onClose();
+				createSuccessNotice( __( 'Image compressed and replaced.' ), {
+					type: 'snackbar',
+				} );
+			},
+			allowedTypes: ALLOWED_MEDIA_TYPES,
+			onError( message ) {
+				createErrorNotice( message, { type: 'snackbar' } );
+				setIsUploading( false );
+			},
+		} );
+	}
+	return (
+		<Modal title={ __( 'Compress image' ) } onRequestClose={ onClose }>
+			<VStack spacing={ 2 }>
+				{ currentTempConversion && (
+					<>
+						{ !! image.meta?._wp_compression_factor && (
+							<Text>
+								{ sprintf(
+									/* translators: %s: compression factor of media. */
+									__( 'Current image quality is: %s' ),
+									`${ image.meta._wp_compression_factor }%`
+								) }
+							</Text>
+						) }
+						<HStack>
+							<Text>
+								{ sprintf(
+									/* translators: %s: compressed file size. */
+									__( 'Compressed: %s' ),
+									humanReadableFileSize(
+										currentTempConversion.size
+									)
+								) }
+							</Text>
+							<Text>
+								{ sprintf(
+									/* translators: %s: uncompressed file size. */
+									__( 'Original: %s' ),
+									humanReadableFileSize(
+										uncompressedMediaBlob.size
+									)
+								) }
+							</Text>
+						</HStack>
+						<CompareImagesSlider
+							first={ window.URL.createObjectURL(
+								currentTempConversion
+							) }
+							second={ uncompressedSourceUrl }
+						/>
+					</>
+				) }
+				<fieldset className="components-border-radius-control">
+					<BaseControl.VisualLabel as="legend">
+						{ __( 'Quality' ) }
+					</BaseControl.VisualLabel>
+					<HStack spacing={ 4 }>
+						<UnitControl
+							label={ __( 'Quality' ) }
+							hideLabelFromVision
+							min={ 1 }
+							max={ 100 }
+							onChange={ ( _value ) => {
+								setQuality( _value );
+							} }
+							value={ quality }
+							size="__unstable-large"
+							units={ EMPTY_ARRAY }
+						/>
+						<FlexItem isBlock>
+							<RangeControl
+								__next40pxDefaultSize
+								label={ __( 'Quality' ) }
+								hideLabelFromVision
+								min={ 1 }
+								max={ 100 }
+								value={ parseInt( quality ) }
+								onChange={ ( _value ) => {
+									setQuality( `${ _value }%` );
+								} }
+								withInputField={ false }
+							/>
+						</FlexItem>
+					</HStack>
+					<p>
+						{ __(
+							'Lower quality results in smaller file size and faster page load speed.'
+						) }
+					</p>
+				</fieldset>
+				<HStack justify="right">
+					<Button variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ uploadImage }
+						disabled={ isUploading || parseInt( quality ) === 100 }
+					>
+						{ __( 'Compress' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}
+
+function CompareImagesSlider( { first, second } ) {
+	const overlayRef = useRef();
+	const firstImageRef = useRef();
+	const secondImageRef = useRef();
+	const handleRef = useRef();
+	const rangeRef = useRef();
+	const [ rangeValue, setRangeValue ] = useState( 50 );
+	useLayoutEffect( () => {
+		if ( ! rangeRef.current?.offsetWidth ) {
+			return;
+		}
+		firstImageRef.current.style.width = `${ rangeRef.current.offsetWidth }px`;
+		secondImageRef.current.style.width = `${ rangeRef.current.offsetWidth }px`;
+	}, [ rangeRef.current?.offsetWidth ] );
+	return (
+		<div className="block-editor-compare-images-slider__container">
+			<div
+				className="block-editor-compare-images-slider__top-image"
+				ref={ overlayRef }
+			>
+				<img
+					src={ first }
+					className="block-editor-compare-images-slider_image"
+					ref={ firstImageRef }
+					alt=""
+				/>
+			</div>
+			<img
+				src={ second }
+				className="block-editor-compare-images-slider_image"
+				ref={ secondImageRef }
+				alt=""
+			/>
+			<div
+				className="block-editor-compare-images-slider__handle"
+				ref={ handleRef }
+			></div>
+			<input
+				className="block-editor-compare-images-slider__range"
+				type="range"
+				min="0"
+				max="100"
+				value={ rangeValue }
+				onChange={ ( event ) => {
+					const newValue = event.target.value;
+					setRangeValue( newValue );
+					if ( newValue ) {
+						overlayRef.current.style.width = newValue + '%';
+						handleRef.current.style.left = newValue + '%';
+					} else {
+						overlayRef.current.style.width = 'calc(0% + 5px)';
+						handleRef.current.style.left = 'calc(0% + 5px)';
+					}
+				} }
+				ref={ rangeRef }
+			/>
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/compress-media/style.scss
+++ b/packages/block-editor/src/components/compress-media/style.scss
@@ -1,0 +1,136 @@
+.compress-image_container {
+	margin-bottom: $grid-unit-30;
+}
+
+.compress-image__thumbnail {
+	width: 20px;
+	min-width: 20px !important;
+	aspect-ratio: 1;
+	object-fit: cover;
+	border-radius: 50%;
+}
+
+// Image compare slider styles.
+.block-editor-compare-images-slider__container {
+	height: 400px;
+	max-height: 50vh;
+	min-width: 550px;
+	overflow: hidden;
+	position: relative;
+	display: flex;
+	align-content: flex-end;
+
+	> div {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		width: 50%;
+		overflow: hidden;
+		display: flex;
+		align-items: flex-end;
+	}
+
+	.block-editor-compare-images-slider_image {
+		display: block;
+		user-select: none;
+		box-sizing: border-box;
+		height: 100%;
+		width: 100%;
+		max-width: initial;
+		pointer-events: none;
+		object-fit: cover;
+		flex: none;
+	}
+
+	.block-editor-compare-images-slider__top-image {
+		z-index: 10;
+		&::before {
+			content: "";
+			position: absolute;
+			top: 0;
+			right: 0;
+			width: 5px;
+			height: 100%;
+			border-right: 5px solid $white;
+			z-index: 20;
+		}
+	}
+
+	// This will act as the controller for the slider.
+	.block-editor-compare-images-slider__handle {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		width: 0;
+		height: 0;
+		// width: 20px;
+		// height: 80px;
+		// border: 8px solid #FFF;
+		z-index: 30;
+		pointer-events: none;
+		margin-left: -2px;
+		overflow: visible;
+
+		&::before {
+			color: $white;
+			content: "";
+			position: absolute;
+			right: -20px;
+			height: 10px;
+			width: 10px;
+			border-bottom: solid 3px currentColor;
+			border-right: solid 3px currentColor;
+			transform: rotate(-45deg);
+			z-index: 99;
+		}
+
+		&::after {
+			color: $white;
+			content: "";
+			position: absolute;
+			left: -20px;
+			height: 10px;
+			width: 10px;
+			border-left: solid 3px currentColor;
+			border-top: solid 3px currentColor;
+			transform: rotate(-45deg);
+			z-index: 99;
+		}
+	}
+
+	input[type="range"] {
+		margin: 0;
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		height: 100%;
+		width: 100%;
+		background: transparent;
+		padding: 0;
+		border: none;
+		z-index: 20;
+		-webkit-appearance: none;
+		appearance: none;
+		&:focus {
+			outline: none;
+		}
+	}
+	input[type="range"],
+	input[type="range"]::-webkit-slider-runnable-track,
+	input[type="range"]::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+	}
+
+	input[type="range"]::-webkit-slider-thumb {
+		width: 20px;
+		height: 500px;
+		background-color: transparent;
+		cursor: ew-resize;
+		display: block;
+		border: none;
+	}
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -42,6 +42,7 @@ export {
 } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';
 export { default as ColorPaletteControl } from './color-palette/control';
+export { default as CompressMedia } from './compress-media';
 export { default as ContrastChecker } from './contrast-checker';
 export { default as __experimentalDateFormatPicker } from './date-format-picker';
 export { default as __experimentalDuotoneControl } from './duotone-control';

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -23,6 +23,7 @@
 @import "./components/block-variation-transforms/style.scss";
 @import "./components/border-radius-control/style.scss";
 @import "./components/colors-gradients/style.scss";
+@import "./components/compress-media/style.scss";
 @import "./components/contrast-checker/style.scss";
 @import "./components/date-format-picker/style.scss";
 @import "./components/duotone-control/style.scss";

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -26,6 +26,7 @@ import {
 	store as blockEditorStore,
 	useSettings,
 	BlockAlignmentControl,
+	CompressMedia,
 	__experimentalImageEditor as ImageEditor,
 	__experimentalGetElementClassName,
 	__experimentalUseBorderProps as useBorderProps,
@@ -223,6 +224,7 @@ export default function Image( {
 		)
 		.map( ( { name, slug } ) => ( { value: slug, label: name } ) );
 	const canUploadMedia = !! mediaUpload;
+	const isExternal = isExternalImage( id, url );
 
 	// If an image is externally hosted, try to fetch the image data. This may
 	// fail if the image host doesn't allow CORS with the domain. If it works,
@@ -614,6 +616,12 @@ export default function Image( {
 						</>
 					}
 				/>
+				{ ! isExternal && (
+					<CompressMedia
+						image={ image }
+						onUploadImage={ onSelectImage }
+					/>
+				) }
 			</InspectorControls>
 		</>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/55106

This PR is a prototype for client side image compression through the `Image` block. 

There are many scenarios here that would need to be handled and tested and there might be lots of nuances with many things, like user capabilities, what info we preserve from the original image, how we 'link' them, etc.. As soon as I'm figuring something, I'm going to add this in the description to be tracked and discussed.

**Noting that this is a prototype and not all functionality is implemented and tested**. Same goes for the design of course, as I took the liberty to do something partly from @jameskoster design in the issue, and partly from me(which could change altogether :)).

## How

Currently the image compression is done at the client and we upload the compressed image to the server only when the button(`compress`) is clicked. This is done mostly because why can't rely/know if a host has disabled the needed extensions for that. Additionally we have the previous on the fly that help the user decide before committing.

I'm very wary of the PHP side and I'll to ask more feedback and suggestions soon. For example could we use the `parent` relationship of attachments to keep the compressed versions? 

### Current notes:
1. Should we delete all compressed versions when the original is deleted? We would probably need to handle this in the REST API layer or in the current media library.
2. We need a new icon for this PR to indicate the compression.
3. Probably we need to make the default quality when opening the Modal, a user setting.
4. Currently there is no check for existing uploaded compressed versions. We should either have these info and avoid uploading an image with the same compression factor, or try to handle it PHP before inserting the attachment. If we go the PHP route, it's connected with the question about what to do with the rest attachment fields like title, caption, etc..
5. How to handle the original image's data? Should we copy some values like now(title, caption, etc..) from it and keep them decoupled in that aspect? If we want to sync these data it should prabably be done in REST layer when preparing the response..
6. I encountered a problem when trying to pass `meta` when creating the attachment. I could use some help/insights. Ideally we should pass the meta values in the REST API and not handle the update in `gutenberg_rest_after_insert_attachment_update_meta`.



## Testing Instructions
1. Add an Image block and select an uploaded image.
7. Go to the Advanced settings and find the `Compress image` section.
8. Click on the icon(the whole row will probably become a button) and test the current prototype.


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/3aa23b40-beed-4c75-8b0f-95889748ab16

