### PR TITLE
Style engine: allow CSS var output for fontSize and fontFamily and update docs

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -224,12 +224,12 @@ require __DIR__ . '/experiments-page.php';
 
 // Copied package PHP files.
 if ( is_dir( __DIR__ . '/../build/style-engine' ) ) {
-	require_once __DIR__ . '/../build/style-engine/style-engine-gutenberg.php';
-	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rule-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-store-gutenberg.php';
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-processor-gutenberg.php';
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php';
+	require_once __DIR__ . '/../build/style-engine/style-engine-gutenberg.php';
 }
 
 // Block supports overrides.

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -210,6 +210,9 @@ final class WP_Style_Engine {
 				'property_keys' => array(
 					'default' => 'font-size',
 				),
+				'css_vars'      => array(
+					'font-size' => '--wp--preset--font-size--$slug',
+				),
 				'path'          => array( 'typography', 'fontSize' ),
 				'classnames'    => array(
 					'has-$slug-font-size' => 'font-size',
@@ -218,6 +221,9 @@ final class WP_Style_Engine {
 			'fontFamily'     => array(
 				'property_keys' => array(
 					'default' => 'font-family',
+				),
+				'css_vars'      => array(
+					'font-family' => '--wp--preset--font-family--$slug',
 				),
 				'path'          => array( 'typography', 'fontFamily' ),
 				'classnames'    => array(

--- a/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
+++ b/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
@@ -51,7 +51,7 @@ When [registering a block support](https://developer.wordpress.org/reference/cla
 
 If a block has opted into the block support, the values of "class" and "style" will be applied to the block element's "class" and "style" attributes accordingly when rendered in the frontend HTML. Note, this applies only to server-side rendered blocks, for example, the [Site Title block](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/#site-title).
 
-The callback receives `$block_type` and `$block_attributes` as arguments. The `style` attribute within `$block_attributes` only contains the raw style object, if any styles have been set for the block, and not any CSS or classnames to be applied to the block's HTML elements. 
+The callback receives `$block_type` and `$block_attributes` as arguments. The `style` attribute within `$block_attributes` only contains the raw style object, if any styles have been set for the block, and not any CSS or classnames to be applied to the block's HTML elements.
 
 Here is where `wp_style_engine_get_styles` comes in handy: it will generate CSS and, if appropriate, classnames to be added to the "style" and "class" HTML attributes in the final rendered block markup.
 
@@ -100,7 +100,7 @@ Before passing the block style object to the Style Engine, you'll need to take i
 
 If a block either:
 
-- has no support for a style, or 
+- has no support for a style, or
 - skips serialization of that style
 
 it's likely that you'll want to remove those style values from the style object before passing it to the Style Engine with help of two functions:
@@ -108,24 +108,24 @@ it's likely that you'll want to remove those style values from the style object 
 - wp_should_skip_block_supports_serialization()
 - block_has_support()
 
-We can now update the apply callback code above so that we'll only return "style" and "class", where a block has support and it doesn't skip serialization:
+We can now update the "apply" callback code above so that we'll only return "style" and "class", where a block has support, and it doesn't skip serialization:
 
 ```php
 function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	// The return value.
 	$attributes = array();
-    
+
 	// Return early if the block skips all serialization for block supports.
 	if ( gutenberg_should_skip_block_supports_serialization( $block_type, 'color' ) ) {
 		return $attributes;
 	}
 
 	// Checks for support and skip serialization.
-	$has_text_support                        = block_has_support( $block_type, array( 'color', 'text' ), false ); 
+	$has_text_support                        = block_has_support( $block_type, array( 'color', 'text' ), false );
 	$has_background_support                  = block_has_support( $block_type, array( 'color', 'background' ), false );
-	$skips_serialization_of_color_text       = wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ); 
-	$skips_serialization_of_color_background = wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ); 
-    
+	$skips_serialization_of_color_text       = wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' );
+	$skips_serialization_of_color_background = wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' );
+
 	// Get the color styles from the style object.
 	$block_color_styles = isset( $block_attributes['style']['color'] ) ? $block_attributes['style']['color'] : null;
 
@@ -161,7 +161,7 @@ Styling a block using these presets normally involves adding the selector to the
 
 For styles that can have preset values, such as text color and font family, the Style Engine knows how to construct the classnames using the preset slug.
 
-To discern CSS values from preset values however, the Style Engine expects a special format.
+To discern CSS values from preset values, the Style Engine expects a special format.
 
 Preset values must follow the pattern `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`.
 
@@ -171,13 +171,16 @@ Example:
 
 ```php
 // Let's say the block attributes styles contain a fontSize preset slug of "small".
+// $block_attributes['fontSize'] = 'var:preset|font-size|small';
 $preset_font_size        = "var:preset|font-size|{$block_attributes['fontSize']}";
 // Now let's say the block attributes styles contain a backgroundColor preset slug of "blue".
+// $block_attributes['backgroundColor'] = 'var:preset|color|blue';
 $preset_background_color = "var:preset|color|{$block_attributes['backgroundColor']}";
 
 $block_styles =  array(
 	'typography' => array( 'fontSize' => $preset_font_size ),
-	'color'      => array( 'background' => $preset_background_color )
+	'color'      => array( 'background' => $preset_background_color ),
+	'spacing'    => array( 'padding' => '10px', 'margin' => array( 'top' => '1em') ),
 );
 
 $styles = wp_style_engine_get_styles(
@@ -187,29 +190,43 @@ print_r( $styles );
 
 /*
 array(
-    'css'        => 'background-color:var(--wp--preset--color--blue);font-size:var(--wp--preset--font-size--small);',
-    'classnames' => 'has-background-color has-blue-background-color has-small-font-size',
+    'css'          => 'background-color:var(--wp--preset--color--blue);padding:10px;margin-top:1em;font-size:var(--wp--preset--font-size--small);',
+	'declarations' => array(
+		'background-color' => 'var(--wp--preset--color--blue)',
+		'padding' => '10px',
+		'margin-top' => '1em',
+		'font-size' => 'var(--wp--preset--font-size--small)',
+	),
+    'classnames'   => 'has-background has-blue-background-color has-small-font-size',
 )
 */
 ```
 
-If you don't want the Style Engine to output the CSS custom vars as well, which you might not if you're applying both the CSS and classnames to the block element, you can pass `'convert_vars_to_classnames' => true` in the options array.
+If you don't want the Style Engine to output the CSS custom vars in the generated CSS string as well, which you might not if you're applying both the CSS rules and classnames to the block element, you can pass `'convert_vars_to_classnames' => true` in the options array.
+
+This flag means "covert the vars to classnames and don't output the vars to the CSS". The Style Engine will therefore **only** generate the required classnames and omit the CSS custom vars in the CSS.
+
+Using the above example code, observe the different output when we pass the option:
 
 ```php
 $options = array(
-	// Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
-	'convert_vars_to_classnames' => 'true',
+	'convert_vars_to_classnames' => true,
 );
+
 $styles = wp_style_engine_get_styles(
-	$block_styles,
-	$options
+    $block_styles,
+    $options
 );
 print_r( $styles );
 
 /*
 array(
-    'css'        => 'letter-spacing:12px;', // non-preset-based CSS will still be compiled.
-    'classnames' => 'has-background-color has-blue-background-color has-small-font-size',
+    'css'          => 'padding:10px;margin-top:1em;',
+	'declarations' => array(
+		'padding' => '10px',
+		'margin-top' => '1em',
+	),
+    'classnames'   => 'has-background has-blue-background-color has-small-font-size',
 )
 */
 ```

--- a/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
+++ b/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
@@ -30,11 +30,11 @@ The global function `wp_style_engine_get_styles` accepts a style object as its f
 
 ```php
 $block_styles =  array(
-     'spacing' => array( 'padding' => '10px', 'margin' => array( 'top' => '1em') ),
-     'typography' => array( 'fontSize' => '2.2rem' ),
+	'spacing' => array( 'padding' => '10px', 'margin' => array( 'top' => '1em') ),
+	'typography' => array( 'fontSize' => '2.2rem' ),
 );
 $styles = wp_style_engine_get_styles(
-    $block_styles
+	$block_styles
 );
 print_r( $styles );
 
@@ -190,7 +190,7 @@ print_r( $styles );
 
 /*
 array(
-    'css'          => 'background-color:var(--wp--preset--color--blue);padding:10px;margin-top:1em;font-size:var(--wp--preset--font-size--small);',
+	'css'          => 'background-color:var(--wp--preset--color--blue);padding:10px;margin-top:1em;font-size:var(--wp--preset--font-size--small);',
 	'declarations' => array(
 		'background-color' => 'var(--wp--preset--color--blue)',
 		'padding' => '10px',
@@ -214,19 +214,19 @@ $options = array(
 );
 
 $styles = wp_style_engine_get_styles(
-    $block_styles,
-    $options
+	$block_styles,
+	$options
 );
 print_r( $styles );
 
 /*
 array(
-    'css'          => 'padding:10px;margin-top:1em;',
+	'css'          => 'padding:10px;margin-top:1em;',
 	'declarations' => array(
 		'padding' => '10px',
 		'margin-top' => '1em',
 	),
-    'classnames'   => 'has-background has-blue-background-color has-small-font-size',
+	'classnames'   => 'has-background has-blue-background-color has-small-font-size',
 )
 */
 ```

--- a/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
+++ b/packages/style-engine/docs/using-the-style-engine-with-block-supports.md
@@ -204,7 +204,7 @@ array(
 
 If you don't want the Style Engine to output the CSS custom vars in the generated CSS string as well, which you might not if you're applying both the CSS rules and classnames to the block element, you can pass `'convert_vars_to_classnames' => true` in the options array.
 
-This flag means "covert the vars to classnames and don't output the vars to the CSS". The Style Engine will therefore **only** generate the required classnames and omit the CSS custom vars in the CSS.
+This flag means "convert the vars to classnames and don't output the vars to the CSS". The Style Engine will therefore **only** generate the required classnames and omit the CSS custom vars in the CSS.
 
 Using the above example code, observe the different output when we pass the option:
 

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -238,19 +238,26 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 			'elements_with_css_var_value'                  => array(
 				'block_styles'    => array(
-					'color' => array(
+					'color'      => array(
 						'text' => 'var:preset|color|my-little-pony',
+					),
+					'typography' => array(
+						'fontSize'   => 'var:preset|font-size|cabbage-patch',
+						'fontFamily' => 'var:preset|font-family|transformers',
 					),
 				),
 				'options'         => array(
 					'selector' => '.wp-selector',
 				),
 				'expected_output' => array(
-					'css'          => '.wp-selector{color:var(--wp--preset--color--my-little-pony);}',
+					'css'          => '.wp-selector{color:var(--wp--preset--color--my-little-pony);font-size:var(--wp--preset--font-size--cabbage-patch);font-family:var(--wp--preset--font-family--transformers);}',
 					'declarations' => array(
-						'color' => 'var(--wp--preset--color--my-little-pony)',
+						'color'       => 'var(--wp--preset--color--my-little-pony)',
+						'font-size'   => 'var(--wp--preset--font-size--cabbage-patch)',
+						'font-family' => 'var(--wp--preset--font-family--transformers)',
+
 					),
-					'classnames'   => 'has-text-color has-my-little-pony-color',
+					'classnames'   => 'has-text-color has-my-little-pony-color has-cabbage-patch-font-size has-transformers-font-family',
 				),
 			),
 


### PR DESCRIPTION
## What?

This PR:

1. Rearranges style engine files load order so that that style engine main files load **after** the utils classes have loaded
2. Adds CSS var parsing capability to fontSize and fontFamily. 
3. Updates docs in relation to CSS var names



## Why?
1. To prevent missing class errors in PHP during development
2. The JS package does this, theme.json has these presets, why not the Style Engine? I think it wasn't a deliberate omission.
3. Make them a bit clearer, especially in relation to `'convert_vars_to_classnames' => true,`

## Testing Instructions

1. Check out this branch
2. Delete the `/build` folder in your local dev environment
3. Rebuild the project `npm run dev`

There should be no build warnings and the site should work as per usual.

Ensure that there are no regressions in block supports styles. Here is some test code:


<details>

<summary>Example block code</summary>

```html
<!-- wp:group {"style":{"border":{"radius":"20px","top":{"width":"14px"},"right":{"color":"#ec0303","width":"46px"},"bottom":{"color":"#d8613c","width":"14px"},"left":{"color":"#636363","width":"46px"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="border-radius:20px;border-top-width:14px;border-right-color:#ec0303;border-right-width:46px;border-bottom-color:#d8613c;border-bottom-width:14px;border-left-color:#636363;border-left-width:46px"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|accent-5"}}},"typography":{"fontStyle":"normal","fontWeight":"500","textTransform":"uppercase"},"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}},"textColor":"accent-5","fontSize":"large"} -->
<h2 class="wp-block-heading has-accent-5-color has-text-color has-link-color has-large-font-size" style="padding-bottom:var(--wp--preset--spacing--40);font-style:normal;font-weight:500;text-transform:uppercase">Heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"fontSize":"small"} -->
<p class="has-small-font-size">Paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:list {"style":{"color":{"background":"#e6e3e3"},"spacing":{"margin":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
<ul style="background-color:#e6e3e3;margin-right:var(--wp--preset--spacing--30);margin-left:var(--wp--preset--spacing--30)" class="has-background"><!-- wp:list-item -->
<li>List</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>List</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>List</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```

</details>


<details>

<summary>Frontend output</summary>

```html
<div class="wp-block-group has-global-padding is-layout-constrained wp-block-group-is-layout-constrained" style="border-radius:20px;border-top-width:14px;border-right-color:#ec0303;border-right-width:46px;border-bottom-color:#d8613c;border-bottom-width:14px;border-left-color:#636363;border-left-width:46px">
<h2 class="wp-block-heading has-accent-5-color has-text-color has-link-color has-large-font-size wp-elements-0ea8f7f38d9a71fcf3ae556b6ed1adb1" style="padding-bottom:var(--wp--preset--spacing--40);font-style:normal;font-weight:500;text-transform:uppercase">Heading</h2>



<p class="has-small-font-size">Paragraph</p>



<ul style="background-color:#e6e3e3;margin-right:var(--wp--preset--spacing--30);margin-left:var(--wp--preset--spacing--30)" class="has-background">
<li>List</li>



<li>List</li>



<li>List</li>
</ul>
</div>
```

</details>


Run the tests!
`npm run test:unit:php:base -- --group style-engine`
