### PR TITLE
Rich text: pad multiple spaces through en/em replacement

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -3,7 +3,7 @@
  */
 import { useRef } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
-import { insert, toHTMLString } from '@wordpress/rich-text';
+import { insert, isCollapsed, toHTMLString } from '@wordpress/rich-text';
 import { getBlockTransforms, findTransform } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 
@@ -43,6 +43,10 @@ function findSelection( blocks ) {
 }
 
 function convertSpaces( value ) {
+	if ( ! isCollapsed( value ) ) {
+		return value;
+	}
+
 	const { text, start } = value;
 	const lastTwoCharacters = text.slice( start - 2, start );
 

--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -42,6 +42,22 @@ function findSelection( blocks ) {
 	return [];
 }
 
+function convertSpaces( value ) {
+	const { text, start } = value;
+	const lastTwoCharacters = text.slice( start - 2, start );
+
+	// Replace two spaces with an em space.
+	if ( lastTwoCharacters === '  ' ) {
+		return insert( value, '\u2002', start - 2, start );
+	}
+	// Replace an en space followed by a space with an em space.
+	else if ( lastTwoCharacters === '\u2002 ' ) {
+		return insert( value, '\u2003', start - 2, start );
+	}
+
+	return value;
+}
+
 export function useInputRules( props ) {
 	const {
 		__unstableMarkLastChangeAsPersistent,
@@ -122,7 +138,7 @@ export function useInputRules( props ) {
 
 					return accumlator;
 				},
-				preventEventDiscovery( value )
+				preventEventDiscovery( convertSpaces( value ) )
 			);
 
 			if ( transformed !== value ) {

--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -42,7 +42,15 @@ function findSelection( blocks ) {
 	return [];
 }
 
-function convertSpaces( value ) {
+/**
+ * An input rule that replaces two spaces with an en space, and an en space
+ * followed by a space with an em space.
+ *
+ * @param {Object} value Value to replace spaces in.
+ *
+ * @return {Object} Value with spaces replaced.
+ */
+function replacePrecedingSpaces( value ) {
 	if ( ! isCollapsed( value ) ) {
 		return value;
 	}
@@ -142,7 +150,7 @@ export function useInputRules( props ) {
 
 					return accumlator;
 				},
-				preventEventDiscovery( convertSpaces( value ) )
+				preventEventDiscovery( replacePrecedingSpaces( value ) )
 			);
 
 			if ( transformed !== value ) {

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -940,8 +940,8 @@ test.describe( 'Links', () => {
 			pageUtils,
 			editor,
 		} ) => {
-			const textToSelect = `         spaces     `;
-			const textWithWhitespace = `Text with leading and trailing${ textToSelect }`;
+			const textToSelect = `\u2003\u2003 spaces\u2003 `;
+			const textWithWhitespace = `Text with leading and trailing       spaces    `;
 
 			// Create a block with some text.
 			await editor.insertBlock( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently, multiple spaces are not preserved on the front-end because normally white space is collapsed in HTML. Browsers normally fix this in `contenteditable` by adding alternating non-breaking spaces. This is what I tried in #56280. The solution is not working great (need more special casing for the start and end of line), and we'd need to make sure that the alternating patterns stays (removing a space in between two non breaking spaces should reset the pattern for example). Additionally, we need to make sure we somehow don't end up with single non breaking spaces littered over the content, because that results in weird text non breaking flows. And we can't just remove _all_ non breaking spaces because we don't know if it was intentional.

@dmsnell came up with the idea to replace them with en/em spaces, which I thought was great!

When you insert a space after another space, replace it with an en space, which HTML doesn't collapse! When you insert a space again, replace with an em space.

This creates a dual function of both acting as a typographical shortcut and preventing the space from collapsing.

It's worth noting that adding multiple spaces should be uncommon. In all these years, there hasn't been a single report about the fact that the spaces disappear on the front-end. Nevertheless, we're looking into using the same white space CSS rules as the front-end, so it would be super odd if you were typing multiple spaces and the space wouldn't increase after 1.

Also, if people really insisted on inserting actual spaces (which browser wouldn't do anyway), they can use the CSS rule, or use the verse or pre block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See above.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
