### PR TITLE
Core data: harmonize getRevision selector and resolver function signatures

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -211,8 +211,10 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		plural: 'globalStylesVariations', // Should be different than name.
 		getTitle: ( record ) => record?.title?.rendered || record?.title,
-		getRevisionsUrl: ( parentId ) =>
-			`/wp/v2/global-styles/${ parentId }/revisions`,
+		getRevisionsUrl: ( parentId, revisionId ) =>
+			`/wp/v2/global-styles/${ parentId }/revisions${
+				revisionId ? '/' + revisionId : ''
+			}`,
 		supports: {
 			revisions: true,
 		},

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -209,7 +209,7 @@ export const rootEntitiesConfig = [
 		kind: 'root',
 		baseURL: '/wp/v2/global-styles',
 		baseURLParams: { context: 'edit' },
-		plural: 'globalStylesVariations', // Should be different than name.
+		plural: 'globalStylesVariations', // Should be different from name.
 		getTitle: ( record ) => record?.title?.rendered || record?.title,
 		getRevisionsUrl: ( parentId, revisionId ) =>
 			`/wp/v2/global-styles/${ parentId }/revisions${

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -57,7 +57,7 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 	for ( let i = 0; i < size; i++ ) {
 		// Preserve existing item ID except for subset of range of next items.
 		// We need to check against the possible maximum upper boundary because
-		// a page could recieve less items than what was previously stored.
+		// a page could receive fewer than what was previously stored.
 		const isInNextItemsRange =
 			i >= nextItemIdsStartIndex && i < nextItemIdsStartIndex + perPage;
 		mergedItemIds[ i ] = isInNextItemsRange

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -801,6 +801,26 @@ export const getRevisions =
 			false,
 			meta
 		);
+
+		// When requesting all fields, the list of results can be used to
+		// resolve the `getEntityRecord` selector in addition to `getEntityRecords`.
+		if ( ! query?._fields && ! query.context ) {
+			const key = entityConfig.key || DEFAULT_ENTITY_KEY;
+			const resolutionsArgs = records
+				.filter( ( record ) => record[ key ] )
+				.map( ( record ) => [ kind, name, recordKey, record[ key ] ] );
+
+			dispatch( {
+				type: 'START_RESOLUTIONS',
+				selectorName: 'getRevision',
+				args: resolutionsArgs,
+			} );
+			dispatch( {
+				type: 'FINISH_RESOLUTIONS',
+				selectorName: 'getRevision',
+				args: resolutionsArgs,
+			} );
+		}
 	};
 
 // Invalidate cache when a new revision is created.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -823,7 +823,7 @@ getRevisions.shouldInvalidate = ( action, kind, name, recordKey ) =>
  *                                       fields, fields must always include the ID.
  */
 export const getRevision =
-	( kind, name, recordKey, revisionKey, query = {} ) =>
+	( kind, name, recordKey, revisionKey, query ) =>
 	async ( { dispatch } ) => {
 		const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
 		const entityConfig = configs.find(

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -803,7 +803,7 @@ export const getRevisions =
 		);
 
 		// When requesting all fields, the list of results can be used to
-		// resolve the `getEntityRecord` selector in addition to `getEntityRecords`.
+		// resolve the `getRevision` selector in addition to `getRevisions`.
 		if ( ! query?._fields && ! query.context ) {
 			const key = entityConfig.key || DEFAULT_ENTITY_KEY;
 			const resolutionsArgs = records


### PR DESCRIPTION
## What?

Follow up for:

- https://github.com/WordPress/gutenberg/pull/54046

Yo!

This amazing PR:

1. Removes default value of query `{}` on `getRevision()`. It messes up selector memoization since the function signatures are different.
2. Resolves individual revisions in `getRevisions()`, the same way `getEntityRecords` does it.
3. Makes a minor grammatical upgrade.

## Why?
1. Selectors should match their resolvers! Also, calling `getRevisions()` then `getRevision()` doesn't return cached store item and replaces current items state.
2. Ensures that any subsequent calls to `getRevision` for revisions that we've already fetched via `getRevisions()` are marked as resolved and therefore do not trigger the resolver (and therefore an API call).
3. My English teacher was cruel.

## Testing Instructions
Check that the state survives multiple requests and that cached results are returned.

For example

### Before

```js
await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'post', 1 ) // Returns full revisions collections

await wp.data.resolveSelect( 'core' ).getRevision( 'postType', 'post', 1, 30 ) // Returns single revision with API call.

await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'post', 1 ) // Returns revisions collections with only a single revision
```

### After

```js
await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'post', 1 ) // Returns full revisions collections

await wp.data.resolveSelect( 'core' ).getRevision( 'postType', 'post', 1, 30 ) // Returns single revision with NO API call.

await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'post', 1 ) // Returns full revisions collections
```
