### PR TITLE
Bug: ToggleGroupControl doesn't update the UI on programmatic changes

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -44,6 +44,15 @@ Create and save content to reuse across your site. Update the pattern, and the c
 -	**Supports:** ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
 -	**Attributes:** ref
 
+## Bug
+
+undefined ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/bug))
+
+-	**Name:** core/bug
+-	**Category:** undefined
+-	**Supports:** 
+-	**Attributes:** testAttribute
+
 ## Button
 
 Prompt visitors to take action with a button-style link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/button))

--- a/packages/block-library/src/bug/block.json
+++ b/packages/block-library/src/bug/block.json
@@ -5,7 +5,8 @@
 	"title": "Bug",
 	"attributes": {
 		"testAttribute": {
-			"type": "string"
+			"type": "string",
+			"default": "off"
 		}
 	}
 }

--- a/packages/block-library/src/bug/block.json
+++ b/packages/block-library/src/bug/block.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/bug",
+	"title": "Bug",
+	"attributes": {
+		"testAttribute": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/bug/block.json
+++ b/packages/block-library/src/bug/block.json
@@ -5,8 +5,8 @@
 	"title": "Bug",
 	"attributes": {
 		"testAttribute": {
-			"type": "string",
-			"default": "off"
+			"type": "boolean",
+			"default": false
 		}
 	}
 }

--- a/packages/block-library/src/bug/edit.js
+++ b/packages/block-library/src/bug/edit.js
@@ -1,14 +1,34 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	PanelBody,
+} from '@wordpress/components';
 
 export default function Test( { attributes, setAttributes } ) {
 	const { testAttribute } = attributes;
 	const blockProps = useBlockProps();
 	return (
 		<>
-			<div { ...blockProps }>hi</div>
+			<InspectorControls group="list">
+				<PanelBody title={ null }>
+					<ToggleGroupControl
+						label="Bug"
+						value={ testAttribute }
+						onChange={ ( value ) =>
+							setAttributes( { testAttribute: value } )
+						}
+					>
+						<ToggleGroupControlOption value="off" label="OFF" />
+						<ToggleGroupControlOption value="on" label="ON" />
+					</ToggleGroupControl>
+				</PanelBody>
+			</InspectorControls>
+
+			<div { ...blockProps }>Bug</div>
 		</>
 	);
 }

--- a/packages/block-library/src/bug/edit.js
+++ b/packages/block-library/src/bug/edit.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function Test( { attributes, setAttributes } ) {
+	const { testAttribute } = attributes;
+	const blockProps = useBlockProps();
+	return (
+		<>
+			<div { ...blockProps }>hi</div>
+		</>
+	);
+}

