### PR TITLE
Components: replace `TabPanel` with `Tabs` in the editor's `ColorGradientControl`

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -148,6 +148,7 @@ function ColorGradientControlInner( {
 									className={
 										'block-editor-color-gradient-control__panel'
 									}
+									focusable={ false }
 								>
 									{ tabPanels.color }
 								</Tabs.TabPanel>
@@ -156,6 +157,7 @@ function ColorGradientControlInner( {
 									className={
 										'block-editor-color-gradient-control__panel'
 									}
+									focusable={ false }
 								>
 									{ tabPanels.gradient }
 								</Tabs.TabPanel>

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -10,15 +10,18 @@ import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,
 	__experimentalVStack as VStack,
-	TabPanel,
 	ColorPalette,
 	GradientPicker,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { useSettings } from '../use-settings';
+import { unlock } from '../../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 const colorsAndGradientKeys = [
 	'colors',
@@ -26,19 +29,6 @@ const colorsAndGradientKeys = [
 	'gradients',
 	'disableCustomGradients',
 ];
-
-const TAB_COLOR = {
-	name: 'color',
-	title: __( 'Solid' ),
-	value: 'color',
-};
-const TAB_GRADIENT = {
-	name: 'gradient',
-	title: __( 'Gradient' ),
-	value: 'gradient',
-};
-
-const TABS_SETTINGS = [ TAB_COLOR, TAB_GRADIENT ];
 
 function ColorGradientControlInner( {
 	colors,
@@ -69,7 +59,7 @@ function ColorGradientControlInner( {
 	}
 
 	const tabPanels = {
-		[ TAB_COLOR.value ]: (
+		color: (
 			<ColorPalette
 				value={ colorValue }
 				onChange={
@@ -89,7 +79,7 @@ function ColorGradientControlInner( {
 				headingLevel={ headingLevel }
 			/>
 		),
-		[ TAB_GRADIENT.value ]: (
+		gradient: (
 			<GradientPicker
 				__nextHasNoMargin
 				value={ gradientValue }
@@ -137,22 +127,44 @@ function ColorGradientControlInner( {
 						</legend>
 					) }
 					{ canChooseAColor && canChooseAGradient && (
-						<TabPanel
-							className="block-editor-color-gradient-control__tabs"
-							tabs={ TABS_SETTINGS }
-							initialTabName={
-								gradientValue
-									? TAB_GRADIENT.value
-									: !! canChooseAColor && TAB_COLOR.value
-							}
-						>
-							{ ( tab ) => renderPanelType( tab.value ) }
-						</TabPanel>
+						<div className="block-editor-color-gradient-control__tabs">
+							<Tabs
+								initialTabId={
+									gradientValue
+										? 'gradient'
+										: !! canChooseAColor && 'color'
+								}
+							>
+								<Tabs.TabList>
+									<Tabs.Tab id={ 'color' }>
+										{ __( 'Solid' ) }
+									</Tabs.Tab>
+									<Tabs.Tab id={ 'gradient' }>
+										{ __( 'Gradient' ) }
+									</Tabs.Tab>
+								</Tabs.TabList>
+								<Tabs.TabPanel
+									id={ 'color' }
+									className={
+										'block-editor-color-gradient-control__panel'
+									}
+								>
+									{ tabPanels.color }
+								</Tabs.TabPanel>
+								<Tabs.TabPanel
+									id={ 'gradient' }
+									className={
+										'block-editor-color-gradient-control__panel'
+									}
+								>
+									{ tabPanels.gradient }
+								</Tabs.TabPanel>
+							</Tabs>
+						</div>
 					) }
-					{ ! canChooseAGradient &&
-						renderPanelType( TAB_COLOR.value ) }
-					{ ! canChooseAColor &&
-						renderPanelType( TAB_GRADIENT.value ) }
+
+					{ ! canChooseAGradient && renderPanelType( 'color' ) }
+					{ ! canChooseAColor && renderPanelType( 'gradient' ) }
 				</VStack>
 			</fieldset>
 		</BaseControl>

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -61,7 +61,7 @@ function ColorGradientControlInner( {
 	}
 
 	const tabPanels = {
-		color: (
+		[ TAB_IDS.color ]: (
 			<ColorPalette
 				value={ colorValue }
 				onChange={
@@ -81,7 +81,7 @@ function ColorGradientControlInner( {
 				headingLevel={ headingLevel }
 			/>
 		),
-		gradient: (
+		[ TAB_IDS.gradient ]: (
 			<GradientPicker
 				__nextHasNoMargin
 				value={ gradientValue }

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -129,42 +129,40 @@ function ColorGradientControlInner( {
 						</legend>
 					) }
 					{ canChooseAColor && canChooseAGradient && (
-						<div className="block-editor-color-gradient-control__tabs">
-							<Tabs
-								initialTabId={
-									gradientValue
-										? TAB_IDS.gradient
-										: !! canChooseAColor && TAB_IDS.color
+						<Tabs
+							initialTabId={
+								gradientValue
+									? TAB_IDS.gradient
+									: !! canChooseAColor && TAB_IDS.color
+							}
+						>
+							<Tabs.TabList>
+								<Tabs.Tab id={ TAB_IDS.color }>
+									{ __( 'Solid' ) }
+								</Tabs.Tab>
+								<Tabs.Tab id={ TAB_IDS.gradient }>
+									{ __( 'Gradient' ) }
+								</Tabs.Tab>
+							</Tabs.TabList>
+							<Tabs.TabPanel
+								id={ TAB_IDS.color }
+								className={
+									'block-editor-color-gradient-control__panel'
 								}
+								focusable={ false }
 							>
-								<Tabs.TabList>
-									<Tabs.Tab id={ TAB_IDS.color }>
-										{ __( 'Solid' ) }
-									</Tabs.Tab>
-									<Tabs.Tab id={ TAB_IDS.gradient }>
-										{ __( 'Gradient' ) }
-									</Tabs.Tab>
-								</Tabs.TabList>
-								<Tabs.TabPanel
-									id={ TAB_IDS.color }
-									className={
-										'block-editor-color-gradient-control__panel'
-									}
-									focusable={ false }
-								>
-									{ tabPanels.color }
-								</Tabs.TabPanel>
-								<Tabs.TabPanel
-									id={ TAB_IDS.gradient }
-									className={
-										'block-editor-color-gradient-control__panel'
-									}
-									focusable={ false }
-								>
-									{ tabPanels.gradient }
-								</Tabs.TabPanel>
-							</Tabs>
-						</div>
+								{ tabPanels.color }
+							</Tabs.TabPanel>
+							<Tabs.TabPanel
+								id={ TAB_IDS.gradient }
+								className={
+									'block-editor-color-gradient-control__panel'
+								}
+								focusable={ false }
+							>
+								{ tabPanels.gradient }
+							</Tabs.TabPanel>
+						</Tabs>
 					) }
 
 					{ ! canChooseAGradient && renderPanelType( TAB_IDS.color ) }

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -129,40 +129,42 @@ function ColorGradientControlInner( {
 						</legend>
 					) }
 					{ canChooseAColor && canChooseAGradient && (
-						<Tabs
-							initialTabId={
-								gradientValue
-									? TAB_IDS.gradient
-									: !! canChooseAColor && TAB_IDS.color
-							}
-						>
-							<Tabs.TabList>
-								<Tabs.Tab id={ TAB_IDS.color }>
-									{ __( 'Solid' ) }
-								</Tabs.Tab>
-								<Tabs.Tab id={ TAB_IDS.gradient }>
-									{ __( 'Gradient' ) }
-								</Tabs.Tab>
-							</Tabs.TabList>
-							<Tabs.TabPanel
-								id={ TAB_IDS.color }
-								className={
-									'block-editor-color-gradient-control__panel'
+						<div>
+							<Tabs
+								initialTabId={
+									gradientValue
+										? TAB_IDS.gradient
+										: !! canChooseAColor && TAB_IDS.color
 								}
-								focusable={ false }
 							>
-								{ tabPanels.color }
-							</Tabs.TabPanel>
-							<Tabs.TabPanel
-								id={ TAB_IDS.gradient }
-								className={
-									'block-editor-color-gradient-control__panel'
-								}
-								focusable={ false }
-							>
-								{ tabPanels.gradient }
-							</Tabs.TabPanel>
-						</Tabs>
+								<Tabs.TabList>
+									<Tabs.Tab id={ TAB_IDS.color }>
+										{ __( 'Solid' ) }
+									</Tabs.Tab>
+									<Tabs.Tab id={ TAB_IDS.gradient }>
+										{ __( 'Gradient' ) }
+									</Tabs.Tab>
+								</Tabs.TabList>
+								<Tabs.TabPanel
+									id={ TAB_IDS.color }
+									className={
+										'block-editor-color-gradient-control__panel'
+									}
+									focusable={ false }
+								>
+									{ tabPanels.color }
+								</Tabs.TabPanel>
+								<Tabs.TabPanel
+									id={ TAB_IDS.gradient }
+									className={
+										'block-editor-color-gradient-control__panel'
+									}
+									focusable={ false }
+								>
+									{ tabPanels.gradient }
+								</Tabs.TabPanel>
+							</Tabs>
+						</div>
 					) }
 
 					{ ! canChooseAGradient && renderPanelType( TAB_IDS.color ) }

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -21,8 +21,6 @@ import {
 import { useSettings } from '../use-settings';
 import { unlock } from '../../lock-unlock';
 
-const { Tabs } = unlock( componentsPrivateApis );
-
 const colorsAndGradientKeys = [
 	'colors',
 	'disableCustomColors',
@@ -108,6 +106,11 @@ function ColorGradientControlInner( {
 			{ tabPanels[ type ] }
 		</div>
 	);
+
+	// Unlocking `Tabs` too early causes the `unlock` method to receive an empty
+	// object, due to circular dependencies.
+	// See https://github.com/WordPress/gutenberg/issues/52692
+	const { Tabs } = unlock( componentsPrivateApis );
 
 	return (
 		<BaseControl

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -30,6 +30,8 @@ const colorsAndGradientKeys = [
 	'disableCustomGradients',
 ];
 
+const TAB_IDS = { color: 'color', gradient: 'gradient' };
+
 function ColorGradientControlInner( {
 	colors,
 	gradients,
@@ -131,20 +133,20 @@ function ColorGradientControlInner( {
 							<Tabs
 								initialTabId={
 									gradientValue
-										? 'gradient'
-										: !! canChooseAColor && 'color'
+										? TAB_IDS.gradient
+										: !! canChooseAColor && TAB_IDS.color
 								}
 							>
 								<Tabs.TabList>
-									<Tabs.Tab id={ 'color' }>
+									<Tabs.Tab id={ TAB_IDS.color }>
 										{ __( 'Solid' ) }
 									</Tabs.Tab>
-									<Tabs.Tab id={ 'gradient' }>
+									<Tabs.Tab id={ TAB_IDS.gradient }>
 										{ __( 'Gradient' ) }
 									</Tabs.Tab>
 								</Tabs.TabList>
 								<Tabs.TabPanel
-									id={ 'color' }
+									id={ TAB_IDS.color }
 									className={
 										'block-editor-color-gradient-control__panel'
 									}
@@ -153,7 +155,7 @@ function ColorGradientControlInner( {
 									{ tabPanels.color }
 								</Tabs.TabPanel>
 								<Tabs.TabPanel
-									id={ 'gradient' }
+									id={ TAB_IDS.gradient }
 									className={
 										'block-editor-color-gradient-control__panel'
 									}
@@ -165,8 +167,8 @@ function ColorGradientControlInner( {
 						</div>
 					) }
 
-					{ ! canChooseAGradient && renderPanelType( 'color' ) }
-					{ ! canChooseAColor && renderPanelType( 'gradient' ) }
+					{ ! canChooseAGradient && renderPanelType( TAB_IDS.color ) }
+					{ ! canChooseAColor && renderPanelType( TAB_IDS.gradient ) }
 				</VStack>
 			</fieldset>
 		</BaseControl>

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -15,12 +15,6 @@ $swatch-gap: 12px;
 	min-width: 0;
 }
 
-.block-editor-color-gradient-control__tabs {
-	.block-editor-color-gradient-control__panel {
-		padding: $grid-unit-20;
-	}
-}
-
 .block-editor-panel-color-gradient-settings.block-editor-panel-color-gradient-settings {
 	&,
 	& > div:not(:first-of-type) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Replaces the legacy `TabPanel` component with the new `Tabs` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of the work outlined in #52997

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
`TabPanel` is swapped out for `Tabs` and its sub-components. This eliminated the needs for a `TABS_SETTINGS` array. I did opt to keep the `tabPanels` array to make it cleaner to address the two different cases where those panels are rendered (one as a `TabPabel` inside `Tabs`, an one as a standalone `div` when only one option is being rendered.

So far unit tests don't seem negatively impacted by these changes, but I'm going to wait for the full CI suite to run. Similarly I didn't see anything in the related styles that needed to be removed as a result of this migration.

## Testing Instructions
1. Apply this PR and open the editor
2. Add a cover block. In the Editor Settings sidebar, select the block's `Styles` tab.
3. Select **Overlay**
4. Ensure the `ColorGradientControl` looks and behaves the same way it does on `trunk`
5. Confirm that when you close the `ColorGradientControl` and then open it again, it selects the right tab (ie, if the block has a gradient background, it should automatically open to the Gradient tab)
6. Now, in the block's styles panel, select **Text** to change the text color. Confirm this control renders and functions as expected - it should be just a color selection, without a second tab for a gradient.

### Testing Instructions for Keyboard
1. Using your keyboard, navigate to and select the Cover block's **Overlay** setting
2. Confirm that the current tab is focused when the `ColorGradientControl` opens.
3. Confirm that arrow keys navigate between the `Solid` and `Gradient` tabs
4. Confirm that the tab key navigates to the the focuable items within the control (specifically, it does not focus the `tabpanel`. It should focus the custom color button or gradient control points)
