### PR TITLE
DataViews: add support for `NOT IN` operator in filter

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -185,6 +185,8 @@ Example:
 -   `type`: the type of the field. Used to generate the proper filters. Only `enumeration` available at the moment.
 -   `enableSorting`: whether the data can be sorted by the given field. True by default.
 -   `enableHiding`: whether the field can be hidden. True by default.
+-   `filterBy`: configuration for the filters.
+    - `operators`: the list of operators supported by the field.
 
 ## Actions
 

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -36,8 +36,7 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 					name: field.header,
 					elements: field.elements || [],
 					isVisible: view.filters.some(
-						( f ) =>
-							f.field === field.id && f.operator === OPERATOR_IN
+						( f ) => f.field === field.id
 					),
 				} );
 		}

--- a/packages/dataviews/src/constants.js
+++ b/packages/dataviews/src/constants.js
@@ -16,6 +16,7 @@ export const ENUMERATION_TYPE = 'enumeration';
 
 // Filter operators.
 export const OPERATOR_IN = 'in';
+export const OPERATOR_NOT_IN = 'notIn';
 
 // View layouts.
 export const LAYOUT_TABLE = 'table';

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -172,7 +172,7 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 								} ) )
 							}
 						>
-							{ __( 'Show matches' ) }
+							{ __( 'Is' ) }
 						</DropdownMenuItem>
 						<DropdownMenuItem
 							key="not-in-filter"
@@ -202,7 +202,7 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 								} ) )
 							}
 						>
-							{ __( 'Hide matches' ) }
+							{ __( 'Is not' ) }
 						</DropdownMenuItem>
 					</DropdownSubMenu>
 				) }

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -140,7 +140,7 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 					<DropdownSubMenu
 						trigger={
 							<DropdownSubMenuTrigger>
-								{ __( 'Settings' ) }
+								{ __( 'Conditions' ) }
 							</DropdownSubMenuTrigger>
 						}
 					>

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -72,7 +72,7 @@ function WithSeparators( { children } ) {
 		) );
 }
 
