### PR TITLE
Social Links Block: Prevent Theme Styles Distorting Size

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -96,6 +96,7 @@
 
 // This needs specificity because themes usually override it with things like .widget-area a.
 .wp-block-social-links .wp-block-social-link.wp-social-link {
+	display: inline-block;
 	margin: 0;
 	padding: 0;
 

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -109,10 +109,6 @@
 			fill: currentColor;
 		}
 	}
-
-	&:after {
-		display: none;
-	}
 }
 
 // Provide colors for a range of icons.

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -95,14 +95,23 @@
 }
 
 // This needs specificity because themes usually override it with things like .widget-area a.
-.wp-block-social-links .wp-block-social-link .wp-block-social-link-anchor {
-	&,
-	&:hover,
-	&:active,
-	&:visited,
-	svg {
-		color: currentColor;
-		fill: currentColor;
+.wp-block-social-links .wp-block-social-link.wp-social-link {
+	margin: 0;
+	padding: 0;
+
+	.wp-block-social-link-anchor {
+		&,
+		&:hover,
+		&:active,
+		&:visited,
+		svg {
+			color: currentColor;
+			fill: currentColor;
+		}
+	}
+
+	&:after {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes #38043
Fixes #53077
Fixes Automattic/themes#5345
Fixes Automattic/themes#6532
Fixes Automattic/themes#6817
Partly fixes Automattic/themes#7062
Fixes Automattic/wp-calypso#79942
etc. 

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensures that theme styles do not distort the Social Links block. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Social Links block is a list. As a result, it inherits a lot of styling from different themes, especially in the Widget Area where themes tend to style lists more specifically. The block already does a lot to override this, but it should also deal with `margin` and `padding` so that it's not distorted on themes. 

Automattic/themes#5345 and Automattic/themes#6532 have a long list of themes affected by this, so I'd suggest that a Core fix is more appropriate here.  

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Overrides any margin and padding set by themes.  

## Testing Instructions

1. Insert a Social Icons block on a theme like Twenty Seventeen in the widgets area
2. Apply these CSS changes 
3. Confirm the difference 

## Screenshots or screencast <!-- if applicable -->

**Before:**
<img width="224" alt="Screenshot 2023-11-19 at 15 04 54" src="https://github.com/WordPress/gutenberg/assets/43215253/63608d91-06e6-44f1-ad78-c97a12019a40">

**After:**
<img width="277" alt="Screenshot 2023-11-19 at 15 04 44" src="https://github.com/WordPress/gutenberg/assets/43215253/51aa3685-9b41-4a77-b634-b28a692b5458">
