### PR TITLE
Update get-started-with-wp-env with reminder for node.js environment

### DIFF
--- a/docs/getting-started/devenv/get-started-with-wp-env.md
+++ b/docs/getting-started/devenv/get-started-with-wp-env.md
@@ -1,5 +1,9 @@
 # Get started with wp-env
 
+<div class="callout callout-info">
+Before following this guide, ensure you have the proper <a href="https://developer.wordpress.org/block-editor/getting-started/devenv/nodejs-development-environment/">Node.js development environment</a> installed
+</div>
+
 The [@wordpress/env](https://www.npmjs.com/package/@wordpress/env) package (`wp-env`) lets you set up a local WordPress environment (site) for building and testing plugins and themes, without any additional configuration.
 
 Before following this guide, install [Node.js development tools](/docs/getting-started/devenv#node-js-development-tools) if you have not already done so.


### PR DESCRIPTION
To improve the developer experience of developers arriving to this page from an external link a reminder to have the proper node.js environment would be useful and will ensure a proper onboarding experience

