### PR TITLE
Template Replace Flow: Avoid column break within the preview box

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/style.scss
@@ -54,4 +54,8 @@ h3.edit-site-template-card__template-areas-title {
 	@include break-wide() {
 		column-count: 4;
 	}
+
+	.block-editor-block-patterns-list__list-item {
+		break-inside: avoid-column;
+	}
 }


### PR DESCRIPTION
Related to #54609

## What?

This PR fixes column wrapping of pattern titles in modal content when replacing template.

### Before

![before](https://github.com/WordPress/gutenberg/assets/54422211/8812b148-cc24-4258-809e-7225b8cf21bf)

### After 

![after](https://github.com/WordPress/gutenberg/assets/54422211/59608166-57d5-4129-95af-1f3d9ff17342)

## Why?

These columns are implemented by `column-count`. My understanding is that this property affects all internal elements, so the title will wrap unintentionally depending on the browser size.

## How?

Added `break-inside: avoid-column;`. This style is also used in many other places.

## Testing Instructions

- Open the Site Editor and go to the template inspector.
- Click the button to the right of the template title.
- Resize your browser.
- No matter what size the browser is, the title should never wrap.