### PR TITLE
useEntityRecord: Improve unit tests

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -130,6 +130,8 @@ describe( 'useEntityRecord', () => {
 		);
 
 		const { rerender } = render( <UI enabled={ true } /> );
+
+		// A minimum delay for a fetch request. The same delay is used again as a control.
 		await act(
 			() => new Promise( ( resolve ) => setTimeout( resolve, 0 ) )
 		);

--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -116,21 +116,26 @@ describe( 'useEntityRecord', () => {
 	} );
 
 	it( 'does not resolve entity record when disabled via options', async () => {
-		// Provide response
 		triggerFetch.mockImplementation( () => TEST_RECORD );
 
 		let data;
-		const TestComponent = () => {
-			data = useEntityRecord( 'root', 'widget', 2, {
-				options: { enabled: false },
-			} );
+		const TestComponent = ( { enabled } ) => {
+			data = useEntityRecord( 'root', 'widget', 1, { enabled } );
 			return <div />;
 		};
-		render(
+		const UI = ( { enabled } ) => (
 			<RegistryProvider value={ registry }>
-				<TestComponent />
+				<TestComponent enabled={ enabled } />
 			</RegistryProvider>
 		);
+
+		const { rerender } = render( <UI enabled={ true } /> );
+		await act(
+			() => new Promise( ( resolve ) => setTimeout( resolve, 0 ) )
+		);
+		expect( triggerFetch ).toHaveBeenCalledTimes( 1 );
+
+		rerender( <UI enabled={ false } /> );
 
 		expect( data ).toEqual( {
 			edit: expect.any( Function ),
@@ -141,14 +146,10 @@ describe( 'useEntityRecord', () => {
 			save: expect.any( Function ),
 		} );
 
-		// Fetch request should have been issued.
-		await waitFor( () => {
-			expect( triggerFetch ).not.toHaveBeenCalled();
-		} );
-		await waitFor( () =>
-			expect( triggerFetch ).not.toHaveBeenCalledWith( {
-				path: '/wp/v2/widgets/2?context=edit',
-			} )
+		// The same delay.
+		await act(
+			() => new Promise( ( resolve ) => setTimeout( resolve, 0 ) )
 		);
+		expect( triggerFetch ).toHaveBeenCalledTimes( 1 );
 	} );
 } );


### PR DESCRIPTION
## What?
This is a follow-up to #56108.

PR improves unit tests `useEntityRecord` hook when it's disabled. Props to @kevin940726 for the suggestion.

## Testing Instructions
```
npm run test:unit -- packages/core-data/src/hooks/test/use-entity-record.js
```
