### PR TITLE
Docs: Fix incorrect build script description in script package

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -98,7 +98,7 @@ This is how you execute the script with presented setup:
 -   `npm run build` - builds the code for production.
 -   `npm run build:custom` - builds the code for production with two entry points and a custom output directory. Paths for custom entry points are relative to the project root.
 -   `npm run build:copy-php` - builds the code for production and opts into copying all PHP files from the `src` directory and its subfolders to the output directory. By default, only PHP files listed in the `render` field in the detected `block.json` files get copied.
--   `build:custom-directory` - builds the code for production using the `custom-directory` as the source code directory.
+-   `npm run build:custom-directory` - builds the code for production using the `custom-directory` as the source code directory.
 
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 


### PR DESCRIPTION
## What?
Added the missing `npm run` to the build script description.


## Testing Instructions
There is no code impact.