### PR TITLE
Remove incorrect version from deprecated `__nextHasNoMarginBottom` prop of `AnglePickerControl` Component

### DIFF
--- a/packages/components/src/angle-picker-control/index.tsx
+++ b/packages/components/src/angle-picker-control/index.tsx
@@ -41,7 +41,6 @@ function UnforwardedAnglePickerControl(
 			'Bottom margin styles for wp.components.AnglePickerControl',
 			{
 				since: '6.1',
-				version: '6.4',
 				hint: 'Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.',
 			}
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the version when the deprecated `__nextHasNoMarginBottom` prop will get removed from `AnglePickerControl` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This prop was supposed to be deprecated as of WordPress 6.4. But since we don't have a clear process for deprecating APIs that shipped in WordPress core the removal is currently on hold. So this PR removes the incorrect version number when the prop will get removed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

/

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

/

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
/ 
## Screenshots or screencast <!-- if applicable -->
/