### PR TITLE
Gutenberg Plugin: Don't display Experiments page to users without  permission

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -51,7 +51,7 @@ function gutenberg_menu() {
 		'gutenberg',
 		__( 'Experiments Settings', 'gutenberg' ),
 		__( 'Experiments', 'gutenberg' ),
-		'edit_posts',
+		'manage_options',
 		'gutenberg-experiments',
 		'the_gutenberg_experiments'
 	);


### PR DESCRIPTION
## What?
This PR prevents the Experiments page from being displayed to users who do not have the `manage_options` permission.

## Why?
My understanding is that in order to update the settings on this page, you need to be logged in as an administrator with `manage_options` privileges.

Therefore, a warning message will be displayed when a non-administrator updates the settings on this page.

https://github.com/WordPress/gutenberg/assets/54422211/e4ac9cad-904b-4ab8-99b0-06f476082a50

## How?

This page will not be displayed if the logged in user does not have `manage_options` permission.

## Testing Instructions

- Log in as a non-administrator.
- Make sure that the Experiments submenu does not exist in the Gutenberg menu.

