### PR TITLE
Use allow-list for mobile editor settings endpoint

### DIFF
--- a/lib/experimental/block-editor-settings-mobile-allowed.php
+++ b/lib/experimental/block-editor-settings-mobile-allowed.php
@@ -65,8 +65,6 @@ if ( ! function_exists( 'gutenberg_get_allowed_block_editor_settings_mobile' ) )
 		} else {
 			return $settings;
 		}
-
-
 	}
 }
 

--- a/lib/experimental/block-editor-settings-mobile-allowed.php
+++ b/lib/experimental/block-editor-settings-mobile-allowed.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Filters settings for the mobile block editor.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( 'filter_by_supported_block_editor_settings_mobile' ) ) {
+	/**
+	 * Recursively filters for supported settings.
+	 *
+	 * This is used to control the editor settings payload. Keys can be specified
+	 * as `true` to be allowed, which will also allow entire nested structures.
+	 * Alternatively, nested structures can have nested allow-lists for their keys.
+	 *
+	 * @param array $initial_array Existing block editor settings.
+	 *
+	 * @param array $allow_list_array Structured allow-list.
+	 *
+	 * @return array New block editor settings.
+	 */
+	function filter_by_supported_block_editor_settings_mobile( $initial_array, $allow_list_array ) {
+		$result = array();
+
+		foreach ( $allow_list_array as $key => $value ) {
+			if ( ! array_key_exists( $key, $initial_array ) ) {
+				continue;
+			}
+
+			$initial_value = $initial_array[ $key ];
+
+			if ( array_key_exists( $key, $initial_array ) ) {
+				if ( is_array( $value ) && is_array( $initial_value ) ) {
+					$result[ $key ] = filter_by_supported_block_editor_settings_mobile( $initial_value, $value );
+				} else {
+					$result[ $key ] = $initial_value;
+				}
+			}
+		}
+
+		return $result;
+	}
+}
+
+if ( ! function_exists( 'gutenberg_get_allowed_block_editor_settings_mobile' ) ) {
+	/**
+	 * Keeps only supported settings for the mobile block editor.
+	 *
+	 * @param array $settings Existing block editor settings.
+	 *
+	 * @return array New block editor settings.
+	 */
+	function gutenberg_get_allowed_block_editor_settings_mobile( $settings ) {
+
+		if (
+			defined( 'REST_REQUEST' ) &&
+			REST_REQUEST &&
+			isset( $_GET['context'] ) &&
+			'mobile' === $_GET['context']
+		) {
+			return filter_by_supported_block_editor_settings_mobile(
+				$settings,
+				BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST
+			);
+		} else {
+			return $settings;
+		}
+
+
+	}
+}
+
+if ( ! defined( 'BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST' ) ) {
+	define(
+		'BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST',
+		array(
+			'alignWide'                        => true,
+			'allowedBlockTypes'                => true,
+			'allowedMimeTypes'                 => true,
+			'defaultEditorStyles'              => true,
+			'blockCategories'                  => true,
+			'isRTL'                            => true,
+			'imageDefaultSize'                 => true,
+			'imageDimensions'                  => true,
+			'imageEditing'                     => true,
+			'imageSizes'                       => true,
+			'maxUploadFileSize'                => true,
+			'__unstableGalleryWithImageBlocks' => true,
+			'disableCustomColors'              => true,
+			'disableCustomFontSizes'           => true,
+			'disableCustomGradients'           => true,
+			'disableLayoutStyles'              => true,
+			'enableCustomLineHeight'           => true,
+			'enableCustomSpacing'              => true,
+			'enableCustomUnits'                => true,
+			'colors'                           => true,
+			'fontSizes'                        => true,
+			'__experimentalStyles'             => array(
+				'elements'   => true,
+				'spacing'    => true,
+				'blocks'     => true,
+				'color'      => true,
+				'typography' => true,
+			),
+			'__experimentalFeatures'           => array(
+				'appearanceTools'               => true,
+				'useRootPaddingAwareAlignments' => true,
+				'border'                        => true,
+				'color'                         => true,
+				'shadow'                        => true,
+				'spacing'                       => true,
+				'typography'                    => array(
+					'dropCap'        => true,
+					'fontSizes'      => true,
+					'fontStyle'      => true,
+					'fontWeight'     => true,
+					'letterSpacing'  => true,
+					'textColumns'    => true,
+					'textDecoration' => true,
+					'textTransform'  => true,
+					'writingMode'    => true,
+				),
+				'blocks'                        => true,
+				'background'                    => true,
+				'dimensions'                    => true,
+				'position'                      => true,
+			),
+			'gradients'                        => true,
+			'disableCustomSpacingSizes'        => true,
+			'spacingSizes'                     => true,
+			'__unstableIsBlockBasedTheme'      => true,
+			'localAutosaveInterval'            => true,
+			'__experimentalDiscussionSettings' => true,
+			'__experimentalEnableQuoteBlockV2' => true,
+			'__experimentalEnableListBlockV2'  => true,
+		)
+	);
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_get_allowed_block_editor_settings_mobile', PHP_INT_MAX );

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -42,37 +42,9 @@ if ( ! function_exists( 'filter_by_supported_block_editor_settings_mobile' ) ) {
 	}
 }
 