--- a/packages/block-library/src/bug/edit.js
+++ b/packages/block-library/src/bug/edit.js
@@ -3,6 +3,7 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
+	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	PanelBody,
@@ -15,15 +16,20 @@ export default function Test( { attributes, setAttributes } ) {
 		<>
 			<InspectorControls group="list">
 				<PanelBody title={ null }>
+					<ToggleControl
+						checked={ testAttribute }
+						onChange={ ( value ) =>
+							setAttributes( { testAttribute: value } )
+						}
+					/>
 					<ToggleGroupControl
-						label="Bug"
 						value={ testAttribute }
 						onChange={ ( value ) =>
 							setAttributes( { testAttribute: value } )
 						}
 					>
-						<ToggleGroupControlOption value="off" label="OFF" />
-						<ToggleGroupControlOption value="on" label="ON" />
+						<ToggleGroupControlOption value={ false } label="OFF" />
+						<ToggleGroupControlOption value={ true } label="ON" />
 					</ToggleGroupControl>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/bug/edit.js
+++ b/packages/block-library/src/bug/edit.js
@@ -23,13 +23,13 @@ export default function Test( { attributes, setAttributes } ) {
 						}
 					/>
 					<ToggleGroupControl
-						value={ testAttribute }
+						value={ testAttribute ? 'on' : 'off' }
 						onChange={ ( value ) =>
-							setAttributes( { testAttribute: value } )
+							setAttributes( { testAttribute: value === 'on' } )
 						}
 					>
-						<ToggleGroupControlOption value={ false } label="OFF" />
-						<ToggleGroupControlOption value={ true } label="ON" />
+						<ToggleGroupControlOption value="off" label="OFF" />
+						<ToggleGroupControlOption value="on" label="ON" />
 					</ToggleGroupControl>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/bug/index.js
+++ b/packages/block-library/src/bug/index.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	edit,
+	save: () => <div>Nothing to see</div>,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -20,6 +20,7 @@ import {
 // production build to make the final bundle smaller.
 //
 // See https://github.com/WordPress/gutenberg/pull/40655 for more context.
+import * as bug from './bug';
 import * as archives from './archives';
 import * as avatar from './avatar';
 import * as audio from './audio';
@@ -129,6 +130,8 @@ import isBlockMetadataExperimental from './utils/is-block-metadata-experimental'
  */
 const getAllBlocks = () => {
 	const blocks = [
+		bug,
+
 		// Common blocks are grouped at the top to prioritize their display
 		// in various contexts — like the inserter and auto-complete components.
 		paragraph,

--- a/packages/components/src/toggle-group-control/toggle-group-control/utils.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/utils.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { usePrevious } from '@wordpress/compose';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,24 +21,28 @@ type ValueProp = ToggleGroupControlProps[ 'value' ];
 export function useComputeControlledOrUncontrolledValue(
 	valueProp: ValueProp
 ): { value: ValueProp; defaultValue: ValueProp } {
-	const hasEverBeenUsedInControlledMode = useRef( false );
+	const [
+		hasEverBeenUsedInControlledMode,
+		setHasEverBeenUsedInControlledMode,
+	] = useState( false );
 	const previousValueProp = usePrevious( valueProp );
 
 	useEffect( () => {
-		if ( ! hasEverBeenUsedInControlledMode.current ) {
+		if ( ! hasEverBeenUsedInControlledMode ) {
 			// Assume the component is being used in controlled mode if:
 			// - the `value` prop is not `undefined`
 			// - the `value` prop was not previously `undefined` and was given a new value
-			hasEverBeenUsedInControlledMode.current =
+			setHasEverBeenUsedInControlledMode(
 				valueProp !== undefined &&
-				previousValueProp !== undefined &&
-				valueProp !== previousValueProp;
+					previousValueProp !== undefined &&
+					valueProp !== previousValueProp
+			);
 		}
-	}, [ valueProp, previousValueProp ] );
+	}, [ valueProp, previousValueProp, hasEverBeenUsedInControlledMode ] );
 
 	let value, defaultValue;
 
-	if ( hasEverBeenUsedInControlledMode.current ) {
+	if ( hasEverBeenUsedInControlledMode ) {
 		// When in controlled mode, use `''` instead of `undefined`
 		value = valueProp ?? '';
 	} else {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

`ToggleGroupControl` doesn't update the UI when another part of the Editor is changing the attribute programmatically.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because sometimes, we need to change an attribute using `setAttribute` instead of clicking on the `ToggleGroupControl`, and when that happens, the UI is not updated, leading to user confusion.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For now, this is only a very simple block to reproduce the issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Go to the Editor.
- Add the "Bug" block.
- Open the inspector panel.
- Toggle the attribute using the `ToggleControl`.
- The UI of the `ToggleGroupControl` is not updated.

It looks like the `ToggleGroupControl` starts updating itself once the user has clicked on it at least once, or when the user hovers over the block list.

## Screenshots or screencast <!-- if applicable -->

<div>
    <a href="https://www.loom.com/share/a15d8d2b560945249c795c875ea68bbf">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/a15d8d2b560945249c795c875ea68bbf-with-play.gif">
    </a>
  </div>

https://www.loom.com/share/a15d8d2b560945249c795c875ea68bbf