### PR TITLE
Update data view menu item actions

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
@@ -120,7 +120,7 @@ function CustomDataViewItem( { dataviewId, isActive } ) {
 							style: {
 								color: 'inherit',
 							},
-							size: 'compact',
+							size: 'small',
 						} }
 					>
 						{ ( { onClose } ) => (

--- a/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
@@ -116,6 +116,7 @@ function CustomDataViewItem( { dataviewId, isActive } ) {
 					<DropdownMenu
 						icon={ moreVertical }
 						label={ __( 'Actions' ) }
+						className="edit-site-sidebar-dataviews-dataview-item__dropdown-menu"
 						toggleProps={ {
 							style: {
 								color: 'inherit',

--- a/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
@@ -120,6 +120,7 @@ function CustomDataViewItem( { dataviewId, isActive } ) {
 							style: {
 								color: 'inherit',
 							},
+							size: 'compact',
 						} }
 					>
 						{ ( { onClose } ) => (

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -8,6 +8,8 @@
 }
 
 .edit-site-sidebar-dataviews-dataview-item {
+	padding-right: $grid-unit-10;
+
 	&:hover,
 	&:focus,
 	&[aria-current] {

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -10,7 +10,7 @@
 .edit-site-sidebar-dataviews-dataview-item {
 	padding-right: $grid-unit-10;
 
-	.components-dropdown-menu {
+	.edit-site-sidebar-dataviews-dataview-item__dropdown-menu {
 		min-width: initial;
 	}
 

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -8,7 +8,7 @@
 }
 
 .edit-site-sidebar-dataviews-dataview-item {
-  border-radius: $radius-block-ui;
+	border-radius: $radius-block-ui;
 	padding-right: $grid-unit-10;
 
 	.edit-site-sidebar-dataviews-dataview-item__dropdown-menu {

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -10,6 +10,10 @@
 .edit-site-sidebar-dataviews-dataview-item {
 	padding-right: $grid-unit-10;
 
+	.components-dropdown-menu {
+		min-width: initial;
+	}
+
 	&:hover,
 	&:focus,
 	&[aria-current] {


### PR DESCRIPTION
## What?
Update the ellipsis button size and position in data view menu items.

## Why?
So that it aligns with the search icon above.

## How?
* Use `small` button size
* Apply padding to `.edit-site-sidebar-dataviews-dataview-item`
* Ensure `.components-dropdown-menu` renders at the correct width

| Before | After |
| --- | --- |
| <img width="81" alt="Screenshot 2023-11-21 at 17 16 02" src="https://github.com/WordPress/gutenberg/assets/846565/f7208fb9-c9ba-4af9-b068-d260473f8d1a"> | <img width="140" alt="Screenshot 2023-11-21 at 17 13 25" src="https://github.com/WordPress/gutenberg/assets/846565/acf839b7-fcda-4f91-b70f-37441f5dbbcf"> | 




