### PR TITLE
Migrating `InserterListbox` to use updated Composite implementation

### DIFF
--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { getBlockMenuDefaultClassName } from '@wordpress/blocks';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -25,11 +26,10 @@ function BlockTypesList( {
 	label,
 	isDraggable = true,
 } ) {
+	const className = 'block-editor-block-types-list';
+	const listId = useInstanceId( BlockTypesList, className );
 	return (
-		<InserterListboxGroup
-			className="block-editor-block-types-list"
-			aria-label={ label }
-		>
+		<InserterListboxGroup className={ className } aria-label={ label }>
 			{ chunk( items, 3 ).map( ( row, i ) => (
 				<InserterListboxRow key={ i }>
 					{ row.map( ( item, j ) => (
@@ -43,6 +43,7 @@ function BlockTypesList( {
 							onHover={ onHover }
 							isDraggable={ isDraggable && ! item.isDisabled }
 							isFirst={ i === 0 && j === 0 }
+							rowId={ `${ listId }-${ i }` }
 						/>
 					) ) }
 				</InserterListboxRow>

--- a/packages/block-editor/src/components/inserter-listbox/index.js
+++ b/packages/block-editor/src/components/inserter-listbox/index.js
@@ -1,26 +1,30 @@
 /**
  * WordPress dependencies
  */
-import { __unstableUseCompositeState as useCompositeState } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import InserterListboxContext from './context';
+import { unlock } from '../../lock-unlock';
 
 export { default as InserterListboxGroup } from './group';
 export { default as InserterListboxRow } from './row';
 export { default as InserterListboxItem } from './item';
 
+const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
+	unlock( componentsPrivateApis );
+
 function InserterListbox( { children } ) {
-	const compositeState = useCompositeState( {
-		shift: true,
-		wrap: 'horizontal',
+	const store = useCompositeStore( {
+		focusShift: true,
+		focusWrap: 'horizontal',
 	} );
+
 	return (
-		<InserterListboxContext.Provider value={ compositeState }>
+		<Composite store={ store } render={ <></> }>
 			{ children }
-		</InserterListboxContext.Provider>
+		</Composite>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter-listbox/item.js
+++ b/packages/block-editor/src/components/inserter-listbox/item.js
@@ -22,10 +22,10 @@ function InserterListboxItem(
 		<CompositeItem
 			ref={ ref }
 			role="option"
-			// Use the CompositeItem `focusable` prop over Button's
-			// isFocusable. The latter was shown to cause an issue
-			// with tab order in the inserter list.
-			focusable
+			// Use the CompositeItem `accessibleWhenDisabled` prop
+			// over Button's `isFocusable`. The latter was shown to
+			// cause an issue with tab order in the inserter list.
+			accessibleWhenDisabled
 			{ ...props }
 			render={ ( htmlProps ) => {
 				const propsWithTabIndex = {

--- a/packages/block-editor/src/components/inserter-listbox/item.js
+++ b/packages/block-editor/src/components/inserter-listbox/item.js
@@ -3,32 +3,31 @@
  */
 import {
 	Button,
-	__unstableCompositeItem as CompositeItem,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { forwardRef, useContext } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import InserterListboxContext from './context';
+import { unlock } from '../../lock-unlock';
+
+const { CompositeItemV2: CompositeItem } = unlock( componentsPrivateApis );
 
 function InserterListboxItem(
 	{ isFirst, as: Component, children, ...props },
 	ref
 ) {
-	const state = useContext( InserterListboxContext );
 	return (
 		<CompositeItem
 			ref={ ref }
-			state={ state }
 			role="option"
 			// Use the CompositeItem `focusable` prop over Button's
 			// isFocusable. The latter was shown to cause an issue
 			// with tab order in the inserter list.
 			focusable
 			{ ...props }
-		>
-			{ ( htmlProps ) => {
+			render={ ( htmlProps ) => {
 				const propsWithTabIndex = {
 					...htmlProps,
 					tabIndex: isFirst ? 0 : htmlProps.tabIndex,
@@ -45,7 +44,7 @@ function InserterListboxItem(
 				}
 				return <Button { ...propsWithTabIndex }>{ children }</Button>;
 			} }
-		</CompositeItem>
+		/>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter-listbox/row.js
+++ b/packages/block-editor/src/components/inserter-listbox/row.js
@@ -1,24 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { forwardRef, useContext } from '@wordpress/element';
-import { __unstableCompositeGroup as CompositeGroup } from '@wordpress/components';
+import { forwardRef } from '@wordpress/element';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import InserterListboxContext from './context';
+import { unlock } from '../../lock-unlock';
+
+const { CompositeGroupV2: CompositeGroup } = unlock( componentsPrivateApis );
 
 function InserterListboxRow( props, ref ) {
-	const state = useContext( InserterListboxContext );
-	return (
-		<CompositeGroup
-			state={ state }
-			role="presentation"
-			ref={ ref }
-			{ ...props }
-		/>
-	);
+	return <CompositeGroup role="presentation" ref={ ref } { ...props } />;
 }
 
 export default forwardRef( InserterListboxRow );


### PR DESCRIPTION
## What?

This PR updates [`InserterListbox`](https://github.com/WordPress/gutenberg/blob/903778cb8b2d450c3ca0ba8a872c1f233b2f5c88/packages/block-editor/src/components/inserter-listbox/index.js), [`InserterListboxRow`](https://github.com/WordPress/gutenberg/blob/903778cb8b2d450c3ca0ba8a872c1f233b2f5c88/packages/block-editor/src/components/inserter-listbox/row.js), and [`InserterListboxItem`](https://github.com/WordPress/gutenberg/blob/903778cb8b2d450c3ca0ba8a872c1f233b2f5c88/packages/block-editor/src/components/inserter-listbox/item.js) in `@wordpress/block-editor` to use the updated `Composite` implementation from #54225.

Additionally, it updates [`BlockTypesList`](https://github.com/WordPress/gutenberg/blob/903778cb8b2d450c3ca0ba8a872c1f233b2f5c88/packages/block-editor/src/components/block-types-list/index.js) (also in `@wordpress/block-editor`) to ensure list items are appropriately grouped.


## Why?

In #54225, an updated implementation of `Composite` was added to `@wordpress/components`. As per #55224, all consumers of `Composite` need to migrate from the old version to the new version.


## How?

- Removes `__unstableComposite` imports from `@wordpress/components`
- Adds private `Composite*` exports from `@wordpress/components`
- Refactors `InserterListbox`, `InserterListboxRow` and `InserterListboxItem` to use updated `Composite` components
- Additionally updates `BlockTypesList` to ensure listbox items are appropriately grouped by adding an explicit `rowId`


## Testing Instructions

In the editor, open the Block Inserter sidebar, with the Blocks tab open. Visually and behaviourally, there should be no difference.

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/5f269925-2701-449a-9197-e2f0fc6d84af" alt="The 'blocks' tab of the block inserter sidebar, before any changes." width="45%">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/60fb6d91-b3ef-4f88-8b91-8eb36675dd0a" alt="The 'blocks' tab of the block inserter sidebar, after changes. It is visually no different." width="45%">
</p>


### Testing Instructions for Keyboard

Navigate to the "Blocks" tab panel:
- Tab should jump through the first item of each section
- Left/right arrow keys should cycle across each line, wrapping to the next/previous
- Up/down arrow keys should move line by line
- Return should insert the selected block into the active document
