### PR TITLE
`CustomSelectControl`: add additional unit tests

### DIFF
--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -31,10 +31,15 @@ const props = {
 		{
 			key: 'color1',
 			name: 'amber',
+			className: 'amber-skies',
 		},
 		{
 			key: 'color2',
 			name: 'aquamarine',
+			style: {
+				backgroundColor: 'rgb(127, 255, 212)',
+				rotate: '13deg',
+			},
 		},
 	],
 	__nextUnconstrainedWidth: true,
@@ -107,6 +112,59 @@ describe.each( [
 		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 
 		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
+	} );
+
+	it( 'Should apply class only to options that have a className defined', async () => {
+		const user = userEvent.setup();
+		const customClass = 'amber-skies';
+
+		render( <CustomSelectControl { ...props } /> );
+
+		await user.click( screen.getByRole( 'button', { text: 'violets' } ) );
+
+		// return an array of items without a className added
+		const classlessItems = props.options.filter(
+			( option ) => option.className === undefined
+		);
+
+		// assert against filtered array
+		classlessItems.map( ( { name } ) =>
+			expect( screen.getByRole( 'option', { name } ) ).not.toHaveClass(
+				customClass
+			)
+		);
+
+		expect( screen.getByRole( 'option', { name: 'amber' } ) ).toHaveClass(
+			customClass
+		);
+	} );
+
+	it( 'Should apply styles only to options that have styles defined', async () => {
+		const user = userEvent.setup();
+		const customStyles =
+			'background-color: rgb(127, 255, 212); rotate: 13deg;';
+
+		render( <CustomSelectControl { ...props } /> );
+
+		await user.click( screen.getByRole( 'button', { text: 'violets' } ) );
+
+		// return an array of items without styles added
+		const unstyledItems = props.options.filter(
+			( option ) => option.style === undefined
+		);
+
+		// assert against filtered array
+		unstyledItems.map( ( { name } ) =>
+			expect( screen.getByRole( 'option', { name } ) ).not.toHaveStyle(
+				customStyles
+			)
+		);
+
+		expect(
+			screen.getByRole( 'option', {
+				name: 'aquamarine',
+			} )
+		).toHaveStyle( customStyles );
 	} );
 
 	it( 'does not show selected hint by default', () => {

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -256,5 +256,32 @@ describe.each( [
 				} )
 			).toBeVisible();
 		} );
