### PR TITLE
Cover block: Pass dropZoneElement reference to fix dragging within cover block area

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import {
@@ -324,6 +324,10 @@ function CoverEdit( {
 		fontSize: hasFontSizes ? 'large' : undefined,
 	} );
 
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the dropZoneElement updates.
+	const [ dropZoneElement, setDropZoneElement ] = useState( null );
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-cover__inner-container',
@@ -335,6 +339,7 @@ function CoverEdit( {
 			templateInsertUpdatesSelection: true,
 			allowedBlocks,
 			templateLock,
+			__unstableDropZoneElement: dropZoneElement,
 		}
 	);
 
@@ -494,6 +499,7 @@ function CoverEdit( {
 			<TagName
 				{ ...blockProps }
 				className={ classnames( classes, blockProps.className ) }
+				ref={ setDropZoneElement }
 				style={ { ...style, ...blockProps.style } }
 				data-url={ url }
 			>

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import {
@@ -324,10 +324,6 @@ function CoverEdit( {
 		fontSize: hasFontSizes ? 'large' : undefined,
 	} );
 
-	// Use internal state instead of a ref to make sure that the component
-	// re-renders when the dropZoneElement updates.
-	const [ dropZoneElement, setDropZoneElement ] = useState( null );
-
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-cover__inner-container',
@@ -339,7 +335,7 @@ function CoverEdit( {
 			templateInsertUpdatesSelection: true,
 			allowedBlocks,
 			templateLock,
-			__unstableDropZoneElement: dropZoneElement,
+			dropZoneElement: ref.current,
 		}
 	);
 
@@ -499,7 +495,6 @@ function CoverEdit( {
 			<TagName
 				{ ...blockProps }
 				className={ classnames( classes, blockProps.className ) }
-				ref={ setDropZoneElement }
 				style={ { ...style, ...blockProps.style } }
 				data-url={ url }
 			>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Note: this PR started out as a proof of concept that we _can_ fix #26049 via passing a drop zone element.

Related to: https://github.com/WordPress/gutenberg/issues/26049, following on from #56070

Pass in a `dropZoneElement` for the wrapper of the Cover block to fix dragging within a cover block's area.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without providing a `dropZoneElement` for the wrapper of the cover block, dragging within the padding of the cover block is treated as dragging either before or after the Cover block instead of within it. This makes it hard to drag something intentionally within a cover block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Pass the existing `ref`'s current value used for the cover wrapper to `useInnerBlocksProps`' `dropZoneElement` prop

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a cover block to a post that has some other blocks in it, and leave the cover block in its placeholder state
2. Drag a paragraph block over the cover block's placeholder — it should nudge you to go above or below the cover block's placeholder
3. Give the cover block a background color so that it becomes "real"
4. Now if you drag a paragraph block over the cover block, anywhere within the top or the bottom of the cover block should now be treated as dragging within the block
5. It should still be possible to drag an image file from the desktop over the cover block to replace the background image

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/ccf05026-8353-4179-bc5a-fd0966024d06

### After

https://github.com/WordPress/gutenberg/assets/14988353/915fc4d1-6dbc-41ef-bfc2-a7b397ddaa31