### PR TITLE
Site editor: Fix navigation screen actions positioning of children

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -72,6 +72,7 @@
 }
 
 .edit-site-sidebar-navigation-screen__actions {
+	display: flex;
 	flex-shrink: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix an issue where the dropdown in the navigation screen actions was displaying too low, as raised in https://github.com/WordPress/gutenberg/pull/56005#issuecomment-1814656603 by @t-hamano. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Due to the change in #56136, the dropdown used in the navigation screen displays too low (seems to be caused by a `vertical-align: top` rule and that the dropdown toggle is `inline-block` within a wrapper that is set to `block`). The fix in this PR is to set the wrapper to explicitly be `flex`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Set the wrapper to be `display: flex`. I went with this over switching to an `HStack` because we don't want any of the other stuff that comes with `HStack` by default (gaps between elements, 100% width, etc), but just want to ensure that children are arranged horizontally next to each other.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In `trunk` go to to a Navigation menu screen within the site editor browse mode
2. Note that the more menu dropdown appears to be displayed too low
3. Apply this PR, and the positioning should be correct
4. Navigate through the rest of browse mode screens (styles, templates, pages, etc) and ensure the actions area in the header always displays correctly

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="353" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/04eda27d-4096-459f-a9d4-12e031fd8561"> | <img width="355" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/0ffaa874-4698-456a-b9a1-834360d2d7e5"> |