### PR TITLE
Dataviews: Update item actions in grid view

### DIFF
--- a/packages/edit-site/src/components/dataviews/item-actions.js
+++ b/packages/edit-site/src/components/dataviews/item-actions.js
@@ -17,10 +17,11 @@ import { moreVertical, Icon } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
 
 const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuGroupV2: DropdownMenuGroup,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
+	DropdownMenuV2Ariakit: DropdownMenu,
+	DropdownMenuGroupV2Ariakit: DropdownMenuGroup,
+	DropdownMenuItemV2Ariakit: DropdownMenuItem,
+	DropdownMenuSeparatorV2Ariakit: DropdownMenuSeparator,
+	DropdownMenuItemLabelV2Ariakit: DropdownMenuItemLabel,
 } = unlock( componentsPrivateApis );
 
 function ButtonTrigger( { action, onClick } ) {
@@ -43,7 +44,7 @@ function DropdownMenuItemTrigger( { action, onClick } ) {
 				action.isPrimary && action.icon && <Icon icon={ action.icon } />
 			}
 		>
-			{ action.label }
+			<DropdownMenuItemLabel>{ action.label }</DropdownMenuItemLabel>
 		</DropdownMenuItem>
 	);
 }
@@ -166,7 +167,7 @@ export default function ItemActions( { item, actions, viewType } ) {
 							label={ __( 'Actions' ) }
 						/>
 					}
-					align="start"
+					placement="bottom-end"
 				>
 					<ActionsDropdownMenuGroup
 						actions={ secondaryActions }
@@ -200,7 +201,7 @@ function GridItemActions( { item, primaryActions, secondaryActions } ) {
 					label={ __( 'Actions' ) }
 				/>
 			}
