### PR TITLE
Clarification over examples at block-development-examples

### DIFF
--- a/docs/how-to-guides/javascript/js-build-setup.md
+++ b/docs/how-to-guides/javascript/js-build-setup.md
@@ -22,7 +22,7 @@ The [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) packa
 
 ## Quick Start
 
-If you prefer a quick start, you can use one of the examples from the [Block Development Examples repository](https://github.com/wordpress/block-development-examples/) and skip below. Each one of the `-esnext` directories in the examples repository contain the necessary files for working with ESNext and JSX.
+If you prefer a quick start, you can use one of the examples from the [Block Development Examples repository](https://github.com/wordpress/block-development-examples/) and skip below. [Most of the examples in this repository](https://github.com/WordPress/block-development-examples/wiki/02-Examples) contain the necessary files for working with ESNext and JSX.
 
 ## Setup
 


### PR DESCRIPTION
The text replaced belongs to the former [gutenberg-examples](https://github.com/WordPress/gutenberg-examples) repo. This PR updates this sentence so it makes sense with the referenced [block-development-examples](https://github.com/WordPress/block-development-examples)

