### PR TITLE
Try: Change "Detach pattern" to "Detach"

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
@@ -212,7 +212,7 @@ const BlockActionsMenu = ( {
 		},
 		convertToRegularBlocks: {
 			id: 'convertToRegularBlocksOption',
-			label: __( 'Detach pattern' ),
+			label: __( 'Detach' ),
 			value: 'convertToRegularBlocksOption',
 			onSelect: () => {
 				/* translators: %s: name of the synced block */

--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-menu.native.js
@@ -212,10 +212,7 @@ const BlockActionsMenu = ( {
 		},
 		convertToRegularBlocks: {
 			id: 'convertToRegularBlocksOption',
-			label:
-				innerBlockCount > 1
-					? __( 'Detach patterns' )
-					: __( 'Detach pattern' ),
+			label: __( 'Detach pattern' ),
 			value: 'convertToRegularBlocksOption',
 			onSelect: () => {
 				/* translators: %s: name of the synced block */

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -78,7 +78,7 @@ export default function ReusableBlockEdit( {
 		styles.spinnerDark
 	);
 
-	const { hasResolved, isEditing, isMissing, innerBlockCount } = useSelect(
+	const { hasResolved, isEditing, isMissing } = useSelect(
 		( select ) => {
 			const persistedBlock = select( coreStore ).getEntityRecord(
 				'postType',
@@ -176,20 +176,12 @@ export default function ReusableBlockEdit( {
 						{ infoTitle }
 					</Text>
 					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
-						{ innerBlockCount > 1
-							? __(
-									'Alternatively, you can detach and edit these blocks separately by tapping “Detach patterns”.'
-							  )
-							: __(
-									'Alternatively, you can detach and edit this block separately by tapping “Detach pattern”.'
-							  ) }
+						{ __(
+							'Alternatively, you can detach and edit this block separately by tapping “Detach pattern”.'
+						) }
 					</Text>
 					<TextControl
-						label={
-							innerBlockCount > 1
-								? __( 'Detach patterns' )
-								: __( 'Detach pattern' )
-						}
+						label={ __( 'Detach pattern' ) }
 						separatorType="topFullWidth"
 						onPress={ onConvertToRegularBlocks }
 						labelStyle={ actionButtonStyle }

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -177,11 +177,11 @@ export default function ReusableBlockEdit( {
 					</Text>
 					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
 						{ __(
-							'Alternatively, you can detach and edit this block separately by tapping “Detach pattern”.'
+							'Alternatively, you can detach and edit this block separately by tapping “Detach”.'
 						) }
 					</Text>
 					<TextControl
-						label={ __( 'Detach pattern' ) }
+						label={ __( 'Detach' ) }
 						separatorType="topFullWidth"
 						onPress={ onConvertToRegularBlocks }
 						labelStyle={ actionButtonStyle }

--- a/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
@@ -219,7 +219,7 @@ describe( 'Pattern blocks', () => {
 
 		// Convert block to a regular block.
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Detach patterns' );
+		await clickMenuItem( 'Detach pattern' );
 
 		// Check that we have two paragraph blocks on the page.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
@@ -112,7 +112,7 @@ describe( 'Pattern blocks', () => {
 
 		// Convert block to a regular block.
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Detach pattern' );
+		await clickMenuItem( 'Detach' );
 
 		// Check that we have a paragraph block on the page.
 		const paragraphBlock = await canvas().$(
@@ -219,7 +219,7 @@ describe( 'Pattern blocks', () => {
 
 		// Convert block to a regular block.
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Detach pattern' );
+		await clickMenuItem( 'Detach' );
 
 		// Check that we have two paragraph blocks on the page.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -352,7 +352,7 @@ describe( 'Pattern blocks', () => {
 		// Convert back to regular blocks.
 		await clickBlockToolbarButton( 'Select Edited block' );
 		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Detach pattern' );
+		await clickMenuItem( 'Detach' );
 		await page.waitForXPath( selector, {
 			hidden: true,
 		} );

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -16,41 +16,40 @@ import { store as patternsStore } from '../store';
 import { unlock } from '../lock-unlock';
 
 function PatternsManageButton( { clientId } ) {
-	const { canRemove, isVisible, innerBlockCount, managePatternsUrl } =
-		useSelect(
-			( select ) => {
-				const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
-					select( blockEditorStore );
-				const { canUser } = select( coreStore );
-				const reusableBlock = getBlock( clientId );
-				const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
+	const { canRemove, isVisible, managePatternsUrl } = useSelect(
+		( select ) => {
+			const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
+				select( blockEditorStore );
+			const { canUser } = select( coreStore );
+			const reusableBlock = getBlock( clientId );
+			const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
 
-				return {
-					canRemove: canRemoveBlock( clientId ),
-					isVisible:
-						!! reusableBlock &&
-						isReusableBlock( reusableBlock ) &&
-						!! canUser(
-							'update',
-							'blocks',
-							reusableBlock.attributes.ref
-						),
-					innerBlockCount: getBlockCount( clientId ),
-					// The site editor and templates both check whether the user
-					// has edit_theme_options capabilities. We can leverage that here
-					// and omit the manage patterns link if the user can't access it.
-					managePatternsUrl:
-						isBlockTheme && canUser( 'read', 'templates' )
-							? addQueryArgs( 'site-editor.php', {
-									path: '/patterns',
-							  } )
-							: addQueryArgs( 'edit.php', {
-									post_type: 'wp_block',
-							  } ),
-				};
-			},
-			[ clientId ]
-		);
+			return {
+				canRemove: canRemoveBlock( clientId ),
+				isVisible:
+					!! reusableBlock &&
+					isReusableBlock( reusableBlock ) &&
+					!! canUser(
+						'update',
+						'blocks',
+						reusableBlock.attributes.ref
+					),
+				innerBlockCount: getBlockCount( clientId ),
+				// The site editor and templates both check whether the user
+				// has edit_theme_options capabilities. We can leverage that here
+				// and omit the manage patterns link if the user can't access it.
+				managePatternsUrl:
+					isBlockTheme && canUser( 'read', 'templates' )
+						? addQueryArgs( 'site-editor.php', {
+								path: '/patterns',
+						  } )
+						: addQueryArgs( 'edit.php', {
+								post_type: 'wp_block',
+						  } ),
+			};
+		},
+		[ clientId ]
+	);
 
 	// Ignore reason: false positive of the lint rule.
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
@@ -68,9 +67,7 @@ function PatternsManageButton( { clientId } ) {
 				<MenuItem
 					onClick={ () => convertSyncedPatternToStatic( clientId ) }
 				>
-					{ innerBlockCount > 1
-						? __( 'Detach patterns' )
-						: __( 'Detach pattern' ) }
+					{ __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
 			<MenuItem href={ managePatternsUrl }>

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -67,7 +67,7 @@ function PatternsManageButton( { clientId } ) {
 				<MenuItem
 					onClick={ () => convertSyncedPatternToStatic( clientId ) }
 				>
-					{ __( 'Detach pattern' ) }
+					{ __( 'Detach' ) }
 				</MenuItem>
 			) }
 			<MenuItem href={ managePatternsUrl }>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -15,41 +15,40 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
-	const { canRemove, isVisible, innerBlockCount, managePatternsUrl } =
-		useSelect(
-			( select ) => {
-				const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
-					select( blockEditorStore );
-				const { canUser } = select( coreStore );
-				const reusableBlock = getBlock( clientId );
-				const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
+	const { canRemove, isVisible, managePatternsUrl } = useSelect(
+		( select ) => {
+			const { getBlock, canRemoveBlock, getBlockCount, getSettings } =
+				select( blockEditorStore );
+			const { canUser } = select( coreStore );
+			const reusableBlock = getBlock( clientId );
+			const isBlockTheme = getSettings().__unstableIsBlockBasedTheme;
 
-				return {
-					canRemove: canRemoveBlock( clientId ),
-					isVisible:
-						!! reusableBlock &&
-						isReusableBlock( reusableBlock ) &&
-						!! canUser(
-							'update',
-							'blocks',
-							reusableBlock.attributes.ref
-						),
-					innerBlockCount: getBlockCount( clientId ),
-					// The site editor and templates both check whether the user
-					// has edit_theme_options capabilities. We can leverage that here
-					// and omit the manage patterns link if the user can't access it.
-					managePatternsUrl:
-						isBlockTheme && canUser( 'read', 'templates' )
-							? addQueryArgs( 'site-editor.php', {
-									path: '/patterns',
-							  } )
-							: addQueryArgs( 'edit.php', {
-									post_type: 'wp_block',
-							  } ),
-				};
-			},
-			[ clientId ]
-		);
+			return {
+				canRemove: canRemoveBlock( clientId ),
+				isVisible:
+					!! reusableBlock &&
+					isReusableBlock( reusableBlock ) &&
+					!! canUser(
+						'update',
+						'blocks',
+						reusableBlock.attributes.ref
+					),
+				innerBlockCount: getBlockCount( clientId ),
+				// The site editor and templates both check whether the user
+				// has edit_theme_options capabilities. We can leverage that here
+				// and omit the manage patterns link if the user can't access it.
+				managePatternsUrl:
+					isBlockTheme && canUser( 'read', 'templates' )
+						? addQueryArgs( 'site-editor.php', {
+								path: '/patterns',
+						  } )
+						: addQueryArgs( 'edit.php', {
+								post_type: 'wp_block',
+						  } ),
+			};
+		},
+		[ clientId ]
+	);
 
 	const { __experimentalConvertBlockToStatic: convertBlockToStatic } =
 		useDispatch( reusableBlocksStore );
@@ -65,9 +64,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 			</MenuItem>
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-					{ innerBlockCount > 1
-						? __( 'Detach patterns' )
-						: __( 'Detach pattern' ) }
+					{ __( 'Detach pattern' ) }
 				</MenuItem>
 			) }
 		</>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -64,7 +64,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 			</MenuItem>
 			{ canRemove && (
 				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-					{ __( 'Detach pattern' ) }
+					{ __( 'Detach' ) }
 				</MenuItem>
 			) }
 		</>


### PR DESCRIPTION
## What?

Alternative to #56317. Not only fixes the pluralization issue the former fixes, but goes a bit further, simplifying the option "Detach pattern" into just "Detach". This is similar to "Ungroup" instead of "Ungroup blocks", and is more direct, actionable, simple.

![Screenshot 2023-11-20 at 15 12 56](https://github.com/WordPress/gutenberg/assets/1204802/aa465cef-8289-470a-a99d-b8d0ed1d2186)

## Testing Instructions

* Create a synced patter
* Insert this synced pattern in a post or page
* Click the ellipsis menu of the synced block and observe "Detach" in the menu.
