### PR TITLE
Rich text: preserve multiple spaces on front-end

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -112,8 +112,12 @@ export function useInputAndSelection( props ) {
 				isCollapsed( newValue ) &&
 				oldStart !== newValue.start &&
 				( oldStart < newValue.start
-					? newValue.text.slice( oldStart, newValue.start ) === SP
-					: isSpOrNbsp(
+					? // Check if the inserted character is a space.
+					  newValue.text.slice( oldStart, newValue.start ) === SP
+					: // Check if the deleted character is a space or
+					  // non-breaking space (in both cases we need to fix the
+					  // alternating pattern).
+					  isSpOrNbsp(
 							record.current.text.slice(
 								newValue.start,
 								oldStart
@@ -124,6 +128,8 @@ export function useInputAndSelection( props ) {
 				let startOffset = newValue.start;
 				let endOffset = newValue.start;
 
+				// We need to make sure the alternating pattern is maintained,
+				// so replace all spaces before and after the selection.
 				while ( isSpOrNbsp( text[ startOffset - 1 ] ) ) {
 					startOffset--;
 				}

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -99,6 +99,24 @@ export function useInputAndSelection( props ) {
 			const currentValue = createRecord();
 			const { start, activeFormats: oldActiveFormats = [] } =
 				record.current;
+			const insertedChars = currentValue.text.slice(
+				start,
+				currentValue.start
+			);
+
+			// When inserting multiple spaces, alternate between a normal space
+			// and a non-breaking space. This is to prevent browsers from
+			// collapsing multiple spaces into one.
+			if ( insertedChars === ' ' ) {
+				const previousChar = currentValue.text.charAt( start - 1 );
+
+				if ( previousChar === ' ' ) {
+					currentValue.text =
+						currentValue.text.slice( 0, currentValue.start - 1 ) +
+						'\u00a0' +
+						currentValue.text.slice( currentValue.start );
+				}
+			}
 
 			// Update the formats between the last and new caret position.
 			const change = updateFormats( {

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -969,9 +969,7 @@ test.describe( 'Links', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Text with leading and trailing<a href="https://wordpress.org/gutenberg">' +
-							textToSelect +
-							'</a>',
+							'Text with leading and trailing<a href="https://wordpress.org/gutenberg">         spaces     </a>',
 					},
 				},
 			] );

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -853,4 +853,64 @@ test.describe( 'RichText', () => {
 			},
 		] );
 	} );
+
+	test( 'should pad multiple spaces', async ( { page, editor } ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a  b' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'a  b' },
+			},
+		] );
+	} );
+
+	test( 'should pad starting from space', async ( { page, editor } ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a b' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.type( ' ' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'a  b' },
+			},
+		] );
+	} );
+
+	test( 'should restore alternating padding on backspace', async ( {
+		page,
+		editor,
+	} ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a    b' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Backspace' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'a   b' },
+			},
+		] );
+	} );
+
+	test( 'should restore alternating padding on delete', async ( {
+		page,
+		editor,
+	} ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a    b' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Delete' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'a   b' },
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes a long standing issue in RichText where multiple inserted spaces are not preserved on the front-end. They are collapsed into a single space.

## Why?

What you see in the editor should be the same as the front-end. It's unexpected that spaces on the front-end are collapsed into a single space, after you explicitly inserted multiple.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When inserting multiple space, we should alternate between normal spaces and non breaking spaces. This is the default behaviour in all browsers, but it's turned off in Gutenberg because we have `white-space: pre-wrap` turned on for all rich text instances. We intentionally enabled this for stability, one of the reasons being that browsers insert the non breaking spaces a bit too much. For example, if you type two spaces, and remove one, you shouldn't be left with a non breaking space.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
