### PR TITLE
Site Editor: Apply the right post content layout in the "post only" mode

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -74,14 +74,14 @@ function extractPostContentBlockFromTemplateBlocks( blocks ) {
 	}
 	for ( let i = 0; i < blocks.length; i++ ) {
 		// Since the Query Block could contain PAGE_CONTENT_BLOCK_TYPES block types,
-		// we skip it because we only want to render stand-alone page content blocks in the block list.
+		// we skip it because we're only looking for post content blocks outside queries
+		// that render the actual post content of the current post/page.
 		if ( blocks[ i ].name === 'core/query' ) {
 			continue;
 		}
 		if ( blocks[ i ].name === 'core/post-content' ) {
 			return blocks[ i ];
 		}
-
 		if ( blocks[ i ].innerBlocks.length ) {
 			const postContentBlock = extractPostContentBlockFromTemplateBlocks(
 				blocks[ i ].innerBlocks

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -188,7 +188,23 @@ function useBlockEditorProps( post, template, mode ) {
 					[ block ]
 				);
 			} );
-			return innerBlocksWithLayout;
+
+			// This group block is only here to leave some space at the top of the canvas.
+			return [
+				createBlock(
+					'core/group',
+					{
+						style: {
+							spacing: {
+								margin: {
+									top: '4em',
+								},
+							},
+						},
+					},
+					innerBlocksWithLayout
+				),
+			];
 		}
 
 		if ( rootLevelPost === 'template' ) {

--- a/packages/editor/src/components/provider/use-post-editor-layout.js
+++ b/packages/editor/src/components/provider/use-post-editor-layout.js
@@ -22,7 +22,11 @@ export function usePostEditorLayout( templatePostContentBlock ) {
 					...templateLayoutDefinition,
 					type: 'constrained',
 			  }
-			: { ...globalStylesLayout, ...layout, type: 'default' };
+			: {
+					...globalStylesLayout,
+					...templateLayoutDefinition,
+					type: 'default',
+			  };
 	}, [ templateLayoutDefinition, globalStylesLayout ] );
 
 	return layout;

--- a/packages/editor/src/components/provider/use-post-editor-layout.js
+++ b/packages/editor/src/components/provider/use-post-editor-layout.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useSettings } from '@wordpress/block-editor';
+
+export function usePostEditorLayout( templatePostContentBlock ) {
+	const [ globalStylesLayout ] = useSettings( 'layout' );
+	const { layout: templateLayoutDefinition } =
+		templatePostContentBlock?.attributes ?? {};
+	const layout = useMemo( () => {
+		if ( ! templateLayoutDefinition ) {
+			return globalStylesLayout;
+		}
+		return templateLayoutDefinition &&
+			( templateLayoutDefinition?.type === 'constrained' ||
+				templateLayoutDefinition?.inherit ||
+				templateLayoutDefinition?.contentSize ||
+				templateLayoutDefinition?.wideSize )
+			? {
+					...globalStylesLayout,
+					...templateLayoutDefinition,
+					type: 'constrained',
+			  }
+			: { ...globalStylesLayout, ...layout, type: 'default' };
+	}, [ templateLayoutDefinition, globalStylesLayout ] );
+
+	return layout;
+}


### PR DESCRIPTION
Related #52632 
Follow-up to #56509 

## What?

In the post editor, for the root level layout, we try to guess the "layout" from the page/post template and otherwise fallback to the global styles layout if no layout is found on the post content block.

In the site editor however, we have a mode where we try to show the post/page in isolation mimicking the post editor but we we were not trying to find the right layout. We were just using the default constrained layout. In this PR I'm trying to bring the logic that exists in the post editor to this mode as well.

The ultimate goal is to actually unify the site editor and post editor (make the post editor use this code instead of its custom code).

## Testing Instructions

1- Open a page in both the site and post editors
2- in the site editor, disable "template preview" to switch to "post only" mode.
3- Notice that you have the same alignment options for top level blocks within the post content block.
