### PR TITLE
Indent/outdent on tab (list, code)

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -27,15 +27,23 @@ import { store as blockEditorStore } from '../../store';
 
 export function useWritingFlow() {
 	const [ before, ref, after ] = useTabNav();
-	const hasMultiSelection = useSelect(
-		( select ) => select( blockEditorStore ).hasMultiSelection(),
+	const { hasMultiSelection, keepCaretInsideBlock } = useSelect(
+		( select ) => {
+			const { hasMultiSelection: _hasMultiSelection, getSettings } =
+				select( blockEditorStore );
+
+			return {
+				hasMultiSelection: _hasMultiSelection(),
+				keepCaretInsideBlock: getSettings().keepCaretInsideBlock,
+			};
+		},
 		[]
 	);
 
 	return [
-		before,
+		keepCaretInsideBlock ? null : before,
 		useMergeRefs( [
-			ref,
+			keepCaretInsideBlock ? null : ref,
 			useClipboardHandler(),
 			useInput(),
 			useDragSelection(),
@@ -67,7 +75,7 @@ export function useWritingFlow() {
 				[ hasMultiSelection ]
 			),
 		] ),
-		after,
+		keepCaretInsideBlock ? null : after,
 	];
 }
 

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -149,17 +149,7 @@ export default function useTabNav() {
 				return;
 			}
 
-			const next = isShift ? focusCaptureBeforeRef : focusCaptureAfterRef;
-
-			// Disable focus capturing on the focus capture element, so it
-			// doesn't refocus this block and so it allows default behaviour
-			// (moving focus to the next tabbable element).
-			noCapture.current = true;
-
-			// Focusing the focus capture element, which is located above and
-			// below the editor, should not scroll the page all the way up or
-			// down.
-			next.current.focus( { preventScroll: true } );
+			event.preventDefault();
 		}
 
 		function onFocusOut( event ) {

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -4,6 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { useRefEffect } from '@wordpress/compose';
+import { TAB } from '@wordpress/keycodes';
 
 export default function CodeEdit( {
 	attributes,
@@ -13,9 +15,34 @@ export default function CodeEdit( {
 	mergeBlocks,
 } ) {
 	const blockProps = useBlockProps();
+	const ref = useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
+
+			if (
+				event.defaultPrevented ||
+				keyCode !== TAB ||
+				// Only override when no modifiers are pressed.
+				shiftKey ||
+				altKey ||
+				metaKey ||
+				ctrlKey
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			element.ownerDocument.execCommand( 'insertText', false, '\t' );
+		}
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
 	return (
 		<pre { ...blockProps }>
 			<RichText
+				ref={ ref }
 				tagName="code"
 				identifier="content"
 				value={ attributes.content }

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -2,10 +2,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useRefEffect } from '@wordpress/compose';
 import { TAB } from '@wordpress/keycodes';
+import { useSelect } from '@wordpress/data';
 
 export default function CodeEdit( {
 	attributes,
@@ -15,6 +20,7 @@ export default function CodeEdit( {
 	mergeBlocks,
 } ) {
 	const blockProps = useBlockProps();
+	const { getSettings } = useSelect( blockEditorStore );
 	const ref = useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
 			const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
@@ -28,6 +34,10 @@ export default function CodeEdit( {
 				metaKey ||
 				ctrlKey
 			) {
+				return;
+			}
+
+			if ( getSettings().keepCaretInsideBlock ) {
 				return;
 			}
 

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -23,6 +23,7 @@ import { useMergeRefs } from '@wordpress/compose';
 import {
 	useEnter,
 	useSpace,
+	useTab,
 	useIndentListItem,
 	useOutdentListItem,
 	useSplit,
@@ -77,7 +78,11 @@ export default function ListItemEdit( {
 		<>
 			<li { ...innerBlocksProps }>
 				<RichText
-					ref={ useMergeRefs( [ useEnterRef, useSpaceRef ] ) }
+					ref={ useMergeRefs( [
+						useEnterRef,
+						useSpaceRef,
+						useTab( clientId ),
+					] ) }
 					identifier="content"
 					tagName="div"
 					onChange={ ( nextContent ) =>

--- a/packages/block-library/src/list-item/hooks/index.js
+++ b/packages/block-library/src/list-item/hooks/index.js
@@ -2,6 +2,7 @@ export { default as useOutdentListItem } from './use-outdent-list-item';
 export { default as useIndentListItem } from './use-indent-list-item';
 export { default as useEnter } from './use-enter';
 export { default as useSpace } from './use-space';
+export { default as useTab } from './use-tab';
 export { default as useSplit } from './use-split';
 export { default as useMerge } from './use-merge';
 export { default as useCopy } from './use-copy';

--- a/packages/block-library/src/list-item/hooks/use-tab.js
+++ b/packages/block-library/src/list-item/hooks/use-tab.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { TAB } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import useIndentListItem from './use-indent-list-item';
+import useOutdentListItem from './use-outdent-list-item';
+
+export default function useTab( clientId ) {
+	const [ canIndent, indentListItem ] = useIndentListItem( clientId );
+	const [ canOutdent, outdentListItem ] = useOutdentListItem( clientId );
+
+	return useRefEffect(
+		( element ) => {
+			function onKeyDown( event ) {
+				const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
+
+				if (
+					event.defaultPrevented ||
+					keyCode !== TAB ||
+					// Only override when no modifiers are pressed.
+					altKey ||
+					metaKey ||
+					ctrlKey
+				) {
+					return;
+				}
+
+				event.preventDefault();
+
+				if ( shiftKey ) {
+					if ( canOutdent ) {
+						outdentListItem();
+					}
+				} else if ( canIndent ) {
+					indentListItem();
+				}
+			}
+
+			element.addEventListener( 'keydown', onKeyDown );
+			return () => {
+				element.removeEventListener( 'keydown', onKeyDown );
+			};
+		},
+		[ canIndent, indentListItem, canOutdent, outdentListItem ]
+	);
+}

--- a/packages/block-library/src/list-item/hooks/use-tab.js
+++ b/packages/block-library/src/list-item/hooks/use-tab.js
@@ -3,6 +3,8 @@
  */
 import { useRefEffect } from '@wordpress/compose';
 import { TAB } from '@wordpress/keycodes';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -13,6 +15,7 @@ import useOutdentListItem from './use-outdent-list-item';
 export default function useTab( clientId ) {
 	const [ canIndent, indentListItem ] = useIndentListItem( clientId );
 	const [ canOutdent, outdentListItem ] = useOutdentListItem( clientId );
+	const { getSettings } = useSelect( blockEditorStore );
 
 	return useRefEffect(
 		( element ) => {
@@ -27,6 +30,10 @@ export default function useTab( clientId ) {
 					metaKey ||
 					ctrlKey
 				) {
+					return;
+				}
+
+				if ( getSettings().keepCaretInsideBlock ) {
 					return;
 				}
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -148,7 +148,7 @@ test.describe( 'Image', () => {
 
 		// Add caption and navigate to inline toolbar.
 		await editor.clickBlockToolbarButton( 'Add caption' );
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'alt+F10' );
 		expect(
 			await page.evaluate( () =>
 				document.activeElement.getAttribute( 'aria-label' )

--- a/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
@@ -232,11 +232,15 @@ class KeyboardNavigableBlocks {
 
 		await expect( activeElement ).toHaveText( paragraphText );
 
+		await this.pageUtils.pressKeys( 'ctrl+`' );
+		await this.expectLabelToHaveFocus( 'Editor settings' );
 		await this.page.keyboard.press( 'Tab' );
 		await this.expectLabelToHaveFocus( 'Post' );
 
-		// Need to shift+tab here to end back in the block. If not, we'll be in the next region and it will only require 4 region jumps instead of 5.
-		await this.pageUtils.pressKeys( 'shift+Tab' );
+		await this.pageUtils.pressKeys( 'shift+ctrl+`' );
+		await this.expectLabelToHaveFocus( 'Editor content' );
+		await this.page.keyboard.press( 'Tab' );
+		await this.page.keyboard.press( 'Tab' );
 		await this.expectLabelToHaveFocus( 'Block: Paragraph' );
 	}
 

--- a/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
@@ -150,15 +150,18 @@ test.describe( 'Order of block keyboard navigation', () => {
 			'Multiple selected blocks'
 		);
 
+		await pageUtils.pressKeys( 'ctrl+`' );
 		await page.keyboard.press( 'Tab' );
 		await KeyboardNavigableBlocks.expectLabelToHaveFocus( 'Post' );
 
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'shift+ctrl+`' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
 		await KeyboardNavigableBlocks.expectLabelToHaveFocus(
 			'Multiple selected blocks'
 		);
 
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'alt+F10' );
 		await page.keyboard.press( 'ArrowRight' );
 		await KeyboardNavigableBlocks.expectLabelToHaveFocus( 'Move up' );
 	} );

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -113,14 +113,14 @@ test.describe( 'Block Toolbar', () => {
 		} );
 	} );
 
-	test( 'should focus with Shift+Tab', async ( {
+	test( 'should focus with alt+F10', async ( {
 		editor,
 		page,
 		pageUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'a' );
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'alt+F10' );
 		await expect(
 			page
 				.getByRole( 'toolbar', { name: 'Block Tools' } )
@@ -183,8 +183,7 @@ test.describe( 'Block Toolbar', () => {
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'Paragraph' );
 
-		// shift + tab
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'alt+F10' );
 		// check focus is within the block toolbar
 		const blockToolbarParagraphButton = page.getByRole( 'button', {
 			name: 'Paragraph',
@@ -199,7 +198,7 @@ test.describe( 'Block Toolbar', () => {
 		await pageUtils.setBrowserViewport( 'small' );
 
 		// TEST: Small screen toolbar without fixed toolbar setting should be the first tabstop before the editor
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'alt+F10' );
 		// check focus is within the block toolbar
 		await expect( blockToolbarParagraphButton ).toBeFocused();
 		await pageUtils.pressKeys( 'Tab' );
@@ -229,7 +228,7 @@ test.describe( 'Block Toolbar', () => {
 
 		// TEST: Small screen toolbar with fixed toolbar setting should be the first tabstop before the editor. Even though the fixed toolbar setting is on, it should not render within the header since it's visually after it.
 		await pageUtils.setBrowserViewport( 'small' );
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'alt+F10' );
 		// check focus is within the block toolbar
 		await expect( blockToolbarParagraphButton ).toBeFocused();
 		await pageUtils.pressKeys( 'Tab' );

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -133,7 +133,7 @@ test.describe( 'Toolbar roving tabindex', () => {
 		await page.keyboard.press( 'ArrowRight' );
 		await ToolbarRovingTabindexUtils.expectLabelToHaveFocus( 'Move up' );
 		await pageUtils.pressKeys( 'Tab' );
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'alt+F10' );
 		await ToolbarRovingTabindexUtils.expectLabelToHaveFocus( 'Move up' );
 	} );
 
@@ -169,7 +169,7 @@ class ToolbarRovingTabindexUtils {
 		await this.expectLabelToHaveFocus( 'Move up' );
 		await this.pageUtils.pressKeys( 'Tab' );
 		await this.expectLabelToHaveFocus( currentBlockLabel );
-		await this.pageUtils.pressKeys( 'shift+Tab' );
+		await this.pageUtils.pressKeys( 'alt+F10' );
 		await this.expectLabelToHaveFocus( 'Move up' );
 	}
 
@@ -200,7 +200,7 @@ class ToolbarRovingTabindexUtils {
 		await this.expectLabelToHaveFocus( 'Block: Group' );
 		await this.page.keyboard.press( 'ArrowRight' );
 		await this.expectLabelToHaveFocus( currentBlockLabel );
-		await this.pageUtils.pressKeys( 'shift+Tab' );
+		await this.pageUtils.pressKeys( 'alt+F10' );
 		await this.expectLabelToHaveFocus( 'Select parent block: Group' );
 		await this.page.keyboard.press( 'ArrowRight' );
 		await this.expectLabelToHaveFocus( currentBlockTitle );

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -33,7 +33,7 @@ test.describe( 'Site editor writing flow', () => {
 		await editor.selectBlocks( siteTitleBlock );
 
 		// Shift tab to the toolbar.
-		await pageUtils.pressKeys( 'shift+Tab' );
+		await pageUtils.pressKeys( 'alt+F10' );
 		const blockToolbarButton = page.locator(
 			'role=toolbar[name="Block tools"i] >> role=button[name="Site Title"i]'
 		);
@@ -64,7 +64,8 @@ test.describe( 'Site editor writing flow', () => {
 		await editor.selectBlocks( siteTaglineBlock );
 
 		// Tab to the inspector, tabbing three times to go past the two resize handles.
-		await pageUtils.pressKeys( 'Tab', { times: 3 } );
+		await pageUtils.pressKeys( 'ctrl+`' );
+		await pageUtils.pressKeys( 'Tab', { times: 4 } );
 		const inspectorTemplateTab = page.locator(
 			'role=region[name="Editor settings"i] >> role=button[name="Template part"i]'
 		);

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -65,9 +65,8 @@ test.describe( 'Site editor writing flow', () => {
 
 		// Tab to the inspector, tabbing three times to go past the two resize handles.
 		await pageUtils.pressKeys( 'ctrl+`' );
-		await pageUtils.pressKeys( 'Tab', { times: 4 } );
 		const inspectorTemplateTab = page.locator(
-			'role=region[name="Editor settings"i] >> role=button[name="Template part"i]'
+			'role=region[name="Editor settings"i]'
 		);
 		await expect( inspectorTemplateTab ).toBeFocused();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows indenting/outdenting list items through tab/shift+tab.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #45404.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR removes tabbing from the editor when in writing mode.

* Note that tabbing still working in Navigation mode (press Esc to get to it)
* You can still focus the block toolbar with the shortcut (Alt+F10)
* You can still navigate regions (Ctrl+`)
* Additionally, tab follows normal DOM order when `keepCaretInsideBlock` is on and disables custom tab behaviour in blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
