### PR TITLE
Post Template: fix incorrect offset query

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -123,7 +123,7 @@ export default function PostTemplateEdit( {
 					slug: templateSlug.replace( 'category-', '' ),
 				} );
 			const query = {
-				offset: perPage ? perPage + offset : 0,
+				offset: perPage ? offset || 0 : 0,
 				order,
 				orderby: orderBy,
 			};

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -123,7 +123,7 @@ export default function PostTemplateEdit( {
 					slug: templateSlug.replace( 'category-', '' ),
 				} );
 			const query = {
-				offset: perPage ? offset || 0 : 0,
+				offset: offset || 0,
 				order,
 				orderby: orderBy,
 			};


### PR DESCRIPTION
Fixes #56439
Related to: #56034

## What?
This PR fixes an issue where the Post Template block's offset query would have an incorrect value when using the Query Loop block in the editor.

## Why?

This offset value was originally calculated using the following formula.

```javascript
const query = {
	offset: perPage ? perPage * ( page - 1 ) + offset : 0,
	// ...
};
```

In a post template block, my understanding is that the `page` variable should always be `1`. In other words, the original `offset` value should have been calculated as follows.

```javascript
const query = {
	offset: perPage ? perPage * 0 + offset : 0,
	// ...
};

to...

const query = {
	offset: perPage ? offset : 0,
	// ...
};
```

Later, in #56034, this calculation formula was changed as follows.
```javascript
const query = {
	offset: perPage ? perPage + offset : 0,
	order,
	orderby: orderBy,
};
```

As a result, the `perPage` value is always added to the offset value, and I suspect that it will deviate from the front end query offset.

## How?
Maintain the original calculation formula.

## Testing Instructions

- Create multiple posts.
- Insert a Query Loop block into the page.
- From the block toolbar, change the "Items Per Page" and "Offset" parameters.
- Query results in the editor and frontend should always match.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/a0c8ebe6-cc5b-4179-b24f-d54e1c41ef00

