### PR TITLE
Extract a PostPanelRow component from the different sidebar panels

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-pending-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-pending-status/index.js
@@ -1,18 +1,25 @@
 /**
  * WordPress dependencies
  */
-import { PanelRow } from '@wordpress/components';
 import {
 	PostPendingStatus as PostPendingStatusForm,
 	PostPendingStatusCheck,
+	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../../lock-unlock';
+
+const { PostPanelRow } = unlock( editorPrivateApis );
 
 export function PostPendingStatus() {
 	return (
 		<PostPendingStatusCheck>
-			<PanelRow>
+			<PostPanelRow>
 				<PostPendingStatusForm />
-			</PanelRow>
+			</PostPanelRow>
 		</PostPendingStatusCheck>
 	);
 }

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -64,12 +64,12 @@ export default function PostStatus() {
 						<PostSchedulePanel />
 						<PostTemplate />
 						<PostURLPanel />
+						<PostSyncStatus />
 						<PostSticky />
 						<PostPendingStatus />
 						<PostFormat />
 						<PostSlug />
 						<PostAuthor />
-						<PostSyncStatus />
 						{ fills }
 						<HStack
 							style={ {

--- a/packages/edit-post/src/components/sidebar/post-sticky/index.js
+++ b/packages/edit-post/src/components/sidebar/post-sticky/index.js
@@ -1,18 +1,25 @@
 /**
  * WordPress dependencies
  */
-import { PanelRow } from '@wordpress/components';
 import {
 	PostSticky as PostStickyForm,
 	PostStickyCheck,
+	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../../lock-unlock';
+
+const { PostPanelRow } = unlock( editorPrivateApis );
 
 export function PostSticky() {
 	return (
 		<PostStickyCheck>
-			<PanelRow>
+			<PostPanelRow>
 				<PostStickyForm />
-			</PanelRow>
+			</PostPanelRow>
 		</PostStickyCheck>
 	);
 }

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -2,10 +2,13 @@
  * WordPress dependencies
  */
 import { useState, useMemo } from '@wordpress/element';
-import { PanelRow, Dropdown, Button } from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
+import {
+	store as editorStore,
+	privateApis as editorPrivateApis,
+} from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -13,6 +16,9 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import PostTemplateForm from './form';
 import { store as editPostStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
+
+const { PostPanelRow } = unlock( editorPrivateApis );
 
 export default function PostTemplate() {
 	// Use internal state instead of a ref to make sure that the component
@@ -53,11 +59,9 @@ export default function PostTemplate() {
 	}
 
 	return (
-		<PanelRow className="edit-post-post-template" ref={ setPopoverAnchor }>
-			<span>{ __( 'Template' ) }</span>
+		<PostPanelRow label={ __( 'Template' ) } ref={ setPopoverAnchor }>
 			<Dropdown
 				popoverProps={ popoverProps }
-				className="edit-post-post-template__dropdown"
 				contentClassName="edit-post-post-template__dialog"
 				focusOnMount
 				renderToggle={ ( { isOpen, onToggle } ) => (
@@ -70,7 +74,7 @@ export default function PostTemplate() {
 					<PostTemplateForm onClose={ onClose } />
 				) }
 			/>
-		</PanelRow>
+		</PostPanelRow>
 	);
 }
 

--- a/packages/edit-post/src/components/sidebar/post-template/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-template/style.scss
@@ -1,18 +1,3 @@
-.edit-post-post-template {
-	width: 100%;
-	justify-content: flex-start;
-
-	span {
-		display: block;
-		width: 30%;
-		margin-right: 8px;
-	}
-}
-
-.edit-post-post-template__dropdown {
-	max-width: 55%;
-}
-
 .components-button.edit-post-post-template__toggle {
 	display: inline-block;
 	width: 100%;

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -2,14 +2,22 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { PanelRow, Dropdown, Button } from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import {
 	PostVisibility as PostVisibilityForm,
 	PostVisibilityLabel,
 	PostVisibilityCheck,
 	usePostVisibilityLabel,
+	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import { useMemo, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../../lock-unlock';
+
+const { PostPanelRow } = unlock( editorPrivateApis );
 
 export function PostVisibility() {
 	// Use internal state instead of a ref to make sure that the component
@@ -29,11 +37,10 @@ export function PostVisibility() {
 	return (
 		<PostVisibilityCheck
 			render={ ( { canEdit } ) => (
-				<PanelRow
+				<PostPanelRow
+					label={ __( 'Visibility' ) }
 					ref={ setPopoverAnchor }
-					className="edit-post-post-visibility"
 				>
-					<span>{ __( 'Visibility' ) }</span>
 					{ ! canEdit && (
 						<span>
 							<PostVisibilityLabel />
@@ -55,7 +62,7 @@ export function PostVisibility() {
 							) }
 						/>
 					) }
-				</PanelRow>
+				</PostPanelRow>
 			) }
 		/>
 	);

--- a/packages/edit-post/src/components/sidebar/post-visibility/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-visibility/style.scss
@@ -1,14 +1,3 @@
-.edit-post-post-visibility {
-	width: 100%;
-	justify-content: flex-start;
-
-	span {
-		display: block;
-		width: 30%;
-		margin-right: 8px;
-	}
-}
-
 .edit-post-post-visibility__dialog .editor-post-visibility {
 	// sidebar width - popover padding - form margin
 	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -3,17 +3,12 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import {
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
-	__experimentalHStack as HStack,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { check } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -23,6 +18,8 @@ import SwapTemplateButton from './swap-template-button';
 import ResetDefaultTemplate from './reset-default-template';
 import { unlock } from '../../../lock-unlock';
 import { PAGE_CONTENT_BLOCK_TYPES } from '../../../utils/constants';
+
+const { PostPanelRow } = unlock( editorPrivateApis );
 
 const POPOVER_PROPS = {
 	className: 'edit-site-page-panels-edit-template__dropdown',
@@ -71,10 +68,7 @@ export default function EditTemplate() {
 	}
 
 	return (
-		<HStack className="edit-site-summary-field">
-			<Text className="edit-site-summary-field__label">
-				{ __( 'Template' ) }
-			</Text>
+		<PostPanelRow label={ __( 'Template' ) }>
 			<DropdownMenu
 				popoverProps={ POPOVER_PROPS }
 				focusOnMount
@@ -122,6 +116,6 @@ export default function EditTemplate() {
 					</>
 				) }
 			</DropdownMenu>
-		</HStack>
+		</PostPanelRow>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/page-status.js
@@ -6,7 +6,6 @@ import {
 	ToggleControl,
 	Dropdown,
 	__experimentalText as Text,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	TextControl,
 	RadioControl,
@@ -19,11 +18,15 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 import { useInstanceId } from '@wordpress/compose';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import StatusLabel from '../../sidebar-navigation-screen-page/status-label';
+import { unlock } from '../../../lock-unlock';
+
+const { PostPanelRow } = unlock( editorPrivateApis );
 
 const STATUS_OPTIONS = [
 	{
@@ -159,10 +162,7 @@ export default function PageStatus( {
 	};
 
 	return (
-		<HStack className="edit-site-summary-field">
-			<Text className="edit-site-summary-field__label">
-				{ __( 'Status' ) }
-			</Text>
+		<PostPanelRow label={ __( 'Status' ) }>
 			<Dropdown
 				contentClassName="edit-site-change-status__content"
 				popoverProps={ popoverProps }
@@ -244,6 +244,6 @@ export default function PageStatus( {
 					</>
 				) }
 			/>
-		</HStack>
+		</PostPanelRow>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/style.scss
@@ -59,25 +59,15 @@
 	}
 }
 
-.edit-site-summary-field {
-	.components-dropdown {
-		width: 70%;
-	}
+.edit-site-summary-field__trigger {
+	max-width: 100%;
 
-	.edit-site-summary-field__trigger {
-		max-width: 100%;
-
-		// Truncate
-		display: block;
-		text-align: left;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-
-	.edit-site-summary-field__label {
-		width: 30%;
-	}
+	// Truncate
+	display: block;
+	text-align: left;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .edit-site-page-panels-edit-template__dropdown {

--- a/packages/editor/src/components/post-panel-row/index.js
+++ b/packages/editor/src/components/post-panel-row/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { forwardRef } from '@wordpress/element';
+
+const PostPanelRow = forwardRef( ( { label, children }, ref ) => {
+	return (
+		<HStack className="editor-post-panel__row" ref={ ref }>
+			<div className="editor-post-panel__row-label">{ label }</div>
+			<div className="editor-post-panel__row-control">{ children }</div>
+		</HStack>
+	);
+} );
+
+export default PostPanelRow;

--- a/packages/editor/src/components/post-panel-row/index.js
+++ b/packages/editor/src/components/post-panel-row/index.js
@@ -1,14 +1,32 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 
-const PostPanelRow = forwardRef( ( { label, children }, ref ) => {
+const PostPanelRow = forwardRef( ( { className, label, children }, ref ) => {
 	return (
-		<HStack className="editor-post-panel__row" ref={ ref }>
-			<div className="editor-post-panel__row-label">{ label }</div>
-			<div className="editor-post-panel__row-control">{ children }</div>
+		<HStack
+			className={ classnames( 'editor-post-panel__row', className ) }
+			ref={ ref }
+		>
+			{ label ? (
+				<>
+					<div className="editor-post-panel__row-label">
+						{ label }
+					</div>
+					<div className="editor-post-panel__row-control">
+						{ children }
+					</div>
+				</>
+			) : (
+				children
+			) }
 		</HStack>
 	);
 } );

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -1,0 +1,13 @@
+.editor-post-panel__row {
+	width: 100%;
+	justify-content: flex-start;
+	align-items: flex-start;
+}
+
+.editor-post-panel__row-label {
+	width: 30%;
+}
+
+.editor-post-panel__row-control {
+	flex-grow: 1;
+}

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -2,10 +2,12 @@
 	width: 100%;
 	justify-content: flex-start;
 	align-items: flex-start;
+	min-height: $button-size;
 }
 
 .editor-post-panel__row-label {
 	width: 30%;
+	flex-shrink: 0;
 }
 
 .editor-post-panel__row-control {

--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	Dropdown,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Button, Dropdown } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 
@@ -15,6 +11,7 @@ import { useState, useMemo } from '@wordpress/element';
 import PostScheduleCheck from './check';
 import PostScheduleForm from './index';
 import { usePostScheduleLabel } from './label';
+import PostPanelRow from '../post-panel-row';
 
 export default function PostSchedulePanel() {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -35,11 +32,7 @@ export default function PostSchedulePanel() {
 
 	return (
 		<PostScheduleCheck>
-			<HStack
-				className="editor-post-schedule__panel"
-				ref={ setPopoverAnchor }
-			>
-				<span>{ __( 'Publish' ) }</span>
+			<PostPanelRow label={ __( 'Publish' ) } ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
 					focusOnMount
@@ -66,7 +59,7 @@ export default function PostSchedulePanel() {
 						<PostScheduleForm onClose={ onClose } />
 					) }
 				/>
-			</HStack>
+			</PostPanelRow>
 		</PostScheduleCheck>
 	);
 }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -1,16 +1,5 @@
-.editor-post-schedule__panel {
-	width: 100%;
-	justify-content: flex-start;
-	align-items: flex-start;
-
-	span {
-		display: block;
-		width: 30%;
-	}
-}
-
 .editor-post-schedule__panel-dropdown {
-	width: 70%;
+	width: 100%;
 }
 
 .editor-post-schedule__dialog {

--- a/packages/editor/src/components/post-sync-status/index.js
+++ b/packages/editor/src/components/post-sync-status/index.js
@@ -4,7 +4,6 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import {
-	PanelRow,
 	Modal,
 	Button,
 	__experimentalHStack as HStack,
@@ -17,6 +16,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
+import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
@@ -44,14 +44,13 @@ export default function PostSyncStatus() {
 	}
 
 	return (
-		<PanelRow className="edit-post-sync-status">
-			<span>{ __( 'Sync status' ) }</span>
-			<div>
+		<PostPanelRow label={ __( 'Sync status' ) }>
+			<div className="editor-post-sync-status__value">
 				{ syncStatus === 'unsynced'
 					? __( 'Not synced' )
 					: __( 'Fully synced' ) }
 			</div>
-		</PanelRow>
+		</PostPanelRow>
 	);
 }
 

--- a/packages/editor/src/components/post-sync-status/style.scss
+++ b/packages/editor/src/components/post-sync-status/style.scss
@@ -1,18 +1,4 @@
-.edit-post-sync-status {
-	width: 100%;
-	position: relative;
-	justify-content: flex-start;
-	align-items: flex-start;
-
-	> span {
-		display: block;
-		width: 30%;
-		margin-right: 8px;
-		word-break: break-word;
-	}
-
-	> div {
-		// Match padding on tertiary buttons for alignment.
-		padding: $grid-unit-15 * 0.5 0 $grid-unit-15 * 0.5 $grid-unit-15;
-	}
+.editor-post-sync-status__value {
+	// Match padding on tertiary buttons for alignment.
+	padding: $grid-unit-15 * 0.5 0 $grid-unit-15 * 0.5 $grid-unit-15;
 }

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import {
-	__experimentalHStack as HStack,
-	Dropdown,
-	Button,
-} from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -15,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import PostURLCheck from './check';
 import PostURL from './index';
 import { usePostURLLabel } from './label';
+import PostPanelRow from '../post-panel-row';
 
 export default function PostURLPanel() {
 	// Use internal state instead of a ref to make sure that the component
@@ -28,8 +25,7 @@ export default function PostURLPanel() {
 
 	return (
 		<PostURLCheck>
-			<HStack className="editor-post-url__panel" ref={ setPopoverAnchor }>
-				<span>{ __( 'URL' ) }</span>
+			<PostPanelRow label={ __( 'URL' ) } ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
 					className="editor-post-url__panel-dropdown"
@@ -42,7 +38,7 @@ export default function PostURLPanel() {
 						<PostURL onClose={ onClose } />
 					) }
 				/>
-			</HStack>
+			</PostPanelRow>
 		</PostURLCheck>
 	);
 }

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -1,16 +1,5 @@
-.editor-post-url__panel {
-	width: 100%;
-	justify-content: flex-start;
-	align-items: flex-start;
-
-	span {
-		display: block;
-		width: 30%;
-	}
-}
-
 .editor-post-url__panel-dropdown {
-	width: 70%;
+	width: 100%;
 }
 
 .components-button.editor-post-url__panel-toggle {

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -5,11 +5,13 @@ import { ExperimentalEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
 import { EntitiesSavedStatesExtensible } from './components/entities-saved-states';
 import useBlockEditorSettings from './components/provider/use-block-editor-settings';
+import PostPanelRow from './components/post-panel-row';
 
 export const privateApis = {};
 lock( privateApis, {
 	ExperimentalEditorProvider,
 	EntitiesSavedStatesExtensible,
+	PostPanelRow,
 
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.
 	useBlockEditorSettings,

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -8,6 +8,7 @@
 @import "./components/post-format/style.scss";
 @import "./components/post-last-revision/style.scss";
 @import "./components/post-locked-modal/style.scss";
+@import "./components/post-panel-row/style.scss";
 @import "./components/post-publish-button/style.scss";
 @import "./components/post-publish-panel/style.scss";
 @import "./components/post-saved-state/style.scss";


### PR DESCRIPTION
I've noticed that we keep repeating the same styles over and over between the different panels in the "summary" panel in the site editor sidebar (or post editor).

This PR just creates a small internal UI component to reuse between the different panels. 