### PR TITLE
Update Readme.txt tested up to 6.4

### DIFF
--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -141,7 +141,7 @@ For example, running the `start` script from inside the generated folder (`npm s
 
 ## External Project Templates
 
-[Click here](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block-tutorial-template/) for information on External Project Templates
+[Click here](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/packages-create-block-external-template/) for information on External Project Templates
 
 ## Contributing to this package
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Gutenberg ===
 Contributors: matveb, joen, karmatosed
-Tested up to: 6.3
+Tested up to: 6.4
 Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## What?
Update the version in "Tested up to" section of the readme.txt of the plugin to the latest WordPress version.

## Why?
To avoid the _"This plugin hasn't been tested for your current version of WordPress"_ banner in the plugin repo and plugin workflow on WPAdmin