### PR TITLE
Patterns: disable editing of pattern entity in block editor

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -867,13 +867,14 @@ function MyBlock( { attributes, setAttributes } ) {
 }
 ```
 
-`mode` can be one of three options:
+`mode` can be one of four options:
 
 -   `'disabled'`: Prevents editing the block entirely, i.e. it cannot be
     selected.
 -   `'contentOnly'`: Hides all non-content UI, e.g. auxiliary controls in the
     toolbar, the block movers, block settings.
 -   `'default'`: Allows editing the block as normal.
+-   `'syncedPattern'`: Restricts editing of pattern block entities to only child blocks that have attribute connections set.
 
 The mode is inherited by all of the block's inner blocks, unless they have
 their own mode.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -874,7 +874,7 @@ function MyBlock( { attributes, setAttributes } ) {
 -   `'contentOnly'`: Hides all non-content UI, e.g. auxiliary controls in the
     toolbar, the block movers, block settings.
 -   `'default'`: Allows editing the block as normal.
--   `'syncedPattern'`: Restricts editing of pattern block entities to only child blocks that have attribute connections set.
+-   `'syncedPattern'`: Restricts editing of synced pattern blocks to only child blocks that have attribute connections set.
 
 The mode is inherited by all of the block's inner blocks, unless they have
 their own mode.

--- a/packages/block-editor/src/components/block-editing-mode/index.js
+++ b/packages/block-editor/src/components/block-editing-mode/index.js
@@ -33,7 +33,7 @@ import { BlockListBlockContext } from '../block-list/block-list-block-context';
  * - `'contentOnly'`: Hides all non-content UI, e.g. auxiliary controls in the
  *   toolbar, the block movers, block settings.
  * - `'default'`: Allows editing the block as normal.
- * - `'syncedPattern'`: Restricts editing of pattern block entities to only child blocks that have attribute connections set.
+ * - `'syncedPattern'`: Restricts editing of synced pattern blocks to only child blocks that have attribute connections set.
  *
  * The mode is inherited by all of the block's inner blocks, unless they have
  * their own mode.

--- a/packages/block-editor/src/components/block-editing-mode/index.js
+++ b/packages/block-editor/src/components/block-editing-mode/index.js
@@ -11,7 +11,7 @@ import { store as blockEditorStore } from '../../store';
 import { BlockListBlockContext } from '../block-list/block-list-block-context';
 
 /**
- * @typedef {'disabled'|'contentOnly'|'default'} BlockEditingMode
+ * @typedef {'disabled'|'contentOnly'|'default'|'syncedPattern'} BlockEditingMode
  */
 
 /**
@@ -26,13 +26,14 @@ import { BlockListBlockContext } from '../block-list/block-list-block-context';
  * }
  * ```
  *
- * `mode` can be one of three options:
+ * `mode` can be one of four options:
  *
  * - `'disabled'`: Prevents editing the block entirely, i.e. it cannot be
  *   selected.
  * - `'contentOnly'`: Hides all non-content UI, e.g. auxiliary controls in the
  *   toolbar, the block movers, block settings.
  * - `'default'`: Allows editing the block as normal.
