### PR TITLE
Show template center UI when no block is selected

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -153,6 +153,7 @@ function Header( {
 					className={ classnames( 'edit-post-header__center', {
 						'is-collapsed':
 							isEditingTemplate &&
+							hasBlockSelected &&
 							! isBlockToolsCollapsed &&
 							hasFixedToolbar &&
 							isLargeViewport,

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -119,7 +119,9 @@ function Header( {
 							className={ classnames(
 								'selected-block-tools-wrapper',
 								{
-									'is-collapsed': isBlockToolsCollapsed,
+									'is-collapsed':
+										isEditingTemplate &&
+										isBlockToolsCollapsed,
 								}
 							) }
 						>
@@ -150,9 +152,10 @@ function Header( {
 				<div
 					className={ classnames( 'edit-post-header__center', {
 						'is-collapsed':
+							isEditingTemplate &&
 							! isBlockToolsCollapsed &&
-							isLargeViewport &&
-							isEditingTemplate,
+							hasFixedToolbar &&
+							isLargeViewport,
 					} ) }
 				>
 					{ isEditingTemplate && <DocumentActions /> }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/56194


## What?
<!-- In a few words, what is the PR actually doing? -->

When using the Template Editor from within a post, the central template ui to go back to the post was not showing after selecting a block in the canvas. We should only be collapsing this area when we're:
- editing a template
- top toolbar mode is on
- a block is selected
- a user has clicked to collapse the area
- the viewport is large

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes a bug where the central template ui was hidden.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check for the correct variables before hiding the UI:
- editing a template
- top toolbar mode is on
- a block is selected
- a user has clicked to collapse the area
- the viewport is large

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
(Partially stealing these from @afercia's issue - thanks for the clear screenshots!)
- Edit a post.
- In the setting panel, click the current template. A popover open. Click 'Edit template'. Screenshot:

![Screenshot 2023-11-16 at 10 39 48](https://github.com/WordPress/gutenberg/assets/1682452/99b3d631-a3f7-4a9d-a3eb-9962730a0f0e)

- The editor switches to a 'Edit template' mode.
- Observe in the top bar there is a 'Back' button to switch back to the normal Post editor mode.
- Observe that whatever you do, the 'Back' button stays there.
- Switch to Top Toolbar mode
- Central area should remain (unless a block is selected)
- Unselecting a block should show the central area
- Selecting a block should show the top toolbar and the central area should be hidden
- Click the Collapse button when a block is selected
- Block tools should collapse, and the central area should show again to be able to go back to the post
- Try to break it :) 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
