### PR TITLE
Patterns: Add a preference to disable the loading the of the choose pattern modal

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -144,11 +144,11 @@ export default function EditPostPreferencesModal() {
 								label={ __( 'Use theme styles' ) }
 							/>
 							<EnableFeature
-								featureName="disableChoosePatternModal"
+								featureName="enableChoosePatternModal"
 								help={ __(
-									'Prevents the choose pattern modal from displaying when adding a new page.'
+									'Enables the choose pattern modal when adding a new page.'
 								) }
-								label={ __( 'Disable choose pattern modal' ) }
+								label={ __( 'Enable choose pattern modal' ) }
 							/>
 							{ showBlockBreadcrumbsOption && (
 								<EnableFeature

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -151,11 +151,9 @@ export default function EditPostPreferencesModal() {
 								<EnableFeature
 									featureName="enableChoosePatternModal"
 									help={ __(
-										'Enables the choose pattern modal when adding a new page.'
+										'Shows starter patterns when creating a new page.'
 									) }
-									label={ __(
-										'Enable choose pattern modal'
-									) }
+									label={ __( 'Show starter patterns' ) }
 								/>
 							) }
 							{ showBlockBreadcrumbsOption && (

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -35,12 +35,16 @@ import {
 import MetaBoxesSection from './meta-boxes-section';
 import { store as editPostStore } from '../../store';
 import BlockManager from '../block-manager';
+import { useStartPatterns } from '../start-page-options';
 
 export const PREFERENCES_MODAL_NAME = 'edit-post/preferences';
 
 export default function EditPostPreferencesModal() {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const { closeModal } = useDispatch( interfaceStore );
+	const starterPatterns = useStartPatterns();
+	const themeHasStarterPatterns = starterPatterns.length > 0;
+
 	const [ isModalActive, showBlockBreadcrumbsOption ] = useSelect(
 		( select ) => {
 			const { getEditorSettings } = select( editorStore );
@@ -143,13 +147,17 @@ export default function EditPostPreferencesModal() {
 								) }
 								label={ __( 'Use theme styles' ) }
 							/>
-							<EnableFeature
-								featureName="enableChoosePatternModal"
-								help={ __(
-									'Enables the choose pattern modal when adding a new page.'
-								) }
-								label={ __( 'Enable choose pattern modal' ) }
-							/>
+							{ themeHasStarterPatterns && (
+								<EnableFeature
+									featureName="enableChoosePatternModal"
+									help={ __(
+										'Enables the choose pattern modal when adding a new page.'
+									) }
+									label={ __(
+										'Enable choose pattern modal'
+									) }
+								/>
+							) }
 							{ showBlockBreadcrumbsOption && (
 								<EnableFeature
 									featureName="showBlockBreadcrumbs"
@@ -259,7 +267,7 @@ export default function EditPostPreferencesModal() {
 				),
 			},
 		],
-		[ isLargeViewport, showBlockBreadcrumbsOption ]
+		[ isLargeViewport, showBlockBreadcrumbsOption, themeHasStarterPatterns ]
 	);
 
 	if ( ! isModalActive ) {

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -143,6 +143,13 @@ export default function EditPostPreferencesModal() {
 								) }
 								label={ __( 'Use theme styles' ) }
 							/>
+							<EnableFeature
+								featureName="disableChoosePatternModal"
+								help={ __(
+									'Prevents the choose pattern modal from displaying when adding a new page.'
+								) }
+								label={ __( 'Disable choose pattern modal' ) }
+							/>
 							{ showBlockBreadcrumbsOption && (
 								<EnableFeature
 									featureName="showBlockBreadcrumbs"

--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -18,7 +18,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { store as editPostStore } from '../../store';
 
-function useStartPatterns() {
+export function useStartPatterns() {
 	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
 	// and it has no postTypes declared and the current post type is page or if
 	// the current post type is part of the postTypes declared.

--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -12,11 +12,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useAsyncList } from '@wordpress/compose';
 import { store as editorStore } from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
  */
 import { store as editPostStore } from '../../store';
+import { PREFERENCES_MODAL_NAME } from '../preferences-modal';
 
 export function useStartPatterns() {
 	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
@@ -97,11 +99,15 @@ export default function StartPageOptions() {
 			'core/edit-post',
 			'enableChoosePatternModal'
 		);
+		const preferencesModalActive = select( interfaceStore ).isModalActive(
+			PREFERENCES_MODAL_NAME
+		);
 		return (
 			! isEditingTemplate() &&
 			! isFeatureActive( 'welcomeGuide' ) &&
 			isCleanNewPost() &&
-			enableChoosePatternModal
+			enableChoosePatternModal &&
+			! preferencesModalActive
 		);
 	}, [] );
 

--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -11,6 +11,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useAsyncList } from '@wordpress/compose';
 import { store as editorStore } from '@wordpress/editor';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -92,11 +93,15 @@ export default function StartPageOptions() {
 	const shouldEnableModal = useSelect( ( select ) => {
 		const { isCleanNewPost } = select( editorStore );
 		const { isEditingTemplate, isFeatureActive } = select( editPostStore );
-
+		const disableChoosePatternModal = select( preferencesStore ).get(
+			'core/edit-post',
+			'disableChoosePatternModal'
+		);
 		return (
 			! isEditingTemplate() &&
 			! isFeatureActive( 'welcomeGuide' ) &&
-			isCleanNewPost()
+			isCleanNewPost() &&
+			! disableChoosePatternModal
 		);
 	}, [] );
 

--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -93,15 +93,15 @@ export default function StartPageOptions() {
 	const shouldEnableModal = useSelect( ( select ) => {
 		const { isCleanNewPost } = select( editorStore );
 		const { isEditingTemplate, isFeatureActive } = select( editPostStore );
-		const disableChoosePatternModal = select( preferencesStore ).get(
+		const enableChoosePatternModal = select( preferencesStore ).get(
 			'core/edit-post',
-			'disableChoosePatternModal'
+			'enableChoosePatternModal'
 		);
 		return (
 			! isEditingTemplate() &&
 			! isFeatureActive( 'welcomeGuide' ) &&
 			isCleanNewPost() &&
-			! disableChoosePatternModal
+			enableChoosePatternModal
 		);
 	}, [] );
 

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -57,6 +57,7 @@ export function initializeEditor(
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		showListViewByDefault: false,
+		disableChoosePatternModal: false,
 		themeStyles: true,
 		welcomeGuide: true,
 		welcomeGuideTemplate: true,

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -57,7 +57,7 @@ export function initializeEditor(
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		showListViewByDefault: false,
-		disableChoosePatternModal: false,
+		enableChoosePatternModal: true,
 		themeStyles: true,
 		welcomeGuide: true,
 		welcomeGuideTemplate: true,


### PR DESCRIPTION
## What?
Adds a preference to disable the loading of the `Choose a pattern` modal when adding new pages

## Why?
If experienced users are always wanting to start with a blank page it is a frustrating extra step in their workflow to dismiss this modal each time.

Fixes: #56181

## How?
Adds a preference to disable this modal to the editor preferences

## Testing Instructions

- Add a new page and check that the `Choose a pattern` modal loads
- In the editor preferences modal toggle on the option to enable this modal off
- Add a new page again and make sure the modal does not load
- In the editor preferences modal toggle the option back on
- Add a new page and check that the `Choose a pattern` modal loads again

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/be9b1f46-8d54-427c-b000-b917593bf95a





