### PR TITLE
scripts: update `jest-dev-server` to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10378,6 +10378,14 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
+		"node_modules/@sideway/address": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+			"integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
 		"node_modules/@sideway/formula": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
@@ -20264,15 +20272,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.0"
 			}
 		},
 		"node_modules/axobject-query": {
@@ -32691,58 +32690,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/jest-dev-server": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-6.0.2.tgz",
-			"integrity": "sha512-cVpBu4KvNnefZsiustbaQmgGEKn72K6yk0OMgXDJ3yMT9N24ZM16TG0QgEacHPkrHKirOXZa1GN9Mi/lNl9Y+Q==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.1.2",
-				"cwd": "^0.10.0",
-				"find-process": "^1.4.5",
-				"prompts": "^2.4.1",
-				"spawnd": "^6.0.2",
-				"tree-kill": "^1.2.2",
-				"wait-on": "^6.0.0"
-			}
-		},
-		"node_modules/jest-dev-server/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest-dev-server/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-dev-server/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/jest-diff": {
 			"version": "29.6.2",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.2.tgz",
@@ -33421,14 +33368,6 @@
 				"@sideway/address": "^4.1.3",
 				"@sideway/formula": "^3.0.0",
 				"@sideway/pinpoint": "^2.0.0"
-			}
-		},
-		"node_modules/joi/node_modules/@sideway/address": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
-			"integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
-			"dependencies": {
-				"@hapi/hoek": "^9.0.0"
 			}
 		},
 		"node_modules/jpeg-js": {
@@ -48763,17 +48702,6 @@
 			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
-		"node_modules/spawnd": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-6.0.2.tgz",
-			"integrity": "sha512-+YJtx0dvy2wt304MrHD//tASc84zinBUYU1jacPBzrjhZUd7RsDo25krxr4HUHAQzEQFuMAs4/p+yLYU5ciZ1w==",
-			"dev": true,
-			"dependencies": {
-				"exit": "^0.1.2",
-				"signal-exit": "^3.0.6",
-				"tree-kill": "^1.2.2"
-			}
-		},
 		"node_modules/spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -52060,34 +51988,6 @@
 			},
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/wait-on": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.0.tgz",
-			"integrity": "sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==",
-			"dev": true,
-			"dependencies": {
-				"axios": "^0.21.1",
-				"joi": "^17.4.0",
-				"lodash": "^4.17.21",
-				"minimist": "^1.2.5",
-				"rxjs": "^7.1.0"
-			},
-			"bin": {
-				"wait-on": "bin/wait-on"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/wait-on/node_modules/rxjs": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/wait-port": {
@@ -56509,7 +56409,7 @@
 				"fast-glob": "^3.2.7",
 				"filenamify": "^4.2.0",
 				"jest": "^29.6.2",
-				"jest-dev-server": "^6.0.2",
+				"jest-dev-server": "^9.0.1",
 				"jest-environment-jsdom": "^29.6.2",
 				"jest-environment-node": "^29.6.2",
 				"markdownlint-cli": "^0.31.1",
@@ -56550,6 +56450,73 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"packages/scripts/node_modules/axios": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+			"integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+			"dev": true,
+			"dependencies": {
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
+		"packages/scripts/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"packages/scripts/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"packages/scripts/node_modules/jest-dev-server": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.1.tgz",
+			"integrity": "sha512-eqpJKSvVl4M0ojHZUPNbka8yEzLNbIMiINXDsuMF3lYfIdRO2iPqy+ASR4wBQ6nUyR3OT24oKPWhpsfLhgAVyg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"cwd": "^0.10.0",
+				"find-process": "^1.4.7",
+				"prompts": "^2.4.2",
+				"spawnd": "^9.0.1",
+				"tree-kill": "^1.2.2",
+				"wait-on": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/scripts/node_modules/joi": {
+			"version": "17.11.0",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
+			"integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0",
+				"@hapi/topo": "^5.0.0",
+				"@sideway/address": "^4.1.3",
+				"@sideway/formula": "^3.0.1",
+				"@sideway/pinpoint": "^2.0.0"
+			}
+		},
 		"packages/scripts/node_modules/playwright-core": {
 			"version": "1.39.0",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
@@ -56560,6 +56527,71 @@
 			},
 			"engines": {
 				"node": ">=16"
+			}
+		},
+		"packages/scripts/node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"packages/scripts/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"packages/scripts/node_modules/spawnd": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.1.tgz",
+			"integrity": "sha512-vaMk8E9CpbjTYToBxLXowDeArGf1+yI7A6PU6Nr57b2g8BVY8nRi5vTBj3bMF8UkCrMdTMyf/Lh+lrcrW2z7pw==",
+			"dev": true,
+			"dependencies": {
+				"signal-exit": "^4.1.0",
+				"tree-kill": "^1.2.2"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/scripts/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"packages/scripts/node_modules/wait-on": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+			"integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+			"dev": true,
+			"dependencies": {
+				"axios": "^1.6.1",
+				"joi": "^17.11.0",
+				"lodash": "^4.17.21",
+				"minimist": "^1.2.8",
+				"rxjs": "^7.8.1"
+			},
+			"bin": {
+				"wait-on": "bin/wait-on"
+			},
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"packages/server-side-render": {
@@ -64013,6 +64045,14 @@
 				}
 			}
 		},
