### PR TITLE
Editor: Move the template focus modes to the editor store

### DIFF
--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -132,11 +132,9 @@ _Returns_
 
 ### hasPageContentFocus
 
+> **Deprecated**
+
 Whether or not the editor allows only page content to be edited.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
 
 _Returns_
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -501,6 +501,18 @@ _Related_
 
 -   getPreviousBlockClientId in core/block-editor store.
 
+### getRenderingMode
+
+Returns the post editor's rendering mode.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `string?`: Rendering mode.
+
 ### getSelectedBlock
 
 _Related_
@@ -1240,6 +1252,18 @@ _Parameters_
 _Related_
 
 -   selectBlock in core/block-editor store.
+
+### setRenderingMode
+
+Returns an action used to set the rendering mode of the post editor.
+
+_Parameters_
+
+-   _mode_ `string`: Mode (one of 'template-only', 'post-only', 'template-locked' or 'all').
+
+_Returns_
+
+-   `Object`: Action object
 
 ### setTemplateValidity
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1255,7 +1255,12 @@ _Related_
 
 ### setRenderingMode
 
-Returns an action used to set the rendering mode of the post editor.
+Returns an action used to set the rendering mode of the post editor. We support multiple rendering modes:
+
+-   `all`: This is the default mode. It renders the post editor with all the features available. If a template is provided, it's preferred over the post.
+-   `template-only`: This mode renders the editor with only the template blocks visible.
+-   `post-only`: This mode extracts the post blocks from the template and renders only those. The idea is to allow the user to edit the post/page in isolation without the wrapping template.
+-   `template-locked`: This mode renders both the template and the post blocks but the template blocks are locked and can't be edited. The post blocks are editable.
 
 _Parameters_
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -511,7 +511,7 @@ _Parameters_
 
 _Returns_
 
--   `string?`: Rendering mode.
+-   `string`: Rendering mode.
 
 ### getSelectedBlock
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1266,10 +1266,6 @@ _Parameters_
 
 -   _mode_ `string`: Mode (one of 'template-only', 'post-only', 'template-locked' or 'all').
 
