### PR TITLE
DataViews: Make disabled pagination buttons focusable

### DIFF
--- a/packages/edit-site/src/components/dataviews/pagination.js
+++ b/packages/edit-site/src/components/dataviews/pagination.js
@@ -48,6 +48,7 @@ function Pagination( {
 								onChangeView( { ...view, page: 1 } )
 							}
 							disabled={ view.page === 1 }
+							__experimentalIsFocusable
 							label={ __( 'First page' ) }
 							icon={ previous }
 							showTooltip
@@ -58,6 +59,7 @@ function Pagination( {
 								onChangeView( { ...view, page: view.page - 1 } )
 							}
 							disabled={ view.page === 1 }
+							__experimentalIsFocusable
 							label={ __( 'Previous page' ) }
 							icon={ chevronLeft }
 							showTooltip
@@ -115,6 +117,7 @@ function Pagination( {
 								onChangeView( { ...view, page: view.page + 1 } )
 							}
 							disabled={ view.page >= totalPages }
+							__experimentalIsFocusable
 							label={ __( 'Next page' ) }
 							icon={ chevronRight }
 							showTooltip
@@ -125,6 +128,7 @@ function Pagination( {
 								onChangeView( { ...view, page: totalPages } )
 							}
 							disabled={ view.page >= totalPages }
+							__experimentalIsFocusable
 							label={ __( 'Last page' ) }
 							icon={ next }
 							showTooltip


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/56396

From the issue:
>A 'change of context' is defined as something "that, if made without user awareness, can disorient users who are not able to view the entire page simultaneously". This includes focus.


## Testing Instructions
1. Enable the admin views experiment and go to manage all templates view all or in manage all pages view
2. You need to have at least two pages of results
3. Click the "last page" button in the pagination controls and ensure the focus remains in the clicked button

