### PR TITLE
Add Reverse on mobile attribute for Media & Text Blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -434,7 +434,7 @@ Set media and words side-by-side for a richer layout. ([Source](https://github.c
 -	**Name:** core/media-text
 -	**Category:** media
 -	**Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** align, allowedBlocks, focalPoint, href, imageFill, isStackedOnMobile, linkClass, linkDestination, linkTarget, mediaAlt, mediaId, mediaLink, mediaPosition, mediaSizeSlug, mediaType, mediaUrl, mediaWidth, rel, verticalAlignment
+-	**Attributes:** align, allowedBlocks, focalPoint, href, imageFill, isReversedOnMobile, isStackedOnMobile, linkClass, linkDestination, linkTarget, mediaAlt, mediaId, mediaLink, mediaPosition, mediaSizeSlug, mediaType, mediaUrl, mediaWidth, rel, verticalAlignment
 
 ## Unsupported
 

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -81,6 +81,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"isReversedOnMobile": {
+			"type": "boolean",
+			"default": false
+		},
 		"verticalAlignment": {
 			"type": "string"
 		},

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -133,6 +133,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		href,
 		imageFill,
 		isStackedOnMobile,
+		isReversedOnMobile,
 		linkClass,
 		linkDestination,
 		linkTarget,
@@ -193,6 +194,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		'has-media-on-the-right': 'right' === mediaPosition,
 		'is-selected': isSelected,
 		'is-stacked-on-mobile': isStackedOnMobile,
+		'is-reversed-on-mobile': isReversedOnMobile,
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		'is-image-fill': imageFill,
 	} );
@@ -237,6 +239,16 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 				onChange={ () =>
 					setAttributes( {
 						isStackedOnMobile: ! isStackedOnMobile,
+					} )
+				}
+			/>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Reverse on mobile' ) }
+				checked={ isReversedOnMobile }
+				onChange={ () =>
+					setAttributes( {
+						isReversedOnMobile: ! isReversedOnMobile,
 					} )
 				}
 			/>
@@ -375,6 +387,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 						imageFill,
 						isSelected,
 						isStackedOnMobile,
+						isReversedOnMobile,
 						mediaAlt,
 						mediaId,
 						mediaPosition,

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -20,6 +20,7 @@ const noop = () => {};
 export default function save( { attributes } ) {
 	const {
 		isStackedOnMobile,
+		isReversedOnMobile,
 		mediaAlt,
 		mediaPosition,
 		mediaType,
@@ -70,6 +71,7 @@ export default function save( { attributes } ) {
 	const className = classnames( {
 		'has-media-on-the-right': 'right' === mediaPosition,
 		'is-stacked-on-mobile': isStackedOnMobile,
+		'is-reversed-on-mobile': isReversedOnMobile,
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		'is-image-fill': imageFill,
 	} );

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -116,4 +116,50 @@
 			grid-row: 2;
 		}
 	}
+
+	.wp-block-media-text.is-stacked-on-mobile.is-reversed-on-mobile {
+		.wp-block-media-text__media {
+			grid-column: 1;
+			grid-row: 2;
+		}
+
+		.wp-block-media-text__content {
+			grid-column: 1;
+			grid-row: 1;
+		}
+	}
+
+	.wp-block-media-text.is-reversed-on-mobile:not(.is-stacked-on-mobile) {
+		.wp-block-media-text__media {
+			/*!rtl:begin:ignore*/
+			grid-column: 2;
+			grid-row: 1;
+			/*!rtl:end:ignore*/
+		}
+
+		.wp-block-media-text__content {
+			direction: ltr;
+			/*!rtl:begin:ignore*/
+			grid-column: 1;
+			grid-row: 1;
+			/*!rtl:end:ignore*/
+		}
+	}
+
+	.wp-block-media-text.is-reversed-on-mobile.has-media-on-the-right:not(.is-stacked-on-mobile) {
+		.wp-block-media-text__media {
+			/*!rtl:begin:ignore*/
+			grid-column: 1;
+			grid-row: 1;
+			/*!rtl:end:ignore*/
+		}
+
+		.wp-block-media-text__content {
+			direction: ltr;
+			/*!rtl:begin:ignore*/
+			grid-column: 2;
+			grid-row: 1;
+			/*!rtl:end:ignore*/
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #26215

Adds an attribute `Reverse on mobile` to the Media & Text Blocks. When selected, the block's column order will be reversed if the screen is narrower than the block's mobile breakpoint.

For Media & Text Blocks, if 'Stacked on mobile' is also selected, then the content will appear on top and the media will appear on bottom, because default behavior is for media to appear on top and content to appear on bottom when 'Stacked on mobile' is selected. If 'Stacked on mobile' is not selected, then 'Reverse on mobile' will simply reverse the column order for mobile views.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR is being submitted along with #55763 because Columns Blocks and Media & Text Blocks are frequently used to display media and content in a zig-zag pattern. For example:
```
[image]   [text ]
[text ]   [image]
[image]   [text ]
```

The Media & Text Block is coded to stack content with the media on top in the mobile view, like this:

```
[image]
[text ]
[image]
[text ]
[image]
[text ]
```

However, some users may wish to have the text stacked on top in the mobile view, like this:

```
[text ]
[image]
[text ]
[image]
[text ]
[image]
```

This PR adds the option to reverse the column order on mobile if desired, giving users more flexibility over how responsive content translates to the site's mobile view.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The Reverse on mobile attribute allows users greater flexibility in determining how their content is translated from unstacked to stacked. Users can choose the order in which the stacked content will appear.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Add at least 3 or 4 Media & Text Blocks.
3. Add media and content in a zig-zag pattern, as described above.
4. Apply the "Reverse on mobile" attribute to every Media & Text Block.
5. Observe the stacking behavior in the editor both with and without the attribute toggled.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Insert a Media & Text Block using existing methods.
2. Select the block using existing methods.
3. Open the Settings sidebar using existing methods.
4. Use the Tab key to highlight Reverse on mobile, and use Space to toggle the attribute.

## Screenshots or screencast <!-- if applicable -->
<img width="1359" alt="Screenshot 2023-11-17 at 3 11 55 PM" src="https://github.com/WordPress/gutenberg/assets/12906034/a668b95f-a7fb-4f7d-84de-6bb28901ae9f">

Screenshot showing the location of the 'Reverse on mobile' attribute in the editor, along with Columns blocks displaying the aforementioned 'zig-zag' pattern.

<img width="861" alt="Screenshot 2023-11-17 at 3 12 50 PM" src="https://github.com/WordPress/gutenberg/assets/12906034/a8115f04-6730-49b5-9651-8ecf4a7bfa17">

Screenshot showing the appearance of stacked Media & Text Blocks in the editor. The 'Reverse on mobile' attribute has been applied to every Media & Text Block so that the 'zig-zag' pattern translates to a 'text on top' pattern.

<img width="548" alt="Screenshot 2023-11-17 at 3 13 08 PM" src="https://github.com/WordPress/gutenberg/assets/12906034/ff93ed1c-5f2c-45f5-bf1b-d120deb4df1c">

Screenshot showing the front end of a page with stacked Media & Text Blocks, with every Media & Text Block having the 'Reverse on mobile' attribute.