### PR TITLE
Fix and improve logic in WP_Fonts_Resolver::get_settings()

### DIFF
--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -221,7 +221,13 @@ class WP_Fonts_Resolver {
 		}
 
 		// Make sure there are no duplicate values with different names (array keys).
-		$settings['typography']['fontFamilies']['theme'] = array_unique( $settings['typography']['fontFamilies']['theme'], SORT_REGULAR );
+		if ( ! empty( $settings['typography']['fontFamilies']['theme'] ) ) {
+			$settings['typography']['fontFamilies']['theme'] = array_unique(
+				$settings['typography']['fontFamilies']['theme'],
+				SORT_REGULAR
+			);
+		}
+
 
 		return $settings;
 	}

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -228,7 +228,6 @@ class WP_Fonts_Resolver {
 			);
 		}
 
-
 		return $settings;
 	}
 

--- a/lib/experimental/fonts-api/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts-api/class-wp-fonts-resolver.php
@@ -191,8 +191,11 @@ class WP_Fonts_Resolver {
 
 		foreach ( $variations as $variation ) {
 
-			// Skip if settings.typography.fontFamilies are not defined in the variation.
-			if ( empty( $variation['settings']['typography']['fontFamilies'] ) ) {
+			// Skip if settings.typography.fontFamilies.theme is not defined or is not an array.
+			if (
+				! isset( $variation['settings']['typography']['fontFamilies']['theme'] ) ||
+				! is_array( $variation['settings']['typography']['fontFamilies']['theme'] )
+			) {
 				continue;
 			}
 
@@ -200,27 +203,25 @@ class WP_Fonts_Resolver {
 			if ( $set_theme_structure ) {
 				$set_theme_structure = false;
 				$settings            = static::set_tyopgraphy_settings_array_structure( $settings );
+
+				// Font families from settings must be an array.
+				if (
+					! isset( $settings['typography']['fontFamilies']['theme'] ) ||
+					! is_array( $settings['typography']['fontFamilies']['theme'] )
+				) {
+					$settings['typography']['fontFamilies']['theme'] = array();
+				}
 			}
 
-			// Initialize the font families from variation if set and is an array, otherwise default to an empty array.
-			$variation_font_families = ( isset( $variation['settings']['typography']['fontFamilies']['theme'] ) && is_array( $variation['settings']['typography']['fontFamilies']['theme'] ) )
-				? $variation['settings']['typography']['fontFamilies']['theme']
-				: array();
-
-			// Merge the variation settings with the global settings.
+			// Merge the variation settings with the global settings. Variations overwrite the globals.
 			$settings['typography']['fontFamilies']['theme'] = array_merge(
 				$settings['typography']['fontFamilies']['theme'],
-				$variation_font_families
+				$variation['settings']['typography']['fontFamilies']['theme']
 			);
-
-			// Make sure there are no duplicates.
-			$settings['typography']['fontFamilies'] = array_unique( $settings['typography']['fontFamilies'], SORT_REGULAR );
-
-			// The font families from settings might become null after running the `array_unique`.
-			if ( ! isset( $settings['typography']['fontFamilies']['theme'] ) || ! is_array( $settings['typography']['fontFamilies']['theme'] ) ) {
-				$settings['typography']['fontFamilies']['theme'] = array();
-			}
 		}
+
+		// Make sure there are no duplicate values with different names (array keys).
+		$settings['typography']['fontFamilies']['theme'] = array_unique( $settings['typography']['fontFamilies']['theme'], SORT_REGULAR );
 
 		return $settings;
 	}


### PR DESCRIPTION
## What?
Follow-up to https://github.com/WordPress/gutenberg/pull/56067.

Changes:
- Check if `$variation['settings']['typography']['fontFamilies']['theme']` are set at the top of the loop. It doesn't make sense to only check for `$variation['settings']['typography']['fontFamilies']`.
- Move the code that sets `$settings['typography']['fontFamilies']['theme']` to a empty array before that array is used. It doesn't make sense for that check to be after the array is needed/used.
- Run the above check only once. It doesn't make sense to run it on every iteration of the loop.
- Move the `array_unique()` after the loop. It doesn't make sense to be inside the loop/to run on every iteration.
- Check the `$settings['typography']['fontFamilies']['theme']` array for uniqueness as we were just modifying it in the loop. It doesn't make sense to check `$settings['typography']['fontFamilies']` for uniqueness as that array was never modified in this function. This erroneous check was also the cause of the fatal errors as far as I see.

## Why?
Attempts to completely fix the errors in `WP_Fonts_Resolver::get_settings()` that merges the default settings with the variations (if any).

## Testing Instructions
See https://github.com/WordPress/gutenberg/pull/56067 for instructions.
