### PR TITLE
Fix data view menu item radius

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -8,6 +8,8 @@
 }
 
 .edit-site-sidebar-dataviews-dataview-item {
+	border-radius: $radius-block-ui;
+	
 	&:hover,
 	&:focus,
 	&[aria-current] {

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -9,7 +9,6 @@
 
 .edit-site-sidebar-dataviews-dataview-item {
 	border-radius: $radius-block-ui;
-	
 	&:hover,
 	&:focus,
 	&[aria-current] {

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -9,6 +9,7 @@
 
 .edit-site-sidebar-dataviews-dataview-item {
 	border-radius: $radius-block-ui;
+
 	&:hover,
 	&:focus,
 	&[aria-current] {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Apply `border-radius` to data view menu items.

## Why?
To be consistent with other menu items in the sidebar.

## Testing Instructions
1. Enable the data views experiment in Gutenberg
2. Navigate to Pages > Manage all pages in the site editor
3. Zoom in to the sidebar
4. Notice that the menu items there have a 2px radius

**Before** 
<img width="1075" alt="Screenshot 2023-11-21 at 16 48 20" src="https://github.com/WordPress/gutenberg/assets/846565/2310c6e1-a12f-4385-a9af-389278436e46">

**After**
<img width="1081" alt="Screenshot 2023-11-21 at 16 48 01" src="https://github.com/WordPress/gutenberg/assets/846565/80cd6917-ca5f-404e-bdad-48824e9ee041">


