### PR TITLE
Additional CSS: fix on change validation

### DIFF
--- a/packages/block-editor/src/components/global-styles/advanced-panel.js
+++ b/packages/block-editor/src/components/global-styles/advanced-panel.js
@@ -30,7 +30,7 @@ export default function AdvancedPanel( {
 		} );
 		if ( cssError ) {
 			const [ transformed ] = transformStyles(
-				[ { css: value } ],
+				[ { css: newValue } ],
 				'.editor-styles-wrapper'
 			);
 			if ( transformed ) {


### PR DESCRIPTION
## What?

Let's pass the new value instead of the old one when re-running style checking in the advanced panel.

In https://github.com/WordPress/gutenberg/pull/56093, I caught this error where when you input invalid CSS, blur the input, and change it, the OLD value is being passed to validate the CSS error tooltip.

Not only it's passing the old value, it's passing in the wrong format, breaking the `transformStyles` call: instead of just the CSS string, we were passing the nested object which includes `css` as a property.

## Why?

With this patch, the CSS error badge is gone as soon as the user fixes the problem (on change) instead of only removing the error once they blur.

| Before | After |
| -------|------|
| <video src="https://github.com/WordPress/gutenberg/assets/26530524/7aaa69a4-721b-45ec-9eee-552818581897" /> | <video src="https://github.com/WordPress/gutenberg/assets/26530524/dedf115a-0121-42b5-8ed2-82da6302201d" /> |

## How?

We should pass the new value instead of the current one, and the string instead of an object with the css property.

## Testing Instructions

On `trunk` (after https://github.com/WordPress/gutenberg/pull/56093 has been merged; use that as a starting point otherwise)

1. open the site editor > styles > additional CSS
2. input `body { background`
3. blur the input and check that the CSS error badge shows up at the bottom-right corner
4. change the input and complete the CSS (i.e., add `: red }`) to it, making it valid CSS
5. verify that the CSS badge still appears, even though the editor reflects valid CSS, and the badge is gone only when blurring the input

Apply this PR to your environment and repeat the same steps, but verify that once the CSS is right, the error badge is gone, even when the user is still typing.