### PR TITLE
Button: try to avoid extra re-renders when toggling internal tooltip by using the `key` prop

### DIFF
--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -7,8 +7,8 @@ import userEvent from '@testing-library/user-event';
 /**
  * WordPress dependencies
  */
-import { createRef } from '@wordpress/element';
-import { plusCircle } from '@wordpress/icons';
+import { createRef, useRef } from '@wordpress/element';
+import { button, plusCircle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -389,6 +389,27 @@ describe( 'Button', () => {
 				expect( screen.getByRole( 'button' ) ).not.toHaveClass(
 					'is-pressed'
 				);
+			} );
+
+			it( 'should not re-render a new button HTML element when toggling the internal tooltip logic', () => {
+				const buttonCallbackRef = jest.fn();
+
+				const buttonProps = {
+					label: 'tooltip text',
+					ref: buttonCallbackRef,
+					children: 'Button text',
+				};
+
+				const { rerender } = render( <Button { ...buttonProps } /> );
+
+				expect( buttonCallbackRef ).toHaveBeenCalledTimes( 1 );
+
+				rerender( <Button { ...buttonProps } showTooltip /> );
+
+				// If the callback hasn't been called more than once, it means that
+				// flipping from hiding to showing the tooltip didn't cause the HTML
+				// button element to be removed and re-added to the DOM.
+				expect( buttonCallbackRef ).toHaveBeenCalledTimes( 1 );
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #56522

This PR attempts to prevent the `Button` from causing its `button` element to be removed and re-added to the DOM when the logic to show a tooltip is toggled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
