### PR TITLE
useMovingAnimation: Clear translate3d rule when animation is finished

### DIFF
--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -129,7 +129,7 @@ function useMovingAnimation( {
 		const finishedMoving = x === 0 && y === 0;
 		ref.current.style.transformOrigin = 'center center';
 		ref.current.style.transform = finishedMoving
-			? null
+			? null // Set to `null` to explicitly remove the transform.
 			: `translate3d(${ x }px,${ y }px,0)`;
 		ref.current.style.zIndex = isSelected ? '1' : '';
 

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -129,7 +129,7 @@ function useMovingAnimation( {
 		const finishedMoving = x === 0 && y === 0;
 		ref.current.style.transformOrigin = 'center center';
 		ref.current.style.transform = finishedMoving
-			? undefined
+			? null
 			: `translate3d(${ x }px,${ y }px,0)`;
 		ref.current.style.zIndex = isSelected ? '1' : '';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #56409

In the `useMovingAnimation` hook, when the animation has finished, set the `transform` style to `null` instead of `undefined` so that the transform style is cleared out. Otherwise the component will be stuck with the last transform style before the animation concluded. In most cases this is _usually_ `0px` and therefore unnoticeable. However there is a case (described in #56409) where sometimes the component will be stuck on either `1px` or `-1px`. Again, mostly this isn't very noticeable, however in the list view, with blocks that have been previously dragged, this becomes noticeable when the blocks are re-selected, as the offset by `1px` creates a white gap between selected blocks and selected blocks that have been dragged previously.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need to switch to `null` instead of `undefined` in order to update the inline style property for `transform`. This is a little subtle, but setting the value to `undefined` is treated as "no change", whereas `null` is treated as clearing out the value. The desired behaviour is the latter.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In `useMovingAnimation`, once the animation is concluded, set the `transform` style to `null` to cause the style value for this property to be cleared out. Prior to this change, the inline style for the element would be stuck on the last `transform` value before the animation concluded (usually `0px`, but sometimes `1px` or `-1px`, causing the visual issue).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a post with lots of blocks, select a few of them in the list view and drag the blocks to a new location (can just be a couple of blocks down)
2. Shift select a larger selection in the list view, that includes the blocks you previously dragged, along with a few above and below that selection.
3. On `trunk`, this can result in an extra gap between some of the blocks in the selection appearing. It looks like an unexpected `1px` white border.
4. With this PR applied, there should be no gap in the selection — you might still see a white line where the currently _focused_ block is — that's expected. But there shouldn't be any _extra_ gaps.
5. If you wish to inspect what's going on with the markup or inline style, try inspect element on the list view rows (the `tr` element) to look at a list view item after it's been dragged to a new position.
6. To check against regressions, double check that rearranging blocks within the editor canvas works as on `trunk`. (I.e. rearranging image blocks within a Gallery block in the editor canvas, using the position controls in the toolbar still works smoothly)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

In the _before_ markup, both the `transformOrigin` and `transform` styles are present in the inline style. In the _after_ markup, the `transform` style is no longer present, but the `transformOrigin` remains (which is expected).

| Before (markup) | After (markup) |
| --- | --- |
| <img width="679" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/2504bce8-0919-4ae1-802b-7e0d810ad47b"> | <img width="677" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/146eef8d-0d5e-4e0f-85b1-9aa2513507ec"> |

### Before (visual)

Note the extra white line (gap) upon re-selecting blocks at the end of this screengrab:

https://github.com/WordPress/gutenberg/assets/14988353/48444287-6102-4c91-8457-1165b58422a3

### After (visual)

At the end of this screengrab, there is no extra gap between blocks:

https://github.com/WordPress/gutenberg/assets/14988353/ba41ad7b-504a-4ec5-8483-d59cec0161cf