-
-/**
- * Adds settings to the mobile block editor.
- *
- * This is used by the settings REST endpoint and it should land in core
- * as soon as lib/class-wp-rest-block-editor-settings-controller.php does.
- *
- * @param array $settings Existing block editor settings.
- *
- * @return array New block editor settings.
- */
-function gutenberg_get_block_editor_settings_mobile( $settings ) {
-	if (
-		defined( 'REST_REQUEST' ) &&
-		REST_REQUEST &&
-		isset( $_GET['context'] ) &&
-		'mobile' === $_GET['context']
-	) {
-		if ( wp_theme_has_theme_json() ) {
-			$settings['__experimentalStyles'] = gutenberg_get_global_styles();
-		}
-
-		// To tell mobile that the site uses quote v2 (inner blocks).
-		// See https://github.com/WordPress/gutenberg/pull/25892.
-		$settings['__experimentalEnableQuoteBlockV2'] = true;
-		// To tell mobile that the site uses list v2 (inner blocks).
-		$settings['__experimentalEnableListBlockV2'] = true;
-	}
-
-	return filter_by_supported_block_editor_settings_mobile(
-		$settings,
+if ( ! defined( 'BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST' ) ) {
+	define(
+		'BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST',
 		array(
 			'alignWide'                        => true,
 			'allowedBlockTypes'                => true,
@@ -136,6 +108,37 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 			'__experimentalEnableListBlockV2'  => true,
 		)
 	);
+}
+
+/**
+ * Adds settings to the mobile block editor.
+ *
+ * This is used by the settings REST endpoint and it should land in core
+ * as soon as lib/class-wp-rest-block-editor-settings-controller.php does.
+ *
+ * @param array $settings Existing block editor settings.
+ *
+ * @return array New block editor settings.
+ */
+function gutenberg_get_block_editor_settings_mobile( $settings ) {
+	if (
+		defined( 'REST_REQUEST' ) &&
+		REST_REQUEST &&
+		isset( $_GET['context'] ) &&
+		'mobile' === $_GET['context']
+	) {
+		if ( wp_theme_has_theme_json() ) {
+			$settings['__experimentalStyles'] = gutenberg_get_global_styles();
+		}
+
+		// To tell mobile that the site uses quote v2 (inner blocks).
+		// See https://github.com/WordPress/gutenberg/pull/25892.
+		$settings['__experimentalEnableQuoteBlockV2'] = true;
+		// To tell mobile that the site uses list v2 (inner blocks).
+		$settings['__experimentalEnableListBlockV2'] = true;
+	}
+
+	return filter_by_supported_block_editor_settings_mobile( $settings, BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST );
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_mobile', PHP_INT_MAX );

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -18,22 +18,22 @@
  *
  * @return array New block editor settings.
  */
-function keep_supported_block_editor_settings_mobile($initial_array, $allow_list_array) {
-    $result = array();
+function keep_supported_block_editor_settings_mobile( $initial_array, $allow_list_array ) {
+	$result = array();
 
-    foreach ($allow_list_array as $key => $value) {
-        $initial_value = $initial_array[$key];
+	foreach ( $allow_list_array as $key => $value ) {
+		$initial_value = $initial_array[ $key ];
 
-        if (array_key_exists($key, $initial_array)) {
-            if (is_array($value) && is_array($initial_value)) {
-							$result[$key] = keep_supported_block_editor_settings_mobile($initial_value, $value);
-            } else {
-							$result[$key] = $initial_value;
-            }
-        }
-    }
+		if ( array_key_exists( $key, $initial_array ) ) {
+			if ( is_array( $value ) && is_array( $initial_value ) ) {
+							$result[ $key ] = keep_supported_block_editor_settings_mobile( $initial_value, $value );
+			} else {
+							$result[ $key ] = $initial_value;
+			}
+		}
+	}
 
-    return $result;
+	return $result;
 }
 
 
@@ -65,61 +65,64 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		$settings['__experimentalEnableListBlockV2'] = true;
 	}
 
-	return keep_supported_block_editor_settings_mobile($settings, array(
-		"alignWide" => true,
-		"allowedBlockTypes" => true,
-		"allowedMimeTypes" => true,
-		"defaultEditorStyles" => true,
-		"blockCategories" => true,
-		"isRTL" => true,
-		"imageDefaultSize" => true,
-		"imageDimensions" => true,
-		"imageEditing" => true,
-		"imageSizes" => true,
-		"maxUploadFileSize" => true,
-		"__unstableGalleryWithImageBlocks" => true,
-		"disableCustomColors" => true,
-		"disableCustomFontSizes" => true,
-		"disableCustomGradients" => true,
-		"disableLayoutStyles" => true,
-		"enableCustomLineHeight" => true,
-		"enableCustomSpacing" => true,
-		"enableCustomUnits" => true,
-		"colors" => true,
-		"fontSizes" => true,
-		"__experimentalFeatures" => array(
-			"appearanceTools" => true,
-			"useRootPaddingAwareAlignments" => true,
-			"border" => true,
-			"color" => true,
-			"shadow" => true,
-			"spacing" => true,
-			"typography" => array(
-				"dropCap" => true,
-				"fontSizes" => true,
-				"fontStyle" => true,
-				"fontWeight" => true,
-				"letterSpacing" => true,
-				"textColumns" => true,
-				"textDecoration" => true,
-				"textTransform" => true,
-				"writingMode" => true,
+	return keep_supported_block_editor_settings_mobile(
+		$settings,
+		array(
+			'alignWide'                        => true,
+			'allowedBlockTypes'                => true,
+			'allowedMimeTypes'                 => true,
+			'defaultEditorStyles'              => true,
+			'blockCategories'                  => true,
+			'isRTL'                            => true,
+			'imageDefaultSize'                 => true,
+			'imageDimensions'                  => true,
+			'imageEditing'                     => true,
+			'imageSizes'                       => true,
+			'maxUploadFileSize'                => true,
+			'__unstableGalleryWithImageBlocks' => true,
+			'disableCustomColors'              => true,
+			'disableCustomFontSizes'           => true,
+			'disableCustomGradients'           => true,
+			'disableLayoutStyles'              => true,
+			'enableCustomLineHeight'           => true,
+			'enableCustomSpacing'              => true,
+			'enableCustomUnits'                => true,
+			'colors'                           => true,
+			'fontSizes'                        => true,
+			'__experimentalFeatures'           => array(
+				'appearanceTools'               => true,
+				'useRootPaddingAwareAlignments' => true,
+				'border'                        => true,
+				'color'                         => true,
+				'shadow'                        => true,
+				'spacing'                       => true,
+				'typography'                    => array(
+					'dropCap'        => true,
+					'fontSizes'      => true,
+					'fontStyle'      => true,
+					'fontWeight'     => true,
+					'letterSpacing'  => true,
+					'textColumns'    => true,
+					'textDecoration' => true,
+					'textTransform'  => true,
+					'writingMode'    => true,
+				),
+				'blocks'                        => true,
+				'background'                    => true,
+				'dimensions'                    => true,
+				'position'                      => true,
 			),
-			"blocks" => true,
-			"background" => true,
-			"dimensions" => true,
-			"position" => true,
-		),
-		"gradients" => true,
-		"disableCustomSpacingSizes" => true,
-		"spacingSizes" => true,
-		"__unstableIsBlockBasedTheme" => true,
-		"localAutosaveInterval" => true,
-		"__experimentalDiscussionSettings" => true,
-		"__experimentalDashboardLink" => true,
-		"__experimentalEnableQuoteBlockV2" => true,
-		"__experimentalEnableListBlockV2" => true,
-	));
+			'gradients'                        => true,
+			'disableCustomSpacingSizes'        => true,
+			'spacingSizes'                     => true,
+			'__unstableIsBlockBasedTheme'      => true,
+			'localAutosaveInterval'            => true,
+			'__experimentalDiscussionSettings' => true,
+			'__experimentalDashboardLink'      => true,
+			'__experimentalEnableQuoteBlockV2' => true,
+			'__experimentalEnableListBlockV2'  => true,
+		)
+	);
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_mobile', PHP_INT_MAX );

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -95,6 +95,13 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 			'enableCustomUnits'                => true,
 			'colors'                           => true,
 			'fontSizes'                        => true,
+			'__experimentalStyles'             => array(
+				'elements'   => true,
+				'spacing'    => true,
+				'blocks'     => true,
+				'color'      => true,
+				'typography' => true,
+			),
 			'__experimentalFeatures'           => array(
 				'appearanceTools'               => true,
 				'useRootPaddingAwareAlignments' => true,

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'keep_supported_block_editor_settings_mobile' ) ) {
+if ( ! function_exists( 'filter_by_supported_block_editor_settings_mobile' ) ) {
 	/**
 	 * Keeps only supported settings for the mobile block editor.
 	 *
@@ -19,7 +19,7 @@ if ( ! function_exists( 'keep_supported_block_editor_settings_mobile' ) ) {
 	 *
 	 * @return array New block editor settings.
 	 */
-	function keep_supported_block_editor_settings_mobile( $initial_array, $allow_list_array ) {
+	function filter_by_supported_block_editor_settings_mobile( $initial_array, $allow_list_array ) {
 		$result = array();
 
 		foreach ( $allow_list_array as $key => $value ) {
@@ -31,7 +31,7 @@ if ( ! function_exists( 'keep_supported_block_editor_settings_mobile' ) ) {
 
 			if ( array_key_exists( $key, $initial_array ) ) {
 				if ( is_array( $value ) && is_array( $initial_value ) ) {
-					$result[ $key ] = keep_supported_block_editor_settings_mobile( $initial_value, $value );
+					$result[ $key ] = filter_by_supported_block_editor_settings_mobile( $initial_value, $value );
 				} else {
 					$result[ $key ] = $initial_value;
 				}
@@ -71,7 +71,7 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		$settings['__experimentalEnableListBlockV2'] = true;
 	}
 
-	return keep_supported_block_editor_settings_mobile(
+	return filter_by_supported_block_editor_settings_mobile(
 		$settings,
 		array(
 			'alignWide'                        => true,

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -103,7 +103,6 @@ if ( ! defined( 'BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST' ) ) {
 			'__unstableIsBlockBasedTheme'      => true,
 			'localAutosaveInterval'            => true,
 			'__experimentalDiscussionSettings' => true,
-			'__experimentalDashboardLink'      => true,
 			'__experimentalEnableQuoteBlockV2' => true,
 			'__experimentalEnableListBlockV2'  => true,
 		)

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -6,6 +6,38 @@
  */
 
 /**
+ * Keeps only supported settings for the mobile block editor.
+ *
+ * This is used to control the editor settings payload. Keys can be specified
+ * as `true` to be allowed, which will also allow entire nested structures.
+ * Alternatively, nested structures can have nested allow-lists for their keys.
+ *
+ * @param array $initial_array Existing block editor settings.
+ *
+ * @param array $allow_list_array Structured allow-list.
+ *
+ * @return array New block editor settings.
+ */
+function keep_supported_block_editor_settings_mobile($initial_array, $allow_list_array) {
+    $result = array();
+
+    foreach ($allow_list_array as $key => $value) {
+        $initial_value = $initial_array[$key];
+
+        if (array_key_exists($key, $initial_array)) {
+            if (is_array($value) && is_array($initial_value)) {
+							$result[$key] = keep_supported_block_editor_settings_mobile($initial_value, $value);
+            } else {
+							$result[$key] = $initial_value;
+            }
+        }
+    }
+
+    return $result;
+}
+
+
+/**
  * Adds settings to the mobile block editor.
  *
  * This is used by the settings REST endpoint and it should land in core
@@ -33,7 +65,61 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		$settings['__experimentalEnableListBlockV2'] = true;
 	}
 
-	return $settings;
+	return keep_supported_block_editor_settings_mobile($settings, array(
+		"alignWide" => true,
+		"allowedBlockTypes" => true,
+		"allowedMimeTypes" => true,
+		"defaultEditorStyles" => true,
+		"blockCategories" => true,
+		"isRTL" => true,
+		"imageDefaultSize" => true,
+		"imageDimensions" => true,
+		"imageEditing" => true,
+		"imageSizes" => true,
+		"maxUploadFileSize" => true,
+		"__unstableGalleryWithImageBlocks" => true,
+		"disableCustomColors" => true,
+		"disableCustomFontSizes" => true,
+		"disableCustomGradients" => true,
+		"disableLayoutStyles" => true,
+		"enableCustomLineHeight" => true,
+		"enableCustomSpacing" => true,
+		"enableCustomUnits" => true,
+		"colors" => true,
+		"fontSizes" => true,
+		"__experimentalFeatures" => array(
+			"appearanceTools" => true,
+			"useRootPaddingAwareAlignments" => true,
+			"border" => true,
+			"color" => true,
+			"shadow" => true,
+			"spacing" => true,
+			"typography" => array(
+				"dropCap" => true,
+				"fontSizes" => true,
+				"fontStyle" => true,
+				"fontWeight" => true,
+				"letterSpacing" => true,
+				"textColumns" => true,
+				"textDecoration" => true,
+				"textTransform" => true,
+				"writingMode" => true,
+			),
+			"blocks" => true,
+			"background" => true,
+			"dimensions" => true,
+			"position" => true,
+		),
+		"gradients" => true,
+		"disableCustomSpacingSizes" => true,
+		"spacingSizes" => true,
+		"__unstableIsBlockBasedTheme" => true,
+		"localAutosaveInterval" => true,
+		"__experimentalDiscussionSettings" => true,
+		"__experimentalDashboardLink" => true,
+		"__experimentalEnableQuoteBlockV2" => true,
+		"__experimentalEnableListBlockV2" => true,
+	));
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_mobile', PHP_INT_MAX );

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -5,35 +5,37 @@
  * @package gutenberg
  */
 
-/**
- * Keeps only supported settings for the mobile block editor.
- *
- * This is used to control the editor settings payload. Keys can be specified
- * as `true` to be allowed, which will also allow entire nested structures.
- * Alternatively, nested structures can have nested allow-lists for their keys.
- *
- * @param array $initial_array Existing block editor settings.
- *
- * @param array $allow_list_array Structured allow-list.
- *
- * @return array New block editor settings.
- */
-function keep_supported_block_editor_settings_mobile( $initial_array, $allow_list_array ) {
-	$result = array();
+if ( ! function_exists( 'keep_supported_block_editor_settings_mobile' ) ) {
+	/**
+	 * Keeps only supported settings for the mobile block editor.
+	 *
+	 * This is used to control the editor settings payload. Keys can be specified
+	 * as `true` to be allowed, which will also allow entire nested structures.
+	 * Alternatively, nested structures can have nested allow-lists for their keys.
+	 *
+	 * @param array $initial_array Existing block editor settings.
+	 *
+	 * @param array $allow_list_array Structured allow-list.
+	 *
+	 * @return array New block editor settings.
+	 */
+	function keep_supported_block_editor_settings_mobile( $initial_array, $allow_list_array ) {
+		$result = array();
 
-	foreach ( $allow_list_array as $key => $value ) {
-		$initial_value = $initial_array[ $key ];
+		foreach ( $allow_list_array as $key => $value ) {
+			$initial_value = $initial_array[ $key ];
 
-		if ( array_key_exists( $key, $initial_array ) ) {
-			if ( is_array( $value ) && is_array( $initial_value ) ) {
-							$result[ $key ] = keep_supported_block_editor_settings_mobile( $initial_value, $value );
-			} else {
-							$result[ $key ] = $initial_value;
+			if ( array_key_exists( $key, $initial_array ) ) {
+				if ( is_array( $value ) && is_array( $initial_value ) ) {
+					$result[ $key ] = keep_supported_block_editor_settings_mobile( $initial_value, $value );
+				} else {
+					$result[ $key ] = $initial_value;
+				}
 			}
 		}
-	}
 
-	return $result;
+		return $result;
+	}
 }
 
 

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -5,110 +5,6 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'filter_by_supported_block_editor_settings_mobile' ) ) {
-	/**
-	 * Keeps only supported settings for the mobile block editor.
-	 *
-	 * This is used to control the editor settings payload. Keys can be specified
-	 * as `true` to be allowed, which will also allow entire nested structures.
-	 * Alternatively, nested structures can have nested allow-lists for their keys.
-	 *
-	 * @param array $initial_array Existing block editor settings.
-	 *
-	 * @param array $allow_list_array Structured allow-list.
-	 *
-	 * @return array New block editor settings.
-	 */
-	function filter_by_supported_block_editor_settings_mobile( $initial_array, $allow_list_array ) {
-		$result = array();
-
-		foreach ( $allow_list_array as $key => $value ) {
-			if ( ! array_key_exists( $key, $initial_array ) ) {
-				continue;
-			}
-
-			$initial_value = $initial_array[ $key ];
-
-			if ( array_key_exists( $key, $initial_array ) ) {
-				if ( is_array( $value ) && is_array( $initial_value ) ) {
-					$result[ $key ] = filter_by_supported_block_editor_settings_mobile( $initial_value, $value );
-				} else {
-					$result[ $key ] = $initial_value;
-				}
-			}
-		}
-
-		return $result;
-	}
-}
-
-if ( ! defined( 'BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST' ) ) {
-	define(
-		'BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST',
-		array(
-			'alignWide'                        => true,
-			'allowedBlockTypes'                => true,
-			'allowedMimeTypes'                 => true,
-			'defaultEditorStyles'              => true,
-			'blockCategories'                  => true,
-			'isRTL'                            => true,
-			'imageDefaultSize'                 => true,
-			'imageDimensions'                  => true,
-			'imageEditing'                     => true,
-			'imageSizes'                       => true,
-			'maxUploadFileSize'                => true,
-			'__unstableGalleryWithImageBlocks' => true,
-			'disableCustomColors'              => true,
-			'disableCustomFontSizes'           => true,
-			'disableCustomGradients'           => true,
-			'disableLayoutStyles'              => true,
-			'enableCustomLineHeight'           => true,
-			'enableCustomSpacing'              => true,
-			'enableCustomUnits'                => true,
-			'colors'                           => true,
-			'fontSizes'                        => true,
-			'__experimentalStyles'             => array(
-				'elements'   => true,
-				'spacing'    => true,
-				'blocks'     => true,
-				'color'      => true,
-				'typography' => true,
-			),
-			'__experimentalFeatures'           => array(
-				'appearanceTools'               => true,
-				'useRootPaddingAwareAlignments' => true,
-				'border'                        => true,
-				'color'                         => true,
-				'shadow'                        => true,
-				'spacing'                       => true,
-				'typography'                    => array(
-					'dropCap'        => true,
-					'fontSizes'      => true,
-					'fontStyle'      => true,
-					'fontWeight'     => true,
-					'letterSpacing'  => true,
-					'textColumns'    => true,
-					'textDecoration' => true,
-					'textTransform'  => true,
-					'writingMode'    => true,
-				),
-				'blocks'                        => true,
-				'background'                    => true,
-				'dimensions'                    => true,
-				'position'                      => true,
-			),
-			'gradients'                        => true,
-			'disableCustomSpacingSizes'        => true,
-			'spacingSizes'                     => true,
-			'__unstableIsBlockBasedTheme'      => true,
-			'localAutosaveInterval'            => true,
-			'__experimentalDiscussionSettings' => true,
-			'__experimentalEnableQuoteBlockV2' => true,
-			'__experimentalEnableListBlockV2'  => true,
-		)
-	);
-}
-
 /**
  * Adds settings to the mobile block editor.
  *
@@ -137,7 +33,7 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		$settings['__experimentalEnableListBlockV2'] = true;
 	}
 
-	return filter_by_supported_block_editor_settings_mobile( $settings, BLOCK_EDITOR_SETTINGS_MOBILE_ALLOW_LIST );
+	return $settings;
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_mobile', PHP_INT_MAX );

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -23,6 +23,10 @@ if ( ! function_exists( 'keep_supported_block_editor_settings_mobile' ) ) {
 		$result = array();
 
 		foreach ( $allow_list_array as $key => $value ) {
+			if ( ! array_key_exists( $key, $initial_array ) ) {
+				continue;
+			}
+
 			$initial_value = $initial_array[ $key ];
 
 			if ( array_key_exists( $key, $initial_array ) ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -127,6 +127,7 @@ require __DIR__ . '/compat/wordpress-6.5/class-wp-navigation-block-renderer.php'
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
+require __DIR__ . '/experimental/block-editor-settings-mobile-allowed.php';
 require __DIR__ . '/experimental/blocks.php';
 require __DIR__ . '/experimental/navigation-theme-opt-in.php';
 require __DIR__ . '/experimental/kses.php';


### PR DESCRIPTION
### Description

This PR introduces an "allow-list" for the mobile endpoint for block editor settings. This gives us a greater degree of control over what the client apps are consuming, and helps avoid prematurely introducing changes which do not yet have support in the mobile apps.

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
