### PR TITLE
DataViews: add missing key to `ResetFilters` component

### DIFF
--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -70,7 +70,11 @@ export default function Filters( { fields, view, onChangeView } ) {
 
 	if ( filterComponents.length > 1 ) {
 		filterComponents.push(
-			<ResetFilters view={ view } onChangeView={ onChangeView } />
+			<ResetFilters
+				key="reset-filters"
+				view={ view }
+				onChangeView={ onChangeView }
+			/>
 		);
 	}
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/55100

Add missing `key` prop to `ResetFilter` component.

