### PR TITLE
Add block toolbar as a navigable region

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -92,6 +92,8 @@ export default function BlockContextualToolbar( {
 			// Resets the index whenever the active block changes so
 			// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
 			key={ selectedBlockClientId }
+			role="region"
+			tabIndex="-1"
 			{ ...props }
 		>
 			<BlockToolbar hideDragHandle={ isFixed } />

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -82,21 +82,21 @@ export default function BlockContextualToolbar( {
 	} );
 
 	return (
-		<NavigableToolbar
-			focusOnMount={ focusOnMount }
-			focusEditorOnEscape
-			className={ classes }
-			/* translators: accessibility text for the block toolbar */
-			aria-label={ __( 'Block tools' ) }
-			variant={ isFixed ? 'unstyled' : undefined }
-			// Resets the index whenever the active block changes so
-			// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-			key={ selectedBlockClientId }
-			role="region"
-			tabIndex="-1"
-			{ ...props }
-		>
-			<BlockToolbar hideDragHandle={ isFixed } />
-		</NavigableToolbar>
+		<div role="region" tabIndex="-1">
+			<NavigableToolbar
+				focusOnMount={ focusOnMount }
+				focusEditorOnEscape
+				className={ classes }
+				/* translators: accessibility text for the block toolbar */
+				aria-label={ __( 'Block tools' ) }
+				variant={ isFixed ? 'unstyled' : undefined }
+				// Resets the index whenever the active block changes so
+				// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+				key={ selectedBlockClientId }
+				{ ...props }
+			>
+				<BlockToolbar hideDragHandle={ isFixed } />
+			</NavigableToolbar>
+		</div>
 	);
 }

--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -42,6 +42,8 @@ function InlineToolbar( { popoverAnchor } ) {
 			anchor={ popoverAnchor }
 			className="block-editor-rich-text__inline-format-toolbar"
 			__unstableSlotName="block-toolbar"
+			role="region"
+			tabIndex="-1"
 		>
 			<NavigableToolbar
 				className="block-editor-rich-text__inline-format-toolbar-group"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds the block toolbar and inline rich text toolbar (for example for image captions) as a region so you can navigate to it directly with ctrl+`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/pull/56474#issuecomment-1826213147

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just makes it focusable and adds the region attribute. We discussed that navigating regions should focus the first element, which I will attempt in a follow-up PR. Maybe we should also consider merging regions with the `Alt+F10` shortcut?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Pressing ctrl+` should cycle through the  block toolbar as well.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![regions-toolbars](https://github.com/WordPress/gutenberg/assets/4710635/b6e43b6f-b7f1-44b1-91c3-7e2098ceed4f)
