### PR TITLE
Simplify dataviews view button

### DIFF
--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -285,7 +285,7 @@ export default function ViewActions( {
 } ) {
 	return (
 		<DropdownMenuV2
-			label={ __( 'Actions' ) }
+			label={ __( 'View options' ) }
 			trigger={
 				<Button
 					variant="tertiary"
@@ -293,9 +293,8 @@ export default function ViewActions( {
 					icon={
 						VIEW_TYPE_ICONS[ view.type ] || VIEW_TYPE_ICONS.list
 					}
-				>
-					{ __( 'View' ) }
-				</Button>
+					label={ __( 'View options' ) }
+				/>
 			}
 		>
 			<DropdownMenuGroupV2>

--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -285,7 +285,6 @@ export default function ViewActions( {
 } ) {
 	return (
 		<DropdownMenuV2
-			label={ __( 'View options' ) }
 			trigger={
 				<Button
 					variant="tertiary"


### PR DESCRIPTION
## What?
Simplify the 'View' button in dataviews.

## Why?
Simplification of a generally noisy / complex UI.

## Testing Instructions
1. Enable the data views Gutenberg experiment
2. Go to "Manage all pages" in the site editor
3. Observe the updated button

<img width="1291" alt="Screenshot 2023-11-23 at 16 59 50" src="https://github.com/WordPress/gutenberg/assets/846565/8b151246-2f7f-4f15-a482-ccb79a339646">

