### PR TITLE
Add `npm install` step in Getting Started guide

### DIFF
--- a/platform-docs/docs/intro.md
+++ b/platform-docs/docs/intro.md
@@ -26,6 +26,10 @@ To build a block editor, you need to install the following dependencies:
  - `@wordpress/block-library`
  - `@wordpress/components`
 
+```cli
+npm add --save @wordpress/block-editor @wordpress/block-library @wordpress/components
+```
+
 ## JSX
 
 We're going to be using JSX to write our UI and components. So one of the first steps we need to do is to configure our build tooling, By default vite supports JSX and and outputs the result as a React pragma. The Block editor uses React so there's no need to configure anything here but if you're using a different bundler/build tool, make sure the JSX transpilation is setup properly.

--- a/platform-docs/docs/intro.md
+++ b/platform-docs/docs/intro.md
@@ -16,7 +16,7 @@ Let's discover how to use the **Gutenberg Block Editor** to build your own block
 
 First bootstrap a vite project using `npm create vite@latest` and pick `Vanilla` variant and `JavaScript` as a language.
 
-Once done, you can navigate to your application folder and run it locally using `npm run dev`. Open the displayed local URL in a browser.
+Once done, you can navigate to your application folder and install its dependencies with `npm install` to finally run it locally using `npm run dev`. Open the displayed local URL in a browser.
 
 ## Installing dependencies
 

--- a/platform-docs/package-lock.json
+++ b/platform-docs/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "platform-docs",
 			"version": "0.0.1",
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@docusaurus/core": "2.4.1",
 				"@docusaurus/preset-classic": "2.4.1",
@@ -21,7 +22,8 @@
 				"@docusaurus/module-type-aliases": "2.4.1"
 			},
 			"engines": {
-				"node": ">=16.14"
+				"node": ">=16.0.0",
+				"npm": ">=8 <9"
 			}
 		},
 		"node_modules/@algolia/autocomplete-core": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It adds the the `npm install` step in Getting Started guide

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because I was following the guide and `npm install` is mandatory to run `npm run dev`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Confirm the changes make sense.

## Screenshots or screencast <!-- if applicable -->
