### PR TITLE
Fix version in useSetting deprecation notice

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -954,7 +954,7 @@ _Parameters_
 
 ### useSetting
 
-> **Deprecated** 6.4.0 Use useSettings instead.
+> **Deprecated** 6.5.0 Use useSettings instead.
 
 Hook that retrieves the given setting for the block instance in use.
 

--- a/packages/block-editor/src/components/use-settings/index.js
+++ b/packages/block-editor/src/components/use-settings/index.js
@@ -254,7 +254,7 @@ export function useSettings( ...paths ) {
  *
  * @param {string} path The path to the setting.
  * @return {any} Returns the value defined for the setting.
- * @deprecated 6.4.0 Use useSettings instead.
+ * @deprecated 6.5.0 Use useSettings instead.
  * @example
  * ```js
  * const isEnabled = useSetting( 'typography.dropCap' );
@@ -262,7 +262,7 @@ export function useSettings( ...paths ) {
  */
 export function useSetting( path ) {
 	deprecated( 'wp.blockEditor.useSetting', {
-		since: '6.4',
+		since: '6.5',
 		alternative: 'wp.blockEditor.useSettings',
 		note: 'The new useSettings function can retrieve multiple settings at once, with better performance.',
 	} );

--- a/packages/block-editor/src/components/use-settings/test/index.js
+++ b/packages/block-editor/src/components/use-settings/test/index.js
@@ -135,7 +135,7 @@ describe( 'useSettings', () => {
 		const result = runHook( () => useSetting( 'layout.contentSize' ) );
 		expect( result ).toBe( '840px' );
 		expect( console ).toHaveWarnedWith(
-			'wp.blockEditor.useSetting is deprecated since version 6.4. Please use wp.blockEditor.useSettings instead.'
+			'wp.blockEditor.useSetting is deprecated since version 6.5. Please use wp.blockEditor.useSettings instead.'
 		);
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix the Version number used in the deprecation notice of the useSetting hook

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it didn't ship in time for 6.4 and therefore isn't actually deprecated in 6.4

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update any reference to 6.4 with 6.5

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
