### PR TITLE
Global styles revisions: remove PHP unit tests that are running in Core

### DIFF
--- a/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-revisions-controller-test.php
@@ -17,22 +17,7 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	/**
 	 * @var int
 	 */
-	protected static $second_admin_id;
-
-	/**
-	 * @var int
-	 */
-	protected static $author_id;
-
-	/**
-	 * @var int
-	 */
 	protected static $global_styles_id;
-
-	/**
-	 * @var int
-	 */
-	private $total_revisions;
 
 	/**
 	 * @var array
@@ -45,44 +30,14 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	private $revision_1_id;
 
 	/**
-	 * @var array
-	 */
-	private $revision_2;
-
-	/**
-	 * @var int
-	 */
-	private $revision_2_id;
-
-	/**
-	 * @var array
-	 */
-	private $revision_3;
-
-	/**
-	 * @var int
-	 */
-	private $revision_3_id;
-
-	/**
 	 * Create fake data before our tests run.
 	 *
 	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
 	public static function wpSetupBeforeClass( $factory ) {
-		self::$admin_id        = $factory->user->create(
+		self::$admin_id = $factory->user->create(
 			array(
 				'role' => 'administrator',
-			)
-		);
-		self::$second_admin_id = $factory->user->create(
-			array(
-				'role' => 'administrator',
-			)
-		);
-		self::$author_id       = $factory->user->create(
-			array(
-				'role' => 'author',
 			)
 		);
 
@@ -199,8 +154,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	 */
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$admin_id );
-		self::delete_user( self::$second_admin_id );
-		self::delete_user( self::$author_id );
 	}
 
 	/**
@@ -209,24 +162,16 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	public function set_up() {
 		parent::set_up();
 		switch_theme( 'emptytheme' );
-		$revisions             = wp_get_post_revisions( self::$global_styles_id );
-		$this->total_revisions = count( $revisions );
-
+		$revisions           = wp_get_post_revisions( self::$global_styles_id );
 		$this->revision_1    = array_pop( $revisions );
 		$this->revision_1_id = $this->revision_1->ID;
-
-		$this->revision_2    = array_pop( $revisions );
-		$this->revision_2_id = $this->revision_2->ID;
-
-		$this->revision_3    = array_pop( $revisions );
-		$this->revision_3_id = $this->revision_3->ID;
 
 		/*
 		 * For some reason the `rest_api_init` doesn't run early enough to ensure an overwritten `get_item_schema()`
 		 * is used. So we manually call it here.
 		 * See: https://github.com/WordPress/gutenberg/pull/52370#issuecomment-1643331655.
 		 */
-		$global_styles_revisions_controller = new Gutenberg_REST_Global_Styles_Revisions_Controller_6_4();
+		$global_styles_revisions_controller = new Gutenberg_REST_Global_Styles_Revisions_Controller_6_5();
 		$global_styles_revisions_controller->register_routes();
 	}
 
@@ -237,11 +182,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey(
-			'/wp/v2/global-styles/(?P<parent>[\d]+)/revisions',
-			$routes,
-			'Global style revisions based on the given parentID route does not exist.'
-		);
 		$this->assertArrayHasKey(
 			'/wp/v2/global-styles/(?P<parent>[\d]+)/revisions/(?P<id>[\d]+)',
 			$routes,
@@ -278,32 +218,6 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	}
 
 	/**
-	 * @ticket 58524
-	 *
-	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_items
-	 */
-	public function test_get_items() {
-		wp_set_current_user( self::$admin_id );
-
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertSame( 200, $response->get_status(), 'Response status is 200.' );
-		$this->assertCount( $this->total_revisions, $data, 'Check that correct number of revisions exists.' );
-
-		// Reverse chronology.
-		$this->assertSame( $this->revision_3_id, $data[0]['id'] );
-		$this->check_get_revision_response( $data[0], $this->revision_3 );
-
-		$this->assertSame( $this->revision_2_id, $data[1]['id'] );
-		$this->check_get_revision_response( $data[1], $this->revision_2 );
-
-		$this->assertSame( $this->revision_1_id, $data[2]['id'] );
-		$this->check_get_revision_response( $data[2], $this->revision_1 );
-	}
-
-	/**
 	 * @ticket 59810
 	 *
 	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_item
@@ -336,26 +250,19 @@ class Gutenberg_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_RES
 	}
 
 	/**
-	 * @ticket 58524
-	 *
-	 * @covers Gutenberg_REST_Global_Styles_Revisions_Controller_6_4::get_item_schema
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_items() {
+		// Unit tests have been more to WordPress Core for test_get_items().
+		// No unique compat unit tests exist.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
 	 */
 	public function test_get_item_schema() {
-		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions' );
-		$response   = rest_get_server()->dispatch( $request );
-		$data       = $response->get_data();
-		$properties = $data['schema']['properties'];
-
-		$this->assertCount( 9, $properties, 'Schema properties array has exactly 9 elements.' );
-		$this->assertArrayHasKey( 'id', $properties, 'Schema properties array has "id" key.' );
-		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array has "styles" key.' );
-		$this->assertArrayHasKey( 'settings', $properties, 'Schema properties array has "settings" key.' );
-		$this->assertArrayHasKey( 'parent', $properties, 'Schema properties array has "parent" key.' );
-		$this->assertArrayHasKey( 'author', $properties, 'Schema properties array has "author" key.' );
-		$this->assertArrayHasKey( 'date', $properties, 'Schema properties array has "date" key.' );
-		$this->assertArrayHasKey( 'date_gmt', $properties, 'Schema properties array has "date_gmt" key.' );
-		$this->assertArrayHasKey( 'modified', $properties, 'Schema properties array has "modified" key.' );
-		$this->assertArrayHasKey( 'modified_gmt', $properties, 'Schema properties array has "modified_gmt" key.' );
+		// Unit tests have been more to WordPress Core for test_get_item_schema().
+		// No unique compat unit tests exist.
 	}
 
 	/**


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Pruning unit tests that have already been migrated to core.
Keeping tests that cover latest compat changes (6.5)

## Why?
The deleted tests do not test any plugin-specific functionality. They test functionality that already exists in Core.

## How?
![image](https://github.com/WordPress/gutenberg/assets/6458278/5f5d26ca-8adc-4e2c-a7fb-b5b8930cc129)

## Testing Instructions
`npm run test:unit:php:base -- --filter Gutenberg_REST_Global_Styles_Revisions_Controller_Test`
