### PR TITLE
Site Editor: Add a fallback template showing the title and content for the post only mode.

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/edit-template.js
@@ -7,7 +7,6 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { check } from '@wordpress/icons';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	privateApis as editorPrivateApis,
 	store as editorStore,
@@ -20,7 +19,6 @@ import { store as editSiteStore } from '../../../store';
 import SwapTemplateButton from './swap-template-button';
 import ResetDefaultTemplate from './reset-default-template';
 import { unlock } from '../../../lock-unlock';
-import { PAGE_CONTENT_BLOCK_TYPES } from '../../../utils/constants';
 
 const { PostPanelRow } = unlock( editorPrivateApis );
 
@@ -30,22 +28,17 @@ const POPOVER_PROPS = {
 };
 
 export default function EditTemplate() {
-	const { hasPostContentBlocks, hasResolved, template, isTemplateHidden } =
-		useSelect( ( select ) => {
+	const { hasResolved, template, isTemplateHidden } = useSelect(
+		( select ) => {
 			const { getEditedPostContext, getEditedPostType, getEditedPostId } =
 				select( editSiteStore );
 			const { getRenderingMode } = unlock( select( editorStore ) );
 			const { getEditedEntityRecord, hasFinishedResolution } =
 				select( coreStore );
-			const { __experimentalGetGlobalBlocksByName } =
-				select( blockEditorStore );
 			const _context = getEditedPostContext();
 			const _postType = getEditedPostType();
 			const queryArgs = [ 'postType', _postType, getEditedPostId() ];
 			return {
-				hasPostContentBlocks: !! __experimentalGetGlobalBlocksByName(
-					Object.keys( PAGE_CONTENT_BLOCK_TYPES )
-				).length,
 				context: _context,
 				hasResolved: hasFinishedResolution(
 					'getEditedEntityRecord',
@@ -55,7 +48,9 @@ export default function EditTemplate() {
 				isTemplateHidden: getRenderingMode() === 'post-only',
 				postType: _postType,
 			};
-		}, [] );
+		},
+		[]
+	);
 
 	const { setRenderingMode } = useDispatch( editorStore );
 
@@ -90,25 +85,21 @@ export default function EditTemplate() {
 							<SwapTemplateButton onClick={ onClose } />
 						</MenuGroup>
 						<ResetDefaultTemplate onClick={ onClose } />
-						{ hasPostContentBlocks && (
-							<MenuGroup>
-								<MenuItem
-									icon={
-										! isTemplateHidden ? check : undefined
-									}
-									isPressed={ ! isTemplateHidden }
-									onClick={ () => {
-										setRenderingMode(
-											isTemplateHidden
-												? 'template-locked'
-												: 'post-only'
-										);
-									} }
-								>
-									{ __( 'Template preview' ) }
-								</MenuItem>
-							</MenuGroup>
-						) }
+						<MenuGroup>
+							<MenuItem
+								icon={ ! isTemplateHidden ? check : undefined }
+								isPressed={ ! isTemplateHidden }
+								onClick={ () => {
+									setRenderingMode(
+										isTemplateHidden
+											? 'template-locked'
+											: 'post-only'
+									);
+								} }
+							>
+								{ __( 'Template preview' ) }
+							</MenuItem>
+						</MenuGroup>
 					</>
 				) }
 			</DropdownMenu>

--- a/packages/edit-site/src/utils/constants.js
+++ b/packages/edit-site/src/utils/constants.js
@@ -38,16 +38,6 @@ export const FOCUSABLE_ENTITIES = [
 	PATTERN_TYPES.user,
 ];
 
-/**
- * Block types that are considered to be page content. These are the only blocks
- * editable when the page is focused.
- */
-export const PAGE_CONTENT_BLOCK_TYPES = {
-	'core/post-title': true,
-	'core/post-featured-image': true,
-	'core/post-content': true,
-};
-
 export const POST_TYPE_LABELS = {
 	[ TEMPLATE_POST_TYPE ]: __( 'Template' ),
 	[ TEMPLATE_PART_POST_TYPE ]: __( 'Template part' ),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -125,6 +125,10 @@ function useBlockEditorProps( post, template, mode ) {
 		}
 
 		if ( mode === 'post-only' ) {
+			const postContentBlocks =
+				extractPageContentBlockTypesFromTemplateBlocks(
+					templateBlocks
+				);
 			return [
 				createBlock(
 					'core/group',
@@ -138,9 +142,12 @@ function useBlockEditorProps( post, template, mode ) {
 							},
 						},
 					},
-					extractPageContentBlockTypesFromTemplateBlocks(
-						templateBlocks
-					)
+					postContentBlocks.length
+						? postContentBlocks
+						: [
+								createBlock( 'core/post-title' ),
+								createBlock( 'core/post-content' ),
+						  ]
 				),
 			];
 		}


### PR DESCRIPTION
Related #52632 
Follow-up #56418

## What?

If your page is using a template with a query loop block rather than using directly post title and post content, disabling the template preview (under "template" panel in the sidebar) resulted in a white page because no post blocks were found in the template.

This PR adds a fallback showing the post title and post content of the page (kind of mimicking the post editor).

My ultimate goal (not sure how possible) is to make the "post-only" mode strictly equivalent to the post editor which would allow us to refactor the post editor to use it instead of handing the switching between template and post manually.

## Testing instructions

- Have a page template that uses a query loop block.
- Assign this template to a page.
- Try disabling "template preview" while editing this page.
- The editor should show the page title and content blocks.
- you should be able to toggle the "template preview" on again.