+
+		it( 'Should call custom event handlers', async () => {
+			const user = userEvent.setup();
+			const onFocusMock = jest.fn();
+			const onBlurMock = jest.fn();
+
+			render(
+				<CustomSelectControl
+					{ ...props }
+					onFocus={ onFocusMock }
+					onBlur={ onBlurMock }
+				/>
+			);
+
+			const currentSelectedItem = screen.getByRole( 'button', {
+				text: 'violets',
+			} );
+
+			await user.tab();
+
+			expect( currentSelectedItem ).toHaveFocus();
+			expect( onFocusMock ).toHaveBeenCalledTimes( 1 );
+
+			await user.tab();
+			expect( currentSelectedItem ).not.toHaveFocus();
+			expect( onBlurMock ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 } );

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -9,24 +9,25 @@ import userEvent from '@testing-library/user-event';
  */
 import CustomSelectControl from '..';
 
+const options = [
+	{
+		key: 'violets',
+		name: 'violets',
+	},
+	{
+		key: 'crimson clover',
+		name: 'crimson clover',
+	},
+	{
+		key: 'poppy',
+		name: 'poppy',
+	},
+];
+
 describe( 'CustomSelectControl', () => {
 	it( 'Captures the keypress event and does not let it propagate', async () => {
 		const user = userEvent.setup();
 		const onKeyDown = jest.fn();
-		const options = [
-			{
-				key: 'one',
-				name: 'Option one',
-			},
-			{
-				key: 'two',
-				name: 'Option two',
-			},
-			{
-				key: 'three',
-				name: 'Option three',
-			},
-		];
 
 		render(
 			<div
@@ -86,5 +87,128 @@ describe( 'CustomSelectControl', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Custom select' } )
 		).toHaveTextContent( 'Hint' );
+	} );
+
+	it( 'Initial value should be replaced when a new item is selected', async () => {
+		const user = userEvent.setup();
+		const mock = jest.fn();
+
+		render(
+			<CustomSelectControl
+				onChange={ ( { selectedItem } ) => mock( selectedItem ) }
+				options={ options }
+				__nextUnconstrainedWidth
+			/>
+		);
+
+		const currentValue = screen.getByRole( 'button' );
+
+		expect( currentValue ).toHaveTextContent( /violets/i );
+
+		await user.click( currentValue );
+
+		const newValue = screen.getByRole( 'option', {
+			name: /poppy/i,
+		} );
+
+		await user.click( newValue );
+
+		expect( currentValue ).toHaveTextContent( /poppy/i );
+		expect( mock ).toHaveBeenCalled();
+	} );
+
+	it( 'Should be able to change selection using keyboard', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
+		);
+
+		const currentValue = screen.getByRole( 'button' );
+		expect( currentValue ).toHaveTextContent( /violets/i );
+
+		await user.tab();
+		expect( currentValue ).toHaveFocus();
+
+		await user.keyboard( '{enter}' );
+		await user.keyboard( '{arrowdown}' );
+		await user.keyboard( '{enter}' );
+
+		expect( currentValue ).toHaveTextContent( /crimson clover/i );
+	} );
+
+	it( 'Should keep current selection if dropdown is closed without changing selection', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
+		);
+
+		const currentValue = screen.getByRole( 'button' );
+		expect( currentValue ).toHaveTextContent( /violets/i );
+
+		await user.tab();
+		await user.keyboard( '{enter}' );
+		expect( screen.getByRole( 'listbox' ) ).toBeVisible();
+		expect( screen.getByRole( 'listbox' ) ).toHaveAttribute(
+			'aria-hidden',
+			'false'
+		);
+		await user.keyboard( '{escape}' );
+		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+
+		expect( currentValue ).toHaveTextContent( /violets/i );
+	} );
+
+	it( 'Should be able to type characters to select matching options', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
+		);
+
+		const currentValue = screen.getByRole( 'button' );
+		expect( currentValue ).toHaveTextContent( /violets/i );
+
+		await user.tab();
+		await user.keyboard( '{enter}' );
+		await user.keyboard( '{p}' );
+		await user.keyboard( '{enter}' );
+
+		expect( currentValue ).toHaveTextContent( /poppy/i );
+	} );
+
+	it( 'Can change selection with a focused input and closed dropdown if typed characters match an option', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
+		);
+
+		const currentValue = screen.getByRole( 'button' );
+		expect( currentValue ).toHaveTextContent( /violets/i );
+
+		await user.tab();
+		await user.keyboard( '{c}' );
+		await user.keyboard( '{enter}' );
+
+		expect( currentValue ).toHaveTextContent( /crimson clover/i );
+	} );
+
+	it( 'Current selection has attribute: aria-selected="true"', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
+		);
+
+		await user.tab();
+		await user.keyboard( '{enter}' );
+
+		expect(
+			screen.getByRole( 'option', {
+				name: /violets/i,
+			} )
+		).toHaveAttribute( 'aria-selected', 'true' );
 	} );
 } );

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -28,6 +28,14 @@ const props = {
 			key: 'flower3',
 			name: 'poppy',
 		},
+		{
+			key: 'color1',
+			name: 'amber',
+		},
+		{
+			key: 'color2',
+			name: 'aquamarine',
+		},
 	],
 	__nextUnconstrainedWidth: true,
 };