-			align="start"
+			placement="bottom-end"
 		>
 			<WithSeparators>
 				{ !! primaryActions.length && (

--- a/packages/edit-site/src/components/dataviews/item-actions.js
+++ b/packages/edit-site/src/components/dataviews/item-actions.js
@@ -8,8 +8,8 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState, Fragment, Children } from '@wordpress/element';
-import { moreVertical, Icon } from '@wordpress/icons';
+import { useMemo, useState } from '@wordpress/element';
+import { moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -20,7 +20,6 @@ const {
 	DropdownMenuV2Ariakit: DropdownMenu,
 	DropdownMenuGroupV2Ariakit: DropdownMenuGroup,
 	DropdownMenuItemV2Ariakit: DropdownMenuItem,
-	DropdownMenuSeparatorV2Ariakit: DropdownMenuSeparator,
 	DropdownMenuItemLabelV2Ariakit: DropdownMenuItemLabel,
 } = unlock( componentsPrivateApis );
 
@@ -38,12 +37,7 @@ function ButtonTrigger( { action, onClick } ) {
 
 function DropdownMenuItemTrigger( { action, onClick } ) {
 	return (
-		<DropdownMenuItem
-			onClick={ onClick }
-			prefix={
-				action.isPrimary && action.icon && <Icon icon={ action.icon } />
-			}
-		>
+		<DropdownMenuItem onClick={ onClick }>
 			<DropdownMenuItemLabel>{ action.label }</DropdownMenuItemLabel>
 		</DropdownMenuItem>
 	);
@@ -161,7 +155,6 @@ export default function ItemActions( { item, actions, viewType } ) {
 				<DropdownMenu
 					trigger={
 						<Button
-							variant="tertiary"
 							size="compact"
 							icon={ moreVertical }
 							label={ __( 'Actions' ) }
@@ -179,23 +172,11 @@ export default function ItemActions( { item, actions, viewType } ) {
 	);
 }
 
-function WithSeparators( { children } ) {
-	return Children.toArray( children )
-		.filter( Boolean )
-		.map( ( child, i ) => (
-			<Fragment key={ i }>
-				{ i > 0 && <DropdownMenuSeparator /> }
-				{ child }
-			</Fragment>
-		) );
-}
-
 function GridItemActions( { item, primaryActions, secondaryActions } ) {
 	return (
 		<DropdownMenu
 			trigger={
 				<Button
-					variant="tertiary"
 					size="compact"
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
@@ -203,20 +184,18 @@ function GridItemActions( { item, primaryActions, secondaryActions } ) {
 			}
 			placement="bottom-end"
 		>
-			<WithSeparators>
-				{ !! primaryActions.length && (
-					<ActionsDropdownMenuGroup
-						actions={ primaryActions }
-						item={ item }
-					/>
-				) }
-				{ !! secondaryActions.length && (
-					<ActionsDropdownMenuGroup
-						actions={ secondaryActions }
-						item={ item }
-					/>
-				) }
-			</WithSeparators>
+			{ !! primaryActions.length && (
+				<ActionsDropdownMenuGroup
+					actions={ primaryActions }
+					item={ item }
+				/>
+			) }
+			{ !! secondaryActions.length && (
+				<ActionsDropdownMenuGroup
+					actions={ secondaryActions }
+					item={ item }
+				/>
+			) }
 		</DropdownMenu>
 	);
 }

--- a/packages/edit-site/src/components/dataviews/item-actions.js
+++ b/packages/edit-site/src/components/dataviews/item-actions.js
@@ -98,7 +98,7 @@ function ActionsDropdownMenuGroup( { actions, item } ) {
 	);
 }
 
-export default function ItemActions( { item, actions, viewType } ) {
+export default function ItemActions( { item, actions, isCompact } ) {
 	const { primaryActions, secondaryActions } = useMemo( () => {
 		return actions.reduce(
 			( accumulator, action ) => {
@@ -120,9 +120,9 @@ export default function ItemActions( { item, actions, viewType } ) {
 	if ( ! primaryActions.length && ! secondaryActions.length ) {
 		return null;
 	}
-	if ( viewType === 'grid' ) {
+	if ( isCompact ) {
 		return (
-			<GridItemActions
+			<CompactItemActions
 				item={ item }
 				primaryActions={ primaryActions }
 				secondaryActions={ secondaryActions }
@@ -172,7 +172,7 @@ export default function ItemActions( { item, actions, viewType } ) {
 	);
 }
 
-function GridItemActions( { item, primaryActions, secondaryActions } ) {
+function CompactItemActions( { item, primaryActions, secondaryActions } ) {
 	return (
 		<DropdownMenu
 			trigger={

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -61,6 +61,7 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 								<ItemActions
 									item={ item }
 									actions={ actions }
+									viewType={ view.type }
 								/>
 							</FlexBlock>
 						</HStack>

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -61,7 +61,7 @@ export function ViewGrid( { data, fields, view, actions, getItemId } ) {
 								<ItemActions
 									item={ item }
 									actions={ actions }
-									viewType={ view.type }
+									isCompact
 								/>
 							</FlexBlock>
 						</HStack>

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -258,6 +258,7 @@ function ViewList( {
 						<ItemActions
 							item={ props.row.original }
 							actions={ actions }
+							viewType={ view.type }
 						/>
 					);
 				},

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -258,7 +258,6 @@ function ViewList( {
 						<ItemActions
 							item={ props.row.original }
 							actions={ actions }
-							viewType={ view.type }
 						/>
 					);
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR updates the item actions in DataViews to have a different design in `grid` view. Namely all the actions are inside a dropdown menu, separated by whether they are primary or not.

Additionally I have used the new Dropdown component that we use in DataViews, for consistency. I know this is going to be replaced by the ariakit version one, but when I tried adding that, I encountered way more problems right now. When the new one is stabilized, we're going to replace all usages.



## Testing Instructions
1. Enable the admin views experiment and go to manage all pages view
2. Play around with the actions in both views


## Screenshots or screencast <!-- if applicable -->
<img width="1022" alt="Screenshot 2023-11-24 at 1 28 08 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/63ebe384-3b02-4ddd-9f96-2de0f6358720">

<img width="1029" alt="Screenshot 2023-11-24 at 1 28 21 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/ecbbd06d-68ef-4df6-8a4c-8f63ddc3a3bc">


