### PR TITLE
Site editor: Remove screen reader title announcement

### DIFF
--- a/packages/edit-site/src/components/routes/use-title.js
+++ b/packages/edit-site/src/components/routes/use-title.js
@@ -5,7 +5,6 @@ import { useEffect, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
-import { speak } from '@wordpress/a11y';
 import { decodeEntities } from '@wordpress/html-entities';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
@@ -45,16 +44,6 @@ export default function useTitle( title ) {
 			);
 
 			document.title = formattedTitle;
-
-			// Announce title on route change for screen readers.
-			speak(
-				sprintf(
-					/* translators: The page title that is currently displaying. */
-					__( 'Now displaying: %s' ),
-					document.title
-				),
-				'assertive'
-			);
 		}
 	}, [ title, siteTitle, location ] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

At one time, it was absolutely critical to tell users where they were in the site editor by announcing the page title. This is no longer necessary so this PR removes it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Focus is now much more predictable in the editor and the title seems to be announced now. Heading structure also provides lots of context as it didn't before, near the start of FSE.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the Appearance > Editor.
2. Ensure the `aria-live` region at the bottom of the page does not display the title as you switch contexts. E.g. viewing a template, pattern, or similar.
3. Ensure the console does not log errors.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
