### PR TITLE
DataViews: remove title from pages

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -303,7 +303,7 @@ export default function PagePages() {
 	// TODO: we need to handle properly `data={ data || EMPTY_ARRAY }` for when `isLoading`.
 	return (
 		<>
-			<Page title={ __( 'Pages' ) }>
+			<Page>
 				<DataViews
 					paginationInfo={ paginationInfo }
 					fields={ fields }

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -208,7 +208,7 @@ export default function DataviewsTemplates() {
 		[ view, setView ]
 	);
 	return (
-		<Page title={ __( 'Templates' ) }>
+		<Page>
 			<DataViews
 				paginationInfo={ paginationInfo }
 				fields={ fields }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Removes the title from the pages.

| Page | Before | After |
| --- | --- | --- |
| Templates | <img width="1494" alt="Captura de ecrã 2023-11-17, às 11 33 54" src="https://github.com/WordPress/gutenberg/assets/583546/2199cb8f-0d79-4e03-8dae-78b015866901"> | <img width="1494" alt="Captura de ecrã 2023-11-17, às 11 33 22" src="https://github.com/WordPress/gutenberg/assets/583546/61020b27-b0ef-4666-a677-86810332fdf6"> |
| Pages | <img width="1494" alt="Captura de ecrã 2023-11-17, às 11 33 46" src="https://github.com/WordPress/gutenberg/assets/583546/c23f3327-6534-4a30-8d19-30fbf97ece41"> | <img width="1494" alt="Captura de ecrã 2023-11-17, às 11 33 33" src="https://github.com/WordPress/gutenberg/assets/583546/9eb72f6f-07ae-4a36-b6e8-c94067ca19e0"> |

## Why?

The page title is redundant, as the sidebar already anchors the user, telling them where they are. Removing the title leaves also more space for the main interaction of the page (filtering, search, pagination, etc.).

## How?

Removes the title from the `<Page>` component.

## Testing Instructions

- Enable the "admin views" experiment and visit the "Manage all templates" and "Manage all pages" pages in "Appaerance > Editor".
- See how it looks like.
