### PR TITLE
Dataview: media view

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -17,11 +17,13 @@ import Filters from './filters';
 import Search from './search';
 import { ViewGrid } from './view-grid';
 import { ViewSideBySide } from './view-side-by-side';
+import { ViewMedia } from './view-media';
 
 // To do: convert to view type registry.
 export const viewTypeSupportsMap = {
 	list: {},
 	grid: {},
+	'media-grid': {},
 	'side-by-side': {
 		preview: true,
 	},
@@ -31,6 +33,7 @@ const viewTypeMap = {
 	list: ViewList,
 	grid: ViewGrid,
 	'side-by-side': ViewSideBySide,
+	'media-grid': ViewMedia,
 };
 
 export default function DataViews( {

--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -43,6 +43,10 @@ const availableViews = [
 		id: 'side-by-side',
 		label: __( 'Side by side' ),
 	},
+	{
+		id: 'media-grid',
+		label: __( 'Grid' ),
+	},
 ];
 
 function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {

--- a/packages/edit-site/src/components/dataviews/view-media.js
+++ b/packages/edit-site/src/components/dataviews/view-media.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalGrid as Grid,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	FlexBlock,
+	Placeholder,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import ItemActions from './item-actions';
+
+export function ViewMedia( { data, fields, view, actions } ) {
+	const visibleFields = fields.filter(
+		( field ) =>
+			! view.hiddenFields.includes( field.id ) &&
+			field.id !== view.layout.mediaField
+	);
+	console.log( 'data, fields, view, actions', data, fields, view, actions );
+	return (
+		<Grid gap={ 8 } columns={ 2 } alignment="top">
+			{ data.map( ( item, index ) => {
+				return (
+					<VStack key={ index }>
+						<div className="dataviews-view-grid__media">
+
+						</div>
+
+						<HStack justify="space-between" alignment="top">
+							<FlexBlock>
+								<VStack>
+									{ visibleFields.map( ( field ) => (
+										<div key={ field.id }>
+											{ field.render( { item, view } ) }
+										</div>
+									) ) }
+								</VStack>
+							</FlexBlock>
+							<FlexBlock>
+								<ItemActions
+									item={ item }
+									actions={ actions }
+								/>
+							</FlexBlock>
+						</HStack>
+					</VStack>
+				);
+			} ) }
+		</Grid>
+	);
+}

--- a/packages/edit-site/src/components/dataviews/view-media.js
+++ b/packages/edit-site/src/components/dataviews/view-media.js
@@ -27,7 +27,7 @@ export function ViewMedia( { data, fields, view, actions } ) {
 				return (
 					<VStack key={ index }>
 						<div className="dataviews-view-grid__media">
-
+							{ /* featured image for files, images for image */ }
 						</div>
 
 						<HStack justify="space-between" alignment="top">

--- a/packages/edit-site/src/components/dataviews/view-media.js
+++ b/packages/edit-site/src/components/dataviews/view-media.js
@@ -6,7 +6,6 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	FlexBlock,
-	Placeholder,
 } from '@wordpress/components';
 
 /**
@@ -20,33 +19,25 @@ export function ViewMedia( { data, fields, view, actions } ) {
 			! view.hiddenFields.includes( field.id ) &&
 			field.id !== view.layout.mediaField
 	);
-	console.log( 'data, fields, view, actions', data, fields, view, actions );
 	return (
-		<Grid gap={ 8 } columns={ 2 } alignment="top">
+		<Grid gap={ 8 } columns={ 3 } alignment="top">
 			{ data.map( ( item, index ) => {
 				return (
-					<VStack key={ index }>
-						<div className="dataviews-view-grid__media">
-							{ /* featured image for files, images for image */ }
-						</div>
-
-						<HStack justify="space-between" alignment="top">
-							<FlexBlock>
-								<VStack>
-									{ visibleFields.map( ( field ) => (
-										<div key={ field.id }>
-											{ field.render( { item, view } ) }
-										</div>
-									) ) }
-								</VStack>
-							</FlexBlock>
-							<FlexBlock>
-								<ItemActions
-									item={ item }
-									actions={ actions }
-								/>
-							</FlexBlock>
-						</HStack>
+					<VStack
+						key={ index }
+						justify="space-between"
+						alignment="top"
+						className="edit-site-dataview-view-media-item"
+					>
+						{ visibleFields.map( ( field ) => (
+							<div key={ field.id }>
+								{ field.render( { item, view } ) }
+							</div>
+						) ) }
+						<ItemActions
+							item={ item }
+							actions={ actions }
+						/>
 					</VStack>
 				);
 			} ) }

