### PR TITLE
List View: Expand state if a block is dragged to within a collapsed block in the editor canvas

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-expand-selected-item.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-expand-selected-item.js
@@ -27,12 +27,6 @@ export default function useListViewExpandSelectedItem( {
 		[ firstSelectedBlockClientId ]
 	);
 
-	const parentClientIds =
-		Array.isArray( selectedBlockParentClientIds ) &&
-		selectedBlockParentClientIds.length
-			? selectedBlockParentClientIds
-			: null;
-
 	// Expand tree when a block is selected.
 	useEffect( () => {
 		// If the selectedTreeId is the same as the selected block,
@@ -42,7 +36,7 @@ export default function useListViewExpandSelectedItem( {
 		}
 
 		// If the selected block has parents, get the top-level parent.
-		if ( parentClientIds ) {
+		if ( selectedBlockParentClientIds?.length ) {
 			// If the selected block has parents,
 			// expand the tree branch.
 			setExpandedState( {
@@ -50,7 +44,12 @@ export default function useListViewExpandSelectedItem( {
 				clientIds: selectedBlockParentClientIds,
 			} );
 		}
-	}, [ firstSelectedBlockClientId ] );
+	}, [
+		firstSelectedBlockClientId,
+		selectedBlockParentClientIds,
+		selectedTreeId,
+		setExpandedState,
+	] );
 
 	return {
 		setSelectedTreeId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #49563 and #33683. Also, partially related to https://github.com/WordPress/gutenberg/issues/33684.

In the list view, when a block is dragged to a different part of the document (i.e. when dragged to a child of a collapsed block) ensure that the tree is expanded for the selected block in its new position.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This resolves an issue where if you drag a block with the list view open, it's possible for the dragged block to no longer be visible in the list view, when you drag to another part of the document that is collapsed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

If the selected block's parents has changed, then update the expanded state for the block's parents.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a post with lots of nesting in different parts of the document, click and drag a block from within the list view to somewhere deeper in the hierarchy within the editor canvas.
2. On trunk, if the target drop location is within a collapsed block in the list view, the selected block will no longer be visible in the list view.
3. With this PR applied, once you drop the block, the list view should expand to reveal the block.
4. Double-check: is this `useEffect` called too frequently, or just when expected?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/dad22e81-ffd1-4da1-8987-b7581356c357

### After

https://github.com/WordPress/gutenberg/assets/14988353/3bec4471-17a5-434b-b618-2bf166732f49