### PR TITLE
File block: Remove anchor tag when copy pasting to file name

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -166,9 +166,9 @@ function ButtonEdit( props ) {
 
 	const TagName = tagName || 'a';
 
-	function setButtonText( newText ) {
-		// Remove anchor tags from button text content.
-		setAttributes( { text: newText.replace( /<\/?a[^>]*>/g, '' ) } );
+	// Remove anchor tags from button text content.
+	function removeAnchorTag( newValue ) {
+		return newValue.replace( /<\/?a[^>]*>/g, '' );
 	}
 
 	function onKeyDown( event ) {
@@ -245,7 +245,11 @@ function ButtonEdit( props ) {
 					aria-label={ __( 'Button text' ) }
 					placeholder={ placeholder || __( 'Add text…' ) }
 					value={ text }
-					onChange={ ( value ) => setButtonText( value ) }
+					onChange={ ( value ) =>
+						setAttributes( {
+							text: removeAnchorTag( value ),
+						} )
+					}
 					withoutInteractiveFormatting
 					className={ classnames(
 						className,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
 import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
+import removeAnchorTag from '../utils/remove-anchor-tag';
 
 /**
  * WordPress dependencies
@@ -165,11 +166,6 @@ function ButtonEdit( props ) {
 	} = attributes;
 
 	const TagName = tagName || 'a';
-
-	// Remove anchor tags from button text content.
-	function removeAnchorTag( newValue ) {
-		return newValue.replace( /<\/?a[^>]*>/g, '' );
-	}
 
 	function onKeyDown( event ) {
 		if ( isKeyboardEvent.primary( event, 'k' ) ) {

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -35,6 +35,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import FileBlockInspector from './inspector';
 import { browserSupportsPdfs } from './utils';
+import removeAnchorTag from '../utils/remove-anchor-tag';
 
 export const MIN_PREVIEW_HEIGHT = 200;
 export const MAX_PREVIEW_HEIGHT = 2000;
@@ -148,11 +149,6 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 
 	function changeShowDownloadButton( newValue ) {
 		setAttributes( { showDownloadButton: newValue } );
-	}
-
-	// Remove anchor tags from file name and button text content.
-	function removeAnchorTag( value ) {
-		return value.replace( /<\/?a[^>]*>/g, '' );
 	}
 
 	function changeDisplayPreview( newValue ) {

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -103,9 +103,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 
 		if ( downloadButtonText === undefined ) {
 			setAttributes( {
-				downloadButtonText: removeAnchorTag(
-					_x( 'Download', 'button label' )
-				),
+				downloadButtonText: _x( 'Download', 'button label' ),
 			} );
 		}
 	}, [] );

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -102,7 +102,11 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		}
 
 		if ( downloadButtonText === undefined ) {
-			changeDownloadButtonText( _x( 'Download', 'button label' ) );
+			setAttributes( {
+				downloadButtonText: removeAnchorTag(
+					_x( 'Download', 'button label' )
+				),
+			} );
 		}
 	}, [] );
 
@@ -148,11 +152,9 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		setAttributes( { showDownloadButton: newValue } );
 	}
 
-	function changeDownloadButtonText( newValue ) {
-		// Remove anchor tags from button text content.
-		setAttributes( {
-			downloadButtonText: newValue.replace( /<\/?a[^>]*>/g, '' ),
-		} );
+	// Remove anchor tags from file name and button text content.
+	function removeAnchorTag( value ) {
+		return value.replace( /<\/?a[^>]*>/g, '' );
 	}
 
 	function changeDisplayPreview( newValue ) {
@@ -277,7 +279,9 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
 						onChange={ ( text ) =>
-							setAttributes( { fileName: text } )
+							setAttributes( {
+								fileName: removeAnchorTag( text ),
+							} )
 						}
 						href={ textLinkHref }
 					/>
@@ -301,7 +305,10 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 								withoutInteractiveFormatting
 								placeholder={ __( 'Add text…' ) }
 								onChange={ ( text ) =>
-									changeDownloadButtonText( text )
+									setAttributes( {
+										downloadButtonText:
+											removeAnchorTag( text ),
+									} )
 								}
 							/>
 						</div>

--- a/packages/block-library/src/utils/remove-anchor-tag.js
+++ b/packages/block-library/src/utils/remove-anchor-tag.js
@@ -1,0 +1,10 @@
+/**
+ * Removes anchor tags from a string.
+ *
+ * @param {string} value The value to remove anchor tags from.
+ *
+ * @return {string} The value with anchor tags removed.
+ */
+export default function removeAnchorTag( value ) {
+	return value.replace( /<\/?a[^>]*>/g, '' );
+}


### PR DESCRIPTION
Fixes #54820
Follow-up #29273

## What?

This PR fixes an issue where if content containing an anchor is pasted into the filename of a file block, validation will fail and the block will become corrupted.

## Why?

This block's file name and button are both anchor elements, so you cannot put an anchor element inside them. In #29273, this issue was fixed for the download button, but the same fix should be applied for the file name as well.

## How?

I also added a process to remove anchors in the file name. At the same time, I changed the function name to something easier to understand, and changed the function to purely processing strings without executing `setAttributes()` inside the function.

## Testing Instructions

- Insert a file block.
- Copy text, including anchor elements, from a web page. You can also use [the code pen sample](https://codepen.io/Tetsuaki-Hamno/pen/rNPvXdR) text that I created.
- Paste it into the file name of the file block.
- Save the post and reload your browser.
- The block should not be broken.
- Open the code editor and verify that the anchor element is removed correctly.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/37362306-3432-40dd-8b97-098857e33488