--- a/packages/edit-site/src/components/page-main/index.js
+++ b/packages/edit-site/src/components/page-main/index.js
@@ -11,6 +11,7 @@ import PageTemplateParts from '../page-template-parts';
 import PageTemplates from '../page-templates';
 import DataviewsTemplates from '../page-templates/dataviews-templates';
 import PagePages from '../page-pages';
+import PageMedia from '../page-media';
 import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
@@ -20,17 +21,27 @@ export default function PageMain() {
 		params: { path },
 	} = useLocation();
 
+	if ( path === '/media/all' ) {
+		return <PageMedia />;
+	}
+
 	if ( path === '/wp_template/all' ) {
 		return window?.__experimentalAdminViews ? (
 			<DataviewsTemplates />
 		) : (
 			<PageTemplates />
 		);
-	} else if ( path === '/wp_template_part/all' ) {
+	}
+
+	if ( path === '/wp_template_part/all' ) {
 		return <PageTemplateParts />;
-	} else if ( path === '/patterns' ) {
+	}
+
+	if ( path === '/patterns' ) {
 		return <PagePatterns />;
-	} else if ( window?.__experimentalAdminViews && path === '/pages' ) {
+	}
+
+	if ( window?.__experimentalAdminViews && path === '/pages' ) {
 		return <PagePages />;
 	}
 

