### PR TITLE
Block Editor: Undeprecate the '__experimentalImageSizeControl' component

### DIFF
--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -8,7 +8,6 @@ import {
 	__experimentalNumberControl as NumberControl,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -31,11 +30,6 @@ export default function ImageSizeControl( {
 	onChange,
 	onChangeImage = noop,
 } ) {
-	deprecated( 'wp.blockEditor.__experimentalImageSizeControl', {
-		since: '6.3',
-		alternative:
-			'wp.blockEditor.privateApis.DimensionsTool and wp.blockEditor.privateApis.ResolutionTool',
-	} );
 	const { currentHeight, currentWidth, updateDimension, updateDimensions } =
 		useDimensionHandler( height, width, imageHeight, imageWidth, onChange );
 


### PR DESCRIPTION
## What?
Resolves #56403.

PR removes deprecation for the `__experimentalImageSizeControl` component, introduced in #51545.

## Why?
See #56403.

## Testing Instructions
1.  Open a post or page.
2. Insert Media & Text block.
3. Upload or select media.
4. Confirm that the deprecation notice isn't logged in the console.

### Testing Instructions for Keyboard
Same.
