### PR TITLE
Use tooltip for the Timezone only when necessary.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fix
 
+-   `DateTime`: Make the Timezone indication render a tooltip only when necessary. ([#56214](https://github.com/WordPress/gutenberg/pull/56214)).
 -   `ToolsPanelItem`: Use useLayoutEffect to prevent rendering glitch for last panel item styling. ([#56536](https://github.com/WordPress/gutenberg/pull/56536)).
 -   `FormTokenField`: Fix broken suggestions scrollbar when the `__experimentalExpandOnFocus` prop is defined ([#56426](https://github.com/WordPress/gutenberg/pull/56426)).
 -   `FormTokenField`: `onFocus` prop is now typed as a React `FocusEvent` ([#56426](https://github.com/WordPress/gutenberg/pull/56426)).

--- a/packages/components/src/date-time/time/timezone.tsx
+++ b/packages/components/src/date-time/time/timezone.tsx
@@ -32,12 +32,22 @@ const TimeZone = () => {
 			? timezone.abbr
 			: `UTC${ offsetSymbol }${ timezone.offset }`;
 
+	// Replace underscore with space in strings like `America/Costa_Rica`.
+	const prettyTimezoneString = timezone.string.replace( '_', ' ' );
+
 	const timezoneDetail =
 		'UTC' === timezone.string
 			? __( 'Coordinated Universal Time' )
-			: `(${ zoneAbbr }) ${ timezone.string.replace( '_', ' ' ) }`;
+			: `(${ zoneAbbr }) ${ prettyTimezoneString }`;
 
-	return (
+	const isAbbrSameAsDetails =
+		`${ zoneAbbr } ${ prettyTimezoneString }`.trim() === zoneAbbr;
+
+	return isAbbrSameAsDetails ? (
+		<StyledComponent className="components-datetime__timezone">
+			{ zoneAbbr }
+		</StyledComponent>
+	) : (
 		<Tooltip placement="top" text={ timezoneDetail }>
 			<StyledComponent className="components-datetime__timezone">
 				{ zoneAbbr }

--- a/packages/components/src/date-time/time/timezone.tsx
+++ b/packages/components/src/date-time/time/timezone.tsx
@@ -40,10 +40,12 @@ const TimeZone = () => {
 			? __( 'Coordinated Universal Time' )
 			: `(${ zoneAbbr }) ${ prettyTimezoneString }`;
 
-	const isAbbrSameAsDetails =
-		`${ zoneAbbr } ${ prettyTimezoneString }`.trim() === zoneAbbr;
+	// When the prettyTimezoneString is empty, there is no additional timezone
+	// detail information to show in a Tooltip.
+	const hasNoAdditionalTimezoneDetail =
+		prettyTimezoneString.trim().length === 0;
 
-	return isAbbrSameAsDetails ? (
+	return hasNoAdditionalTimezoneDetail ? (
 		<StyledComponent className="components-datetime__timezone">
 			{ zoneAbbr }
 		</StyledComponent>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/56211

## What?
<!-- In a few words, what is the PR actually doing? -->
The Timezone indication may render an unnecessary tooltip when the visible text and the tooltip text are the same.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There is no need to repeat in the tooltip the same information that is already in the visible text e.g. `UTC+3` and again `UTC+3`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Checks whether the abbreviation and the detailed values contain the same information and add the tooltip conditionally.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
 - Repeat the steps described in the issue https://github.com/WordPress/gutenberg/issues/56211
 - Observe that the tooltip shows only when the detailed information is actually different from the visible text.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
