### PR TITLE
Editor: reinstate anonymous callback for saved post state

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -166,7 +166,7 @@ export default function PostSavedState( {
 						  } )
 						: undefined
 				}
-				onClick={ isDisabled ? undefined : savePost }
+				onClick={ isDisabled ? undefined : () => savePost() }
 				variant="tertiary"
 				icon={ isLargeViewport ? undefined : cloudUpload }
 				// Make sure the aria-label has always a value, as the default `text` is undefined on small screens.


### PR DESCRIPTION

## What?

Reverts [this line](https://github.com/WordPress/gutenberg/pull/56502/files#diff-400ecd69365f6525ab2e55887f776362df1a28a4b4fdef0347442ce7f1704915R169) merged in https://github.com/WordPress/gutenberg/pull/56502.



## Why?
The [savePost](https://github.com/WordPress/gutenberg/blob/5d86605316cc339cb8f15264a3fdf395f935618f/packages/editor/src/store/actions.js#L147-L147) action in the editor store doesn't expect to be passed an event object.

See the [relevant test](https://github.com/WordPress/gutenberg/blob/9b372d6480e4b697ede9aaadfb6ff5917b840fe5/packages/editor/src/components/post-saved-state/test/index.js#L88-L88).


## How are you?

Fine thanks!

## Testing Instructions
Run the tests!

`npm run test:unit packages/editor/src/components/post-saved-state/test/index.js`