### PR TITLE
Add: Bulk actions API to dataviews and an initial bulk trash action.

### DIFF
--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -1,0 +1,117 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	ToolbarButton,
+	Toolbar,
+	ToolbarGroup,
+	Popover,
+} from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { ActionWithModal } from './item-actions';
+
+function PrimaryActionTrigger( { action, onClick } ) {
+	return (
+		<ToolbarButton
+			label={ action.label }
+			icon={ action.icon }
+			isDestructive={ action.isDestructive }
+			size="compact"
+			onClick={ onClick }
+		/>
+	);
+}
+
+const EMPTY_ARRAY = [];
+
+export default function BulkActions( {
+	data,
+	selection,
+	actions = EMPTY_ARRAY,
+	setSelection,
+} ) {
+	const items = useMemo(
+		() =>
+			data?.filter( ( item ) => selection?.includes( item.id ) ) ??
+			EMPTY_ARRAY,
+		[ data, selection ]
+	);
+	const primaryActions = useMemo(
+		() =>
+			actions.filter( ( action ) => {
+				return (
+					action.isBulk &&
+					action.isPrimary &&
+					items.every( ( item ) => action.isEligible( item ) )
+				);
+			} ),
+		[ actions, items ]
+	);
+
+	if (
+		( selection && selection.length === 0 ) ||
+		primaryActions.length === 0
+	) {
+		return null;
+	}
+
+	return (
+		<Popover
+			placement="top-middle"
+			className="dataviews-bulk-actions-popover"
+		>
+			<Toolbar label="Bulk actions">
+				<div className="dataviews-bulk-actions-toolbar-wrapper">
+					<ToolbarGroup>
+						<ToolbarButton onClick={ () => {} } disabled={ true }>
+							{
+								// translators: %s: Total number of selected items.
+								sprintf(
+									// translators: %s: Total number of selected items.
+									_n(
+										'%s item selected',
+										'%s items selected',
+										selection.length
+									),
+									selection.length
+								)
+							}
+						</ToolbarButton>
+						<ToolbarButton
+							onClick={ () => {
+								setSelection( EMPTY_ARRAY );
+							} }
+						>
+							{ __( 'Deselect' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+					<ToolbarGroup>
+						{ primaryActions.map( ( action ) => {
+							if ( !! action.RenderModal ) {
+								return (
+									<ActionWithModal
+										key={ action.id }
+										action={ action }
+										items={ items }
+										ActionTrigger={ PrimaryActionTrigger }
+									/>
+								);
+							}
+							return (
+								<PrimaryActionTrigger
+									key={ action.id }
+									action={ action }
+									onClick={ () => action.callback( items ) }
+								/>
+							);
+						} ) }
+					</ToolbarGroup>
+				</div>
+			</Toolbar>
+		</Popover>
+	);
+}

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -15,6 +15,7 @@ import ViewActions from './view-actions';
 import Filters from './filters';
 import Search from './search';
 import { VIEW_LAYOUTS } from './constants';
+import BulkActions from './bulk-actions';
 
 export default function DataViews( {
 	view,
@@ -28,6 +29,9 @@ export default function DataViews( {
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
+	selection,
+	setSelection,
+	labels,
 } ) {
 	const ViewComponent = VIEW_LAYOUTS.find(
 		( v ) => v.type === view.type
@@ -72,12 +76,24 @@ export default function DataViews( {
 					data={ data }
 					getItemId={ getItemId }
 					isLoading={ isLoading }
+					selection={ selection }
+					setSelection={ setSelection }
+					labels={ labels }
 				/>
+
+				<div>
 				<Pagination
 					view={ view }
 					onChangeView={ onChangeView }
 					paginationInfo={ paginationInfo }
 				/>
+					<BulkActions
+						data={ data }
+						actions={ actions }
+						selection={ selection }
+						setSelection={ setSelection }
+					/>
+				</div>
 			</VStack>
 		</div>
 	);

--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -46,12 +46,18 @@ function DropdownMenuItemTrigger( { action, onClick } ) {
 	);
 }
 
-function ActionWithModal( { action, item, ActionTrigger } ) {
+export function ActionWithModal( { action, item, items, ActionTrigger } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const actionTriggerProps = {
 		action,
 		onClick: () => setIsModalOpen( true ),
 	};
+	const additionalProps = {};
+	if ( action.isBulk ) {
+		additionalProps.items = items ? items : [ item ];
+	} else {
+		additionalProps.item = item;
+	}
 	const { RenderModal, hideModalHeader } = action;
 	return (
 		<>
@@ -66,7 +72,7 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 					overlayClassName="dataviews-action-modal"
 				>
 					<RenderModal
-						item={ item }
+						{ ...additionalProps }
 						closeModal={ () => setIsModalOpen( false ) }
 					/>
 				</Modal>
@@ -157,7 +163,11 @@ export default function ItemActions( { item, actions, isCompact } ) {
 						<ButtonTrigger
 							key={ action.id }
 							action={ action }
-							onClick={ () => action.callback( item ) }
+							onClick={
+								action.isBulk
+									? () => action.callback( [ item ] )
+									: () => action.callback( item )
+							}
 						/>
 					);
 				} ) }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -130,3 +130,25 @@
 .dataviews-action-modal {
 	z-index: z-index(".dataviews-action-modal");
 }
+
+.dataviews-bulk-actions-popover .components-popover__content {
+	min-width: max-content;
+}
+
+.dataviews-bulk-actions-toolbar-wrapper {
+	display: flex;
+	flex-grow: 1;
+	width: 100%;
+}
+
+.dataviews-table-view__selection-column label {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -154,7 +154,7 @@ export const removeTemplate =
 
 			registry.dispatch( noticesStore ).createSuccessNotice(
 				sprintf(
-					/* translators: The template/part's name. */
+					/* translators: %s: The template or template part's name. */
 					__( '"%s" deleted.' ),
 					decodeEntities( templateTitle )
 				),


### PR DESCRIPTION
This PR adds a bulk actions mechanism to the dataviews and an initial bulk trash action.
It also adds an item selection mechanism to the list view.

## Testing
Verify we can select all visible rows.
Verify we can deselect all visible rows.
Select some pages and verify it is possible to trash them all.
Verify the Deselect button works.


## Screenshot

<img width="2007" alt="Screenshot 2023-11-23 at 12 22 07" src="https://github.com/WordPress/gutenberg/assets/11271197/0ba7b1ca-b8d8-4438-a420-cf9af17ef3ae">

