### PR TITLE
Post Featured Image: Add a useFirstImageFromPost attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -630,7 +630,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/post-featured-image
 -	**Category:** theme
 -	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), spacing (margin, padding), ~~html~~
--	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, width
+-	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link
 

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -51,6 +51,10 @@
 		},
 		"customGradient": {
 			"type": "string"
+		},
+		"useFirstImageFromPost": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -82,14 +82,15 @@ export default function PostFeaturedImageEdit( {
 		'content',
 		postId
 	);
-	const blocks = parse( postContent );
-	const imageBlock = blocks.find( ( block ) => block.name === 'core/image' );
-	if (
-		! featuredImage &&
-		useFirstImageFromPost &&
-		imageBlock?.attributes?.id
-	) {
-		featuredImage = imageBlock.attributes.id;
+
+	if ( ! featuredImage && useFirstImageFromPost && postContent ) {
+		const blocks = parse( postContent );
+		const imageBlock = blocks.find(
+			( block ) => block.name === 'core/image'
+		);
+		if ( imageBlock?.attributes?.id ) {
+			featuredImage = imageBlock.attributes.id;
+		}
 	}
 
 	const { media, postType, postPermalink } = useSelect(

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -84,10 +84,17 @@ export default function PostFeaturedImageEdit( {
 	);
 
 	if ( ! featuredImage && useFirstImageFromPost && postContent ) {
-		const blocks = parse( postContent );
-		const imageBlock = blocks.find(
-			( block ) => block.name === 'core/image'
+		const firstImageCloser = /<!--\s+\/wp:(?:core\/)?image\s+-->/.exec(
+			postContent
 		);
+		const content = firstImageCloser
+			? postContent.slice(
+					0,
+					firstImageCloser.index + firstImageCloser[ 0 ].length
+			  )
+			: '';
+		const blocks = parse( content );
+		const imageBlock = blocks.find( ( { name } ) => name === 'core/image' );
 		if ( imageBlock?.attributes?.id ) {
 			featuredImage = imageBlock.attributes.id;
 		}

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -209,16 +209,6 @@ export default function PostFeaturedImageEdit( {
 							/>
 						</>
 					) }
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Use first image from post' ) }
-						onChange={ ( value ) =>
-							setAttributes( {
-								useFirstImageFromPost: value,
-							} )
-						}
-						checked={ useFirstImageFromPost }
-					/>
 				</PanelBody>
 			</InspectorControls>
 		</>

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { parse } from '@wordpress/blocks';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
@@ -94,22 +93,14 @@ export default function PostFeaturedImageEdit( {
 			return;
 		}
 
-		const firstImageCloser = /<!--\s+\/wp:(?:core\/)?image\s+-->/.exec(
-			postContent
-		);
-
-		if ( ! firstImageCloser ) {
-			return;
-		}
-
-		const content = postContent.slice(
-			0,
-			firstImageCloser.index + firstImageCloser[ 0 ].length
-		);
-
-		const blocks = parse( content );
-		const imageBlock = blocks.find( ( { name } ) => name === 'core/image' );
-		return imageBlock?.attributes?.id;
+		const imageOpener =
+			/<!--\s+wp:(?:core\/)?image\s+(?<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*)?}\s+)?-->/.exec(
+				postContent
+			);
+		const imageId =
+			imageOpener?.groups?.attrs &&
+			JSON.parse( imageOpener.groups.attrs )?.id;
+		return imageId;
 	}, [ storedFeaturedImage, useFirstImageFromPost, postContent ] );
 
 	const { media, postType, postPermalink } = useSelect(

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -58,8 +58,9 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	// Get the first image from the post.
 	if ( $attributes['useFirstImageFromPost'] && ! $featured_image ) {
 		$content_post = get_post( $post_ID );
-		$content = $content_post->post_content;
-		$processor = new WP_HTML_Tag_Processor( $content );
+		$content      = $content_post->post_content;
+		$processor    = new WP_HTML_Tag_Processor( $content );
+
 		/*
 		 * Transfer the image tag from the post into a new text snippet.
 		 * Because the HTML API doesn't currently expose a way to extract

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -54,9 +54,26 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 
 	$featured_image = get_the_post_thumbnail( $post_ID, $size_slug, $attr );
+
+	// Get the first image from the post.
+	if ( $attributes['useFirstImageFromPost'] && ! $featured_image ) {
+		$content_post = get_post( $post_ID );
+		$content = $content_post->post_content;
+		$processor = new WP_HTML_Tag_Processor( $content );
+		if ( $processor->next_tag( 'img' ) ) {
+			$tag_html = new WP_HTML_Tag_Processor( '<img>' );
+			$tag_html->next_tag();
+			foreach ( $processor->get_attribute_names_with_prefix( '' ) as $name ) {
+				$tag_html->set_attribute( $name, $processor->get_attribute( $name ) );
+			}
+			$featured_image = $tag_html->get_updated_html();
+		}
+	}
+
 	if ( ! $featured_image ) {
 		return '';
 	}
+
 	if ( $is_link ) {
 		$link_target    = $attributes['linkTarget'];
 		$rel            = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -60,6 +60,19 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$content_post = get_post( $post_ID );
 		$content = $content_post->post_content;
 		$processor = new WP_HTML_Tag_Processor( $content );
+		/*
+		 * Transfer the image tag from the post into a new text snippet.
+		 * Because the HTML API doesn't currently expose a way to extract
+		 * HTML substrings this is necessary as a workaround. Of note, this
+		 * is different than directly extracting the IMG tag:
+		 * - If there are duplicate attributes in the source there will only be one in the output.
+		 * - If there are single-quoted or unquoted attributes they will be double-quoted in the output.
+		 * - If there are named character references in the attribute values they may be replaced with their direct code points. E.g. `&hellip;` becomes `…`.
+		 * In the future there will likely be a mechanism to copy snippets of HTML from
+		 * one document into another, via the HTML Processor's `get_outer_html()` or
+		 * equivalent. When that happens it would be appropriate to replace this custom
+		 * code with that canonical code.
+		 */
 		if ( $processor->next_tag( 'img' ) ) {
 			$tag_html = new WP_HTML_Tag_Processor( '<img>' );
 			$tag_html->next_tag();

--- a/test/integration/fixtures/blocks/core__post-featured-image.json
+++ b/test/integration/fixtures/blocks/core__post-featured-image.json
@@ -7,7 +7,8 @@
 			"scale": "cover",
 			"rel": "",
 			"linkTarget": "_self",
-			"dimRatio": 0
+			"dimRatio": 0,
+			"useFirstImageFromPost": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds an option called "Use first image from post". When this option is enabled the Post Featured Image block will pull the first image from the post.

## Why?
For users with a lot of old posts without featured images this is a useful way to display images in the query block without having to manually add many featured images.

## How?
- Add a new attribute called `useFirstImageFromPost`.
- Add code to the block renderer to pull the first image from the post using the tag processor.
- Add code to the edit function to pull the first image from the post using `parse`.

## Testing Instructions
1. Create a new post with an image in it, but no Featured image.
2. Edit a template with a query block that contains a Featured image block.
3. Notice that the Query Block doesn't display any image in the Featured image block in the editor or the frontend.
4. Edit the Featured image block to enable the "Use first image from post".
5. Notice that the Query Block now displays the image in the Featured image block in the editor and the frontend.

## Screenshots or screencast <!-- if applicable -->
We decided not to expose this setting in the UI for now. Since this is a more advanced feature, we are happy for now to only expose it through an attribute that theme builders can add via the code.