--- a/packages/edit-site/src/components/page-media/index.js
+++ b/packages/edit-site/src/components/page-media/index.js
@@ -1,0 +1,203 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Icon,
+	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEntityRecords } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useState, useMemo, useCallback } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import Page from '../page';
+import { DataViews } from '../dataviews';
+import { useAddedBy, AvatarImage } from '../list/added-by';
+
+const EMPTY_ARRAY = [];
+
+const DEFAULT_VIEW = {
+	type: 'list',
+	search: '',
+	page: 1,
+	perPage: 20,
+	// All fields are visible by default, so it's
+	// better to keep track of the hidden ones.
+	hiddenFields: [],
+	layout: {},
+};
+
+function AuthorField( { item } ) {
+	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
+	return (
+		<HStack alignment="left">
+			{ imageUrl ? (
+				<AvatarImage imageUrl={ imageUrl } />
+			) : (
+				<div className="edit-site-list-added-by__icon">
+					<Icon icon={ icon } />
+				</div>
+			) }
+			<span>{ text }</span>
+		</HStack>
+	);
+}
+
+export default function PageMedia() {
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const { records: attachments, isResolving: isLoadingData } =
+		useEntityRecords( 'root', 'media', {
+			per_page: -1,
+		} );
+
+	const mediaItems = useMemo( () => {
+		if ( ! attachments ) {
+			return EMPTY_ARRAY;
+		}
+		return attachments.map( ( item ) => ( {
+			title: item.title?.rendered || item.slug || __( '(no title)' ),
+			type: item.media_type,
+			alt: item.alt_text,
+			thumbnail: item.media_details.sizes.thumbnail.source_url,
+			filesize: item?.media_details?.filesize,
+			author: item?.author,
+		} ) );
+	}, [ attachments ] );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'title',
+				header: __( 'Media item' ),
+				getValue: ( { item } ) => item.title,
+				render: ( { item } ) => (
+					<HStack spacing={ 2 } justify="flex-start">
+						<img
+							src={ item.thumbnail }
+							alt={ item.alt }
+							style={ {
+								maxHeight: '80px',
+							} }
+						/>
+						<Heading as="h3" level={ 5 }>
+							{ decodeEntities( item.title ) }
+						</Heading>
+					</HStack>
+				),
+				maxWidth: 400,
+				enableHiding: false,
+			},
+			{
+				id: 'type',
+				header: __( 'Type' ),
+				getValue: ( { item } ) => item.type,
+				render: ( { item } ) => item.type,
+			},
+			{
+				id: 'filesize',
+				header: __( 'Filesize' ),
+				getValue: ( { item } ) => item?.filesize,
+				render: ( { item } ) =>
+					`${ Math.round( item?.filesize / 1000 ) } kb`,
+			},
+			{
+				id: 'author',
+				header: __( 'Author' ),
+				getValue: ( { item } ) => item.author,
+				render: ( { item } ) => <AuthorField item={ item } />,
+			},
+		],
+		[]
+	);
+	const { paginationInfo, shownTemplates } = useMemo( () => {
+		if ( ! attachments ) {
+			return {
+				shownTemplates: EMPTY_ARRAY,
+				paginationInfo: { totalItems: 0, totalPages: 0 },
+			};
+		}
+		let filteredAttachments = [ ...mediaItems ];
+		// Handle global search.
+		if ( view.search ) {
+			filteredAttachments = filteredAttachments.filter( ( item ) => {
+				return (
+					item.title.includes( view.search ) ||
+					item.description.includes( view.search )
+				);
+			} );
+		}
+		// Handle sorting.
+		// TODO: Explore how this can be more dynamic..
+		if ( view.sort ) {
+			if ( view.sort.direction === 'asc' ) {
+				filteredAttachments.sort( ( a, b ) =>
+					// eslint-disable-next-line no-nested-ternary
+					a[ view.sort.field ] > b[ view.sort.field ]
+						? 1
+						: a[ view.sort.field ] < b[ view.sort.field ]
+						? -1
+						: 0
+				);
+			} else {
+				filteredAttachments.sort( ( a, b ) =>
+					// eslint-disable-next-line no-nested-ternary
+					a[ view.sort.field ] < b[ view.sort.field ]
+						? 1
+						: a[ view.sort.field ] > b[ view.sort.field ]
+						? -1
+						: 0
+				);
+			}
+		}
+
+		// Handle pagination.
+		const start = ( view.page - 1 ) * view.perPage;
+		const totalItems = filteredAttachments?.length || 0;
+		filteredAttachments = filteredAttachments?.slice(
+			start,
+			start + view.perPage
+		);
+		return {
+			shownTemplates: filteredAttachments,
+			paginationInfo: {
+				totalItems,
+				totalPages: Math.ceil( totalItems / view.perPage ),
+			},
+		};
+	}, [ mediaItems, view ] );
+
+	const onChangeView = useCallback(
+		( viewUpdater ) => {
+			const updatedView =
+				typeof viewUpdater === 'function'
+					? viewUpdater( view )
+					: viewUpdater;
+			setView( updatedView );
+		},
+		[ view, setView ]
+	);
+	return (
+		<Page
+			title={ __( 'Media' ) }
+			/*actions={} Upload flow */
+		>
+			<DataViews
+				// paginationInfo: totalItems and totalPages are required
+				paginationInfo={ paginationInfo }
+				actions={ [] }
+				// onChangeView: required
+				onChangeView={ onChangeView }
+				// data: must be []
+				data={ shownTemplates }
+				// fields: required
+				fields={ fields }
+				isLoading={ isLoadingData }
+				view={ view }
+				supportedLayouts={ [ 'list', 'grid' ] }
+			/>
+		</Page>
+	);
+}

