### PR TITLE
Remove `version` paramerer from `deprecated` calls throughout the codebase

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -33,7 +33,6 @@ export function BlockPreview( {
 		minHeight = __experimentalMinHeight;
 		deprecated( 'The __experimentalMinHeight prop', {
 			since: '6.2',
-			version: '6.4',
 			alternative: 'minHeight',
 		} );
 	}
@@ -44,7 +43,6 @@ export function BlockPreview( {
 		];
 		deprecated( 'The __experimentalPadding prop of BlockPreview', {
 			since: '6.2',
-			version: '6.4',
 			alternative: 'additionalStyles',
 		} );
 	}

--- a/packages/block-editor/src/components/block-tools/back-compat.js
+++ b/packages/block-editor/src/components/block-tools/back-compat.js
@@ -23,7 +23,6 @@ export default function BlockToolsBackCompat( { children } ) {
 	deprecated( 'wp.components.Popover.Slot name="block-toolbar"', {
 		alternative: 'wp.blockEditor.BlockTools',
 		since: '5.8',
-		version: '6.3',
 	} );
 
 	return (

--- a/packages/block-editor/src/components/color-style-selector/index.js
+++ b/packages/block-editor/src/components/color-style-selector/index.js
@@ -82,7 +82,6 @@ const BlockColorsStyleSelector = ( { children, ...other } ) => {
 	deprecated( `wp.blockEditor.BlockColorsStyleSelector`, {
 		alternative: 'block supports API',
 		since: '6.1',
-		version: '6.3',
 	} );
 
 	return (

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -15,7 +15,6 @@ export const __unstableUseClipboardHandler = () => {
 	deprecated( '__unstableUseClipboardHandler', {
 		alternative: 'BlockCanvas or WritingFlow',
 		since: '6.4',
-		version: '6.7',
 	} );
 	return useClipboardHandler();
 };
@@ -28,7 +27,6 @@ export default function CopyHandler( props ) {
 	deprecated( 'CopyHandler', {
 		alternative: 'BlockCanvas or WritingFlow',
 		since: '6.4',
-		version: '6.7',
 	} );
 	return <div { ...props } ref={ useClipboardHandler() } />;
 }

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -123,7 +123,6 @@ export default function useNestedSettingsUpdate(
 			deprecated( '__experimentalDefaultBlock', {
 				alternative: 'defaultBlock',
 				since: '6.3',
-				version: '6.4',
 			} );
 			newSettings.defaultBlock = __experimentalDefaultBlock;
 		}
@@ -136,7 +135,6 @@ export default function useNestedSettingsUpdate(
 			deprecated( '__experimentalDirectInsert', {
 				alternative: 'directInsert',
 				since: '6.3',
-				version: '6.4',
 			} );
 			newSettings.directInsert = __experimentalDirectInsert;
 		}

--- a/packages/block-editor/src/components/inspector-controls/fill.native.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.native.js
@@ -29,7 +29,6 @@ export default function InspectorControlsFill( {
 			'`__experimentalGroup` property in `InspectorControlsFill`',
 			{
 				since: '6.2',
-				version: '6.4',
 				alternative: '`group`',
 			}
 		);

--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -28,7 +28,6 @@ export default function InspectorControlsSlot( {
 			'`__experimentalGroup` property in `InspectorControlsSlot`',
 			{
 				since: '6.2',
-				version: '6.4',
 				alternative: '`group`',
 			}
 		);

--- a/packages/block-editor/src/components/inspector-controls/slot.native.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.native.js
@@ -19,7 +19,6 @@ export default function InspectorControlsSlot( {
 			'`__experimentalGroup` property in `InspectorControlsSlot`',
 			{
 				since: '6.2',
-				version: '6.4',
 				alternative: '`group`',
 			}
 		);

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -77,7 +77,6 @@ const LineHeightControl = ( {
 			'Bottom margin styles for wp.blockEditor.LineHeightControl',
 			{
 				since: '6.0',
-				version: '6.4',
 				hint: 'Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version',
 			}
 		);

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -129,7 +129,6 @@ export function MediaPlaceholder( {
 	if ( deprecatedOnHTMLDrop ) {
 		deprecated( 'wp.blockEditor.MediaPlaceholder onHTMLDrop prop', {
 			since: '6.2',
-			version: '6.4',
 		} );
 	}
 

--- a/packages/block-editor/src/components/rich-text/content.js
+++ b/packages/block-editor/src/components/rich-text/content.js
@@ -15,7 +15,6 @@ export const Content = ( { value, tagName: Tag, multiline, ...props } ) => {
 	if ( Array.isArray( value ) ) {
 		deprecated( 'wp.blockEditor.RichText value prop as children type', {
 			since: '6.1',
-			version: '6.3',
 			alternative: 'value prop as string',
 			link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 		} );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -397,7 +397,6 @@ function RichTextSwitcher( props, ref ) {
 	if ( Array.isArray( value ) ) {
 		deprecated( 'wp.blockEditor.RichText value prop as children type', {
 			since: '6.1',
-			version: '6.3',
 			alternative: 'value prop as string',
 			link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 		} );

--- a/packages/block-editor/src/components/rich-text/multiline.js
+++ b/packages/block-editor/src/components/rich-text/multiline.js
@@ -27,7 +27,6 @@ function RichTextMultiline(
 ) {
 	deprecated( 'wp.blockEditor.RichText multiline prop', {
 		since: '6.1',
-		version: '6.3',
 		alternative: 'nested blocks (InnerBlocks)',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/',
 	} );

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -485,7 +485,6 @@ class URLInput extends Component {
 		if ( ! __nextHasNoMarginBottom ) {
 			deprecated( 'Bottom margin styles for wp.blockEditor.URLInput', {
 				since: '6.2',
-				version: '6.5',
 				hint: 'Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version',
 			} );
 		}

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -133,6 +133,5 @@ export function DimensionsPanel( props ) {
 export function useCustomSides() {
 	deprecated( 'wp.blockEditor.__experimentalUseCustomSides', {
 		since: '6.3',
-		version: '6.4',
 	} );
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1290,7 +1290,6 @@ export function stopDraggingBlocks() {
 export function enterFormattedText() {
 	deprecated( 'wp.data.dispatch( "core/block-editor" ).enterFormattedText', {
 		since: '6.1',
-		version: '6.3',
 	} );
 	return {
 		type: 'DO_NOTHING',
@@ -1307,7 +1306,6 @@ export function enterFormattedText() {
 export function exitFormattedText() {
 	deprecated( 'wp.data.dispatch( "core/block-editor" ).exitFormattedText', {
 		since: '6.1',
-		version: '6.3',
 	} );
 	return {
 		type: 'DO_NOTHING',

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -201,7 +201,6 @@ export const __unstableGetClientIdWithClientIdsTree = createSelector(
 			"wp.data.select( 'core/block-editor' ).__unstableGetClientIdWithClientIdsTree",
 			{
 				since: '6.3',
-				version: '6.5',
 			}
 		);
 		return {
@@ -230,7 +229,6 @@ export const __unstableGetClientIdsTree = createSelector(
 			"wp.data.select( 'core/block-editor' ).__unstableGetClientIdsTree",
 			{
 				since: '6.3',
-				version: '6.5',
 			}
 		);
 		return getBlockOrder( state, rootClientId ).map( ( clientId ) =>
@@ -1386,7 +1384,6 @@ export function isCaretWithinFormattedText() {
 		'wp.data.select( "core/block-editor" ).isCaretWithinFormattedText',
 		{
 			since: '6.1',
-			version: '6.3',
 		}
 	);
 
@@ -2182,7 +2179,6 @@ export const __experimentalGetAllowedBlocks = createSelector(
 				alternative:
 					'wp.data.select( "core/block-editor" ).getAllowedBlocks',
 				since: '6.2',
-				version: '6.4',
 			}
 		);
 		return getAllowedBlocks( state, rootClientId );
@@ -2238,7 +2234,6 @@ export const __experimentalGetDirectInsertBlock = createSelector(
 				alternative:
 					'wp.data.select( "core/block-editor" ).getDirectInsertBlock',
 				since: '6.3',
-				version: '6.4',
 			}
 		);
 		return getDirectInsertBlock( state, rootClientId );
@@ -2437,7 +2432,6 @@ export const __experimentalGetPatternsByBlockTypes = createSelector(
 				alternative:
 					'wp.data.select( "core/block-editor" ).getPatternsByBlockTypes',
 				since: '6.2',
-				version: '6.4',
 			}
 		);
 		return getPatternsByBlockTypes( state, blockNames, rootClientId );

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -56,7 +56,6 @@ function useMigrateOnLoad( attributes, clientId ) {
 
 		deprecated( 'Value attribute on the list block', {
 			since: '6.0',
-			version: '6.5',
 			alternative: 'inner blocks',
 		} );
 

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -55,7 +55,6 @@ const useMigrateOnLoad = ( attributes, clientId ) => {
 
 		deprecated( 'Value attribute on the quote block', {
 			since: '6.0',
-			version: '6.5',
 			alternative: 'inner blocks',
 		} );
 

--- a/packages/blocks/src/api/children.js
+++ b/packages/blocks/src/api/children.js
@@ -42,7 +42,6 @@ export function getSerializeCapableElement( children ) {
 function getChildrenArray( children ) {
 	deprecated( 'wp.blocks.children.getChildrenArray', {
 		since: '6.1',
-		version: '6.3',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );
 
@@ -63,7 +62,6 @@ function getChildrenArray( children ) {
 export function concat( ...blockNodes ) {
 	deprecated( 'wp.blocks.children.concat', {
 		since: '6.1',
-		version: '6.3',
 		alternative: 'wp.richText.concat',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );
@@ -101,7 +99,6 @@ export function concat( ...blockNodes ) {
 export function fromDOM( domNodes ) {
 	deprecated( 'wp.blocks.children.fromDOM', {
 		since: '6.1',
-		version: '6.3',
 		alternative: 'wp.richText.create',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );
@@ -128,7 +125,6 @@ export function fromDOM( domNodes ) {
 export function toHTML( children ) {
 	deprecated( 'wp.blocks.children.toHTML', {
 		since: '6.1',
-		version: '6.3',
 		alternative: 'wp.richText.toHTMLString',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );
@@ -149,7 +145,6 @@ export function toHTML( children ) {
 export function matcher( selector ) {
 	deprecated( 'wp.blocks.children.matcher', {
 		since: '6.1',
-		version: '6.3',
 		alternative: 'html source',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );

--- a/packages/blocks/src/api/node.js
+++ b/packages/blocks/src/api/node.js
@@ -31,7 +31,6 @@ import * as children from './children';
 function isNodeOfType( node, type ) {
 	deprecated( 'wp.blocks.node.isNodeOfType', {
 		since: '6.1',
-		version: '6.3',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );
 
@@ -71,7 +70,6 @@ export function getNamedNodeMapAsObject( nodeMap ) {
 export function fromDOM( domNode ) {
 	deprecated( 'wp.blocks.node.fromDOM', {
 		since: '6.1',
-		version: '6.3',
 		alternative: 'wp.richText.create',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );
@@ -106,7 +104,6 @@ export function fromDOM( domNode ) {
 export function toHTML( node ) {
 	deprecated( 'wp.blocks.node.toHTML', {
 		since: '6.1',
-		version: '6.3',
 		alternative: 'wp.richText.toHTMLString',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );
@@ -125,7 +122,6 @@ export function toHTML( node ) {
 export function matcher( selector ) {
 	deprecated( 'wp.blocks.node.matcher', {
 		since: '6.1',
-		version: '6.3',
 		alternative: 'html source',
 		link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/',
 	} );

--- a/packages/components/src/angle-picker-control/index.tsx
+++ b/packages/components/src/angle-picker-control/index.tsx
@@ -41,7 +41,6 @@ function UnforwardedAnglePickerControl(
 			'Bottom margin styles for wp.components.AnglePickerControl',
 			{
 				since: '6.1',
-				version: '6.4',
 				hint: 'Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.',
 			}
 		);

--- a/packages/components/src/button/deprecated.tsx
+++ b/packages/components/src/button/deprecated.tsx
@@ -29,7 +29,6 @@ function UnforwardedIconButton(
 	deprecated( 'wp.components.IconButton', {
 		since: '5.4',
 		alternative: 'wp.components.Button',
-		version: '6.2',
 	} );
 
 	return (

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -68,7 +68,6 @@ function useDeprecatedProps( {
 		deprecated( 'Button isDefault prop', {
 			since: '5.4',
 			alternative: 'variant="secondary"',
-			version: '6.2',
 		} );
 
 		computedVariant ??= 'secondary';

--- a/packages/components/src/custom-gradient-picker/index.tsx
+++ b/packages/components/src/custom-gradient-picker/index.tsx
@@ -171,7 +171,6 @@ export function CustomGradientPicker( {
 			'Outer margin styles for wp.components.CustomGradientPicker',
 			{
 				since: '6.1',
-				version: '6.4',
 				hint: 'Set the `__nextHasNoMargin` prop to true to start opting into the new styles, which will become the default in a future version',
 			}
 		);

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -125,7 +125,6 @@ export default function CustomSelectControl( props ) {
 			'Constrained width styles for wp.components.CustomSelectControl',
 			{
 				since: '6.1',
-				version: '6.4',
 				hint: 'Set the `__nextUnconstrainedWidth` prop to true to start opting into the new styles, which will become the default in a future version',
 			}
 		);

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -59,7 +59,6 @@ const UnforwardedFontSizePicker = (
 	if ( ! __nextHasNoMarginBottom ) {
 		deprecated( 'Bottom margin styles for wp.components.FontSizePicker', {
 			since: '6.1',
-			version: '6.4',
 			hint: 'Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.',
 		} );
 	}

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -231,7 +231,6 @@ export function GradientPicker( {
 	if ( ! __nextHasNoMargin ) {
 		deprecated( 'Outer margin styles for wp.components.GradientPicker', {
 			since: '6.1',
-			version: '6.4',
 			hint: 'Set the `__nextHasNoMargin` prop to true to start opting into the new styles, which will become the default in a future version',
 		} );
 	}

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -64,7 +64,6 @@ function UnforwardedNumberControl(
 		deprecated( 'wp.components.NumberControl hideHTMLArrows prop ', {
 			alternative: 'spinControls="none"',
 			since: '6.2',
-			version: '6.3',
 		} );
 	}
 	const inputRef = useRef< HTMLInputElement >();

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -160,7 +160,6 @@ const UnconnectedPopover = (
 	if ( __unstableForcePosition !== undefined ) {
 		deprecated( '`__unstableForcePosition` prop in wp.components.Popover', {
 			since: '6.1',
-			version: '6.3',
 			alternative: '`flip={ false }` and  `resize={ false }`',
 		} );
 

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -66,7 +66,6 @@ function UnforwardedUnitControl(
 		deprecated( 'UnitControl unit prop', {
 			since: '5.6',
 			hint: 'The unit should be provided within the `value` prop.',
-			version: '6.2',
 		} );
 	}
 

--- a/packages/dom/src/dom/is-number-input.js
+++ b/packages/dom/src/dom/is-number-input.js
@@ -19,7 +19,6 @@ import isHTMLInputElement from './is-html-input-element';
 export default function isNumberInput( node ) {
 	deprecated( 'wp.dom.isNumberInput', {
 		since: '6.1',
-		version: '6.5',
 	} );
 	/* eslint-enable jsdoc/valid-types */
 	return (

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -192,7 +192,6 @@ export function initializeEditor(
 export function reinitializeEditor() {
 	deprecated( 'wp.editPost.reinitializeEditor', {
 		since: '6.2',
-		version: '6.3',
 	} );
 }
 

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -93,7 +93,6 @@ export function initializeEditor( id, settings ) {
 export function reinitializeEditor() {
 	deprecated( 'wp.editSite.reinitializeEditor', {
 		since: '6.2',
-		version: '6.3',
 	} );
 }
 

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -74,7 +74,6 @@ export const getReusableBlocks = createRegistrySelector( ( select ) => () => {
 		"select( 'core/core' ).getEntityRecords( 'postType', 'wp_block' )",
 		{
 			since: '6.5',
-			version: '6.8',
 		}
 	);
 	const isWeb = Platform.OS === 'web';
@@ -105,7 +104,6 @@ export function getSettings( state ) {
 export function getHomeTemplateId() {
 	deprecated( "select( 'core/edit-site' ).getHomeTemplateId", {
 		since: '6.2',
-		version: '6.4',
 	} );
 }
 
@@ -269,7 +267,6 @@ export function getCurrentTemplateNavigationPanelSubMenu() {
 		"dispatch( 'core/edit-site' ).getCurrentTemplateNavigationPanelSubMenu",
 		{
 			since: '6.2',
-			version: '6.4',
 		}
 	);
 }
@@ -280,7 +277,6 @@ export function getCurrentTemplateNavigationPanelSubMenu() {
 export function getNavigationPanelActiveMenu() {
 	deprecated( "dispatch( 'core/edit-site' ).getNavigationPanelActiveMenu", {
 		since: '6.2',
-		version: '6.4',
 	} );
 }
 
@@ -290,7 +286,6 @@ export function getNavigationPanelActiveMenu() {
 export function isNavigationOpened() {
 	deprecated( "dispatch( 'core/edit-site' ).isNavigationOpened", {
 		since: '6.2',
-		version: '6.4',
 	} );
 }
 

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -104,7 +104,6 @@ export const initialize = initializeEditor;
 export function reinitializeEditor() {
 	deprecated( 'wp.editWidgets.reinitializeEditor', {
 		since: '6.2',
-		version: '6.3',
 	} );
 }
 

--- a/packages/editor/src/components/deprecated.js
+++ b/packages/editor/src/components/deprecated.js
@@ -66,7 +66,6 @@ function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
 		deprecated( 'wp.editor.' + name, {
 			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
-			version: '6.2',
 		} );
 
 		return <Wrapped ref={ ref } { ...props } />;
@@ -87,7 +86,6 @@ function deprecateFunction( name, func ) {
 		deprecated( 'wp.editor.' + name, {
 			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
-			version: '6.2',
 		} );
 
 		return func( ...args );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -85,7 +85,6 @@ export function __experimentalTearDownEditor() {
 export function resetPost() {
 	deprecated( "wp.data.dispatch( 'core/editor' ).resetPost", {
 		since: '6.0',
-		version: '6.3',
 		alternative: 'Initialize the editor with the setupEditorState action',
 	} );
 	return { type: 'DO_NOTHING' };
@@ -240,7 +239,6 @@ export const savePost =
 export function refreshPost() {
 	deprecated( "wp.data.dispatch( 'core/editor' ).refreshPost", {
 		since: '6.0',
-		version: '6.3',
 		alternative: 'Use the core entities store instead',
 	} );
 	return { type: 'DO_NOTHING' };
@@ -347,7 +345,6 @@ export const undo =
 export function createUndoLevel() {
 	deprecated( "wp.data.dispatch( 'core/editor' ).createUndoLevel", {
 		since: '6.0',
-		version: '6.3',
 		alternative: 'Use the core entities store instead',
 	} );
 	return { type: 'DO_NOTHING' };
@@ -560,7 +557,6 @@ const getBlockEditorAction =
 			since: '5.3',
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
-			version: '6.2',
 		} );
 		registry.dispatch( blockEditorStore )[ name ]( ...args );
 	};

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1225,7 +1225,6 @@ function getBlockEditorSelector( name ) {
 		deprecated( "`wp.data.select( 'core/editor' )." + name + '`', {
 			since: '5.3',
 			alternative: "`wp.data.select( 'core/block-editor' )." + name + '`',
-			version: '6.2',
 		} );
 
 		return select( blockEditorStore )[ name ]( ...args );

--- a/packages/nux/src/index.js
+++ b/packages/nux/src/index.js
@@ -9,5 +9,4 @@ export { default as DotTip } from './components/dot-tip';
 deprecated( 'wp.nux', {
 	since: '5.4',
 	hint: 'wp.components.Guide can be used to show a user guide.',
-	version: '6.2',
 } );


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove any `version` number passed to the `deprecated` function throughout the Gutenberg codebase.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Till we have an agreed upon strategy for dealing with deprecations in WordPress core (See #41265), it doesn’t make sense to have incorrect version numbers logged.

Looking at the removed versions you can see that a good chunk of these is already in the past so they are just outright incorrect.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove any `version` number passed to the `deprecated` function throughout the Gutenberg codebase.
