### PR TITLE
(RichText)(Workaround)(17.1.x) Fallback to a string arg in `collapseWhiteSpace()` if `value` is not a string

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -69,6 +69,14 @@ export function useRichText( {
 	const record = useRef();
 
 	function setRecordFromProps() {
+		// `value` needs to be a string, but there are times when `null` seems to be explicitely passed
+		// for some reason, after https://github.com/WordPress/gutenberg/pull/55999 was introduced in 17.1.
+		// This needs further investigation, but for now, we add a safe-guard here to make sure it's always
+		// a string.
+		if ( typeof value !== 'string' ) {
+			value = '';
+		}
+
 		_value.current = value;
 		record.current = create( {
 			html: preserveWhiteSpace ? value : collapseWhiteSpace( value ),

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -69,17 +69,11 @@ export function useRichText( {
 	const record = useRef();
 
 	function setRecordFromProps() {
-		// `value` needs to be a string, but there are times when `null` seems to be explicitely passed
-		// for some reason, after https://github.com/WordPress/gutenberg/pull/55999 was introduced in 17.1.
-		// This needs further investigation, but for now, we add a safe-guard here to make sure it's always
-		// a string.
-		if ( typeof value !== 'string' ) {
-			value = '';
-		}
-
 		_value.current = value;
 		record.current = create( {
-			html: preserveWhiteSpace ? value : collapseWhiteSpace( value ),
+			html: preserveWhiteSpace
+				? value
+				: collapseWhiteSpace( typeof value === 'string' ? value : '' ),
 		} );
 		if ( disableFormats ) {
 			record.current.formats = Array( value.length );


### PR DESCRIPTION
## What?

Add a safeguard type-check that sets the `value` to `''` if it's not a string in the `RichText` component.

A better solution would be to figure out why `null` is being passed there, but this seems to be a feasible temporary workaround if we don't get to the real culprit.

## Why?

The issue that led to this fix was found in the `Multi-Line Text Field block, provided by Jetpack. The block is completely broken in 17.1.2 and (current) `trunk`. 
## How?

By passing an empty string to the `collapseWhiteSpace` if `value` is not a string.

## Testing Instructions

1. Install a clean version of 17.1.2 into a WP site with JP activated, you must be able to install the `Multi-Line Text Field`;
2. Notice how the block doesn't render, instead, the `This block has encountered an error and cannot be previewed.` is rendered;
4. Now build a custom GB version out of this branch and upload and activate it in your JP site;
5. Add a new `Multi-Line Text Field` block to the page and notice how it render and works correctly now.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
