### PR TITLE
Raw handling: fix block schema merging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54775,7 +54775,6 @@
 				"@wordpress/shortcode": "file:../shortcode",
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
-				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70054,7 +70054,6 @@
 				"@wordpress/shortcode": "file:../shortcode",
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
-				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -45,7 +45,6 @@
 		"@wordpress/shortcode": "file:../shortcode",
 		"change-case": "^4.1.2",
 		"colord": "^2.7.0",
-		"deepmerge": "^4.3.0",
 		"fast-deep-equal": "^3.1.3",
 		"hpq": "^1.3.0",
 		"is-plain-object": "^5.0.0",

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -74,9 +74,9 @@ export function getBlockContentSchemaFromTransforms( transforms, context ) {
 		}
 	}
 
-	// An tagName schema is an object with children, attributes, require, and
+	// A tagName schema is an object with children, attributes, require, and
 	// isMatch properties.
-	function mergeElementSchemas( a, b ) {
+	function mergeTagNameSchemas( a, b ) {
 		for ( const key in b ) {
 			a[ key ] = a[ key ]
 				? mergeTagNameSchemaProperties( a[ key ], b[ key ], key )
@@ -89,7 +89,7 @@ export function getBlockContentSchemaFromTransforms( transforms, context ) {
 	function mergeSchemas( a, b ) {
 		for ( const key in b ) {
 			a[ key ] = a[ key ]
-				? mergeElementSchemas( a[ key ], b[ key ] )
+				? mergeTagNameSchemas( a[ key ], b[ key ] )
 				: { ...b[ key ] };
 		}
 		return a;

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import deepmerge from 'deepmerge';
-
-/**
  * WordPress dependencies
  */
 import { isPhrasingContent, getPhrasingContentSchema } from '@wordpress/dom';
@@ -13,41 +8,6 @@ import { isPhrasingContent, getPhrasingContentSchema } from '@wordpress/dom';
  */
 import { hasBlockSupport } from '..';
 import { getRawTransforms } from './get-raw-transforms';
-
-const customMerge = ( key ) => {
-	return ( srcValue, objValue ) => {
-		switch ( key ) {
-			case 'children': {
-				if ( objValue === '*' || srcValue === '*' ) {
-					return '*';
-				}
-
-				return { ...objValue, ...srcValue };
-			}
-			case 'attributes':
-			case 'require': {
-				return [ ...( objValue || [] ), ...( srcValue || [] ) ];
-			}
-			case 'isMatch': {
-				// If one of the values being merge is undefined (matches everything),
-				// the result of the merge will be undefined.
-				if ( ! objValue || ! srcValue ) {
-					return undefined;
-				}
-				// When merging two isMatch functions, the result is a new function
-				// that returns if one of the source functions returns true.
-				return ( ...args ) => {
-					return objValue( ...args ) || srcValue( ...args );
-				};
-			}
-		}
-
-		return deepmerge( objValue, srcValue, {
-			customMerge,
-			clone: false,
-		} );
-	};
-};
 
 export function getBlockContentSchemaFromTransforms( transforms, context ) {
 	const phrasingContentSchema = getPhrasingContentSchema( context );
@@ -86,10 +46,56 @@ export function getBlockContentSchemaFromTransforms( transforms, context ) {
 		);
 	} );
 
-	return deepmerge.all( schemas, {
-		customMerge,
-		clone: false,
-	} );
+	function mergeTagNameSchemaProperties( objValue, srcValue, key ) {
+		switch ( key ) {
+			case 'children': {
+				if ( objValue === '*' || srcValue === '*' ) {
+					return '*';
+				}
+
+				return { ...objValue, ...srcValue };
+			}
+			case 'attributes':
+			case 'require': {
+				return [ ...( objValue || [] ), ...( srcValue || [] ) ];
+			}
+			case 'isMatch': {
+				// If one of the values being merge is undefined (matches everything),
+				// the result of the merge will be undefined.
+				if ( ! objValue || ! srcValue ) {
+					return undefined;
+				}
+				// When merging two isMatch functions, the result is a new function
+				// that returns if one of the source functions returns true.
+				return ( ...args ) => {
+					return objValue( ...args ) || srcValue( ...args );
+				};
+			}
+		}
+	}
+
+	// An tagName schema is an object with children, attributes, require, and
+	// isMatch properties.
+	function mergeElementSchemas( a, b ) {
+		for ( const key in b ) {
+			a[ key ] = a[ key ]
+				? mergeTagNameSchemaProperties( a[ key ], b[ key ], key )
+				: { ...b[ key ] };
+		}
+		return a;
+	}
+
+	// A schema is an object with tagName schemas by tag name.
+	function mergeSchemas( a, b ) {
+		for ( const key in b ) {
+			a[ key ] = a[ key ]
+				? mergeElementSchemas( a[ key ], b[ key ] )
+				: { ...b[ key ] };
+		}
+		return a;
+	}
+
+	return schemas.reduce( mergeSchemas, {} );
 }
 
 /**

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -369,6 +369,34 @@ describe( 'Blocks raw handling', () => {
 		expect( console ).toHaveLogged();
 	} );
 
+	it( 'should convert pre', () => {
+		const transformed = pasteHandler( {
+			HTML: '<pre>1\n2</pre>',
+			plainText: '1\n2',
+		} )
+			.map( getBlockContent )
+			.join( '' );
+
+		expect( transformed ).toBe(
+			'<pre class="wp-block-preformatted">1\n2</pre>'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should convert code', () => {
+		const transformed = pasteHandler( {
+			HTML: '<pre><code>1\n2</code></pre>',
+			plainText: '1\n2',
+		} )
+			.map( getBlockContent )
+			.join( '' );
+
+		expect( transformed ).toBe(
+			'<pre class="wp-block-code"><code>1\n2</code></pre>'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
 	describe( 'pasteHandler', () => {
 		[
 			'plain',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

#50637 introduced a problem with schema merging. It seems the `isMatch` functions are not properly merged. For some reason the custom merge function is not working, while it was working with the lodash function.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just merge it ourselves.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to https://www.gutenberg.org/cache/epub/11/pg11.txt, select a few paragraphs, and paste it into GB. Instead of a Preformatted block, it's a paragraph with one giant text block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
