### PR TITLE
Editor styles: scope without adding specificity

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -65,7 +65,7 @@
 
 // This CSS Custom Properties aren't used anymore as defaults,
 // but we still need to keep them for backward compatibility.
-.editor-styles-wrapper {
+:where(.editor-styles-wrapper) {
 	--wp--preset--font-size--normal: 16px;
 	--wp--preset--font-size--huge: 42px;
 }

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -74,19 +74,19 @@
 //
 // The reason we add the editor class wrapper here is
 // to avoid enqueing the classes twice: here and in ./editor.scss
-.editor-styles-wrapper .has-regular-font-size {
+:where(.editor-styles-wrapper) .has-regular-font-size {
 	font-size: 16px;
 }
 
-.editor-styles-wrapper .has-larger-font-size {
+:where(.editor-styles-wrapper) .has-larger-font-size {
 	font-size: 42px;
 }
 
-.editor-styles-wrapper .has-normal-font-size {
+:where(.editor-styles-wrapper) .has-normal-font-size {
 	font-size: var(--wp--preset--font-size--normal);
 }
 
-.editor-styles-wrapper .has-huge-font-size {
+:where(.editor-styles-wrapper) .has-huge-font-size {
 	font-size: var(--wp--preset--font-size--huge);
 }
 
@@ -98,6 +98,6 @@
  */
 
 // Remove the browser default border for iframe in Custom HTML block, Embed block, etc.
-.editor-styles-wrapper iframe:not([frameborder]) {
+:where(.editor-styles-wrapper) iframe:not([frameborder]) {
 	border: 0;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This _should_ fix #56293, but I'm not familiar enough to understand how to test. Would appreciate testing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Editor styles with hardcoded and unconditional scoping (.editor-styles-wrapper) add extra CSS specificity, which causes unscoped CSS to be overridden. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using `:where(.editor-styles-wrapper)` should remove this specificity.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
