### PR TITLE
Site Editor Sidebar: fix actions vertical alignment

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -72,6 +72,7 @@
 }
 
 .edit-site-sidebar-navigation-screen__actions {
+	display: flex;
 	flex-shrink: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a layout bug discovered in https://github.com/WordPress/gutenberg/pull/55360#pullrequestreview-1734332254

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Changes from #55360 caused this misalignment as a side effect

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Setting the parent actions wrapper as a flexbox parent correctly aligns all action icon buttons

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the site editor
- Select "Navigation"
- In the navigation sidebar, make sure that the action icon buttons are vertically aligned
- Navigate to other screens and make sure that all other action icon buttons are also correctly aligned

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2023-11-16 at 17 56 42](https://github.com/WordPress/gutenberg/assets/1083581/df79f1db-83be-4c1a-ae53-6b3a31360958) | ![Screenshot 2023-11-16 at 17 56 19](https://github.com/WordPress/gutenberg/assets/1083581/8012e435-2f34-478f-9014-682baaba1c32) |
