### PR TITLE
Block editor: Storybook: BlockTools must wrap around editor

### DIFF
--- a/storybook/stories/playground/box/index.js
+++ b/storybook/stories/playground/box/index.js
@@ -32,12 +32,10 @@ export default function EditorBox() {
 				value={ blocks }
 				onInput={ updateBlocks }
 				onChange={ updateBlocks }
-				settings={ {
-					hasFixedToolbar: true,
-				} }
 			>
-				<BlockTools />
-				<BlockCanvas height="100%" styles={ editorStyles } />
+				<BlockTools>
+					<BlockCanvas height="100%" styles={ editorStyles } />
+				</BlockTools>
 			</BlockEditorProvider>
 		</div>
 	);

--- a/storybook/stories/playground/with-undo-redo/index.js
+++ b/storybook/stories/playground/with-undo-redo/index.js
@@ -41,9 +41,6 @@ export default function EditorWithUndoRedo() {
 				onChange={ ( blocks, { selection } ) =>
 					setValue( { blocks, selection }, false )
 				}
-				settings={ {
-					hasFixedToolbar: true,
-				} }
 			>
 				<div className="editor-with-undo-redo__toolbar">
 					<Button
@@ -58,9 +55,10 @@ export default function EditorWithUndoRedo() {
 						icon={ redoIcon }
 						label="Redo"
 					/>
-					<BlockTools />
 				</div>
-				<BlockCanvas height="100%" styles={ editorStyles } />
+				<BlockTools>
+					<BlockCanvas height="100%" styles={ editorStyles } />
+				</BlockTools>
 			</BlockEditorProvider>
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

There's currently two instances in Storybook that don't correctly use `BlockTools`. It must wrap around the editor for it to work, otherwise you get an error.

Additionally I removed `hasFixedToolbar` because that doesn't work. Maybe in the future we need to expose a Slot or Component that you can render elsewhere. There's some context in #55787.

Also, the positioning of the toolbar is off, we'll need to figure out what is wrong in CSS. Most likely we also need to pass the content ref to the block tools, which is something we should build in (maybe with context).

From using the components elsewhere, I can tell it's quite tricky to get the floating toolbar to work nicely btw, you need to ensure there's enough padding around the content so that it doesn't overlap with content. For some reason the logic where it should move it under the block is broken.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the Storybook block editor section. Type in a block and move the mouse so the block toolbar shows (it doesn't show with an empty paragraph).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="686" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/a696e5f9-e5c0-4e3a-a9ec-983a9974d986">