+		"@sideway/address": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+			"integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+			"requires": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
 		"@sideway/formula": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
@@ -71209,7 +71249,7 @@
 				"fast-glob": "^3.2.7",
 				"filenamify": "^4.2.0",
 				"jest": "^29.6.2",
-				"jest-dev-server": "^6.0.2",
+				"jest-dev-server": "^9.0.1",
 				"jest-environment-jsdom": "^29.6.2",
 				"jest-environment-node": "^29.6.2",
 				"markdownlint-cli": "^0.31.1",
@@ -71238,11 +71278,113 @@
 				"webpack-dev-server": "^4.15.1"
 			},
 			"dependencies": {
+				"axios": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+					"integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+					"dev": true,
+					"requires": {
+						"follow-redirects": "^1.15.0",
+						"form-data": "^4.0.0",
+						"proxy-from-env": "^1.1.0"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-dev-server": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.1.tgz",
+					"integrity": "sha512-eqpJKSvVl4M0ojHZUPNbka8yEzLNbIMiINXDsuMF3lYfIdRO2iPqy+ASR4wBQ6nUyR3OT24oKPWhpsfLhgAVyg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^4.1.2",
+						"cwd": "^0.10.0",
+						"find-process": "^1.4.7",
+						"prompts": "^2.4.2",
+						"spawnd": "^9.0.1",
+						"tree-kill": "^1.2.2",
+						"wait-on": "^7.0.1"
+					}
+				},
+				"joi": {
+					"version": "17.11.0",
+					"resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
+					"integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+					"dev": true,
+					"requires": {
+						"@hapi/hoek": "^9.0.0",
+						"@hapi/topo": "^5.0.0",
+						"@sideway/address": "^4.1.3",
+						"@sideway/formula": "^3.0.1",
+						"@sideway/pinpoint": "^2.0.0"
+					}
+				},
 				"playwright-core": {
 					"version": "1.39.0",
 					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
 					"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
 					"dev": true
+				},
+				"rxjs": {
+					"version": "7.8.1",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+					"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				},
+				"spawnd": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.1.tgz",
+					"integrity": "sha512-vaMk8E9CpbjTYToBxLXowDeArGf1+yI7A6PU6Nr57b2g8BVY8nRi5vTBj3bMF8UkCrMdTMyf/Lh+lrcrW2z7pw==",
+					"dev": true,
+					"requires": {
+						"signal-exit": "^4.1.0",
+						"tree-kill": "^1.2.2"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"wait-on": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+					"integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+					"dev": true,
+					"requires": {
+						"axios": "^1.6.1",
+						"joi": "^17.11.0",
+						"lodash": "^4.17.21",
+						"minimist": "^1.2.8",
+						"rxjs": "^7.8.1"
+					}
 				}
 			}
 		},
@@ -72626,15 +72768,6 @@
 			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
 			"integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
 			"dev": true
-		},
-		"axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-			"dev": true,
-			"requires": {
-				"follow-redirects": "^1.14.0"
-			}
 		},
 		"axobject-query": {
 			"version": "2.2.0",
@@ -82106,48 +82239,6 @@
 				}
 			}
 		},
