### PR TITLE
[TRY] Core data: extend stable key to use per_page and page query parts

### DIFF
--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -8,6 +8,13 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { withWeakMapCache, getNormalizedCommaSeparable } from '../utils';
 
+function appendToStableKey( stableKey, key, value ) {
+	stableKey +=
+		( stableKey ? '&' : '' ) +
+		addQueryArgs( '', { [ key ]: value } ).slice( 1 );
+	return stableKey;
+}
+
 /**
  * An object of properties describing a specific query.
  *
@@ -56,10 +63,22 @@ export function getQueryParts( query ) {
 		switch ( key ) {
 			case 'page':
 				parts[ key ] = Number( value );
+				// Add query param to stableKey to ensure it's included in cache key.
+				parts.stableKey = appendToStableKey(
+					parts.stableKey,
+					key,
+					parts[ key ]
+				);
 				break;
 
 			case 'per_page':
 				parts.perPage = Number( value );
+				// Add query param to stableKey to ensure it's included in cache key.
+				parts.stableKey = appendToStableKey(
+					parts.stableKey,
+					key,
+					parts.perPage
+				);
 				break;
 
 			case 'context':
@@ -97,9 +116,11 @@ export function getQueryParts( query ) {
 				// should accept a key value pair, which may optimize its
 				// implementation for our use here, vs. iterating an object
 				// with only a single key.
-				parts.stableKey +=
-					( parts.stableKey ? '&' : '' ) +
-					addQueryArgs( '', { [ key ]: value } ).slice( 1 );
+				parts.stableKey = appendToStableKey(
+					parts.stableKey,
+					key,
+					value
+				);
 		}
 	}
 

--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -63,12 +63,6 @@ export function getQueryParts( query ) {
 		switch ( key ) {
 			case 'page':
 				parts[ key ] = Number( value );
-				// Add query param to stableKey to ensure it's included in cache key.
-				parts.stableKey = appendToStableKey(
-					parts.stableKey,
-					key,
-					parts[ key ]
-				);
 				break;
 
 			case 'per_page':

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -4,14 +4,14 @@
 import { getQueryParts } from '../get-query-parts';
 
 describe( 'getQueryParts', () => {
-	it( 'parses out pagination data', () => {
+	it( 'parses out pagination data and adds to returned object', () => {
 		const parts = getQueryParts( { page: 2, per_page: 2 } );
 
 		expect( parts ).toEqual( {
 			context: 'default',
 			page: 2,
 			perPage: 2,
-			stableKey: '',
+			stableKey: 'per_page=2',
 			fields: null,
 			include: null,
 		} );
@@ -71,7 +71,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 1,
 			perPage: 10,
-			stableKey: 'b=2',
+			stableKey: 'b=2&per_page=10',
 			fields: null,
 			include: null,
 		} );
@@ -84,7 +84,7 @@ describe( 'getQueryParts', () => {
 			context: 'default',
 			page: 1,
 			perPage: -1,
-			stableKey: 'b=2',
+			stableKey: 'b=2&per_page=-1',
 			fields: null,
 			include: null,
 		} );

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -170,7 +170,7 @@ describe( 'reducer', () => {
 				default: { 1: true },
 			},
 			queries: {
-				default: { 's=a': { itemIds: [ 1 ] } },
+				default: { 'per_page=3&s=a': { itemIds: [ 1 ] } },
 			},
 		} );
 	} );


### PR DESCRIPTION
Maybe resolves https://github.com/WordPress/gutenberg/issues/56355

Follow up to https://github.com/WordPress/gutenberg/pull/54046

❗ I'm not sure this is the right way forward. There's [a test that explicitly checks that stableKey does not contain any pagination data](https://github.com/WordPress/gutenberg/blob/trunk/packages/core-data/src/queried-data/test/get-query-parts.js#L7). I'm not sure why.

------- 

## What?
This is a test to check whether extending the stable key with params, which should trigger new API calls, can be added to the state: `per_page`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
Adding an entry to the `queries` reducer every time the `per_page` query part changes


<img width="467" alt="Screenshot 2023-11-21 at 3 08 45 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/d4c94619-0998-4d6f-86e3-664f8850094e">


## Testing Instructions

Does this break anything?

```
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 2 } ) // API call, returns null
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 2 } ) // No API call, returns results

await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 3 } ) // API call, returns null
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 3 } ) // No API call, returns results

await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 4 } ) // API call, returns null
await wp.data.select( 'core' ).getEntityRecords( 'postType', 'post', { per_page: 4 } )  // No API call, returns results
```


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
