### PR TITLE
Refactor Media Upload Progress component converting from Class to Function

### DIFF
--- a/packages/block-editor/src/components/media-upload-progress/index.native.js
+++ b/packages/block-editor/src/components/media-upload-progress/index.native.js
@@ -6,7 +6,7 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { subscribeMediaUpload } from '@wordpress/react-native-bridge';
@@ -21,129 +21,143 @@ export const MEDIA_UPLOAD_STATE_SUCCEEDED = 2;
 export const MEDIA_UPLOAD_STATE_FAILED = 3;
 export const MEDIA_UPLOAD_STATE_RESET = 4;
 
-export class MediaUploadProgress extends Component {
-	constructor( props ) {
-		super( props );
+// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
+const retryMessage = __( 'Failed to insert media.\nTap for more info.' );
 
-		this.state = {
-			progress: 0,
-			isUploadInProgress: false,
-			isUploadFailed: false,
-		};
+export function MediaUploadProgress( props ) {
+	const [ progress, setProgress ] = useState( 0 );
+	const [ isUploadInProgress, setIsUploadInProgress ] = useState( false );
+	const [ isUploadFailed, setIsUploadFailed ] = useState( false );
+	const [ subscriptionParentMediaUpload, setSubscriptionParentMediaUpload ] =
+		useState( null );
+	const [ progressBarStyle, setProgressBarStyle ] = useState( [] );
 
-		this.mediaUpload = this.mediaUpload.bind( this );
-	}
+	const { renderContent = () => null } = props;
 
-	componentDidMount() {
-		this.addMediaUploadListener();
-	}
+	const mediaUpload = useCallback(
+		( payload ) => {
+			const { mediaId } = props;
 
-	componentWillUnmount() {
-		this.removeMediaUploadListener();
-	}
-
-	mediaUpload( payload ) {
-		const { mediaId } = this.props;
-
-		if ( payload.mediaId !== mediaId ) {
-			return;
-		}
-
-		switch ( payload.state ) {
-			case MEDIA_UPLOAD_STATE_UPLOADING:
-				this.updateMediaProgress( payload );
-				break;
-			case MEDIA_UPLOAD_STATE_SUCCEEDED:
-				this.finishMediaUploadWithSuccess( payload );
-				break;
-			case MEDIA_UPLOAD_STATE_FAILED:
-				this.finishMediaUploadWithFailure( payload );
-				break;
-			case MEDIA_UPLOAD_STATE_RESET:
-				this.mediaUploadStateReset( payload );
-				break;
-		}
-	}
-
-	updateMediaProgress( payload ) {
-		this.setState( {
-			progress: payload.progress,
-			isUploadInProgress: true,
-			isUploadFailed: false,
-		} );
-		if ( this.props.onUpdateMediaProgress ) {
-			this.props.onUpdateMediaProgress( payload );
-		}
-	}
-
-	finishMediaUploadWithSuccess( payload ) {
-		this.setState( { isUploadInProgress: false } );
-		if ( this.props.onFinishMediaUploadWithSuccess ) {
-			this.props.onFinishMediaUploadWithSuccess( payload );
-		}
-	}
-
-	finishMediaUploadWithFailure( payload ) {
-		this.setState( { isUploadInProgress: false, isUploadFailed: true } );
-		if ( this.props.onFinishMediaUploadWithFailure ) {
-			this.props.onFinishMediaUploadWithFailure( payload );
-		}
-	}
-
-	mediaUploadStateReset( payload ) {
-		this.setState( { isUploadInProgress: false, isUploadFailed: false } );
-		if ( this.props.onMediaUploadStateReset ) {
-			this.props.onMediaUploadStateReset( payload );
-		}
-	}
-
-	addMediaUploadListener() {
-		// If we already have a subscription not worth doing it again.
-		if ( this.subscriptionParentMediaUpload ) {
-			return;
-		}
-		this.subscriptionParentMediaUpload = subscribeMediaUpload(
-			( payload ) => {
-				this.mediaUpload( payload );
+			if ( payload.mediaId !== mediaId ) {
+				return;
 			}
-		);
-	}
 
-	removeMediaUploadListener() {
-		if ( this.subscriptionParentMediaUpload ) {
-			this.subscriptionParentMediaUpload.remove();
+			switch ( payload.state ) {
+				case MEDIA_UPLOAD_STATE_UPLOADING:
+					updateMediaProgress( payload );
+					break;
+				case MEDIA_UPLOAD_STATE_SUCCEEDED:
+					finishMediaUploadWithSuccess( payload );
+					break;
+				case MEDIA_UPLOAD_STATE_FAILED:
+					finishMediaUploadWithFailure( payload );
+					break;
+				case MEDIA_UPLOAD_STATE_RESET:
+					mediaUploadStateReset( payload );
+					break;
+			}
+		},
+		[
+			props,
+			updateMediaProgress,
+			finishMediaUploadWithSuccess,
+			finishMediaUploadWithFailure,
+			mediaUploadStateReset,
+		]
+	);
+
+	const updateMediaProgress = useCallback(
+		( payload ) => {
+			setProgress( payload.progress );
+			setIsUploadInProgress( true );
+			setIsUploadFailed( false );
+
+			if ( props.onUpdateMediaProgress ) {
+				props.onUpdateMediaProgress( payload );
+			}
+		},
+		[ props.onUpdateMediaProgress ]
+	);
+
+	const finishMediaUploadWithSuccess = useCallback(
+		( payload ) => {
+			setIsUploadInProgress( false );
+			if ( props.onFinishMediaUploadWithSuccess ) {
+				props.onFinishMediaUploadWithSuccess( payload );
+			}
+		},
+		[ props.onFinishMediaUploadWithSuccess ]
+	);
+
+	const finishMediaUploadWithFailure = useCallback(
+		( payload ) => {
+			setIsUploadInProgress( false );
+			setIsUploadFailed( true );
+
+			if ( props.onFinishMediaUploadWithFailure ) {
+				props.onFinishMediaUploadWithFailure( payload );
+			}
+		},
+		[ props.onFinishMediaUploadWithFailure ]
+	);
+
+	const mediaUploadStateReset = useCallback(
+		( payload ) => {
+			setIsUploadInProgress( false );
+			setIsUploadFailed( false );
+
+			if ( props.onMediaUploadStateReset ) {
+				props.onMediaUploadStateReset( payload );
+			}
+		},
+		[ props.onMediaUploadStateReset ]
+	);
+
+	const addMediaUploadListener = useCallback( () => {
+		// If we already have a subscription not worth doing it again.
+		if ( subscriptionParentMediaUpload ) {
+			return;
 		}
-	}
-
-	render() {
-		const { renderContent = () => null } = this.props;
-		const { isUploadInProgress, isUploadFailed } = this.state;
-		const showSpinner = this.state.isUploadInProgress;
-		const progress = this.state.progress * 100;
-		// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
-		const retryMessage = __(
-			'Failed to insert media.\nTap for more info.'
+		setSubscriptionParentMediaUpload(
+			subscribeMediaUpload( ( payload ) => {
+				mediaUpload( payload );
+			} )
 		);
+	}, [ subscriptionParentMediaUpload ] );
 
-		const progressBarStyle = [
+	const removeMediaUploadListener = useCallback( () => {
+		if ( subscriptionParentMediaUpload ) {
+			subscriptionParentMediaUpload.remove();
+		}
+	}, [ subscriptionParentMediaUpload ] );
+
+	useEffect( () => {
+		setProgressBarStyle( [
 			styles.progressBar,
-			showSpinner || styles.progressBarHidden,
-			this.props.progressBarStyle,
-		];
+			isUploadInProgress || styles.progressBarHidden,
+			props.progressBarStyle,
+		] );
+	}, [ isUploadInProgress, props.progressBarStyle ] );
 
-		return (
+	useEffect( () => {
+		addMediaUploadListener();
+
+		return () => {
+			removeMediaUploadListener();
+		};
+	}, [] );
+
+	return useMemo(
+		() => (
 			<View
-				style={ [
-					styles.mediaUploadProgress,
-					this.props.containerStyle,
-				] }
+				style={ [ styles.mediaUploadProgress, props.containerStyle ] }
 				pointerEvents="box-none"
 			>
 				<View style={ progressBarStyle }>
-					{ showSpinner && (
+					{ isUploadInProgress && (
 						<Spinner
-							progress={ progress }
-							style={ this.props.spinnerStyle }
+							progress={ progress * 100 }
+							style={ props.spinnerStyle }
 							testID="spinner"
 						/>
 					) }
@@ -154,8 +168,16 @@ export class MediaUploadProgress extends Component {
 					retryMessage,
 				} ) }
 			</View>
-		);
-	}
+		),
+		[
+			isUploadInProgress,
+			isUploadFailed,
+			progress,
+			progressBarStyle,
+			renderContent,
+			props,
+		]
+	);
 }
 
 export default MediaUploadProgress;


### PR DESCRIPTION
Based on #22890 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Migrate the [MediaUploadProgress](https://github.com/dantovbein/gutenberg/blob/a542359709025d42c4fa47cd92b64c0ffa41e22e/packages/block-editor/src/components/media-upload-progress/index.native.js) react native component, currently as a React Class, to a Functional Component.

## Why?
React introduced Hooks after `16.8.*` version.
👇 Taken from their [official documentation ](https://react.dev/reference/react/PureComponent#skipping-unnecessary-re-renders-for-class-components).
> We recommend defining components as functions instead of classes. [See how to migrate.](https://react.dev/reference/react/PureComponent#alternatives)  

## How?
[Following this document ](https://react.dev/reference/react/PureComponent#alternatives)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert an image block.
3. Upload a new image
