### PR TITLE
[Data Views] Experimental keyboard navigation for table view

### DIFF
--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -34,6 +34,13 @@
 		&[data-field-id="actions"] {
 			text-align: right;
 		}
+
+		&:focus,
+		&:focus-visible,
+		&:focus-within {
+			background-color: #f0f0f0;
+			outline: none;
+		}
 	}
 	tr {
 		border-bottom: 1px solid $gray-100;

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -8,7 +8,13 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	useCallback,
+	useEffect,
+	forwardRef,
+} from '@wordpress/element';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -41,6 +47,8 @@ const defaultConfigPerViewType = {
 		mediaField: 'featured-image',
 	},
 };
+
+const DefaultWidget = forwardRef( ( { render } ) => render );
 
 function useView( type ) {
 	const {
@@ -192,33 +200,39 @@ export default function PagePages() {
 				header: __( 'Title' ),
 				id: 'title',
 				getValue: ( { item } ) => item.title?.rendered || item.slug,
-				render: ( { item, view: { type } } ) => {
-					return (
-						<VStack spacing={ 1 }>
-							<Heading as="h3" level={ 5 }>
-								<Link
-									params={ {
-										postId: item.id,
-										postType: item.type,
-										canvas: 'edit',
-									} }
-									onClick={ ( event ) => {
-										if (
-											viewTypeSupportsMap[ type ].preview
-										) {
-											event.preventDefault();
-											setSelection( [ item.id ] );
-										}
-									} }
-								>
-									{ decodeEntities(
-										item.title?.rendered || item.slug
-									) || __( '(no title)' ) }
-								</Link>
-							</Heading>
-						</VStack>
-					);
-				},
+				render: (
+					{ item, view: { type } },
+					Widget = DefaultWidget
+				) => (
+					<VStack spacing={ 1 }>
+						<Heading as="h3" level={ 5 }>
+							<Widget
+								render={
+									<Link
+										params={ {
+											postId: item.id,
+											postType: item.type,
+											canvas: 'edit',
+										} }
+										onClick={ ( event ) => {
+											if (
+												viewTypeSupportsMap[ type ]
+													.preview
+											) {
+												event.preventDefault();
+												setSelection( [ item.id ] );
+											}
+										} }
+									>
+										{ decodeEntities(
+											item.title?.rendered || item.slug
+										) || __( '(no title)' ) }
+									</Link>
+								}
+							/>
+						</Heading>
+					</VStack>
+				),
 				maxWidth: 400,
 				enableHiding: false,
 			},
@@ -226,12 +240,18 @@ export default function PagePages() {
 				header: __( 'Author' ),
 				id: 'author',
 				getValue: ( { item } ) => item._embedded?.author[ 0 ]?.name,
-				render: ( { item } ) => {
+				render: ( { item }, Widget = DefaultWidget ) => {
 					const author = item._embedded?.author[ 0 ];
 					return (
-						<a href={ `user-edit.php?user_id=${ author.id }` }>
-							{ author.name }
-						</a>
+						<Widget
+							render={
+								<a
+									href={ `user-edit.php?user_id=${ author.id }` }
+								>
+									{ author.name }
+								</a>
+							}
+						/>
 					);
 				},
 				type: ENUMERATION_TYPE,

--- a/packages/edit-site/src/components/routes/link.js
+++ b/packages/edit-site/src/components/routes/link.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { forwardRef } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -49,18 +50,17 @@ export function useLink( params = {}, state, shouldReplace = false ) {
 	};
 }
 
-export default function Link( {
-	params = {},
-	state,
-	replace: shouldReplace = false,
-	children,
-	...props
-} ) {
+export function UnforwardedLink(
+	{ params = {}, state, replace: shouldReplace = false, children, ...props },
+	ref
+) {
 	const { href, onClick } = useLink( params, state, shouldReplace );
 
 	return (
-		<a href={ href } onClick={ onClick } { ...props }>
+		<a ref={ ref } href={ href } onClick={ onClick } { ...props }>
 			{ children }
 		</a>
 	);
 }
+
+export default forwardRef( UnforwardedLink );


### PR DESCRIPTION
> [!IMPORTANT]
> The primary intent of this PR is ensuring tables are easier to navigate with a keyboard. As such, the code changes aren't super focused, and there's plenty of room for improvement! That being said, comments are of course welcome.

(Potentially) resolves #56328.


## What?
This PR improves the keyboard navigation in list views, presenting the table as a single tab-stop to be navigated with directional keys (<kbd>up</kbd>, <kbd>down</kbd>, <kbd>left</kbd>, <kbd>right</kbd>, etc).

https://github.com/WordPress/gutenberg/assets/159848/c22b8cbc-d142-4d50-8163-5a989c30999a


## Why?

As per #56328...
> Currently every focusable element (or "widget") in a list layout (header action buttons, linked items, etc) presents as its own tab stop. This can make it difficult and tedious for a non-mouse user to move across content.


## How?

The `Composite` component is used to render the various table elements, to provide embedded keyboard navigation.

A `Widget` system is introduced to allow render functions to indicate where navigable content should replace the wrapper context in the navigation flow.


## Testing Instructions

1. Open a data view to a table layout ("list view")
2. The table should render as before
3. Columns should remain sortable, hideable and filterable, where relevant
4. Grid views should continue to work

### Testing Instructions for Keyboard

With a list view open:
1. Tab to the first cell in the table
2. Use the arrow keys to navigate around the table
3. Interactive elements should gain focus where appropriate
5. Tab out of the table to the pagination controls


## To do

- [ ] Focus is lost when the table is reloaded (sorting, filtering, etc)
- [ ] The "more actions" dropdown in each row isn't an Ariakit implementation, so doesn't play nicely
- [ ] Sometimes the table forgets it's supposed to be focusable, and you can't get back in
- [ ] ...