### PR TITLE
DataViews: scope names of V2 UI components

### DIFF
--- a/packages/edit-site/src/components/dataviews/add-filter.js
+++ b/packages/edit-site/src/components/dataviews/add-filter.js
@@ -16,10 +16,10 @@ import { unlock } from '../../lock-unlock';
 import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
 
 const {
-	DropdownMenuV2,
-	DropdownSubMenuV2,
-	DropdownSubMenuTriggerV2,
-	DropdownMenuItemV2,
+	DropdownMenuV2: DropdownMenu,
+	DropdownSubMenuV2: DropdownSubMenu,
+	DropdownSubMenuTriggerV2: DropdownSubMenuTrigger,
+	DropdownMenuItemV2: DropdownMenuItem,
 } = unlock( componentsPrivateApis );
 
 export default function AddFilter( { fields, view, onChangeView } ) {
@@ -48,7 +48,7 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 	}
 
 	return (
-		<DropdownMenuV2
+		<DropdownMenu
 			label={ __( 'Add filter' ) }
 			trigger={
 				<Button
@@ -68,18 +68,18 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 				}
 
 				return (
-					<DropdownSubMenuV2
+					<DropdownSubMenu
 						key={ filter.field }
 						trigger={
-							<DropdownSubMenuTriggerV2
+							<DropdownSubMenuTrigger
 								suffix={ <Icon icon={ chevronRightSmall } /> }
 							>
 								{ filter.name }
-							</DropdownSubMenuTriggerV2>
+							</DropdownSubMenuTrigger>
 						}
 					>
 						{ filter.elements.map( ( element ) => (
-							<DropdownMenuItemV2
+							<DropdownMenuItem
 								key={ element.value }
 								onSelect={ () => {
 									onChangeView( ( currentView ) => ( {
@@ -98,11 +98,11 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 								role="menuitemcheckbox"
 							>
 								{ element.label }
-							</DropdownMenuItemV2>
+							</DropdownMenuItem>
 						) ) }
-					</DropdownSubMenuV2>
+					</DropdownSubMenu>
 				);
 			} ) }
-		</DropdownMenuV2>
+		</DropdownMenu>
 	);
 }

--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -23,11 +23,11 @@ import { __ } from '@wordpress/i18n';
 import { unlock } from '../../lock-unlock';
 
 const {
-	DropdownMenuV2,
-	DropdownMenuGroupV2,
-	DropdownMenuItemV2,
-	DropdownSubMenuV2,
-	DropdownSubMenuTriggerV2,
+	DropdownMenuV2: DropdownMenu,
+	DropdownMenuGroupV2: DropdownMenuGroup,
+	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownSubMenuV2: DropdownSubMenu,
+	DropdownSubMenuTriggerV2: DropdownSubMenuTrigger,
 } = unlock( componentsPrivateApis );
 
 const availableViews = [
@@ -57,9 +57,9 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 	}
 	const activeView = _availableViews.find( ( v ) => view.type === v.id );
 	return (
-		<DropdownSubMenuV2
+		<DropdownSubMenu
 			trigger={
-				<DropdownSubMenuTriggerV2
+				<DropdownSubMenuTrigger
 					suffix={
 						<>
 							{ activeView.label }
@@ -68,12 +68,12 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 					}
 				>
 					{ __( 'Layout' ) }
-				</DropdownSubMenuTriggerV2>
+				</DropdownSubMenuTrigger>
 			}
 		>
 			{ _availableViews.map( ( availableView ) => {
 				return (
-					<DropdownMenuItemV2
+					<DropdownMenuItem
 						key={ availableView.id }
 						prefix={
 							availableView.id === view.type && (
@@ -89,19 +89,19 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 						role="menuitemcheckbox"
 					>
 						{ availableView.label }
-					</DropdownMenuItemV2>
+					</DropdownMenuItem>
 				);
 			} ) }
-		</DropdownSubMenuV2>
+		</DropdownSubMenu>
 	);
 }
 
 const PAGE_SIZE_VALUES = [ 10, 20, 50, 100 ];
 function PageSizeMenu( { view, onChangeView } ) {
 	return (
-		<DropdownSubMenuV2
+		<DropdownSubMenu
 			trigger={
-				<DropdownSubMenuTriggerV2
+				<DropdownSubMenuTrigger
 					suffix={
 						<>
 							{ view.perPage }
@@ -111,12 +111,12 @@ function PageSizeMenu( { view, onChangeView } ) {
 				>
 					{ /* TODO: probably label per view type. */ }
 					{ __( 'Rows per page' ) }
-				</DropdownSubMenuTriggerV2>
+				</DropdownSubMenuTrigger>
 			}
 		>
 			{ PAGE_SIZE_VALUES.map( ( size ) => {
 				return (
-					<DropdownMenuItemV2
+					<DropdownMenuItem
 						key={ size }
 						prefix={
 							view.perPage === size && <Icon icon={ check } />
@@ -130,10 +130,10 @@ function PageSizeMenu( { view, onChangeView } ) {
 						role="menuitemcheckbox"
 					>
 						{ size }
-					</DropdownMenuItemV2>
+					</DropdownMenuItem>
 				);
 			} ) }
-		</DropdownSubMenuV2>
+		</DropdownSubMenu>
 	);
 }
 
@@ -145,18 +145,18 @@ function FieldsVisibilityMenu( { view, onChangeView, fields } ) {
 		return null;
 	}
 	return (
-		<DropdownSubMenuV2
+		<DropdownSubMenu
 			trigger={
-				<DropdownSubMenuTriggerV2
+				<DropdownSubMenuTrigger
 					suffix={ <Icon icon={ chevronRightSmall } /> }
 				>
 					{ __( 'Fields' ) }
-				</DropdownSubMenuTriggerV2>
+				</DropdownSubMenuTrigger>
 			}
 		>
 			{ hidableFields?.map( ( field ) => {
 				return (
-					<DropdownMenuItemV2
+					<DropdownMenuItem
 						key={ field.id }
 						prefix={
 							! view.hiddenFields?.includes( field.id ) && (
@@ -179,10 +179,10 @@ function FieldsVisibilityMenu( { view, onChangeView, fields } ) {
 						role="menuitemcheckbox"
 					>
 						{ field.header }
-					</DropdownMenuItemV2>
+					</DropdownMenuItem>
 				);
 			} ) }
-		</DropdownSubMenuV2>
+		</DropdownSubMenu>
 	);
 }
 
@@ -202,9 +202,9 @@ function SortMenu( { fields, view, onChangeView } ) {
 		( field ) => field.id === view.sort?.field
 	);
 	return (
-		<DropdownSubMenuV2
+		<DropdownSubMenu
 			trigger={
-				<DropdownSubMenuTriggerV2
+				<DropdownSubMenuTrigger
 					suffix={
 						<>
 							{ currentSortedField?.header }
@@ -213,20 +213,20 @@ function SortMenu( { fields, view, onChangeView } ) {
 					}
 				>
 					{ __( 'Sort by' ) }
-				</DropdownSubMenuTriggerV2>
+				</DropdownSubMenuTrigger>
 			}
 		>
 			{ sortableFields?.map( ( field ) => {
 				const sortedDirection = view.sort?.direction;
 				return (
-					<DropdownSubMenuV2
+					<DropdownSubMenu
 						key={ field.id }
 						trigger={
-							<DropdownSubMenuTriggerV2
+							<DropdownSubMenuTrigger
 								suffix={ <Icon icon={ chevronRightSmall } /> }
 							>
 								{ field.header }
-							</DropdownSubMenuTriggerV2>
+							</DropdownSubMenuTrigger>
 						}
 						side="left"
 					>
@@ -237,7 +237,7 @@ function SortMenu( { fields, view, onChangeView } ) {
 									sortedDirection === direction &&
 									field.id === currentSortedField.id;
 								return (
-									<DropdownMenuItemV2
+									<DropdownMenuItem
 										key={ direction }
 										prefix={ <Icon icon={ info.icon } /> }
 										suffix={
@@ -264,14 +264,14 @@ function SortMenu( { fields, view, onChangeView } ) {
 										} }
 									>
 										{ info.label }
-									</DropdownMenuItemV2>
+									</DropdownMenuItem>
 								);
 							}
 						) }
-					</DropdownSubMenuV2>
+					</DropdownSubMenu>
 				);
 			} ) }
-		</DropdownSubMenuV2>
+		</DropdownSubMenu>
 	);
 }
 
@@ -284,7 +284,7 @@ export default function ViewActions( {
 	supportedLayouts,
 } ) {
 	return (
-		<DropdownMenuV2
+		<DropdownMenu
 			trigger={
 				<Button
 					variant="tertiary"
@@ -296,7 +296,7 @@ export default function ViewActions( {
 				/>
 			}
 		>
-			<DropdownMenuGroupV2>
+			<DropdownMenuGroup>
 				<ViewTypeMenu
 					view={ view }
 					onChangeView={ onChangeView }
@@ -313,7 +313,7 @@ export default function ViewActions( {
 					onChangeView={ onChangeView }
 				/>
 				<PageSizeMenu view={ view } onChangeView={ onChangeView } />
-			</DropdownMenuGroupV2>
-		</DropdownMenuV2>
+			</DropdownMenuGroup>
+		</DropdownMenu>
 	);
 }

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -40,12 +40,12 @@ import ItemActions from './item-actions';
 import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
 
 const {
-	DropdownMenuV2,
-	DropdownMenuGroupV2,
-	DropdownMenuItemV2,
-	DropdownMenuSeparatorV2,
-	DropdownSubMenuV2,
-	DropdownSubMenuTriggerV2,
+	DropdownMenuV2: DropdownMenu,
+	DropdownMenuGroupV2: DropdownMenuGroup,
+	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuSeparatorV2: DropdownMenuSeparator,
+	DropdownSubMenuV2: DropdownSubMenu,
+	DropdownSubMenuTriggerV2: DropdownSubMenuTrigger,
 } = unlock( componentsPrivateApis );
 
 const EMPTY_OBJECT = {};
@@ -80,7 +80,7 @@ function HeaderMenu( { dataView, header } ) {
 	const isFilterable = !! filter;
 
 	return (
-		<DropdownMenuV2
+		<DropdownMenu
 			align="start"
 			trigger={
 				<Button
@@ -93,10 +93,10 @@ function HeaderMenu( { dataView, header } ) {
 		>
 			<WithSeparators>
 				{ isSortable && (
-					<DropdownMenuGroupV2>
+					<DropdownMenuGroup>
 						{ Object.entries( sortingItemsInfo ).map(
 							( [ direction, info ] ) => (
-								<DropdownMenuItemV2
+								<DropdownMenuItem
 									key={ direction }
 									prefix={ <Icon icon={ info.icon } /> }
 									suffix={
@@ -119,13 +119,13 @@ function HeaderMenu( { dataView, header } ) {
 									} }
 								>
 									{ info.label }
-								</DropdownMenuItemV2>
+								</DropdownMenuItem>
 							)
 						) }
-					</DropdownMenuGroupV2>
+					</DropdownMenuGroup>
 				) }
 				{ isHidable && (
-					<DropdownMenuItemV2
+					<DropdownMenuItem
 						prefix={ <Icon icon={ unseen } /> }
 						onSelect={ ( event ) => {
 							event.preventDefault();
@@ -133,21 +133,21 @@ function HeaderMenu( { dataView, header } ) {
 						} }
 					>
 						{ __( 'Hide' ) }
-					</DropdownMenuItemV2>
+					</DropdownMenuItem>
 				) }
 				{ isFilterable && (
-					<DropdownMenuGroupV2>
-						<DropdownSubMenuV2
+					<DropdownMenuGroup>
+						<DropdownSubMenu
 							key={ filter.field }
 							trigger={
-								<DropdownSubMenuTriggerV2
+								<DropdownSubMenuTrigger
 									prefix={ <Icon icon={ funnel } /> }
 									suffix={
 										<Icon icon={ chevronRightSmall } />
 									}
 								>
 									{ __( 'Filter by' ) }
-								</DropdownSubMenuTriggerV2>
+								</DropdownSubMenuTrigger>
 							}
 						>
 							{ filter.elements.map( ( element ) => {
@@ -170,7 +170,7 @@ function HeaderMenu( { dataView, header } ) {
 								}
 
 								return (
-									<DropdownMenuItemV2
+									<DropdownMenuItem
 										key={ element.value }
 										suffix={
 											isActive && <Icon icon={ check } />
@@ -207,14 +207,14 @@ function HeaderMenu( { dataView, header } ) {
 										} }
 									>
 										{ element.label }
-									</DropdownMenuItemV2>
+									</DropdownMenuItem>
 								);
 							} ) }
-						</DropdownSubMenuV2>
-					</DropdownMenuGroupV2>
+						</DropdownSubMenu>
+					</DropdownMenuGroup>
 				) }
 			</WithSeparators>
-		</DropdownMenuV2>
+		</DropdownMenu>
 	);
 }
 
@@ -223,7 +223,7 @@ function WithSeparators( { children } ) {
 		.filter( Boolean )
 		.map( ( child, i ) => (
 			<Fragment key={ i }>
-				{ i > 0 && <DropdownMenuSeparatorV2 /> }
+				{ i > 0 && <DropdownMenuSeparator /> }
 				{ child }
 			</Fragment>
 		) );


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Removes the `V2` suffix from all the React components, limiting it to importing.

## Why?

It's easier to change when time comes.

## Testing Instructions

- Enable the "view admin" experiment and visit "Appareance > Editor > Pages > Manage all pages".
- Verify that things still work as expected.

