### PR TITLE
Migrating block inserter media tab components

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-list.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-list.js
@@ -1,16 +1,17 @@
 /**
  * WordPress dependencies
  */
-import {
-	__unstableComposite as Composite,
-	__unstableUseCompositeState as useCompositeState,
-} from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { MediaPreview } from './media-preview';
+import { unlock } from '../../../lock-unlock';
+
+const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
+	unlock( componentsPrivateApis );
 
 function MediaList( {
 	mediaList,
@@ -18,10 +19,10 @@ function MediaList( {
 	onClick,
 	label = __( 'Media List' ),
 } ) {
-	const composite = useCompositeState();
+	const compositeStore = useCompositeStore();
 	return (
 		<Composite
-			{ ...composite }
+			store={ compositeStore }
 			role="listbox"
 			className="block-editor-inserter__media-list"
 			aria-label={ label }
@@ -32,7 +33,6 @@ function MediaList( {
 					media={ media }
 					category={ category }
 					onClick={ onClick }
-					composite={ composite }
 				/>
 			) ) }
 		</Composite>

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	__unstableCompositeItem as CompositeItem,
 	Tooltip,
 	DropdownMenu,
 	MenuGroup,
@@ -17,6 +16,7 @@ import {
 	Flex,
 	FlexItem,
 	Button,
+	privateApis as componentsPrivateApis,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -33,6 +33,7 @@ import { isBlobURL } from '@wordpress/blob';
 import InserterDraggableBlocks from '../../inserter-draggable-blocks';
 import { getBlockAndPreviewFromMedia } from './utils';
 import { store as blockEditorStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const MAXIMUM_TITLE_LENGTH = 25;
@@ -41,6 +42,8 @@ const MEDIA_OPTIONS_POPOVER_PROPS = {
 	className:
 		'block-editor-inserter__media-list__item-preview-options__popover',
 };
+
+const { CompositeItemV2: CompositeItem } = unlock( componentsPrivateApis );
 
 function MediaPreviewOptions( { category, media } ) {
 	if ( ! category.getReportUrl ) {
@@ -113,7 +116,7 @@ function InsertExternalImageModal( { onClose, onSubmit } ) {
 	);
 }
 
-export function MediaPreview( { media, onClick, composite, category } ) {
+export function MediaPreview( { media, onClick, category } ) {
 	const [ showExternalUploadModal, setShowExternalUploadModal ] =
 		useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -216,20 +219,22 @@ export function MediaPreview( { media, onClick, composite, category } ) {
 						onDragStart={ onDragStart }
 						onDragEnd={ onDragEnd }
 					>
-						<Tooltip text={ truncatedTitle || title }>
-							{ /* Adding `is-hovered` class to the wrapper element is needed
-							because the options Popover is rendered outside of this node. */ }
-							<div
-								onMouseEnter={ onMouseEnter }
-								onMouseLeave={ onMouseLeave }
-							>
+						{ /* Adding `is-hovered` class to the wrapper element is needed
+						because the options Popover is rendered outside of this node. */ }
+						<div
+							onMouseEnter={ onMouseEnter }
+							onMouseLeave={ onMouseLeave }
+						>
+							<Tooltip text={ truncatedTitle || title }>
 								<CompositeItem
-									role="option"
-									as="div"
-									{ ...composite }
-									className="block-editor-inserter__media-list__item"
+									render={
+										<div
+											aria-label={ title }
+											role="option"
+											className="block-editor-inserter__media-list__item"
+										/>
+									}
 									onClick={ () => onMediaInsert( block ) }
-									aria-label={ title }
 								>
 									<div className="block-editor-inserter__media-list__item-preview">
 										{ preview }
@@ -240,14 +245,14 @@ export function MediaPreview( { media, onClick, composite, category } ) {
 										) }
 									</div>
 								</CompositeItem>
-								{ ! isInserting && (
-									<MediaPreviewOptions
-										category={ category }
-										media={ media }
-									/>
-								) }
-							</div>
-						</Tooltip>
+							</Tooltip>
+							{ ! isInserting && (
+								<MediaPreviewOptions
+									category={ category }
+									media={ media }
+								/>
+							) }
+						</div>
 					</div>
 				) }
 			</InserterDraggableBlocks>


### PR DESCRIPTION
## What?

This PR updates [`MediaList`](https://github.com/WordPress/gutenberg/blob/8fa043bae1265a37ab27fc1cd25fb612feae26e9/packages/block-editor/src/components/inserter/media-tab/media-list.js) and [`MediaPreview`](https://github.com/WordPress/gutenberg/blob/8fa043bae1265a37ab27fc1cd25fb612feae26e9/packages/block-editor/src/components/inserter/media-tab/media-preview.js) in `@wordpress/block-editor` to use the updated `Composite` implementation from #54225.


## Why?

In #54225, an updated implementation of `Composite` was added to `@wordpress/components`. As per #55224, all consumers of `Composite` need to migrate from the old version to the new version.

## How?

- Removes `__unstableComposite` imports from `@wordpress/components`
- Adds private `Composite*` exports from `@wordpress/components`
- Refactors `MediaList` and `MediaPreview` to use updated `Composite` components
- Additionally, reorganises the `MediaPreview` structure slightly to remove redundant tab stops


## Testing Instructions

1. In the editor, open the block inserter sidebar
2. Navigate to the "media" tab and select an option to open the media list
3. There should be no visible differences
4. Tooltips should appear on hover, and if using the Openverse media selector, so should the options menu button

### Before and after

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/de19b4b6-65b8-4292-a73d-2b160094fc41" alt="The Gutenberg block sidebar before any changes, with the media tab selected and the Openverse list open, showing three images." width="45%">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/338e6d79-40d2-4dd7-b6ec-f29171a72162" alt="The Gutenberg block sidebar after changes, with the media tab selected and the Openverse list open, showing three images." width="45%">
</p>

### Testing Instructions for Keyboard

1. With the block inserter open and the media tab selected, select  an option to open the media list – the search field should have focus.
2. Navigate to the "Media List" listbox
3. There should be no redundant tab stops, and the arrow keys should navigate between media items
5. Note that the "options" menu in the Openverse media list is not accessible – this has always been the case (and should be fixed!)