### PR TITLE
Fix: PHP 8.1 deprecated warning strpos()

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -819,7 +819,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			break;
 		}
 
-		if ( false !== strpos( $processor->get_attribute( 'class' ), $inner_block_wrapper_classes ) ) {
+		if ( false !== strpos( $processor->get_attribute( 'class' ) ?? '', $inner_block_wrapper_classes ) ) {
 			break;
 		}
 	} while ( $processor->next_tag() );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -819,7 +819,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			break;
 		}
 
-		if ( false !== strpos( $processor->get_attribute( 'class' ) ?? '', $inner_block_wrapper_classes ) ) {
+		$class_attribute = $processor->get_attribute( 'class' );
+		if ( is_string( $class_attribute ) && false !== strpos( $class_attribute, $inner_block_wrapper_classes ) ) {
 			break;
 		}
 	} while ( $processor->next_tag() );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix for PHP warning

## Why?
https://github.com/WordPress/gutenberg/issues/56169