-export function FilterSummary( { filter, view, onChangeView } ) {
+export default function FilterSummary( { filter, view, onChangeView } ) {
 	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
 	const activeElement = filter.elements.find(
 		( element ) => element.value === filterInView?.value

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -6,7 +6,7 @@ import {
 	privateApis as componentsPrivateApis,
 	Icon,
 } from '@wordpress/components';
-import { chevronDown, check } from '@wordpress/icons';
+import { chevronDown, chevronRightSmall, check } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { Children, Fragment } from '@wordpress/element';
 
@@ -139,7 +139,16 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 				{ filter.operators.length > 1 && (
 					<DropdownSubMenu
 						trigger={
-							<DropdownSubMenuTrigger>
+							<DropdownSubMenuTrigger
+								suffix={
+									<>
+										{ filterInView.operator === OPERATOR_IN
+											? __( 'Is' )
+											: __( 'Is not' ) }
+										<Icon icon={ chevronRightSmall } />{ ' ' }
+									</>
+								}
+							>
 								{ __( 'Conditions' ) }
 							</DropdownSubMenuTrigger>
 						}

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -113,7 +113,9 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 											),
 											{
 												field: filter.field,
-												operator: OPERATOR_IN,
+												operator:
+													filterInView?.operator ||
+													filter.operators[ 0 ],
 												value:
 													activeElement?.value ===
 													element.value

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -6,8 +6,13 @@ import {
 	privateApis as componentsPrivateApis,
 	Icon,
 } from '@wordpress/components';
-import { chevronDown, chevronRightSmall, check } from '@wordpress/icons';
-import { __, sprintf } from '@wordpress/i18n';
+import {
+	chevronDown,
+	chevronRightSmall,
+	check,
+	chevronLeftSmall,
+} from '@wordpress/icons';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { Children, Fragment } from '@wordpress/element';
 
 /**
@@ -145,7 +150,13 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 										{ filterInView.operator === OPERATOR_IN
 											? __( 'Is' )
 											: __( 'Is not' ) }
-										<Icon icon={ chevronRightSmall } />{ ' ' }
+										<Icon
+											icon={
+												isRTL()
+													? chevronRightSmall
+													: chevronLeftSmall
+											}
+										/>{ ' ' }
 									</>
 								}
 							>

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -6,13 +6,8 @@ import {
 	privateApis as componentsPrivateApis,
 	Icon,
 } from '@wordpress/components';
-import {
-	chevronDown,
-	chevronRightSmall,
-	check,
-	chevronLeftSmall,
-} from '@wordpress/icons';
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { chevronDown, chevronRightSmall, check } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
 import { Children, Fragment } from '@wordpress/element';
 
 /**
@@ -150,13 +145,7 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 										{ filterInView.operator === OPERATOR_IN
 											? __( 'Is' )
 											: __( 'Is not' ) }
-										<Icon
-											icon={
-												isRTL()
-													? chevronRightSmall
-													: chevronLeftSmall
-											}
-										/>{ ' ' }
+										<Icon icon={ chevronRightSmall } />{ ' ' }
 									</>
 								}
 							>

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -6,7 +6,7 @@ import {
 	privateApis as componentsPrivateApis,
 	Icon,
 } from '@wordpress/components';
-import { chevronDown } from '@wordpress/icons';
+import { chevronDown, check } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { Children, Fragment } from '@wordpress/element';
 
@@ -19,7 +19,7 @@ import { unlock } from '../../lock-unlock';
 const {
 	DropdownMenuV2: DropdownMenu,
 	DropdownMenuGroupV2: DropdownMenuGroup,
-	DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
+	DropdownMenuItemV2: DropdownMenuItem,
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 	DropdownSubMenuV2: DropdownSubMenu,
 	DropdownSubMenuTriggerV2: DropdownSubMenuTrigger,
@@ -96,11 +96,13 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 				<DropdownMenuGroup>
 					{ filter.elements.map( ( element ) => {
 						return (
-							<DropdownMenuCheckboxItem
+							<DropdownMenuItem
 								key={ element.value }
-								value={ element.value }
-								checked={
-									activeElement?.value === element.value
+								role="menuitemradio"
+								prefix={
+									activeElement?.value === element.value && (
+										<Icon icon={ check } />
+									)
 								}
 								onSelect={ () =>
 									onChangeView( ( currentView ) => ( {
@@ -127,7 +129,7 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 								}
 							>
 								{ element.label }
-							</DropdownMenuCheckboxItem>
+							</DropdownMenuItem>
 						);
 					} ) }
 				</DropdownMenuGroup>
@@ -139,10 +141,14 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 							</DropdownSubMenuTrigger>
 						}
 					>
-						<DropdownMenuCheckboxItem
+						<DropdownMenuItem
 							key="in-filter"
-							value={ OPERATOR_IN }
-							checked={ filterInView?.operator === OPERATOR_IN }
+							role="menuitemradio"
+							prefix={
+								filterInView?.operator === OPERATOR_IN && (
+									<Icon icon={ check } />
+								)
+							}
 							onSelect={ () =>
 								onChangeView( ( currentView ) => ( {
 									...currentView,
@@ -161,12 +167,14 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 							}
 						>
 							{ __( 'Show matches' ) }
-						</DropdownMenuCheckboxItem>
-						<DropdownMenuCheckboxItem
+						</DropdownMenuItem>
+						<DropdownMenuItem
 							key="not-in-filter"
-							value={ OPERATOR_NOT_IN }
-							checked={
-								filterInView?.operator === OPERATOR_NOT_IN
+							role="menuitemradio"
+							prefix={
+								filterInView?.operator === OPERATOR_NOT_IN && (
+									<Icon icon={ check } />
+								)
 							}
 							onSelect={ () =>
 								onChangeView( ( currentView ) => ( {
@@ -186,7 +194,7 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 							}
 						>
 							{ __( 'Hide matches' ) }
-						</DropdownMenuCheckboxItem>
+						</DropdownMenuItem>
 					</DropdownSubMenu>
 				) }
 			</WithSeparators>

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -99,6 +99,9 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 							<DropdownMenuItem
 								key={ element.value }
 								role="menuitemradio"
+								aria-checked={
+									activeElement?.value === element.value
+								}
 								prefix={
 									activeElement?.value === element.value && (
 										<Icon icon={ check } />
@@ -144,6 +147,9 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 						<DropdownMenuItem
 							key="in-filter"
 							role="menuitemradio"
+							aria-checked={
+								filterInView?.operator === OPERATOR_IN
+							}
 							prefix={
 								filterInView?.operator === OPERATOR_IN && (
 									<Icon icon={ check } />
@@ -171,6 +177,9 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 						<DropdownMenuItem
 							key="not-in-filter"
 							role="menuitemradio"
+							aria-checked={
+								filterInView?.operator === OPERATOR_NOT_IN
+							}
 							prefix={
 								filterInView?.operator === OPERATOR_NOT_IN && (
 									<Icon icon={ check } />

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -14,7 +14,7 @@ import { Children, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
-import { unlock } from '../../lock-unlock';
+import { unlock } from './lock-unlock';
 
 const {
 	DropdownMenuV2: DropdownMenu,

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
+import { Children, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import { unlock } from '../../lock-unlock';
 
 const {
 	DropdownMenuV2: DropdownMenu,
+	DropdownMenuGroupV2: DropdownMenuGroup,
 	DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 	DropdownSubMenuV2: DropdownSubMenu,
@@ -59,6 +61,17 @@ const FilterText = ( { activeElement, filterInView, filter } ) => {
 	);
 };
 
+function WithSeparators( { children } ) {
+	return Children.toArray( children )
+		.filter( Boolean )
+		.map( ( child, i ) => (
+			<Fragment key={ i }>
+				{ i > 0 && <DropdownMenuSeparator /> }
+				{ child }
+			</Fragment>
+		) );
+}
+
 export function FilterSummary( { filter, view, onChangeView } ) {
 	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
 	const activeElement = filter.elements.find(
@@ -79,92 +92,102 @@ export function FilterSummary( { filter, view, onChangeView } ) {
 				</Button>
 			}
 		>
-			{ filter.elements.map( ( element ) => {
-				return (
-					<DropdownMenuCheckboxItem
-						key={ element.value }
-						value={ element.value }
-						checked={ activeElement?.value === element.value }
-						onSelect={ () =>
-							onChangeView( ( currentView ) => ( {
-								...currentView,
-								page: 1,
-								filters: [
-									...view.filters.filter(
-										( f ) => f.field !== filter.field
-									),
-									{
-										field: filter.field,
-										operator: OPERATOR_IN,
-										value:
-											activeElement?.value ===
-											element.value
-												? undefined
-												: element.value,
-									},
-								],
-							} ) )
+			<WithSeparators>
+				<DropdownMenuGroup>
+					{ filter.elements.map( ( element ) => {
+						return (
+							<DropdownMenuCheckboxItem
+								key={ element.value }
+								value={ element.value }
+								checked={
+									activeElement?.value === element.value
+								}
+								onSelect={ () =>
+									onChangeView( ( currentView ) => ( {
+										...currentView,
+										page: 1,
+										filters: [
+											...view.filters.filter(
+												( f ) =>
+													f.field !== filter.field
+											),
+											{
+												field: filter.field,
+												operator: OPERATOR_IN,
+												value:
+													activeElement?.value ===
+													element.value
+														? undefined
+														: element.value,
+											},
+										],
+									} ) )
+								}
+							>
+								{ element.label }
+							</DropdownMenuCheckboxItem>
+						);
+					} ) }
+				</DropdownMenuGroup>
+				{ filter.operators.length > 1 && (
+					<DropdownSubMenu
+						trigger={
+							<DropdownSubMenuTrigger>
+								{ __( 'Settings' ) }
+							</DropdownSubMenuTrigger>
 						}
 					>
-						{ element.label }
-					</DropdownMenuCheckboxItem>
-				);
-			} ) }
-			<DropdownMenuSeparator />
-			<DropdownSubMenu
-				trigger={
-					<DropdownSubMenuTrigger>
-						{ __( 'Settings' ) }
-					</DropdownSubMenuTrigger>
-				}
-			>
-				<DropdownMenuCheckboxItem
-					key="in-filter"
-					value={ OPERATOR_IN }
-					checked={ filterInView?.operator === OPERATOR_IN }
-					onSelect={ () =>
-						onChangeView( ( currentView ) => ( {
-							...currentView,
-							page: 1,
-							filters: [
-								...view.filters.filter(
-									( f ) => f.field !== filter.field
-								),
-								{
-									field: filter.field,
-									operator: OPERATOR_IN,
-									value: filterInView?.value,
-								},
-							],
-						} ) )
-					}
-				>
-					{ __( 'Show matches' ) }
-				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem
-					key="not-in-filter"
-					value={ OPERATOR_NOT_IN }
-					checked={ filterInView?.operator === OPERATOR_NOT_IN }
-					onSelect={ () =>
-						onChangeView( ( currentView ) => ( {
-							...currentView,
-							page: 1,
-							filters: [
-								...view.filters.filter(
-									( f ) => f.field !== filter.field
-								),
-								{
-									field: filter.field,
-									operator: OPERATOR_NOT_IN,
-									value: filterInView?.value,
-								},
-							],
-						} ) )
-					}
-				>
-					{ __( 'Hide matches' ) }
-				</DropdownMenuCheckboxItem>
-			</DropdownSubMenu>
+						<DropdownMenuCheckboxItem
+							key="in-filter"
+							value={ OPERATOR_IN }
+							checked={ filterInView?.operator === OPERATOR_IN }
+							onSelect={ () =>
+								onChangeView( ( currentView ) => ( {
+									...currentView,
+									page: 1,
+									filters: [
+										...view.filters.filter(
+											( f ) => f.field !== filter.field
+										),
+										{
+											field: filter.field,
+											operator: OPERATOR_IN,
+											value: filterInView?.value,
+										},
+									],
+								} ) )
+							}
+						>
+							{ __( 'Show matches' ) }
+						</DropdownMenuCheckboxItem>
+						<DropdownMenuCheckboxItem
+							key="not-in-filter"
+							value={ OPERATOR_NOT_IN }
+							checked={
+								filterInView?.operator === OPERATOR_NOT_IN
+							}
+							onSelect={ () =>
+								onChangeView( ( currentView ) => ( {
+									...currentView,
+									page: 1,
+									filters: [
+										...view.filters.filter(
+											( f ) => f.field !== filter.field
+										),
+										{
+											field: filter.field,
+											operator: OPERATOR_NOT_IN,
+											value: filterInView?.value,
+										},
+									],
+								} ) )
+							}
+						>
+							{ __( 'Hide matches' ) }
+						</DropdownMenuCheckboxItem>
+					</DropdownSubMenu>
+				) }
+			</WithSeparators>
 		</DropdownMenu>
 	);
 }

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -19,6 +19,10 @@ export default function Filters( { fields, view, onChangeView } ) {
 					field: field.id,
 					name: field.header,
 					elements: field.elements || [],
+					operators: field.filterBy?.operators || [
+						OPERATOR_IN,
+						OPERATOR_NOT_IN,
+					],
 					isVisible: view.filters.some(
 						( f ) =>
 							f.field === field.id &&

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -4,7 +4,7 @@
 import FilterSummary from './filter-summary';
 import AddFilter from './add-filter';
 import ResetFilters from './reset-filters';
-import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
+import { ENUMERATION_TYPE, OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
 
 export default function Filters( { fields, view, onChangeView } ) {
 	const filters = [];
@@ -21,7 +21,10 @@ export default function Filters( { fields, view, onChangeView } ) {
 					elements: field.elements || [],
 					isVisible: view.filters.some(
 						( f ) =>
-							f.field === field.id && f.operator === OPERATOR_IN
+							f.field === field.id &&
+							[ OPERATOR_IN, OPERATOR_NOT_IN ].includes(
+								f.operator
+							)
 					),
 				} );
 		}

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -6,10 +6,25 @@ import AddFilter from './add-filter';
 import ResetFilters from './reset-filters';
 import { ENUMERATION_TYPE, OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
 
+const operatorsFromField = ( field ) => {
+	let operators = field.filterBy?.operators;
+	if ( ! operators || ! Array.isArray( operators ) ) {
+		operators = [ OPERATOR_IN, OPERATOR_NOT_IN ];
+	}
+	return operators.filter( ( operator ) =>
+		[ OPERATOR_IN, OPERATOR_NOT_IN ].includes( operator )
+	);
+};
+
 export default function Filters( { fields, view, onChangeView } ) {
 	const filters = [];
 	fields.forEach( ( field ) => {
 		if ( ! field.type ) {
+			return;
+		}
+
+		const operators = operatorsFromField( field );
+		if ( operators.length === 0 ) {
 			return;
 		}
 
@@ -19,10 +34,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 					field: field.id,
 					name: field.header,
 					elements: field.elements || [],
-					operators: field.filterBy?.operators || [
-						OPERATOR_IN,
-						OPERATOR_NOT_IN,
-					],
+					operators,
 					isVisible: view.filters.some(
 						( f ) =>
 							f.field === field.id &&

--- a/packages/dataviews/src/index.js
+++ b/packages/dataviews/src/index.js
@@ -6,4 +6,5 @@ export {
 	LAYOUT_LIST,
 	ENUMERATION_TYPE,
 	OPERATOR_IN,
+	OPERATOR_NOT_IN,
 } from './constants';

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -37,7 +37,7 @@ import { useMemo, Children, Fragment } from '@wordpress/element';
  */
 import { unlock } from './lock-unlock';
 import ItemActions from './item-actions';
-import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
+import { ENUMERATION_TYPE, OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -70,14 +70,48 @@ function HeaderMenu( { dataView, header } ) {
 	}
 	const sortedDirection = header.column.getIsSorted();
 
-	let filter;
+	let filter, filterInView;
+	const otherFilters = [];
 	if ( header.column.columnDef.type === ENUMERATION_TYPE ) {
-		filter = {
-			field: header.column.columnDef.id,
-			elements: header.column.columnDef.elements || [],
-		};
+		let columnOperators = header.column.columnDef.filterBy?.operators;
+		if ( ! columnOperators || ! Array.isArray( columnOperators ) ) {
+			columnOperators = [ OPERATOR_IN, OPERATOR_NOT_IN ];
+		}
+		const operators = columnOperators.filter( ( operator ) =>
+			[ OPERATOR_IN, OPERATOR_NOT_IN ].includes( operator )
+		);
+		if ( operators.length >= 0 ) {
+			filter = {
+				field: header.column.columnDef.id,
+				operators,
+				elements: header.column.columnDef.elements || [],
+			};
+			filterInView = {
+				field: filter.field,
+				operator: filter.operators[ 0 ],
+				value: undefined,
+			};
+		}
 	}
 	const isFilterable = !! filter;
+
+	if ( isFilterable ) {
+		const columnFilters = dataView.getState().columnFilters;
+		columnFilters.forEach( ( columnFilter ) => {
+			const [ field, operator ] =
+				Object.keys( columnFilter )[ 0 ].split( ':' );
+			const value = Object.values( columnFilter )[ 0 ];
+			if ( field === filter.field ) {
+				filterInView = {
+					field,
+					operator,
+					value,
+				};
+			} else {
+				otherFilters.push( columnFilter );
+			}
+		} );
+	}
 
 	return (
 		<DropdownMenu
@@ -156,68 +190,128 @@ function HeaderMenu( { dataView, header } ) {
 								</DropdownSubMenuTrigger>
 							}
 						>
-							{ filter.elements.map( ( element ) => {
-								let isActive = false;
-								const columnFilters =
-									dataView.getState().columnFilters;
-								const columnFilter = columnFilters.find(
-									( f ) =>
-										Object.keys( f )[ 0 ].split(
-											':'
-										)[ 0 ] === filter.field
-								);
-
-								if ( columnFilter ) {
-									const value =
-										Object.values( columnFilter )[ 0 ];
-									// Intentionally use loose comparison, so it does type conversion.
-									// This covers the case where a top-level filter for the same field converts a number into a string.
-									isActive = element.value == value; // eslint-disable-line eqeqeq
-								}
-
-								return (
-									<DropdownMenuItem
-										key={ element.value }
-										role="menuitemradio"
-										aria-checked={ isActive }
-										suffix={
-											isActive && <Icon icon={ check } />
+							<WithSeparators>
+								<DropdownMenuGroup>
+									{ filter.elements.map( ( element ) => {
+										let isActive = false;
+										if ( filterInView ) {
+											// Intentionally use loose comparison, so it does type conversion.
+											// This covers the case where a top-level filter for the same field converts a number into a string.
+											/* eslint-disable eqeqeq */
+											isActive =
+												element.value ==
+												filterInView.value;
+											/* eslint-enable eqeqeq */
 										}
-										onSelect={ () => {
-											const otherFilters =
-												columnFilters?.filter(
-													( f ) => {
-														const [
-															field,
-															operator,
-														] =
-															Object.keys(
-																f
-															)[ 0 ].split( ':' );
-														return (
-															field !==
-																filter.field ||
-															operator !==
-																OPERATOR_IN
-														);
-													}
-												);
 
-											dataView.setColumnFilters( [
-												...otherFilters,
-												{
-													[ filter.field + ':in' ]:
-														isActive
-															? undefined
-															: element.value,
-												},
-											] );
-										} }
+										return (
+											<DropdownMenuItem
+												key={ element.value }
+												role="menuitemradio"
+												aria-checked={ isActive }
+												prefix={
+													isActive && (
+														<Icon icon={ check } />
+													)
+												}
+												onSelect={ () => {
+													dataView.setColumnFilters( [
+														...otherFilters,
+														{
+															[ filter.field +
+															':' +
+															filterInView?.operator ]:
+																isActive
+																	? undefined
+																	: element.value,
+														},
+													] );
+												} }
+											>
+												{ element.label }
+											</DropdownMenuItem>
+										);
+									} ) }
+								</DropdownMenuGroup>
+								{ filter.operators.length > 1 && (
+									<DropdownSubMenu
+										trigger={
+											<DropdownSubMenuTrigger
+												suffix={
+													<>
+														{ filterInView.operator ===
+														OPERATOR_IN
+															? __( 'Is' )
+															: __( 'Is not' ) }
+														<Icon
+															icon={
+																chevronRightSmall
+															}
+														/>{ ' ' }
+													</>
+												}
+											>
+												{ __( 'Conditions' ) }
+											</DropdownSubMenuTrigger>
+										}
 									>
-										{ element.label }
-									</DropdownMenuItem>
-								);
-							} ) }
+										<DropdownMenuItem
+											key="in-filter"
+											role="menuitemradio"
+											aria-checked={
+												filterInView?.operator ===
+												OPERATOR_IN
+											}
+											prefix={
+												filterInView?.operator ===
+													OPERATOR_IN && (
+													<Icon icon={ check } />
+												)
+											}
+											onSelect={ () =>
+												dataView.setColumnFilters( [
+													...otherFilters,
+													{
+														[ filter.field +
+														':' +
+														OPERATOR_IN ]:
+															filterInView?.value,
+													},
+												] )
+											}
+										>
+											{ __( 'Is' ) }
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											key="not-in-filter"
+											role="menuitemradio"
+											aria-checked={
+												filterInView?.operator ===
+												OPERATOR_NOT_IN
+											}
+											prefix={
+												filterInView?.operator ===
+													OPERATOR_NOT_IN && (
+													<Icon icon={ check } />
+												)
+											}
+											onSelect={ () =>
+												dataView.setColumnFilters( [
+													...otherFilters,
+													{
+														[ filter.field +
+														':' +
+														OPERATOR_NOT_IN ]:
+															filterInView?.value,
+													},
+												] )
+											}
+										>
+											{ __( 'Is not' ) }
+										</DropdownMenuItem>
+									</DropdownSubMenu>
+								) }
+							</WithSeparators>
 						</DropdownSubMenu>
 					</DropdownMenuGroup>
 				) }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -265,6 +265,9 @@ export default function PagePages() {
 				type: ENUMERATION_TYPE,
 				elements: STATUSES,
 				enableSorting: false,
+				filterBy: {
+					operators: [ OPERATOR_IN ],
+				},
 			},
 			{
 				header: __( 'Date' ),

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -26,6 +26,15 @@ import {
  */
 import Page from '../page';
 import Link from '../routes/link';
+import {
+	DataViews,
+	VIEW_LAYOUTS,
+	ENUMERATION_TYPE,
+	LAYOUT_GRID,
+	LAYOUT_TABLE,
+	OPERATOR_IN,
+	OPERATOR_NOT_IN,
+} from '../dataviews';
 import { default as DEFAULT_VIEWS } from '../sidebar-dataviews/default-views';
 import {
 	trashPostAction,
@@ -139,6 +148,11 @@ export default function PagePages() {
 				filter.operator === OPERATOR_IN
 			) {
 				filters.author = filter.value;
+			} else if (
+				filter.field === 'author' &&
+				filter.operator === OPERATOR_NOT_IN
+			) {
+				filters.author_exclude = filter.value;
 			}
 		} );
 		// We want to provide a different default item for the status filter

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -15,10 +15,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	DataViews,
 	ENUMERATION_TYPE,
-	VIEW_LAYOUTS,
-	OPERATOR_IN,
 	LAYOUT_GRID,
 	LAYOUT_TABLE,
+	OPERATOR_IN,
+	OPERATOR_NOT_IN,
+	VIEW_LAYOUTS,
 } from '@wordpress/dataviews';
 
 /**
@@ -26,15 +27,6 @@ import {
  */
 import Page from '../page';
 import Link from '../routes/link';
-import {
-	DataViews,
-	VIEW_LAYOUTS,
-	ENUMERATION_TYPE,
-	LAYOUT_GRID,
-	LAYOUT_TABLE,
-	OPERATOR_IN,
-	OPERATOR_NOT_IN,
-} from '../dataviews';
 import { default as DEFAULT_VIEWS } from '../sidebar-dataviews/default-views';
 import {
 	trashPostAction,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related to https://github.com/WordPress/gutenberg/issues/55100

## What?

Adds support for `NOT IN` operator in the `Author` filter while leaving `Status` as it is (only supports `IN` operator).

https://github.com/WordPress/gutenberg/assets/583546/6e022bd5-b725-4423-8fe9-37dc0c8385a1

## Why?

It's part of the interactions we want to achieve.

## How?

- Fields API:
  - by default, any field of `type: ENUMERATION` gets the filter with both operator (`IN`, and `NOT IN`).
  - this can be configurable by providing the specific ones in the `filterBy.operators` property (see how the `Author` field uses it to only enable the `IN` operator).
- Filter component: add support for both operators.

## Testing Instructions

- Enable the "admin views" Gutenberg experiment and visit "Appearance > Editor > Pages > Manage all pages".
- Interact with the filters.
