### PR TITLE
Add setting to disable custom content size controls

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -556,6 +556,7 @@ supports: {
     -   `allowVerticalAlignment`: type `boolean`, default value `true`
     -   `allowJustification`: type `boolean`, default value `true`
     -   `allowOrientation`: type `boolean`, default value `true`
+    -   `allowCustomContentSize`: type `boolean`, default value `true`
 
 This value only applies to blocks that are containers for inner blocks. If set to `true` the layout type will be `flow`. For other layout types it's necessary to set the `type` explicitly inside the `default` object.
 
@@ -614,6 +615,13 @@ For the `flex` layout type, determines display of the justification control in t
 -   Default value: `true`
 
 For the `flex` layout type only, determines display of the orientation control in the block toolbar.
+
+### layout.allowCustomContentSize
+
+-   Type: `boolean`
+-   Default value: `true`
+
+For the `constrained` layout type only, determines display of the custom content and wide size controls in the block sidebar.
 
 
 ## multiple

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -556,7 +556,7 @@ supports: {
     -   `allowVerticalAlignment`: type `boolean`, default value `true`
     -   `allowJustification`: type `boolean`, default value `true`
     -   `allowOrientation`: type `boolean`, default value `true`
-    -   `allowCustomContentSize`: type `boolean`, default value `true`
+    -   `allowCustomContentAndWideSize`: type `boolean`, default value `true`
 
 This value only applies to blocks that are containers for inner blocks. If set to `true` the layout type will be `flow`. For other layout types it's necessary to set the `type` explicitly inside the `default` object.
 
@@ -616,7 +616,7 @@ For the `flex` layout type, determines display of the justification control in t
 
 For the `flex` layout type only, determines display of the orientation control in the block toolbar.
 
-### layout.allowCustomContentSize
+### layout.allowCustomContentAndWideSize
 
 -   Type: `boolean`
 -   Default value: `true`

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -129,6 +129,7 @@ Settings related to layout.
 | contentSize | string |  |  |
 | wideSize | string |  |  |
 | allowEditing | boolean | true |  |
+| allowCustomContentSize | boolean | true |  |
 
 ---
 

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -129,7 +129,7 @@ Settings related to layout.
 | contentSize | string |  |  |
 | wideSize | string |  |  |
 | allowEditing | boolean | true |  |
-| allowCustomContentSize | boolean | true |  |
+| allowCustomContentAndWideSize | boolean | true |  |
 
 ---
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -383,9 +383,10 @@ class WP_Theme_JSON_Gutenberg {
 			'minHeight' => null,
 		),
 		'layout'                        => array(
-			'contentSize'  => null,
-			'wideSize'     => null,
-			'allowEditing' => null,
+			'contentSize'            => null,
+			'wideSize'               => null,
+			'allowEditing'           => null,
+			'allowCustomContentSize' => null,
 		),
 		'lightbox'                      => array(
 			'enabled'      => null,

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -383,10 +383,10 @@ class WP_Theme_JSON_Gutenberg {
 			'minHeight' => null,
 		),
 		'layout'                        => array(
-			'contentSize'            => null,
-			'wideSize'               => null,
-			'allowEditing'           => null,
-			'allowCustomContentSize' => null,
+			'contentSize'                   => null,
+			'wideSize'                      => null,
+			'allowEditing'                  => null,
+			'allowCustomContentAndWideSize' => null,
 		),
 		'lightbox'                      => array(
 			'enabled'      => null,

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -136,12 +136,7 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const settings = useBlockSettings( blockName );
 	// Block settings come from theme.json under settings.[blockName].
-	const {
-		layout: {
-			allowEditing: allowEditingSetting,
-			allowCustomContentSize: allowCustomContentSizeSetting,
-		},
-	} = settings;
+	const { layout: layoutSettings } = settings;
 	// Layout comes from block attributes.
 	const { layout } = attributes;
 	const [ defaultThemeLayout ] = useSettings( 'layout' );
@@ -164,9 +159,8 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		{}
 	);
 	const blockSupportAndThemeSettings = {
+		...layoutSettings,
 		...layoutBlockSupport,
-		allowEditing: allowEditingSetting ?? true,
-		allowCustomContentSize: allowCustomContentSizeSetting ?? true,
 	};
 	const {
 		allowSwitching,

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -136,7 +136,12 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const settings = useBlockSettings( blockName );
 	// Block settings come from theme.json under settings.[blockName].
-	const { layout: layoutSettings } = settings;
+	const {
+		layout: {
+			allowEditing: allowEditingSetting,
+			allowCustomContentSize: allowCustomContentSizeSetting,
+		},
+	} = settings;
 	// Layout comes from block attributes.
 	const { layout } = attributes;
 	const [ defaultThemeLayout ] = useSettings( 'layout' );
@@ -159,8 +164,9 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		{}
 	);
 	const blockSupportAndThemeSettings = {
-		...layoutSettings,
 		...layoutBlockSupport,
+		allowEditing: allowEditingSetting ?? true,
+		allowCustomContentSize: allowCustomContentSizeSetting ?? true,
 	};
 	const {
 		allowSwitching,

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -135,10 +135,9 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const settings = useBlockSettings( blockName );
-	const {
-		layout: { allowEditing: allowEditingSetting },
-	} = settings;
-
+	// Block settings come from theme.json under settings.[blockName].
+	const { layout: layoutSettings } = settings;
+	// Layout comes from block attributes.
 	const { layout } = attributes;
 	const [ defaultThemeLayout ] = useSettings( 'layout' );
 	const { themeSupportsLayout } = useSelect( ( select ) => {
@@ -153,17 +152,22 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		return null;
 	}
 
+	// Layout block support comes from the block's block.json.
 	const layoutBlockSupport = getBlockSupport(
 		blockName,
 		layoutBlockSupportKey,
 		{}
 	);
+	const blockSupportAndThemeSettings = {
+		...layoutSettings,
+		...layoutBlockSupport,
+	};
 	const {
 		allowSwitching,
-		allowEditing = allowEditingSetting ?? true,
+		allowEditing = true,
 		allowInheriting = true,
 		default: defaultBlockLayout,
-	} = layoutBlockSupport;
+	} = blockSupportAndThemeSettings;
 
 	if ( ! allowEditing ) {
 		return null;
@@ -260,14 +264,14 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 						<layoutType.inspectorControls
 							layout={ usedLayout }
 							onChange={ onChangeLayout }
-							layoutBlockSupport={ layoutBlockSupport }
+							layoutBlockSupport={ blockSupportAndThemeSettings }
 						/>
 					) }
 					{ constrainedType && displayControlsForLegacyLayouts && (
 						<constrainedType.inspectorControls
 							layout={ usedLayout }
 							onChange={ onChangeLayout }
-							layoutBlockSupport={ layoutBlockSupport }
+							layoutBlockSupport={ blockSupportAndThemeSettings }
 						/>
 					) }
 				</PanelBody>

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -36,7 +36,8 @@ export default {
 		layoutBlockSupport = {},
 	} ) {
 		const { wideSize, contentSize, justifyContent = 'center' } = layout;
-		const { allowJustification = true } = layoutBlockSupport;
+		const { allowJustification = true, allowCustomContentSize = true } =
+			layoutBlockSupport;
 		const onJustificationChange = ( value ) => {
 			onChange( {
 				...layout,
@@ -66,55 +67,59 @@ export default {
 		} );
 		return (
 			<>
-				<div className="block-editor-hooks__layout-controls">
-					<div className="block-editor-hooks__layout-controls-unit">
-						<UnitControl
-							className="block-editor-hooks__layout-controls-unit-input"
-							label={ __( 'Content' ) }
-							labelPosition="top"
-							__unstableInputWidth="80px"
-							value={ contentSize || wideSize || '' }
-							onChange={ ( nextWidth ) => {
-								nextWidth =
-									0 > parseFloat( nextWidth )
-										? '0'
-										: nextWidth;
-								onChange( {
-									...layout,
-									contentSize: nextWidth,
-								} );
-							} }
-							units={ units }
-						/>
-						<Icon icon={ positionCenter } />
-					</div>
-					<div className="block-editor-hooks__layout-controls-unit">
-						<UnitControl
-							className="block-editor-hooks__layout-controls-unit-input"
-							label={ __( 'Wide' ) }
-							labelPosition="top"
-							__unstableInputWidth="80px"
-							value={ wideSize || contentSize || '' }
-							onChange={ ( nextWidth ) => {
-								nextWidth =
-									0 > parseFloat( nextWidth )
-										? '0'
-										: nextWidth;
-								onChange( {
-									...layout,
-									wideSize: nextWidth,
-								} );
-							} }
-							units={ units }
-						/>
-						<Icon icon={ stretchWide } />
-					</div>
-				</div>
-				<p className="block-editor-hooks__layout-controls-helptext">
-					{ __(
-						'Customize the width for all elements that are assigned to the center or wide columns.'
-					) }
-				</p>
+				{ allowCustomContentSize && (
+					<>
+						<div className="block-editor-hooks__layout-controls">
+							<div className="block-editor-hooks__layout-controls-unit">
+								<UnitControl
+									className="block-editor-hooks__layout-controls-unit-input"
+									label={ __( 'Content' ) }
+									labelPosition="top"
+									__unstableInputWidth="80px"
+									value={ contentSize || wideSize || '' }
+									onChange={ ( nextWidth ) => {
+										nextWidth =
+											0 > parseFloat( nextWidth )
+												? '0'
+												: nextWidth;
+										onChange( {
+											...layout,
+											contentSize: nextWidth,
+										} );
+									} }
+									units={ units }
+								/>
+								<Icon icon={ positionCenter } />
+							</div>
+							<div className="block-editor-hooks__layout-controls-unit">
+								<UnitControl
+									className="block-editor-hooks__layout-controls-unit-input"
+									label={ __( 'Wide' ) }
+									labelPosition="top"
+									__unstableInputWidth="80px"
+									value={ wideSize || contentSize || '' }
+									onChange={ ( nextWidth ) => {
+										nextWidth =
+											0 > parseFloat( nextWidth )
+												? '0'
+												: nextWidth;
+										onChange( {
+											...layout,
+											wideSize: nextWidth,
+										} );
+									} }
+									units={ units }
+								/>
+								<Icon icon={ stretchWide } />
+							</div>
+						</div>
+						<p className="block-editor-hooks__layout-controls-helptext">
+							{ __(
+								'Customize the width for all elements that are assigned to the center or wide columns.'
+							) }
+						</p>
+					</>
+				) }
 				{ allowJustification && (
 					<ToggleGroupControl
 						__nextHasNoMarginBottom

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -36,8 +36,10 @@ export default {
 		layoutBlockSupport = {},
 	} ) {
 		const { wideSize, contentSize, justifyContent = 'center' } = layout;
-		const { allowJustification = true, allowCustomContentSize = true } =
-			layoutBlockSupport;
+		const {
+			allowJustification = true,
+			allowCustomContentAndWideSize = true,
+		} = layoutBlockSupport;
 		const onJustificationChange = ( value ) => {
 			onChange( {
 				...layout,
@@ -67,7 +69,7 @@ export default {
 		} );
 		return (
 			<>
-				{ allowCustomContentSize && (
+				{ allowCustomContentAndWideSize && (
 					<>
 						<div className="block-editor-hooks__layout-controls">
 							<div className="block-editor-hooks__layout-controls-unit">

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -301,7 +301,7 @@
 							"type": "boolean",
 							"default": true
 						},
-						"allowCustomContentSize": {
+						"allowCustomContentAndWideSize": {
 							"description": "Enable or disable the custom content and wide size controls.",
 							"type": "boolean",
 							"default": true

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -300,6 +300,11 @@
 							"description": "Disable the layout UI controls.",
 							"type": "boolean",
 							"default": true
+						},
+						"allowCustomContentSize": {
+							"description": "Enable or disable the custom content and wide size controls.",
+							"type": "boolean",
+							"default": true
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Similar to the setting that allows disabling layout controls in #53378, this allows only the content and wide size controls for constrained layout to be disabled from theme.json, globally or at a per-block level (note that disabling globally only affects the controls displayed in the block sidebar, not the ones under global styles > layout)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In theme.json under settings, add the following:
```
"blocks": {
	"core/group": {
		"layout": {
			"allowCustomContentAndWideSize": false
		}
	}
}
```
2. Check that the Group block controls don't show custom content/wide size inputs:

<img width="281" alt="Screenshot 2023-11-17 at 3 24 09 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/5f53f4dc-b367-4109-9d42-818864c19205">
