### PR TITLE
Implement partially synced patterns behind an experimental flag

### DIFF
--- a/lib/block-supports/pattern.php
+++ b/lib/block-supports/pattern.php
@@ -8,7 +8,7 @@
 $gutenberg_experiments = get_option( 'gutenberg-experiments' );
 if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $gutenberg_experiments ) ) {
 	/**
-	 * Registers the dynamicContent context for block types that support it.
+	 * Registers the overrides context for block types that support it.
 	 *
 	 * @param WP_Block_Type $block_type Block Type.
 	 */
@@ -20,8 +20,8 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 				$block_type->uses_context = array();
 			}
 
-			if ( ! in_array( 'dynamicContent', $block_type->uses_context, true ) ) {
-				$block_type->uses_context[] = 'dynamicContent';
+			if ( ! in_array( 'overrides', $block_type->uses_context, true ) ) {
+				$block_type->uses_context[] = 'overrides';
 			}
 		}
 	}

--- a/lib/block-supports/pattern.php
+++ b/lib/block-supports/pattern.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Pattern block support flag.
+ *
+ * @package gutenberg
+ */
+
+$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $gutenberg_experiments ) ) {
+	/**
+	 * Registers the dynamicContent context for block types that support it.
+	 *
+	 * @param WP_Block_Type $block_type Block Type.
+	 */
+	function gutenberg_register_pattern_support( $block_type ) {
+		$pattern_support = property_exists( $block_type, 'supports' ) ? _wp_array_get( $block_type->supports, array( '__experimentalConnections' ), false ) : false;
+
+		if ( $pattern_support ) {
+			if ( ! $block_type->uses_context ) {
+				$block_type->uses_context = array();
+			}
+
+			if ( ! in_array( 'dynamicContent', $block_type->uses_context, true ) ) {
+				$block_type->uses_context[] = 'dynamicContent';
+			}
+		}
+	}
+
+	// Register the block support.
+	WP_Block_Supports::get_instance()->register(
+		'pattern',
+		array(
+			'register_attribute' => 'gutenberg_register_pattern_support',
+		)
+	);
+}

--- a/lib/block-supports/pattern.php
+++ b/lib/block-supports/pattern.php
@@ -6,7 +6,7 @@
  */
 
 $gutenberg_experiments = get_option( 'gutenberg-experiments' );
