### PR TITLE
Site Editor: Update the order of the sidebar items

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -47,20 +47,6 @@ export default function SidebarNavigationScreenMain() {
 					<ItemGroup>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/navigation"
-							withChevron
-							icon={ navigation }
-						>
-							{ __( 'Navigation' ) }
-						</NavigatorButton>
-						<SidebarNavigationItemGlobalStyles
-							withChevron
-							icon={ styles }
-						>
-							{ __( 'Styles' ) }
-						</SidebarNavigationItemGlobalStyles>
-						<NavigatorButton
-							as={ SidebarNavigationItem }
 							path="/page"
 							withChevron
 							icon={ page }
@@ -82,6 +68,20 @@ export default function SidebarNavigationScreenMain() {
 							icon={ symbol }
 						>
 							{ __( 'Patterns' ) }
+						</NavigatorButton>
+						<SidebarNavigationItemGlobalStyles
+							withChevron
+							icon={ styles }
+						>
+							{ __( 'Styles' ) }
+						</SidebarNavigationItemGlobalStyles>
+						<NavigatorButton
+							as={ SidebarNavigationItem }
+							path="/navigation"
+							withChevron
+							icon={ navigation }
+						>
+							{ __( 'Navigation' ) }
 						</NavigatorButton>
 					</ItemGroup>
 					<TemplatePartHint />

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -45,6 +45,20 @@ export default function SidebarNavigationScreenMain() {
 			content={
 				<>
 					<ItemGroup>
+						<SidebarNavigationItemGlobalStyles
+							withChevron
+							icon={ styles }
+						>
+							{ __( 'Styles' ) }
+						</SidebarNavigationItemGlobalStyles>
+						<NavigatorButton
+							as={ SidebarNavigationItem }
+							path="/wp_template"
+							withChevron
+							icon={ layout }
+						>
+							{ __( 'Templates' ) }
+						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
 							path="/page"
@@ -63,26 +77,12 @@ export default function SidebarNavigationScreenMain() {
 						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/wp_template"
-							withChevron
-							icon={ layout }
-						>
-							{ __( 'Templates' ) }
-						</NavigatorButton>
-						<NavigatorButton
-							as={ SidebarNavigationItem }
 							path="/navigation"
 							withChevron
 							icon={ navigation }
 						>
 							{ __( 'Navigation' ) }
 						</NavigatorButton>
-						<SidebarNavigationItemGlobalStyles
-							withChevron
-							icon={ styles }
-						>
-							{ __( 'Styles' ) }
-						</SidebarNavigationItemGlobalStyles>
 					</ItemGroup>
 					<TemplatePartHint />
 				</>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -55,6 +55,14 @@ export default function SidebarNavigationScreenMain() {
 						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
+							path="/patterns"
+							withChevron
+							icon={ symbol }
+						>
+							{ __( 'Patterns' ) }
+						</NavigatorButton>
+						<NavigatorButton
+							as={ SidebarNavigationItem }
 							path="/wp_template"
 							withChevron
 							icon={ layout }
@@ -63,11 +71,11 @@ export default function SidebarNavigationScreenMain() {
 						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/patterns"
+							path="/navigation"
 							withChevron
-							icon={ symbol }
+							icon={ navigation }
 						>
-							{ __( 'Patterns' ) }
+							{ __( 'Navigation' ) }
 						</NavigatorButton>
 						<SidebarNavigationItemGlobalStyles
 							withChevron
@@ -75,14 +83,6 @@ export default function SidebarNavigationScreenMain() {
 						>
 							{ __( 'Styles' ) }
 						</SidebarNavigationItemGlobalStyles>
-						<NavigatorButton
-							as={ SidebarNavigationItem }
-							path="/navigation"
-							withChevron
-							icon={ navigation }
-						>
-							{ __( 'Navigation' ) }
-						</NavigatorButton>
 					</ItemGroup>
 					<TemplatePartHint />
 				</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reorders the items in the sidebar of the Site Editor, in Site View.

## Why?
Users are much more likely to want to edit pages and templates than Navigation or Styles, so we should raise these up. We would also prefer that they begin by working on their pages than their navigation, as its an easier place to start.

## How?
Simply reorder the code

## Testing Instructions
Go to the Site Editor and check the order of the items in the sidebar.

## Screenshots or screencast <!-- if applicable -->
Before
<img width="181" alt="Screenshot 2023-11-22 at 11 09 44" src="https://github.com/WordPress/gutenberg/assets/275961/a28371fe-71ff-4ce1-9020-c5d6c93fdc08">

After
<img width="358" alt="Screenshot 2023-11-23 at 14 38 20" src="https://github.com/WordPress/gutenberg/assets/275961/d7ca5579-b4c8-4013-a634-5f32e0227980">
