### PR TITLE
Global styles revisions: migrate API call to getRevisions() 

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -128,6 +128,8 @@ _Returns_
 
 ### getCurrentThemeGlobalStylesRevisions
 
+> **Deprecated** since WordPress 6.5.0. Callers should use `select( 'core' ).getRevisions( 'root', 'globalStyles', ${ recordKey } )` instead, where `recordKey` is the id of the global styles parent post.
+
 Returns the revisions of the current global styles theme.
 
 _Parameters_

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -453,6 +453,8 @@ _Returns_
 
 ### getCurrentThemeGlobalStylesRevisions
 
+> **Deprecated** since WordPress 6.5.0. Callers should use `select( 'core' ).getRevisions( 'root', 'globalStyles', ${ recordKey } )` instead, where `recordKey` is the id of the global styles parent post.
+
 Returns the revisions of the current global styles theme.
 
 _Parameters_

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -218,6 +218,8 @@ export function receiveThemeSupports() {
  * Returns an action object used in signalling that the theme global styles CPT post revisions have been received.
  * Ignored from documentation as it's internal to the data store.
  *
+ * @deprecated since WordPress 6.5.0. Callers should use `dispatch( 'core' ).receiveRevision` instead.
+ *
  * @ignore
  *
  * @param {number} currentId The post id.
@@ -226,6 +228,13 @@ export function receiveThemeSupports() {
  * @return {Object} Action object.
  */
 export function receiveThemeGlobalStyleRevisions( currentId, revisions ) {
+	deprecated(
+		"wp.data.dispatch( 'core' ).receiveThemeGlobalStyleRevisions()",
+		{
+			since: '6.5.0',
+			alternative: "wp.data.dispatch( 'core' ).receiveRevisions",
+		}
+	);
 	return {
 		type: 'RECEIVE_THEME_GLOBAL_STYLE_REVISIONS',
 		currentId,

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1353,13 +1353,20 @@ export function getUserPatternCategories(
 /**
  * Returns the revisions of the current global styles theme.
  *
- * @param state Data state.
+ * @deprecated since WordPress 6.5.0. Callers should use `select( 'core' ).getRevisions( 'root', 'globalStyles', ${ recordKey } )` instead, where `recordKey` is the id of the global styles parent post.
+ *
+ * @param      state Data state.
  *
  * @return The current global styles.
  */
 export function getCurrentThemeGlobalStylesRevisions(
 	state: State
 ): Array< object > | null {
+	deprecated( "select( 'core' ).getCurrentThemeGlobalStylesRevisions()", {
+		since: '6.5.0',
+		alternative:
+			"select( 'core' ).getRevisions( 'root', 'globalStyles', ${ recordKey } )",
+	} );
 	const currentGlobalStylesId =
 		__experimentalGetCurrentGlobalStylesId( state );
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -32,14 +32,19 @@ export default function useGlobalStylesRevisions() {
 			__experimentalGetDirtyEntityRecords,
 			getCurrentUser,
 			getUsers,
-			getCurrentThemeGlobalStylesRevisions,
+			getRevisions,
+			__experimentalGetCurrentGlobalStylesId,
 			isResolving,
 		} = select( coreStore );
 		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 		const _currentUser = getCurrentUser();
 		const _isDirty = dirtyEntityRecords.length > 0;
 		const globalStylesRevisions =
-			getCurrentThemeGlobalStylesRevisions() || EMPTY_ARRAY;
+			getRevisions(
+				'root',
+				'globalStyles',
+				__experimentalGetCurrentGlobalStylesId()
+			) || EMPTY_ARRAY;
 		const _authors = getUsers( SITE_EDITOR_AUTHORS_QUERY ) || EMPTY_ARRAY;
 
 		return {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -43,7 +43,10 @@ export default function useGlobalStylesRevisions() {
 			getRevisions(
 				'root',
 				'globalStyles',
-				__experimentalGetCurrentGlobalStylesId()
+				__experimentalGetCurrentGlobalStylesId(),
+				{
+					per_page: 100,
+				}
 			) || EMPTY_ARRAY;
 		const _authors = getUsers( SITE_EDITOR_AUTHORS_QUERY ) || EMPTY_ARRAY;
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Ho!

Now that the [core data revisions API](https://github.com/WordPress/gutenberg/pull/54046) is merged, we can use it to fetch global styles revisions and deprecate the old stuff, namely the `*ThemeGlobalStyleRevision` selector and action.

## Why?
We must sacrifice in the name of progress.

## Testing Instructions

Fire up the site editor, and make/save global styles changes.

Check that there are no regressions to the global styles revisions list, especially:

1. The list should load all revisions
2. The list should update when you save a new revision


Here are some demonstration videos we prepared earlier:

https://github.com/WordPress/gutenberg/assets/6458278/218d157c-83cd-4070-89db-f513cc74fada



https://github.com/WordPress/gutenberg/assets/6458278/2c7562a2-db84-46eb-884a-50295ac6ad1e
