### PR TITLE
Components:  Add opt-in prop for 40px default size for `BoxControl`, `BorderControl`, and `BorderBoxControl`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -37,6 +37,7 @@
 -   `Tooltip`: no-op when nested inside other `Tooltip` components ([#57202](https://github.com/WordPress/gutenberg/pull/57202)).
 -   `PaletteEdit`: improve unit tests ([#57645](https://github.com/WordPress/gutenberg/pull/57645)).
 -   `ColorPalette` and `CircularOptionPicker`: improve unit tests ([#57809](https://github.com/WordPress/gutenberg/pull/57809)).
+-   `BoxControl`, `BorderControl`, `BorderBoxControl`: Add opt-in prop for 40px default size ([#56185](https://github.com/WordPress/gutenberg/pull/56185)).
 
 ### Experimental
 

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -43,6 +43,7 @@ const UnconnectedBorderBoxControl = (
 	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {
+		__next40pxDefaultSize = false,
 		className,
 		colors,
 		disableCustomColors,
@@ -90,6 +91,8 @@ const UnconnectedBorderBoxControl = (
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );
 
+	const inputHeight = __next40pxDefaultSize ? '__unstable-large' : size;
+
 	return (
 		<View className={ className } { ...otherProps } ref={ mergedRef }>
 			<BorderLabel
@@ -119,7 +122,7 @@ const UnconnectedBorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
-						size={ size }
+						size={ inputHeight }
 					/>
 				) : (
 					<BorderBoxControlSplitControls
@@ -134,13 +137,13 @@ const UnconnectedBorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
-						size={ size }
+						size={ inputHeight }
 					/>
 				) }
 				<BorderBoxControlLinkedButton
 					onClick={ toggleLinked }
 					isLinked={ isLinked }
-					size={ size }
+					size={ inputHeight }
 				/>
 			</View>
 		</View>

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -43,7 +43,6 @@ const UnconnectedBorderBoxControl = (
 	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {
-		__next40pxDefaultSize = false,
 		className,
 		colors,
 		disableCustomColors,
@@ -90,9 +89,6 @@ const UnconnectedBorderBoxControl = (
 		);
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );
-
-	const inputHeight = __next40pxDefaultSize ? '__unstable-large' : size;
-
 	return (
 		<View className={ className } { ...otherProps } ref={ mergedRef }>
 			<BorderLabel
@@ -122,7 +118,7 @@ const UnconnectedBorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
-						size={ inputHeight }
+						size={ size }
 					/>
 				) : (
 					<BorderBoxControlSplitControls
@@ -137,13 +133,13 @@ const UnconnectedBorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
-						size={ inputHeight }
+						size={ size }
 					/>
 				) }
 				<BorderBoxControlLinkedButton
 					onClick={ toggleLinked }
 					isLinked={ isLinked }
-					size={ inputHeight }
+					size={ size }
 				/>
 			</View>
 		</View>

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -35,8 +35,12 @@ export function useBorderBoxControl(
 		size = 'default',
 		value,
 		__experimentalIsRenderedInSidebar = false,
+		__next40pxDefaultSize,
 		...otherProps
 	} = useContextSystem( props, 'BorderBoxControl' );
+
+	const computedSize =
+		size === 'default' && __next40pxDefaultSize ? '__unstable-large' : size;
 
 	const mixedBorders = hasMixedBorders( value );
 	const splitBorders = hasSplitBorders( value );
@@ -133,7 +137,7 @@ export function useBorderBoxControl(
 		onSplitChange,
 		toggleLinked,
 		linkedValue,
-		size,
+		size: computedSize,
 		splitValue,
 		wrapperClassName,
 		__experimentalIsRenderedInSidebar,

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -45,6 +45,12 @@ export type BorderBoxControlProps = ColorProps &
 		 * properties but for each side; `top`, `right`, `bottom`, and `left`.
 		 */
 		value: AnyBorder;
+		/**
+		 * Start opting into the larger default height that will become the default size in a future version.
+		 *
+		 * @default false
+		 */
+		__next40pxDefaultSize?: boolean;
 	};
 
 export type LinkedButtonProps = Pick< BorderBoxControlProps, 'size' > & {

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -38,6 +38,7 @@ const UnconnectedBorderControl = (
 	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {
+		__next40pxDefaultSize = false,
 		colors,
 		disableCustomColors,
 		disableUnits,
@@ -64,6 +65,8 @@ const UnconnectedBorderControl = (
 		...otherProps
 	} = useBorderControl( props );
 
+	const inputHeight = __next40pxDefaultSize ? '__unstable-large' : size;
+
 	return (
 		<View as="fieldset" { ...otherProps } ref={ forwardedRef }>
 			<BorderLabel
@@ -86,7 +89,7 @@ const UnconnectedBorderControl = (
 							__experimentalIsRenderedInSidebar={
 								__experimentalIsRenderedInSidebar
 							}
-							size={ size }
+							size={ inputHeight }
 						/>
 					}
 					label={ __( 'Border width' ) }
@@ -97,7 +100,7 @@ const UnconnectedBorderControl = (
 					placeholder={ placeholder }
 					disableUnits={ disableUnits }
 					__unstableInputWidth={ inputWidth }
-					size={ size }
+					size={ inputHeight }
 				/>
 				{ withSlider && (
 					<RangeControl

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -65,8 +65,6 @@ const UnconnectedBorderControl = (
 		...otherProps
 	} = useBorderControl( props );
 
-	const inputHeight = __next40pxDefaultSize ? '__unstable-large' : size;
-
 	return (
 		<View as="fieldset" { ...otherProps } ref={ forwardedRef }>
 			<BorderLabel
@@ -89,7 +87,7 @@ const UnconnectedBorderControl = (
 							__experimentalIsRenderedInSidebar={
 								__experimentalIsRenderedInSidebar
 							}
-							size={ inputHeight }
+							size={ size }
 						/>
 					}
 					label={ __( 'Border width' ) }
@@ -100,7 +98,7 @@ const UnconnectedBorderControl = (
 					placeholder={ placeholder }
 					disableUnits={ disableUnits }
 					__unstableInputWidth={ inputWidth }
-					size={ inputHeight }
+					size={ size }
 				/>
 				{ withSlider && (
 					<RangeControl
@@ -115,6 +113,7 @@ const UnconnectedBorderControl = (
 						step={ [ 'px', '%' ].includes( widthUnit ) ? 1 : 0.1 }
 						value={ widthValue || undefined }
 						withInputField={ false }
+						__next40pxDefaultSize={ __next40pxDefaultSize }
 					/>
 				) }
 			</HStack>

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -41,8 +41,12 @@ export function useBorderControl(
 		value: border,
 		width,
 		__experimentalIsRenderedInSidebar = false,
+		__next40pxDefaultSize,
 		...otherProps
 	} = useContextSystem( props, 'BorderControl' );
+
+	const computedSize =
+		size === 'default' && __next40pxDefaultSize ? '__unstable-large' : size;
 
 	const [ widthValue, originalWidthUnit ] = parseQuantityAndUnitFromRawValue(
 		border?.width
@@ -130,10 +134,10 @@ export function useBorderControl(
 	}
 	const innerWrapperClassName = useMemo( () => {
 		const widthStyle = !! wrapperWidth && styles.wrapperWidth;
-		const heightStyle = styles.wrapperHeight( size );
+		const heightStyle = styles.wrapperHeight( computedSize );
 
 		return cx( styles.innerWrapper(), widthStyle, heightStyle );
-	}, [ wrapperWidth, cx, size ] );
+	}, [ wrapperWidth, cx, computedSize ] );
 
 	const sliderClassName = useMemo( () => {
 		return cx( styles.borderSlider() );
@@ -155,7 +159,8 @@ export function useBorderControl(
 		value: border,
 		widthUnit,
 		widthValue,
-		size,
+		size: computedSize,
 		__experimentalIsRenderedInSidebar,
+		__next40pxDefaultSize,
 	};
 }

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -99,6 +99,12 @@ export type BorderControlProps = ColorProps &
 		 * `RangeControl` for additional control over a border's width.
 		 */
 		withSlider?: boolean;
+		/**
+		 * Start opting into the larger default height that will become the default size in a future version.
+		 *
+		 * @default false
+		 */
+		__next40pxDefaultSize?: boolean;
 	};
 
 export type DropdownProps = ColorProps &

--- a/packages/components/src/box-control/all-input-control.tsx
+++ b/packages/components/src/box-control/all-input-control.tsx
@@ -25,6 +25,7 @@ import {
 const noop = () => {};
 
 export default function AllInputControl( {
+	__next40pxDefaultSize,
 	onChange = noop,
 	onFocus = noop,
 	values,
@@ -74,6 +75,7 @@ export default function AllInputControl( {
 		<HStack>
 			<StyledUnitControl
 				{ ...props }
+				__next40pxDefaultSize={ __next40pxDefaultSize }
 				className="component-box-control__unit-control"
 				disableUnits={ isMixed }
 				id={ inputId }
@@ -89,6 +91,7 @@ export default function AllInputControl( {
 
 			<FlexedRangeControl
 				__nextHasNoMarginBottom
+				__next40pxDefaultSize={ __next40pxDefaultSize }
 				aria-controls={ inputId }
 				label={ LABELS.all }
 				hideLabelFromVision

--- a/packages/components/src/box-control/axial-input-controls.tsx
+++ b/packages/components/src/box-control/axial-input-controls.tsx
@@ -20,6 +20,7 @@ const groupedSides = [ 'vertical', 'horizontal' ] as const;
 type GroupedSide = ( typeof groupedSides )[ number ];
 
 export default function AxialInputControls( {
+	__next40pxDefaultSize,
 	onChange,
 	onFocus,
 	values,
@@ -105,6 +106,7 @@ export default function AxialInputControls( {
 						<Tooltip placement="top-end" text={ LABELS[ side ] }>
 							<StyledUnitControl
 								{ ...props }
+								__next40pxDefaultSize={ __next40pxDefaultSize }
 								className="component-box-control__unit-control"
 								id={ inputId }
 								isPressEnterToChange
@@ -126,6 +128,7 @@ export default function AxialInputControls( {
 						</Tooltip>
 						<FlexedRangeControl
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize={ __next40pxDefaultSize }
 							aria-controls={ inputId }
 							label={ LABELS[ side ] }
 							hideLabelFromVision

--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -72,6 +72,7 @@ function useUniqueId( idProp?: string ) {
  * ```
  */
 function BoxControl( {
+	__next40pxDefaultSize = false,
 	id: idProp,
 	inputProps = defaultInputProps,
 	onChange = noop,
@@ -151,6 +152,7 @@ function BoxControl( {
 		values: inputValues,
 		onMouseOver,
 		onMouseOut,
+		__next40pxDefaultSize,
 	};
 
 	return (

--- a/packages/components/src/box-control/input-controls.tsx
+++ b/packages/components/src/box-control/input-controls.tsx
@@ -19,6 +19,7 @@ import type { BoxControlInputControlProps, BoxControlValue } from './types';
 const noop = () => {};
 
 export default function BoxInputControls( {
+	__next40pxDefaultSize,
 	onChange = noop,
 	onFocus = noop,
 	values,
@@ -107,6 +108,7 @@ export default function BoxInputControls( {
 						<Tooltip placement="top-end" text={ LABELS[ side ] }>
 							<StyledUnitControl
 								{ ...props }
+								__next40pxDefaultSize={ __next40pxDefaultSize }
 								className="component-box-control__unit-control"
 								id={ inputId }
 								isPressEnterToChange
@@ -131,6 +133,7 @@ export default function BoxInputControls( {
 
 						<FlexedRangeControl
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize={ __next40pxDefaultSize }
 							aria-controls={ inputId }
 							label={ LABELS[ side ] }
 							hideLabelFromVision

--- a/packages/components/src/box-control/types.ts
+++ b/packages/components/src/box-control/types.ts
@@ -71,6 +71,12 @@ export type BoxControlProps = Pick<
 	 * The current values of the control, expressed as an object of `top`, `right`, `bottom`, and `left` values.
 	 */
 	values?: BoxControlValue;
+	/**
+	 * Start opting into the larger default height that will become the default size in a future version.
+	 *
+	 * @default false
+	 */
+	__next40pxDefaultSize?: boolean;
 };
 
 export type BoxControlInputControlProps = UnitControlPassthroughProps & {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/46741

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a new opt-in prop `__next40pxDefaultSize` to `BoxControl`, `BorderControl`, and `BorderBoxControl`, following the plan outlined in above mentioned PR. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For more consistency in styling. I've grouped these three together since they are very similar. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A new, temporary `__next40pxDefaultSize` prop. When the prop is set to `true`, the input will have a height of 40px. 

### `BoxControl` 

I've included some changes to the width when the prop is enabled, otherwise, the text isn't visible. I used the sizing from `BorderControl`'s compact size, but I'd like to hear from @WordPress/gutenberg-design on this. 

| Before  | After |
| ------------- | ------------- |
|  <img width="264" alt="Screenshot 2023-11-15 at 6 32 19 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/1f766e83-bed0-4809-aa94-d85820b64303"> | <img width="343" alt="Screenshot 2023-11-15 at 6 52 10 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/32e74805-2a85-44ef-8ded-270877afed90"> |

Also, due to the narrow size, only 2-3 numbers will be visible without a horizontal scroll. 

<img width="373" alt="Screenshot 2023-11-15 at 6 34 53 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/0a76d1f0-c626-480e-8847-ea5270f9e8b6">

## Testing Instructions

### In Storybook: 

1. `npm run storybook:dev`
2. See initially that each component hasn't changed 
3. Enable the prop / set to true
4. See the new size
5. Ensure all inputs are affected and match

### In the editor

Smoke test the components in the editor; `BoxControl`, `BorderControl`, and `BorderBoxControl` shouldn't have any visible changes for now. 

>[!NOTE]
> `BoxControl` is only used in `DimensionsPanel` for backward compatibility. The only way I've been able to test it is by setting `showSpacingPresetsControl` to true here: 
>https://github.com/WordPress/gutenberg/blob/d69ee811b5476df483c129fb68b9cc99b6e078ba/packages/block-editor/src/components/global-styles/dimensions-panel.js#L487-L499
>However, `__next40pxDefaultSize` causes issues in `BoxControl`, where the text in the input is not visible due to the width constraints of the inspector. So we may need to pause this for `BoxControl` to reassess the design. 