### PR TITLE
Update preferences organization

### DIFF
--- a/packages/e2e-test-utils/src/disable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/disable-pre-publish-checks.js
@@ -10,7 +10,7 @@ import { toggleMoreMenu } from './toggle-more-menu';
 export async function disablePrePublishChecks() {
 	await togglePreferencesOption(
 		'General',
-		'Include pre-publish checklist',
+		'Enable pre-publish flow',
 		false
 	);
 	await toggleMoreMenu( 'close' );

--- a/packages/e2e-test-utils/src/enable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/enable-pre-publish-checks.js
@@ -8,10 +8,6 @@ import { toggleMoreMenu } from './toggle-more-menu';
  * Enables Pre-publish checks.
  */
 export async function enablePrePublishChecks() {
-	await togglePreferencesOption(
-		'General',
-		'Include pre-publish checklist',
-		true
-	);
+	await togglePreferencesOption( 'General', 'Enable pre-publish flow', true );
 	await toggleMoreMenu( 'close' );
 }

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { useDispatch, useRegistry } from '@wordpress/data';
 import { MenuGroup } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
@@ -10,7 +10,6 @@ import {
 	PreferenceToggleMenuItem,
 	store as preferencesStore,
 } from '@wordpress/preferences';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -19,11 +18,6 @@ import { store as postEditorStore } from '../../../store';
 
 function WritingMenu() {
 	const registry = useRegistry();
-	const isDistractionFree = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().isDistractionFree,
-		[]
-	);
 
 	const { setIsInserterOpened, setIsListViewOpened, closeGeneralSidebar } =
 		useDispatch( postEditorStore );
@@ -38,6 +32,10 @@ function WritingMenu() {
 		} );
 	};
 
