### PR TITLE
Dataviews: Grid layout refinements

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -71,14 +71,12 @@ export default function DataViews( {
 							onChangeView={ onChangeView }
 						/>
 					</HStack>
-					<HStack justify="end" expanded={ false }>
-						<ViewActions
-							fields={ fields }
-							view={ view }
-							onChangeView={ onChangeView }
-							supportedLayouts={ supportedLayouts }
-						/>
-					</HStack>
+					<ViewActions
+						fields={ fields }
+						view={ view }
+						onChangeView={ onChangeView }
+						supportedLayouts={ supportedLayouts }
+					/>
 				</HStack>
 				<ViewComponent
 					fields={ _fields }

--- a/packages/edit-site/src/components/dataviews/item-actions.js
+++ b/packages/edit-site/src/components/dataviews/item-actions.js
@@ -130,7 +130,14 @@ export default function ItemActions( { item, actions, isCompact } ) {
 		);
 	}
 	return (
-		<HStack justify="flex-end">
+		<HStack
+			spacing={ 1 }
+			justify="flex-end"
+			style={ {
+				flexShrink: '0',
+				width: 'auto',
+			} }
+		>
 			{ !! primaryActions.length &&
 				primaryActions.map( ( action ) => {
 					if ( !! action.RenderModal ) {

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -41,13 +41,14 @@
 }
 
 .dataviews-grid-view {
+	margin-bottom: $grid-unit-30;
 	grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
 
-	@include break-wide() {
+	@include break-xlarge() {
 		grid-template-columns: repeat(3, minmax(0, 1fr)) !important; // Todo: eliminate !important dependency
 	}
 
-	@include break-xhuge() {
+	@include break-huge() {
 		grid-template-columns: repeat(4, minmax(0, 1fr)) !important; // Todo: eliminate !important dependency
 	}
 
@@ -74,27 +75,27 @@
 		}
 	}
 
+	.dataviews-view-grid__title {
+		min-height: $grid-unit-30;
+		
+		a {
+			color: $gray-900;
+			text-decoration: none;
+			font-weight: 500;
+		}
+	}
+
 	.dataviews-view-grid__fields {
 		position: relative;
+		font-size: 12px;
+		line-height: 16px;
 
 		.dataviews-view-grid__field {
-			display: inline-flex;
-
-			&::after {
-				content: "•";
-				display: inline-block;
-				margin: 0 $grid-unit-05;
-			}
-
-			&:last-child {
-				&::after {
-					display: none;
-				}
-			}
-
-			.dataviews-view-grid__field-value {
+			.dataviews-view-grid__field-header {
 				color: $gray-700;
-				cursor: default;
+			}
+			.dataviews-view-grid__field-value {
+				color: $gray-900;
 			}
 		}
 	}

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -40,13 +40,63 @@
 	}
 }
 
-.dataviews-view-grid__media {
-	width: 100%;
-	min-height: 200px;
+.dataviews-grid-view {
+	grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
 
-	> * {
-		max-width: 100%;
-		object-fit: cover;
+	@include break-wide() {
+		grid-template-columns: repeat(3, minmax(0, 1fr)) !important; // Todo: eliminate !important dependency
+	}
+
+	@include break-xhuge() {
+		grid-template-columns: repeat(4, minmax(0, 1fr)) !important; // Todo: eliminate !important dependency
+	}
+
+	.dataviews-view-grid__card {
+		h3 { // Todo: A better way to target this
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+
+	.dataviews-view-grid__media {
+		width: 100%;
+		min-height: 200px;
+		aspect-ratio: 1/1;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+		border-radius: $radius-block-ui * 2;
+		overflow: hidden;
+
+		> * {
+			object-fit: cover;
+			width: 100%;
+			height: 100%;
+		}
+	}
+
+	.dataviews-view-grid__fields {
+		position: relative;
+
+		.dataviews-view-grid__field {
+			display: inline-flex;
+
+			&::after {
+				content: "•";
+				display: inline-block;
+				margin: 0 $grid-unit-05;
+			}
+
+			&:last-child {
+				&::after {
+					display: none;
+				}
+			}
+
+			.dataviews-view-grid__field-value {
+				color: $gray-700;
+				cursor: default;
+			}
+		}
 	}
 }
 

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -77,7 +77,7 @@
 
 	.dataviews-view-grid__title {
 		min-height: $grid-unit-30;
-		
+
 		a {
 			color: $gray-900;
 			text-decoration: none;

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -44,7 +44,10 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 					<div className="dataviews-view-grid__media">
 						{ mediaField?.render( { item, view } ) }
 					</div>
-					<HStack className="dataviews-view-grid__title" justify="space-between">
+					<HStack
+						className="dataviews-view-grid__title"
+						justify="space-between"
+					>
 						{ primaryField?.render( { item, view } ) }
 						<ItemActions
 							item={ item }
@@ -52,7 +55,10 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 							isCompact
 						/>
 					</HStack>
-					<VStack className="dataviews-view-grid__fields" spacing={ 3 }>
+					<VStack
+						className="dataviews-view-grid__fields"
+						spacing={ 3 }
+					>
 						{ visibleFields.map( ( field ) => {
 							const renderedValue = field.render( {
 								item,

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -47,7 +47,11 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 					</div>
 					<HStack justify="space-between">
 						{ primaryField?.render( { item, view } ) }
-						<ItemActions item={ item } actions={ actions } />
+						<ItemActions
+							item={ item }
+							actions={ actions }
+							isCompact
+						/>
 					</HStack>
 					<div className="dataviews-view-grid__fields">
 						{ visibleFields.map( ( field ) => (

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -5,8 +5,8 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	FlexBlock,
-	Placeholder,
+	Tooltip,
+	VisuallyHidden,
 } from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
 
@@ -19,10 +19,15 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField
 	);
+	const primaryField = fields.find(
+		( field ) => field.id === view.layout.primaryField
+	);
 	const visibleFields = fields.filter(
 		( field ) =>
 			! view.hiddenFields.includes( field.id ) &&
-			field.id !== view.layout.mediaField
+			! [ view.layout.mediaField, view.layout.primaryField ].includes(
+				field.id
+			)
 	);
 	const shownData = useAsyncList( data, { step: 3 } );
 	return (
@@ -32,42 +37,42 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 			alignment="top"
 			className="dataviews-grid-view"
 		>
-			{ shownData.map( ( item, index ) => {
-				return (
-					<VStack key={ getItemId?.( item ) || index }>
-						<div className="dataviews-view-grid__media">
-							{ mediaField?.render( { item, view } ) || (
-								<Placeholder
-									withIllustration
-									style={ {
-										width: '100%',
-										minHeight: '200px',
-									} }
-								/>
-							) }
-						</div>
-
-						<HStack justify="space-between" alignment="top">
-							<FlexBlock>
-								<VStack>
-									{ visibleFields.map( ( field ) => (
-										<div key={ field.id }>
+			{ shownData.map( ( item, index ) => (
+				<VStack
+					key={ getItemId?.( item ) || index }
+					className="dataviews-view-grid__card"
+				>
+					<div className="dataviews-view-grid__media">
+						{ mediaField?.render( { item, view } ) }
+					</div>
+					<HStack justify="space-between">
+						{ primaryField?.render( { item, view } ) }
+						<ItemActions item={ item } actions={ actions } />
+					</HStack>
+					<div className="dataviews-view-grid__fields">
+						{ visibleFields.map( ( field ) => (
+							<div
+								className="dataviews-view-grid__field"
+								key={ field.id }
+							>
+								<VisuallyHidden>
+									{ field.header }
+								</VisuallyHidden>
+								<span className="dataviews-view-grid__field-value">
+									<Tooltip
+										text={ field.header }
+										placement="top"
+									>
+										<span>
 											{ field.render( { item, view } ) }
-										</div>
-									) ) }
-								</VStack>
-							</FlexBlock>
-							<FlexBlock style={ { maxWidth: 'min-content' } }>
-								<ItemActions
-									item={ item }
-									actions={ actions }
-									isCompact
-								/>
-							</FlexBlock>
-						</HStack>
-					</VStack>
-				);
-			} ) }
+										</span>
+									</Tooltip>
+								</span>
+							</div>
+						) ) }
+					</div>
+				</VStack>
+			) ) }
 		</Grid>
 	);
 }

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -5,8 +5,6 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	Tooltip,
-	VisuallyHidden,
 } from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
 
@@ -39,13 +37,14 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 		>
 			{ shownData.map( ( item, index ) => (
 				<VStack
+					spacing={ 3 }
 					key={ getItemId?.( item ) || index }
 					className="dataviews-view-grid__card"
 				>
 					<div className="dataviews-view-grid__media">
 						{ mediaField?.render( { item, view } ) }
 					</div>
-					<HStack justify="space-between">
+					<HStack className="dataviews-view-grid__title" justify="space-between">
 						{ primaryField?.render( { item, view } ) }
 						<ItemActions
 							item={ item }
@@ -53,28 +52,31 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 							isCompact
 						/>
 					</HStack>
-					<div className="dataviews-view-grid__fields">
-						{ visibleFields.map( ( field ) => (
-							<div
-								className="dataviews-view-grid__field"
-								key={ field.id }
-							>
-								<VisuallyHidden>
-									{ field.header }
-								</VisuallyHidden>
-								<span className="dataviews-view-grid__field-value">
-									<Tooltip
-										text={ field.header }
-										placement="top"
-									>
-										<span>
-											{ field.render( { item, view } ) }
-										</span>
-									</Tooltip>
-								</span>
-							</div>
-						) ) }
-					</div>
+					<VStack className="dataviews-view-grid__fields" spacing={ 3 }>
+						{ visibleFields.map( ( field ) => {
+							const renderedValue = field.render( {
+								item,
+								view,
+							} );
+							if ( ! renderedValue ) {
+								return null;
+							}
+							return (
+								<VStack
+									className="dataviews-view-grid__field"
+									key={ field.id }
+									spacing={ 1 }
+								>
+									<div className="dataviews-view-grid__field-header">
+										{ field.header }
+									</div>
+									<div className="dataviews-view-grid__field-value">
+										{ field.render( { item, view } ) }
+									</div>
+								</VStack>
+							);
+						} ) }
+					</VStack>
 				</VStack>
 			) ) }
 		</Grid>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -39,6 +39,7 @@ const defaultConfigPerViewType = {
 	list: {},
 	grid: {
 		mediaField: 'featured-image',
+		primaryField: 'title',
 	},
 };
 

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -47,6 +47,7 @@ const defaultConfigPerViewType = {
 	list: {},
 	grid: {
 		mediaField: 'preview',
+		primaryField: 'title',
 	},
 };
 

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -12,7 +12,7 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	VisuallyHidden
+	VisuallyHidden,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from '@wordpress/element';
@@ -175,19 +175,17 @@ export default function DataviewsTemplates() {
 				id: 'description',
 				getValue: ( { item } ) => item.description,
 				render: ( { item } ) => {
-					return (
-						item.description ? (
-							decodeEntities( item.description )
-						) : (
-							<>
+					return item.description ? (
+						decodeEntities( item.description )
+					) : (
+						<>
 							<Text variant="muted" aria-hidden="true">
 								&#8212;
 							</Text>
 							<VisuallyHidden>
 								{ __( 'No description.' ) }
 							</VisuallyHidden>
-							</>
-						)
+						</>
 					);
 				},
 				maxWidth: 200,

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -174,7 +174,10 @@ export default function DataviewsTemplates() {
 				header: __( 'Description' ),
 				id: 'description',
 				getValue: ( { item } ) => item.description,
-				render: ( { item } ) => {
+				render: ( { item, view: _view } ) => {
+					if ( _view.type === 'grid' && ! item.description ) {
+						return null;
+					}
 					return item.description ? (
 						decodeEntities( item.description )
 					) : (

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -12,6 +12,7 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	VisuallyHidden
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from '@wordpress/element';
@@ -175,10 +176,17 @@ export default function DataviewsTemplates() {
 				getValue: ( { item } ) => item.description,
 				render: ( { item } ) => {
 					return (
-						item.description && (
-							<Text variant="muted">
-								{ decodeEntities( item.description ) }
+						item.description ? (
+							decodeEntities( item.description )
+						) : (
+							<>
+							<Text variant="muted" aria-hidden="true">
+								&#8212;
 							</Text>
+							<VisuallyHidden>
+								{ __( 'No description.' ) }
+							</VisuallyHidden>
+							</>
 						)
 					);
 				},

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -40,7 +40,9 @@ import {
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
+const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
+	blockEditorPrivateApis
+);
 
 const EMPTY_ARRAY = [];
 
@@ -114,6 +116,7 @@ function AuthorField( { item } ) {
 
 function TemplatePreview( { content, viewType } ) {
 	const settings = usePatternSettings();
+	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
 	const blocks = useMemo( () => {
 		return parse( content );
 	}, [ content ] );
@@ -131,6 +134,7 @@ function TemplatePreview( { content, viewType } ) {
 		<ExperimentalBlockEditorProvider settings={ settings }>
 			<div
 				className={ `page-templates-preview-field is-viewtype-${ viewType }` }
+				style={ { backgroundColor } }
 			>
 				<BlockPreview blocks={ blocks } />
 			</div>
@@ -174,10 +178,7 @@ export default function DataviewsTemplates() {
 				header: __( 'Description' ),
 				id: 'description',
 				getValue: ( { item } ) => item.description,
-				render: ( { item, view: _view } ) => {
-					if ( _view.type === 'grid' && ! item.description ) {
-						return null;
-					}
+				render: ( { item } ) => {
 					return item.description ? (
 						decodeEntities( item.description )
 					) : (

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -1,9 +1,4 @@
 .page-templates-preview-field {
-	.block-editor-block-preview__container {
-		border: 1px solid $gray-300;
-		border-radius: $radius-block-ui;
-	}
-
 	&.is-viewtype-list {
 		.block-editor-block-preview__container {
 			height: 120px;
@@ -12,7 +7,7 @@
 
 	&.is-viewtype-grid {
 		.block-editor-block-preview__container {
-			height: 320px;
+			height: auto;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/55733

This PR includes some Grid layout refinements. This is the starting point and designer input and polishing is needed.

It will be better to test when we land the preview in [templates list
](https://github.com/WordPress/gutenberg/pull/56382).


## Testing Instructions
1. Enable the admin views experiment and go to manage all pages view
2. Play around with the grid view


<img width="1349" alt="Screenshot 2023-11-29 at 8 57 03 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/d0b4430b-5e96-4c41-a795-fc8ef186da30">

