### PR TITLE
Global styles revisions: update isResolving flag

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -39,25 +39,26 @@ export default function useGlobalStylesRevisions() {
 		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 		const _currentUser = getCurrentUser();
 		const _isDirty = dirtyEntityRecords.length > 0;
+		const query = {
+			per_page: 100,
+		};
+		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
 		const globalStylesRevisions =
-			getRevisions(
-				'root',
-				'globalStyles',
-				__experimentalGetCurrentGlobalStylesId(),
-				{
-					per_page: 100,
-				}
-			) || EMPTY_ARRAY;
+			getRevisions( 'root', 'globalStyles', globalStylesId, query ) ||
+			EMPTY_ARRAY;
 		const _authors = getUsers( SITE_EDITOR_AUTHORS_QUERY ) || EMPTY_ARRAY;
-
+		const _isResolving = isResolving( 'getRevisions', [
+			'root',
+			'globalStyles',
+			globalStylesId,
+			query,
+		] );
 		return {
 			authors: _authors,
 			currentUser: _currentUser,
 			isDirty: _isDirty,
 			revisions: globalStylesRevisions,
-			isLoadingGlobalStylesRevisions: isResolving(
-				'getCurrentThemeGlobalStylesRevisions'
-			),
+			isLoadingGlobalStylesRevisions: _isResolving,
 		};
 	}, [] );
 	return useMemo( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
https://github.com/WordPress/gutenberg/pull/56349 updated global styles revisions to use the new getRevisions selector.

Great.

I forgot to also update the `isResolving` flag.

This PR does that.

Thanks.

## Why?
To make sure `isLoading` returns the right value in the hook.



## Testing Instructions
Old skool:

```diff
diff --git a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
index bacc79a97c..c69d2394c8 100644
--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -53,6 +53,7 @@ export default function useGlobalStylesRevisions() {
 			globalStylesId,
 			query,
 		] );
+		console.log( '_isResolving', _isResolving );
 		return {
 			authors: _authors,
 			currentUser: _currentUser,

```

Check that the `isResolving` value flips from `true` to `false` during and after resolution (the revisions have been fetched and stored in state)

```bash
_isResolving true // fetching
_isResolving false // fetched!
```
