### PR TITLE
NavigableContainers: Fix doc typo in onKeyDown prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -35,6 +35,10 @@
 -   `DropdownMenu`: remove extra vertical space around the toggle button ([#56136](https://github.com/WordPress/gutenberg/pull/56136)).
 -   Package should not depend on `@ariakit/test`, that package is only needed for testing ([#56091](https://github.com/WordPress/gutenberg/pull/56091)).
 
+### Documentation
+
+-   `NavigableContainers`: Fix document typo in `onKeyDown` prop ([#56352](https://github.com/WordPress/gutenberg/pull/56352)).
+
 ## 25.11.0 (2023-11-02)
 
 ### Enhancements

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -35,10 +35,6 @@
 -   `DropdownMenu`: remove extra vertical space around the toggle button ([#56136](https://github.com/WordPress/gutenberg/pull/56136)).
 -   Package should not depend on `@ariakit/test`, that package is only needed for testing ([#56091](https://github.com/WordPress/gutenberg/pull/56091)).
 
-### Documentation
-
--   `NavigableContainers`: Fix document typo in `onKeyDown` prop ([#56352](https://github.com/WordPress/gutenberg/pull/56352)).
-
 ## 25.11.0 (2023-11-02)
 
 ### Enhancements

--- a/packages/components/src/navigable-container/README.md
+++ b/packages/components/src/navigable-container/README.md
@@ -24,7 +24,7 @@ Gets an offset, given an event.
 
 -   Required: No
 
-### `onKeydown`: `( event: KeyboardEvent ) => void`
+### `onKeyDown`: `( event: KeyboardEvent ) => void`
 
 A callback invoked on the keydown event.
 


### PR DESCRIPTION
Similar to #56322

## What?

Correct `onKeydown` to `onKeyDown`

## Testing Instructions

There is no code impact.
