### PR TITLE
Fix FormTokenField suggestions broken scrollbar when `__experimentalExpandOnFocus` is defined

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `ToolsPanelItem`: Use useLayoutEffect to prevent rendering glitch for last panel item styling. ([#56536](https://github.com/WordPress/gutenberg/pull/56536)).
 -   `FormTokenField`: Fix broken suggestions scrollbar when the `__experimentalExpandOnFocus` prop is defined ([#56426](https://github.com/WordPress/gutenberg/pull/56426)).
+-   `FormTokenField`: `onFocus` prop is now typed as a React `FocusEvent` ([#56426](https://github.com/WordPress/gutenberg/pull/56426)).
 
 ### Experimental
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fix
 
 -   `ToolsPanelItem`: Use useLayoutEffect to prevent rendering glitch for last panel item styling. ([#56536](https://github.com/WordPress/gutenberg/pull/56536)).
+-   `FormTokenField`: Fix broken suggestions scrollbar when the `__experimentalExpandOnFocus` prop is defined ([#56426](https://github.com/WordPress/gutenberg/pull/56426)).
 
 ### Experimental
 

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import type { KeyboardEvent, MouseEvent, TouchEvent } from 'react';
+import type {
+	KeyboardEvent,
+	MouseEvent,
+	TouchEvent,
+	FocusEvent as ReactFocusEvent,
+} from 'react';
 
 /**
  * WordPress dependencies
@@ -162,7 +167,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		}
 	}
 
-	function onBlur( event: FocusEvent ) {
+	function onBlur( event: ReactFocusEvent ) {
 		if (
 			inputHasValidValue() &&
 			__experimentalValidateInput( incompleteTokenValue )

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -162,7 +162,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		}
 	}
 
-	function onBlur() {
+	function onBlur( event: FocusEvent ) {
 		if (
 			inputHasValidValue() &&
 			__experimentalValidateInput( incompleteTokenValue )
@@ -176,7 +176,15 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			setIncompleteTokenValue( '' );
 			setInputOffsetFromEnd( 0 );
 			setIsActive( false );
-			setIsExpanded( false );
+
+			// If `__experimentalExpandOnFocus` is true, don't close the suggestions list when
+			// the user clicks on it (`tokensAndInput` will be the element that caused the blur).
+			const shouldKeepSuggestionsExpanded =
+				! __experimentalExpandOnFocus ||
+				( __experimentalExpandOnFocus &&
+					event.relatedTarget === tokensAndInput.current );
+			setIsExpanded( shouldKeepSuggestionsExpanded );
+
 			setSelectedSuggestionIndex( -1 );
 			setSelectedSuggestionScroll( false );
 		}

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -148,7 +148,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		return input.current === input.current?.ownerDocument.activeElement;
 	}
 
-	function onFocusHandler( event: FocusEvent ) {
+	function onFocusHandler( event: ReactFocusEvent ) {
 		// If focus is on the input or on the container, set the isActive state to true.
 		if ( hasFocus() || event.target === tokensAndInput.current ) {
 			setIsActive( true );

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -2,12 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import type {
-	KeyboardEvent,
-	MouseEvent,
-	TouchEvent,
-	FocusEvent as ReactFocusEvent,
-} from 'react';
+import type { KeyboardEvent, MouseEvent, TouchEvent, FocusEvent } from 'react';
 
 /**
  * WordPress dependencies
@@ -148,7 +143,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		return input.current === input.current?.ownerDocument.activeElement;
 	}
 
-	function onFocusHandler( event: ReactFocusEvent ) {
+	function onFocusHandler( event: FocusEvent ) {
 		// If focus is on the input or on the container, set the isActive state to true.
 		if ( hasFocus() || event.target === tokensAndInput.current ) {
 			setIsActive( true );
@@ -167,7 +162,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		}
 	}
 
-	function onBlur( event: ReactFocusEvent ) {
+	function onBlur( event: FocusEvent ) {
 		if (
 			inputHasValidValue() &&
 			__experimentalValidateInput( incompleteTokenValue )

--- a/packages/components/src/form-token-field/token-input.tsx
+++ b/packages/components/src/form-token-field/token-input.tsx
@@ -48,9 +48,7 @@ export function UnForwardedTokenInput(
 		onFocus?.( e );
 	};
 
-	const onBlurHandler: React.FocusEventHandler< HTMLInputElement > = (
-		e
-	) => {
+	const onBlurHandler: FocusEventHandler< HTMLInputElement > = ( e ) => {
 		setHasFocus( false );
 		onBlur?.( e );
 	};

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -5,7 +5,7 @@ import type {
 	ComponentPropsWithRef,
 	MouseEventHandler,
 	ReactNode,
-	FocusEvent as ReactFocusEvent,
+	FocusEvent,
 } from 'react';
 
 type Messages = {
@@ -106,7 +106,7 @@ export interface FormTokenFieldProps
 	 * Function to call when the TokenField has been focused on. The event is passed to the callback. Useful for analytics.
 	 *
 	 */
-	onFocus?: ( event: ReactFocusEvent ) => void;
+	onFocus?: ( event: FocusEvent ) => void;
 	/**
 	 *  When true, renders tokens as without a background.
 	 */

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -5,6 +5,7 @@ import type {
 	ComponentPropsWithRef,
 	MouseEventHandler,
 	ReactNode,
+	FocusEvent as ReactFocusEvent,
 } from 'react';
 
 type Messages = {
@@ -105,7 +106,7 @@ export interface FormTokenFieldProps
 	 * Function to call when the TokenField has been focused on. The event is passed to the callback. Useful for analytics.
 	 *
 	 */
-	onFocus?: ( event: FocusEvent ) => void;
+	onFocus?: ( event: ReactFocusEvent ) => void;
 	/**
 	 *  When true, renders tokens as without a background.
 	 */


### PR DESCRIPTION
Fixes #56419

## What?
Fixes an issue with `FormTokenField` whereby when the `__experimentalExpandOnFocus` prop is defined, the suggestions list can't be scrolled by dragging it with the mouse.

## How?
The issue seemed to be that the `isExpanded` prop was being repeatedly switched between `true` and `false`. This remounting of the suggestions was causing the scroll position to be fixed in place.

Notably the `onFocusHandler` handler checks both input focus and container focus, while the `onBlur` handler didn't, so the fix was to replicate that in `onBlur` to prevent `isExpanded` being set to `false`.

(note: I'm not sure if this is a good enough explanation, as I don't know why it works ok normally 😄 ).

## Testing Instructions
1. Pop open the storybook at the FormTokenField component (https://wordpress.github.io/gutenberg/?path=/docs/components-formtokenfield--docs)
2. Enable `__experimentalExpandOnFocus`
3. Click on the input and try scrolling the suggestions by dragging on the scrollbar

### Testing Instructions for Keyboard
I don't think this is reproducible using the keyboard

## Screenshots or screencast <!-- if applicable -->
### Before
https://github.com/WordPress/gutenberg/assets/677833/0d52d03e-d6a8-4294-a2c0-accbf4e885b6

### After
https://github.com/WordPress/gutenberg/assets/677833/8efb8f07-c3f9-4576-abd1-877a46abcfb6


