### PR TITLE
Spacing: fix block error if spacing unit array empty in theme.json

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -139,7 +139,7 @@ export default function SpacingInputControl( {
 		useMemo(
 			() => parseQuantityAndUnitFromRawValue( currentValue ),
 			[ currentValue ]
-		)[ 1 ] || units[ 0 ].value;
+		)[ 1 ] || units[ 0 ]?.value;
 
 	const setInitialValue = () => {
 		if ( value === undefined ) {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -364,7 +364,8 @@
 							"items": {
 								"type": "string"
 							},
-							"default": [ "px", "em", "rem", "vh", "vw", "%" ]
+							"default": [ "px", "em", "rem", "vh", "vw", "%" ],
+							"minItems": 1
 						},
 						"customSpacingSize": {
 							"description": "Allow users to set custom space sizes.",


### PR DESCRIPTION
## What?
Adds a check to make sure that the spacing units array first entry is set before falling back to it as a default, and also adds a `minItems` setting to the `theme.json` schema.

## Why?
Currently if a theme author adds an empty `units` array to `theme.json` any blocks that use spacing settings will crash in the editor.
Fixes: #56176

## How?

- Adds an optional chaining operator to the fallback to the `selectedUnit` definition
- Adds `"minItems": 1` to the json schema for the spacing settings

## Testing Instructions

1. In your current theme's `theme.json` add and empty spacing units array, eg. `settings.spacing.units: []`
2. Add a group block in the post editor and check that the block doesn't crash when trying to change padding or margin settings (units should default to px and not be changeable)
3. In GB repo set the schema at top of `lib/theme.json` to `"$schema": "../schemas/json/theme.json"
4. Set the spacing units to an empty array and make sure a linting error displays that states the need for at least 1 array entry

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/044567bb-00ec-4ff6-91e1-7bc649aafa48

<img width="420" alt="Screenshot 2023-11-20 at 12 13 35 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/53c3f446-75c4-4a64-b913-7150bd34788a">

After:

https://github.com/WordPress/gutenberg/assets/3629020/ef7afc20-c7e4-4cc6-8b4b-09746c155c87

<img width="526" alt="Screenshot 2023-11-20 at 11 52 46 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/bce929ea-f119-4017-bebd-c2634115f66d">
