### PR TITLE
Layout: Fix issue where layout classnames are injected for blocks without layout support

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -618,8 +618,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 		return $processor->get_updated_html();
 	} elseif ( ! $block_supports_layout ) {
-		// Ensure that layout classnames are not injected if the block does not
-		// support layout, and no child layout styles were generated.
+		// Ensure layout classnames are not injected if there is no layout support.
 		return $block_content;
 	}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -617,6 +617,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$processor->add_class( $class_name );
 		}
 		return $processor->get_updated_html();
+	} elseif ( ! $block_supports_layout ) {
+		// Ensure that layout classnames are not injected if the block does not
+		// support layout, and no child layout styles were generated.
+		return $block_content;
 	}
 
 	$global_settings = gutenberg_get_global_settings();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This resolves an issue found while testing https://github.com/WordPress/gutenberg/pull/56130#pullrequestreview-1733535422 — if a child of a Row block is explicitly set to `Fit` then layout classnames are erroneously injected for blocks that do not support layout (e.g. a paragraph block set to Fit as a child of the Row block).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Layout classnames should not be output for blocks without layout support. They were being injected because we didn't have an early return condition for if a block has `selfStretch` set, doesn't have layout support, but does not generate any styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Following the condition for outputting the outer wrapper classname for `selfStretch` rules, perform an early return if the block does not support layout.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Row block with a few child Paragraph blocks and set one of the Paragraphs to be explicitly Fit (i.e. set it to Fill, then set it back to Fit)
2. Save the post and view the markup on the site frontend. Notice that on `trunk` extra layout classnames are injected into the paragraph block.
3. With this PR applied, there should be no unexpected classnames injected to the paragraph block.
4. Switch the paragraph block to use an explicit fixed width. After saving and reloading, it should get its expected `wp-container-content-x` classname and associated styles.

Test markup:

```html
<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Paragraph 1</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
<p>Paragraph 2</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Paragraph 3</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/WordPress/gutenberg/assets/14988353/a5848119-98ed-4566-9218-4131c3588992)

### After

![image](https://github.com/WordPress/gutenberg/assets/14988353/80cbc4b2-214f-4126-91ed-589044e56dea)
