### PR TITLE
Update: Change "Detach patterns" to singular.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
@@ -212,10 +212,7 @@ const BlockActionsMenu = ( {
 		},
 		convertToRegularBlocks: {
 			id: 'convertToRegularBlocksOption',
-			label:
-				innerBlockCount > 1
-					? __( 'Detach patterns' )
-					: __( 'Detach pattern' ),
+			label: __( 'Detach pattern' ),
 			value: 'convertToRegularBlocksOption',
 			onSelect: () => {
 				/* translators: %s: name of the synced block */

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -78,7 +78,7 @@ export default function ReusableBlockEdit( {
 		styles.spinnerDark
 	);
 
-	const { hasResolved, isEditing, isMissing, innerBlockCount } = useSelect(
+	const { hasResolved, isEditing, isMissing } = useSelect(
 		( select ) => {
 			const persistedBlock = select( coreStore ).getEntityRecord(
 				'postType',
@@ -176,20 +176,12 @@ export default function ReusableBlockEdit( {
 						{ infoTitle }
 					</Text>
 					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
-						{ innerBlockCount > 1
-							? __(
-									'Alternatively, you can detach and edit these blocks separately by tapping “Detach patterns”.'
-							  )
-							: __(
-									'Alternatively, you can detach and edit this block separately by tapping “Detach pattern”.'
-							  ) }
+						{ __(
+							'Alternatively, you can detach and edit this block separately by tapping “Detach pattern”.'
+						) }
 					</Text>
 					<TextControl
-						label={
-							innerBlockCount > 1
-								? __( 'Detach patterns' )
-								: __( 'Detach pattern' )
-						}
+						label={ __( 'Detach pattern' ) }
 						separatorType="topFullWidth"
 						onPress={ onConvertToRegularBlocks }
 						labelStyle={ actionButtonStyle }

--- a/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
@@ -219,7 +219,7 @@ describe( 'Pattern blocks', () => {
 
 		// Convert block to a regular block.
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Detach patterns' );
+		await clickMenuItem( 'Detach pattern' );
 
 		// Check that we have two paragraph blocks on the page.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -16,41 +16,40 @@ import { store as patternsStore } from '../store';
 import { unlock } from '../lock-unlock';
 
 function PatternsManageButton( { clientId } ) {
-	const { canRemove, isVisible, innerBlockCount, managePatternsUrl } =
-		useSelect(
-			( select ) => {
-				const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
-					select( blockEditorStore );
-				const { canUser } = select( coreStore );
-				const reusableBlock = getBlock( clientId );
-				const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
+	const { canRemove, isVisible, managePatternsUrl } = useSelect(
+		( select ) => {
+			const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
+				select( blockEditorStore );
+			const { canUser } = select( coreStore );
+			const reusableBlock = getBlock( clientId );
+			const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
 
-				return {
-					canRemove: canRemoveBlock( clientId ),
-					isVisible:
-						!! reusableBlock &&
-						isReusableBlock( reusableBlock ) &&
-						!! canUser(
-							'update',
-							'blocks',
-							reusableBlock.attributes.ref
-						),
-					innerBlockCount: getBlockCount( clientId ),
-					// The site editor and templates both check whether the user
-					// has edit_theme_options capabilities. We can leverage that here
-					// and omit the manage patterns link if the user can't access it.
-					managePatternsUrl:
-						isBlockTheme && canUser( 'read', 'templates' )
-							? addQueryArgs( 'site-editor.php', {
-									path: '/patterns',
-							  } )
-							: addQueryArgs( 'edit.php', {
-									post_type: 'wp_block',
-							  } ),
-				};
-			},
-			[ clientId ]
-		);
+			return {
+				canRemove: canRemoveBlock( clientId ),
+				isVisible:
+					!! reusableBlock &&
+					isReusableBlock( reusableBlock ) &&
+					!! canUser(
+						'update',
+						'blocks',
+						reusableBlock.attributes.ref
+					),
+				innerBlockCount: getBlockCount( clientId ),
+				// The site editor and templates both check whether the user
+				// has edit_theme_options capabilities. We can leverage that here
+				// and omit the manage patterns link if the user can't access it.
+				managePatternsUrl:
+					isBlockTheme && canUser( 'read', 'templates' )
+						? addQueryArgs( 'site-editor.php', {
+								path: '/patterns',
+						  } )
+						: addQueryArgs( 'edit.php', {
+								post_type: 'wp_block',
+						  } ),
+			};
+		},
+		[ clientId ]
+	);
 
 	// Ignore reason: false positive of the lint rule.
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
@@ -68,9 +67,7 @@ function PatternsManageButton( { clientId } ) {
 				<MenuItem
 					onClick={ () => convertSyncedPatternToStatic( clientId ) }
 				>
-					{ innerBlockCount > 1
-						? __( 'Detach patterns' )
-						: __( 'Detach pattern' ) }
+					{ __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
 			<MenuItem href={ managePatternsUrl }>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -15,41 +15,40 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
-	const { canRemove, isVisible, innerBlockCount, managePatternsUrl } =
-		useSelect(
-			( select ) => {
-				const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
-					select( blockEditorStore );
-				const { canUser } = select( coreStore );
-				const reusableBlock = getBlock( clientId );
-				const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
+	const { canRemove, isVisible, managePatternsUrl } = useSelect(
+		( select ) => {
+			const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
+				select( blockEditorStore );
+			const { canUser } = select( coreStore );
+			const reusableBlock = getBlock( clientId );
+			const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
 
-				return {
-					canRemove: canRemoveBlock( clientId ),
-					isVisible:
-						!! reusableBlock &&
-						isReusableBlock( reusableBlock ) &&
-						!! canUser(
-							'update',
-							'blocks',
-							reusableBlock.attributes.ref
-						),
-					innerBlockCount: getBlockCount( clientId ),
-					// The site editor and templates both check whether the user
-					// has edit_theme_options capabilities. We can leverage that here
-					// and omit the manage patterns link if the user can't access it.
-					managePatternsUrl:
-						isBlockTheme && canUser( 'read', 'templates' )
-							? addQueryArgs( 'site-editor.php', {
-									path: '/patterns',
-							  } )
-							: addQueryArgs( 'edit.php', {
-									post_type: 'wp_block',
-							  } ),
-				};
-			},
-			[ clientId ]
-		);
+			return {
+				canRemove: canRemoveBlock( clientId ),
+				isVisible:
+					!! reusableBlock &&
+					isReusableBlock( reusableBlock ) &&
+					!! canUser(
+						'update',
+						'blocks',
+						reusableBlock.attributes.ref
+					),
+				innerBlockCount: getBlockCount( clientId ),
+				// The site editor and templates both check whether the user
+				// has edit_theme_options capabilities. We can leverage that here
+				// and omit the manage patterns link if the user can't access it.
+				managePatternsUrl:
+					isBlockTheme && canUser( 'read', 'templates' )
+						? addQueryArgs( 'site-editor.php', {
+								path: '/patterns',
+						  } )
+						: addQueryArgs( 'edit.php', {
+								post_type: 'wp_block',
+						  } ),
+			};
+		},
+		[ clientId ]
+	);
 
 	const { __experimentalConvertBlockToStatic: convertBlockToStatic } =
 		useDispatch( reusableBlocksStore );
@@ -65,9 +64,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 			</MenuItem>
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-					{ innerBlockCount > 1
-						? __( 'Detach patterns' )
-						: __( 'Detach pattern' ) }
+					{ __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
 		</>


### PR DESCRIPTION
## What?

Followup to #51993. When you insert a synced pattern that features more than 1 inner block, the ellipsis menu says "Detach patterns", plural. 

![Screenshot showing the ellipsis menu with a focus on the "Detach patterns" item.](https://github.com/WordPress/gutenberg/assets/1204802/4101f717-a163-4d03-900d-25b15d8fe897)

But the synced pattern itself is what gets detached, so the plural should not relate to the number of innerblocks. This PR changes all instances to singular.

## Testing Instructions

* Create a synced pattern featuring multiple inner blocks.
* Insert it in a page or post.
* From the ellipsis menu, select "Detach pattern" and notice it's singular.

_Note for the PR review, all the red is due to indentation changing._