### PR TITLE
Fix DropdownMenu svg icon size

### DIFF
--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -34,6 +34,11 @@
 			height: 1px;
 		}
 
+		> svg {
+			width: $button-size-small;
+			height: $button-size-small;
+		}
+
 		&.is-active {
 			svg,
 			.dashicon {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #56448

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on Sensei LMS, we realized that there's a new issue with the `DropdownMenu` component. Here is the issue: https://github.com/Automattic/sensei/issues/7308

It seems it started happening after this change: https://github.com/WordPress/gutenberg/pull/43574/files#r1240745574.

I'm not sure if there were additional styles setting the `svg` size at some point, but if there were, they are no longer present.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR adds back that properties with the `svg` size.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Use the `DropdownMenu` component with the `controls` prop. You can use the example from https://developer.wordpress.org/block-editor/reference-guides/components/dropdown-menu/#usage-2.
2. Check that the icons are now working properly.

## Screenshots or screencast <!-- if applicable -->

<img width="1257" alt="Screenshot 2023-11-22 at 16 01 10" src="https://github.com/WordPress/gutenberg/assets/876340/1634a611-b7f2-416c-86df-3fa6ade2f112">