-		"jest-dev-server": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-6.0.2.tgz",
-			"integrity": "sha512-cVpBu4KvNnefZsiustbaQmgGEKn72K6yk0OMgXDJ3yMT9N24ZM16TG0QgEacHPkrHKirOXZa1GN9Mi/lNl9Y+Q==",
-			"dev": true,
-			"requires": {
-				"chalk": "^4.1.2",
-				"cwd": "^0.10.0",
-				"find-process": "^1.4.5",
-				"prompts": "^2.4.1",
-				"spawnd": "^6.0.2",
-				"tree-kill": "^1.2.2",
-				"wait-on": "^6.0.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"jest-diff": {
 			"version": "29.6.2",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.2.tgz",
@@ -82664,16 +82755,6 @@
 				"@sideway/address": "^4.1.3",
 				"@sideway/formula": "^3.0.0",
 				"@sideway/pinpoint": "^2.0.0"
-			},
-			"dependencies": {
-				"@sideway/address": {
-					"version": "4.1.3",
-					"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
-					"integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
-					"requires": {
-						"@hapi/hoek": "^9.0.0"
-					}
-				}
 			}
 		},
 		"jpeg-js": {
@@ -94498,17 +94579,6 @@
 			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
-		"spawnd": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-6.0.2.tgz",
-			"integrity": "sha512-+YJtx0dvy2wt304MrHD//tASc84zinBUYU1jacPBzrjhZUd7RsDo25krxr4HUHAQzEQFuMAs4/p+yLYU5ciZ1w==",
-			"dev": true,
-			"requires": {
-				"exit": "^0.1.2",
-				"signal-exit": "^3.0.6",
-				"tree-kill": "^1.2.2"
-			}
-		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -96992,30 +97062,6 @@
 			"dev": true,
 			"requires": {
 				"xml-name-validator": "^4.0.0"
-			}
-		},
-		"wait-on": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.0.tgz",
-			"integrity": "sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==",
-			"dev": true,
-			"requires": {
-				"axios": "^0.21.1",
-				"joi": "^17.4.0",
-				"lodash": "^4.17.21",
-				"minimist": "^1.2.5",
-				"rxjs": "^7.1.0"
-			},
-			"dependencies": {
-				"rxjs": {
-					"version": "7.8.1",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-					"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-					"dev": true,
-					"requires": {
-						"tslib": "^2.1.0"
-					}
-				}
 			}
 		},
 		"wait-port": {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   The bundled `jest-dev-server` dependency has been updated from `^6.0.2` to `^9.0.1` ([#33287](https://github.com/WordPress/gutenberg/pull/33287)).
+
 ## 26.17.0 (2023-11-16)
 
 ## 26.16.0 (2023-11-02)

--- a/packages/scripts/config/jest-environment-puppeteer/global.js
+++ b/packages/scripts/config/jest-environment-puppeteer/global.js
@@ -30,8 +30,8 @@ const chalk = require( 'chalk' );
 const { readConfig, getPuppeteer } = require( './config' );
 
 let browser;
-
 let didAlreadyRunInWatchMode = false;
+let servers = [];
 
 async function setup( jestConfig = {} ) {
 	const config = await readConfig();
@@ -51,7 +51,7 @@ async function setup( jestConfig = {} ) {
 
 	if ( config.server ) {
 		try {
-			await setupServer( config.server );
+			servers = await setupServer( config.server );
 		} catch ( error ) {
 			const { error: printError } = console;
 			if ( error.code === ERROR_TIMEOUT ) {
@@ -89,7 +89,7 @@ async function teardown( jestConfig = {} ) {
 	}
 
 	if ( ! jestConfig.watch && ! jestConfig.watchAll ) {
-		await teardownServer();
+		await teardownServer( servers );
 	}
 }
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -63,7 +63,7 @@
 		"fast-glob": "^3.2.7",
 		"filenamify": "^4.2.0",
 		"jest": "^29.6.2",
-		"jest-dev-server": "^6.0.2",
+		"jest-dev-server": "^9.0.1",
 		"jest-environment-jsdom": "^29.6.2",
 		"jest-environment-node": "^29.6.2",
 		"markdownlint-cli": "^0.31.1",


### PR DESCRIPTION
## What?

Update `jest-dev-server` dependency of `@wordpress/scripts` to `^9.0.1` (previously `6.0.2`).

## Why?

There are reported vulnerabilities reported in some dependencies of our currently used version of `jest-dev-server` (https://github.com/WordPress/gutenberg/issues/56069).
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Bump the version in `packages/scripts/package.json` to the most recent version.

## Testing Instructions

I think we should see in E2E tests if this is working although I didn't spot any particular breaking changes in the docs regarding our usage.

### Testing Instructions for Keyboard

none
