### PR TITLE
Tabs: cleanup and improvements

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `Tabs`: Update sub-components to accept relevant HTML element props ([#55860](https://github.com/WordPress/gutenberg/pull/55860))
 -   `DropdownMenuV2`: Fix radio menu item check icon not rendering correctly in some browsers ([#55964](https://github.com/WordPress/gutenberg/pull/55964))
 -   `DropdownMenuV2`: prevent default when pressing Escape key to close menu ([#55962](https://github.com/WordPress/gutenberg/pull/55962))
+-   `Tabs`: Memoize and expose the component context ([#56224](https://github.com/WordPress/gutenberg/pull/56224)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Experimental
+
+-   `Tabs`: Memoize and expose the component context ([#56224](https://github.com/WordPress/gutenberg/pull/56224)).
+
 ## 25.12.0 (2023-11-16)
 
 ### Bug Fix
@@ -20,7 +24,6 @@
 -   `Tabs`: Update sub-components to accept relevant HTML element props ([#55860](https://github.com/WordPress/gutenberg/pull/55860))
 -   `DropdownMenuV2`: Fix radio menu item check icon not rendering correctly in some browsers ([#55964](https://github.com/WordPress/gutenberg/pull/55964))
 -   `DropdownMenuV2`: prevent default when pressing Escape key to close menu ([#55962](https://github.com/WordPress/gutenberg/pull/55962))
--   `Tabs`: Memoize and expose the component context ([#56224](https://github.com/WordPress/gutenberg/pull/56224)).
 
 ### Enhancements
 

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -172,4 +172,6 @@ function Tabs( {
 Tabs.TabList = TabList;
 Tabs.Tab = Tab;
 Tabs.TabPanel = TabPanel;
+Tabs.Context = TabsContext;
+
 export default Tabs;

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -8,7 +8,7 @@ import * as Ariakit from '@ariakit/react';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useLayoutEffect, useRef } from '@wordpress/element';
+import { useLayoutEffect, useMemo, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -154,8 +154,16 @@ function Tabs( {
 		setSelectedId,
 	] );
 
+	const contextValue = useMemo(
+		() => ( {
+			store,
+			instanceId,
+		} ),
+		[ store, instanceId ]
+	);
+
 	return (
-		<TabsContext.Provider value={ { store, instanceId } }>
+		<TabsContext.Provider value={ contextValue }>
 			{ children }
 		</TabsContext.Provider>
 	);

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -20,6 +20,14 @@ import Button from '../../button';
 const meta: Meta< typeof Tabs > = {
 	title: 'Components (Experimental)/Tabs',
 	component: Tabs,
+	subcomponents: {
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'Tabs.TabList': Tabs.TabList,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'Tabs.Tab': Tabs.Tab,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'Tabs.TabPanel': Tabs.TabPanel,
+	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },

--- a/packages/components/src/tabs/tab.tsx
+++ b/packages/components/src/tabs/tab.tsx
@@ -19,9 +19,7 @@ export const Tab = forwardRef<
 >( function Tab( { children, id, disabled, render, ...otherProps }, ref ) {
 	const context = useTabsContext();
 	if ( ! context ) {
-		warning(
-			'`Tabs.Tab` needs to receive context from a `Tabs` component or a `Tabs.Context.Provider`.'
-		);
+		warning( '`Tabs.Tab` must be wrapped in a `Tabs` component.' );
 		return null;
 	}
 	const { store, instanceId } = context;

--- a/packages/components/src/tabs/tab.tsx
+++ b/packages/components/src/tabs/tab.tsx
@@ -19,7 +19,9 @@ export const Tab = forwardRef<
 >( function Tab( { children, id, disabled, render, ...otherProps }, ref ) {
 	const context = useTabsContext();
 	if ( ! context ) {
-		warning( '`Tabs.TabList` must be wrapped in a `Tabs` component.' );
+		warning(
+			'`Tabs.Tab` needs to receive context from a `Tabs` component or a `Tabs.Context.Provider`.'
+		);
 		return null;
 	}
 	const { store, instanceId } = context;

--- a/packages/components/src/tabs/tab.tsx
+++ b/packages/components/src/tabs/tab.tsx
@@ -2,14 +2,14 @@
  * WordPress dependencies
  */
 
-import { useContext, forwardRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import type { TabProps } from './types';
 import warning from '@wordpress/warning';
-import { TabsContext } from './context';
+import { useTabsContext } from './context';
 import { Tab as StyledTab } from './styles';
 import type { WordPressComponentProps } from '../context';
 
@@ -17,7 +17,7 @@ export const Tab = forwardRef<
 	HTMLButtonElement,
 	WordPressComponentProps< TabProps, 'button', false >
 >( function Tab( { children, id, disabled, render, ...otherProps }, ref ) {
-	const context = useContext( TabsContext );
+	const context = useTabsContext();
 	if ( ! context ) {
 		warning( '`Tabs.TabList` must be wrapped in a `Tabs` component.' );
 		return null;

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -24,7 +24,9 @@ export const TabList = forwardRef<
 >( function TabList( { children, ...otherProps }, ref ) {
 	const context = useTabsContext();
 	if ( ! context ) {
-		warning( '`Tabs.TabList` must be wrapped in a `Tabs` component.' );
+		warning(
+			'`Tabs.TabList` needs to receive context from a `Tabs` component or a `Tabs.Context.Provider`.'
+		);
 		return null;
 	}
 	const { store } = context;

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -24,9 +24,7 @@ export const TabList = forwardRef<
 >( function TabList( { children, ...otherProps }, ref ) {
 	const context = useTabsContext();
 	if ( ! context ) {
-		warning(
-			'`Tabs.TabList` needs to receive context from a `Tabs` component or a `Tabs.Context.Provider`.'
-		);
+		warning( '`Tabs.TabList` must be wrapped in a `Tabs` component.' );
 		return null;
 	}
 	const { store } = context;

--- a/packages/components/src/tabs/tabpanel.tsx
+++ b/packages/components/src/tabs/tabpanel.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 
-import { forwardRef, useContext } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,14 +15,14 @@ import type { TabPanelProps } from './types';
 import { TabPanel as StyledTabPanel } from './styles';
 
 import warning from '@wordpress/warning';
-import { TabsContext } from './context';
+import { useTabsContext } from './context';
 import type { WordPressComponentProps } from '../context';
 
 export const TabPanel = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< TabPanelProps, 'div', false >
 >( function TabPanel( { children, id, focusable = true, ...otherProps }, ref ) {
-	const context = useContext( TabsContext );
+	const context = useTabsContext();
 	if ( ! context ) {
 		warning( '`Tabs.TabPanel` must be wrapped in a `Tabs` component.' );
 		return null;

--- a/packages/components/src/tabs/tabpanel.tsx
+++ b/packages/components/src/tabs/tabpanel.tsx
@@ -24,9 +24,7 @@ export const TabPanel = forwardRef<
 >( function TabPanel( { children, id, focusable = true, ...otherProps }, ref ) {
 	const context = useTabsContext();
 	if ( ! context ) {
-		warning(
-			'`Tabs.TabPanel` needs to receive context from a `Tabs` component or a `Tabs.Context.Provider`.'
-		);
+		warning( '`Tabs.TabPanel` must be wrapped in a `Tabs` component.' );
 		return null;
 	}
 	const { store, instanceId } = context;

--- a/packages/components/src/tabs/tabpanel.tsx
+++ b/packages/components/src/tabs/tabpanel.tsx
@@ -24,7 +24,9 @@ export const TabPanel = forwardRef<
 >( function TabPanel( { children, id, focusable = true, ...otherProps }, ref ) {
 	const context = useTabsContext();
 	if ( ! context ) {
-		warning( '`Tabs.TabPanel` must be wrapped in a `Tabs` component.' );
+		warning(
+			'`Tabs.TabPanel` needs to receive context from a `Tabs` component or a `Tabs.Context.Provider`.'
+		);
 		return null;
 	}
 	const { store, instanceId } = context;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A few small updates to the `Tabs` component family:

1. use `useTabContext()` consistently, instead of sometimes using `useContext()` 
2. memoize the context value
3. expose `Tabs.Context` 
4. add sub-components to Storybook

## Why?
These are items that came up while working on other things. While they could be broken into their own separate PRs, they felt small enough to batch together. More specifically:

**useTabContext()**
No change in behavior here, it just wasn't being used consistently

**Memoize context value**
Was causing unnecessary re-renders.

**Expose `Tabs.Context`**
In some implications involving `slot`/`fills`, it's necessary to wrap subcomponents in an additional context provider. See #55360 for a real-life example. This also meant updating the warning thrown when context is missing to include the possibility of using a `Tabs.Context.Provider`

**Add sub-components to Storybook**
I forgot them initially, but now they can be viewed in the component docs in Storybook.

## Testing Instructions
N/A, other than making sure all the tests pass.
