### PR TITLE
useInnerBlocksProps: stabilise dropZoneElement prop

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -172,7 +172,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	const {
 		__unstableDisableLayoutClassNames,
 		__unstableDisableDropZone,
-		__unstableDropZoneElement,
+		dropZoneElement,
 	} = options;
 	const {
 		clientId,
@@ -214,7 +214,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	);
 
 	const blockDropZoneRef = useBlockDropZone( {
-		dropZoneElement: __unstableDropZoneElement,
+		dropZoneElement,
 		rootClientId: clientId,
 	} );
 

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -411,7 +411,7 @@ export default function VisualEditor( { styles } ) {
 										: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
 								}
 								layout={ blockListLayout }
-								__unstableDropZoneElement={
+								dropZoneElement={
 									// When iframed, pass in the html element of the iframe to
 									// ensure the drop zone extends to the edges of the iframe.
 									isToBeIframed

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -134,7 +134,7 @@ export default function SiteEditorCanvas() {
 													isTemplateTypeNavigation,
 											}
 										) }
-										__unstableDropZoneElement={
+										dropZoneElement={
 											// Pass in the html element of the iframe to ensure that
 											// the drop zone extends to the very edges of the iframe,
 											// even if the template is shorter than the viewport.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to https://github.com/WordPress/gutenberg/pull/56308, which sought to make `dropZoneElement` private, this PR proposes stabilising the prop instead.

Happy for any feedback, ideas, or opinions on whether it's better to go private for now, or to stabilise the prop!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Based on discussion in https://github.com/WordPress/gutenberg/pull/56070#discussion_r1398637453 there's a good case to be made that we will need `dropZoneElement` as a stable prop in `useInnerBlocksProps`. See the prototype in https://github.com/WordPress/gutenberg/pull/56312 for an example use case, which would be part of resolving https://github.com/WordPress/gutenberg/issues/26049.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Rename `__unstableDropZoneElement` to `dropZoneElement`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Same testing steps as #56070:

* Test that dragging to the top and bottom of the post editor respects the top and bottom most positions
* Test that dragging to the bottom of a short template in the site editor still works