@@ -191,10 +199,10 @@ describe.each( [
 
 			await user.tab();
 			await user.keyboard( '{enter}' );
-			await user.keyboard( '{p}' );
+			await user.keyboard( '{a}' );
 			await user.keyboard( '{enter}' );
 
-			expect( currentSelectedItem ).toHaveTextContent( 'poppy' );
+			expect( currentSelectedItem ).toHaveTextContent( 'amber' );
 		} );
 
 		it( 'Can change selection with a focused input and closed dropdown if typed characters match an option', async () => {
@@ -206,10 +214,11 @@ describe.each( [
 			expect( currentSelectedItem ).toHaveTextContent( 'violets' );
 
 			await user.tab();
-			await user.keyboard( '{c}' );
+			await user.keyboard( '{a}' );
+			await user.keyboard( '{q}' );
 			await user.keyboard( '{enter}' );
 
-			expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
+			expect( currentSelectedItem ).toHaveTextContent( 'aquamarine' );
 		} );
 
 		it( 'Should have correct aria-selected value for selections', async () => {

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -89,7 +89,7 @@ describe( 'CustomSelectControl', () => {
 		).toHaveTextContent( 'Hint' );
 	} );
 
-	it( 'Should replace the initial value when a new item is selected', async () => {
+	it( 'Should replace the initial selection when a new item is selected', async () => {
 		const user = userEvent.setup();
 		const onChangeMock = jest.fn();
 
@@ -103,23 +103,23 @@ describe( 'CustomSelectControl', () => {
 			/>
 		);
 
-		const currentValue = screen.getByRole( 'button' );
+		const currentSelectedItem = screen.getByRole( 'button' );
 
-		expect( currentValue ).toHaveTextContent( 'violets' );
+		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
 
 		expect( onChangeMock ).toHaveBeenCalledTimes( 0 );
 
-		await user.click( currentValue );
+		await user.click( currentSelectedItem );
 
-		const newValue = screen.getByRole( 'option', {
+		const nextSelectedItem = screen.getByRole( 'option', {
 			name: 'poppy',
 		} );
 
-		await user.click( newValue );
+		await user.click( nextSelectedItem );
 
 		expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
 
-		expect( currentValue ).toHaveTextContent( 'poppy' );
+		expect( currentSelectedItem ).toHaveTextContent( 'poppy' );
 	} );
 
 	it( 'Should be able to change selection using keyboard', async () => {
@@ -129,17 +129,17 @@ describe( 'CustomSelectControl', () => {
 			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
 		);
 
-		const currentValue = screen.getByRole( 'button' );
-		expect( currentValue ).toHaveTextContent( 'violets' );
+		const currentSelectedItem = screen.getByRole( 'button' );
+		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
 
 		await user.tab();
-		expect( currentValue ).toHaveFocus();
+		expect( currentSelectedItem ).toHaveFocus();
 
 		await user.keyboard( '{enter}' );
 		await user.keyboard( '{arrowdown}' );
 		await user.keyboard( '{enter}' );
 
-		expect( currentValue ).toHaveTextContent( 'crimson clover' );
+		expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
 	} );
 
 	it( 'Should keep current selection if dropdown is closed without changing selection', async () => {
@@ -149,8 +149,8 @@ describe( 'CustomSelectControl', () => {
 			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
 		);
 
-		const currentValue = screen.getByRole( 'button' );
-		expect( currentValue ).toHaveTextContent( 'violets' );
+		const currentSelectedItem = screen.getByRole( 'button' );
+		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
 
 		await user.tab();
 		await user.keyboard( '{enter}' );
@@ -163,7 +163,7 @@ describe( 'CustomSelectControl', () => {
 		await user.keyboard( '{escape}' );
 		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 
-		expect( currentValue ).toHaveTextContent( 'violets' );
+		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
 	} );
 
 	it( 'Should be able to type characters to select matching options', async () => {
@@ -173,15 +173,15 @@ describe( 'CustomSelectControl', () => {
 			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
 		);
 
-		const currentValue = screen.getByRole( 'button' );
-		expect( currentValue ).toHaveTextContent( 'violets' );
+		const currentSelectedItem = screen.getByRole( 'button' );
+		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
 
 		await user.tab();
 		await user.keyboard( '{enter}' );
 		await user.keyboard( '{p}' );
 		await user.keyboard( '{enter}' );
 
-		expect( currentValue ).toHaveTextContent( 'poppy' );
+		expect( currentSelectedItem ).toHaveTextContent( 'poppy' );
 	} );
 
 	it( 'Can change selection with a focused input and closed dropdown if typed characters match an option', async () => {
@@ -191,14 +191,14 @@ describe( 'CustomSelectControl', () => {
 			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
 		);
 
-		const currentValue = screen.getByRole( 'button' );
-		expect( currentValue ).toHaveTextContent( 'violets' );
+		const currentSelectedItem = screen.getByRole( 'button' );
+		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
 
 		await user.tab();
 		await user.keyboard( '{c}' );
 		await user.keyboard( '{enter}' );
 
-		expect( currentValue ).toHaveTextContent( 'crimson clover' );
+		expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
 	} );
 
 	it( 'Should have correct aria-selected value for selections', async () => {
@@ -208,9 +208,9 @@ describe( 'CustomSelectControl', () => {
 			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
 		);
 
-		const currentValue = screen.getByRole( 'button' );
+		const currentSelectedItem = screen.getByRole( 'button' );
 
-		await user.click( currentValue );
+		await user.click( currentSelectedItem );
 
 		expect(
 			screen.getByRole( 'option', {
@@ -233,7 +233,7 @@ describe( 'CustomSelectControl', () => {
 		).toBeVisible();
 
 		await user.click( screen.getByRole( 'option', { name: 'poppy' } ) );
-		await user.click( currentValue );
+		await user.click( currentSelectedItem );
 		expect(
 			screen.getByRole( 'option', {
 				name: 'violets',

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -111,13 +111,24 @@ describe( 'CustomSelectControl', () => {
 
 		await user.click( currentSelectedItem );
 
-		const nextSelectedItem = screen.getByRole( 'option', {
-			name: 'poppy',
-		} );
-
-		await user.click( nextSelectedItem );
+		await user.click(
+			screen.getByRole( 'option', {
+				name: 'crimson clover',
+			} )
+		);
 
 		expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
+		expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
+
+		await user.click( currentSelectedItem );
+
+		await user.click(
+			screen.getByRole( 'option', {
+				name: 'poppy',
+			} )
+		);
+
+		expect( onChangeMock ).toHaveBeenCalledTimes( 2 );
 
 		expect( currentSelectedItem ).toHaveTextContent( 'poppy' );
 	} );

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -11,15 +11,15 @@ import CustomSelectControl from '..';
 
 const options = [
 	{
-		key: 'violets',
+		key: 'flower1',
 		name: 'violets',
 	},
 	{
-		key: 'crimson clover',
+		key: 'flower2',
 		name: 'crimson clover',
 	},
 	{
-		key: 'poppy',
+		key: 'flower3',
 		name: 'poppy',
 	},
 ];
@@ -89,13 +89,15 @@ describe( 'CustomSelectControl', () => {
 		).toHaveTextContent( 'Hint' );
 	} );
 
-	it( 'Initial value should be replaced when a new item is selected', async () => {
+	it( 'Should replace the initial value when a new item is selected', async () => {
 		const user = userEvent.setup();
-		const mock = jest.fn();
+		const onChangeMock = jest.fn();
 
 		render(
 			<CustomSelectControl
-				onChange={ ( { selectedItem } ) => mock( selectedItem ) }
+				onChange={ ( { selectedItem } ) =>
+					onChangeMock( selectedItem )
+				}
 				options={ options }
 				__nextUnconstrainedWidth
 			/>
@@ -103,18 +105,21 @@ describe( 'CustomSelectControl', () => {
 
 		const currentValue = screen.getByRole( 'button' );
 
-		expect( currentValue ).toHaveTextContent( /violets/i );
+		expect( currentValue ).toHaveTextContent( 'violets' );
+
+		expect( onChangeMock ).toHaveBeenCalledTimes( 0 );
 
 		await user.click( currentValue );
 
 		const newValue = screen.getByRole( 'option', {
-			name: /poppy/i,
+			name: 'poppy',
 		} );
 
 		await user.click( newValue );
 
-		expect( currentValue ).toHaveTextContent( /poppy/i );
-		expect( mock ).toHaveBeenCalled();
+		expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
+
+		expect( currentValue ).toHaveTextContent( 'poppy' );
 	} );
 
 	it( 'Should be able to change selection using keyboard', async () => {
@@ -125,7 +130,7 @@ describe( 'CustomSelectControl', () => {
 		);
 
 		const currentValue = screen.getByRole( 'button' );
-		expect( currentValue ).toHaveTextContent( /violets/i );
+		expect( currentValue ).toHaveTextContent( 'violets' );
 
 		await user.tab();
 		expect( currentValue ).toHaveFocus();
@@ -134,7 +139,7 @@ describe( 'CustomSelectControl', () => {
 		await user.keyboard( '{arrowdown}' );
 		await user.keyboard( '{enter}' );
 
-		expect( currentValue ).toHaveTextContent( /crimson clover/i );
+		expect( currentValue ).toHaveTextContent( 'crimson clover' );
 	} );
 
 	it( 'Should keep current selection if dropdown is closed without changing selection', async () => {
@@ -145,7 +150,7 @@ describe( 'CustomSelectControl', () => {
 		);
 
 		const currentValue = screen.getByRole( 'button' );
-		expect( currentValue ).toHaveTextContent( /violets/i );
+		expect( currentValue ).toHaveTextContent( 'violets' );
 
 		await user.tab();
 		await user.keyboard( '{enter}' );
@@ -154,10 +159,11 @@ describe( 'CustomSelectControl', () => {
 			'aria-hidden',
 			'false'
 		);
+
 		await user.keyboard( '{escape}' );
 		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 
-		expect( currentValue ).toHaveTextContent( /violets/i );
+		expect( currentValue ).toHaveTextContent( 'violets' );
 	} );
 
 	it( 'Should be able to type characters to select matching options', async () => {
@@ -168,14 +174,14 @@ describe( 'CustomSelectControl', () => {
 		);
 
 		const currentValue = screen.getByRole( 'button' );
-		expect( currentValue ).toHaveTextContent( /violets/i );
+		expect( currentValue ).toHaveTextContent( 'violets' );
 
 		await user.tab();
 		await user.keyboard( '{enter}' );
 		await user.keyboard( '{p}' );
 		await user.keyboard( '{enter}' );
 
-		expect( currentValue ).toHaveTextContent( /poppy/i );
+		expect( currentValue ).toHaveTextContent( 'poppy' );
 	} );
 
 	it( 'Can change selection with a focused input and closed dropdown if typed characters match an option', async () => {
@@ -186,29 +192,59 @@ describe( 'CustomSelectControl', () => {
 		);
 
 		const currentValue = screen.getByRole( 'button' );
-		expect( currentValue ).toHaveTextContent( /violets/i );
+		expect( currentValue ).toHaveTextContent( 'violets' );
 
 		await user.tab();
 		await user.keyboard( '{c}' );
 		await user.keyboard( '{enter}' );
 
-		expect( currentValue ).toHaveTextContent( /crimson clover/i );
+		expect( currentValue ).toHaveTextContent( 'crimson clover' );
 	} );
 
-	it( 'Current selection has attribute: aria-selected="true"', async () => {
+	it( 'Should have correct aria-selected value for selections', async () => {
 		const user = userEvent.setup();
 
 		render(
 			<CustomSelectControl options={ options } __nextUnconstrainedWidth />
 		);
 
-		await user.tab();
-		await user.keyboard( '{enter}' );
+		const currentValue = screen.getByRole( 'button' );
+
+		await user.click( currentValue );
 
 		expect(
 			screen.getByRole( 'option', {
-				name: /violets/i,
+				name: 'poppy',
+				selected: false,
 			} )
-		).toHaveAttribute( 'aria-selected', 'true' );
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'option', {
+				name: 'crimson clover',
+				selected: false,
+			} )
+		).toBeVisible();
+
+		expect(
+			screen.getByRole( 'option', {
+				name: 'violets',
+				selected: true,
+			} )
+		).toBeVisible();
+
+		await user.click( screen.getByRole( 'option', { name: 'poppy' } ) );
+		await user.click( currentValue );
+		expect(
+			screen.getByRole( 'option', {
+				name: 'violets',
+				selected: false,
+			} )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'option', {
+				name: 'poppy',
+				selected: true,
+			} )
+		).toBeVisible();
 	} );
 } );

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -278,6 +278,12 @@ describe.each( [
 			expect( currentSelectedItem ).toHaveFocus();
 
 			await user.keyboard( '{enter}' );
+			expect(
+				screen.getByRole( 'listbox', {
+					name: 'label!',
+				} )
+			).toHaveFocus();
+
 			await user.keyboard( '{arrowdown}' );
 			await user.keyboard( '{enter}' );
 
@@ -295,9 +301,14 @@ describe.each( [
 
 			await user.tab();
 			await user.keyboard( '{enter}' );
+			expect(
+				screen.getByRole( 'listbox', {
+					name: 'label!',
+				} )
+			).toHaveFocus();
+
 			await user.keyboard( '{a}' );
 			await user.keyboard( '{enter}' );
-
 			expect( currentSelectedItem ).toHaveTextContent( 'amber' );
 		} );
 
@@ -311,10 +322,19 @@ describe.each( [
 			} );
 
 			await user.tab();
+			expect( currentSelectedItem ).toHaveFocus();
+
 			await user.keyboard( '{a}' );
 			await user.keyboard( '{q}' );
-			await user.keyboard( '{enter}' );
 
+			expect(
+				screen.queryByRole( 'listbox', {
+					name: 'label!',
+					hidden: true,
+				} )
+			).not.toBeInTheDocument();
+
+			await user.keyboard( '{enter}' );
 			expect( currentSelectedItem ).toHaveTextContent( 'aquamarine' );
 		} );
 

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -17,6 +17,7 @@ import CustomSelectControl from '..';
 const customClass = 'amber-skies';
 
 const props = {
+	label: 'label!',
 	options: [
 		{
 			key: 'flower1',
@@ -107,11 +108,17 @@ describe.each( [
 		await user.tab();
 		await user.keyboard( '{enter}' );
 		expect(
-			screen.getByRole( 'listbox', { hidden: false } )
+			screen.getByRole( 'listbox', {
+				name: 'label!',
+			} )
 		).toBeVisible();
 
 		await user.keyboard( '{escape}' );
-		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'listbox', {
+				name: 'label!',
+			} )
+		).not.toBeInTheDocument();
 
 		expect( currentSelectedItem ).toHaveTextContent(
 			props.options[ 0 ].name
@@ -250,7 +257,9 @@ describe.each( [
 			} );
 			await user.click( currentSelectedItem );
 
-			const customSelect = screen.getByRole( 'listbox' );
+			const customSelect = screen.getByRole( 'listbox', {
+				name: 'label!',
+			} );
 			await user.type( customSelect, '{enter}' );
 
 			expect( onKeyDown ).toHaveBeenCalledTimes( 0 );

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -349,34 +349,41 @@ describe.each( [
 
 			await user.click( currentSelectedItem );
 
-			expect(
-				screen.getByRole( 'option', {
-					name: 'poppy',
-					selected: false,
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'option', {
-					name: 'crimson clover',
-					selected: false,
-				} )
-			).toBeVisible();
+			// get all items except for first option
+			const unselectedItems = props.options.filter(
+				( { name } ) => name !== props.options[ 0 ].name
+			);
 
+			// assert that all other items have aria-selected="false"
+			unselectedItems.map( ( { name } ) =>
+				expect(
+					screen.getByRole( 'option', { name, selected: false } )
+				).toBeVisible()
+			);
+
+			// assert that first item has aria-selected="true"
 			expect(
 				screen.getByRole( 'option', {
-					name: 'violets',
+					name: props.options[ 0 ].name,
 					selected: true,
 				} )
 			).toBeVisible();
 
+			// change the current selection
 			await user.click( screen.getByRole( 'option', { name: 'poppy' } ) );
+
+			// click button to mount listbox with options again
 			await user.click( currentSelectedItem );
+
+			// check that first item is has aria-selected="false" after new selection
 			expect(
 				screen.getByRole( 'option', {
-					name: 'violets',
+					name: props.options[ 0 ].name,
 					selected: false,
 				} )
 			).toBeVisible();
+
+			// check that new selected item now has aria-selected="true"
 			expect(
 				screen.getByRole( 'option', {
 					name: 'poppy',

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -70,9 +70,9 @@ describe.each( [
 
 		render( <Component { ...props } /> );
 
-		const currentSelectedItem = screen.getByRole( 'button' );
-
-		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
+		const currentSelectedItem = screen.getByRole( 'button', {
+			expanded: false,
+		} );
 
 		await user.click( currentSelectedItem );
 
@@ -100,21 +100,22 @@ describe.each( [
 
 		render( <CustomSelectControl { ...props } /> );
 
-		const currentSelectedItem = screen.getByRole( 'button' );
-		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
+		const currentSelectedItem = screen.getByRole( 'button', {
+			expanded: false,
+		} );
 
 		await user.tab();
 		await user.keyboard( '{enter}' );
-		expect( screen.getByRole( 'listbox' ) ).toBeVisible();
-		expect( screen.getByRole( 'listbox' ) ).toHaveAttribute(
-			'aria-hidden',
-			'false'
-		);
+		expect(
+			screen.getByRole( 'listbox', { hidden: false } )
+		).toBeVisible();
 
 		await user.keyboard( '{escape}' );
 		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 
-		expect( currentSelectedItem ).toHaveTextContent( 'violets' );
+		expect( currentSelectedItem ).toHaveTextContent(
+			props.options[ 0 ].name
+		);
 	} );
 
 	it( 'Should apply class only to options that have a className defined', async () => {
@@ -122,7 +123,11 @@ describe.each( [
 
 		render( <CustomSelectControl { ...props } /> );
 
-		await user.click( screen.getByRole( 'button', { text: 'violets' } ) );
+		await user.click(
+			screen.getByRole( 'button', {
+				expanded: false,
+			} )
+		);
 
 		// return an array of items _with_ a className added
 		const itemsWithClass = props.options.filter(
@@ -156,7 +161,11 @@ describe.each( [
 
 		render( <CustomSelectControl { ...props } /> );
 
-		await user.click( screen.getByRole( 'button', { text: 'violets' } ) );
+		await user.click(
+			screen.getByRole( 'button', {
+				expanded: false,
+			} )
+		);
 
 		// return an array of items _with_ styles added
 		const styledItems = props.options.filter(
@@ -236,8 +245,10 @@ describe.each( [
 					<CustomSelectControl { ...props } />
 				</div>
 			);
-			const toggleButton = screen.getByRole( 'button' );
-			await user.click( toggleButton );
+			const currentSelectedItem = screen.getByRole( 'button', {
+				expanded: false,
+			} );
+			await user.click( currentSelectedItem );
 
 			const customSelect = screen.getByRole( 'listbox' );
 			await user.type( customSelect, '{enter}' );
@@ -250,8 +261,9 @@ describe.each( [
 
 			render( <CustomSelectControl { ...props } /> );
 
-			const currentSelectedItem = screen.getByRole( 'button' );
-			expect( currentSelectedItem ).toHaveTextContent( 'violets' );
+			const currentSelectedItem = screen.getByRole( 'button', {
+				expanded: false,
+			} );
 
 			await user.tab();
 			expect( currentSelectedItem ).toHaveFocus();
@@ -268,8 +280,9 @@ describe.each( [
 
 			render( <CustomSelectControl { ...props } /> );
 
-			const currentSelectedItem = screen.getByRole( 'button' );
-			expect( currentSelectedItem ).toHaveTextContent( 'violets' );
+			const currentSelectedItem = screen.getByRole( 'button', {
+				expanded: false,
+			} );
 
 			await user.tab();
 			await user.keyboard( '{enter}' );
@@ -284,8 +297,9 @@ describe.each( [
 
 			render( <CustomSelectControl { ...props } /> );
 
-			const currentSelectedItem = screen.getByRole( 'button' );
-			expect( currentSelectedItem ).toHaveTextContent( 'violets' );
+			const currentSelectedItem = screen.getByRole( 'button', {
+				expanded: false,
+			} );
 
 			await user.tab();
 			await user.keyboard( '{a}' );
@@ -300,7 +314,9 @@ describe.each( [
 
 			render( <CustomSelectControl { ...props } /> );
 
-			const currentSelectedItem = screen.getByRole( 'button' );
+			const currentSelectedItem = screen.getByRole( 'button', {
+				expanded: false,
+			} );
 
 			await user.click( currentSelectedItem );
 
@@ -354,7 +370,7 @@ describe.each( [
 			);
 
 			const currentSelectedItem = screen.getByRole( 'button', {
-				text: 'violets',
+				expanded: false,
 			} );
 
 			await user.tab();

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -14,6 +14,8 @@ import { useState } from '@wordpress/element';
  */
 import CustomSelectControl from '..';
 
+const customClass = 'amber-skies';
+
 const props = {
 	options: [
 		{
@@ -23,6 +25,7 @@ const props = {
 		{
 			key: 'flower2',
 			name: 'crimson clover',
+			className: customClass,
 		},
 		{
 			key: 'flower3',
@@ -31,7 +34,7 @@ const props = {
 		{
 			key: 'color1',
 			name: 'amber',
-			className: 'amber-skies',
+			className: customClass,
 		},
 		{
 			key: 'color2',
@@ -116,26 +119,33 @@ describe.each( [
 
 	it( 'Should apply class only to options that have a className defined', async () => {
 		const user = userEvent.setup();
-		const customClass = 'amber-skies';
 
 		render( <CustomSelectControl { ...props } /> );
 
 		await user.click( screen.getByRole( 'button', { text: 'violets' } ) );
 
-		// return an array of items without a className added
-		const classlessItems = props.options.filter(
-			( option ) => option.className === undefined
+		// return an array of items _with_ a className added
+		const itemsWithClass = props.options.filter(
+			( option ) => option.className !== undefined
 		);
 
 		// assert against filtered array
-		classlessItems.map( ( { name } ) =>
-			expect( screen.getByRole( 'option', { name } ) ).not.toHaveClass(
+		itemsWithClass.map( ( { name } ) =>
+			expect( screen.getByRole( 'option', { name } ) ).toHaveClass(
 				customClass
 			)
 		);
 
-		expect( screen.getByRole( 'option', { name: 'amber' } ) ).toHaveClass(
-			customClass
+		// return an array of items _without_ a className added
+		const itemsWithoutClass = props.options.filter(
+			( option ) => option.className === undefined
+		);
+
+		// assert against filtered array
+		itemsWithoutClass.map( ( { name } ) =>
+			expect( screen.getByRole( 'option', { name } ) ).not.toHaveClass(
+				customClass
+			)
 		);
 	} );
 
@@ -148,7 +158,19 @@ describe.each( [
 
 		await user.click( screen.getByRole( 'button', { text: 'violets' } ) );
 
-		// return an array of items without styles added
+		// return an array of items _with_ styles added
+		const styledItems = props.options.filter(
+			( option ) => option.style !== undefined
+		);
+
+		// assert against filtered array
+		styledItems.map( ( { name } ) =>
+			expect( screen.getByRole( 'option', { name } ) ).toHaveStyle(
+				customStyles
+			)
+		);
+
+		// return an array of items _without_ styles added
 		const unstyledItems = props.options.filter(
 			( option ) => option.style === undefined
 		);
@@ -159,12 +181,6 @@ describe.each( [
 				customStyles
 			)
 		);
-
-		expect(
-			screen.getByRole( 'option', {
-				name: 'aquamarine',
-			} )
-		).toHaveStyle( customStyles );
 	} );
 
 	it( 'does not show selected hint by default', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023

While looking into improving `CustomSelectControl`, the first stop is to refine the current tests and add additional ones. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Since `CustomSelectControl` isn't a native `select` element, it seems important to add tests that ensure it behaves the same as one. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The additional tests are based on both `listbox` and `combobox` roles, the two appropriate roles for a `select`. 

## Notes 

After making changes to the component, the following tests/improvements could be implemented: 
- Replace `toHaveTextContent` with `toHaveValue`
- Ensure that HTML attributes valid for a `select` can be added (i.e. `disabled`)
- The default value or initially selected values will have focus when opening the popover, otherwise, it'll be the first element 
- Replace tests for experimental hint prop with tests for rendering any element

## Testing Instructions
Ensure tests pass: `npm run test:unit packages/components/src/custom-select-control/test/index.js`