### PR TITLE
Remove unnecessary CSS for shrinking central header area

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -12,11 +12,6 @@
 	border-radius: $grid-unit-05;
 	width: min(100%, 450px);
 
-	// Make the document title shorter in top-toolbar mode, as it has to be covered.
-	.has-fixed-toolbar & {
-		width: min(100%, 380px);
-	}
-
 	&:hover {
 		background-color: $gray-200;
 	}


### PR DESCRIPTION
This CSS was necessary before moving the top toolbar into the header DOM. Now that the toolbar is in the header DOM, we can remove this CSS since the width is dynamically handled by flexbox.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes unnecessary CSS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The central area was shrinking based on the top toolbar mode, when it didn't need to.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the CSS that caused the central area to shrink when top toolbar was on.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the site editor
- Toggle on/off the top toolbar
- Central area should remain the same width regardless of setting

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
### Before

https://github.com/WordPress/gutenberg/assets/967608/637583c0-9f7d-4002-a12a-a9c388675620

### After

https://github.com/WordPress/gutenberg/assets/967608/c08acd7a-df13-4597-bcae-81f33626ab2e