-_Returns_
-
--   `Object`: Action object
-
 ### setTemplateValidity
 
 _Related_

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -26,6 +26,7 @@ import {
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
+import { useRef, useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -80,6 +81,15 @@ function PageDocumentActions() {
 	);
 
 	const { setRenderingMode } = useDispatch( editorStore );
+	const [ isAnimated, setIsAnimated ] = useState( false );
+	const isLoading = useRef( true );
+
+	useEffect( () => {
+		if ( ! isLoading.current ) {
+			setIsAnimated( true );
+		}
+		isLoading.current = false;
+	}, [ isEditingPage ] );
 
 	if ( ! hasResolved ) {
 		return null;
@@ -93,14 +103,20 @@ function PageDocumentActions() {
 		);
 	}
 
-	// Todo: check animation
 	return isEditingPage ? (
-		<BaseDocumentActions className="is-page" icon={ pageIcon }>
+		<BaseDocumentActions
+			className={ classnames( 'is-page', {
+				'is-animated': isAnimated,
+			} ) }
+			icon={ pageIcon }
+		>
 			{ title }
 		</BaseDocumentActions>
 	) : (
 		<TemplateDocumentActions
-			className="is-animated"
+			className={ classnames( {
+				'is-animated': isAnimated,
+			} ) }
 			onBack={ () => setRenderingMode( 'template-locked' ) }
 		/>
 	);

--- a/packages/edit-site/src/components/page-content-focus-notifications/back-to-page-notification.js
+++ b/packages/edit-site/src/components/page-content-focus-notifications/back-to-page-notification.js
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -25,35 +26,33 @@ export default function BackToPageNotification() {
  * switches from focusing on editing page content to editing a template.
  */
 export function useBackToPageNotification() {
-	const hasPageContentFocus = useSelect(
-		( select ) => select( editSiteStore ).hasPageContentFocus(),
+	const renderingMode = useSelect(
+		( select ) => select( editorStore ).getRenderingMode(),
 		[]
 	);
 	const { isPage } = useSelect( editSiteStore );
+	const { setRenderingMode } = useDispatch( editorStore );
+	const { createInfoNotice } = useDispatch( noticesStore );
 
 	const alreadySeen = useRef( false );
 
-	const { createInfoNotice } = useDispatch( noticesStore );
-	const { setHasPageContentFocus } = useDispatch( editSiteStore );
-
 	useEffect( () => {
-		if ( isPage() && ! alreadySeen.current && ! hasPageContentFocus ) {
+		if (
+			isPage() &&
+			! alreadySeen.current &&
+			renderingMode === 'template-only'
+		) {
 			createInfoNotice( __( 'You are editing a template.' ), {
 				isDismissible: true,
 				type: 'snackbar',
 				actions: [
 					{
 						label: __( 'Back to page' ),
-						onClick: () => setHasPageContentFocus( true ),
+						onClick: () => setRenderingMode( 'template-locked' ),
 					},
 				],
 			} );
 			alreadySeen.current = true;
 		}
-	}, [
-		isPage,
-		hasPageContentFocus,
-		createInfoNotice,
-		setHasPageContentFocus,
-	] );
+	}, [ isPage, renderingMode, createInfoNotice, setRenderingMode ] );
 }

--- a/packages/edit-site/src/components/page-content-focus-notifications/edit-template-notification.js
+++ b/packages/edit-site/src/components/page-content-focus-notifications/edit-template-notification.js
@@ -6,11 +6,7 @@ import { useEffect, useState, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { store as editSiteStore } from '../../store';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Component that:
@@ -27,14 +23,14 @@ import { store as editSiteStore } from '../../store';
  *                                                                  editor iframe canvas.
  */
 export default function EditTemplateNotification( { contentRef } ) {
-	const hasPageContentFocus = useSelect(
-		( select ) => select( editSiteStore ).hasPageContentFocus(),
+	const renderingMode = useSelect(
+		( select ) => select( editorStore ).getRenderingMode(),
 		[]
 	);
 	const { getNotices } = useSelect( noticesStore );
 
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
-	const { setHasPageContentFocus } = useDispatch( editSiteStore );
+	const { setRenderingMode } = useDispatch( editorStore );
 
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
 
@@ -42,7 +38,7 @@ export default function EditTemplateNotification( { contentRef } ) {
 
 	useEffect( () => {
 		const handleClick = async ( event ) => {
-			if ( ! hasPageContentFocus ) {
+			if ( renderingMode === 'template-only' ) {
 				return;
 			}
 			if ( ! event.target.classList.contains( 'is-root-container' ) ) {
@@ -62,7 +58,7 @@ export default function EditTemplateNotification( { contentRef } ) {
 					actions: [
 						{
 							label: __( 'Edit template' ),
-							onClick: () => setHasPageContentFocus( false ),
+							onClick: () => setRenderingMode( 'template-only' ),
 						},
 					],
 				}
@@ -71,7 +67,7 @@ export default function EditTemplateNotification( { contentRef } ) {
 		};
 
 		const handleDblClick = ( event ) => {
-			if ( ! hasPageContentFocus ) {
+			if ( renderingMode === 'template-only' ) {
 				return;
 			}
 			if ( ! event.target.classList.contains( 'is-root-container' ) ) {
@@ -90,7 +86,7 @@ export default function EditTemplateNotification( { contentRef } ) {
 			canvas?.removeEventListener( 'click', handleClick );
 			canvas?.removeEventListener( 'dblclick', handleDblClick );
 		};
-	}, [ lastNoticeId, hasPageContentFocus, contentRef.current ] );
+	}, [ lastNoticeId, renderingMode, contentRef.current ] );
 
 	return (
 		<ConfirmDialog
@@ -98,7 +94,7 @@ export default function EditTemplateNotification( { contentRef } ) {
 			confirmButtonText={ __( 'Edit template' ) }
 			onConfirm={ () => {
 				setIsDialogOpen( false );
-				setHasPageContentFocus( false );
+				setRenderingMode( 'template-only' );
 			} }
 			onCancel={ () => setIsDialogOpen( false ) }
 		>

--- a/packages/edit-site/src/components/page-content-focus-notifications/index.js
+++ b/packages/edit-site/src/components/page-content-focus-notifications/index.js
@@ -1,40 +1,10 @@
 /**
- * WordPress dependencies
- */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
-/**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../store';
 import EditTemplateNotification from './edit-template-notification';
 import BackToPageNotification from './back-to-page-notification';
-import { unlock } from '../../lock-unlock';
 
 export default function PageContentFocusNotifications( { contentRef } ) {
-	const { pageContentFocusType, canvasMode } = useSelect( ( select ) => {
-		const { getPageContentFocusType, getCanvasMode } = unlock(
-			select( editSiteStore )
-		);
-		const _canvasMode = getCanvasMode();
-		return {
-			canvasMode: _canvasMode,
-			pageContentFocusType: getPageContentFocusType(),
-		};
-	}, [] );
-	const { setPageContentFocusType } = unlock( useDispatch( editSiteStore ) );
-
-	/*
-	 * Ensure that the page content focus type is set to `disableTemplate` when
-	 * the canvas mode is not `edit`. This makes the experience consistent with
-	 * refreshing the page, which resets the page content focus type.
-	 */
-	useEffect( () => {
-		if ( canvasMode !== 'edit' && !! pageContentFocusType ) {
-			setPageContentFocusType( null );
-		}
-	}, [ canvasMode, pageContentFocusType, setPageContentFocusType ] );
-
 	return (
 		<>
 			<EditTemplateNotification contentRef={ contentRef } />

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -8,6 +8,7 @@ import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -33,7 +34,7 @@ export function SidebarComplementaryAreaFills() {
 		isEditorSidebarOpened,
 		hasBlockSelection,
 		supportsGlobalStyles,
-		hasPageContentFocus,
+		isEditingPage,
 	} = useSelect( ( select ) => {
 		const _sidebar =
 			select( interfaceStore ).getActiveComplementaryArea( STORE_NAME );
@@ -48,7 +49,9 @@ export function SidebarComplementaryAreaFills() {
 			hasBlockSelection:
 				!! select( blockEditorStore ).getBlockSelectionStart(),
 			supportsGlobalStyles: ! settings?.supportsTemplatePartsMode,
-			hasPageContentFocus: select( editSiteStore ).hasPageContentFocus(),
+			isEditingPage:
+				select( editSiteStore ).isPage() &&
+				select( editorStore ).getRenderingMode() !== 'template-only',
 		};
 	}, [] );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
@@ -60,13 +63,18 @@ export function SidebarComplementaryAreaFills() {
 			return;
 		}
 		if ( hasBlockSelection ) {
-			if ( ! hasPageContentFocus ) {
+			if ( ! isEditingPage ) {
 				enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
 			}
 		} else {
 			enableComplementaryArea( STORE_NAME, SIDEBAR_TEMPLATE );
 		}
-	}, [ hasBlockSelection, isEditorSidebarOpened, hasPageContentFocus ] );
+	}, [
+		hasBlockSelection,
+		isEditorSidebarOpened,
+		isEditingPage,
+		enableComplementaryArea,
+	] );
 
 	let sidebarName = sidebar;
 	if ( ! isEditorSidebarOpened ) {
@@ -85,11 +93,7 @@ export function SidebarComplementaryAreaFills() {
 			>
 				{ sidebarName === SIDEBAR_TEMPLATE && (
 					<>
-						{ hasPageContentFocus ? (
-							<PagePanels />
-						) : (
-							<TemplatePanel />
-						) }
+						{ isEditingPage ? <PagePanels /> : <TemplatePanel /> }
 						<PluginTemplateSettingPanel.Slot />
 					</>
 				) }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -8,7 +8,10 @@ import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { check } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import {
+	privateApis as editorPrivateApis,
+	store as editorStore,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -31,9 +34,7 @@ export default function EditTemplate() {
 		useSelect( ( select ) => {
 			const { getEditedPostContext, getEditedPostType, getEditedPostId } =
 				select( editSiteStore );
-			const { getCanvasMode, getPageContentFocusType } = unlock(
-				select( editSiteStore )
-			);
+			const { getRenderingMode } = unlock( select( editorStore ) );
 			const { getEditedEntityRecord, hasFinishedResolution } =
 				select( coreStore );
 			const { __experimentalGetGlobalBlocksByName } =
@@ -51,17 +52,12 @@ export default function EditTemplate() {
 					queryArgs
 				),
 				template: getEditedEntityRecord( ...queryArgs ),
-				isTemplateHidden:
-					getCanvasMode() === 'edit' &&
-					getPageContentFocusType() === 'hideTemplate',
+				isTemplateHidden: getRenderingMode() === 'post-only',
 				postType: _postType,
 			};
 		}, [] );
 
-	const { setHasPageContentFocus } = useDispatch( editSiteStore );
-	// Disable reason: `useDispatch` can't be called conditionally.
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const { setPageContentFocusType } = unlock( useDispatch( editSiteStore ) );
+	const { setRenderingMode } = useDispatch( editorStore );
 
 	if ( ! hasResolved ) {
 		return null;
@@ -85,7 +81,7 @@ export default function EditTemplate() {
 						<MenuGroup>
 							<MenuItem
 								onClick={ () => {
-									setHasPageContentFocus( false );
+									setRenderingMode( 'template-only' );
 									onClose();
 								} }
 							>
@@ -102,10 +98,10 @@ export default function EditTemplate() {
 									}
 									isPressed={ ! isTemplateHidden }
 									onClick={ () => {
-										setPageContentFocusType(
+										setRenderingMode(
 											isTemplateHidden
-												? 'disableTemplate'
-												: 'hideTemplate'
+												? 'template-locked'
+												: 'post-only'
 										);
 									} }
 								>

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
@@ -10,6 +10,7 @@ import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -20,12 +21,12 @@ import { store as editSiteStore } from '../../../store';
 import { POST_TYPE_LABELS, TEMPLATE_POST_TYPE } from '../../../utils/constants';
 
 const SettingsHeader = ( { sidebarName } ) => {
-	const { hasPageContentFocus, entityType } = useSelect( ( select ) => {
-		const { getEditedPostType, hasPageContentFocus: _hasPageContentFocus } =
-			select( editSiteStore );
+	const { isEditingPage, entityType } = useSelect( ( select ) => {
+		const { getEditedPostType, isPage } = select( editSiteStore );
+		const { getRenderingMode } = select( editorStore );
 
 		return {
-			hasPageContentFocus: _hasPageContentFocus(),
+			isEditingPage: isPage() && getRenderingMode() !== 'template-only',
 			entityType: getEditedPostType(),
 		};
 	} );
@@ -41,7 +42,7 @@ const SettingsHeader = ( { sidebarName } ) => {
 		enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
 
 	let templateAriaLabel;
-	if ( hasPageContentFocus ) {
+	if ( isEditingPage ) {
 		templateAriaLabel =
 			sidebarName === SIDEBAR_TEMPLATE
 				? // translators: ARIA label for the Template sidebar tab, selected.
@@ -70,11 +71,9 @@ const SettingsHeader = ( { sidebarName } ) => {
 						}
 					) }
 					aria-label={ templateAriaLabel }
-					data-label={
-						hasPageContentFocus ? __( 'Page' ) : entityLabel
-					}
+					data-label={ isEditingPage ? __( 'Page' ) : entityLabel }
 				>
-					{ hasPageContentFocus ? __( 'Page' ) : entityLabel }
+					{ isEditingPage ? __( 'Page' ) : entityLabel }
 				</Button>
 			</li>
 			<li>

--- a/packages/edit-site/src/components/welcome-guide/page.js
+++ b/packages/edit-site/src/components/welcome-guide/page.js
@@ -23,8 +23,8 @@ export default function WelcomeGuidePage() {
 			'core/edit-site',
 			'welcomeGuide'
 		);
-		const { hasPageContentFocus } = select( editSiteStore );
-		return isPageActive && ! isEditorActive && hasPageContentFocus();
+		const { isPage } = select( editSiteStore );
+		return isPageActive && ! isEditorActive && isPage();
 	}, [] );
 
 	if ( ! isVisible ) {

--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -23,12 +24,13 @@ export default function WelcomeGuideTemplate() {
 			'core/edit-site',
 			'welcomeGuide'
 		);
-		const { isPage, hasPageContentFocus } = select( editSiteStore );
+		const { isPage } = select( editSiteStore );
+		const { getRenderingMode } = select( editorStore );
 		return (
 			isTemplateActive &&
 			! isEditorActive &&
 			isPage() &&
-			! hasPageContentFocus()
+			getRenderingMode() === 'template-only'
 		);
 	}, [] );
 

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -575,6 +575,10 @@ export const switchEditorMode =
 export const setHasPageContentFocus =
 	( hasPageContentFocus ) =>
 	( { dispatch, registry } ) => {
+		deprecated( `dispatch( 'core/edit-site' ).setHasPageContentFocus`, {
+			since: '6.5',
+		} );
+
 		if ( hasPageContentFocus ) {
 			registry.dispatch( blockEditorStore ).clearSelectedBlock();
 		}

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -3,7 +3,6 @@
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Action that switches the canvas mode.
@@ -45,27 +44,4 @@ export const setEditorCanvasContainerView =
 			type: 'SET_EDITOR_CANVAS_CONTAINER_VIEW',
 			view,
 		} );
-	};
-
-/**
- * Sets the type of page content focus. Can be one of:
- *
- * - `'disableTemplate'`: Disable the blocks belonging to the page's template.
- * - `'hideTemplate'`: Hide the blocks belonging to the page's template.
- *
- * @param {'disableTemplate'|'hideTemplate'} pageContentFocusType The type of page content focus.
- *
- * @return {Object} Action object.
- */
-export const setPageContentFocusType =
-	( pageContentFocusType ) =>
-	( { registry } ) => {
-		registry
-			.dispatch( editorStore )
-			.setRenderingMode(
-				! pageContentFocusType ||
-					pageContentFocusType === 'disableTemplate'
-					? 'template-locked'
-					: 'post-only'
-			);
 	};

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -3,6 +3,7 @@
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Action that switches the canvas mode.
@@ -11,7 +12,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 export const setCanvasMode =
 	( mode ) =>
-	( { registry, dispatch, select } ) => {
+	( { registry, dispatch } ) => {
 		registry.dispatch( blockEditorStore ).__unstableSetEditorMode( 'edit' );
 		dispatch( {
 			type: 'SET_CANVAS_MODE',
@@ -29,10 +30,6 @@ export const setCanvasMode =
 				.get( 'core/edit-site', 'distractionFree' )
 		) {
 			dispatch.setIsListViewOpened( true );
-		}
-		// Switch focus away from editing the template when switching to view mode.
-		if ( mode === 'view' && select.isPage() ) {
-			dispatch.setHasPageContentFocus( true );
 		}
 	};
 
@@ -62,9 +59,13 @@ export const setEditorCanvasContainerView =
  */
 export const setPageContentFocusType =
 	( pageContentFocusType ) =>
-	( { dispatch } ) => {
-		dispatch( {
-			type: 'SET_PAGE_CONTENT_FOCUS_TYPE',
-			pageContentFocusType,
-		} );
+	( { registry } ) => {
+		registry
+			.dispatch( editorStore )
+			.setRenderingMode(
+				! pageContentFocusType ||
+					pageContentFocusType === 'disableTemplate'
+					? 'template-locked'
+					: 'post-only'
+			);
 	};

--- a/packages/edit-site/src/store/private-selectors.js
+++ b/packages/edit-site/src/store/private-selectors.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { hasPageContentFocus } from './selectors';
-
-/**
  * Returns the current canvas mode.
  *
  * @param {Object} state Global application state.
@@ -23,21 +18,4 @@ export function getCanvasMode( state ) {
  */
 export function getEditorCanvasContainerView( state ) {
 	return state.editorCanvasContainerView;
-}
-
-/**
- * Returns the type of the current page content focus, or null if there is no
- * page content focus.
- *
- * Possible values are:
- *
- * - `'disableTemplate'`: Disable the blocks belonging to the page's template.
- * - `'hideTemplate'`: Hide the blocks belonging to the page's template.
- *
- * @param {Object} state Global application state.
- *
- * @return {'disableTemplate'|'hideTemplate'|null} Type of the current page content focus.
- */
-export function getPageContentFocusType( state ) {
-	return hasPageContentFocus( state ) ? state.pageContentFocusType : null;
 }

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -157,43 +157,6 @@ function editorCanvasContainerView( state = undefined, action ) {
 	return state;
 }
 
-/**
- * Reducer used to track whether the editor allows only page content to be
- * edited.
- *
- * @param {boolean} state  Current state.
- * @param {Object}  action Dispatched action.
- *
- * @return {boolean} Updated state.
- */
-export function hasPageContentFocus( state = false, action ) {
-	switch ( action.type ) {
-		case 'SET_EDITED_POST':
-			return !! action.context?.postId;
-		case 'SET_HAS_PAGE_CONTENT_FOCUS':
-			return action.hasPageContentFocus;
-	}
-
-	return state;
-}
-
-/**
- * Reducer used to track the type of page content focus.
- *
- * @param {string} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {string} Updated state.
- */
-export function pageContentFocusType( state = 'disableTemplate', action ) {
-	switch ( action.type ) {
-		case 'SET_PAGE_CONTENT_FOCUS_TYPE':
-			return action.pageContentFocusType;
-	}
-
-	return state;
-}
-
 export default combineReducers( {
 	deviceType,
 	settings,
@@ -203,6 +166,4 @@ export default combineReducers( {
 	saveViewPanel,
 	canvasMode,
 	editorCanvasContainerView,
-	hasPageContentFocus,
-	pageContentFocusType,
 } );

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -7,6 +7,7 @@ import deprecated from '@wordpress/deprecated';
 import { Platform } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -181,7 +182,10 @@ export const __experimentalGetInsertionPoint = createRegistrySelector(
 			return { rootClientId, insertionIndex, filterValue };
 		}
 
-		if ( hasPageContentFocus( state ) ) {
+		if (
+			isPage( state ) &&
+			select( editorStore ).getRenderingMode() !== 'template-only'
+		) {
 			const [ postContentClientId ] =
 				select( blockEditorStore ).__experimentalGetGlobalBlocksByName(
 					'core/post-content'
@@ -310,10 +314,14 @@ export function isPage( state ) {
 /**
  * Whether or not the editor allows only page content to be edited.
  *
- * @param {Object} state Global application state.
+ * @deprecated
  *
  * @return {boolean} Whether or not focus is on editing page content.
  */
-export function hasPageContentFocus( state ) {
-	return isPage( state ) ? state.hasPageContentFocus : false;
+export function hasPageContentFocus() {
+	deprecated( `select( 'core/edit-site' ).hasPageContentFocus`, {
+		since: '6.5',
+	} );
+
+	return false;
 }

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -7,18 +7,19 @@ import { createRegistry } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import { store as editSiteStore } from '..';
-import { setHasPageContentFocus } from '../actions';
 
 function createRegistryWithStores() {
 	// create a registry
 	const registry = createRegistry();
 
 	// register stores
+	registry.register( editorStore );
 	registry.register( blockEditorStore );
 	registry.register( coreStore );
 	registry.register( editSiteStore );
@@ -175,36 +176,6 @@ describe( 'actions', () => {
 					.select( preferencesStore )
 					.get( 'core/edit-site', 'distractionFree' )
 			).toBe( true );
-		} );
-	} );
-
-	describe( 'setHasPageContentFocus', () => {
-		it( 'toggles the page content lock on', () => {
-			const dispatch = jest.fn();
-			const clearSelectedBlock = jest.fn();
-			const registry = {
-				dispatch: () => ( { clearSelectedBlock } ),
-			};
-			setHasPageContentFocus( true )( { dispatch, registry } );
-			expect( clearSelectedBlock ).toHaveBeenCalled();
-			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'SET_HAS_PAGE_CONTENT_FOCUS',
-				hasPageContentFocus: true,
-			} );
-		} );
-
-		it( 'toggles the page content lock off', () => {
-			const dispatch = jest.fn();
-			const clearSelectedBlock = jest.fn();
-			const registry = {
-				dispatch: () => ( { clearSelectedBlock } ),
-			};
-			setHasPageContentFocus( false )( { dispatch, registry } );
-			expect( clearSelectedBlock ).not.toHaveBeenCalled();
-			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'SET_HAS_PAGE_CONTENT_FOCUS',
-				hasPageContentFocus: false,
-			} );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -11,8 +11,6 @@ import {
 	editedPost,
 	blockInserterPanel,
 	listViewPanel,
-	hasPageContentFocus,
-	pageContentFocusType,
 } from '../reducer';
 
 import { setIsInserterOpened } from '../actions';
@@ -147,66 +145,6 @@ describe( 'state', () => {
 			expect( listViewPanel( true, setIsInserterOpened( false ) ) ).toBe(
 				true
 			);
-		} );
-	} );
-
-	describe( 'hasPageContentFocus()', () => {
-		it( 'defaults to false', () => {
-			expect( hasPageContentFocus( undefined, {} ) ).toBe( false );
-		} );
-
-		it( 'becomes false when editing a template', () => {
-			expect(
-				hasPageContentFocus( true, {
-					type: 'SET_EDITED_POST',
-					postType: 'wp_template',
-				} )
-			).toBe( false );
-		} );
-
-		it( 'becomes true when editing a page', () => {
-			expect(
-				hasPageContentFocus( false, {
-					type: 'SET_EDITED_POST',
-					postType: 'wp_template',
-					context: {
-						postType: 'page',
-						postId: 123,
-					},
-				} )
-			).toBe( true );
-		} );
-
-		it( 'can be set', () => {
-			expect(
-				hasPageContentFocus( false, {
-					type: 'SET_HAS_PAGE_CONTENT_FOCUS',
-					hasPageContentFocus: true,
-				} )
-			).toBe( true );
-			expect(
-				hasPageContentFocus( true, {
-					type: 'SET_HAS_PAGE_CONTENT_FOCUS',
-					hasPageContentFocus: false,
-				} )
-			).toBe( false );
-		} );
-	} );
-
-	describe( 'pageContentFocusType', () => {
-		it( 'defaults to disableTemplate', () => {
-			expect( pageContentFocusType( undefined, {} ) ).toBe(
-				'disableTemplate'
-			);
-		} );
-
-		it( 'can be set', () => {
-			expect(
-				pageContentFocusType( 'disableTemplate', {
-					type: 'SET_PAGE_CONTENT_FOCUS_TYPE',
-					pageContentFocusType: 'enableTemplate',
-				} )
-			).toBe( 'enableTemplate' );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -13,7 +13,6 @@ import {
 	isInserterOpened,
 	isListViewOpened,
 	isPage,
-	hasPageContentFocus,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -86,40 +85,6 @@ describe( 'selectors', () => {
 				},
 			};
 			expect( isPage( state ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'hasPageContentFocus', () => {
-		it( 'returns true if locked and the edited post type is a page', () => {
-			const state = {
-				editedPost: {
-					postType: 'wp_template',
-					context: { postType: 'page', postId: 123 },
-				},
-				hasPageContentFocus: true,
-			};
-			expect( hasPageContentFocus( state ) ).toBe( true );
-		} );
-
-		it( 'returns false if not locked and the edited post type is a page', () => {
-			const state = {
-				editedPost: {
-					postType: 'wp_template',
-					context: { postType: 'page', postId: 123 },
-				},
-				hasPageContentFocus: false,
-			};
-			expect( hasPageContentFocus( state ) ).toBe( false );
-		} );
-
-		it( 'returns false if locked and the edited post type is a template', () => {
-			const state = {
-				editedPost: {
-					postType: 'wp_template',
-				},
-				hasPageContentFocus: true,
-			};
-			expect( hasPageContentFocus( state ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -40,7 +40,7 @@ export const FOCUSABLE_ENTITIES = [
 
 /**
  * Block types that are considered to be page content. These are the only blocks
- * editable when hasPageContentFocus() is true.
+ * editable when the page is focused.
  */
 export const PAGE_CONTENT_BLOCK_TYPES = {
 	'core/post-title': true,

--- a/packages/editor/src/components/provider/README.md
+++ b/packages/editor/src/components/provider/README.md
@@ -22,19 +22,6 @@ The post object to edit
 
 The template object wrapper the edited post. This is optional and can only be used when the post type supports templates (like posts and pages).
 
-### `mode`
-
--   **Type:** `String`
--   **Required** `no`
--   **default** `all`
-
-This is the rendering mode of the post editor. We support multiple rendering modes:
-
--   `all`: This is the default mode. It renders the post editor with all the features available. If a template is provided, it's preferred over the post.
--   `template-only`: This mode renders the editor with only the template blocks visible.
--   `post-only`: This mode extracts the post blocks from the template and renders only those. The idea is to allow the user to edit the post/page in isolation without the wrapping template.
--   `template-locked`: This mode renders both the template and the post blocks but the template blocks are locked and can't be edited. The post blocks are editable.
-
 ### `settings`
 
 -   **Type:** `Object`

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -178,7 +178,6 @@ function useBlockEditorProps( post, template, mode ) {
 
 export const ExperimentalEditorProvider = withRegistryProvider(
 	( {
-		mode = 'all',
 		post,
 		settings,
 		recovery,
@@ -187,6 +186,10 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		BlockEditorProviderComponent = ExperimentalBlockEditorProvider,
 		__unstableTemplate: template,
 	} ) => {
+		const mode = useSelect(
+			( select ) => select( editorStore ).getRenderingMode(),
+			[]
+		);
 		const shouldRenderTemplate = !! template && mode !== 'post-only';
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -549,6 +549,20 @@ export function updateEditorSettings( settings ) {
 }
 
 /**
+ * Returns an action used to set the rendering mode of the post editor.
+ *
+ * @param {string} mode Mode (one of 'template-only', 'post-only', 'template-locked' or 'all').
+ *
+ * @return {Object} Action object
+ */
+export function setRenderingMode( mode ) {
+	return {
+		type: 'SET_RENDERING_MODE',
+		mode,
+	};
+}
+
+/**
  * Backward compatibility
  */
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -557,15 +557,17 @@ export function updateEditorSettings( settings ) {
  * -   `template-locked`: This mode renders both the template and the post blocks but the template blocks are locked and can't be edited. The post blocks are editable.
  *
  * @param {string} mode Mode (one of 'template-only', 'post-only', 'template-locked' or 'all').
- *
- * @return {Object} Action object
  */
-export function setRenderingMode( mode ) {
-	return {
-		type: 'SET_RENDERING_MODE',
-		mode,
+export const setRenderingMode =
+	( mode ) =>
+	( { dispatch, registry } ) => {
+		registry.dispatch( blockEditorStore ).clearSelectedBlock();
+
+		dispatch( {
+			type: 'SET_RENDERING_MODE',
+			mode,
+		} );
 	};
-}
 
 /**
  * Backward compatibility

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -549,7 +549,12 @@ export function updateEditorSettings( settings ) {
 }
 
 /**
- * Returns an action used to set the rendering mode of the post editor.
+ * Returns an action used to set the rendering mode of the post editor. We support multiple rendering modes:
+ *
+ * -   `all`: This is the default mode. It renders the post editor with all the features available. If a template is provided, it's preferred over the post.
+ * -   `template-only`: This mode renders the editor with only the template blocks visible.
+ * -   `post-only`: This mode extracts the post blocks from the template and renders only those. The idea is to allow the user to edit the post/page in isolation without the wrapping template.
+ * -   `template-locked`: This mode renders both the template and the post blocks but the template blocks are locked and can't be edited. The post blocks are editable.
  *
  * @param {string} mode Mode (one of 'template-only', 'post-only', 'template-locked' or 'all').
  *

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -279,6 +279,15 @@ export function editorSettings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
 	return state;
 }
 
+export function renderingMode( state = 'all', action ) {
+	switch ( action.type ) {
+		case 'SET_RENDERING_MODE':
+			return action.mode;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	postId,
 	postType,
@@ -290,4 +299,5 @@ export default combineReducers( {
 	isReady,
 	editorSettings,
 	postAutosavingLock,
+	renderingMode,
 } );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1188,6 +1188,17 @@ export function getEditorSettings( state ) {
 	return state.editorSettings;
 }
 
+/**
+ * Returns the post editor's rendering mode.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string?} Rendering mode.
+ */
+export function getRenderingMode( state ) {
+	return state.renderingMode;
+}
+
 /*
  * Backward compatibility
  */

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1193,7 +1193,7 @@ export function getEditorSettings( state ) {
  *
  * @param {Object} state Editor state.
  *
- * @return {string?} Rendering mode.
+ * @return {string} Rendering mode.
  */
 export function getRenderingMode( state ) {
 	return state.renderingMode;


### PR DESCRIPTION
Related #52632 

## What?

This PR is a refactoring PR that moves the "template mode / page focus" modes state from the edit-site store to the editor store. The idea is that by moving the state and the components to the editor-store, we will be able to implement the same modes in the post editor as well.

The current PR only moves the "state" and doesn't touch the component. It should not have any impact on the behavior of these different modes in the site editor.

## Testing Instructions

Check things like: "editing page", "switching to templates", "editing template parts"... in the site editor.