### PR TITLE
Bring back non-JS tabs in block editor handbook

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -69,7 +69,8 @@ To address this need, we've started to experiment with CSS Custom Properties, ak
 
 - **Presets**: [color palettes](/docs/how-to-guides/themes/theme-support.md#block-color-palettes), [font sizes](/docs/how-to-guides/themes/theme-support.md#block-font-sizes), or [gradients](/docs/how-to-guides/themes/theme-support.md#block-gradient-presets) declared by the theme are converted to CSS Custom Properties and enqueued both the front-end and the editors.
 
-#### Input
+{% codetabs %}
+{% Input %}
 
 ```json
 {
@@ -93,7 +94,7 @@ To address this need, we've started to experiment with CSS Custom Properties, ak
 }
 ```
 
-#### Output
+{% Output %}
 
 ```css
 body {
@@ -104,8 +105,10 @@ body {
 
 -   **Custom properties**: there's also a mechanism to create your own CSS Custom Properties.
 
+{% end %}
 
-#### Input
+{% codetabs %}
+{% Input %}
 
 ```json
 {
@@ -121,7 +124,7 @@ body {
 }
 ```
 
-#### Output
+{% Output %}
 
 ```css
 body {
@@ -129,6 +132,8 @@ body {
 	--wp--custom--line-height--heading: 1.3;
 }
 ```
+
+{% end %}
 
 ## Specification
 
@@ -161,8 +166,8 @@ The tabs below show WordPress 5.8 supported settings and the ones supported by t
 
 The settings section has the following structure:
 
-
-#### WordPress
+{% codetabs %}
+{% WordPress %}
 
 ```json
 {
@@ -226,7 +231,7 @@ The settings section has the following structure:
 }
 ```
 
-#### Gutenberg
+{% Gutenberg %}
 
 ```json
 {
@@ -304,6 +309,7 @@ The settings section has the following structure:
 	}
 }
 ```
+{% end %}
 
 Each block can configure any of these settings separately, providing a more fine-grained control over what exists via `add_theme_support`. The settings declared at the top-level affect to all blocks, unless a particular block overwrites it. It's a way to provide inheritance and configure all blocks at once.
 
@@ -370,7 +376,8 @@ The naming schema for the classes and the custom properties is as follows:
 - Classes: `.has-{preset-slug}-{preset-category}` such as `.has-black-color`.
 
 
-#### Input
+{% codetabs %}
+{% Input %}
 
 ```json
 {
@@ -483,7 +490,7 @@ The naming schema for the classes and the custom properties is as follows:
 }
 ```
 
-#### Output
+{% Output %}
 
 ```css
 /* Top-level custom properties */
@@ -532,6 +539,7 @@ body {
 .wp-block-group.has-white-border-color { border-color: #444 !important; }
 
 ```
+{% end %}
 
 To maintain backward compatibility, the presets declared via `add_theme_support` will also generate the CSS Custom Properties. If the `theme.json` contains any presets, these will take precedence over the ones declared via `add_theme_support`.
 
@@ -543,7 +551,8 @@ In addition to create CSS Custom Properties for the presets, the `theme.json` al
 
 For example:
 
-#### Input
+{% codetabs %}
+{% Input %}
 
 ```json
 {
@@ -568,7 +577,7 @@ For example:
 }
 ```
 
-#### Output
+{% Output %}
 
 ```css
 body {
@@ -582,6 +591,7 @@ body {
 }
 ```
 
+{% end %}
 
 Note that the name of the variable is created by adding `--` in between each nesting level and `camelCase` fields are transformed to `kebab-case`.
 
@@ -691,9 +701,8 @@ The tabs below show WordPress 5.8 supported styles and the ones supported by the
 
 Each block declares which style properties it exposes via the [block supports mechanism](/docs/reference-guides/block-api/block-supports.md). The support declarations are used to automatically generate the UI controls for the block in the editor. Themes can use any style property via the `theme.json` for any block ― it's the theme's responsibility to verify that it works properly according to the block markup, etc.
 
-
-
-#### WordPress
+{% codetabs %}
+{% WordPress %}
 
 ```json
 {
@@ -772,8 +781,7 @@ Each block declares which style properties it exposes via the [block supports me
 	}
 }
 ```
-
-#### Gutenberg
+{% Gutenberg %}
 
 ```json
 {
@@ -861,12 +869,13 @@ Each block declares which style properties it exposes via the [block supports me
 	}
 }
 ```
-
+{% end %}
 ### Top-level styles
 
 Styles found at the top-level will be enqueued using the `body` selector.
 
-#### Input
+{% codetabs %}
+{% Input %}
 
 ```json
 {
@@ -879,7 +888,7 @@ Styles found at the top-level will be enqueued using the `body` selector.
 }
 ```
 
-#### Output
+{% Output %}
 
 ```css
 body {
@@ -887,14 +896,15 @@ body {
 }
 ```
 
-
+{% end %}
 ### Block styles
 
 Styles found within a block will be enqueued using the block selector.
 
 By default, the block selector is generated based on its name such as `.wp-block-<blockname-without-namespace>`. For example, `.wp-block-group` for the `core/group` block. There are some blocks that want to opt-out from this default behavior. They can do so by explicitly telling the system which selector to use for them via the `__experimentalSelector` key within the `supports` section of its `block.json` file. Note that the block needs to be registered server-side for the `__experimentalSelector` field to be available to the style engine.
 
-#### Input
+{% codetabs %}
+{% Input %}
 
 ```json
 {
@@ -919,7 +929,7 @@ By default, the block selector is generated based on its name such as `.wp-block
 }
 ```
 
-#### Output
+{% Output %}
 
 ```css
 body {
@@ -932,7 +942,7 @@ p { /* The core/paragraph opts out from the default behaviour and uses p as a se
 	color: var( --wp--preset--color--tertiary );
 }
 ```
-
+{% end %}
 
 #### Referencing a style
 
@@ -980,7 +990,8 @@ Supported by WordPress:
 If they're found in the top-level the element selector will be used. If they're found within a block, the selector to be used will be the element's appended to the corresponding block.
 
 
-#### Input
+{% codetabs %}
+{% Input %}
 
 ```json
 {
@@ -1026,7 +1037,7 @@ If they're found in the top-level the element selector will be used. If they're 
 }
 ```
 
-#### Output
+{% Output %}
 
 ```css
 body {
@@ -1048,7 +1059,7 @@ h3 {
 	font-size: var( --wp--preset--font-size--smaller );
 }
 ```
-
+{% end %}
 ##### Element pseudo selectors
 
 Pseudo selectors `:hover`, `:focus`, `:visited`, `:active`, `:link`, `:any-link` are supported by Gutenberg.
@@ -1217,8 +1228,8 @@ This is for clarity, but also because we want a mechanism to parse back a variab
 
 For example:
 
-
-#### Input
+{% codetabs %}
+{% Input %}
 
 ```json
 {
@@ -1234,7 +1245,7 @@ For example:
 }
 ```
 
-#### Output
+{% Output %}
 
 ```css
 body {
@@ -1242,7 +1253,7 @@ body {
 	--wp--custom--font-primary: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif";
 }
 ```
-
+{% end %}
 
 A few notes about this process:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to #56121 to resurrect some of the tabs removed in that PR

## Why?
These items are better handled in tabs and with tabs now being supported in the upcoming redesign it made sense to bring them back.
