### PR TITLE
Templates: fix bug with icon and outline on template replace modal

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -71,7 +71,7 @@ function BlockPattern( {
 					} }
 				>
 					<WithToolTip
-						showTooltip={ showTooltip && ! pattern.id }
+						showTooltip={ showTooltip && ! pattern.type === 'user' }
 						title={ pattern.title }
 					>
 						<CompositeItem
@@ -82,7 +82,8 @@ function BlockPattern( {
 								'block-editor-block-patterns-list__item',
 								{
 									'block-editor-block-patterns-list__list-item-synced':
-										pattern.id && ! pattern.syncStatus,
+										pattern.type === 'user' &&
+										! pattern.syncStatus,
 								}
 							) }
 							onClick={ () => {
@@ -107,15 +108,17 @@ function BlockPattern( {
 							/>
 
 							<HStack className="block-editor-patterns__pattern-details">
-								{ pattern.id && ! pattern.syncStatus && (
-									<div className="block-editor-patterns__pattern-icon-wrapper">
-										<Icon
-											className="block-editor-patterns__pattern-icon"
-											icon={ symbol }
-										/>
-									</div>
-								) }
-								{ ( ! showTooltip || pattern.id ) && (
+								{ pattern.type === 'user' &&
+									! pattern.syncStatus && (
+										<div className="block-editor-patterns__pattern-icon-wrapper">
+											<Icon
+												className="block-editor-patterns__pattern-icon"
+												icon={ symbol }
+											/>
+										</div>
+									) }
+								{ ( ! showTooltip ||
+									pattern.type === 'user' ) && (
 									<div className="block-editor-block-patterns-list__item-title">
 										{ pattern.title }
 									</div>

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2304,6 +2304,7 @@ function getUserPatterns( state ) {
 		return {
 			name: `core/block/${ userPattern.id }`,
 			id: userPattern.id,
+			type: 'user',
 			title: userPattern.title.raw,
 			categories: userPattern.wp_pattern_category.map( ( catId ) =>
 				categories && categories.get( catId )


### PR DESCRIPTION
## What?
Fixes an issue with some templates displaying as synced patterns by mistake.

## Why?
In the switch templates screen on the page editor the templates show the synced pattern icon and highlighting which is confusing to users.

This is a minimal implementation of the fix for  #56380 from https://github.com/WordPress/gutenberg/pull/56407 in order to backport to 6.4.2. The full fix included much wider changes and new constants that are not available in 6.4

## How?
This screen was identifying user patterns by the presence of `pattern.id` but it turns out that some templates also have an `id` field set. This PR adds a `type=user` field to user patterns to more reliably identify them.

## Testing Instructions

- In the site editor add or edit a page
- In the inspector panel click on the page template and choose the option to switch templates
- Check that that templates that display do not have a purple highlight when hovered and do not have the purple synced pattern icon
- In the inserter Patterns tab make sure that synced user patterns still display with purple icon and highlight and that  source filters for `User` still work as expected


## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/b63de640-d462-477d-9bd6-24fd54e2c5e0

After:

https://github.com/WordPress/gutenberg/assets/3629020/5eeaa342-304b-44b3-8ffd-ebc784561e55



