### PR TITLE
Style Revisions: Remove style revisions dropdown menu

### DIFF
--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -9,21 +9,10 @@ import {
 	__experimentalView as View,
 	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 
-/**
- * Internal dependencies
- */
-import { unlock } from '../../lock-unlock';
-import { store as editSiteStore } from '../../store';
-
-function ScreenHeader( { title, description } ) {
-	const { setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
-
+function ScreenHeader( { title, description, onClick } ) {
 	return (
 		<VStack spacing={ 0 }>
 			<View>
@@ -38,9 +27,7 @@ function ScreenHeader( { title, description } ) {
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							isSmall
 							aria-label={ __( 'Navigate to the previous view' ) }
-							onClick={ () =>
-								setEditorCanvasContainerView( undefined )
-							}
+							onClick={ onClick }
 						/>
 						<Spacer>
 							<Heading

--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -12,7 +12,7 @@ import {
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 
-function ScreenHeader( { title, description, onClick } ) {
+function ScreenHeader( { title, description, onBack } ) {
 	return (
 		<VStack spacing={ 0 }>
 			<View>
@@ -27,7 +27,7 @@ function ScreenHeader( { title, description, onClick } ) {
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							isSmall
 							aria-label={ __( 'Navigate to the previous view' ) }
-							onClick={ onClick }
+							onClick={ onBack }
 						/>
 						<Spacer>
 							<Heading

--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -9,10 +9,21 @@ import {
 	__experimentalView as View,
 	__experimentalNavigatorToParentButton as NavigatorToParentButton,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as editSiteStore } from '../../store';
+
 function ScreenHeader( { title, description } ) {
+	const { setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
+
 	return (
 		<VStack spacing={ 0 }>
 			<View>
@@ -27,6 +38,9 @@ function ScreenHeader( { title, description } ) {
 							icon={ isRTL() ? chevronRight : chevronLeft }
 							isSmall
 							aria-label={ __( 'Navigate to the previous view' ) }
+							onClick={ () =>
+								setEditorCanvasContainerView( undefined )
+							}
 						/>
 						<Spacer>
 							<Heading

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	__experimentalUseNavigator as useNavigator,
@@ -10,6 +10,7 @@ import {
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useContext, useState, useEffect } from '@wordpress/element';
 import {
 	privateApis as blockEditorPrivateApis,
@@ -35,14 +36,36 @@ function ScreenRevisions() {
 	const { goTo } = useNavigator();
 	const { user: currentEditorGlobalStyles, setUserConfig } =
 		useContext( GlobalStylesContext );
-	const { blocks, editorCanvasContainerView } = useSelect( ( select ) => {
-		return {
-			editorCanvasContainerView: unlock(
-				select( editSiteStore )
-			).getEditorCanvasContainerView(),
-			blocks: select( blockEditorStore ).getBlocks(),
-		};
-	}, [] );
+	const { blocks, editorCanvasContainerView, revisionsCount } = useSelect(
+		( select ) => {
+			const {
+				getEntityRecord,
+				__experimentalGetCurrentGlobalStylesId,
+				__experimentalGetDirtyEntityRecords,
+			} = select( coreStore );
+			const isDirty = __experimentalGetDirtyEntityRecords().length > 0;
+			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+			const globalStyles = globalStylesId
+				? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+				: undefined;
+			let _revisionsCount =
+				globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count || 0;
+			// one for the reset item.
+			_revisionsCount++;
+			// one for any dirty changes (unsaved).
+			if ( isDirty ) {
+				_revisionsCount++;
+			}
+			return {
+				editorCanvasContainerView: unlock(
+					select( editSiteStore )
+				).getEditorCanvasContainerView(),
+				blocks: select( blockEditorStore ).getBlocks(),
+				revisionsCount: _revisionsCount,
+			};
+		},
+		[]
+	);
 	const { revisions, isLoading, hasUnsavedChanges } =
 		useGlobalStylesRevisions();
 	const [ currentlySelectedRevision, setCurrentlySelectedRevision ] =
@@ -117,18 +140,14 @@ function ScreenRevisions() {
 		!! currentlySelectedRevisionId && ! selectedRevisionMatchesEditorStyles;
 	const shouldShowRevisions = ! isLoading && revisions.length;
 
-	const revisionsCountBadge = () => {
-		if ( revisions.length ) {
-			return ' (' + revisions.length + ')';
-		}
-
-		return '';
-	};
-
 	return (
 		<>
 			<ScreenHeader
-				title={ __( 'Revisions' ) + revisionsCountBadge() }
+				title={
+					revisionsCount &&
+					// translators: %s: number of revisions.
+					sprintf( __( 'Revisions (%s)' ), revisionsCount )
+				}
 				description={ __(
 					'Click on previously saved styles to preview them. To restore a selected version to the editor, hit "Apply." When you\'re ready, use the Save button to save your changes.'
 				) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -61,6 +61,7 @@ function ScreenRevisions() {
 
 	const onCloseRevisions = () => {
 		goTo( '/' ); // Return to global styles main panel.
+		setEditorCanvasContainerView( undefined );
 	};
 
 	const restoreRevision = ( revision ) => {
@@ -116,10 +117,18 @@ function ScreenRevisions() {
 		!! currentlySelectedRevisionId && ! selectedRevisionMatchesEditorStyles;
 	const shouldShowRevisions = ! isLoading && revisions.length;
 
+	const revisionsCountBadge = () => {
+		if ( revisions.length ) {
+			return ' (' + revisions.length + ')';
+		}
+
+		return '';
+	};
+
 	return (
 		<>
 			<ScreenHeader
-				title={ __( 'Revisions' ) }
+				title={ __( 'Revisions' ) + revisionsCountBadge() }
 				description={ __(
 					'Click on previously saved styles to preview them. To restore a selected version to the editor, hit "Apply." When you\'re ready, use the Save button to save your changes.'
 				) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -151,7 +151,7 @@ function ScreenRevisions() {
 				description={ __(
 					'Click on previously saved styles to preview them. To restore a selected version to the editor, hit "Apply." When you\'re ready, use the Save button to save your changes.'
 				) }
-				onClick={ onCloseRevisions }
+				onBack={ onCloseRevisions }
 			/>
 			{ isLoading && (
 				<Spinner className="edit-site-global-styles-screen-revisions__loading" />

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -151,6 +151,7 @@ function ScreenRevisions() {
 				description={ __(
 					'Click on previously saved styles to preview them. To restore a selected version to the editor, hit "Apply." When you\'re ready, use the Save button to save your changes.'
 				) }
+				onClick={ onCloseRevisions }
 			/>
 			{ isLoading && (
 				<Spinner className="edit-site-global-styles-screen-revisions__loading" />

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -191,14 +191,3 @@
 .edit-site-global-styles-sidebar__panel .block-editor-block-icon svg {
 	fill: currentColor;
 }
-
-[class][class].edit-site-global-styles-sidebar__revisions-count-badge {
-	align-items: center;
-	background: $gray-800;
-	border-radius: 2px;
-	color: $white;
-	display: inline-flex;
-	justify-content: center;
-	min-height: $icon-size;
-	min-width: $icon-size;
-}

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -1,7 +1,7 @@
-/**
- * External dependencies
- */
-import classnames from 'classnames';
+// /**
+//  * External dependencies
+//  */
+// import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -55,6 +55,7 @@ const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
 	createSlotFill( SLOT_FILL_NAME );
 
 function GlobalStylesActionMenu() {
+	const [ canReset, onReset ] = useGlobalStylesReset();
 	const { toggle } = useDispatch( preferencesStore );
 	const { canEditCSS } = useSelect( ( select ) => {
 		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
@@ -76,42 +77,56 @@ function GlobalStylesActionMenu() {
 		<GlobalStylesMenuFill>
 			<DropdownMenu icon={ moreVertical } label={ __( 'More' ) }>
 				{ ( { onClose } ) => (
-					<MenuGroup>
-						{ canEditCSS && (
-							<MenuItem onClick={ loadCustomCSS }>
-								{ __( 'Additional CSS' ) }
+					<>
+						<MenuGroup>
+							{ canEditCSS && (
+								<MenuItem onClick={ loadCustomCSS }>
+									{ __( 'Additional CSS' ) }
+								</MenuItem>
+							) }
+							<MenuItem
+								onClick={ () => {
+									toggle(
+										'core/edit-site',
+										'welcomeGuideStyles'
+									);
+									onClose();
+								} }
+							>
+								{ __( 'Welcome Guide' ) }
 							</MenuItem>
-						) }
-						<MenuItem
-							onClick={ () => {
-								toggle(
-									'core/edit-site',
-									'welcomeGuideStyles'
-								);
-								onClose();
-							} }
-						>
-							{ __( 'Welcome Guide' ) }
-						</MenuItem>
-					</MenuGroup>
+						</MenuGroup>
+						<MenuGroup>
+							<MenuItem
+								onClick={ () => {
+									onReset();
+									onClose();
+								} }
+								disabled={ ! canReset }
+							>
+								{ __( 'Reset styles' ) }
+							</MenuItem>
+						</MenuGroup>
+					</>
 				) }
 			</DropdownMenu>
 		</GlobalStylesMenuFill>
 	);
 }
 
-function RevisionsCountBadge( { className, children } ) {
-	return (
-		<span
-			className={ classnames(
-				className,
-				'edit-site-global-styles-sidebar__revisions-count-badge'
-			) }
-		>
-			{ children }
-		</span>
-	);
-}
+// function RevisionsCountBadge( { className, children } ) {
+// 	return (
+// 		<span
+// 			className={ classnames(
+// 				className,
+// 				'edit-site-global-styles-sidebar__revisions-count-badge'
+// 			) }
+// 		>
+// 			{ children }
+// 		</span>
+// 	);
+// }
+
 function GlobalStylesRevisionsMenu() {
 	const { setIsListViewOpened } = useDispatch( editSiteStore );
 	const { revisionsCount } = useSelect( ( select ) => {
@@ -128,56 +143,38 @@ function GlobalStylesRevisionsMenu() {
 				globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0,
 		};
 	}, [] );
-	const [ canReset, onReset ] = useGlobalStylesReset();
 	const { goTo } = useNavigator();
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
 	const loadRevisions = () => {
 		setIsListViewOpened( false );
-		goTo( '/revisions' );
-		setEditorCanvasContainerView( 'global-styles-revisions' );
+
+		if ( ! isRevisionsOpened ) {
+			goTo( '/revisions' );
+			setEditorCanvasContainerView( 'global-styles-revisions' );
+		} else {
+			goTo( '/' );
+			setEditorCanvasContainerView( '' );
+		}
 	};
 	const hasRevisions = revisionsCount > 0;
+	const isRevisionsOpened = useSelect(
+		( select ) =>
+			'global-styles-revisions' ===
+			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
+		[]
+	);
 
 	return (
 		<GlobalStylesMenuFill>
-			{ canReset || hasRevisions ? (
-				<DropdownMenu icon={ backup } label={ __( 'Revisions' ) }>
-					{ ( { onClose } ) => (
-						<MenuGroup>
-							{ hasRevisions && (
-								<MenuItem
-									onClick={ loadRevisions }
-									icon={
-										<RevisionsCountBadge>
-											{ revisionsCount }
-										</RevisionsCountBadge>
-									}
-								>
-									{ __( 'Revision history' ) }
-								</MenuItem>
-							) }
-							<MenuItem
-								onClick={ () => {
-									onReset();
-									onClose();
-								} }
-								disabled={ ! canReset }
-							>
-								{ __( 'Reset to defaults' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
-				</DropdownMenu>
-			) : (
-				<Button
-					label={ __( 'Revisions' ) }
-					icon={ backup }
-					disabled
-					__experimentalIsFocusable
-				/>
-			) }
+			<Button
+				label={ __( 'Revisions' ) }
+				icon={ backup }
+				onClick={ loadRevisions }
+				disabled={ ! hasRevisions }
+				isPressed={ isRevisionsOpened }
+			/>
 		</GlobalStylesMenuFill>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -135,6 +135,12 @@ function GlobalStylesRevisionsMenu() {
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
+	const isRevisionsOpened = useSelect(
+		( select ) =>
+			'global-styles-revisions' ===
+			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
+		[]
+	);
 	const loadRevisions = () => {
 		setIsListViewOpened( false );
 
@@ -147,12 +153,6 @@ function GlobalStylesRevisionsMenu() {
 		}
 	};
 	const hasRevisions = revisionsCount > 0;
-	const isRevisionsOpened = useSelect(
-		( select ) =>
-			'global-styles-revisions' ===
-			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
-		[]
-	);
 
 	return (
 		<GlobalStylesMenuFill>

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -1,8 +1,3 @@
-// /**
-//  * External dependencies
-//  */
-// import classnames from 'classnames';
-
 /**
  * WordPress dependencies
  */
@@ -70,8 +65,14 @@ function GlobalStylesActionMenu() {
 			canEditCSS: !! globalStyles?._links?.[ 'wp:action-edit-css' ],
 		};
 	}, [] );
+	const { setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
 	const { goTo } = useNavigator();
-	const loadCustomCSS = () => goTo( '/css' );
+	const loadCustomCSS = () => {
+		setEditorCanvasContainerView( 'global-styles-css' );
+		goTo( '/css' );
+	};
 
 	return (
 		<GlobalStylesMenuFill>
@@ -114,19 +115,6 @@ function GlobalStylesActionMenu() {
 	);
 }
 
-// function RevisionsCountBadge( { className, children } ) {
-// 	return (
-// 		<span
-// 			className={ classnames(
-// 				className,
-// 				'edit-site-global-styles-sidebar__revisions-count-badge'
-// 			) }
-// 		>
-// 			{ children }
-// 		</span>
-// 	);
-// }
-
 function GlobalStylesRevisionsMenu() {
 	const { setIsListViewOpened } = useDispatch( editSiteStore );
 	const { revisionsCount } = useSelect( ( select ) => {
@@ -155,7 +143,7 @@ function GlobalStylesRevisionsMenu() {
 			setEditorCanvasContainerView( 'global-styles-revisions' );
 		} else {
 			goTo( '/' );
-			setEditorCanvasContainerView( '' );
+			setEditorCanvasContainerView( undefined );
 		}
 	};
 	const hasRevisions = revisionsCount > 0;

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -147,9 +147,6 @@ class UserGlobalStylesRevisions {
 			.getByRole( 'menubar', { name: 'Styles actions' } )
 			.click();
 		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
-		await this.page
-			.getByRole( 'menuitem', { name: /^Revision history/ } )
-			.click();
 	}
 
 	async openStylesPanel() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #55779

This PR does three things:

1. Removes the global styles revisions dropdown menu that showed the "Revision history [count]" and "Reset to defaults" options.
2. Moves the "Reset to defaults" to the three dot menu and renames to "Reset styles".
3. Replaces the dropdown menu with a toggle button, and moves the revision history count to the title in the sidebar.

As part of the changes I've also cleaned up the setting and unsetting of `setEditorCanvasContainerView` so that it's consistent throughout all of the screens in global styles. Previously values were not getting set correctly with the header back chevron button, or when looking at the additional css view.

## Why?
The dropdown is unusual and not needed. By switching to the toggle we can match other buttons in the editor, and the way the style book button next to it works.

## How?
Remove `DropdownMenu` usage and replace with `Button`. Also adjust `setEditorCanvasContainerView` usage as mentioned above.

## Testing Instructions
1. Open the site editor and go to global styles.
2. Select the global styles revisions option in the styles sidebar toolbar.
3. Confirm that the button toggles on and the global styles revisions UI shows in the sidebar.
4. Confirm that the revision count is correct next to the "Revisions" title.
5. Use the back chevron and confirm that the revisions button toggles off in the toolbar.
6. Go back and repeat step 2 and 3, then select a different section of global styles, confirm the revisions button toggles off.
7. Go to the more menu, and confirm that the "Reset styles" option works correctly.
8. Check everything else in global styles continues to be navigable.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/WordPress/gutenberg/assets/1464705/4f60cea6-94ae-41d8-a859-2f8f039c6ce8


**After**

https://github.com/WordPress/gutenberg/assets/1464705/177bc1b4-7b4b-4576-b644-083e52f0668c

****