+ * - `'syncedPattern'`: Restricts editing of pattern block entities to only child blocks that have attribute connections set.
  *
  * The mode is inherited by all of the block's inner blocks, unless they have
  * their own mode.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -113,6 +113,8 @@ function BlockListBlock( {
 	);
 	const { removeBlock } = useDispatch( blockEditorStore );
 	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
+	const isSyncedPatternChild =
+		name !== 'core/block' && blockEditingMode === 'syncedPattern';
 
 	const parentLayout = useLayout() || {};
 
@@ -142,7 +144,7 @@ function BlockListBlock( {
 
 	const blockType = getBlockType( name );
 
-	if ( blockEditingMode === 'disabled' ) {
+	if ( blockEditingMode === 'disabled' || isSyncedPatternChild ) {
 		wrapperProps = {
 			...wrapperProps,
 			tabIndex: -1,
@@ -216,7 +218,8 @@ function BlockListBlock( {
 		clientId,
 		className: classnames(
 			{
-				'is-editing-disabled': blockEditingMode === 'disabled',
+				'is-editing-disabled':
+					blockEditingMode === 'disabled' || isSyncedPatternChild,
 				'is-content-locked-temporarily-editing-as-blocks':
 					isTemporarilyEditingAsBlocks,
 			},

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -75,7 +75,8 @@ export function useInBetweenInserter() {
 
 				if (
 					getTemplateLock( rootClientId ) ||
-					getBlockEditingMode( rootClientId ) === 'disabled'
+					getBlockEditingMode( rootClientId ) === 'disabled' ||
+					getBlockEditingMode( rootClientId ) === 'syncedPattern'
 				) {
 					return;
 				}

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -25,7 +25,7 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 
 // Entity based blocks which allow edit locking
-const ALLOWS_EDIT_LOCKING = [ 'core/block', 'core/navigation' ];
+const ALLOWS_EDIT_LOCKING = [ 'core/navigation' ];
 
 function getTemplateLockValue( lock ) {
 	// Prevents all operations.

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -91,6 +91,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 	const isSynced =
 		isReusableBlock( blockType ) || isTemplatePart( blockType );
 
+	const isSyncedPattern = isReusableBlock( blockType );
 	const classes = classnames( 'block-editor-block-toolbar', {
 		'is-synced': isSynced,
 	} );
@@ -101,7 +102,8 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 				isLargeViewport &&
 				blockEditingMode === 'default' && <BlockParentSelector /> }
 			{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
-				blockEditingMode === 'default' && (
+				( blockEditingMode === 'default' ||
+					blockEditingMode === 'syncedPattern' ) && (
 					<div ref={ nodeRef } { ...showHoveredOrFocusedGestures }>
 						<ToolbarGroup className="block-editor-block-toolbar__block-controls">
 							<BlockSwitcher clientIds={ blockClientIds } />
@@ -148,7 +150,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 				</>
 			) }
 			<BlockEditVisuallyButton clientIds={ blockClientIds } />
-			{ blockEditingMode === 'default' && (
+			{ ( blockEditingMode === 'default' || isSyncedPattern ) && (
 				<BlockSettingsMenu clientIds={ blockClientIds } />
 			) }
 		</div>

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -70,7 +70,9 @@ export default function BlockContextualToolbar( {
 	const hasAnyBlockControls = useHasAnyBlockControls();
 	if (
 		! isToolbarEnabled ||
-		( blockEditingMode !== 'default' && ! hasAnyBlockControls )
+		( blockEditingMode !== 'syncedPattern' &&
+			blockEditingMode !== 'default' &&
+			! hasAnyBlockControls )
 	) {
 		return null;
 	}

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -89,7 +89,9 @@ function ListViewBlock( {
 		// List View respects this by also hiding the block settings menu.
 		hasBlockSupport( blockName, '__experimentalToolbar', true ) &&
 		// Don't show the settings menu if block is disabled or content only.
-		blockEditingMode === 'default';
+		( blockEditingMode === 'default' ||
+			( blockName === 'core/block' &&
+				blockEditingMode === 'syncedPattern' ) );
 	const instanceId = useInstanceId( ListViewBlock );
 	const descriptionId = `list-view-block-select-button__${ instanceId }`;
 	const blockPositionDescription = getBlockPositionDescription(

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -245,7 +245,9 @@ function ListViewBlock( {
 			path={ path }
 			id={ `list-view-${ listViewInstanceId }-block-${ clientId }` }
 			data-block={ clientId }
-			data-expanded={ canEdit ? isExpanded : undefined }
+			data-expanded={
+				canEdit && blockName !== 'core/block' ? isExpanded : undefined
+			}
 			ref={ rowRef }
 		>
 			<TreeGridCell

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -6,6 +6,7 @@
 	"category": "reusable",
 	"description": "Create and save content to reuse across your site. Update the pattern, and the changes apply everywhere it’s used.",
 	"keywords": [ "reusable" ],
+	"usesContext": [ "postId" ],
 	"textdomain": "default",
 	"attributes": {
 		"ref": {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -80,6 +80,7 @@ export default function ReusableBlockEdit( {
 	name,
 	attributes: { ref },
 	__unstableParentLayout: parentLayout,
+	context: { postId },
 } ) {
 	const editUrl = useSelect(
 		( select ) => {
@@ -96,6 +97,7 @@ export default function ReusableBlockEdit( {
 				postId: ref,
 				categoryType: 'pattern',
 				canvas: 'edit',
+				refererId: postId,
 			} );
 
 			// For editing link to the site editor if the theme and user permissions support it.
@@ -103,7 +105,7 @@ export default function ReusableBlockEdit( {
 				? siteEditorUrl
 				: defaultUrl;
 		},
-		[ ref ]
+		[ postId, ref ]
 	);
 	useBlockEditingMode( 'syncedPattern' );
 	const hasAlreadyRendered = useHasRecursion( ref );

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -98,7 +98,7 @@ export default function ReusableBlockEdit( {
 				canvas: 'edit',
 			} );
 
-			// For editing link to the site editor if the theme and user permissions support it
+			// For editing link to the site editor if the theme and user permissions support it.
 			return canUser( 'read', 'templates' ) && isBlockTheme
 				? siteEditorUrl
 				: defaultUrl;

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -27,6 +27,7 @@ import {
 	useBlockProps,
 	Warning,
 	privateApis as blockEditorPrivateApis,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useRef, useMemo } from '@wordpress/element';
 
@@ -72,6 +73,7 @@ export default function ReusableBlockEdit( {
 	attributes: { ref },
 	__unstableParentLayout: parentLayout,
 } ) {
+	useBlockEditingMode( 'syncedPattern' );
 	const hasAlreadyRendered = useHasRecursion( ref );
 	const { record, hasResolved } = useEntityRecord(
 		'postType',

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -27,6 +27,7 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { useRef, useState, useEffect } from '@wordpress/element';
+import { getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -142,6 +143,13 @@ function TemplateDocumentActions( { className, onBack } ) {
 		typeIcon = navigationIcon;
 	} else if ( record.type === PATTERN_TYPES.user ) {
 		typeIcon = symbol;
+	}
+
+	const { refererId } = getQueryArgs( window.location.href );
+
+	if ( ! onBack && refererId ) {
+		onBack = () =>
+			( document.location = `post.php?post=${ refererId }&action=edit` );
 	}
 
 	return (


### PR DESCRIPTION
## What?
Disables the editing of the synced pattern entity in the block editor and adds an `Edit` button to redirect to site editor pattern editor for full entity editing.

## Why?
As part of the work on allowing [selective editing of synced patterns](https://github.com/WordPress/gutenberg/issues/53705) we want to disable full editing of the synced pattern entities within the block editor.

This will make it easier to indicate to users when they are editing just a section of the pattern for that instance of the pattern only, versus editing the global source pattern instance.

## How?

Adds a new block editing mode of `syncedPattern` - this will make identifying blocks that are in the context of a synched pattern easier, and to apply custom editing controls accordingly.  I played around with using the existing states but it made it less clear in the code what was happening, and would also require some additional checks to see if one of parents is `core/block`.

While currently the child blocks are all disabled future work will allow `contentOnly` editing of some blocks if the blocks attributes are connected to the pattern parents attributes.

## Testing Instructions

- Add a synced pattern 
- Insert the pattern into the block editor and check that the child blocks can't be edited
- Check that the `Edit` button in the block toolbar redirects to site editor pattern edit canvas for blocked based theme and admin user, or post editor for entity for non-block themes or non-admin users

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/b0996a4c-2468-4c4f-a090-942142695c60

