### PR TITLE
Rich text: remove forced `white-space: pre` rule

### DIFF
--- a/packages/rich-text/src/component/use-default-style.js
+++ b/packages/rich-text/src/component/use-default-style.js
@@ -4,28 +4,6 @@
 import { useCallback } from '@wordpress/element';
 
 /**
- * In HTML, leading and trailing spaces are not visible, and multiple spaces
- * elsewhere are visually reduced to one space. This rule prevents spaces from
- * collapsing so all space is visible in the editor and can be removed. It also
- * prevents some browsers from inserting non-breaking spaces at the end of a
- * line to prevent the space from visually disappearing. Sometimes these non
- * breaking spaces can linger in the editor causing unwanted non breaking spaces
- * in between words. If also prevent Firefox from inserting a trailing `br` node
- * to visualise any trailing space, causing the element to be saved.
- *
- * > Authors are encouraged to set the 'white-space' property on editing hosts
- * > and on markup that was originally created through these editing mechanisms
- * > to the value 'pre-wrap'. Default HTML whitespace handling is not well
- * > suited to WYSIWYG editing, and line wrapping will not work correctly in
- * > some corner cases if 'white-space' is left at its default value.
- *
- * https://html.spec.whatwg.org/multipage/interaction.html#best-practices-for-in-page-editors
- *
- * @type {string}
- */
-const whiteSpace = 'pre-wrap';
-
-/**
  * A minimum width of 1px will prevent the rich text container from collapsing
  * to 0 width and hiding the caret. This is useful for inline containers.
  */
@@ -34,7 +12,6 @@ const minWidth = '1px';
 export function useDefaultStyle() {
 	return useCallback( ( element ) => {
 		if ( ! element ) return;
-		element.style.whiteSpace = whiteSpace;
 		element.style.minWidth = minWidth;
 	}, [] );
 }

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -9,6 +9,7 @@ import { useRefEffect } from '@wordpress/compose';
  */
 import { getActiveFormats } from '../get-active-formats';
 import { updateFormats } from '../update-formats';
+import { insert } from '../insert';
 
 /**
  * All inserting input types that would insert HTML into the DOM.
@@ -83,6 +84,18 @@ export function useInputAndSelection( props ) {
 
 			const { record, applyRecord, createRecord, handleChange } =
 				propsRef.current;
+
+			// When white space is collapsed (default rendering rule), the
+			// browser will insert non-breaking spaces instead of regular spaces
+			// when inserting multiple. We should prevent this behaviour because
+			// the browser doesn't always remove them when they're no longer
+			// needed, and we have custom handling for multiple spaces (see en
+			// and em input rule). At the start and end of a line with a regular
+			// space, we pad with a zero-width non-breaking space.
+			if ( inputType === 'insertText' && event?.data === ' ' ) {
+				applyRecord( insert( record.current, ' ' ) );
+				return;
+			}
 
 			// The browser formatted something or tried to insert HTML.
 			// Overwrite it. It will be handled later by the format library if

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -85,18 +85,6 @@ export function useInputAndSelection( props ) {
 			const { record, applyRecord, createRecord, handleChange } =
 				propsRef.current;
 
-			// When white space is collapsed (default rendering rule), the
-			// browser will insert non-breaking spaces instead of regular spaces
-			// when inserting multiple. We should prevent this behaviour because
-			// the browser doesn't always remove them when they're no longer
-			// needed, and we have custom handling for multiple spaces (see en
-			// and em input rule). At the start and end of a line with a regular
-			// space, we pad with a zero-width non-breaking space.
-			if ( inputType === 'insertText' && event?.data === ' ' ) {
-				applyRecord( insert( record.current, ' ' ) );
-				return;
-			}
-
 			// The browser formatted something or tried to insert HTML.
 			// Overwrite it. It will be handled later by the format library if
 			// needed.
@@ -109,9 +97,20 @@ export function useInputAndSelection( props ) {
 				return;
 			}
 
-			const currentValue = createRecord();
+			let currentValue = createRecord();
 			const { start, activeFormats: oldActiveFormats = [] } =
 				record.current;
+
+			// When white space is collapsed (default rendering rule), the
+			// browser will insert non-breaking spaces instead of regular spaces
+			// when inserting multiple. We should prevent this behaviour because
+			// the browser doesn't always remove them when they're no longer
+			// needed, and we have custom handling for multiple spaces (see en
+			// and em input rule). At the start and end of a line with a regular
+			// space, we pad with a zero-width non-breaking space.
+			if ( inputType === 'insertText' && event?.data === ' ' ) {
+				currentValue = insert( record.current, ' ' );
+			}
 
 			// Update the formats between the last and new caret position.
 			const change = updateFormats( {

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -151,7 +151,7 @@ export function toTree( {
 	let lastCharacterFormats;
 	let lastCharacter;
 
-	append( tree, '' );
+	append( tree, isEditableTree && text[ 0 ] === ' ' ? ZWNBSP : '' );
 
 	for ( let i = 0; i < formatsLength; i++ ) {
 		const character = text.charAt( i );
@@ -159,9 +159,10 @@ export function toTree( {
 			isEditableTree &&
 			// Pad the line if the line is empty.
 			( ! lastCharacter ||
-				// Pad the line if the previous character is a line break, otherwise
-				// the line break won't be visible.
-				lastCharacter === '\n' );
+				// Pad the line if the previous character is a line break or
+				// space, otherwise it won't be visible.
+				lastCharacter === '\n' ||
+				lastCharacter === ' ' );
 
 		const characterFormats = formats[ i ];
 		let pointer = getLastChild( tree );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

_Note: there will probably be some test failures that I will look into._

Removes the currently mandatory `white-space: pre` for rich text instances on the editor side.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

1) It does not reflect the front-end correctly.
2) We cannot store all whitespace in rich text instance because otherwise it will be visible in the editor. Currently, we need manually collapse whitespace in rich text values when parsing HTML.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Possible since #56341.
Also adds the existing zero width non breaking space as padding when a space is used at the start or end, similar to what we currently do for a line break element at the end.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