-if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $gutenberg_experiments ) ) {
+if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-partial-syncing', $gutenberg_experiments ) ) {
 	/**
 	 * Registers the overrides context for block types that support it.
 	 *

--- a/lib/block-supports/pattern.php
+++ b/lib/block-supports/pattern.php
@@ -20,8 +20,8 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-partial-sync
 				$block_type->uses_context = array();
 			}
 
-			if ( ! in_array( 'overrides', $block_type->uses_context, true ) ) {
-				$block_type->uses_context[] = 'overrides';
+			if ( ! in_array( 'pattern/overrides', $block_type->uses_context, true ) ) {
+				$block_type->uses_context[] = 'pattern/overrides';
 			}
 		}
 	}

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -132,9 +132,8 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 				continue;
 			}
 
-			// If the source value is not "meta_fields", skip it because the only supported
-			// connection source is meta (custom fields) for now.
-			if ( 'meta_fields' !== $attribute_value['source'] ) {
+			// Skip if the source value is not "meta_fields" or "pattern_attributes".
+			if ( 'meta_fields' !== $attribute_value['source'] && 'pattern_attributes' !== $attribute_value['source'] ) {
 				continue;
 			}
 
@@ -153,6 +152,10 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 				$block_instance,
 				$attribute_value['value']
 			);
+
+			if ( false === $custom_value ) {
+				continue;
+			}
 
 			$tags  = new WP_HTML_Tag_Processor( $block_content );
 			$found = $tags->next_tag(
@@ -181,5 +184,6 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 
 		return $block_content;
 	}
+
 	add_filter( 'render_block', 'gutenberg_render_block_connections', 10, 3 );
 }

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -97,9 +97,11 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 		// Allowlist of blocks that support block connections.
 		// Currently, we only allow the following blocks and attributes:
 		// - Paragraph: content.
+		// - Button: text.
 		// - Image: url.
 		$blocks_attributes_allowlist = array(
 			'core/paragraph' => array( 'content' ),
+			'core/button'    => array( 'text' ),
 			'core/image'     => array( 'url' ),
 		);
 
@@ -142,16 +144,24 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 				continue;
 			}
 
-			// If the attribute does not specify the name of the custom field, skip it.
-			if ( ! isset( $attribute_value['value'] ) ) {
-				continue;
-			}
+			if ( 'pattern_attributes' === $attribute_value['source'] ) {
+				if ( ! _wp_array_get( $block_instance->attributes, array( 'metadata', 'id' ), false ) ) {
+					continue;
+				}
 
-			// Get the content from the connection source.
-			$custom_value = $connection_sources[ $attribute_value['source'] ](
-				$block_instance,
-				$attribute_value['value']
-			);
+				$custom_value = $connection_sources[ $attribute_value['source'] ]( $block_instance );
+			} else {
+				// If the attribute does not specify the name of the custom field, skip it.
+				if ( ! isset( $attribute_value['value'] ) ) {
+					continue;
+				}
+
+				// Get the content from the connection source.
+				$custom_value = $connection_sources[ $attribute_value['source'] ](
+					$block_instance,
+					$attribute_value['value']
+				);
+			}
 
 			if ( false === $custom_value ) {
 				continue;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -82,7 +82,10 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 
 
 $gutenberg_experiments = get_option( 'gutenberg-experiments' );
-if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $gutenberg_experiments ) ) {
+if ( $gutenberg_experiments && (
+	array_key_exists( 'gutenberg-connections', $gutenberg_experiments ) ||
+	array_key_exists( 'gutenberg-pattern-partial-syncing', $gutenberg_experiments )
+) ) {
 	/**
 	 * Renders the block meta attributes.
 	 *
@@ -97,11 +100,9 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 		// Allowlist of blocks that support block connections.
 		// Currently, we only allow the following blocks and attributes:
 		// - Paragraph: content.
-		// - Button: text.
 		// - Image: url.
 		$blocks_attributes_allowlist = array(
 			'core/paragraph' => array( 'content' ),
-			'core/button'    => array( 'text' ),
 			'core/image'     => array( 'url' ),
 		);
 

--- a/lib/experimental/connection-sources/index.php
+++ b/lib/experimental/connection-sources/index.php
@@ -13,6 +13,6 @@ return array(
 		return get_post_meta( $block_instance->context['postId'], $meta_field, true );
 	},
 	'pattern_attributes' => function ( $block_instance, $meta_field ) {
-		return _wp_array_get( $block_instance->context, array( 'dynamicContent', $meta_field ), false );
+		return _wp_array_get( $block_instance->context, array( 'overrides', $meta_field ), false );
 	},
 );

--- a/lib/experimental/connection-sources/index.php
+++ b/lib/experimental/connection-sources/index.php
@@ -14,6 +14,6 @@ return array(
 	},
 	'pattern_attributes' => function ( $block_instance ) {
 		$block_id = $block_instance->attributes['metadata']['id'];
-		return _wp_array_get( $block_instance->context, array( 'overrides', $block_id ), false );
+		return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id ), false );
 	},
 );

--- a/lib/experimental/connection-sources/index.php
+++ b/lib/experimental/connection-sources/index.php
@@ -6,10 +6,13 @@
  */
 
 return array(
-	'name'        => 'meta',
-	'meta_fields' => function ( $block_instance, $meta_field ) {
+	'name'               => 'meta',
+	'meta_fields'        => function ( $block_instance, $meta_field ) {
 		// We should probably also check if the meta field exists but for now it's okay because
 		// if it doesn't, `get_post_meta()` will just return an empty string.
 		return get_post_meta( $block_instance->context['postId'], $meta_field, true );
+	},
+	'pattern_attributes' => function ( $block_instance, $meta_field ) {
+		return _wp_array_get( $block_instance->context, array( 'dynamicContent', $meta_field ), false );
 	},
 );

--- a/lib/experimental/connection-sources/index.php
+++ b/lib/experimental/connection-sources/index.php
@@ -12,7 +12,8 @@ return array(
 		// if it doesn't, `get_post_meta()` will just return an empty string.
 		return get_post_meta( $block_instance->context['postId'], $meta_field, true );
 	},
-	'pattern_attributes' => function ( $block_instance, $meta_field ) {
-		return _wp_array_get( $block_instance->context, array( 'overrides', $meta_field ), false );
+	'pattern_attributes' => function ( $block_instance ) {
+		$block_id = $block_instance->attributes['metadata']['id'];
+		return _wp_array_get( $block_instance->context, array( 'overrides', $block_id ), false );
 	},
 );

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -33,6 +33,10 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalDisableTinymce = true', 'before' );
 	}
+
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-partial-syncing', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalPatternPartialSyncing = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -138,6 +138,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-pattern-partial-syncing',
+		__( 'Synced patterns partial syncing', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test partial syncing of patterns', 'gutenberg' ),
+			'id'    => 'gutenberg-pattern-partial-syncing',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/load.php
+++ b/lib/load.php
@@ -270,6 +270,7 @@ require __DIR__ . '/block-supports/duotone.php';
 require __DIR__ . '/block-supports/shadow.php';
 require __DIR__ . '/block-supports/background.php';
 require __DIR__ . '/block-supports/behaviors.php';
+require __DIR__ . '/block-supports/pattern.php';
 
 // Data views.
 require_once __DIR__ . '/experimental/data-views.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -56046,7 +56046,8 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
-				"@wordpress/url": "file:../url"
+				"@wordpress/url": "file:../url",
+				"nanoid": "^3.3.4"
 			},
 			"engines": {
 				"node": ">=16.0.0"
@@ -70916,7 +70917,8 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
-				"@wordpress/url": "file:../url"
+				"@wordpress/url": "file:../url",
+				"nanoid": "^3.3.4"
 			}
 		},
 		"@wordpress/plugins": {

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { PanelBody, TextControl, SelectControl } from '@wordpress/components';
+import { PanelBody, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -47,71 +47,45 @@ function CustomFieldsControl( props ) {
 	if ( props.name === 'core/paragraph' ) attributeName = 'content';
 	if ( props.name === 'core/image' ) attributeName = 'url';
 
-	const connectionSource =
-		props.attributes?.connections?.attributes?.[ attributeName ]?.source ||
-		'';
-	const connectionValue =
-		props.attributes?.connections?.attributes?.[ attributeName ]?.value ||
-		'';
-
-	function updateConnections( source, value ) {
-		if ( value === '' ) {
-			props.setAttributes( {
-				connections: undefined,
-				placeholder: undefined,
-			} );
-		} else {
-			props.setAttributes( {
-				connections: {
-					attributes: {
-						// The attributeName will be either `content` or `url`.
-						[ attributeName ]: {
-							// Source will be variable, could be post_meta, user_meta, term_meta, etc.
-							// Could even be a custom source like a social media attribute.
-							source,
-							value,
-						},
-					},
-				},
-				placeholder: sprintf(
-					'This content will be replaced on the frontend by the value of "%s" custom field.',
-					value
-				),
-			} );
-		}
-	}
-
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Connections' ) } initialOpen={ true }>
-				<SelectControl
-					label={ __( 'Source' ) }
-					value={ connectionSource }
-					options={ [
-						{
-							label: __( 'None' ),
-							value: '',
-						},
-						{
-							label: __( 'Meta fields' ),
-							value: 'meta_fields',
-						},
-						{
-							label: __( 'Pattern attributes' ),
-							value: 'pattern_attributes',
-						},
-					] }
-					onChange={ ( nextSource ) => {
-						updateConnections( nextSource, connectionValue );
-					} }
-				/>
 				<TextControl
 					__nextHasNoMarginBottom
 					autoComplete="off"
 					label={ __( 'Custom field meta_key' ) }
-					value={ connectionValue }
+					value={
+						props.attributes?.connections?.attributes?.[
+							attributeName
+						]?.value || ''
+					}
 					onChange={ ( nextValue ) => {
-						updateConnections( connectionSource, nextValue );
+						if ( nextValue === '' ) {
+							props.setAttributes( {
+								connections: undefined,
+								[ attributeName ]: undefined,
+								placeholder: undefined,
+							} );
+						} else {
+							props.setAttributes( {
+								connections: {
+									attributes: {
+										// The attributeName will be either `content` or `url`.
+										[ attributeName ]: {
+											// Source will be variable, could be post_meta, user_meta, term_meta, etc.
+											// Could even be a custom source like a social media attribute.
+											source: 'meta_fields',
+											value: nextValue,
+										},
+									},
+								},
+								[ attributeName ]: undefined,
+								placeholder: sprintf(
+									'This content will be replaced on the frontend by the value of "%s" custom field.',
+									nextValue
+								),
+							} );
+						}
 					} }
 				/>
 			</PanelBody>

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -128,12 +128,17 @@ const withCustomFieldsControls = createHigherOrderComponent( ( BlockEdit ) => {
 	};
 }, 'withCustomFieldsControls' );
 
-if ( window.__experimentalConnections ) {
+if (
+	window.__experimentalConnections ||
+	window.__experimentalPatternPartialSyncing
+) {
 	addFilter(
 		'blocks.registerBlockType',
 		'core/editor/connections/attribute',
 		addAttribute
 	);
+}
+if ( window.__experimentalConnections ) {
 	addFilter(
 		'editor.BlockEdit',
 		'core/editor/connections/with-inspector-controls',

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody, TextControl, SelectControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -47,45 +47,71 @@ function CustomFieldsControl( props ) {
 	if ( props.name === 'core/paragraph' ) attributeName = 'content';
 	if ( props.name === 'core/image' ) attributeName = 'url';
 
+	const connectionSource =
+		props.attributes?.connections?.attributes?.[ attributeName ]?.source ||
+		'';
+	const connectionValue =
+		props.attributes?.connections?.attributes?.[ attributeName ]?.value ||
+		'';
+
+	function updateConnections( source, value ) {
+		if ( value === '' ) {
+			props.setAttributes( {
+				connections: undefined,
+				placeholder: undefined,
+			} );
+		} else {
+			props.setAttributes( {
+				connections: {
+					attributes: {
+						// The attributeName will be either `content` or `url`.
+						[ attributeName ]: {
+							// Source will be variable, could be post_meta, user_meta, term_meta, etc.
+							// Could even be a custom source like a social media attribute.
+							source,
+							value,
+						},
+					},
+				},
+				placeholder: sprintf(
+					'This content will be replaced on the frontend by the value of "%s" custom field.',
+					value
+				),
+			} );
+		}
+	}
+
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Connections' ) } initialOpen={ true }>
+				<SelectControl
+					label={ __( 'Source' ) }
+					value={ connectionSource }
+					options={ [
+						{
+							label: __( 'None' ),
+							value: '',
+						},
+						{
+							label: __( 'Meta fields' ),
+							value: 'meta_fields',
+						},
+						{
+							label: __( 'Pattern attributes' ),
+							value: 'pattern_attributes',
+						},
+					] }
+					onChange={ ( nextSource ) => {
+						updateConnections( nextSource, connectionValue );
+					} }
+				/>
 				<TextControl
 					__nextHasNoMarginBottom
 					autoComplete="off"
 					label={ __( 'Custom field meta_key' ) }
-					value={
-						props.attributes?.connections?.attributes?.[
-							attributeName
-						]?.value || ''
-					}
+					value={ connectionValue }
 					onChange={ ( nextValue ) => {
-						if ( nextValue === '' ) {
-							props.setAttributes( {
-								connections: undefined,
-								[ attributeName ]: undefined,
-								placeholder: undefined,
-							} );
-						} else {
-							props.setAttributes( {
-								connections: {
-									attributes: {
-										// The attributeName will be either `content` or `url`.
-										[ attributeName ]: {
-											// Source will be variable, could be post_meta, user_meta, term_meta, etc.
-											// Could even be a custom source like a social media attribute.
-											source: 'meta_fields',
-											value: nextValue,
-										},
-									},
-								},
-								[ attributeName ]: undefined,
-								placeholder: sprintf(
-									'This content will be replaced on the frontend by the value of "%s" custom field.',
-									nextValue
-								),
-							} );
-						}
+						updateConnections( connectionSource, nextValue );
 					} }
 				/>
 			</PanelBody>

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -290,3 +290,11 @@ export function deleteStyleOverride( id ) {
 		id,
 	};
 }
+
+export function syncDerivedBlockAttributes( clientId, attributes ) {
+	return {
+		type: 'SYNC_DERIVED_BLOCK_ATTRIBUTES',
+		clientIds: [ clientId ],
+		attributes,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -283,6 +283,7 @@ const withBlockTree =
 					false
 				);
 				break;
+			case 'SYNC_DERIVED_BLOCK_ATTRIBUTES':
 			case 'UPDATE_BLOCK_ATTRIBUTES': {
 				newState.tree = new Map( newState.tree );
 				action.clientIds.forEach( ( clientId ) => {
@@ -455,6 +456,12 @@ function withPersistentBlockChange( reducer ) {
 
 	return ( state, action ) => {
 		let nextState = reducer( state, action );
+
+		if ( action.type === 'SYNC_DERIVED_BLOCK_ATTRIBUTES' ) {
+			return nextState.isPersistentChange
+				? { ...nextState, isPersistentChange: false }
+				: nextState;
+		}
 
 		const isExplicitPersistentChange =
 			action.type === 'MARK_LAST_CHANGE_AS_PERSISTENT' ||
@@ -860,6 +867,7 @@ export const blocks = pipe(
 				return newState;
 			}
 
+			case 'SYNC_DERIVED_BLOCK_ATTRIBUTES':
 			case 'UPDATE_BLOCK_ATTRIBUTES': {
 				// Avoid a state change if none of the block IDs are known.
 				if ( action.clientIds.every( ( id ) => ! state.get( id ) ) ) {

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -8,14 +8,15 @@ import { symbol as icon } from '@wordpress/icons';
  */
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
-import edit from './edit';
+import editV1 from './v1/edit';
+import editV2 from './edit';
 
 const { name } = metadata;
 
 export { metadata, name };
 
 export const settings = {
-	edit,
+	edit: window.__experimentalConnections ? editV2 : editV1,
 	icon,
 };
 

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	edit: window.__experimentalConnections ? editV2 : editV1,
+	edit: window.__experimentalPatternPartialSyncing ? editV2 : editV1,
 	icon,
 };
 

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -47,13 +47,13 @@ function render_block_core_block( $attributes ) {
 	$content = $wp_embed->autoembed( $content );
 
 	/**
-	 * We set the `dynamicContent` context through the `render_block_context`
+	 * We set the `overrides` context through the `render_block_context`
 	 * filter so that it is available when a pattern's inner blocks are
 	 * rendering via do_blocks given it only receives the inner content.
 	 */
-	if ( isset( $attributes['dynamicContent'] ) ) {
+	if ( isset( $attributes['overrides'] ) ) {
 		$filter_block_context = static function ( $context ) use ( $attributes ) {
-			$context['dynamicContent'] = $attributes['dynamicContent'];
+			$context['overrides'] = $attributes['overrides'];
 			return $context;
 		};
 		add_filter( 'render_block_context', $filter_block_context, 1 );
@@ -62,7 +62,7 @@ function render_block_core_block( $attributes ) {
 	$content = do_blocks( $content );
 	unset( $seen_refs[ $attributes['ref'] ] );
 
-	if ( isset( $attributes['dynamicContent'] ) ) {
+	if ( isset( $attributes['overrides'] ) ) {
 		remove_filter( 'render_block_context', $filter_block_context, 1 );
 	}
 
@@ -85,7 +85,7 @@ add_action( 'init', 'register_block_core_block' );
 $gutenberg_experiments = get_option( 'gutenberg-experiments' );
 if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $gutenberg_experiments ) ) {
 	/**
-	 * Registers the dynamicContent attribute for core/block.
+	 * Registers the overrides attribute for core/block.
 	 *
 	 * @param array  $args       Array of arguments for registering a block type.
 	 * @param string $block_name Block name including namespace.
@@ -96,7 +96,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $guten
 			$args['attributes'] = array_merge(
 				$args['attributes'],
 				array(
-					'dynamicContent' => array(
+					'overrides' => array(
 						'type' => 'object',
 					),
 				)

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -46,7 +46,7 @@ function render_block_core_block( $attributes ) {
 	$content = $wp_embed->run_shortcode( $reusable_block->post_content );
 	$content = $wp_embed->autoembed( $content );
 
-	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	$gutenberg_experiments        = get_option( 'gutenberg-experiments' );
 	$has_partial_synced_overrides = $gutenberg_experiments
 		&& array_key_exists( 'gutenberg-pattern-partial-syncing', $gutenberg_experiments )
 		&& isset( $attributes['overrides'] );

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -52,13 +52,13 @@ function render_block_core_block( $attributes ) {
 		&& isset( $attributes['overrides'] );
 
 	/**
-	 * We set the `overrides` context through the `render_block_context`
+	 * We set the `pattern/overrides` context through the `render_block_context`
 	 * filter so that it is available when a pattern's inner blocks are
 	 * rendering via do_blocks given it only receives the inner content.
 	 */
 	if ( $has_partial_synced_overrides ) {
 		$filter_block_context = static function ( $context ) use ( $attributes ) {
-			$context['overrides'] = $attributes['overrides'];
+			$context['pattern/overrides'] = $attributes['overrides'];
 			return $context;
 		};
 		add_filter( 'render_block_context', $filter_block_context, 1 );

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -83,7 +83,7 @@ function register_block_core_block() {
 add_action( 'init', 'register_block_core_block' );
 
 $gutenberg_experiments = get_option( 'gutenberg-experiments' );
-if ( $gutenberg_experiments && array_key_exists( 'gutenberg-connections', $gutenberg_experiments ) ) {
+if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-partial-syncing', $gutenberg_experiments ) ) {
 	/**
 	 * Registers the overrides attribute for core/block.
 	 *

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -46,12 +46,17 @@ function render_block_core_block( $attributes ) {
 	$content = $wp_embed->run_shortcode( $reusable_block->post_content );
 	$content = $wp_embed->autoembed( $content );
 
+	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	$has_partial_synced_overrides = $gutenberg_experiments
+		&& array_key_exists( 'gutenberg-pattern-partial-syncing', $gutenberg_experiments )
+		&& isset( $attributes['overrides'] );
+
 	/**
 	 * We set the `overrides` context through the `render_block_context`
 	 * filter so that it is available when a pattern's inner blocks are
 	 * rendering via do_blocks given it only receives the inner content.
 	 */
-	if ( isset( $attributes['overrides'] ) ) {
+	if ( $has_partial_synced_overrides ) {
 		$filter_block_context = static function ( $context ) use ( $attributes ) {
 			$context['overrides'] = $attributes['overrides'];
 			return $context;
@@ -62,7 +67,7 @@ function render_block_core_block( $attributes ) {
 	$content = do_blocks( $content );
 	unset( $seen_refs[ $attributes['ref'] ] );
 
-	if ( isset( $attributes['overrides'] ) ) {
+	if ( $has_partial_synced_overrides ) {
 		remove_filter( 'render_block_context', $filter_block_context, 1 );
 	}
 

--- a/packages/block-library/src/block/v1/edit.js
+++ b/packages/block-library/src/block/v1/edit.js
@@ -1,0 +1,163 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useEntityBlockEditor,
+	useEntityProp,
+	useEntityRecord,
+} from '@wordpress/core-data';
+import {
+	Placeholder,
+	Spinner,
+	TextControl,
+	PanelBody,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	useInnerBlocksProps,
+	__experimentalRecursionProvider as RecursionProvider,
+	__experimentalUseHasRecursion as useHasRecursion,
+	InnerBlocks,
+	InspectorControls,
+	useBlockProps,
+	Warning,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { useRef, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useLayoutClasses } = unlock( blockEditorPrivateApis );
+const fullAlignments = [ 'full', 'wide', 'left', 'right' ];
+
+const useInferredLayout = ( blocks, parentLayout ) => {
+	const initialInferredAlignmentRef = useRef();
+
+	return useMemo( () => {
+		// Exit early if the pattern's blocks haven't loaded yet.
+		if ( ! blocks?.length ) {
+			return {};
+		}
+
+		let alignment = initialInferredAlignmentRef.current;
+
+		// Only track the initial alignment so that temporarily removed
+		// alignments can be reapplied.
+		if ( alignment === undefined ) {
+			const isConstrained = parentLayout?.type === 'constrained';
+			const hasFullAlignment = blocks.some( ( block ) =>
+				fullAlignments.includes( block.attributes.align )
+			);
+
+			alignment = isConstrained && hasFullAlignment ? 'full' : null;
+			initialInferredAlignmentRef.current = alignment;
+		}
+
+		const layout = alignment ? parentLayout : undefined;
+
+		return { alignment, layout };
+	}, [ blocks, parentLayout ] );
+};
+
+export default function ReusableBlockEdit( {
+	name,
+	attributes: { ref },
+	__unstableParentLayout: parentLayout,
+} ) {
+	const hasAlreadyRendered = useHasRecursion( ref );
+	const { record, hasResolved } = useEntityRecord(
+		'postType',
+		'wp_block',
+		ref
+	);
+	const isMissing = hasResolved && ! record;
+
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		'wp_block',
+		{ id: ref }
+	);
+
+	const [ title, setTitle ] = useEntityProp(
+		'postType',
+		'wp_block',
+		'title',
+		ref
+	);
+
+	const { alignment, layout } = useInferredLayout( blocks, parentLayout );
+	const layoutClasses = useLayoutClasses( { layout }, name );
+
+	const blockProps = useBlockProps( {
+		className: classnames(
+			'block-library-block__reusable-block-container',
+			layout && layoutClasses,
+			{ [ `align${ alignment }` ]: alignment }
+		),
+	} );
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		value: blocks,
+		layout,
+		onInput,
+		onChange,
+		renderAppender: blocks?.length
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
+	} );
+
+	let children = null;
+
+	if ( hasAlreadyRendered ) {
+		children = (
+			<Warning>
+				{ __( 'Block cannot be rendered inside itself.' ) }
+			</Warning>
+		);
+	}
+
+	if ( isMissing ) {
+		children = (
+			<Warning>
+				{ __( 'Block has been deleted or is unavailable.' ) }
+			</Warning>
+		);
+	}
+
+	if ( ! hasResolved ) {
+		children = (
+			<Placeholder>
+				<Spinner />
+			</Placeholder>
+		);
+	}
+
+	return (
+		<RecursionProvider uniqueId={ ref }>
+			<InspectorControls>
+				<PanelBody>
+					<TextControl
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+				</PanelBody>
+			</InspectorControls>
+			{ children === null ? (
+				<div { ...innerBlocksProps } />
+			) : (
+				<div { ...blockProps }>{ children }</div>
+			) }
+		</RecursionProvider>
+	);
+}

--- a/packages/block-library/src/block/v1/edit.native.js
+++ b/packages/block-library/src/block/v1/edit.native.js
@@ -42,8 +42,8 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import styles from './editor.scss';
-import EditTitle from './edit-title';
+import styles from '../editor.scss';
+import EditTitle from '../edit-title';
 
 export default function ReusableBlockEdit( {
 	attributes: { ref },

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -118,7 +118,8 @@
 				"width": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-button .wp-block-button__link"
+		"__experimentalSelector": ".wp-block-button .wp-block-button__link",
+		"__experimentalConnections": true
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -118,8 +118,7 @@
 				"width": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-button .wp-block-button__link",
-		"__experimentalConnections": true
+		"__experimentalSelector": ".wp-block-button .wp-block-button__link"
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/editor/src/hooks/index.js
+++ b/packages/editor/src/hooks/index.js
@@ -3,3 +3,4 @@
  */
 import './custom-sources-backwards-compatibility';
 import './default-autocompleters';
+import './pattern-partial-syncing';

--- a/packages/editor/src/hooks/pattern-partial-syncing.js
+++ b/packages/editor/src/hooks/pattern-partial-syncing.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { privateApis } from '@wordpress/patterns';
+import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useBlockEditingMode } from '@wordpress/block-editor';
 import { hasBlockSupport } from '@wordpress/blocks';
@@ -18,7 +18,7 @@ const {
 	PartialSyncingControls,
 	PATTERN_TYPES,
 	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
-} = unlock( privateApis );
+} = unlock( patternsPrivateApis );
 
 /**
  * Override the default edit UI to include a new block inspector control for

--- a/packages/editor/src/hooks/pattern-partial-syncing.js
+++ b/packages/editor/src/hooks/pattern-partial-syncing.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { privateApis } from '@wordpress/patterns';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useBlockEditingMode } from '@wordpress/block-editor';
+import { hasBlockSupport } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../store';
+import { unlock } from '../lock-unlock';
+
+const {
+	PartialSyncingControls,
+	PATTERN_TYPES,
+	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
+} = unlock( privateApis );
+
+/**
+ * Override the default edit UI to include a new block inspector control for
+ * assigning a partial syncing controls to supported blocks in the pattern editor.
+ * Currently, only the `core/paragraph` block is supported.
+ *
+ * @param {Component} BlockEdit Original component.
+ *
+ * @return {Component} Wrapped component.
+ */
+const withPartialSyncingControls = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const blockEditingMode = useBlockEditingMode();
+		const hasCustomFieldsSupport = hasBlockSupport(
+			props.name,
+			'__experimentalConnections',
+			false
+		);
+		const isEditingPattern = useSelect(
+			( select ) =>
+				select( editorStore ).getCurrentPostType() ===
+				PATTERN_TYPES.user,
+			[]
+		);
+
+		const shouldShowPartialSyncingControls =
+			hasCustomFieldsSupport &&
+			props.isSelected &&
+			isEditingPattern &&
+			blockEditingMode === 'default' &&
+			Object.keys( PARTIAL_SYNCING_SUPPORTED_BLOCKS ).includes(
+				props.name
+			);
+
+		return (
+			<>
+				<BlockEdit { ...props } />
+				{ shouldShowPartialSyncingControls && (
+					<PartialSyncingControls { ...props } />
+				) }
+			</>
+		);
+	}
+);
+
+if ( window.__experimentalConnections ) {
+	addFilter(
+		'editor.BlockEdit',
+		'core/editor/with-partial-syncing-controls',
+		withPartialSyncingControls
+	);
+}

--- a/packages/editor/src/hooks/pattern-partial-syncing.js
+++ b/packages/editor/src/hooks/pattern-partial-syncing.js
@@ -64,7 +64,7 @@ const withPartialSyncingControls = createHigherOrderComponent(
 	}
 );
 
-if ( window.__experimentalConnections ) {
+if ( window.__experimentalPatternPartialSyncing ) {
 	addFilter(
 		'editor.BlockEdit',
 		'core/editor/with-partial-syncing-controls',

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -44,7 +44,8 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
-		"@wordpress/url": "file:../url"
+		"@wordpress/url": "file:../url",
+		"nanoid": "^3.3.4"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { nanoid } from 'nanoid';
+
+/**
+ * WordPress dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import { BaseControl, CheckboxControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
+
+function PartialSyncingControls( { name, attributes, setAttributes } ) {
+	const syncedAttributes = PARTIAL_SYNCING_SUPPORTED_BLOCKS[ name ];
+
+	function updateConnections( attributeName, isChecked ) {
+		if ( ! isChecked ) {
+			let updatedConnections = {
+				...attributes.connections,
+				attributes: {
+					...attributes.connections?.attributes,
+					[ attributeName ]: undefined,
+				},
+			};
+			if ( Object.keys( updatedConnections.attributes ).length === 1 ) {
+				updatedConnections.attributes = undefined;
+			}
+			if (
+				Object.keys( updatedConnections ).length === 1 &&
+				updateConnections.attributes === undefined
+			) {
+				updatedConnections = undefined;
+			}
+			setAttributes( {
+				connections: updatedConnections,
+			} );
+			return;
+		}
+
+		const updatedConnections = {
+			...attributes.connections,
+			attributes: {
+				...attributes.connections?.attributes,
+				[ attributeName ]: {
+					source: 'pattern_attributes',
+				},
+			},
+		};
+
+		if ( typeof attributes.metadata?.id === 'string' ) {
+			setAttributes( { connections: updatedConnections } );
+			return;
+		}
+
+		const id = nanoid( 6 );
+		setAttributes( {
+			connections: updatedConnections,
+			metadata: {
+				...attributes.metadata,
+				id,
+			},
+		} );
+	}
+
+	return (
+		<InspectorControls group="advanced">
+			<BaseControl __nextHasNoMarginBottom>
+				<BaseControl.VisualLabel>
+					{ __( 'Synced attributes' ) }
+				</BaseControl.VisualLabel>
+				{ Object.entries( syncedAttributes ).map(
+					( [ attributeName, label ] ) => (
+						<CheckboxControl
+							key={ attributeName }
+							__nextHasNoMarginBottom
+							label={ label }
+							checked={
+								attributes.connections?.attributes?.[
+									attributeName
+								]?.source === 'pattern_attributes'
+							}
+							onChange={ ( isChecked ) => {
+								updateConnections( attributeName, isChecked );
+							} }
+						/>
+					)
+				) }
+			</BaseControl>
+		</InspectorControls>
+	);
+}
+
+export default PartialSyncingControls;

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -1,3 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 export const PATTERN_TYPES = {
 	theme: 'pattern',
 	user: 'wp_block',
@@ -13,4 +18,10 @@ export const EXCLUDED_PATTERN_SOURCES = [
 export const PATTERN_SYNC_TYPES = {
 	full: 'fully',
 	unsynced: 'unsynced',
+};
+
+// TODO: This should not be hardcoded. Maybe there should be a config and/or an UI.
+export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
+	'core/paragraph': { content: __( 'Content' ) },
+	'core/button': { text: __( 'Text' ) },
 };

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -23,5 +23,4 @@ export const PATTERN_SYNC_TYPES = {
 // TODO: This should not be hardcoded. Maybe there should be a config and/or an UI.
 export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 	'core/paragraph': { content: __( 'Content' ) },
-	'core/button': { text: __( 'Text' ) },
 };

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -7,12 +7,14 @@ import DuplicatePatternModal from './components/duplicate-pattern-modal';
 import RenamePatternModal from './components/rename-pattern-modal';
 import PatternsMenuItems from './components';
 import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
+import PartialSyncingControls from './components/partial-syncing-controls';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,
 	EXCLUDED_PATTERN_SOURCES,
 	PATTERN_SYNC_TYPES,
+	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
 } from './constants';
 
 export const privateApis = {};
@@ -22,9 +24,11 @@ lock( privateApis, {
 	RenamePatternModal,
 	PatternsMenuItems,
 	RenamePatternCategoryModal,
+	PartialSyncingControls,
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,
 	EXCLUDED_PATTERN_SOURCES,
 	PATTERN_SYNC_TYPES,
+	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
 } );

--- a/test/unit/scripts/resolver.js
+++ b/test/unit/scripts/resolver.js
@@ -24,7 +24,8 @@ module.exports = ( path, options ) => {
 				pkg.name === 'uuid' ||
 				pkg.name === 'react-colorful' ||
 				pkg.name === '@eslint/eslintrc' ||
-				pkg.name === 'expect'
+				pkg.name === 'expect' ||
+				pkg.name === 'nanoid'
 			) {
 				delete pkg.exports;
 				delete pkg.module;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Alternative to https://github.com/WordPress/gutenberg/pull/55807.

This PR also includes #56495, which sets the block id using `nanoid` when the inspector control is checked.

It only supports the `content` attribute for the `core/paragraph` for now. More blocks and attributes will be supported in future PRs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See #53705. The reason to explore this approach is try to avoid monkey-patching `setAttributes` to limit the pattern-related logic inside the scope of the pattern block itself.

In https://github.com/WordPress/gutenberg/pull/55807, we explored the approach of using nested registry to achieve that. That approach has a flaw of assuming only `setAttributes` could alter a block's attributes, but in theory there are more ways to do that (`updateBlock` for instance). The same goes for the "reading" side of the flow, which is more complicated too.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This approach replaces the inner blocks of the pattern block to create an isolated entity that doesn't get saved to the post but has impact over the undo/redo history. We can then derive the `overrides` from the updated blocks and update the pattern block.

Because `setAttributes` internally always creates a new undo level for each different block updates, we have to find a way to ignore some updates so that it doesn't break the undo/redo history. This PR creates a new private action `syncDerivedBlockAttributes` that behaves just the same as `updateBlockAttributes` but completely ignores the undo/redo history.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in #55807.

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/677833/09520aa7-f629-4f7b-ae7e-7e5aed5f345b


