### PR TITLE
Update handling of empty template description cell

### DIFF
--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -175,7 +175,7 @@ export default function DataviewsTemplates() {
 						) : (
 							<>
 							<Text variant="muted" aria-hidden="true">
-								{ __( '—' ) }
+								&#8212;
 							</Text>
 							<VisuallyHidden>
 								{ __( 'No description.' ) }

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -12,6 +12,7 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	VisuallyHidden,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from '@wordpress/element';
@@ -167,10 +168,19 @@ export default function DataviewsTemplates() {
 				getValue: ( { item } ) => item.description,
 				render: ( { item } ) => {
 					return (
-						item.description && (
+						item.description ? (
 							<Text variant="muted">
 								{ decodeEntities( item.description ) }
 							</Text>
+						) : (
+							<>
+							<Text variant="muted" aria-hidden="true">
+								{ __( '—' ) }
+							</Text>
+							<VisuallyHidden>
+								{ __( 'No description.' ) }
+							</VisuallyHidden>
+							</>
 						)
 					);
 				},


### PR DESCRIPTION
## What?
Display a dash (–) when the template has no description. Include a more verbose "No description." message for screen readers.

## Why?
An empty cell can give the impression that the data failed to load. 

## How?
Copies the same technique used to handle empty cells in wp-admin:

* Display `–` with `aria-hidden="true"`.
* Include a visually hidden verbose label for screen readers.

## Testing Instructions
1. Enable the data views experiment in github.
2. Navigate to Templates > Manage templates in the site editor.
3. Toggle on the "Description" field if it's not visible.
4. Notice that custom templates no longer have an empty description cell.

<img width="970" alt="Screenshot 2023-11-21 at 16 39 06" src="https://github.com/WordPress/gutenberg/assets/846565/82e28088-2ed2-45a3-bc4b-f0153e00d5e4">

