### PR TITLE
Design Tools: Fix last ToolsPanelItem styling

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Button`: Add focus rings to focusable disabled buttons ([#56383](https://github.com/WordPress/gutenberg/pull/56383)).
 
+### Bug Fix
+
+-   `ToolsPanelItem`: Use useLayoutEffect to prevent rendering glitch for last panel item styling. ([#56536](https://github.com/WordPress/gutenberg/pull/56536)).
+
 ### Experimental
 
 -   `Tabs`: Memoize and expose the component context ([#56224](https://github.com/WordPress/gutenberg/pull/56224)).

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { usePrevious } from '@wordpress/compose';
-import { useCallback, useEffect, useMemo } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -59,7 +64,11 @@ export function useToolsPanelItem(
 
 	// Registering the panel item allows the panel to include it in its
 	// automatically generated menu and determine its initial checked status.
-	useEffect( () => {
+	//
+	// This is performed in a layout effect to ensure that the panel item
+	// is registered before it is rendered preventing a rendering glitch.
+	// See: https://github.com/WordPress/gutenberg/issues/56470
+	useLayoutEffect( () => {
 		if ( hasMatchingPanel && previousPanelId !== null ) {
 			registerPanelItem( {
 				hasValue: hasValueCallback,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/56470

## What?

Updates `ToolsPanelItem` to use `useLayoutEffect` for its registration hook to prevent a race condition causing a rendering glitch in a few browsers for the last panel item.

Kudos to @t-hamano for the suggested fix and the debugging efforts of @ciampo and @andrewserong 🙇 

## Why?

Prevents a rendering glitch causing the appearance of a broken layout in the color panel.

## How?

- Switch the panel item registration hook to useLayoutEffect

## Testing Instructions

1. Edit a post and add a couple of blocks to it that have color support
2. Select some of the blocks and select background colors for them only
3. Switch between blocks and confirm that there is no space between the background color button and the text color above it
4. Now try adding some other element colors for blocks (e.g. link, heading etc) and select a color for the last color control in the panel
5. Again, switch between blocks and confirm the layout of the color controls is as expected


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="280" alt="Screenshot 2023-11-27 at 11 39 46 am" src="https://github.com/WordPress/gutenberg/assets/60436221/20683379-2cec-481a-99b8-b69b403fa9e4"> | <img width="284" alt="Screenshot 2023-11-27 at 11 39 14 am" src="https://github.com/WordPress/gutenberg/assets/60436221/6132e2f6-a529-44ef-8f5d-c11b579b33de"> |

