### PR TITLE
Site Editor: Fix template resolution for templates assigned as home page

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -18,13 +18,19 @@ export function useEditedPostContext() {
 	);
 }
 
-export function useIsPostsPage() {
+export function useIsPostsPageOrFrontPage() {
 	const { postId } = useEditedPostContext();
 	return useSelect(
-		( select ) =>
-			+postId ===
-			select( coreStore ).getEntityRecord( 'root', 'site' )
-				?.page_for_posts,
+		( select ) => {
+			const siteSettings = select( coreStore ).getEntityRecord(
+				'root',
+				'site'
+			);
+			return [
+				siteSettings?.page_for_posts,
+				siteSettings?.page_on_front,
+			].includes( +postId );
+		},
 		[ postId ]
 	);
 }
@@ -46,19 +52,19 @@ function useTemplates() {
 
 export function useAvailableTemplates() {
 	const currentTemplateSlug = useCurrentTemplateSlug();
-	const isPostsPage = useIsPostsPage();
+	const isPostsPageOrFrontPage = useIsPostsPageOrFrontPage();
 	const templates = useTemplates();
 	return useMemo(
 		() =>
 			// The posts page template cannot be changed.
-			! isPostsPage &&
+			! isPostsPageOrFrontPage &&
 			templates?.filter(
 				( template ) =>
 					template.is_custom &&
 					template.slug !== currentTemplateSlug &&
 					!! template.content.raw // Skip empty templates.
 			),
-		[ templates, currentTemplateSlug, isPostsPage ]
+		[ templates, currentTemplateSlug, isPostsPageOrFrontPage ]
 	);
 }
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -22,14 +22,20 @@ export function useIsPostsPageOrFrontPage() {
 	const { postId } = useEditedPostContext();
 	return useSelect(
 		( select ) => {
-			const siteSettings = select( coreStore ).getEntityRecord(
-				'root',
-				'site'
+			const { getEntityRecord, getEntityRecords } = select( coreStore );
+			const siteSettings = getEntityRecord( 'root', 'site' );
+			const templates = getEntityRecords(
+				'postType',
+				TEMPLATE_POST_TYPE,
+				{ per_page: -1 }
 			);
-			return [
-				siteSettings?.page_for_posts,
-				siteSettings?.page_on_front,
-			].includes( +postId );
+			const isPostsPage = +postId === siteSettings?.page_for_posts;
+			// If current page is set front page or posts page, we also need
+			// to check if the current theme has a template for it. If not
+			const isFrontPage =
+				+postId === siteSettings?.page_on_front &&
+				templates?.some( ( { slug } ) => slug === 'front-page' );
+			return isPostsPage || isFrontPage;
 		},
 		[ postId ]
 	);

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/hooks.js
@@ -18,7 +18,7 @@ export function useEditedPostContext() {
 	);
 }
 
-export function useIsPostsPageOrFrontPage() {
+export function useAllowSwitchingTemplates() {
 	const { postId } = useEditedPostContext();
 	return useSelect(
 		( select ) => {
@@ -35,7 +35,7 @@ export function useIsPostsPageOrFrontPage() {
 			const isFrontPage =
 				+postId === siteSettings?.page_on_front &&
 				templates?.some( ( { slug } ) => slug === 'front-page' );
-			return isPostsPage || isFrontPage;
+			return ! isPostsPage && ! isFrontPage;
 		},
 		[ postId ]
 	);
@@ -58,19 +58,18 @@ function useTemplates() {
 
 export function useAvailableTemplates() {
 	const currentTemplateSlug = useCurrentTemplateSlug();
-	const isPostsPageOrFrontPage = useIsPostsPageOrFrontPage();
+	const allowSwitchingTemplate = useAllowSwitchingTemplates();
 	const templates = useTemplates();
 	return useMemo(
 		() =>
-			// The posts page template cannot be changed.
-			! isPostsPageOrFrontPage &&
+			allowSwitchingTemplate &&
 			templates?.filter(
 				( template ) =>
 					template.is_custom &&
 					template.slug !== currentTemplateSlug &&
 					!! template.content.raw // Skip empty templates.
 			),
-		[ templates, currentTemplateSlug, isPostsPageOrFrontPage ]
+		[ templates, currentTemplateSlug, allowSwitchingTemplate ]
 	);
 }
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
@@ -12,16 +12,16 @@ import { store as coreStore } from '@wordpress/core-data';
 import {
 	useCurrentTemplateSlug,
 	useEditedPostContext,
-	useIsPostsPage,
+	useIsPostsPageOrFrontPage,
 } from './hooks';
 
 export default function ResetDefaultTemplate( { onClick } ) {
 	const currentTemplateSlug = useCurrentTemplateSlug();
-	const isPostsPage = useIsPostsPage();
+	const isPostsPageOrFrontPage = useIsPostsPageOrFrontPage();
 	const { postType, postId } = useEditedPostContext();
 	const { editEntityRecord } = useDispatch( coreStore );
 	// The default template in a post is indicated by an empty string.
-	if ( ! currentTemplateSlug || isPostsPage ) {
+	if ( ! currentTemplateSlug || isPostsPageOrFrontPage ) {
 		return null;
 	}
 	return (

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/reset-default-template.js
@@ -10,18 +10,18 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import {
+	useAllowSwitchingTemplates,
 	useCurrentTemplateSlug,
 	useEditedPostContext,
-	useIsPostsPageOrFrontPage,
 } from './hooks';
 
 export default function ResetDefaultTemplate( { onClick } ) {
 	const currentTemplateSlug = useCurrentTemplateSlug();
-	const isPostsPageOrFrontPage = useIsPostsPageOrFrontPage();
+	const allowSwitchingTemplate = useAllowSwitchingTemplates();
 	const { postType, postId } = useEditedPostContext();
 	const { editEntityRecord } = useDispatch( coreStore );
 	// The default template in a post is indicated by an empty string.
-	if ( ! currentTemplateSlug || isPostsPageOrFrontPage ) {
+	if ( ! currentTemplateSlug || ! allowSwitchingTemplate ) {
 		return null;
 	}
 	return (

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -87,7 +87,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				postTypeToResolve,
 				postIdToResolve
 			) {
-				// For the front page, we alwayse use the front page template if existing.
+				// For the front page, we always use the front page template if existing.
 				if (
 					postTypeToResolve === 'page' &&
 					homepageId === postIdToResolve

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -28,7 +28,7 @@ const postTypesWithoutParentTemplate = [
 ];
 
 function useResolveEditedEntityAndContext( { postId, postType } ) {
-	const { isRequestingSite, homepageId, url, frontPageTemplateId } =
+	const { hasLoadedAllDependencies, homepageId, url, frontPageTemplateId } =
 		useSelect( ( select ) => {
 			const { getSite, getUnstableBase, getEntityRecords } =
 				select( coreDataStore );
@@ -52,10 +52,10 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 			}
 
 			return {
-				isRequestingSite: ! base,
+				hasLoadedAllDependencies: !! base && !! siteData,
 				homepageId:
 					siteData?.show_on_front === 'page'
-						? siteData.page_on_front
+						? siteData.page_on_front.toString()
 						: null,
 				url: base?.home,
 				frontPageTemplateId: _frontPateTemplateId,
@@ -132,6 +132,10 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				} );
 			}
 
+			if ( ! hasLoadedAllDependencies ) {
+				return undefined;
+			}
+
 			// If we're rendering a specific page, post... we need to resolve its template.
 			if ( postType && postId ) {
 				return resolveTemplateForPostTypeAndId( postType, postId );
@@ -143,14 +147,14 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 			}
 
 			// If we're not rendering a specific page, use the front page template.
-			if ( ! isRequestingSite && url ) {
+			if ( url ) {
 				const template = __experimentalGetTemplateForLink( url );
 				return template?.id;
 			}
 		},
 		[
 			homepageId,
-			isRequestingSite,
+			hasLoadedAllDependencies,
 			url,
 			postId,
 			postType,
@@ -178,7 +182,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 		return { isReady: true, postType, postId, context };
 	}
 
-	if ( ( postType && postId ) || homepageId || ! isRequestingSite ) {
+	if ( hasLoadedAllDependencies ) {
 		return {
 			isReady: resolvedTemplateId !== undefined,
 			postType: TEMPLATE_POST_TYPE,

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -28,21 +28,46 @@ const postTypesWithoutParentTemplate = [
 ];
 
 function useResolveEditedEntityAndContext( { postId, postType } ) {
-	const { isRequestingSite, homepageId, url } = useSelect( ( select ) => {
-		const { getSite, getUnstableBase } = select( coreDataStore );
-		const siteData = getSite();
-		const base = getUnstableBase();
+	const { isRequestingSite, homepageId, url, frontPageTemplateId } =
+		useSelect( ( select ) => {
+			const { getSite, getUnstableBase, getEntityRecords } =
+				select( coreDataStore );
+			const siteData = getSite();
+			const base = getUnstableBase();
+			const templates = getEntityRecords(
+				'postType',
+				TEMPLATE_POST_TYPE,
+				{
+					per_page: -1,
+				}
+			);
+			let _frontPateTemplateId;
+			if ( templates ) {
+				const frontPageTemplate = templates.find(
+					( t ) => t.slug === 'front-page'
+				);
+				_frontPateTemplateId = frontPageTemplate
+					? frontPageTemplate.id
+					: false;
+			}
 
-		return {
-			isRequestingSite: ! base,
-			homepageId:
-				siteData?.show_on_front === 'page'
-					? siteData.page_on_front
-					: null,
-			url: base?.home,
-		};
-	}, [] );
+			return {
+				isRequestingSite: ! base,
+				homepageId:
+					siteData?.show_on_front === 'page'
+						? siteData.page_on_front
+						: null,
+				url: base?.home,
+				frontPageTemplateId: _frontPateTemplateId,
+			};
+		}, [] );
 
+	/**
+	 * This is a hook that recreates the logic to resolve a template for a given WordPress postID postTypeId
+	 * in order to match the frontend as closely as possible in the site editor.
+	 *
+	 * It is not possible to rely on the server logic because there maybe unsaved changes that impact the template resolution.
+	 */
 	const resolvedTemplateId = useSelect(
 		( select ) => {
 			// If we're rendering a post type that doesn't have a template
@@ -62,6 +87,22 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				postTypeToResolve,
 				postIdToResolve
 			) {
+				// For the front page, we alwayse use the front page template if existing.
+				if (
+					postTypeToResolve === 'page' &&
+					homepageId === postIdToResolve
+				) {
+					// We're still checking whether the front page template exists.
+					// Don't resolve the template yet.
+					if ( frontPageTemplateId === undefined ) {
+						return undefined;
+					}
+
+					if ( !! frontPageTemplateId ) {
+						return frontPageTemplateId;
+					}
+				}
+
 				const editedEntity = getEditedEntityRecord(
 					'postType',
 					postTypeToResolve,
@@ -107,7 +148,14 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				return template?.id;
 			}
 		},
-		[ homepageId, isRequestingSite, url, postId, postType ]
+		[
+			homepageId,
+			isRequestingSite,
+			url,
+			postId,
+			postType,
+			frontPageTemplateId,
+		]
 	);
 
 	const context = useMemo( () => {


### PR DESCRIPTION
closes #56267 
Alternative to #56326 

## What

If a page was set as "static home page", and you had a "front page" template on your theme, this template was not being picked as the template to use for your home page, instead we were always using the default "page" template regardless of whether that template exited.

This PR fixes that by checking for the existence of the front page template if the page that we're resolving is the one set as "fixed home page".

## Why?

I initially tried to solve this problem by relying on a server API to resolve the template, the problem is that unsaved user changes might impact the resolved template and we do want to reflect these changes in the site editor.

## Testing Instructions

1- Create a random page and use it as "static home page" in your "reading" settings
2- Ensure that you have a front page template on your theme
3- Open the site editor: The front page template should be loaded for your page.