### PR TITLE
DataViews: extract `FilterEnumeration` component

### DIFF
--- a/packages/edit-site/src/components/dataviews/add-filter.js
+++ b/packages/edit-site/src/components/dataviews/add-filter.js
@@ -14,12 +14,12 @@ import { __ } from '@wordpress/i18n';
  */
 import { unlock } from '../../lock-unlock';
 import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
+import FilterEnumeration from './filter-enumeration';
 
 const {
 	DropdownMenuV2: DropdownMenu,
 	DropdownSubMenuV2: DropdownSubMenu,
 	DropdownSubMenuTriggerV2: DropdownSubMenuTrigger,
-	DropdownMenuItemV2: DropdownMenuItem,
 } = unlock( componentsPrivateApis );
 
 export default function AddFilter( { fields, view, onChangeView } ) {
@@ -78,28 +78,11 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 							</DropdownSubMenuTrigger>
 						}
 					>
-						{ filter.elements.map( ( element ) => (
-							<DropdownMenuItem
-								key={ element.value }
-								onSelect={ () => {
-									onChangeView( ( currentView ) => ( {
-										...currentView,
-										page: 1,
-										filters: [
-											...currentView.filters,
-											{
-												field: filter.field,
-												operator: OPERATOR_IN,
-												value: element.value,
-											},
-										],
-									} ) );
-								} }
-								role="menuitemcheckbox"
-							>
-								{ element.label }
-							</DropdownMenuItem>
-						) ) }
+						<FilterEnumeration
+							filter={ filter }
+							view={ view }
+							onChangeView={ onChangeView }
+						/>
 					</DropdownSubMenu>
 				);
 			} ) }

--- a/packages/edit-site/src/components/dataviews/filter-enumeration.js
+++ b/packages/edit-site/src/components/dataviews/filter-enumeration.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { OPERATOR_IN } from './constants';
+
+const { DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem } = unlock(
+	componentsPrivateApis
+);
+
+export default function ( { filter, view, onChangeView } ) {
+	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
+	const activeElement = filter.elements.find(
+		( element ) => element.value === filterInView?.value
+	);
+
+	return filter.elements.map( ( element ) => {
+		return (
+			<DropdownMenuCheckboxItem
+				key={ element.value }
+				value={ element.value }
+				checked={ activeElement?.value === element.value }
+				onSelect={ () =>
+					onChangeView( ( currentView ) => ( {
+						...currentView,
+						page: 1,
+						filters: [
+							...view.filters.filter(
+								( f ) => f.field !== filter.field
+							),
+							{
+								field: filter.field,
+								operator: OPERATOR_IN,
+								value:
+									activeElement?.value === element.value
+										? undefined
+										: element.value,
+							},
+						],
+					} ) )
+				}
+			>
+				{ element.label }
+			</DropdownMenuCheckboxItem>
+		);
+	} );
+}

--- a/packages/edit-site/src/components/dataviews/filter-summary.js
+++ b/packages/edit-site/src/components/dataviews/filter-summary.js
@@ -12,13 +12,10 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { OPERATOR_IN } from './constants';
 import { unlock } from '../../lock-unlock';
+import FilterEnumeration from './filter-enumeration';
 
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2: DropdownMenu } = unlock( componentsPrivateApis );
 
 export default function FilterSummary( { filter, view, onChangeView } ) {
 	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
@@ -43,37 +40,11 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 				</Button>
 			}
 		>
-			{ filter.elements.map( ( element ) => {
-				return (
-					<DropdownMenuCheckboxItem
-						key={ element.value }
-						value={ element.value }
-						checked={ activeElement?.value === element.value }
-						onSelect={ () =>
-							onChangeView( ( currentView ) => ( {
-								...currentView,
-								page: 1,
-								filters: [
-									...view.filters.filter(
-										( f ) => f.field !== filter.field
-									),
-									{
-										field: filter.field,
-										operator: OPERATOR_IN,
-										value:
-											activeElement?.value ===
-											element.value
-												? undefined
-												: element.value,
-									},
-								],
-							} ) )
-						}
-					>
-						{ element.label }
-					</DropdownMenuCheckboxItem>
-				);
-			} ) }
+			<FilterEnumeration
+				filter={ filter }
+				view={ view }
+				onChangeView={ onChangeView }
+			/>
 		</DropdownMenu>
 	);
 }


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/55083

## What?

Extracts a new `FilterEnumeration` component for the existing filters:

<img width="225" alt="Captura de ecrã 2023-11-24, às 17 10 26" src="https://github.com/WordPress/gutenberg/assets/583546/01e670c3-656b-4c19-802f-8708fa770b1f">

## Why?

I plan to add new features to it, such as `NOT IN` operator [#56479](https://github.com/WordPress/gutenberg/pull/56479) or multiselection [#56468](https://github.com/WordPress/gutenberg/pull/56468). Those are easier to implement if all the components that trigger the filter use the same component.

## How?

- Create a new `FilterEnumeration` component.
- Use it in `AddFilter` and `FilterSummary` components, replacing the existing ones.

## Testing Instructions

- Enable the "view admin" experiments and visit "Appearance > Editor > Pages > Manage All Pages".
- Verify that filters still work as expected.

## TODO / Follow-ups

- ~I'd like to also reuse this component in the column's filters. I'll do it in subsequent PRs, as that code uses TanStack APIs (`dataView`/React Table and `header`) instead of our own `view`, etc. It needs a little refactoring first.~ I've gone ahead and update the viewlist here at [67d5dec](https://github.com/WordPress/gutenberg/pull/56514/commits/67d5dec0eb24f8b30cda46a7ee631adf5e3eae96). If it ends being too much or there is no agreement I'll extract to a different PR to work on separately.
