### PR TITLE
Add isSaving and isDeleting to useEntityRecord, add props to existing…

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -151,6 +151,8 @@ describe( 'useEntityRecord', () => {
 			hasEdits: false,
 			edits: {},
 			record: null,
+			isSaving: false,
+			isDeleting: false,
 			save: expect.any( Function ),
 		} );
 

--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -52,6 +52,8 @@ describe( 'useEntityRecord', () => {
 			save: expect.any( Function ),
 			hasResolved: false,
 			isResolving: false,
+			isSaving: false,
+			isDeleting: false,
 			status: 'IDLE',
 		} );
 
@@ -71,6 +73,8 @@ describe( 'useEntityRecord', () => {
 			save: expect.any( Function ),
 			hasResolved: true,
 			isResolving: false,
+			isSaving: false,
+			isDeleting: false,
 			status: 'SUCCESS',
 		} );
 	} );
@@ -100,6 +104,8 @@ describe( 'useEntityRecord', () => {
 				save: expect.any( Function ),
 				hasResolved: true,
 				isResolving: false,
+				isSaving: false,
+				isDeleting: false,
 				status: 'SUCCESS',
 			} )
 		);

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -185,6 +185,8 @@ export default function useEntityRecord< RecordType >(
 					editedRecord: EMPTY_OBJECT,
 					hasEdits: false,
 					edits: EMPTY_OBJECT,
+					isSaving: false,
+					isDeleting: false,
 				};
 			}
 

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -34,6 +34,16 @@ export interface EntityRecordResolution< RecordType > {
 	isResolving: boolean;
 
 	/**
+	 * Is the record still being saved?
+	 */
+	isSaving: boolean;
+
+	/**
+	 * Is the record still being deleted?
+	 */
+	isDeleting: boolean;
+
+	/**
 	 * Does the record have any local edits?
 	 */
 	hasEdits: boolean;
@@ -168,7 +178,7 @@ export default function useEntityRecord< RecordType >(
 		[ editEntityRecord, kind, name, recordId, saveEditedEntityRecord ]
 	);
 
-	const { editedRecord, hasEdits, edits } = useSelect(
+	const { editedRecord, hasEdits, edits, isSaving, isDeleting } = useSelect(
 		( select ) => {
 			if ( ! options.enabled ) {
 				return {
@@ -190,6 +200,16 @@ export default function useEntityRecord< RecordType >(
 					recordId
 				),
 				edits: select( coreStore ).getEntityRecordNonTransientEdits(
+					kind,
+					name,
+					recordId
+				),
+				isSaving: select( coreStore ).isSavingEntityRecord(
+					kind,
+					name,
+					recordId
+				),
+				isDeleting: select( coreStore ).isDeletingEntityRecord(
 					kind,
 					name,
 					recordId
@@ -216,6 +236,8 @@ export default function useEntityRecord< RecordType >(
 		editedRecord,
 		hasEdits,
 		edits,
+		isSaving,
+		isDeleting,
 		...querySelectRest,
 		...mutations,
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This exposes `isSaving` and `isDeleting` on `useEntityRecord`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
`useEntityRecord` exposes _nearly_ all actions and data releated to entity records, without having to go an use an additional `useSelect` to get anything else... except [`isSaving` and `isDeleting` still require a seperate `select` call](https://github.com/WordPress/gutenberg/issues/56471).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I've added `isSavingEntityRecord` and `isDeletingEntityRecord` inside the `useEntityRecord` hook.

I did look at `useQuerySelect` but that seems to deal more with getting things and checking if a record has resolved.

The best place I figured would be directly inside the hook, in the existing `useSelect`.

## Testing Instructions
You can now use `useEntityRecord` like this:
```
const {
	record,
	editedRecord,
	hasEdits,
	edit,
	save,
	isResolving,
	hasResolved,
	isSaving,
	isDeleting,
} = useEntityRecord( 'postType', 'page', postId );
```
Notice `isSaving` and `isDeleting` are now exposed.


### Testing
I'm really not too confident with updating and writing the tests for this, but I've added these new props to the expected testing outputs, I've not written any additional tests to check whether `isSaving` and `isDeleting` actually work as expected.

I would be interested to learn how to do this though.


