### PR TITLE
Add focus rings to focusable disabled buttons

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements 
+
+-   `Button`: Add focus rings to focusable disabled buttons ([#56383](https://github.com/WordPress/gutenberg/pull/56383)).
+
 ### Experimental
 
 -   `Tabs`: Memoize and expose the component context ([#56224](https://github.com/WordPress/gutenberg/pull/56224)).

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -129,8 +129,11 @@
 			background: transparent;
 			transform: none;
 			opacity: 1;
-			box-shadow: none;
-			outline: none;
+
+			&:not(:focus) {
+				box-shadow: none;
+				outline: none;
+			}
 		}
 	}
 


### PR DESCRIPTION
## What?

Secondary and tertiary buttons don't have focus rings when they are disabled but `__experimentalIsFocusable` is true. This PR updates [the button CSS](https://github.com/WordPress/gutenberg/blob/e95bb8c9530bbdef1db623eca11b80bd73493197/packages/components/src/button/style.scss) to ensure that they do.

Resolves #56149.


## Why?

As per [WCAG SC 2.4.7](https://www.w3.org/TR/WCAG21/#focus-visible) _(Focus visible)_:
> Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible.

It is ambiguous as to whether a disabled button should be considered "operable" or not, but as the purpose of the success criterion is "to help a person know which element has the keyboard focus", that should be prioritised. As such, even when a button is disabled and not actionable, if it can receive focus this state should be indicated appropriately.


## How?

The CSS is altered to remove outlines/borders/etc only when the control does not have focus.

### Follow-up

Note that no attempt has been made in this PR to change the colour or other styling of the focus ring in this context; there are too many variables at play to safely make assumptions about what works everywhere that a focus ring might be needed. This should however be investigated separately.

<details>
  <summary><b>Something to consider...</b></summary>

  One potential option would be to desaturate the focus ring for disabled controls – we would need to find the right balance between being different enough to denote diverging states, but similar enough to not be confusing.

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/27b2caaa-471d-4597-868b-64dfb307ddb8" alt="Two buttons, both with outlines but no background. The first has blue text, and a heavy blue outline. The second has grey text, and a paler blue outline.">
</p>

  This could be achieved by using [`color-mix`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) (which has wide browser support) to desaturate the set accent colour automatically:

```diff
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -42,6 +42,10 @@
                outline: 3px solid transparent;
        }

+       &[aria-disabled="true"]:focus:not(:disabled) {
+               box-shadow: 0 0 0 var(--wp-admin-border-width-focus)
+                           color-mix(in srgb, $components-color-accent, white 50%);
+       }
+
        /**
         * Primary button style.
         */
```
</details>


## Testing Instructions

Navigate to [the Button component in Storybook](https://wordpress.github.io/gutenberg/?path=/docs/components-button--docs).

### Button types

#### Primary buttons

Confirm that primary buttons remain unaffected. They should have blue backgrounds, regardless of disabled or focused state. They should have white text, or desaturated blue text when disabled, focusable or not. They should have a heavy blue outline when focused, disabled or not. There should be no pointer change on disabled buttons.

![A set of "primary" buttons, showing a standard button, a focused button, a disabled button, a disabled but focusable button, and a focused disabled button.](https://github.com/WordPress/gutenberg/assets/159848/66c3e621-6bfa-48c0-af55-2239e7b65f05)

#### Secondary buttons

Confirm that regular secondary buttons remain unaffected. They should have no background, regardless of disabled or focused state. They should have blue text, or grey text when disabled, focusable or not. They should have a blue outline as standard, but not when disabled. They should have a heavy blue outline when focused, disabled or not. There should be no pointer change on disabled buttons.

![A set of "secondary" buttons, showing a standard button, a focused button, a disabled button, a disabled but focusable button, and a focused disabled button.](https://github.com/WordPress/gutenberg/assets/159848/0dbd7b91-de91-40ce-9431-f01962a93fbe)

#### Tertiary buttons

Confirm that regular tertiary buttons remain unaffected. They should have no background, regardless of disabled or focused state. They should not have an outline as standard. They should have blue text, or grey text when disabled, focusable or not. They should have a heavy blue outline when focused, disabled or not. There should be no pointer change on disabled buttons.

![A set of "tertiary" buttons, showing a standard button, a focused button, a disabled button, a disabled but focusable button, and a focused disabled button.](https://github.com/WordPress/gutenberg/assets/159848/52415e67-56e9-4d94-a17f-7f313b822a7a)

### Testing Instructions for Keyboard

In all cases:
- Standard buttons should show a focus ring when navigated to
- By default, disabled buttons should not be able to receive focus at all
- _Focusable_ disabled buttons (that is, where `__experimentalIsFocusable` is set to `true`), should be able to receive focus, and should show a focus ring when navigated to