### PR TITLE
Font Library: remove insecure properties

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -300,7 +300,7 @@ class WP_Font_Family {
 			'version'  => '2',
 			'settings' => array(
 				'typography' => array(
-					'fontFamilies' => array( 
+					'fontFamilies' => array(
 						'custom' => array(
 							$this->data,
 						),
@@ -310,7 +310,7 @@ class WP_Font_Family {
 		);
 		// Creates a new WP_Theme_JSON object with the new fonts to
 		// leverage sanitization and validation.
-		$fonts_json 	= WP_Theme_JSON_Gutenberg::remove_insecure_properties( $fonts_json );
+		$fonts_json     = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $fonts_json );
 		$theme_json     = new WP_Theme_JSON_Gutenberg( $fonts_json );
 		$theme_data     = $theme_json->get_data();
 		$sanitized_font = ! empty( $theme_data['settings']['typography']['fontFamilies'] )

--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -300,12 +300,17 @@ class WP_Font_Family {
 			'version'  => '2',
 			'settings' => array(
 				'typography' => array(
-					'fontFamilies' => array( $this->data ),
+					'fontFamilies' => array( 
+						'custom' => array(
+							$this->data,
+						),
+					),
 				),
 			),
 		);
 		// Creates a new WP_Theme_JSON object with the new fonts to
 		// leverage sanitization and validation.
+		$fonts_json 	= WP_Theme_JSON_Gutenberg::remove_insecure_properties( $fonts_json );
 		$theme_json     = new WP_Theme_JSON_Gutenberg( $fonts_json );
 		$theme_data     = $theme_json->get_data();
 		$sanitized_font = ! empty( $theme_data['settings']['typography']['fontFamilies'] )

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -899,19 +899,19 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_remove_invalid_font_family_settings() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings'  => array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
 					'typography' => array(
 						'fontFamilies' => array(
 							'custom' => array(
 								array(
-									'name' => 'Open Sans',
-									'slug' => 'open-sans',
+									'name'       => 'Open Sans',
+									'slug'       => 'open-sans',
 									'fontFamily' => '"Open Sans", sans-serif</style><script>alert("xss")</script>',
 								),
 								array(
-									'name' => 'Arial',
-									'slug' => 'arial',
+									'name'       => 'Arial',
+									'slug'       => 'arial',
 									'fontFamily' => 'Arial, serif',
 								),
 							),
@@ -923,18 +923,18 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$expected = array(
-			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-			'settings'  => array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
 				'typography' => array(
 					'fontFamilies' => array(
 						'custom' => array(
 							array(
-								'name' => 'Arial',
-								'slug' => 'arial',
+								'name'       => 'Arial',
+								'slug'       => 'arial',
 								'fontFamily' => 'Arial, serif',
 							),
 						),
-					)
+					),
 				),
 			),
 		);

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -896,6 +896,52 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	public function test_remove_invalid_font_family_settings() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings'  => array(
+					'typography' => array(
+						'fontFamilies' => array(
+							'custom' => array(
+								array(
+									'name' => 'Open Sans',
+									'slug' => 'open-sans',
+									'fontFamily' => '"Open Sans", sans-serif</style><script>alert("xss")</script>',
+								),
+								array(
+									'name' => 'Arial',
+									'slug' => 'arial',
+									'fontFamily' => 'Arial, serif',
+								),
+							),
+						),
+					),
+				),
+			),
+			true
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings'  => array(
+				'typography' => array(
+					'fontFamilies' => array(
+						'custom' => array(
+							array(
+								'name' => 'Arial',
+								'slug' => 'arial',
+								'fontFamily' => 'Arial, serif',
+							),
+						),
+					)
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
 	public function test_get_element_class_name_button() {
 		$expected = 'wp-element-button';
 		$actual   = WP_Theme_JSON_Gutenberg::get_element_class_name( 'button' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Leverages the `remove_insecure_properties` method of WP_Theme_JSON class to further validate the CSS saved to the database and output to the client.

The PR also adds a unit test to verify the use case.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently it is possible to include and output non-valid CSS in the font family definition of global styles. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Run the unit tests.
- Ensure fonts still install as expected. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
