### PR TITLE
Site editor: redirect to main page menu if page record not found

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -28,6 +28,7 @@ import SidebarButton from '../sidebar-button';
 import PageDetails from './page-details';
 import PageActions from '../page-actions';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
+
 const { useHistory } = unlock( routerPrivateApis );
 
 export default function SidebarNavigationScreenPage() {
@@ -43,35 +44,31 @@ export default function SidebarNavigationScreenPage() {
 		postId
 	);
 
-	const { isCanvasModeView, featuredMediaAltText, featuredMediaSourceUrl } =
-		useSelect(
-			( select ) => {
-				const { getEntityRecord } = select( coreStore );
-				// Featured image.
-				const attachedMedia = record?.featured_media
-					? getEntityRecord(
-							'postType',
-							'attachment',
-							record?.featured_media
-					  )
-					: null;
+	const { featuredMediaAltText, featuredMediaSourceUrl } = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( coreStore );
+			// Featured image.
+			const attachedMedia = record?.featured_media
+				? getEntityRecord(
+						'postType',
+						'attachment',
+						record?.featured_media
+				  )
+				: null;
 
-				return {
-					isCanvasModeView:
-						unlock( select( editSiteStore ) ).getCanvasMode() ===
-						'view',
-					featuredMediaSourceUrl:
-						attachedMedia?.media_details.sizes?.medium
-							?.source_url || attachedMedia?.source_url,
-					featuredMediaAltText: escapeAttribute(
-						attachedMedia?.alt_text ||
-							attachedMedia?.description?.raw ||
-							''
-					),
-				};
-			},
-			[ record ]
-		);
+			return {
+				featuredMediaSourceUrl:
+					attachedMedia?.media_details.sizes?.medium?.source_url ||
+					attachedMedia?.source_url,
+				featuredMediaAltText: escapeAttribute(
+					attachedMedia?.alt_text ||
+						attachedMedia?.description?.raw ||
+						''
+				),
+			};
+		},
+		[ record ]
+	);
 
 	// Redirect to the main pages navigation screen if the page is not found or has been deleted.
 	useEffect( () => {
@@ -83,7 +80,7 @@ export default function SidebarNavigationScreenPage() {
 				canvas: 'view',
 			} );
 		}
-	}, [ hasResolved, isCanvasModeView, history ] );
+	}, [ hasResolved, history ] );
 
 	const featureImageAltText = featuredMediaAltText
 		? decodeEntities( featuredMediaAltText )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a test. It might not work.

This PR redirects to `/page` when a record has resolved but has not been found, probably deleted.


https://github.com/WordPress/gutenberg/assets/6458278/c6dad9a2-f655-478b-9d77-12f7160d2197



## Why?
At the moment the site editor will hang if it tried to load an entity that does not exist.

This applies also for templates etc, but starting with pages to test out the approach.

## How?
Pushing an entry to the history.

```js
			history.push( {
				path: '/page',
				postId: undefined,
				postType: undefined,
				canvas: 'view',
			} );
```

## TODO

Add E2E test 

## Testing Instructions

Try to navigate to a page that has been deleted, e.g., 

`/wp-admin/site-editor.php?postType=page&postId=37&canvas=edit`

Even better, create a page and navigate to the site editor > pages. 

Delete the page in another tab, then back in the site editor, try to open that page.

Observe that you're redirected to `/pages`.

Check that loading existing pages works!

