### PR TITLE
DropdownMenuV2: inherit placement for nested submenus

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `Tabs`: Add `focusable` prop to the `Tabs.TabPanel` sub-component ([#55287](https://github.com/WordPress/gutenberg/pull/55287))
 -   `Tabs`: Update sub-components to accept relevant HTML element props ([#55860](https://github.com/WordPress/gutenberg/pull/55860))
 -   `DropdownMenuV2`: Fix radio menu item check icon not rendering correctly in some browsers ([#55964](https://github.com/WordPress/gutenberg/pull/55964))
+-   `DropdownMenuV2`: inherit placement for nested submenus ([#56213](https://github.com/WordPress/gutenberg/pull/56213))
 -   `DropdownMenuV2`: prevent default when pressing Escape key to close menu ([#55962](https://github.com/WordPress/gutenberg/pull/55962))
 
 ### Enhancements

--- a/packages/components/src/dropdown-menu-v2-ariakit/README.md
+++ b/packages/components/src/dropdown-menu-v2-ariakit/README.md
@@ -96,6 +96,8 @@ The modality of the dropdown menu. When set to true, interaction with outside el
 
 The placement of the dropdown menu popover.
 
+Submenus from the second level of nesting onwards will inherit the parent menu's placement by default, which can still be changed via this prop.
+
 - Required: no
 - Default: `'bottom-start'` for root-level menus, `'right-start'` for nested menus
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -195,12 +195,23 @@ const UnconnectedDropdownMenu = (
 
 	const computedDirection = isRTL() ? 'rtl' : 'ltr';
 
-	// If an explicit value for the `placement` prop is not passed,
-	// apply a default placement of `bottom-start` for the root dropdown,
-	// and of `right-start` for nested dropdowns.
-	let computedPlacement =
-		props.placement ??
-		( parentContext?.store ? 'right-start' : 'bottom-start' );
+	let computedPlacement: typeof props.placement;
+	if ( props.placement ) {
+		// The `placement` prop has priority.
+		computedPlacement = props.placement;
+	} else if ( parentContext?.store.parent ) {
+		// If the current menu is at least a second-gen nested menu, it inherits
+		// the placement from its parent menu.
+		computedPlacement = parentContext.store.useState( 'currentPlacement' );
+	} else if ( parentContext?.store ) {
+		// If the current menu is at least a first-gen nested menu, the default
+		// placement is `right-start`.
+		computedPlacement = 'right-start';
+	} else {
+		// For the root dropdown menu, the default placement is `bottom-start`.
+		computedPlacement = 'bottom-start';
+	}
+
 	// Swap left/right in case of RTL direction
 	if ( computedDirection === 'rtl' ) {
 		if ( /right/.test( computedPlacement ) ) {

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -52,6 +52,9 @@ export interface DropdownMenuProps {
 	/**
 	 * The placement of the dropdown menu popover.
 	 *
+	 * Submenus from the second level of nesting onwards will inherit the parent
+	 * menu's placement by default, which can still be changed via this prop.
+	 *
 	 * @default 'bottom-start' for root-level menus, 'right-start' for nested menus
 	 */
 	placement?: Placement;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR proposes an additional piece of logic to the new experimental `DropdownMenu` component, by letting nested submenus inherit the `placement` from their parent menus.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The idea is that having nested submenus opening in the same "direction" is easier for the users both in terms of how the UI looks, but also in terms of UX and a11y (especially keyboard navigation) — here's [an example scenario](https://github.com/WordPress/gutenberg/pull/55625#issuecomment-1802018020).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See above 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Apply the changes from this PR to your local machine
2. Load the "With Submenu" example in a standalone tab ([link](http://localhost:50240/iframe.html?args=&id=components-experimental-dropdownmenu-v2-ariakit--with-submenu&viewMode=story))
3. Open all nested menus, notice how the all open to the right (without any `placement` prop applied)
4. Apply this change to move the menu trigger button to the right part of the screen in the Storybook examples

<details>
<summary>Click to expand</summary>

```diff
diff --git a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
index a6319c6cfd..2802d7f960 100644
--- a/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/stories/index.story.tsx
@@ -119,7 +119,11 @@ export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 );
 Default.args = {
 	trigger: (
-		<Button __next40pxDefaultSize variant="secondary">
+		<Button
+			__next40pxDefaultSize
+			variant="secondary"
+			style={ { float: 'right' } }
+		>
 			Open menu
 		</Button>
 	),

```
</details>


5. Reload the same submenu example
6. Notice how all submenus open to the left (still without any explicit `placement` prop)
7. Modify the storybook example and set the `placement` prop on the various `DropdownMenu` components, make sure that the prop always takes priority on the default behaviour

## Screenshots

| Before | After (this PR) |
|---|---|
| ![Screenshot 2023-11-16 at 20 15 24](https://github.com/WordPress/gutenberg/assets/1083581/778efae2-8f3a-4701-8552-dade5f470e88) | ![Screenshot 2023-11-16 at 20 15 53](https://github.com/WordPress/gutenberg/assets/1083581/32ca4bc4-56d9-41c7-a58e-1dc3e29a91d1) |
