### PR TITLE
Try/dropdown menu combobox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37500,6 +37500,20 @@
 			"integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
 			"dev": true
 		},
+		"node_modules/match-sorter": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+			"integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"remove-accents": "0.4.2"
+			}
+		},
+		"node_modules/match-sorter/node_modules/remove-accents": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+			"integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+		},
 		"node_modules/mathjs": {
 			"version": "10.6.4",
 			"resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.6.4.tgz",
@@ -54882,6 +54896,7 @@
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
+				"match-sorter": "^6.3.1",
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
@@ -70136,6 +70151,7 @@
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
+				"match-sorter": "^6.3.1",
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
@@ -85830,6 +85846,22 @@
 			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
 			"integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
 			"dev": true
+		},
+		"match-sorter": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+			"integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+			"requires": {
+				"@babel/runtime": "^7.12.5",
+				"remove-accents": "0.4.2"
+			},
+			"dependencies": {
+				"remove-accents": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+					"integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+				}
+			}
 		},
 		"mathjs": {
 			"version": "10.6.4",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -72,6 +72,7 @@
 		"gradient-parser": "^0.1.5",
 		"highlight-words-core": "^1.2.2",
 		"is-plain-object": "^5.0.0",
+		"match-sorter": "^6.3.1",
 		"memize": "^2.1.0",
 		"path-to-regexp": "^6.2.1",
 		"re-resizable": "^6.4.0",

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -169,7 +169,7 @@ const UnconnectedDropdownMenu = (
 	const {
 		// Store props
 		open,
-		defaultOpen = false,
+		defaultOpen,
 		onOpenChange,
 		placement,
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -344,12 +344,6 @@ const ComboboxValuesContext = createContext<
 	React.Dispatch< React.SetStateAction< string[] > >
 >( () => {} );
 
-// TODO:
-// - custom search prop
-// - reuse dropdowmmenu
-// - maybe no need to use store + provider, and use custom context instead
-// - other props and ref, should they go to the menu or to the combobox?
-// - focus management
 const UnconnectedDropdownComboboxMenu = (
 	props: WordPressComponentProps< DropdownComboboxMenuProps, 'div', false >,
 	ref: React.ForwardedRef< HTMLDivElement >
@@ -556,7 +550,6 @@ const UnconnectedDropdownComboboxMenu = (
 									placeholder={ placeholder }
 								/>
 								<Ariakit.ComboboxList
-									className="popover"
 									alwaysVisible
 									render={ <Ariakit.SelectList /> }
 								>
@@ -578,12 +571,6 @@ export const DropdownComboboxMenu = contextConnect(
 	'DropdownMenu'
 );
 
-// TODO:
-// - value mandatory
-// - is there a better way to do matches?
-// - style
-// - potentially consider adding onChange and communicate directly with combobox provider
-//   in order to handle selection individually on the item via selected prop?
 interface ComboboxItemProps extends Ariakit.SelectItemProps {
 	children?: React.ReactNode;
 	value: string;
@@ -596,8 +583,10 @@ export const DropdownComboboxMenuItem = forwardRef<
 	const setValues = useContext( ComboboxValuesContext );
 
 	useEffect( () => {
+		// Register item's value
 		setValues( ( values ) => [ ...values, value ] );
 		return () =>
+			// Unregister item's value
 			setValues( ( values ) => values.filter( ( v ) => v !== value ) );
 	}, [ value, setValues ] );
 

--- a/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
+++ b/packages/components/src/dropdown-menu-v2-ariakit/index.tsx
@@ -609,7 +609,7 @@ export const DropdownComboboxMenuItem = forwardRef<
 	}
 
 	return (
-		<Ariakit.SelectItem
+		<Styled.DropdownComboboxMenuItem
 			ref={ ref }
 			{ ...props }
 			value={ value }
@@ -618,6 +618,6 @@ export const DropdownComboboxMenuItem = forwardRef<
 		>
 			<Ariakit.SelectItemCheck />
 			{ props.children ?? value }
-		</Ariakit.SelectItem>
+		</Styled.DropdownComboboxMenuItem>
 	);
 } );

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -248,6 +248,10 @@ export const DropdownMenuRadioItem = styled( Ariakit.MenuItemRadio )`
 	${ baseItem }
 `;
 
+export const DropdownComboboxMenuItem = styled( Ariakit.SelectItem )`
+	${ baseItem }
+`;
+
 export const DropdownMenuGroup = styled( Ariakit.MenuGroup )``;
 
 export const DropdownMenuGroupLabel = styled( Ariakit.MenuGroupLabel )`

--- a/packages/components/src/dropdown-menu-v2-ariakit/types.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/types.ts
@@ -10,6 +10,7 @@ export interface DropdownMenuContext {
 	 * The ariakit store shared across all DropdownMenu subcomponents.
 	 */
 	store: Ariakit.MenuStore;
+	comboboxMatches?: string[];
 	/**
 	 * The variant used by the underlying menu popover.
 	 */
@@ -79,6 +80,16 @@ export interface DropdownMenuProps {
 		| ( (
 				event: KeyboardEvent | React.KeyboardEvent< Element >
 		  ) => boolean );
+}
+
+export interface DropdownComboboxMenuProps extends DropdownMenuProps {
+	placeholder: string;
+	searchValue?: string;
+	onSearchValueChange?: ( value: string ) => void;
+	defaultSearchValue?: string;
+	selectedValues?: string[];
+	onSelectedValuesChange?: ( values: string[] ) => void;
+	defaultSelectedValues?: string[];
 }
 
 export interface DropdownMenuGroupProps {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

TODO:
 - [ ] Polish styles
 - [ ] Try using components completely uncontrolled
 - [ ] Try using components controlled, but via individual `checked`/`onChange` prop on each item
 - [ ] Add extra prop for consumers to customize search function (or disabling filtering completely?)
 - [ ] Refactor `DropdownComboboxMenu` to reuse `DropdownMenu` as much as possible
 - [ ] Consider removing `ComboboxValuesContext`, and moving all context variables under `DropdownMenuContext`
 - [ ] See if there's a way to avoid using both store and provides for combobox and select components
 - [ ] `DropdownComboboxMenu`: should `...restProps` go to the menu, to the combobox, or to the select?
 - [ ]  `DropdownComboboxMenu`: should we expose multiple `ref`s (menu, combobox/select) ?
 - [ ] Investigate single vs multiple selection
 - [ ] Refine focus management 
     - [ ] When opening/closing combobox menu, focus should be moved to input/selected item correctly
     - [ ] Using arrows up/down while the input is focused should move the selection correctly

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

WIP

![image](https://github.com/WordPress/gutenberg/assets/1083581/1f2d60d9-05ad-4a9b-801f-c64bbaef16de)

