### PR TITLE
Allow dragging between adjacent container blocks based on a threshold

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -81,10 +81,10 @@ export function getDropTargetPosition(
 		// TODO: Check if the parent block is horizontal / vertical orientation.
 		if ( distance < THRESHOLD_DISTANCE ) {
 			if ( edge === 'top' ) {
-				return [ rootBlockIndex, 'insert', 'before' ];
+				return [ rootBlockIndex, 'before' ];
 			}
 			if ( edge === 'bottom' ) {
-				return [ rootBlockIndex + 1, 'insert', 'after' ];
+				return [ rootBlockIndex + 1, 'after' ];
 			}
 		}
 	}
@@ -205,7 +205,6 @@ export default function useBlockDropZone( {
 		useDispatch( blockEditorStore );
 
 	const onBlockDrop = useOnBlockDrop( targetRootClientId, dropTarget.index, {
-		moveBeforeOrAfter: dropTarget.moveBeforeOrAfter,
 		operation: dropTarget.operation,
 	} );
 	const throttled = useThrottle(
@@ -241,32 +240,31 @@ export default function useBlockDropZone( {
 					};
 				} );
 
-				const [ targetIndex, operation, moveBeforeOrAfter ] =
-					getDropTargetPosition(
-						blocksData,
-						{ x: event.clientX, y: event.clientY },
-						getBlockListSettings( targetRootClientId )?.orientation,
-						{
-							dropZoneElement,
-							parentBlock,
-							rootBlockIndex,
-						}
-					);
+				const [ targetIndex, operation ] = getDropTargetPosition(
+					blocksData,
+					{ x: event.clientX, y: event.clientY },
+					getBlockListSettings( targetRootClientId )?.orientation,
+					{
+						dropZoneElement,
+						parentBlock,
+						rootBlockIndex,
+					}
+				);
 
 				registry.batch( () => {
 					setDropTarget( {
-						moveBeforeOrAfter,
 						index: targetIndex,
 						operation,
 					} );
 
-					const insertionPointClientId = moveBeforeOrAfter
+					const insertionPointClientId = [
+						'before',
+						'after',
+					].includes( operation )
 						? parentBlock
 						: targetRootClientId;
 
-					// TODO: Fix display of insertion point, so that it matches onBlockDrop logic.
 					showInsertionPoint( insertionPointClientId, targetIndex, {
-						moveBeforeOrAfter,
 						operation,
 					} );
 				} );

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -204,9 +204,15 @@ export default function useBlockDropZone( {
 	const { showInsertionPoint, hideInsertionPoint } =
 		useDispatch( blockEditorStore );
 
-	const onBlockDrop = useOnBlockDrop( targetRootClientId, dropTarget.index, {
-		operation: dropTarget.operation,
-	} );
+	const onBlockDrop = useOnBlockDrop(
+		dropTarget.operation === 'before' || dropTarget.operation === 'after'
+			? parentBlock
+			: targetRootClientId,
+		dropTarget.index,
+		{
+			operation: dropTarget.operation,
+		}
+	);
 	const throttled = useThrottle(
 		useCallback(
 			( event, ownerDocument ) => {

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -21,6 +21,7 @@ import {
 import { store as blockEditorStore } from '../../store';
 
 const THRESHOLD_DISTANCE = 30;
+const MINIMUM_HEIGHT_FOR_THRESHOLD = 120;
 
 /** @typedef {import('../../utils/math').WPPoint} WPPoint */
 /** @typedef {import('../use-on-block-drop/types').WPDropOperation} WPDropOperation */
@@ -85,7 +86,10 @@ export function getDropTargetPosition(
 		// If dragging over the top or bottom of the drop zone, insert the block
 		// before or after the parent block. This only applies to blocks that use
 		// a drop zone element, typically container blocks such as Group or Cover.
-		if ( distance < THRESHOLD_DISTANCE ) {
+		if (
+			rect.height > MINIMUM_HEIGHT_FOR_THRESHOLD &&
+			distance < THRESHOLD_DISTANCE
+		) {
 			if ( edge === 'top' ) {
 				return [ rootBlockIndex, 'before' ];
 			}

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -282,8 +282,10 @@ export default function useOnBlockDrop(
 				} );
 			} else {
 				if ( moveBeforeOrAfter ) {
-					const parentBlock =
-						getBlockParents( targetRootClientId )[ 0 ];
+					const parentBlock = getBlockParents(
+						targetRootClientId,
+						true
+					)[ 0 ];
 					// const targetBlockClientIds = getBlockOrder( parentBlock );
 					let blockIndex = getBlockIndex( targetRootClientId );
 					if ( moveBeforeOrAfter === 'after' ) {

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -210,7 +210,7 @@ export default function useOnBlockDrop(
 	targetBlockIndex,
 	options = {}
 ) {
-	const { operation = 'insert' } = options;
+	const { operation = 'insert', moveBeforeOrAfter } = options;
 	const hasUploadPermissions = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
 		[]
@@ -220,6 +220,7 @@ export default function useOnBlockDrop(
 		getBlockIndex,
 		getClientIdsOfDescendants,
 		getBlockOrder,
+		getBlockParents,
 		getBlocksByClientId,
 	} = useSelect( blockEditorStore );
 	const {
@@ -280,6 +281,24 @@ export default function useOnBlockDrop(
 					);
 				} );
 			} else {
+				if ( moveBeforeOrAfter ) {
+					const parentBlock =
+						getBlockParents( targetRootClientId )[ 0 ];
+					// const targetBlockClientIds = getBlockOrder( parentBlock );
+					let blockIndex = getBlockIndex( targetRootClientId );
+					if ( moveBeforeOrAfter === 'after' ) {
+						++blockIndex;
+					}
+					// const targetBlockClientId =
+					// 	targetBlockClientIds[ blockIndex ];
+					moveBlocksToPosition(
+						sourceClientIds,
+						sourceRootClientId,
+						parentBlock,
+						blockIndex
+					);
+					return;
+				}
 				moveBlocksToPosition(
 					sourceClientIds,
 					sourceRootClientId,
@@ -293,6 +312,7 @@ export default function useOnBlockDrop(
 			getBlockOrder,
 			getBlocksByClientId,
 			insertBlocks,
+			moveBeforeOrAfter,
 			moveBlocksToPosition,
 			removeBlocks,
 			targetBlockIndex,

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -198,15 +198,15 @@ export function onHTMLDrop(
 /**
  * A React hook for handling block drop events.
  *
- * @param {string}          originalTargetRootClientId The root client id where the block(s) will be inserted.
- * @param {number}          targetBlockIndex           The index where the block(s) will be inserted.
- * @param {Object}          options                    The optional options.
- * @param {WPDropOperation} [options.operation]        The type of operation to perform on drop. Could be `insert` or `replace` for now.
+ * @param {string}          targetRootClientId  The root client id where the block(s) will be inserted.
+ * @param {number}          targetBlockIndex    The index where the block(s) will be inserted.
+ * @param {Object}          options             The optional options.
+ * @param {WPDropOperation} [options.operation] The type of operation to perform on drop. Could be `insert` or `replace` for now.
  *
  * @return {Function} A function to be passed to the onDrop handler.
  */
 export default function useOnBlockDrop(
-	originalTargetRootClientId,
+	targetRootClientId,
 	targetBlockIndex,
 	options = {}
 ) {
@@ -231,21 +231,6 @@ export default function useOnBlockDrop(
 		removeBlocks,
 	} = useDispatch( blockEditorStore );
 	const registry = useRegistry();
-
-	const { targetRootClientId } = useSelect(
-		( select ) => {
-			const firstParent = select( blockEditorStore ).getBlockParents(
-				originalTargetRootClientId,
-				true
-			)[ 0 ];
-			return {
-				targetRootClientId: [ 'before', 'after' ].includes( operation )
-					? firstParent
-					: originalTargetRootClientId,
-			};
-		},
-		[ originalTargetRootClientId, operation ]
-	);
 
 	const insertOrReplaceBlocks = useCallback(
 		( blocks, updateSelection = true, initialPosition = 0 ) => {

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -210,7 +210,7 @@ export default function useOnBlockDrop(
 	targetBlockIndex,
 	options = {}
 ) {
-	const { operation = 'insert', moveBeforeOrAfter } = options;
+	const { operation = 'insert' } = options;
 	const hasUploadPermissions = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
 		[]
@@ -280,43 +280,44 @@ export default function useOnBlockDrop(
 						0
 					);
 				} );
-			} else {
-				if ( moveBeforeOrAfter ) {
-					const parentBlock = getBlockParents(
-						targetRootClientId,
-						true
-					)[ 0 ];
-					// const targetBlockClientIds = getBlockOrder( parentBlock );
-					let blockIndex = getBlockIndex( targetRootClientId );
-					if ( moveBeforeOrAfter === 'after' ) {
-						++blockIndex;
-					}
-					// const targetBlockClientId =
-					// 	targetBlockClientIds[ blockIndex ];
-					moveBlocksToPosition(
-						sourceClientIds,
-						sourceRootClientId,
-						parentBlock,
-						blockIndex
-					);
-					return;
+			} else if ( [ 'after', 'before' ].includes( operation ) ) {
+				const parentBlock = getBlockParents(
+					targetRootClientId,
+					true
+				)[ 0 ];
+				// const targetBlockClientIds = getBlockOrder( parentBlock );
+				let blockIndex = getBlockIndex( targetRootClientId );
+
+				if ( operation === 'after' ) {
+					++blockIndex;
 				}
+				// const targetBlockClientId =
+				// 	targetBlockClientIds[ blockIndex ];
 				moveBlocksToPosition(
 					sourceClientIds,
 					sourceRootClientId,
-					targetRootClientId,
-					insertIndex
+					parentBlock,
+					blockIndex
 				);
+				return;
 			}
+			moveBlocksToPosition(
+				sourceClientIds,
+				sourceRootClientId,
+				targetRootClientId,
+				insertIndex
+			);
 		},
 		[
 			operation,
+			getBlockIndex,
+			getBlockParents,
 			getBlockOrder,
 			getBlocksByClientId,
-			insertBlocks,
-			moveBeforeOrAfter,
 			moveBlocksToPosition,
+			registry,
 			removeBlocks,
+			replaceBlocks,
 			targetBlockIndex,
 			targetRootClientId,
 		]

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -10,6 +10,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { SelectControl } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { View } from '@wordpress/primitives';
 
@@ -97,7 +98,8 @@ function GroupEdit( { attributes, name, setAttributes, clientId } ) {
 		themeSupportsLayout || type === 'flex' || type === 'grid';
 
 	// Hooks.
-	const blockProps = useBlockProps();
+	const ref = useRef();
+	const blockProps = useBlockProps( { ref } );
 
 	const [ showPlaceholder, setShowPlaceholder ] = useShouldShowPlaceHolder( {
 		attributes,
@@ -124,6 +126,7 @@ function GroupEdit( { attributes, name, setAttributes, clientId } ) {
 			? blockProps
 			: { className: 'wp-block-group__inner-container' },
 		{
+			dropZoneElement: ref.current,
 			templateLock,
 			allowedBlocks,
 			renderAppender,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #56463 

This PR explores a potential fix for dragging between adjacent container blocks (specifically Group and Cover blocks) when dragging within their padding area.

The proposal here is to add a threshold area (within `30px`) of the vertical and horizontal edges of the container block, where if a user drags in that area, we attempt to drop _before_ or _after_ the container block rather than within it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If you have a template with adjacent Group or Cover blocks where there is no gap between those blocks, it is either very difficult or impossible to drag between them. This PR explores one potential solution to it, by adding a threshold area to allow dragging between these blocks (in the vertical and horizontal axes)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* If the block uses a `dropZoneElement` and the user is dragging toward the top or bottom of the block (i.e. within a `30px` threshold) then treat the drag/drop as being intended for before or after the block instead of within it.
* As above, but if the user is dragging within the left and right edges _and_ the parent block is in a horizontal orientation (i.e. it is a Row block) then allow dragging before and after the block instead of within it.
* Only enable the drag between behaviour if the block is big enough for it to be useable (currently 4 x the threshold, or `120px`)
* Add the `dropZoneElement` for the Group block so that its container element can be used to determine where to place the drop.

Note: the behaviour in this PR is most noticeable / mostly applies when a Group block has padding set. The Cover block already uses a padding area, so it's quite noticeable with the Cover block, too.

## To-do

* [x] Ensure that dragging from a first child position to the above next block works (e.g. drag from first child of Cover to just previous to the Cover block)
* [x] Move the threshold to a constant
* [x] Update the drop indicator line
* [x] Fix issue when dragging a block that is already just before the target block (ensure that the logic that factors in the indexes of dragged blocks is reused)
* ~Ensure the parent block allows drag to the position (i.e. what if the user shouldn't be allowed to break out of the current block in this context)~ Out of scope, as this is tracked in: https://github.com/WordPress/gutenberg/issues/24174
* [x] Detect the orientation of the next block up — what should happen if the parent block is horizontally oriented, for example?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In a post or template (the TwentyTwentyFour template is good for testing this) attempt to drag and drop a block between two adjacent container blocks (in particular Cover and Group blocks). With this PR applied, you should be able to drag just within the padding area (or `30px` of it) of the block to drag between the adjacent blocks. Note: it's expected that Group blocks without any padding should not receive this threshold, as the user will be dragging over a child of the Group block.

Test the above, but with Row as a parent block, and set the Row's block spacing to `0` so there are no gaps. If the children are Cover blocks or Group blocks with some padding, then the threshold behaviour in this PR should apply. That is, it should now be easier to drag between adjacent blocks. The logic should also work correctly in RTL languages.

See if this adversely affects drag or performance in any way compared to `trunk`.

## Screenshots or screencast <!-- if applicable -->

### Vertical

The following screengrab shows dragging between adjacent Cover and Group blocks, where dragging just toward the vertical edge allows for dragging between the blocks.

https://github.com/WordPress/gutenberg/assets/14988353/08f67495-7cda-49da-be56-41b091928aed

### Horizontal (LTR language)

https://github.com/WordPress/gutenberg/assets/14988353/78ca2b3a-05ac-4492-9a4b-d7723ea79997

### Horizontal (RTL language)

https://github.com/WordPress/gutenberg/assets/14988353/880db701-9daa-456b-adf0-e6470c8038fe

<!--
https://github.com/WordPress/gutenberg/assets/14988353/3eab510d-6eb2-4d42-83c1-8dc4b207247e
https://github.com/WordPress/gutenberg/assets/14988353/fa492bca-d7c6-4b17-91b2-022a11f816d6
-->