### PR TITLE
Block Editor: Add <base> to Block Canvas Iframe head

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -218,6 +218,7 @@ function Iframe( {
 <html>
 	<head>
 		<meta charset="utf-8">
+  		<base href="${ window.location.origin }">
 		<script>window.frameElement._load()</script>
 		<style>html{height:auto!important;min-height:100%;}body{margin:0}</style>
 		${ styles }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
This allows relative paths to work inside a Block Canvas IFrame.
## What?
<!-- In a few words, what is the PR actually doing? -->
Adding `<base> `with the current location to the blob used as a source for the Block Canvas Iframe.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In WordPress that's not an issue but on other projects using the Block Editor component it might be. It is an issue at Drupal Gutenberg.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding` <base> `with current location, all urls will consider the url from that tag.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Not really an issue on WordPress but it can been seen at Drupal Gutenberg 3.0.0 Beta.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
