### PR TITLE
Post Schedule Panel: Fix Sass deprecation warning for division

### DIFF
--- a/packages/editor/src/components/post-schedule/style.scss
+++ b/packages/editor/src/components/post-schedule/style.scss
@@ -18,6 +18,6 @@
 	height: auto;
 
 	// The line height + the padding should be the same as the button size.
-	padding: ( ( $button-size - $grid-unit-20 ) / 2 ) 12px;
+	padding: math.div($button-size - $grid-unit-20, 2) 12px;
 	line-height: $grid-unit-20;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to https://github.com/WordPress/gutenberg/pull/56319 to fix a Sass deprecation warning about the `/` character being used for division. The warning says to use `math.div` instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To fix the warning from appearing when building Gutenberg (it shows when you run `npm run dev` locally).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the recommended replacement [math.div](https://sass-lang.com/documentation/modules/math/#div)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Just double-check that the calculated padding is the same as in #56319. I see the following locally:

<img width="153" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/f0db822c-0dad-43fb-a994-656157a82840">

`10px` which is a result of the button size (`36px`) minus the 20 grid unit size (`16px`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

This warning should no longer appear when building Gutenberg:

![image](https://github.com/WordPress/gutenberg/assets/14988353/08fd9f9d-230a-4cff-a604-fa025b8f1c2b)
