### PR TITLE
Reduce specificity of default Cover text color styles.

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -123,7 +123,7 @@
 	h4,
 	h5,
 	h6 {
-		&:not(.has-text-color) {
+		&:where(:not(.has-text-color)) {
 			color: inherit;
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #56006.

Reduces the specificity of CSS setting default colour for paragraphs and headings inside Cover block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Cover block with a heading and paragraphs inside it and set a colour for its headings in the sidebar under styles > color > heading.
2. Check that the new heading color applies both in editor and front end.
3. Do the same for text color and check it applies to paragraphs.
4. Change the color of the heading directly and check that it works as expected.

<img width="647" alt="Screenshot 2023-11-22 at 2 43 18 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/cc8fa649-e037-4e11-8b10-6b7b60a5360c">
