### PR TITLE
Save post button: avoid extra re-renders when enablng/disabling tooltip

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -132,9 +132,9 @@ export default function PostSavedState( {
 	const buttonAccessibleLabel = text || label;
 
 	/**
-	 * The tooltip needs to be enabled only is the button is not disabled. When
+	 * The tooltip needs to be enabled only if the button is not disabled. When
 	 * relying on the internal Button tooltip functionality, this causes the
-	 * resulting `button` element to be always remove and re-added to the DOM,
+	 * resulting `button` element to be always removed and re-added to the DOM,
 	 * causing focus loss. An alternative approach to circumvent the issue
 	 * is not to use the `label` and `shortcut` props on `Button` (which would
 	 * trigger the tooltip), and instead manually wrap the `Button` in a separate

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -9,12 +9,13 @@ import classnames from 'classnames';
 import {
 	__unstableGetAnimateClassName as getAnimateClassName,
 	Button,
+	Tooltip,
 } from '@wordpress/components';
 import { usePrevious, useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, check, cloud, cloudUpload } from '@wordpress/icons';
+import { Icon, button, check, cloud, cloudUpload } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 
 /**
@@ -128,45 +129,57 @@ export default function PostSavedState( {
 		text = shortLabel;
 	}
 
+	const buttonAccessibleLabel = text || label;
+
+	/**
+	 * The tooltip needs to be enabled only is the button is not disabled. When
+	 * relying on the internal Button tooltip functionality, this causes the
+	 * resulting `button` element to be always remove and re-added to the DOM,
+	 * causing focus loss. An alternative approach to circumvent the issue
+	 * is not to use the `label` and `shortcut` props on `Button` (which would
+	 * trigger the tooltip), and instead manually wrap the `Button` in a separate
+	 * `Tooltip` component.
+	 */
+	const tooltipProps = isDisabled
+		? undefined
+		: {
+				text: buttonAccessibleLabel,
+				shortcut: displayShortcut.primary( 's' ),
+		  };
+
 	// Use common Button instance for all saved states so that focus is not
 	// lost.
 	return (
-		<Button
-			className={
-				isSaveable || isSaving
-					? classnames( {
-							'editor-post-save-draft': ! isSavedState,
-							'editor-post-saved-state': isSavedState,
-							'is-saving': isSaving,
-							'is-autosaving': isAutosaving,
-							'is-saved': isSaved,
-							[ getAnimateClassName( {
-								type: 'loading',
-							} ) ]: isSaving,
-					  } )
-					: undefined
-			}
-			onClick={ isDisabled ? undefined : () => savePost() }
-			/*
-			 * We want the tooltip to show the keyboard shortcut only when the
-			 * button does something, i.e. when it's not disabled.
-			 */
-			shortcut={ isDisabled ? undefined : displayShortcut.primary( 's' ) }
-			/*
-			 * Displaying the keyboard shortcut conditionally makes the tooltip
-			 * itself show conditionally. This would trigger a full-rerendering
-			 * of the button that we want to avoid. By setting `showTooltip`,
-			 * the tooltip is always rendered even when there's no keyboard shortcut.
-			 */
-			showTooltip
-			variant="tertiary"
-			icon={ isLargeViewport ? undefined : cloudUpload }
-			// Make sure the aria-label has always a value, as the default `text` is undefined on small screens.
-			label={ text || label }
-			aria-disabled={ isDisabled }
-		>
-			{ isSavedState && <Icon icon={ isSaved ? check : cloud } /> }
-			{ text }
-		</Button>
+		<Tooltip { ...tooltipProps }>
+			<Button
+				className={
+					isSaveable || isSaving
+						? classnames( {
+								'editor-post-save-draft': ! isSavedState,
+								'editor-post-saved-state': isSavedState,
+								'is-saving': isSaving,
+								'is-autosaving': isAutosaving,
+								'is-saved': isSaved,
+								[ getAnimateClassName( {
+									type: 'loading',
+								} ) ]: isSaving,
+						  } )
+						: undefined
+				}
+				onClick={ isDisabled ? undefined : () => savePost() }
+				/*
+				 * We want the tooltip to show the keyboard shortcut only when the
+				 * button does something, i.e. when it's not disabled.
+				 */
+				variant="tertiary"
+				icon={ isLargeViewport ? undefined : cloudUpload }
+				// Make sure the aria-label has always a value, as the default `text` is undefined on small screens.
+				aria-label={ buttonAccessibleLabel }
+				aria-disabled={ isDisabled }
+			>
+				{ isSavedState && <Icon icon={ isSaved ? check : cloud } /> }
+				{ text }
+			</Button>
+		</Tooltip>
 	);
 }

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -167,10 +167,6 @@ export default function PostSavedState( {
 						: undefined
 				}
 				onClick={ isDisabled ? undefined : () => savePost() }
-				/*
-				 * We want the tooltip to show the keyboard shortcut only when the
-				 * button does something, i.e. when it's not disabled.
-				 */
 				variant="tertiary"
 				icon={ isLargeViewport ? undefined : cloudUpload }
 				// Make sure the aria-label has always a value, as the default `text` is undefined on small screens.

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -15,7 +15,7 @@ import { usePrevious, useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, button, check, cloud, cloudUpload } from '@wordpress/icons';
+import { Icon, check, cloud, cloudUpload } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 
 /**

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -166,7 +166,7 @@ export default function PostSavedState( {
 						  } )
 						: undefined
 				}
-				onClick={ isDisabled ? undefined : () => savePost() }
+				onClick={ isDisabled ? undefined : savePost }
 				variant="tertiary"
 				icon={ isLargeViewport ? undefined : cloudUpload }
 				// Make sure the aria-label has always a value, as the default `text` is undefined on small screens.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/discussions/44735
Alternative approach to https://github.com/WordPress/gutenberg/pull/56490

This PR makes changes to how the tooltip is rendered for the post save button, thus fixing an issue that was causing loss of keyboard focus on that button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This change is necessary to fix the issue described in https://github.com/WordPress/gutenberg/discussions/44735, where basically the element rendered by `Button` would be removed and re-added to the DOM any time the `Button` component switches from having to show a tooltip to not having to show it, and vice-versa.

The fact that a new HTML element is re-created every time triggers a focus loss that can be very annoying, especially to assistive technology users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The approach is similar to what proposed in #56490 — although the fix is applied only for this specific instance of `Button`, instead of applying it directly to the button component (since that [could have broader consequences](https://github.com/WordPress/gutenberg/pull/56490#issuecomment-1825498243)).

The issue is related to the fact that React can't reconciliate the "with tooltip" and "without tooltip" version of the `Button` component without re-creating the whole button every time.

To solve this, I decided to tweak the code so that:
- the `Button` component never renders a tooltip (thanks to removing the `showTooltip` and `shortcut` props, and changing the `label` prop to `aria-label`)
- the `Button` component is always wrapped in a `Tooltip` component. The component receives a different set of props depending on whether a tooltip should be effectively shown.

_Note: this doesn't mean that the tooltip will always be shown, though — the original user-facing behaviour should have been retained by only passing props to the `Tooltip` component when needed._

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

From https://github.com/WordPress/gutenberg/discussions/44735#discussioncomment-7639716: 

- Edit a draft post and make sure it's saved so that the Save button shows the text 'Saved'.
- Make sure that when focusing or hovering the button, no tooltips are shown
- Make any edit so that the button text changes to 'Save draft'.
- Make sure that when focusing or hovering the button, a tooltip with the text "Save draft ⌘S" is shown
- Select the Save button in the dev tools inspector.
- Right click and enable 'Break on > node removal'.
- Click the Save button.
- Observe the button doesn't gets removed from the DOM, and the keyboard focus stays on the button

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1083581/aa35002b-60ad-4d28-b8c0-498331147fde


