### PR TITLE
Fix Patterns modal dialog focusable buttons and focusOutside for Safari.

### DIFF
--- a/packages/block-editor/src/components/block-patterns-paging/index.js
+++ b/packages/block-editor/src/components/block-patterns-paging/index.js
@@ -18,6 +18,8 @@ export default function Pagination( {
 	const isFirstPage = currentPage === 1;
 	const isLastPage = currentPage === numPages;
 
+	// Buttons in this component use `tabIndex={ 0 }` to workaround a Safari bug not
+	// setting focus on buttons when clicking them. See https://github.com/WordPress/gutenberg/pull/56162
 	return (
 		<VStack className="block-editor-patterns__grid-pagination-wrapper">
 			<Text variant="muted">

--- a/packages/block-editor/src/components/block-patterns-paging/index.js
+++ b/packages/block-editor/src/components/block-patterns-paging/index.js
@@ -15,6 +15,9 @@ export default function Pagination( {
 	changePage,
 	totalItems,
 } ) {
+	const isFirstPage = currentPage === 1;
+	const isLastPage = currentPage === numPages;
+
 	return (
 		<VStack className="block-editor-patterns__grid-pagination-wrapper">
 			<Text variant="muted">
@@ -42,17 +45,25 @@ export default function Pagination( {
 					>
 						<Button
 							variant="tertiary"
-							onClick={ () => changePage( 1 ) }
-							disabled={ currentPage === 1 }
+							onClick={
+								isFirstPage ? undefined : () => changePage( 1 )
+							}
+							aria-disabled={ isFirstPage }
 							aria-label={ __( 'First page' ) }
+							tabIndex={ 0 }
 						>
 							<span>«</span>
 						</Button>
 						<Button
 							variant="tertiary"
-							onClick={ () => changePage( currentPage - 1 ) }
-							disabled={ currentPage === 1 }
+							onClick={
+								isFirstPage
+									? undefined
+									: () => changePage( currentPage - 1 )
+							}
+							aria-disabled={ isFirstPage }
 							aria-label={ __( 'Previous page' ) }
+							tabIndex={ 0 }
 						>
 							<span>‹</span>
 						</Button>
@@ -72,18 +83,28 @@ export default function Pagination( {
 					>
 						<Button
 							variant="tertiary"
-							onClick={ () => changePage( currentPage + 1 ) }
-							disabled={ currentPage === numPages }
+							onClick={
+								isLastPage
+									? undefined
+									: () => changePage( currentPage + 1 )
+							}
+							aria-disabled={ isLastPage }
 							aria-label={ __( 'Next page' ) }
+							tabIndex={ 0 }
 						>
 							<span>›</span>
 						</Button>
 						<Button
 							variant="tertiary"
-							onClick={ () => changePage( numPages ) }
-							disabled={ currentPage === numPages }
+							onClick={
+								isLastPage
+									? undefined
+									: () => changePage( numPages )
+							}
+							aria-disabled={ isLastPage }
 							aria-label={ __( 'Last page' ) }
 							size="default"
+							tabIndex={ 0 }
 						>
 							<span>»</span>
 						</Button>

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-explorer-sidebar.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-explorer-sidebar.js
@@ -22,6 +22,7 @@ function PatternCategoriesList( {
 						onClick={ () => {
 							onClickCategory( name );
 						} }
+						tabIndex={ 0 }
 					>
 						{ label }
 					</Button>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -777,9 +777,3 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 }
-
-:focus {
-	outline: 4px solid $alert-red !important;
-	outline-offset: -4px;
-	box-shadow: 0 0 0 4px $alert-red !important;
-}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -777,3 +777,9 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 }
+
+:focus {
+	outline: 4px solid $alert-red !important;
+	outline-offset: -4px;
+	box-shadow: 0 0 0 4px $alert-red !important;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/55110

This is only a proof of concept for now, please do not merge.
I'm using a thick red outline styling for focus, to make testing easier. This styling should be eventually removed of course.

## What?
<!-- In a few words, what is the PR actually doing? -->
The patterns categories modal dialog is buggy with Safari and it closes unexpectedly.
Also, using the pagination buttons makes constraining tabbing within the modal fail.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Safari does not set focus on buttons when clicking them, this needs a workaround to prevent the modal dialog from closing unexpectedly.
Pagination buttons get disabled dynamically, this needs to be avoided to make constrained tabbing work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds tabindex=0 to the categories buttons within the modal.
- For pagination buttons:
  -Uuses aria-disabled in favor of disabled
  - Noops the buttons when aria-disabled 
  - Always adds tabindex=0 to the buttons, to workaround the Safari bug

The purpose ot this PR is to prove that interactive controls within the content of the modal dialog _must_ always be focusable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Test with Safari 17.1
- Edit a post, click the inserter, click the Patterns tab, click 'Explore all Patterns'.
- Observe initial focus is set to the modal dialog container.
- Click on the various categories buttons.
- Observe the modal dialog stays open.
- Click a category that has pagination buttons.
- Click the pagination button to go to the last page.
- Press the Tab key and observe tabbing is constrained within the modal dialog,
- Test any other flow and make sure that:
  - The modal dialog does not close unexpectedly.
  - Tabbing is always constrained within the modal dialog.
- Repeat with all major browsers.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
