### PR TITLE
Allow drag and drop to create Rows and Galleries

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -34,6 +34,7 @@ function BlockPopoverInbetween( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 	operation = 'insert',
+	nearestSide = 'right',
 	...props
 } ) {
 	// This is a temporary hack to get the inbetween inserter to recompute properly.
@@ -82,7 +83,10 @@ function BlockPopoverInbetween( {
 			return undefined;
 		}
 
-		const contextElement = previousElement || nextElement;
+		const contextElement =
+			operation === 'group'
+				? nextElement || previousElement
+				: previousElement || nextElement;
 
 		return {
 			contextElement,
@@ -100,12 +104,16 @@ function BlockPopoverInbetween( {
 				let height = 0;
 
 				if ( operation === 'group' ) {
-					// If the operation is group, nextRect is the target to be grouped.
-					// Not sure if previousRect is needed here.
-					top = nextRect ? nextRect.top : previousRect.top;
-					width = nextRect ? nextRect.width : previousRect.width;
-					height = nextRect ? nextRect.bottom - nextRect.top : 0;
-					left = nextRect ? nextRect.left : previousRect.left;
+					const targetRect = nextRect || previousRect;
+					top = targetRect.top;
+					width = targetRect.width;
+					height = targetRect.bottom - targetRect.top;
+					// Popover calculates its distance from mid-block so some
+					// adjustments are needed to make it appear in the right place.
+					left =
+						nearestSide === 'left'
+							? -targetRect.width / 2 + targetRect.left
+							: targetRect.width / 2 + targetRect.left;
 				} else if ( isVertical ) {
 					// vertical
 					top = previousRect ? previousRect.bottom : nextRect.top;
@@ -149,6 +157,8 @@ function BlockPopoverInbetween( {
 		popoverRecomputeCounter,
 		isVertical,
 		isVisible,
+		operation,
+		nearestSide,
 	] );
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -33,6 +33,7 @@ function BlockPopoverInbetween( {
 	children,
 	__unstablePopoverSlot,
 	__unstableContentRef,
+	operation = 'insert',
 	...props
 } ) {
 	// This is a temporary hack to get the inbetween inserter to recompute properly.
@@ -67,7 +68,7 @@ function BlockPopoverInbetween( {
 	);
 	const previousElement = useBlockElement( previousClientId );
 	const nextElement = useBlockElement( nextClientId );
-	const isVertical = orientation === 'vertical';
+	const isVertical = operation !== 'group' && orientation === 'vertical';
 
 	const popoverAnchor = useMemo( () => {
 		if (

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -68,7 +68,7 @@ function BlockPopoverInbetween( {
 	);
 	const previousElement = useBlockElement( previousClientId );
 	const nextElement = useBlockElement( nextClientId );
-	const isVertical = operation !== 'group' && orientation === 'vertical';
+	const isVertical = orientation === 'vertical';
 
 	const popoverAnchor = useMemo( () => {
 		if (
@@ -99,7 +99,14 @@ function BlockPopoverInbetween( {
 				let width = 0;
 				let height = 0;
 
-				if ( isVertical ) {
+				if ( operation === 'group' ) {
+					// If the operation is group, nextRect is the target to be grouped.
+					// Not sure if previousRect is needed here.
+					top = nextRect ? nextRect.top : previousRect.top;
+					width = nextRect ? nextRect.width : previousRect.width;
+					height = nextRect ? nextRect.bottom - nextRect.top : 0;
+					left = nextRect ? nextRect.left : previousRect.left;
+				} else if ( isVertical ) {
 					// vertical
 					top = previousRect ? previousRect.bottom : nextRect.top;
 					width = previousRect ? previousRect.width : nextRect.width;

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -106,14 +106,16 @@ function BlockPopoverInbetween( {
 				if ( operation === 'group' ) {
 					const targetRect = nextRect || previousRect;
 					top = targetRect.top;
-					width = targetRect.width;
+					// No spacing is likely around blocks in this operation.
+					// So width of the inserter containing rect is set to 0.
+					width = 0;
 					height = targetRect.bottom - targetRect.top;
 					// Popover calculates its distance from mid-block so some
 					// adjustments are needed to make it appear in the right place.
 					left =
 						nearestSide === 'left'
-							? -targetRect.width / 2 + targetRect.left
-							: targetRect.width / 2 + targetRect.left;
+							? targetRect.left - 2
+							: targetRect.right - 2;
 				} else if ( isVertical ) {
 					// vertical
 					top = previousRect ? previousRect.bottom : nextRect.top;

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -24,6 +24,7 @@ export const InsertionPointOpenRef = createContext();
 function InbetweenInsertionPointPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
+	operation = 'insert',
 } ) {
 	const { selectBlock, hideInsertionPoint } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
@@ -138,9 +139,14 @@ function InbetweenInsertionPointPopover( {
 		return null;
 	}
 
+	const orientationClassname =
+		orientation === 'horizontal' || operation === 'group'
+			? 'is-horizontal'
+			: 'is-vertical';
+
 	const className = classnames(
 		'block-editor-block-list__insertion-point',
-		'is-' + orientation
+		orientationClassname
 	);
 
 	return (
@@ -149,6 +155,7 @@ function InbetweenInsertionPointPopover( {
 			nextClientId={ nextClientId }
 			__unstablePopoverSlot={ __unstablePopoverSlot }
 			__unstableContentRef={ __unstableContentRef }
+			operation={ operation }
 		>
 			<motion.div
 				layout={ ! disableMotion }
@@ -229,14 +236,16 @@ export default function InsertionPoint( props ) {
 	 * Render a popover that overlays the block when the desired operation is to replace it.
 	 * Otherwise, render a popover in between blocks for the indication of inserting between them.
 	 */
-	return insertionPoint.operation === 'replace' ||
-		insertionPoint.operation === 'group' ? (
+	return insertionPoint.operation === 'replace' ? (
 		<BlockDropZonePopover
 			// Force remount to trigger the animation.
 			key={ `${ insertionPoint.rootClientId }-${ insertionPoint.index }` }
 			{ ...props }
 		/>
 	) : (
-		<InbetweenInsertionPointPopover { ...props } />
+		<InbetweenInsertionPointPopover
+			operation={ insertionPoint.operation }
+			{ ...props }
+		/>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -25,6 +25,7 @@ function InbetweenInsertionPointPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 	operation = 'insert',
+	nearestSide = 'right',
 } ) {
 	const { selectBlock, hideInsertionPoint } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
@@ -156,6 +157,7 @@ function InbetweenInsertionPointPopover( {
 			__unstablePopoverSlot={ __unstablePopoverSlot }
 			__unstableContentRef={ __unstableContentRef }
 			operation={ operation }
+			nearestSide={ nearestSide }
 		>
 			<motion.div
 				layout={ ! disableMotion }
@@ -245,6 +247,7 @@ export default function InsertionPoint( props ) {
 	) : (
 		<InbetweenInsertionPointPopover
 			operation={ insertionPoint.operation }
+			nearestSide={ insertionPoint.nearestSide }
 			{ ...props }
 		/>
 	);

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -229,7 +229,8 @@ export default function InsertionPoint( props ) {
 	 * Render a popover that overlays the block when the desired operation is to replace it.
 	 * Otherwise, render a popover in between blocks for the indication of inserting between them.
 	 */
-	return insertionPoint.operation === 'replace' ? (
+	return insertionPoint.operation === 'replace' ||
+		insertionPoint.operation === 'group' ? (
 		<BlockDropZonePopover
 			// Force remount to trigger the animation.
 			key={ `${ insertionPoint.rootClientId }-${ insertionPoint.index }` }

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -139,7 +139,12 @@ export function getDropTargetPosition(
 	}
 
 	blocksData.forEach(
-		( { isUnmodifiedDefaultBlock, getBoundingClientRect, blockIndex } ) => {
+		( {
+			isUnmodifiedDefaultBlock,
+			getBoundingClientRect,
+			blockIndex,
+			blockOrientation,
+		} ) => {
 			const rect = getBoundingClientRect();
 
 			let [ distance, edge ] = getDistanceToNearestEdge(
@@ -161,6 +166,7 @@ export function getDropTargetPosition(
 				distance = 0;
 			} else if (
 				orientation === 'vertical' &&
+				blockOrientation !== 'horizontal' &&
 				( ( isPointInsideRect && sideDistance < THRESHOLD_DISTANCE ) ||
 					( ! isPointInsideRect &&
 						isPointWithinTopAndBottomBoundariesOfRect(
@@ -363,6 +369,8 @@ export default function useBlockDropZone( {
 								.getElementById( `block-${ clientId }` )
 								.getBoundingClientRect(),
 						blockIndex: getBlockIndex( clientId ),
+						blockOrientation:
+							getBlockListSettings( clientId )?.orientation,
 					};
 				} );
 

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -161,7 +161,7 @@ export function getDropTargetPosition(
 				distance = 0;
 			} else if (
 				orientation === 'vertical' &&
-				( ( isPointInsideRect && sideDistance < rect.width / 4 ) ||
+				( ( isPointInsideRect && sideDistance < THRESHOLD_DISTANCE ) ||
 					( ! isPointInsideRect &&
 						isPointWithinTopAndBottomBoundariesOfRect(
 							position,

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -73,6 +73,7 @@ export function getDropTargetPosition(
 	let insertPosition = 'before';
 	let minDistance = Infinity;
 	let targetBlockIndex = null;
+	let nearestSide = 'right';
 
 	const {
 		dropZoneElement,
@@ -155,6 +156,13 @@ export function getDropTargetPosition(
 				// Set target block index if the point is inside of the block
 				// and the block is modified.
 				targetBlockIndex = blockIndex;
+				// If the point is inside of the block, find nearest side.
+				const [ , sideEdge ] = getDistanceToNearestEdge(
+					position,
+					rect,
+					[ 'left', 'right' ]
+				);
+				nearestSide = sideEdge;
 			}
 
 			if ( distance < minDistance ) {
@@ -182,7 +190,7 @@ export function getDropTargetPosition(
 
 	// If the target index is set then group with the block at that index.
 	if ( targetBlockIndex !== null ) {
-		return [ targetBlockIndex, 'group' ];
+		return [ targetBlockIndex, 'group', nearestSide ];
 	}
 	// If both blocks are not unmodified default blocks then just insert between them.
 	if (
@@ -293,6 +301,7 @@ export default function useBlockDropZone( {
 		dropTarget.index,
 		{
 			operation: dropTarget.operation,
+			nearestSide: dropTarget.nearestSide,
 		}
 	);
 	const throttled = useThrottle(
@@ -345,25 +354,27 @@ export default function useBlockDropZone( {
 					};
 				} );
 
-				const [ targetIndex, operation ] = getDropTargetPosition(
-					blocksData,
-					{ x: event.clientX, y: event.clientY },
-					getBlockListSettings( targetRootClientId )?.orientation,
-					{
-						dropZoneElement,
-						parentBlockClientId,
-						parentBlockOrientation: parentBlockClientId
-							? getBlockListSettings( parentBlockClientId )
-									?.orientation
-							: undefined,
-						rootBlockIndex: getBlockIndex( targetRootClientId ),
-					}
-				);
+				const [ targetIndex, operation, nearestSide ] =
+					getDropTargetPosition(
+						blocksData,
+						{ x: event.clientX, y: event.clientY },
+						getBlockListSettings( targetRootClientId )?.orientation,
+						{
+							dropZoneElement,
+							parentBlockClientId,
+							parentBlockOrientation: parentBlockClientId
+								? getBlockListSettings( parentBlockClientId )
+										?.orientation
+								: undefined,
+							rootBlockIndex: getBlockIndex( targetRootClientId ),
+						}
+					);
 
 				registry.batch( () => {
 					setDropTarget( {
 						index: targetIndex,
 						operation,
+						nearestSide,
 					} );
 
 					const insertionPointClientId = [
@@ -375,6 +386,7 @@ export default function useBlockDropZone( {
 
 					showInsertionPoint( insertionPointClientId, targetIndex, {
 						operation,
+						nearestSide,
 					} );
 				} );
 			},

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -72,6 +72,7 @@ export function getDropTargetPosition(
 	let nearestIndex = 0;
 	let insertPosition = 'before';
 	let minDistance = Infinity;
+	let targetBlockIndex = null;
 
 	const {
 		dropZoneElement,
@@ -150,6 +151,10 @@ export function getDropTargetPosition(
 				isPointContainedByRect( position, rect )
 			) {
 				distance = 0;
+			} else if ( isPointContainedByRect( position, rect ) ) {
+				// Set target block index if the point is inside of the block
+				// and the block is modified.
+				targetBlockIndex = blockIndex;
 			}
 
 			if ( distance < minDistance ) {
@@ -175,6 +180,10 @@ export function getDropTargetPosition(
 	const isAdjacentBlockUnmodifiedDefaultBlock =
 		!! blocksData[ adjacentIndex ]?.isUnmodifiedDefaultBlock;
 
+	// If the target index is set then group with the block at that index.
+	if ( targetBlockIndex !== null ) {
+		return [ targetBlockIndex, 'group' ];
+	}
 	// If both blocks are not unmodified default blocks then just insert between them.
 	if (
 		! isNearestBlockUnmodifiedDefaultBlock &&

--- a/packages/block-editor/src/components/use-block-drop-zone/test/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/test/index.js
@@ -22,13 +22,6 @@ const elementData = [
 		bottom: 900,
 		right: 400,
 	},
-	// Fourth block wraps to the next row/column.
-	{
-		top: 0,
-		left: 400,
-		bottom: 300,
-		right: 800,
-	},
 ];
 
 const mapElements =
@@ -73,7 +66,7 @@ describe( 'getDropTargetPosition', () => {
 		const orientation = 'vertical';
 
 		it( 'returns `0` when the position is nearest to the start of the first block', () => {
-			const position = { x: 0, y: 0 };
+			const position = { x: 32, y: 0 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -85,7 +78,7 @@ describe( 'getDropTargetPosition', () => {
 		} );
 
 		it( 'returns `1` when the position is nearest to the end of the first block', () => {
-			const position = { x: 0, y: 190 };
+			const position = { x: 32, y: 190 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -97,7 +90,7 @@ describe( 'getDropTargetPosition', () => {
 		} );
 
 		it( 'returns `1` when the position is nearest to the start of the second block', () => {
-			const position = { x: 0, y: 210 };
+			const position = { x: 32, y: 210 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -109,7 +102,7 @@ describe( 'getDropTargetPosition', () => {
 		} );
 
 		it( 'returns `2` when the position is nearest to the end of the second block', () => {
-			const position = { x: 0, y: 450 };
+			const position = { x: 32, y: 450 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -121,7 +114,7 @@ describe( 'getDropTargetPosition', () => {
 		} );
 
 		it( 'returns `2` when the position is nearest to the start of the third block', () => {
-			const position = { x: 0, y: 510 };
+			const position = { x: 32, y: 510 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -133,7 +126,7 @@ describe( 'getDropTargetPosition', () => {
 		} );
 
 		it( 'returns `3` when the position is nearest to the end of the third block', () => {
-			const position = { x: 0, y: 880 };
+			const position = { x: 32, y: 880 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -145,7 +138,7 @@ describe( 'getDropTargetPosition', () => {
 		} );
 
 		it( 'returns `3` when the position is past the end of the third block', () => {
-			const position = { x: 0, y: 920 };
+			const position = { x: 32, y: 920 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -155,9 +148,8 @@ describe( 'getDropTargetPosition', () => {
 
 			expect( result ).toEqual( [ 3, 'insert' ] );
 		} );
-
-		it( 'returns `4` when the position is nearest to the start of the fourth block', () => {
-			const position = { x: 401, y: 0 };
+		it( 'returns group with index 0 when position is close to the right of the first block', () => {
+			const position = { x: 372, y: 0 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -165,11 +157,10 @@ describe( 'getDropTargetPosition', () => {
 				orientation
 			);
 
-			expect( result ).toEqual( [ 3, 'insert' ] );
+			expect( result ).toEqual( [ 0, 'group', 'right' ] );
 		} );
-
-		it( 'returns `5` when the position is nearest to the end of the fourth block', () => {
-			const position = { x: 401, y: 300 };
+		it( 'returns group with index 1 when position is close to the left of the second block', () => {
+			const position = { x: 12, y: 212 };
 
 			const result = getDropTargetPosition(
 				verticalBlocksData,
@@ -177,7 +168,7 @@ describe( 'getDropTargetPosition', () => {
 				orientation
 			);
 
-			expect( result ).toEqual( [ 4, 'insert' ] );
+			expect( result ).toEqual( [ 1, 'group', 'left' ] );
 		} );
 	} );
 
@@ -267,30 +258,6 @@ describe( 'getDropTargetPosition', () => {
 
 			expect( result ).toEqual( [ 3, 'insert' ] );
 		} );
-
-		it( 'returns `3` when the position is nearest to the start of the last block', () => {
-			const position = { x: 0, y: 401 };
-
-			const result = getDropTargetPosition(
-				horizontalBlocksData,
-				position,
-				orientation
-			);
-
-			expect( result ).toEqual( [ 3, 'insert' ] );
-		} );
-
-		it( 'returns `4` when the position is nearest to the end of the last block', () => {
-			const position = { x: 300, y: 401 };
-
-			const result = getDropTargetPosition(
-				horizontalBlocksData,
-				position,
-				orientation
-			);
-
-			expect( result ).toEqual( [ 4, 'insert' ] );
-		} );
 	} );
 
 	describe( 'Unmodified default blocks', () => {
@@ -316,14 +283,18 @@ describe( 'getDropTargetPosition', () => {
 
 			// Dropping above the first block.
 			expect(
-				getDropTargetPosition( blocksData, { x: 0, y: 0 }, orientation )
+				getDropTargetPosition(
+					blocksData,
+					{ x: 32, y: 0 },
+					orientation
+				)
 			).toEqual( [ 0, 'replace' ] );
 
 			// Dropping on the top half of the first block.
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 20 },
+					{ x: 32, y: 20 },
 					orientation
 				)
 			).toEqual( [ 0, 'replace' ] );
@@ -332,7 +303,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 200 },
+					{ x: 32, y: 200 },
 					orientation
 				)
 			).toEqual( [ 0, 'replace' ] );
@@ -341,7 +312,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 211 },
+					{ x: 32, y: 211 },
 					orientation
 				)
 			).toEqual( [ 0, 'replace' ] );
@@ -350,7 +321,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 219 },
+					{ x: 32, y: 219 },
 					orientation
 				)
 			).toEqual( [ 0, 'replace' ] );
@@ -359,7 +330,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 230 },
+					{ x: 32, y: 230 },
 					orientation
 				)
 			).toEqual( [ 0, 'replace' ] );
@@ -368,7 +339,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 410 },
+					{ x: 32, y: 410 },
 					orientation
 				)
 			).toEqual( [ 2, 'insert' ] );
@@ -377,7 +348,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 421 },
+					{ x: 32, y: 421 },
 					orientation
 				)
 			).toEqual( [ 2, 'insert' ] );
@@ -410,7 +381,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 20 },
+					{ x: 32, y: 20 },
 					orientation
 				)
 			).toEqual( [ 0, 'insert' ] );
@@ -419,7 +390,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 200 },
+					{ x: 32, y: 200 },
 					orientation
 				)
 			).toEqual( [ 1, 'replace' ] );
@@ -428,7 +399,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 211 },
+					{ x: 32, y: 211 },
 					orientation
 				)
 			).toEqual( [ 1, 'replace' ] );
@@ -437,7 +408,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 219 },
+					{ x: 32, y: 219 },
 					orientation
 				)
 			).toEqual( [ 1, 'replace' ] );
@@ -446,7 +417,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 230 },
+					{ x: 32, y: 230 },
 					orientation
 				)
 			).toEqual( [ 1, 'replace' ] );
@@ -455,7 +426,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 410 },
+					{ x: 32, y: 410 },
 					orientation
 				)
 			).toEqual( [ 1, 'replace' ] );
@@ -464,7 +435,7 @@ describe( 'getDropTargetPosition', () => {
 			expect(
 				getDropTargetPosition(
 					blocksData,
-					{ x: 0, y: 421 },
+					{ x: 32, y: 421 },
 					orientation
 				)
 			).toEqual( [ 1, 'replace' ] );

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -232,6 +232,7 @@ export default function useOnBlockDrop(
 		getBlocksByClientId,
 		getSettings,
 		getBlock,
+		getBlockListSettings,
 	} = useSelect( blockEditorStore );
 	const { getBlockType, getGroupingBlockName } = useSelect( blocksStore );
 	const {
@@ -253,10 +254,16 @@ export default function useOnBlockDrop(
 		) => {
 			const clientIds = getBlockOrder( targetRootClientId );
 			const clientId = clientIds[ targetBlockIndex ];
+
+			// For grouping operation to proceed, the target shouldn't be a Row block.
+			const targetBlock = getBlock( clientId );
+			const isTargetBlockRow =
+				getBlockListSettings( clientId )?.orientation ===
+					'horizontal' && targetBlock.name === 'core/group';
+
 			if ( operation === 'replace' ) {
 				replaceBlocks( clientId, blocks, undefined, initialPosition );
-			} else if ( operation === 'group' ) {
-				const targetBlock = getBlock( clientId );
+			} else if ( operation === 'group' && ! isTargetBlockRow ) {
 				if ( nearestSide === 'left' ) {
 					blocks.push( targetBlock );
 				} else {

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -232,7 +232,6 @@ export default function useOnBlockDrop(
 		getBlocksByClientId,
 		getSettings,
 		getBlock,
-		getBlockListSettings,
 	} = useSelect( blockEditorStore );
 	const { getBlockType, getGroupingBlockName } = useSelect( blocksStore );
 	const {
@@ -255,15 +254,10 @@ export default function useOnBlockDrop(
 			const clientIds = getBlockOrder( targetRootClientId );
 			const clientId = clientIds[ targetBlockIndex ];
 
-			// For grouping operation to proceed, the target shouldn't be a Row block.
-			const targetBlock = getBlock( clientId );
-			const isTargetBlockRow =
-				getBlockListSettings( clientId )?.orientation ===
-					'horizontal' && targetBlock.name === 'core/group';
-
 			if ( operation === 'replace' ) {
 				replaceBlocks( clientId, blocks, undefined, initialPosition );
-			} else if ( operation === 'group' && ! isTargetBlockRow ) {
+			} else if ( operation === 'group' ) {
+				const targetBlock = getBlock( clientId );
 				if ( nearestSide === 'left' ) {
 					blocks.push( targetBlock );
 				} else {

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -232,6 +232,7 @@ export default function useOnBlockDrop(
 		getBlocksByClientId,
 		getSettings,
 		getBlock,
+		isGroupable,
 	} = useSelect( blockEditorStore );
 	const { getBlockType, getGroupingBlockName } = useSelect( blocksStore );
 	const {
@@ -253,10 +254,14 @@ export default function useOnBlockDrop(
 		) => {
 			const clientIds = getBlockOrder( targetRootClientId );
 			const clientId = clientIds[ targetBlockIndex ];
-
+			const blocksClientIds = blocks.map( ( block ) => block.clientId );
+			const areGroupableBlocks = isGroupable( [
+				...blocksClientIds,
+				clientId,
+			] );
 			if ( operation === 'replace' ) {
 				replaceBlocks( clientId, blocks, undefined, initialPosition );
-			} else if ( operation === 'group' ) {
+			} else if ( operation === 'group' && areGroupableBlocks ) {
 				const targetBlock = getBlock( clientId );
 				if ( nearestSide === 'left' ) {
 					blocks.push( targetBlock );

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -269,10 +269,17 @@ export default function useOnBlockDrop(
 					);
 				} );
 
+				const areAllImages = blocks.every( ( block ) => {
+					return block.name === 'core/image';
+				} );
+
 				const wrappedBlocks = createBlock(
-					'core/group',
+					areAllImages ? 'core/gallery' : 'core/group',
 					{
-						layout: { type: 'flex', flexWrap: 'nowrap' },
+						layout: {
+							type: 'flex',
+							flexWrap: areAllImages ? null : 'nowrap',
+						},
 					},
 					groupInnerBlocks
 				);

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -222,7 +222,7 @@ export default function useOnBlockDrop(
 	targetBlockIndex,
 	options = {}
 ) {
-	const { operation = 'insert' } = options;
+	const { operation = 'insert', nearestSide = 'right' } = options;
 	const {
 		canInsertBlockType,
 		getBlockIndex,
@@ -255,7 +255,11 @@ export default function useOnBlockDrop(
 				replaceBlocks( clientId, blocks, undefined, initialPosition );
 			} else if ( operation === 'group' ) {
 				const targetBlock = getBlock( clientId );
-				blocks.unshift( targetBlock );
+				if ( nearestSide === 'left' ) {
+					blocks.push( targetBlock );
+				} else {
+					blocks.unshift( targetBlock );
+				}
 
 				const groupInnerBlocks = blocks.map( ( block ) => {
 					return createBlock(
@@ -268,7 +272,7 @@ export default function useOnBlockDrop(
 				const wrappedBlocks = createBlock(
 					'core/group',
 					{
-						layout: { type: 'flex' },
+						layout: { type: 'flex', flexWrap: 'nowrap' },
 					},
 					groupInnerBlocks
 				);

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -8,6 +8,7 @@ import {
 	findTransform,
 	getBlockTransforms,
 	pasteHandler,
+	store as blocksStore,
 } from '@wordpress/blocks';
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { getFilesFromDataTransfer } from '@wordpress/dom';
@@ -232,6 +233,7 @@ export default function useOnBlockDrop(
 		getSettings,
 		getBlock,
 	} = useSelect( blockEditorStore );
+	const { getBlockType, getGroupingBlockName } = useSelect( blocksStore );
 	const {
 		insertBlocks,
 		moveBlocksToPosition,
@@ -273,8 +275,12 @@ export default function useOnBlockDrop(
 					return block.name === 'core/image';
 				} );
 
+				const galleryBlock = !! getBlockType( 'core/gallery' );
+
 				const wrappedBlocks = createBlock(
-					areAllImages ? 'core/gallery' : 'core/group',
+					areAllImages && galleryBlock
+						? 'core/gallery'
+						: getGroupingBlockName(),
 					{
 						layout: {
 							type: 'flex',
@@ -308,6 +314,9 @@ export default function useOnBlockDrop(
 			operation,
 			replaceBlocks,
 			getBlock,
+			nearestSide,
+			getBlockType,
+			getGroupingBlockName,
 			insertBlocks,
 		]
 	);

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -640,13 +640,15 @@ export function showInsertionPoint(
 	index,
 	__unstableOptions = {}
 ) {
-	const { __unstableWithInserter, operation } = __unstableOptions;
+	const { __unstableWithInserter, operation, nearestSide } =
+		__unstableOptions;
 	return {
 		type: 'SHOW_INSERTION_POINT',
 		rootClientId,
 		index,
 		__unstableWithInserter,
 		operation,
+		nearestSide,
 	};
 }
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1599,13 +1599,19 @@ export function blocksMode( state = {}, action ) {
 export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
 		case 'SHOW_INSERTION_POINT': {
-			const { rootClientId, index, __unstableWithInserter, operation } =
-				action;
+			const {
+				rootClientId,
+				index,
+				__unstableWithInserter,
+				operation,
+				nearestSide,
+			} = action;
 			const nextState = {
 				rootClientId,
 				index,
 				__unstableWithInserter,
 				operation,
+				nearestSide,
 			};
 
 			// Bail out updates if the states are the same.

--- a/packages/block-editor/src/utils/math.js
+++ b/packages/block-editor/src/utils/math.js
@@ -106,3 +106,15 @@ export function isPointContainedByRect( point, rect ) {
 		rect.bottom >= point.y
 	);
 }
+
+/**
+ * Is the point within the top and bottom boundaries of the rectangle.
+ *
+ * @param {WPPoint} point The point.
+ * @param {DOMRect} rect  The rectangle.
+ *
+ * @return {boolean} True if the point is within top and bottom of rectangle, false otherwise.
+ */
+export function isPointWithinTopAndBottomBoundariesOfRect( point, rect ) {
+	return rect.top <= point.y && rect.bottom >= point.y;
+}

--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -252,8 +252,9 @@ test.describe( 'Paragraph', () => {
 
 				{
 					// Dragging on the bottom half of the heading block.
+					// Make sure to target the bottom dropzone by dragging > 30px inside the block.
 					await draggingUtils.dragOver(
-						headingBox.x,
+						headingBox.x + 32,
 						headingBox.y + headingBox.height - 1
 					);
 					await expect( draggingUtils.dropZone ).toBeHidden();
@@ -267,6 +268,26 @@ test.describe( 'Paragraph', () => {
 								.then( ( { y, height } ) => y + height )
 						)
 						.toBeGreaterThan( headingBox.y + headingBox.height );
+				}
+
+				{
+					// Dragging on the right edge of the heading block.
+					// Targets the right hand dropzone.
+					await draggingUtils.dragOver(
+						headingBox.x + headingBox.width - 1,
+						headingBox.y + headingBox.height - 1
+					);
+					await expect( draggingUtils.dropZone ).toBeHidden();
+					await expect(
+						draggingUtils.insertionIndicator
+					).toBeVisible();
+					await expect
+						.poll( () =>
+							draggingUtils.insertionIndicator
+								.boundingBox()
+								.then( ( { x, width } ) => x + width )
+						)
+						.toBe( headingBox.x + headingBox.width );
 				}
 			} );
 
@@ -299,7 +320,7 @@ test.describe( 'Paragraph', () => {
 				{
 					// Dragging on the top half of the heading block.
 					await draggingUtils.dragOver(
-						headingBox.x,
+						headingBox.x + 32,
 						headingBox.y + 1
 					);
 					await expect( draggingUtils.dropZone ).toBeHidden();
@@ -318,7 +339,7 @@ test.describe( 'Paragraph', () => {
 				{
 					// Dragging on the bottom half of the heading block.
 					await draggingUtils.dragOver(
-						headingBox.x,
+						headingBox.x + 32,
 						headingBox.y + headingBox.height - 1
 					);
 					await expect( draggingUtils.dropZone ).toBeVisible();

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -134,9 +134,10 @@ test.describe( 'Draggable block', () => {
 		const secondParagraphBound = await secondParagraph.boundingBox();
 		// Call the move function twice to make sure the `dragOver` event is sent.
 		// @see https://github.com/microsoft/playwright/issues/17153
+		// Make sure mouse is > 30px within the block for bottom drop indicator to appear.
 		for ( let i = 0; i < 2; i += 1 ) {
 			await page.mouse.move(
-				secondParagraphBound.x,
+				secondParagraphBound.x + 32,
 				secondParagraphBound.y + secondParagraphBound.height * 0.75
 			);
 		}

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -451,7 +451,8 @@ class InsertingBlocksUtils {
 		for ( let i = 0; i < 2; i += 1 ) {
 			await this.page.mouse.move(
 				// Hover on the right side of the block to avoid collapsing with the preview.
-				boundingBox.x + boundingBox.width - 1,
+				// But not too far to avoid triggering the grouping block inserter.
+				boundingBox.x + boundingBox.width - 32,
 				// Hover on the bottom of the paragraph block.
 				boundingBox.y + boundingBox.height - 1
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Implements #13202

Enhances drag and drop so that, when hovering over or around blocks in a vertical layout, dropzones appear around the sides to allow for grouping blocks horizontally into Rows. 

Additionally, if an Image block is dropped beside another Image block, they will transform into a Gallery. 

Is this a good addition? Feedback appreciated!


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post and multiple blocks;
2. Try dragging them around each other to see the lateral dropzones appear;
3. Try dropping a block into a lateral dropzone and check that a Row is created with both blocks;
4. Drag an image from outside into the editor and check that it can also be formed into  a Row with existing blocks;
5. Drag an Image block beside another Image block and check that they become a Gallery block;
6. Try to break this in imaginative ways.

Todo: 
* make images dragged in from outside onto Image blocks become Galleries too (currently they just become Rows)
* address test failures



https://github.com/WordPress/gutenberg/assets/8096000/bcc04337-5e0e-437c-b4af-d3cab022e7b2