+	const turnOffDistractionFree = () => {
+		setPreference( 'core/edit-post', 'distractionFree', false );
+	};
+
 	const isLargeViewport = useViewportMatch( 'medium' );
 	if ( ! isLargeViewport ) {
 		return null;
@@ -47,14 +45,24 @@ function WritingMenu() {
 		<MenuGroup label={ _x( 'View', 'noun' ) }>
 			<PreferenceToggleMenuItem
 				scope="core/edit-post"
-				disabled={ isDistractionFree }
 				name="fixedToolbar"
+				onToggle={ turnOffDistractionFree }
 				label={ __( 'Top toolbar' ) }
 				info={ __(
 					'Access all block and document tools in a single place'
 				) }
 				messageActivated={ __( 'Top toolbar activated' ) }
 				messageDeactivated={ __( 'Top toolbar deactivated' ) }
+			/>
+			<PreferenceToggleMenuItem
+				scope="core/edit-post"
+				name="distractionFree"
+				onToggle={ toggleDistractionFree }
+				label={ __( 'Distraction free' ) }
+				info={ __( 'Write with calmness' ) }
+				messageActivated={ __( 'Distraction free mode activated' ) }
+				messageDeactivated={ __( 'Distraction free mode deactivated' ) }
+				shortcut={ displayShortcut.primaryShift( '\\' ) }
 			/>
 			<PreferenceToggleMenuItem
 				scope="core/edit-post"
@@ -72,16 +80,6 @@ function WritingMenu() {
 				messageActivated={ __( 'Fullscreen mode activated' ) }
 				messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
 				shortcut={ displayShortcut.secondary( 'f' ) }
-			/>
-			<PreferenceToggleMenuItem
-				scope="core/edit-post"
-				name="distractionFree"
-				onToggle={ toggleDistractionFree }
-				label={ __( 'Distraction free' ) }
-				info={ __( 'Write with calmness' ) }
-				messageActivated={ __( 'Distraction free mode activated' ) }
-				messageDeactivated={ __( 'Distraction free mode deactivated' ) }
-				shortcut={ displayShortcut.primaryShift( '\\' ) }
 			/>
 		</MenuGroup>
 	);

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -170,6 +170,13 @@ export default function EditPostPreferencesModal() {
 						) }
 					>
 						<EnableFeature
+							featureName="fixedToolbar"
+							help={ __(
+								'Access all block and document tools in a single place.'
+							) }
+							label={ __( 'Top toolbar' ) }
+						/>
+						<EnableFeature
 							featureName="distractionFree"
 							onToggle={ toggleDistractionFree }
 							help={ __(

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -182,7 +182,7 @@ export default function EditPostPreferencesModal() {
 							help={ __(
 								'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
 							) }
-							label={ __( 'Enable Distraction-Free' ) }
+							label={ __( 'Distraction free' ) }
 						/>
 						<EnableFeature
 							featureName="focusMode"

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -86,49 +86,16 @@ export default function EditPostPreferencesModal() {
 						{ isLargeViewport && (
 							<PreferencesModalSection
 								title={ __( 'Publishing' ) }
-								description={ __(
-									'Change options related to publishing.'
-								) }
 							>
 								<EnablePublishSidebarOption
 									help={ __(
 										'Review settings, such as visibility and tags.'
 									) }
-									label={ __(
-										'Include pre-publish checklist'
-									) }
+									label={ __( 'Enable pre-publish flow' ) }
 								/>
 							</PreferencesModalSection>
 						) }
-
-						<PreferencesModalSection
-							title={ __( 'Appearance' ) }
-							description={ __(
-								'Customize options related to the block editor interface and editing flow.'
-							) }
-						>
-							<EnableFeature
-								featureName="distractionFree"
-								onToggle={ toggleDistractionFree }
-								help={ __(
-									'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
-								) }
-								label={ __( 'Distraction free' ) }
-							/>
-							<EnableFeature
-								featureName="focusMode"
-								help={ __(
-									'Highlights the current block and fades other content.'
-								) }
-								label={ __( 'Spotlight mode' ) }
-							/>
-							<EnableFeature
-								featureName="showIconLabels"
-								label={ __( 'Show button text labels' ) }
-								help={ __(
-									'Show text instead of icons on buttons.'
-								) }
-							/>
+						<PreferencesModalSection title={ __( 'Interface' ) }>
 							<EnableFeature
 								featureName="showListViewByDefault"
 								help={ __(
@@ -136,74 +103,20 @@ export default function EditPostPreferencesModal() {
 								) }
 								label={ __( 'Always open list view' ) }
 							/>
-							<EnableFeature
-								featureName="themeStyles"
-								help={ __(
-									'Make the editor look like your theme.'
-								) }
-								label={ __( 'Use theme styles' ) }
-							/>
 							{ showBlockBreadcrumbsOption && (
 								<EnableFeature
 									featureName="showBlockBreadcrumbs"
 									help={ __(
 										'Shows block breadcrumbs at the bottom of the editor.'
 									) }
-									label={ __( 'Display block breadcrumbs' ) }
+									label={ __( 'Show block breadcrumbs' ) }
 								/>
 							) }
 						</PreferencesModalSection>
-					</>
-				),
-			},
-			{
-				name: 'blocks',
-				tabLabel: __( 'Blocks' ),
-				content: (
-					<>
-						<PreferencesModalSection
-							title={ __( 'Block interactions' ) }
-							description={ __(
-								'Customize how you interact with blocks in the block library and editing canvas.'
-							) }
-						>
-							<EnableFeature
-								featureName="mostUsedBlocks"
-								help={ __(
-									'Places the most frequent blocks in the block library.'
-								) }
-								label={ __( 'Show most used blocks' ) }
-							/>
-							<EnableFeature
-								featureName="keepCaretInsideBlock"
-								help={ __(
-									'Aids screen readers by stopping text caret from leaving blocks.'
-								) }
-								label={ __(
-									'Contain text cursor inside block'
-								) }
-							/>
-						</PreferencesModalSection>
-						<PreferencesModalSection
-							title={ __( 'Visible blocks' ) }
-							description={ __(
-								"Disable blocks that you don't want to appear in the inserter. They can always be toggled back on later."
-							) }
-						>
-							<BlockManager />
-						</PreferencesModalSection>
-					</>
-				),
-			},
-			{
-				name: 'panels',
-				tabLabel: __( 'Panels' ),
-				content: (
-					<>
 						<PreferencesModalSection
 							title={ __( 'Document settings' ) }
 							description={ __(
-								'Choose what displays in the panel.'
+								'Select what settings are shown in the document panel.'
 							) }
 						>
 							<EnablePluginDocumentSettingPanelOption.Slot />
@@ -242,12 +155,100 @@ export default function EditPostPreferencesModal() {
 								/>
 							</PageAttributesCheck>
 						</PreferencesModalSection>
-						<MetaBoxesSection
-							title={ __( 'Additional' ) }
-							description={ __(
-								'Add extra areas to the editor.'
+						<MetaBoxesSection title={ __( 'Advanced' ) } />
+					</>
+				),
+			},
+			{
+				name: 'appearance',
+				tabLabel: __( 'Appearance' ),
+				content: (
+					<PreferencesModalSection
+						title={ __( 'Appearance' ) }
+						description={ __(
+							'Customize the editor interface to suit your needs.'
+						) }
+					>
+						<EnableFeature
+							featureName="distractionFree"
+							onToggle={ toggleDistractionFree }
+							help={ __(
+								'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
 							) }
+							label={ __( 'Enable Distraction-Free' ) }
 						/>
+						<EnableFeature
+							featureName="focusMode"
+							help={ __(
+								'Highlights the current block and fades other content.'
+							) }
+							label={ __( 'Spotlight mode' ) }
+						/>
+						<EnableFeature
+							featureName="themeStyles"
+							help={ __(
+								'Make the editor look like your theme.'
+							) }
+							label={ __( 'Use theme styles' ) }
+						/>
+					</PreferencesModalSection>
+				),
+			},
+			{
+				name: 'accessibility',
+				tabLabel: __( 'Accessibility' ),
+				content: (
+					<>
+						<PreferencesModalSection
+							title={ __( 'Navigation' ) }
+							description={ __(
+								'Optimize the editing experience for enhanced control.'
+							) }
+						>
+							<EnableFeature
+								featureName="keepCaretInsideBlock"
+								help={ __(
+									'Keeps the text cursor within the block boundaries, aiding users with screen readers by preventing unintentional cursor movement outside the block.'
+								) }
+								label={ __(
+									'Contain text cursor inside block'
+								) }
+							/>
+						</PreferencesModalSection>
+						<PreferencesModalSection title={ __( 'Interface' ) }>
+							<EnableFeature
+								featureName="showIconLabels"
+								label={ __( 'Show button text labels' ) }
+								help={ __(
+									'Show text instead of icons on buttons across the interface.'
+								) }
+							/>
+						</PreferencesModalSection>
+					</>
+				),
+			},
+			{
+				name: 'blocks',
+				tabLabel: __( 'Blocks' ),
+				content: (
+					<>
+						<PreferencesModalSection title={ __( 'Inserter' ) }>
+							<EnableFeature
+								featureName="mostUsedBlocks"
+								help={ __(
+									'Adds a category with the most frequently used blocks in the inserter.'
+								) }
+								label={ __( 'Show most used blocks' ) }
+							/>
+						</PreferencesModalSection>
+						<PreferencesModalSection
+							title={ __( 'Manage block visibility' ) }
+							description={ __(
+								"Disable blocks that you don't want to appear in the inserter. They can always be toggled back on later."
+							) }
+						>
+							<BlockManager />
+						</PreferencesModalSection>
 					</>
 				),
 			},

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -107,7 +107,7 @@ export default function EditPostPreferencesModal() {
 								<EnableFeature
 									featureName="showBlockBreadcrumbs"
 									help={ __(
-										'Shows block breadcrumbs at the bottom of the editor.'
+										'Display the block hierarchy trail at the bottom of the editor.'
 									) }
 									label={ __( 'Show block breadcrumbs' ) }
 								/>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -76,6 +76,10 @@ export default function EditPostPreferencesModal() {
 		closeGeneralSidebar();
 	};
 
+	const turnOffDistractionFree = () => {
+		setPreference( 'core/edit-post', 'distractionFree', false );
+	};
+
 	const sections = useMemo(
 		() => [
 			{
@@ -171,6 +175,7 @@ export default function EditPostPreferencesModal() {
 					>
 						<EnableFeature
 							featureName="fixedToolbar"
+							onToggle={ turnOffDistractionFree }
 							help={ __(
 								'Access all block and document tools in a single place.'
 							) }

--- a/packages/edit-post/src/components/preferences-modal/test/index.js
+++ b/packages/edit-post/src/components/preferences-modal/test/index.js
@@ -32,9 +32,7 @@ describe( 'EditPostPreferencesModal', () => {
 			} );
 
 			expect(
-				within( tabPanel ).getByLabelText(
-					'Include pre-publish checklist'
-				)
+				within( tabPanel ).getByLabelText( 'Enable pre-publish flow' )
 			).toBeInTheDocument();
 		} );
 		it( 'small viewports', async () => {
@@ -55,9 +53,7 @@ describe( 'EditPostPreferencesModal', () => {
 
 			// Checkbox toggle controls are not rendered in small viewports.
 			expect(
-				within( dialog ).queryByLabelText(
-					'Include pre-publish checklist'
-				)
+				within( dialog ).queryByLabelText( 'Enable pre-publish flow' )
 			).not.toBeInTheDocument();
 
 			// Individual preference nav buttons are rendered in small viewports.

--- a/packages/edit-post/src/components/preferences-modal/test/index.js
+++ b/packages/edit-post/src/components/preferences-modal/test/index.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -19,52 +18,6 @@ jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 jest.mock( '@wordpress/compose/src/hooks/use-viewport-match', () => jest.fn() );
 
 describe( 'EditPostPreferencesModal', () => {
-	describe( 'should match snapshot when the modal is active', () => {
-		afterEach( () => {
-			useViewportMatch.mockClear();
-		} );
-		it( 'large viewports', async () => {
-			useSelect.mockImplementation( () => [ true, true, false ] );
-			useViewportMatch.mockImplementation( () => true );
-			render( <EditPostPreferencesModal /> );
-			const tabPanel = await screen.findByRole( 'tabpanel', {
-				name: 'General',
-			} );
-
-			expect(
-				within( tabPanel ).getByLabelText( 'Enable pre-publish flow' )
-			).toBeInTheDocument();
-		} );
-		it( 'small viewports', async () => {
-			useSelect.mockImplementation( () => [ true, true, false ] );
-			useViewportMatch.mockImplementation( () => false );
-			render( <EditPostPreferencesModal /> );
-
-			// The tabpanel is not rendered in small viewports.
-			expect(
-				screen.queryByRole( 'tabpanel', {
-					name: 'General',
-				} )
-			).not.toBeInTheDocument();
-
-			const dialog = screen.getByRole( 'dialog', {
-				name: 'Preferences',
-			} );
-
-			// Checkbox toggle controls are not rendered in small viewports.
-			expect(
-				within( dialog ).queryByLabelText( 'Enable pre-publish flow' )
-			).not.toBeInTheDocument();
-
-			// Individual preference nav buttons are rendered in small viewports.
-			expect(
-				within( dialog ).getByRole( 'button', {
-					name: 'General',
-				} )
-			).toBeInTheDocument();
-		} );
-	} );
-
 	it( 'should not render when the modal is not active', () => {
 		useSelect.mockImplementation( () => [ false, false, false ] );
 		render( <EditPostPreferencesModal /> );

--- a/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { useDispatch, useRegistry } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
 import { external } from '@wordpress/icons';
 import { MenuGroup, MenuItem, VisuallyHidden } from '@wordpress/components';
@@ -36,14 +36,6 @@ import { store as siteEditorStore } from '../../../store';
 
 export default function MoreMenu( { showIconLabels } ) {
 	const registry = useRegistry();
-	const isDistractionFree = useSelect(
-		( select ) =>
-			select( preferencesStore ).get(
-				'core/edit-site',
-				'distractionFree'
-			),
-		[]
-	);
 
 	const { setIsInserterOpened, setIsListViewOpened, closeGeneralSidebar } =
 		useDispatch( siteEditorStore );
@@ -57,6 +49,10 @@ export default function MoreMenu( { showIconLabels } ) {
 			setIsListViewOpened( false );
 			closeGeneralSidebar();
 		} );
+	};
+
+	const turnOffDistractionFree = () => {
+		setPreference( 'core/edit-site', 'distractionFree', false );
 	};
 
 	return (
@@ -73,7 +69,7 @@ export default function MoreMenu( { showIconLabels } ) {
 							<PreferenceToggleMenuItem
 								scope="core/edit-site"
 								name="fixedToolbar"
-								disabled={ isDistractionFree }
+								onToggle={ turnOffDistractionFree }
 								label={ __( 'Top toolbar' ) }
 								info={ __(
 									'Access all block and document tools in a single place'
@@ -83,18 +79,6 @@ export default function MoreMenu( { showIconLabels } ) {
 								) }
 								messageDeactivated={ __(
 									'Top toolbar deactivated'
-								) }
-							/>
-							<PreferenceToggleMenuItem
-								scope="core/edit-site"
-								name="focusMode"
-								label={ __( 'Spotlight mode' ) }
-								info={ __( 'Focus on one block at a time' ) }
-								messageActivated={ __(
-									'Spotlight mode activated'
-								) }
-								messageDeactivated={ __(
-									'Spotlight mode deactivated'
 								) }
 							/>
 							<PreferenceToggleMenuItem
@@ -111,6 +95,18 @@ export default function MoreMenu( { showIconLabels } ) {
 								) }
 								shortcut={ displayShortcut.primaryShift(
 									'\\'
+								) }
+							/>
+							<PreferenceToggleMenuItem
+								scope="core/edit-site"
+								name="focusMode"
+								label={ __( 'Spotlight mode' ) }
+								info={ __( 'Focus on one block at a time' ) }
+								messageActivated={ __(
+									'Spotlight mode activated'
+								) }
+								messageDeactivated={ __(
+									'Spotlight mode deactivated'
 								) }
 							/>
 						</MenuGroup>

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -46,32 +46,7 @@ export default function EditSitePreferencesModal() {
 			name: 'general',
 			tabLabel: __( 'General' ),
 			content: (
-				<PreferencesModalSection
-					title={ __( 'Appearance' ) }
-					description={ __(
-						'Customize options related to the block editor interface and editing flow.'
-					) }
-				>
-					<EnableFeature
-						featureName="distractionFree"
-						onToggle={ toggleDistractionFree }
-						help={ __(
-							'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
-						) }
-						label={ __( 'Distraction free' ) }
-					/>
-					<EnableFeature
-						featureName="focusMode"
-						help={ __(
-							'Highlights the current block and fades other content.'
-						) }
-						label={ __( 'Spotlight mode' ) }
-					/>
-					<EnableFeature
-						featureName="showIconLabels"
-						label={ __( 'Show button text labels' ) }
-						help={ __( 'Show text instead of icons on buttons.' ) }
-					/>
+				<PreferencesModalSection title={ __( 'Interface' ) }>
 					<EnableFeature
 						featureName="showListViewByDefault"
 						help={ __(
@@ -90,23 +65,76 @@ export default function EditSitePreferencesModal() {
 			),
 		},
 		{
-			name: 'blocks',
-			tabLabel: __( 'Blocks' ),
+			name: 'appearance',
+			tabLabel: __( 'Appearance' ),
 			content: (
 				<PreferencesModalSection
-					title={ __( 'Block interactions' ) }
+					title={ __( 'Appearance' ) }
 					description={ __(
-						'Customize how you interact with blocks in the block library and editing canvas.'
+						'Customize the editor interface to suit your needs.'
 					) }
 				>
 					<EnableFeature
-						featureName="keepCaretInsideBlock"
+						featureName="fixedToolbar"
 						help={ __(
-							'Aids screen readers by stopping text caret from leaving blocks.'
+							'Access all block and document tools in a single place.'
 						) }
-						label={ __( 'Contain text cursor inside block' ) }
+						label={ __( 'Top toolbar' ) }
+					/>
+					<EnableFeature
+						featureName="distractionFree"
+						onToggle={ toggleDistractionFree }
+						help={ __(
+							'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
+						) }
+						label={ __( 'Distraction free' ) }
+					/>
+					<EnableFeature
+						featureName="focusMode"
+						help={ __(
+							'Highlights the current block and fades other content.'
+						) }
+						label={ __( 'Spotlight mode' ) }
+					/>
+					<EnableFeature
+						featureName="showBlockBreadcrumbs"
+						help={ __(
+							'Shows block breadcrumbs at the bottom of the editor.'
+						) }
+						label={ __( 'Display block breadcrumbs' ) }
 					/>
 				</PreferencesModalSection>
+			),
+		},
+		{
+			name: 'accessibility',
+			tabLabel: __( 'Accessibility' ),
+			content: (
+				<>
+					<PreferencesModalSection
+						title={ __( 'Navigation' ) }
+						description={ __(
+							'Optimize the editing experience for enhanced control.'
+						) }
+					>
+						<EnableFeature
+							featureName="keepCaretInsideBlock"
+							help={ __(
+								'Keeps the text cursor within the block boundaries, aiding users with screen readers by preventing unintentional cursor movement outside the block.'
+							) }
+							label={ __( 'Contain text cursor inside block' ) }
+						/>
+					</PreferencesModalSection>
+					<PreferencesModalSection title={ __( 'Interface' ) }>
+						<EnableFeature
+							featureName="showIconLabels"
+							label={ __( 'Show button text labels' ) }
+							help={ __(
+								'Show text instead of icons on buttons across the interface.'
+							) }
+						/>
+					</PreferencesModalSection>
+				</>
 			),
 		},
 	] );

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -41,6 +41,10 @@ export default function EditSitePreferencesModal() {
 		} );
 	};
 
+	const turnOffDistractionFree = () => {
+		setPreference( 'core/edit-site', 'distractionFree', false );
+	};
+
 	const sections = useMemo( () => [
 		{
 			name: 'general',
@@ -76,6 +80,7 @@ export default function EditSitePreferencesModal() {
 				>
 					<EnableFeature
 						featureName="fixedToolbar"
+						onToggle={ turnOffDistractionFree }
 						help={ __(
 							'Access all block and document tools in a single place.'
 						) }
@@ -95,13 +100,6 @@ export default function EditSitePreferencesModal() {
 							'Highlights the current block and fades other content.'
 						) }
 						label={ __( 'Spotlight mode' ) }
-					/>
-					<EnableFeature
-						featureName="showBlockBreadcrumbs"
-						help={ __(
-							'Shows block breadcrumbs at the bottom of the editor.'
-						) }
-						label={ __( 'Display block breadcrumbs' ) }
 					/>
 				</PreferencesModalSection>
 			),

--- a/packages/interface/src/components/preferences-modal/README.md
+++ b/packages/interface/src/components/preferences-modal/README.md
@@ -28,11 +28,11 @@ function MyEditorPreferencesModal() {
 									'Review settings, such as visibility and tags.'
 								) }
 								label={ __(
-									'Include pre-publish checklist'
+									'Enable pre-publish flow'
 								) }
 							/>
 						</PreferencesModalSection>
-					) 
+					)
 
 		}
 		{
@@ -47,7 +47,7 @@ function MyEditorPreferencesModal() {
 						>
 							// Section content here
 						</PreferencesModalSection>
-					) 
+					)
 
 		}
 	]

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -148,9 +148,6 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		const blocksTab = preferencesModal.locator(
 			'role=tab[name="Blocks"i]'
 		);
-		const panelsTab = preferencesModal.locator(
-			'role=tab[name="Panels"i]'
-		);
 
 		// Check initial focus is on the modal dialog container.
 		await expect( preferencesModal ).toBeFocused();
@@ -200,14 +197,6 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 			'qwerty'
 		);
 		await clickAndFocusTab( blocksTab );
-		await pageUtils.pressKeys( 'Shift+Tab' );
-		await expect( closeButton ).toBeFocused();
-		await pageUtils.pressKeys( 'Shift+Tab' );
-		await expect( preferencesModalContent ).not.toBeFocused();
-
-		// The Panels tab panel content is short and not scrollable.
-		// Check it's not focusable.
-		await clickAndFocusTab( panelsTab );
 		await pageUtils.pressKeys( 'Shift+Tab' );
 		await expect( closeButton ).toBeFocused();
 		await pageUtils.pressKeys( 'Shift+Tab' );

--- a/test/e2e/specs/editor/various/pref-modal.spec.js
+++ b/test/e2e/specs/editor/various/pref-modal.spec.js
@@ -16,23 +16,14 @@ test.describe( 'Preferences modal', () => {
 		test( 'Enable pre-publish flow is visible on desktop ', async ( {
 			page,
 		} ) => {
-			const optionsButton = page
-				.getByRole( 'region', { name: 'Editor top bar' } )
-				.getByRole( 'buton', {
-					name: 'Options',
-				} );
+			await page.click(
+				'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
+			);
+			await page.click( 'role=menuitem[name="Preferences"i]' );
 
-			await optionsButton.click();
-
-			const preferencesButton = page.getByRole( 'menuitem', {
-				name: 'Preferences',
-			} );
-
-			await preferencesButton.click();
-
-			const prePublishToggle = page.getByRole( 'label', {
-				name: 'Enable pre-publish flow',
-			} );
+			const prePublishToggle = page.locator(
+				'role=label[name="Enable pre-publish flow"i]'
+			);
 
 			await expect( prePublishToggle ).toBeVisible();
 		} );

--- a/test/e2e/specs/editor/various/pref-modal.spec.js
+++ b/test/e2e/specs/editor/various/pref-modal.spec.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Preferences modal', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { admin } ) => {
+		await admin.trashPost();
+	} );
+
+	test.describe( 'Preferences modal adaps to viewport', () => {
+		test( 'Enable pre-publish flow is visible on desktop ', async ( {
+			page,
+		} ) => {
+			const optionsButton = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'buton', {
+					name: 'Options',
+				} );
+
+			await optionsButton.click();
+
+			const preferencesButton = page.getByRole( 'menuitem', {
+				name: 'Preferences',
+			} );
+
+			await preferencesButton.click();
+
+			const prePublishToggle = page.getByRole( 'label', {
+				name: 'Enable pre-publish flow',
+			} );
+
+			await expect( prePublishToggle ).toBeVisible();
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/various/pref-modal.spec.js
+++ b/test/e2e/specs/editor/various/pref-modal.spec.js
@@ -8,10 +8,6 @@ test.describe( 'Preferences modal', () => {
 		await admin.createNewPost();
 	} );
 
-	test.afterEach( async ( { admin } ) => {
-		await admin.trashPost();
-	} );
-
 	test.describe( 'Preferences modal adaps to viewport', () => {
 		test( 'Enable pre-publish flow is visible on desktop ', async ( {
 			page,
@@ -22,10 +18,38 @@ test.describe( 'Preferences modal', () => {
 			await page.click( 'role=menuitem[name="Preferences"i]' );
 
 			const prePublishToggle = page.locator(
-				'role=label[name="Enable pre-publish flow"i]'
+				'role=checkbox[name="Enable pre-publish flow"i]'
 			);
 
 			await expect( prePublishToggle ).toBeVisible();
+		} );
+	} );
+	test.describe( 'Preferences modal adaps to viewport', () => {
+		test( 'Enable pre-publish flow is not visible on mobile ', async ( {
+			page,
+		} ) => {
+			await page.setViewportSize( { width: 500, height: 800 } );
+
+			await page.click(
+				'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
+			);
+			await page.click( 'role=menuitem[name="Preferences"i]' );
+
+			const generalButton = page.locator(
+				'role=button[name="General"i]'
+			);
+
+			const generalTabPanel = page.locator(
+				'role=tabPanel[name="General"i]'
+			);
+
+			const prePublishToggle = page.locator(
+				'role=checkbox[name="Enable pre-publish flow"i]'
+			);
+
+			await expect( generalButton ).toBeVisible();
+			await expect( generalTabPanel ).toBeHidden();
+			await expect( prePublishToggle ).toBeHidden();
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -335,9 +335,9 @@ class PreviewUtils {
 		);
 		await this.page.click( 'role=menuitem[name="Preferences"i]' );
 
-		// Navigate to panels section.
+		// Navigate to general section.
 		await this.page.click(
-			'role=dialog[name="Preferences"i] >> role=tab[name="Panels"i]'
+			'role=dialog[name="Preferences"i] >> role=tab[name="General"i]'
 		);
 
 		// Find custom fields checkbox.


### PR DESCRIPTION
Closes #56510.

<img width="1040" alt="image" src="https://github.com/WordPress/gutenberg/assets/548849/692e4169-17c6-4310-8f29-418dc7b5cb56">

This seeks to improve the organization of the preferences modal.

- Introduces "Appearance" and "Accessibility" panels.
- Updates some inner sections.
- Improves copy for clarity, consistency, and removes some redundancy in text descriptions.
- Adds "top toolbar" as a setting (was missing before).