### PR TITLE
Pattern placeholder: Remove duplicate 'useDispatch' hook

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -24,9 +24,11 @@ const PatternEdit = ( { attributes, clientId } ) => {
 		[]
 	);
 
-	const { replaceBlocks, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
-	const { setBlockEditingMode } = useDispatch( blockEditorStore );
+	const {
+		replaceBlocks,
+		setBlockEditingMode,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
 	const { getBlockRootClientId, getBlockEditingMode } =
 		useSelect( blockEditorStore );
 


### PR DESCRIPTION
## What?
PR removes the duplicate `useDispatch` hook for the "Pattern placeholder" block.

## Why?
This is probably a left over from #52094.

## How?
Get all block editor store action using a single hook.

## Testing Instructions
CI checks are passing.
