### PR TITLE
Update image block save to only save align none class

### DIFF
--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -18,6 +18,7 @@ export default function save( { attributes } ) {
 		url,
 		alt,
 		caption,
+		align,
 		href,
 		rel,
 		linkClass,
@@ -35,6 +36,7 @@ export default function save( { attributes } ) {
 	const borderProps = getBorderClassesAndStyles( attributes );
 
 	const classes = classnames( {
+		alignnone: 'none' === align,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 		'is-resized': width || height,
 		'has-custom-border':

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -18,7 +18,6 @@ export default function save( { attributes } ) {
 		url,
 		alt,
 		caption,
-		align,
 		href,
 		rel,
 		linkClass,
@@ -36,7 +35,6 @@ export default function save( { attributes } ) {
 	const borderProps = getBorderClassesAndStyles( attributes );
 
 	const classes = classnames( {
-		[ `align${ align }` ]: align,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 		'is-resized': width || height,
 		'has-custom-border':

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -36,6 +36,8 @@ export default function save( { attributes } ) {
 	const borderProps = getBorderClassesAndStyles( attributes );
 
 	const classes = classnames( {
+		// All other align classes are handled by block supports.
+		// `{ align: 'none' }` is unique to transforms for the image block.
 		alignnone: 'none' === align,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 		'is-resized': width || height,


### PR DESCRIPTION
Follow up from #55954 to update the save function of the image block to no longer set the align class on render.

That was an oversight of the original PR. #55954 did work - not ending up with duplicate classes - because of implementation consistency :) the name of the class set by the support is the same as the one set by the save function and it would just be replaced.

This should be a benign change, but @youknowriad 's [observation](https://github.com/WordPress/gutenberg/pull/55954#issuecomment-1822781413) about the complexity of this block is something to keep an eye on.