### PR TITLE
Core data revisions: extend support to other post types

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -741,7 +741,7 @@ _Returns_
 
 ### receiveRevisions
 
-Returns an action object used in signalling that revisions have been received.
+Action triggered to receive revision items.
 
 _Parameters_
 
@@ -752,10 +752,6 @@ _Parameters_
 -   _query_ `?Object`: Query Object.
 -   _invalidateCache_ `?boolean`: Should invalidate query caches.
 -   _meta_ `?Object`: Meta information about pagination.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### receiveThemeSupports
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -250,7 +250,7 @@ _Returns_
 
 ### receiveRevisions
 
-Returns an action object used in signalling that revisions have been received.
+Action triggered to receive revision items.
 
 _Parameters_
 
@@ -261,10 +261,6 @@ _Parameters_
 -   _query_ `?Object`: Query Object.
 -   _invalidateCache_ `?boolean`: Should invalidate query caches.
 -   _meta_ `?Object`: Meta information about pagination.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### receiveThemeSupports
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -945,7 +945,6 @@ export function receiveDefaultTemplateId( query, templateId ) {
  * @param {?boolean}      invalidateCache Should invalidate query caches.
  * @param {?Object}       meta            Meta information about pagination.
  */
-
 export const receiveRevisions =
 	( kind, name, recordKey, records, query, invalidateCache = false, meta ) =>
 	async ( { dispatch } ) => {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -935,7 +935,7 @@ export function receiveDefaultTemplateId( query, templateId ) {
 }
 
 /**
- * Returns an action object used in signalling that revisions have been received.
+ * Action triggered to receive revision items.
  *
  * @param {string}        kind            Kind of the received entity record revisions.
  * @param {string}        name            Name of the received entity record revisions.
@@ -944,27 +944,29 @@ export function receiveDefaultTemplateId( query, templateId ) {
  * @param {?Object}       query           Query Object.
  * @param {?boolean}      invalidateCache Should invalidate query caches.
  * @param {?Object}       meta            Meta information about pagination.
- * @return {Object} Action object.
  */
-export function receiveRevisions(
-	kind,
-	name,
-	recordKey,
-	records,
-	query,
-	invalidateCache = false,
-	meta
-) {
-	const isTemplate = [ 'wp_template', 'wp_template_part' ].includes( name );
-	return {
-		type: 'RECEIVE_ITEM_REVISIONS',
-		key: isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
-		items: Array.isArray( records ) ? records : [ records ],
-		recordKey,
-		meta,
-		query,
-		kind,
-		name,
-		invalidateCache,
+
+export const receiveRevisions =
+	( kind, name, recordKey, records, query, invalidateCache = false, meta ) =>
+	async ( { dispatch } ) => {
+		const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
+		const entityConfig = configs.find(
+			( config ) => config.kind === kind && config.name === name
+		);
+		const key =
+			entityConfig && entityConfig?.revisionKey
+				? entityConfig.revisionKey
+				: DEFAULT_ENTITY_KEY;
+
+		dispatch( {
+			type: 'RECEIVE_ITEM_REVISIONS',
+			key,
+			items: Array.isArray( records ) ? records : [ records ],
+			recordKey,
+			meta,
+			query,
+			kind,
+			name,
+			invalidateCache,
+		} );
 	};
-}

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -955,8 +955,10 @@ export function receiveRevisions(
 	invalidateCache = false,
 	meta
 ) {
+	const isTemplate = [ 'wp_template', 'wp_template_part' ].includes( name );
 	return {
 		type: 'RECEIVE_ITEM_REVISIONS',
+		key: isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
 		items: Array.isArray( records ) ? records : [ records ],
 		recordKey,
 		meta,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -21,7 +21,12 @@ const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
 
 // A hardcoded list of post types that support revisions.
 // @TODO: Ideally this should be fetched from the  `/types` REST API's view context.
-const POST_TYPES_WITH_REVISIONS_SUPPORT = [ 'post', 'page' ];
+const POST_TYPES_WITH_REVISIONS_SUPPORT = [
+	'post',
+	'page',
+	'wp_template',
+	'wp_template_part',
+];
 
 export const rootEntitiesConfig = [
 	{

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -359,6 +359,7 @@ async function loadPostTypeEntities() {
 				}/${ parentId }/revisions${
 					revisionId ? '/' + revisionId : ''
 				}`,
+			revisionKey: isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
 		};
 	} );
 }

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -20,10 +20,13 @@ export const DEFAULT_ENTITY_KEY = 'id';
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
 
 // A hardcoded list of post types that support revisions.
+// Reflects post types in Core's src/wp-includes/post.php.
 // @TODO: Ideally this should be fetched from the  `/types` REST API's view context.
-const POST_TYPES_WITH_REVISIONS_SUPPORT = [
+const POST_TYPE_ENTITIES_WITH_REVISIONS_SUPPORT = [
 	'post',
 	'page',
+	'wp_block',
+	'wp_navigation',
 	'wp_template',
 	'wp_template_part',
 ];
@@ -313,7 +316,7 @@ async function loadPostTypeEntities() {
 			},
 			mergedEdits: { meta: true },
 			supports: {
-				revisions: POST_TYPES_WITH_REVISIONS_SUPPORT.includes(
+				revisions: POST_TYPE_ENTITIES_WITH_REVISIONS_SUPPORT.includes(
 					postType?.slug
 				),
 			},

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -377,12 +377,6 @@ function entity( entityConfig ) {
 							}
 
 							if ( action.type === 'REMOVE_ITEMS' ) {
-								/*
-									For templates;
-									itemIds: ['twentytwentyfour//wp-custom-template-nag']
-									But the state key is with one slash: twentytwentyfour/wp-custom-template-nag
-									So deleteEntityRecord needs send extra data to removeItems?
-								 */
 								return Object.fromEntries(
 									Object.entries( state ).filter(
 										( [ id ] ) =>

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -238,8 +238,8 @@ function entity( entityConfig ) {
 		// Inject the entity config into the action.
 		replaceAction( ( action ) => {
 			return {
-				...action,
 				key: entityConfig.key || DEFAULT_ENTITY_KEY,
+				...action,
 			};
 		} ),
 	] )(
@@ -377,6 +377,12 @@ function entity( entityConfig ) {
 							}
 
 							if ( action.type === 'REMOVE_ITEMS' ) {
+								/*
+									For templates;
+									itemIds: ['twentytwentyfour//wp-custom-template-nag']
+									But the state key is with one slash: twentytwentyfour/wp-custom-template-nag
+									So deleteEntityRecord needs send extra data to removeItems?
+								 */
 								return Object.fromEntries(
 									Object.entries( state ).filter(
 										( [ id ] ) =>

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -744,7 +744,9 @@ export const getRevisions =
 		) {
 			return;
 		}
-
+		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
+			name
+		);
 		if ( query._fields ) {
 			// If requesting specific fields, items and query association to said
 			// records are stored by ID reference. Thus, fields must always include
@@ -755,7 +757,7 @@ export const getRevisions =
 					...new Set( [
 						...( getNormalizedCommaSeparable( query._fields ) ||
 							[] ),
-						DEFAULT_ENTITY_KEY,
+						isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
 					] ),
 				].join(),
 			};
@@ -857,7 +859,9 @@ export const getRevision =
 		) {
 			return;
 		}
-
+		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
+			name
+		);
 		if ( query !== undefined && query._fields ) {
 			// If requesting specific fields, items and query association to said
 			// records are stored by ID reference. Thus, fields must always include
@@ -868,7 +872,7 @@ export const getRevision =
 					...new Set( [
 						...( getNormalizedCommaSeparable( query._fields ) ||
 							[] ),
-						DEFAULT_ENTITY_KEY,
+						isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
 					] ),
 				].join(),
 			};

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -744,9 +744,7 @@ export const getRevisions =
 		) {
 			return;
 		}
-		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-			name
-		);
+
 		if ( query._fields ) {
 			// If requesting specific fields, items and query association to said
 			// records are stored by ID reference. Thus, fields must always include
@@ -757,7 +755,7 @@ export const getRevisions =
 					...new Set( [
 						...( getNormalizedCommaSeparable( query._fields ) ||
 							[] ),
-						isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
+						entityConfig.revisionKey || DEFAULT_ENTITY_KEY,
 					] ),
 				].join(),
 			};
@@ -859,9 +857,7 @@ export const getRevision =
 		) {
 			return;
 		}
-		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-			name
-		);
+
 		if ( query !== undefined && query._fields ) {
 			// If requesting specific fields, items and query association to said
 			// records are stored by ID reference. Thus, fields must always include
@@ -872,7 +868,7 @@ export const getRevision =
 					...new Set( [
 						...( getNormalizedCommaSeparable( query._fields ) ||
 							[] ),
-						isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
+						entityConfig.revisionKey || DEFAULT_ENTITY_KEY,
 					] ),
 				].join(),
 			};


### PR DESCRIPTION
Follow up to:

- https://github.com/WordPress/gutenberg/pull/54046

## What?
While we decide how best to expose revisions support to the frontend from the server, let's allow revisions support for templates, template parts, patterns and navigation post types.

Also changing the name of the supports array to `POST_TYPE_ENTITIES_WITH_REVISIONS_SUPPORT` to highlight that it's for "post entities", not root entities. 

## Why?
Share the love.

## How?
Adding the post type slugs to the `POST_TYPE_ENTITIES_WITH_REVISIONS_SUPPORT` array.

## Testing Instructions

Fire up a block theme, head to the site editor and make some changes to:

1. a theme or custom template
2. a theme or custom template part
3. A pattern
4. The site's navigation

Here's how to grab revisions for each post type in the browser's console:

### Templates
Replace `templateSlug` with the template slug, e.g., `home` or `wp-custom-template-my-template`.

`await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'wp_template', `twentytwentyfour//${ templateSlug }` )`

### Template parts
Replace `templateSlug` with the template part slug, e.g., `header`.

`await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'wp_template_part', `twentytwentyfour//${ templateSlug }` )`

### Navigation
Replace `parentId` with the ID of the navigation post.
`await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'wp_navigation', parentId )`

### Patterns
Replace `parentId` with the ID of the pattern post.
`await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'wp_block', parentId )`

Also check that the revisions response updates as you continue to edit these posts.