### PR TITLE
Site Editor: Apply `box-sizing:reset` to popover component

### DIFF
--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -67,7 +67,8 @@ body.js.site-editor-php {
 }
 
 .edit-site,
-// The modals are shown outside the .edit-site wrapper, they need these styles.
+// The popovers and modals are shown outside the .edit-site wrapper, they need these styles.
+.components-popover,
 .components-modal__frame {
 	@include reset;
 }


### PR DESCRIPTION
Fixes #56190

## What?
This PR fixes an issue where a scrollbar may appear when a popover is rendered in the Site Editor.

### Before

![before](https://github.com/WordPress/gutenberg/assets/54422211/3d187da7-6ccc-4c33-961e-ee4e9dc7e5be)

### After

![after](https://github.com/WordPress/gutenberg/assets/54422211/23889154-394d-4953-a7e2-39e4e9c06db9)

## Why?
Popovers may be rendered outside of the `.edit-site` wrapper. Therefore, the `box-sizing:border-box` reset style is not applied.

## How?
Added `.components-popover` to the class to reset. This approach is also taken by [the Post Editor](https://github.com/WordPress/gutenberg/blob/d4dc45f014a052cd7ece453872d83dfae7450337/packages/edit-post/src/style.scss#L58).

## Testing Instructions

- Create a new draft page from the navigation block's inserter.
- Scrollbars should not appear in the popover.