### PR TITLE
Fix fatal error when calling undefined block library function.

### DIFF
--- a/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
+++ b/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
@@ -170,7 +170,7 @@ class WP_Navigation_Block_Renderer {
 		// Add directives to the submenu if needed.
 		if ( $has_submenus && $should_load_view_script ) {
 			$tags              = new WP_HTML_Tag_Processor( $inner_blocks_html );
-			$inner_blocks_html = block_core_navigation_add_directives_to_submenu( $tags, $attributes );
+			$inner_blocks_html = gutenberg_block_core_navigation_add_directives_to_submenu( $tags, $attributes );
 		}
 
 		return $inner_blocks_html;
@@ -195,7 +195,7 @@ class WP_Navigation_Block_Renderer {
 
 			// 'parse_blocks' includes a null block with '\n\n' as the content when
 			// it encounters whitespace. This code strips it.
-			$compacted_blocks = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
+			$compacted_blocks = gutenberg_block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
 
 			// TODO - this uses the full navigation block attributes for the
 			// context which could be refined.
@@ -210,7 +210,7 @@ class WP_Navigation_Block_Renderer {
 	 * @return WP_Block_List Returns the inner blocks for the navigation block.
 	 */
 	private static function get_inner_blocks_from_fallback( $attributes ) {
-		$fallback_blocks = block_core_navigation_get_fallback_blocks();
+		$fallback_blocks = gutenberg_block_core_navigation_get_fallback_blocks();
 
 		// Fallback my have been filtered so do basic test for validity.
 		if ( empty( $fallback_blocks ) || ! is_array( $fallback_blocks ) ) {
@@ -245,9 +245,9 @@ class WP_Navigation_Block_Renderer {
 			defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN &&
 			array_key_exists( '__unstableLocation', $attributes ) &&
 			! array_key_exists( 'ref', $attributes ) &&
-			! empty( block_core_navigation_get_menu_items_at_location( $attributes['__unstableLocation'] ) )
+			! empty( gutenberg_block_core_navigation_get_menu_items_at_location( $attributes['__unstableLocation'] ) )
 		) {
-			$inner_blocks = block_core_navigation_get_inner_blocks_from_unstable_location( $attributes );
+			$inner_blocks = gutenberg_block_core_navigation_get_inner_blocks_from_unstable_location( $attributes );
 		}
 
 		// Load inner blocks from the navigation post.
@@ -270,7 +270,7 @@ class WP_Navigation_Block_Renderer {
 		 */
 		$inner_blocks = apply_filters( 'block_core_navigation_render_inner_blocks', $inner_blocks );
 
-		$post_ids = block_core_navigation_get_post_ids( $inner_blocks );
+		$post_ids = gutenberg_block_core_navigation_get_post_ids( $inner_blocks );
 		if ( $post_ids ) {
 			_prime_post_caches( $post_ids, false, false );
 		}
@@ -353,8 +353,8 @@ class WP_Navigation_Block_Renderer {
 	private static function get_classes( $attributes ) {
 		// Restore legacy classnames for submenu positioning.
 		$layout_class       = static::get_layout_class( $attributes );
-		$colors             = block_core_navigation_build_css_colors( $attributes );
-		$font_sizes         = block_core_navigation_build_css_font_sizes( $attributes );
+		$colors             = gutenberg_block_core_navigation_build_css_colors( $attributes );
+		$font_sizes         = gutenberg_block_core_navigation_build_css_font_sizes( $attributes );
 		$is_responsive_menu = static::is_responsive( $attributes );
 
 		// Manually add block support text decoration as CSS class.
@@ -378,8 +378,8 @@ class WP_Navigation_Block_Renderer {
 	 * @return string Returns the styles for the navigation block.
 	 */
 	private static function get_styles( $attributes ) {
-		$colors       = block_core_navigation_build_css_colors( $attributes );
-		$font_sizes   = block_core_navigation_build_css_font_sizes( $attributes );
+		$colors       = gutenberg_block_core_navigation_build_css_colors( $attributes );
+		$font_sizes   = gutenberg_block_core_navigation_build_css_font_sizes( $attributes );
 		$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';
 		return $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'];
 	}
@@ -394,7 +394,7 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function get_responsive_container_markup( $attributes, $inner_blocks, $inner_blocks_html ) {
 		$should_load_view_script = static::should_load_view_script( $attributes, $inner_blocks );
-		$colors                  = block_core_navigation_build_css_colors( $attributes );
+		$colors                  = gutenberg_block_core_navigation_build_css_colors( $attributes );
 		$modal_unique_id         = wp_unique_id( 'modal-' );
 
 		$is_hidden_by_default = isset( $attributes['overlayMenu'] ) && 'always' === $attributes['overlayMenu'];
@@ -627,7 +627,7 @@ class WP_Navigation_Block_Renderer {
 
 		$inner_blocks = static::get_inner_blocks( $attributes, $block );
 		// Prevent navigation blocks referencing themselves from rendering.
-		if ( block_core_navigation_block_contains_core_navigation( $inner_blocks ) ) {
+		if ( gutenberg_block_core_navigation_block_contains_core_navigation( $inner_blocks ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #56453.

The newly-added `WP_Navigation_Block_Renderer` was calling some block-library functions by their unprefixed names, which will cause a fatal error if those functions happen to not be defined in core. All block library PHP functions are prefixed with `gutenberg_` at build time, so anywhere they are called outside of block-library (within the plugin) the prefixed version of their name should be used. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This is a tricky one to test in 6.4.1 because it can only be reproduced on a site that has a Navigation block created from a classic menu some time ago, so that it both has the `__unstableLocation` attribute and doesn't have the `ref` one. Essentially we need to make sure that [this line](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php#L248) runs.

An easier way to test is by downgrading to 6.3.2 and making sure there is a Nav with a submenu set to open on click on the page, so that [this line](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php#L173) runs.

With this PR, there should be no Navigation-related errors in WP 6.4.1 or 6.3.2.
