### PR TITLE
Add hasBlockSelected check when collapsing center header area

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -198,7 +198,9 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 						'edit-site-header-edit-mode__center',
 						{
 							'is-collapsed':
-								! isBlockToolsCollapsed && isLargeViewport,
+								! isBlockToolsCollapsed &&
+								hasBlockSelected &&
+								isLargeViewport,
 						}
 					) }
 				>


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

On the site editor with top toolbar mode on, you could arrive at a state with no block toolbar and no central area. We should only collapse the central area when there is also a block selected.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The central area was hidden when it should be showing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check for `hasBlockSelected` before collapsing this area.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the site editor and edit a template
- Have Top Toolbar on
- Select a block
- Deselect the block by clicking on an area with no blocks
- Block toolbar should disappear and central area should show

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