--- a/packages/edit-site/src/components/page-media/index.js
+++ b/packages/edit-site/src/components/page-media/index.js
@@ -61,7 +61,7 @@ export default function PageMedia() {
 			title: item.title?.rendered || item.slug || __( '(no title)' ),
 			type: item.media_type,
 			alt: item.alt_text,
-			thumbnail: item.media_details.sizes.thumbnail.source_url,
+			thumbnail: item?.media_details?.sizes?.thumbnail?.source_url,
 			filesize: item?.media_details?.filesize,
 			author: item?.author,
 		} ) );

--- a/packages/edit-site/src/components/page-media/sidebar-content.js
+++ b/packages/edit-site/src/components/page-media/sidebar-content.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import { media, video, image, audio, pages } from '@wordpress/icons';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+const { useLocation } = unlock( routerPrivateApis );
+import DataViewItem from '../sidebar-dataviews/dataview-item';
+
+const PATH_TO_TYPE = {
+	'/media/all': 'media',
+};
+
+export default function MediaSidebarContent() {
+	const {
+		params: { path, activeView = 'all', isCustom = 'false' },
+	} = useLocation();
+	if ( ! path || ! PATH_TO_TYPE[ path ] ) {
+		return null;
+	}
+
+	return (
+		<>
+			<ItemGroup>
+				<DataViewItem
+					key="image"
+					slug="image"
+					title="Images"
+					icon={ image }
+					type="image"
+					isActive={ isCustom === 'false' && 'image' === activeView }
+					isCustom="false"
+				/>
+				<DataViewItem
+					key="video"
+					slug="video"
+					title="Videos"
+					icon={ video }
+					type="video"
+					isActive={ isCustom === 'false' && 'video' === activeView }
+					isCustom="false"
+				/>
+				<DataViewItem
+					key="audio"
+					slug="audio"
+					title="Audio"
+					icon={ audio }
+					type="audio"
+					isActive={ isCustom === 'false' && 'audio' === activeView }
+					isCustom="false"
+				/>
+			</ItemGroup>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/page-media/style.scss
+++ b/packages/edit-site/src/components/page-media/style.scss
@@ -1,0 +1,20 @@
+.edit-site-page-media {
+
+	.is-view-list img,
+	.is-view-list video {
+		width: 80px;
+	}
+	.is-view-media-grid {
+		text-align: center;
+		video,
+		img {
+			width: 300px;
+		}
+	}
+}
+
+.edit-site-dataview-view-media-item {
+	padding: 10px;
+	background-color: #f8f7f7;
+}
+

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -7,7 +7,14 @@ import {
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { layout, symbol, navigation, styles, page } from '@wordpress/icons';
+import {
+	layout,
+	media,
+	symbol,
+	navigation,
+	styles,
+	page,
+} from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 
 import { useEffect } from '@wordpress/element';
@@ -82,6 +89,14 @@ export default function SidebarNavigationScreenMain() {
 							icon={ symbol }
 						>
 							{ __( 'Patterns' ) }
+						</NavigatorButton>
+						<NavigatorButton
+							as={ SidebarNavigationItem }
+							path="/media/all"
+							withChevron
+							icon={ media }
+						>
+							{ __( 'Media' ) }
 						</NavigatorButton>
 					</ItemGroup>
 					<TemplatePartHint />

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -12,12 +12,17 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import { store as editSiteStore } from '../../store';
 import {
+	ATTACHMENT_POST_TYPE,
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 
 const config = {
+	[ ATTACHMENT_POST_TYPE ]: {
+		title: __( 'Media' ),
+		description: __( 'Media, media, media!' ),
+	},
 	[ TEMPLATE_POST_TYPE ]: {
 		title: __( 'All templates' ),
 		description: __(

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -12,17 +12,12 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import { store as editSiteStore } from '../../store';
 import {
-	ATTACHMENT_POST_TYPE,
 	TEMPLATE_POST_TYPE,
 	TEMPLATE_PART_POST_TYPE,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 
 const config = {
-	[ ATTACHMENT_POST_TYPE ]: {
-		title: __( 'Media' ),
-		description: __( 'Media, media, media!' ),
-	},
 	[ TEMPLATE_POST_TYPE ]: {
 		title: __( 'All templates' ),
 		description: __(

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -30,6 +30,7 @@ import SidebarNavigationScreenPages from '../sidebar-navigation-screen-pages';
 import SidebarNavigationScreenPage from '../sidebar-navigation-screen-page';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import DataViewsSidebarContent from '../sidebar-dataviews';
+import MediaSidebarContent from '../page-media/sidebar-content';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -71,7 +72,7 @@ function SidebarScreens() {
 			<NavigatorScreen path="/patterns">
 				<SidebarNavigationScreenPatterns />
 			</NavigatorScreen>
-			<NavigatorScreen path="/:postType(wp_template|wp_template_part|media)/all">
+			<NavigatorScreen path="/:postType(wp_template|wp_template_part)/all">
 				<SidebarNavigationScreenTemplatesBrowse />
 			</NavigatorScreen>
 			<NavigatorScreen path="/:postType(wp_template_part|wp_block)/:postId">
@@ -79,6 +80,13 @@ function SidebarScreens() {
 			</NavigatorScreen>
 			<NavigatorScreen path="/:postType(wp_template)/:postId">
 				<SidebarNavigationScreenTemplate />
+			</NavigatorScreen>
+			<NavigatorScreen path="/media/all">
+				<SidebarNavigationScreen
+					title={ __( 'Media' ) }
+					backPath="/"
+					content={ <MediaSidebarContent /> }
+				/>
 			</NavigatorScreen>
 		</>
 	);

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -71,7 +71,7 @@ function SidebarScreens() {
 			<NavigatorScreen path="/patterns">
 				<SidebarNavigationScreenPatterns />
 			</NavigatorScreen>
-			<NavigatorScreen path="/:postType(wp_template|wp_template_part)/all">
+			<NavigatorScreen path="/:postType(wp_template|wp_template_part|media)/all">
 				<SidebarNavigationScreenTemplatesBrowse />
 			</NavigatorScreen>
 			<NavigatorScreen path="/:postType(wp_template_part|wp_block)/:postId">

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -48,6 +48,7 @@
 @import "./components/resizable-frame/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";
 @import "./components/global-styles/font-library-modal/style.scss";
+@import "./components/page-media/style.scss";
 
 body.js #wpadminbar {
 	display: none;

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -15,6 +15,7 @@ export const NAVIGATION_POST_TYPE = 'wp_navigation';
 // Templates.
 export const TEMPLATE_POST_TYPE = 'wp_template';
 export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
+export const ATTACHMENT_POST_TYPE = 'media';
 export const TEMPLATE_ORIGINS = {
 	custom: 'custom',
 	theme: 'theme',

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -14,9 +14,12 @@ export default function getIsListPage(
 	isMobileViewport
 ) {
 	return (
-		[ '/wp_template/all', '/wp_template_part/all', '/pages' ].includes(
-			path
-		) ||
+		[
+			'/wp_template/all',
+			'/wp_template_part/all',
+			'/pages',
+			'/media/all',
+		].includes( path ) ||
 		( path === '/patterns' &&
 			// Don't treat "/patterns" without categoryType and categoryId as a
 			// list page in mobile because the sidebar covers the whole page.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is an exploration to see how we can work with the current state of data views to display media items.

Just setting up so far:


https://github.com/WordPress/gutenberg/assets/6458278/c57d7651-c4a3-4e3d-8a63-3fced4437530



#### Notes

- what about a generic asc/desc sorting function in the dataviews component? packages/edit-site/src/components/dataviews
- better to massage incoming post collections, especially to make sorting by nested values easier
- grid view is build for posts it seems. no matter the point of this pr is to introduce a media view
- Dropzone around all views to upload media. Probably needs placeholder in each view for temporary files
- There also needs to be a single-item view.
- How to bake image editing in (in the single item view only?)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Related
- https://github.com/WordPress/gutenberg/pull/53788
- https://github.com/WordPress/gutenberg/issues/55238