### PR TITLE
DataViews: extract common constants to file

### DIFF
--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -44,8 +44,8 @@ Example:
 	},
 	search: '',
 	filters: [
-		{ field: 'author', operator: 'in', value: 2 },
-		{ field: 'status', operator: 'in', value: 'publish,draft' }
+		{ field: 'author', operator: OPERATOR_IN, value: 2 },
+		{ field: 'status', operator: OPERATOR_IN, value: 'publish,draft' }
 	],
 	hiddenFields: [ 'date', 'featured-image' ],
 	layout: {},
@@ -83,8 +83,8 @@ function MyCustomPageList() {
 		},
 		search: '',
 		filters: [
-			{ field: 'author', operator: 'in', value: 2 },
-			{ field: 'status', operator: 'in', value: 'publish,draft' }
+			{ field: 'author', operator: OPERATOR_IN, value: 2 },
+			{ field: 'status', operator: OPERATOR_IN, value: 'publish,draft' }
 		],
 		hiddenFields: [ 'date', 'featured-image' ],
 		layout: {},
@@ -93,10 +93,10 @@ function MyCustomPageList() {
 	const queryArgs = useMemo( () => {
 		const filters = {};
 		view.filters.forEach( ( filter ) => {
-			if ( filter.field === 'status' && filter.operator === 'in' ) {
+			if ( filter.field === 'status' && filter.operator === OPERATOR_IN ) {
 				filters.status = filter.value;
 			}
-			if ( filter.field === 'author' && filter.operator === 'in' ) {
+			if ( filter.field === 'author' && filter.operator === OPERATOR_IN ) {
 				filters.author = filter.value;
 			}
 		} );
@@ -154,7 +154,7 @@ Example:
 				<a href="...">{ item.author }</a>
 			);
 		},
-		type: 'enumeration',
+		type: ENUMERATION_TYPE,
 		elements: [
 			{ value: 1, label: 'Admin' }
 			{ value: 2, label: 'User' }

--- a/packages/edit-site/src/components/dataviews/add-filter.js
+++ b/packages/edit-site/src/components/dataviews/add-filter.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { OPERATOR_IN } from './in-filter';
+import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
 
 const {
 	DropdownMenuV2,
@@ -21,9 +21,6 @@ const {
 	DropdownSubMenuTriggerV2,
 	DropdownMenuItemV2,
 } = unlock( componentsPrivateApis );
-
-// TODO: find a place where these constants can be shared across components.
-const ENUMERATION_TYPE = 'enumeration';
 
 export default function AddFilter( { fields, view, onChangeView } ) {
 	const filters = [];

--- a/packages/edit-site/src/components/dataviews/constants.js
+++ b/packages/edit-site/src/components/dataviews/constants.js
@@ -1,0 +1,5 @@
+// Field types.
+export const ENUMERATION_TYPE = 'enumeration';
+
+// Filter operators.
+export const OPERATOR_IN = 'in';

--- a/packages/edit-site/src/components/dataviews/filters.js
+++ b/packages/edit-site/src/components/dataviews/filters.js
@@ -6,11 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { default as InFilter, OPERATOR_IN } from './in-filter';
+import { default as InFilter } from './in-filter';
 import AddFilter from './add-filter';
 import ResetFilters from './reset-filters';
-
-const ENUMERATION_TYPE = 'enumeration';
+import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
 
 export default function Filters( { fields, view, onChangeView } ) {
 	const filters = [];

--- a/packages/edit-site/src/components/dataviews/in-filter.js
+++ b/packages/edit-site/src/components/dataviews/in-filter.js
@@ -7,8 +7,10 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
-// TODO: find a place where these constants can be shared across components.
-export const OPERATOR_IN = 'in';
+/**
+ * Internal dependencies
+ */
+import { OPERATOR_IN } from './constants';
 
 export default ( { filter, view, onChangeView } ) => {
 	const valueFound = view.filters.find(

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -36,6 +36,7 @@ import { useMemo, Children, Fragment } from '@wordpress/element';
  */
 import { unlock } from '../../lock-unlock';
 import ItemActions from './item-actions';
+import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
 
 const {
 	DropdownMenuV2,
@@ -52,10 +53,6 @@ const sortingItemsInfo = {
 	desc: { icon: arrowDown, label: __( 'Sort descending' ) },
 };
 const sortIcons = { asc: chevronUp, desc: chevronDown };
-
-// TODO: find a place where these constants can be shared across components.
-const ENUMERATION_TYPE = 'enumeration';
-const OPERATOR_IN = 'in';
 
 function HeaderMenu( { dataView, header } ) {
 	if ( header.isPlaceholder ) {

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -31,6 +31,7 @@ import {
 import SideEditor from './side-editor';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
+import { ENUMERATION_TYPE, OPERATOR_IN } from '../dataviews/constants';
 const { useLocation } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
@@ -120,10 +121,16 @@ export default function PagePages() {
 	const queryArgs = useMemo( () => {
 		const filters = {};
 		view.filters.forEach( ( filter ) => {
-			if ( filter.field === 'status' && filter.operator === 'in' ) {
+			if (
+				filter.field === 'status' &&
+				filter.operator === OPERATOR_IN
+			) {
 				filters.status = filter.value;
 			}
-			if ( filter.field === 'author' && filter.operator === 'in' ) {
+			if (
+				filter.field === 'author' &&
+				filter.operator === OPERATOR_IN
+			) {
 				filters.author = filter.value;
 			}
 		} );
@@ -227,7 +234,7 @@ export default function PagePages() {
 						</a>
 					);
 				},
-				type: 'enumeration',
+				type: ENUMERATION_TYPE,
 				elements:
 					authors?.map( ( { id, name } ) => ( {
 						value: id,
@@ -240,7 +247,7 @@ export default function PagePages() {
 				getValue: ( { item } ) =>
 					STATUSES.find( ( { value } ) => value === item.status )
 						?.label ?? item.status,
-				type: 'enumeration',
+				type: ENUMERATION_TYPE,
 				elements: STATUSES,
 				enableSorting: false,
 			},

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -4,6 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { OPERATOR_IN } from '../dataviews/constants';
+
 const DEFAULT_PAGE_BASE = {
 	type: 'list',
 	search: '',
@@ -33,7 +38,7 @@ const DEFAULT_VIEWS = {
 			view: {
 				...DEFAULT_PAGE_BASE,
 				filters: [
-					{ field: 'status', operator: 'in', value: 'draft' },
+					{ field: 'status', operator: OPERATOR_IN, value: 'draft' },
 				],
 			},
 		},
@@ -44,7 +49,7 @@ const DEFAULT_VIEWS = {
 			view: {
 				...DEFAULT_PAGE_BASE,
 				filters: [
-					{ field: 'status', operator: 'in', value: 'trash' },
+					{ field: 'status', operator: OPERATOR_IN, value: 'trash' },
 				],
 			},
 		},


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Extracts a couple of common constants to its own `constants.js` file.

## Why?

To centralize where they live.

## How?

Create a new `constant.js` file.

## Testing Instructions

- Enable the "admins views" experiment and visit "Appareance > Editor > Manage all pages".
- Verify everything works the same as before.
