### PR TITLE
Post Schedule Panel: Remove text overflow ellipsis

### DIFF
--- a/packages/editor/src/components/post-panel-row/index.js
+++ b/packages/editor/src/components/post-panel-row/index.js
@@ -12,9 +12,7 @@ import { forwardRef } from '@wordpress/element';
 const PostPanelRow = forwardRef( ( { className, label, children }, ref ) => {
 	return (
 		<HStack
-			className={ classnames( 'editor-post-panel__row', className, {
-				'has-label': !! label,
-			} ) }
+			className={ classnames( 'editor-post-panel__row', className ) }
 			ref={ ref }
 		>
 			{ label ? (

--- a/packages/editor/src/components/post-panel-row/index.js
+++ b/packages/editor/src/components/post-panel-row/index.js
@@ -12,7 +12,9 @@ import { forwardRef } from '@wordpress/element';
 const PostPanelRow = forwardRef( ( { className, label, children }, ref ) => {
 	return (
 		<HStack
-			className={ classnames( 'editor-post-panel__row', className ) }
+			className={ classnames( 'editor-post-panel__row', className, {
+				'has-label': !! label,
+			} ) }
 			ref={ ref }
 		>
 			{ label ? (

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -1,13 +1,19 @@
 .editor-post-panel__row {
 	width: 100%;
-	justify-content: flex-start;
-	align-items: flex-start;
 	min-height: $button-size;
+}
+
+.editor-post-panel__row.has-label {
+	justify-content: flex-start !important;
+	align-items: flex-start !important;
 }
 
 .editor-post-panel__row-label {
 	width: 30%;
 	flex-shrink: 0;
+	min-height: $button-size;
+	display: flex;
+	align-items: center;
 }
 
 .editor-post-panel__row-control {

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -1,9 +1,6 @@
 .editor-post-panel__row {
 	width: 100%;
 	min-height: $button-size;
-}
-
-.editor-post-panel__row.has-label {
 	justify-content: flex-start !important;
 	align-items: flex-start !important;
 }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -9,11 +9,11 @@
 	}
 }
 
-.editor-post-schedule__dialog-toggle {
+.editor-post-schedule__dialog-toggle.components-button {
 	display: block;
 	max-width: 100%;
 	overflow: hidden;
 	text-align: left;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	white-space: unset;
+	height: auto;
 }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -18,6 +18,6 @@
 	height: auto;
 
 	// The line height + the padding should be the same as the button size.
-	padding: 10px 12px;
-	line-height: 16px;
+	padding: ( ( $button-size - $grid-unit-20 ) / 2 ) 12px;
+	line-height: $grid-unit-20;
 }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -16,5 +16,8 @@
 	text-align: left;
 	white-space: unset;
 	height: auto;
+
+	// The line height + the padding should be the same as the button size.
 	padding: 10px 12px;
+	line-height: 16px;
 }

--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -16,4 +16,5 @@
 	text-align: left;
 	white-space: unset;
 	height: auto;
+	padding: 10px 12px;
 }


### PR DESCRIPTION
Follow-up to #56196 
Closes #56262

## What?

The PostSchedule unification PR kept the format of the post editor (full date visible) but kept the style of the site editor (text overflow cut using an ellipsis). This PR restores the styling of the post editor which used to render the full date.

## Testing Instructions

1- Schedule a post in the future
2- Notice that the date is shown fully.

<img width="282" alt="Screenshot 2023-11-20 at 2 15 04 PM" src="https://github.com/WordPress/gutenberg/assets/272444/743fcb9d-08fd-44cb-8ad9-18916f378dd0">
