### PR TITLE
Playwright Utils: Fix the method of getting post ID in 'publishPost'

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
@@ -28,12 +28,11 @@ export async function publishPost( this: Editor ) {
 		'role=region[name="Editor publish"i] >> role=button[name="Publish"i]'
 	);
 
-	const urlString = await this.page
-		.getByRole( 'region', { name: 'Editor publish' } )
-		.getByRole( 'textbox', { name: 'address' } )
-		.inputValue();
-	const url = new URL( urlString );
-	const postId = url.searchParams.get( 'p' );
+	await this.page
+		.getByRole( 'button', { name: 'Dismiss this notice' } )
+		.filter( { hasText: 'published' } )
+		.waitFor();
+	const postId = new URL( this.page.url() ).searchParams.get( 'post' );
 
 	return typeof postId === 'string' ? parseInt( postId, 10 ) : null;
 }

--- a/test/e2e/specs/editor/various/sidebar-permalink.spec.js
+++ b/test/e2e/specs/editor/various/sidebar-permalink.spec.js
@@ -48,7 +48,7 @@ test.describe( 'Sidebar Permalink', () => {
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaaa' );
-		await editor.saveDraft();
+		await editor.publishPost();
 		// Start editing again.
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/56253#discussion_r1397306664.

PR fixes the method of getting post ID in `publishPost` to avoid failures when the post publish panel isn't displayed.

## Why?
Displaying the post-publish panel isn't guaranteed. It can be hidden when a post-type isn't viewable or disabled using the "Include pre-publish checklist" preference.

## How?
* Wait for the "Post Published" notice instead of the panel.
* Get the post ID from the editor's page URL.

## Testing Instructions
Playwright E2E tests are passing on CI.
