### PR TITLE
Global style revisions: show change summary on selected item

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -23,28 +23,6 @@ const translationMap = {
 	'typography.fontWeight': __( 'font weight' ),
 };
 
-/**
- * Returns an array of translated strings describing high level global styles and settings.
- *
- * @param {Object} revision
- * @param {Object} revision.settings Global styles settings.
- * @param {Object} revision.styles   Global styles.
- * @return {string[] | []} An array of translated labels.
- */
-export function getGlobalStylesChanges( { settings = {}, styles = {} } ) {
-	const changes = [];
-	if ( Object.keys( settings ).length > 0 ) {
-		changes.push( __( 'Global settings' ) );
-	}
-	Object.keys( styles ).forEach( ( key ) => {
-		if ( translationMap[ key ] ) {
-			changes.push( translationMap[ key ] );
-		}
-	} );
-
-	return changes;
-}
-
 function getTranslation( key, blockNames ) {
 	if ( translationMap[ key ] ) {
 		return translationMap[ key ];

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 
-const globalStylesChangesCache = new WeakMap();
+const globalStylesChangesCache = new Map();
 
 const translationMap = {
 	caption: __( 'caption' ),
@@ -117,7 +117,7 @@ export default function getRevisionChanges(
 	previousRevision,
 	blockNames
 ) {
-	const cacheKey = { revision, previousRevision };
+	const cacheKey = JSON.stringify( { revision, previousRevision } );
 
 	if ( globalStylesChangesCache.has( cacheKey ) ) {
 		return globalStylesChangesCache.get( cacheKey );

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -4,10 +4,19 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 const translationMap = {
-	border: __( 'Border' ),
-	color: __( 'Colors' ),
-	spacing: __( 'Spacing' ),
-	typography: __( 'Typography' ),
+	elements: __( 'elements' ),
+	variations: __( 'variations' ),
+	css: __( 'CSS' ),
+	filter: __( 'filter' ),
+	border: __( 'border' ),
+	color: __( 'color' ),
+	spacing: __( 'spacing' ),
+	typography: __( 'typography' ),
+	caption: __( 'caption' ),
+	link: __( 'link' ),
+	button: __( 'button' ),
+	heading: __( 'heading' ),
+	':hover': __( 'hover' ),
 	'settings.color.palette': __( 'color palette' ),
 	'settings.color.gradients': __( 'gradients' ),
 	'settings.color.duotone': __( 'duotone colors' ),
@@ -55,23 +64,19 @@ export function getGlobalStylesChanges( { settings = {}, styles = {} } ) {
 	return changes;
 }
 
-function getTranslation( key ) {
-	console.log( 'key', key );
-
+function getTranslation( key, blockNames ) {
 	if ( translationMap[ key ] ) {
 		return translationMap[ key ];
 	}
 	const keyArray = key.split( '.' );
 
 	if ( keyArray?.[ 0 ] === 'blocks' ) {
-		let blockName = keyArray[ 1 ].split( '/' )?.[ 1 ];
-		blockName = blockName.charAt( 0 ).toUpperCase() + blockName.slice( 1 );
-		// @todo maybe getBlockTypes() and find the block name from the block type.
+		const blockName = blockNames[ keyArray[ 1 ] ];
 		return sprintf(
 			// translators: %1$s: block name, %2$s: changed property.
 			__( '%1$s block %2$s' ),
-			blockName.replace( /-/g, ' ' ),
-			keyArray?.[ 2 ]
+			blockName,
+			translationMap[ keyArray[ 2 ] ]
 		);
 	}
 
@@ -79,8 +84,8 @@ function getTranslation( key ) {
 		return sprintf(
 			// translators: %1$s: block name, %2$s: changed property.
 			__( '%1$s element %2$s' ),
-			keyArray?.[ 1 ],
-			keyArray?.[ 2 ]
+			translationMap[ keyArray[ 1 ] ],
+			translationMap[ keyArray[ 2 ] ]
 		);
 	}
 }
@@ -99,6 +104,7 @@ const cache = new Map();
 export function getRevisionChanges(
 	revision,
 	previousRevision,
+	blockNames,
 	maxResults = 4
 ) {
 	if ( cache.has( revision.id ) ) {
@@ -129,7 +135,7 @@ export function getRevisionChanges(
 		// Limit to max results.
 		.slice( 0, maxResults )
 		// Translate the keys.
-		.map( ( key ) => getTranslation( key ) )
+		.map( ( key ) => getTranslation( key, blockNames ) )
 		.filter( ( str ) => !! str )
 		.join( ', ' );
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -69,7 +69,7 @@ function getTranslation( key, blockNames ) {
 	}
 }
 
-const cache = new Map();
+const cache = new WeakMap();
 
 export function getRevisionChanges(
 	revision,

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -113,9 +113,8 @@ export function getRevisionChanges(
 		}, [] );
 
 	let joined = result.slice( 0, maxResults ).join( ', ' );
-	const hasMore = result.length > maxResults;
 
-	if ( hasMore ) {
+	if ( result.length > maxResults ) {
 		joined += '…';
 	}
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -14,7 +14,7 @@ const translationMap = {
 	'color.background': __( 'background colors' ),
 	'spacing.margin': __( 'margin styles' ),
 	'spacing.padding': __( 'padding styles' ),
-	'spacing.blockGap': __( 'block gap' ),
+	'spacing.blockGap': __( 'block spacing' ),
 	'settings.layout': __( 'layout settings' ),
 	'typography.fontStyle': __( 'font style' ),
 	'typography.fontSize': __( 'font size' ),
@@ -69,15 +69,6 @@ function getTranslation( key, blockNames ) {
 	}
 }
 
-function shuffle( array ) {
-	for ( let i = array.length - 1; i > 0; i-- ) {
-		// eslint-disable-next-line no-restricted-syntax
-		const j = Math.floor( Math.random() * ( i + 1 ) );
-		[ array[ i ], array[ j ] ] = [ array[ j ], array[ i ] ];
-	}
-	return array;
-}
-
 const cache = new Map();
 
 export function getRevisionChanges(
@@ -109,10 +100,11 @@ export function getRevisionChanges(
 		}
 	);
 
-	// Remove dupes and shuffle results.
-	const result = shuffle( [ ...new Set( changedValueTree ) ] )
+	// Remove duplicate results.
+	const result = [ ...new Set( changedValueTree ) ]
 		// Translate the keys.
 		.map( ( key ) => getTranslation( key, blockNames ) )
+		// Remove duplicate or empty translations.
 		.reduce( ( acc, curr ) => {
 			if ( curr && ! acc.includes( curr ) ) {
 				acc.push( curr );

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -1,0 +1,137 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const translationMap = {
+	blocks: __( 'Block styles' ),
+	border: __( 'Border' ),
+	color: __( 'Colors' ),
+	elements: __( 'Elements' ),
+	link: __( 'Links' ),
+	layout: __( 'Layout' ),
+	spacing: __( 'Spacing' ),
+	typography: __( 'Typography' ),
+};
+
+/**
+ * Returns an array of translated strings describing high level global styles and settings.
+ *
+ * @param {Object} revision
+ * @param {Object} revision.settings Global styles settings.
+ * @param {Object} revision.styles   Global styles.
+ * @return {string[] | []} An array of translated labels.
+ */
+export function getGlobalStylesChanges( { settings = {}, styles = {} } ) {
+	const changes = [];
+	if ( Object.keys( settings ).length > 0 ) {
+		changes.push( __( 'Global settings' ) );
+	}
+	Object.keys( styles ).forEach( ( key ) => {
+		if ( translationMap[ key ] ) {
+			changes.push( translationMap[ key ] );
+		}
+	} );
+
+	return changes;
+}
+
+const shuffle = ( array ) => {
+	for ( let i = array.length - 1; i > 0; i-- ) {
+		// eslint-disable-next-line no-restricted-syntax
+		const j = Math.floor( Math.random() * ( i + 1 ) );
+		[ array[ i ], array[ j ] ] = [ array[ j ], array[ i ] ];
+	}
+	return array;
+};
+
+const cache = {}; // Should be a Set?
+
+export function getRevisionChanges(
+	revision,
+	previousRevision,
+	maxResults = 10
+) {
+	if ( cache[ revision.id ] ) {
+		return cache[ revision.id ];
+	}
+console.log( 'revision, previousRevision', revision, previousRevision );
+	const changedValueTree = deepCompare(
+		{
+			blocks: revision?.styles?.blocks,
+			elements: revision?.styles?.elements,
+			color: revision?.styles?.color,
+			typography: revision?.styles?.typography,
+			dimensions: revision?.styles?.dimensions,
+			spacing: revision?.styles?.spacing,
+			border: revision?.styles?.border,
+			settingsColor: revision?.settings?.color,
+		},
+		{
+			blocks: previousRevision?.styles?.blocks,
+			elements: previousRevision?.styles?.elements,
+			color: previousRevision?.styles?.color,
+			typography: previousRevision?.styles?.typography,
+			dimensions: previousRevision?.styles?.dimensions,
+			spacing: previousRevision?.styles?.spacing,
+			border: previousRevision?.styles?.border,
+			settingsColor: previousRevision?.settings?.color,
+		}
+	);
+
+
+	console.log( 'flattenedChanges', changedValueTree);
+	const shuffled = shuffle(
+		changedValueTree.filter( ( { hasChanged, path } ) => hasChanged )
+	);
+	console.log( 'shuffled', shuffled );
+	/*	cache[ revision.id ] = shuffled
+		.slice( 0, maxResults )
+		.map( ( { path } ) => path )
+		.join( ', ' );
+
+	return cache[ revision.id ];*/
+}
+
+function isObject( obj ) {
+	return obj !== null && typeof obj === 'object';
+}
+
+function deepCompare( revisionValue, configValue, depth = 0, parentPath = '' ) {
+	if ( ! isObject( revisionValue ) && ! isObject( configValue ) ) {
+		return [
+			{
+				path: parentPath,
+				revisionValue,
+				configValue,
+				hasChanged: revisionValue !== configValue,
+			},
+		];
+	}
+
+	revisionValue = isObject( revisionValue ) ? revisionValue : {};
+	configValue = isObject( configValue ) ? configValue : {};
+
+	const keys1 = Object.keys( revisionValue );
+	const keys2 = Object.keys( configValue );
+	const allKeys = new Set( [ ...keys1, ...keys2 ] );
+
+	let diffs = [];
+	for ( const key of allKeys ) {
+		const path = parentPath ? parentPath + '.' + key : key;
+		const subDiffs = deepCompare(
+			revisionValue[ key ],
+			configValue[ key ],
+			depth + 1,
+			path
+		);
+		diffs = diffs.concat( subDiffs );
+	}
+/*	diffs = diffs.filter(
+		( diff ) =>
+			diff.path.includes( 'behaviors' ) ||
+			diff.path.includes( 'settings' ) ||
+			diff.path.includes( 'styles' )
+	);*/
+	return diffs;
+}

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -103,23 +103,24 @@ export function getRevisionChanges(
 	// Remove duplicate results.
 	const result = [ ...new Set( changedValueTree ) ]
 		// Translate the keys.
-		.map( ( key ) => getTranslation( key, blockNames ) )
 		// Remove duplicate or empty translations.
 		.reduce( ( acc, curr ) => {
-			if ( curr && ! acc.includes( curr ) ) {
-				acc.push( curr );
+			const translation = getTranslation( curr, blockNames );
+			if ( translation && ! acc.includes( translation ) ) {
+				acc.push( translation );
 			}
 			return acc;
 		}, [] );
 
-	let joined = result.slice( 0, maxResults ).join( ', ' );
+	const slicedResult = result.slice( 0, maxResults );
 
 	if ( result.length > maxResults ) {
-		joined += '…';
+		// translators: follows comma-separated list of changed styles.
+		slicedResult.push( __( 'and more.' ) );
 	}
 
+	const joined = slicedResult.join( ', ' );
 	cache.set( revision, joined );
-
 	return joined;
 }
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -77,8 +77,8 @@ export function getRevisionChanges(
 	blockNames,
 	maxResults = 5
 ) {
-	if ( cache.has( revision.id ) ) {
-		return cache.get( revision.id );
+	if ( cache.has( revision ) ) {
+		return cache.get( revision );
 	}
 
 	const changedValueTree = deepCompare(
@@ -119,7 +119,7 @@ export function getRevisionChanges(
 		joined += '…';
 	}
 
-	cache.set( revision.id, joined );
+	cache.set( revision, joined );
 
 	return joined;
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 const globalStylesChangesCache = new Map();
+const EMPTY_ARRAY = [];
 
 const translationMap = {
 	caption: __( 'caption' ),
@@ -142,6 +143,11 @@ export default function getRevisionChanges(
 			settings: previousRevision?.settings,
 		}
 	);
+
+	if ( ! changedValueTree.length ) {
+		globalStylesChangesCache.set( cacheKey, EMPTY_ARRAY );
+		return EMPTY_ARRAY;
+	}
 
 	// Remove duplicate results.
 	const result = [ ...new Set( changedValueTree ) ]

--- a/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/get-revision-changes.js
@@ -104,40 +104,23 @@ function deepCompare( changedObject, originalObject, parentPath = '' ) {
 }
 
 /**
- * Get a concatenated summary of translated global styles changes.
+ * Get an array of translated summarized global styles changes.
  * Results are cached using a WeakMap key of `{ revision, previousRevision }`.
  *
  * @param {Object}                revision         The changed object to compare.
  * @param {Object}                previousRevision The original object to compare against.
  * @param {Record<string,string>} blockNames       A key/value pair object of block names and their rendered titles.
- * @param {number?}               maxResults       The maximum number of changed items to feature in the returned summary.
- * @return {string}                                A comma-separated list of changes.
+ * @return {string[]}                              An array of translated changes.
  */
 export default function getRevisionChanges(
 	revision,
 	previousRevision,
-	blockNames,
-	maxResults
+	blockNames
 ) {
 	const cacheKey = { revision, previousRevision };
 
 	if ( globalStylesChangesCache.has( cacheKey ) ) {
-		const cachedResult = globalStylesChangesCache.get( cacheKey );
-		if ( ! maxResults ) {
-			return cachedResult;
-		}
-
-		// We may need to update the cache if a new maxResults is passed.
-		const cachedResultArray = cachedResult.split( ', ' );
-		const cachedResultArrayLength = cachedResultArray.length;
-		if ( maxResults === cachedResultArrayLength ) {
-			return cachedResult;
-		}
-
-		// If the cached result has more results than the max results, return a spliced cached result.
-		if ( maxResults < cachedResultArrayLength ) {
-			return cachedResultArray.slice( 0, maxResults ).join( ', ' );
-		}
+		return globalStylesChangesCache.get( cacheKey );
 	}
 
 	// Compare the two revisions with normalized keys.
@@ -172,8 +155,7 @@ export default function getRevisionChanges(
 			return acc;
 		}, [] );
 
-	const changes = maxResults ? result.slice( 0, maxResults ) : result;
-	const joined = changes.join( ', ' );
-	globalStylesChangesCache.set( cacheKey, joined );
-	return joined;
+	globalStylesChangesCache.set( cacheKey, result );
+
+	return result;
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import {
-	Button,
 	__experimentalUseNavigator as useNavigator,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Spinner,
@@ -23,7 +22,6 @@ import {
 import ScreenHeader from '../header';
 import { unlock } from '../../../lock-unlock';
 import Revisions from '../../revisions';
-import SidebarFixedBottom from '../../sidebar-edit-mode/sidebar-fixed-bottom';
 import { store as editSiteStore } from '../../../store';
 import useGlobalStylesRevisions from './use-global-styles-revisions';
 import RevisionsButtons from './revisions-buttons';
@@ -135,7 +133,8 @@ function ScreenRevisions() {
 		}
 	}, [ shouldSelectFirstItem, firstRevision ] );
 
-	// Only display load button if there is a revision to load and it is different from the current editor styles.
+	// Only display load button if there is a revision to load,
+	// and it is different from the current editor styles.
 	const isLoadButtonEnabled =
 		!! currentlySelectedRevisionId && ! selectedRevisionMatchesEditorStyles;
 	const shouldShowRevisions = ! isLoading && revisions.length;
@@ -168,35 +167,19 @@ function ScreenRevisions() {
 							onChange={ selectRevision }
 							selectedRevisionId={ currentlySelectedRevisionId }
 							userRevisions={ revisions }
+							canApplyRevision={ isLoadButtonEnabled }
+							onSelect={ () => {
+								if ( hasUnsavedChanges ) {
+									setIsLoadingRevisionWithUnsavedChanges(
+										true
+									);
+								} else {
+									restoreRevision(
+										currentlySelectedRevision
+									);
+								}
+							} }
 						/>
-						{ isLoadButtonEnabled && (
-							<SidebarFixedBottom>
-								<Button
-									variant="primary"
-									className="edit-site-global-styles-screen-revisions__button"
-									disabled={
-										! currentlySelectedRevisionId ||
-										currentlySelectedRevisionId ===
-											'unsaved'
-									}
-									onClick={ () => {
-										if ( hasUnsavedChanges ) {
-											setIsLoadingRevisionWithUnsavedChanges(
-												true
-											);
-										} else {
-											restoreRevision(
-												currentlySelectedRevision
-											);
-										}
-									} }
-								>
-									{ currentlySelectedRevisionId === 'parent'
-										? __( 'Reset to defaults' )
-										: __( 'Apply' ) }
-								</Button>
-							</SidebarFixedBottom>
-						) }
 					</div>
 					{ isLoadingRevisionWithUnsavedChanges && (
 						<ConfirmDialog

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import {
+	Button,
 	__experimentalUseNavigator as useNavigator,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Spinner,
@@ -22,6 +23,7 @@ import {
 import ScreenHeader from '../header';
 import { unlock } from '../../../lock-unlock';
 import Revisions from '../../revisions';
+import SidebarFixedBottom from '../../sidebar-edit-mode/sidebar-fixed-bottom';
 import { store as editSiteStore } from '../../../store';
 import useGlobalStylesRevisions from './use-global-styles-revisions';
 import RevisionsButtons from './revisions-buttons';
@@ -168,18 +170,35 @@ function ScreenRevisions() {
 							selectedRevisionId={ currentlySelectedRevisionId }
 							userRevisions={ revisions }
 							canApplyRevision={ isLoadButtonEnabled }
-							onSelect={ () => {
-								if ( hasUnsavedChanges ) {
-									setIsLoadingRevisionWithUnsavedChanges(
-										true
-									);
-								} else {
-									restoreRevision(
-										currentlySelectedRevision
-									);
-								}
-							} }
 						/>
+						{ isLoadButtonEnabled && (
+							<SidebarFixedBottom>
+								<Button
+									variant="primary"
+									className="edit-site-global-styles-screen-revisions__button"
+									disabled={
+										! currentlySelectedRevisionId ||
+										currentlySelectedRevisionId ===
+											'unsaved'
+									}
+									onClick={ () => {
+										if ( hasUnsavedChanges ) {
+											setIsLoadingRevisionWithUnsavedChanges(
+												true
+											);
+										} else {
+											restoreRevision(
+												currentlySelectedRevision
+											);
+										}
+									} }
+								>
+									{ currentlySelectedRevisionId === 'parent'
+										? __( 'Reset to defaults' )
+										: __( 'Apply' ) }
+								</Button>
+							</SidebarFixedBottom>
+						) }
 					</div>
 					{ isLoadingRevisionWithUnsavedChanges && (
 						<ConfirmDialog

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -7,7 +7,6 @@ import {
 	__experimentalUseNavigator as useNavigator,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Spinner,
-	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -157,7 +156,7 @@ function ScreenRevisions() {
 			{ isLoading && (
 				<Spinner className="edit-site-global-styles-screen-revisions__loading" />
 			) }
-			{ shouldShowRevisions ? (
+			{ shouldShowRevisions && (
 				<>
 					<Revisions
 						blocks={ blocks }
@@ -217,14 +216,6 @@ function ScreenRevisions() {
 						</ConfirmDialog>
 					) }
 				</>
-			) : (
-				<Spacer marginX={ 4 } data-testid="global-styles-no-revisions">
-					{
-						// Adding an existing translation here in case these changes are shipped to WordPress 6.3.
-						// Later we could update to something better, e.g., "There are currently no style revisions.".
-						__( 'No results found.' )
-					}
-				</Spacer>
 			) }
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -23,7 +23,11 @@ const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 const MAX_CHANGES = 7;
 
 function ChangedSummary( { revision, previousRevision, blockNames } ) {
-	let changes = getRevisionChanges( revision, previousRevision, blockNames );
+	const changes = getRevisionChanges(
+		revision,
+		previousRevision,
+		blockNames
+	);
 
 	const changesLength = changes.length;
 
@@ -33,14 +37,28 @@ function ChangedSummary( { revision, previousRevision, blockNames } ) {
 
 	// Truncate to `n` results.
 	if ( changesLength > MAX_CHANGES ) {
-		changes = changes.slice( 0, MAX_CHANGES ).join( ', ' ) + __( '…' );
-	} else {
-		changes = changes.join( ', ' );
+		const deleteCount = changesLength - MAX_CHANGES;
+		changes.splice(
+			MAX_CHANGES,
+			deleteCount,
+			sprintf(
+				/* translators: %d remaining changes that aren't displayed */
+				__( 'and %d more…' ),
+				deleteCount
+			)
+		);
 	}
 
 	return (
 		<span className="edit-site-global-styles-screen-revision__changes">
-			{ changes }
+			<div className="edit-site-global-styles-screen-revision__changes-title">
+				{ __( 'Changes:' ) }
+			</div>
+			<ul className="edit-site-global-styles-screen-revision__changes-list">
+				{ changes.map( ( change ) => (
+					<li key={ change }>{ change }</li>
+				) ) }
+			</ul>
 		</span>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -12,6 +12,11 @@ import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { getRevisionChanges } from './get-revision-changes';
+
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 
 /**
@@ -67,7 +72,13 @@ function getRevisionLabel(
  * @param    {props}         Component          props.
  * @return {JSX.Element} The modal component.
  */
-function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
+function RevisionsButtons( {
+	userRevisions,
+	selectedRevisionId,
+	onChange,
+	onSelect,
+	canApplyRevision,
+} ) {
 	const { currentThemeName, currentUser } = useSelect( ( select ) => {
 		const { getCurrentTheme, getCurrentUser } = select( coreStore );
 		const currentTheme = getCurrentTheme();
@@ -78,7 +89,7 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 		};
 	}, [] );
 	const dateNowInMs = getDate().getTime();
-	const { date: dateFormat, datetimeAbbreviated } = getSettings().formats;
+	const { datetimeAbbreviated } = getSettings().formats;
 
 	return (
 		<ol
@@ -101,7 +112,7 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 				const displayDate =
 					modified &&
 					dateNowInMs - modifiedDate.getTime() > DAY_IN_MILLISECONDS
-						? dateI18n( dateFormat, modifiedDate )
+						? dateI18n( datetimeAbbreviated, modifiedDate )
 						: humanTimeDiff( modified );
 				const revisionLabel = getRevisionLabel(
 					id,
@@ -160,6 +171,27 @@ function RevisionsButtons( { userRevisions, selectedRevisionId, onChange } ) {
 								</span>
 							) }
 						</Button>
+						{ isSelected && canApplyRevision && (
+							<>
+								<p>
+									{ getRevisionChanges(
+										revision,
+										index < userRevisions.length
+											? userRevisions[ index + 1 ]
+											: {}
+									) }
+								</p>
+								<Button
+									variant="primary"
+									className="edit-site-global-styles-screen-revision__button"
+									onClick={ onSelect }
+								>
+									{ isReset
+										? __( 'Reset to defaults' )
+										: __( 'Apply' ) }
+								</Button>
+							</>
+						) }
 					</li>
 				);
 			} ) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -17,7 +17,7 @@ import { getBlockTypes } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { getRevisionChanges } from './get-revision-changes';
+import getRevisionChanges from './get-revision-changes';
 
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -11,6 +11,8 @@ import { Button } from '@wordpress/components';
 import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -20,7 +22,18 @@ import { getRevisionChanges } from './get-revision-changes';
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 
 function ChangedSummary( { revision, previousRevision } ) {
-	const summary = getRevisionChanges( revision, previousRevision );
+	const blockNames = useMemo( () => {
+		const blockTypes = getBlockTypes();
+		return blockTypes.reduce( ( accumulator, { name, title } ) => {
+			accumulator[ name ] = title;
+			return accumulator;
+		}, {} );
+	}, [] );
+	const summary = getRevisionChanges(
+		revision,
+		previousRevision,
+		blockNames
+	);
 
 	if ( ! summary ) {
 		return null;
@@ -199,7 +212,7 @@ function RevisionsButtons( {
 								{ /* eslint-disable-next-line no-nested-ternary */ }
 								{ canApplyRevision ? (
 									<Button
-										variant="primary"
+										variant="secondary"
 										className="edit-site-global-styles-screen-revision__button"
 										onClick={ onSelect }
 									>

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -22,14 +22,7 @@ import getRevisionChanges from './get-revision-changes';
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 const MAX_CHANGES = 7;
 
-function ChangedSummary( { revision, previousRevision } ) {
-	const blockNames = useMemo( () => {
-		const blockTypes = getBlockTypes();
-		return blockTypes.reduce( ( accumulator, { name, title } ) => {
-			accumulator[ name ] = title;
-			return accumulator;
-		}, {} );
-	}, [] );
+function ChangedSummary( { revision, previousRevision, blockNames } ) {
 	const changes = getRevisionChanges(
 		revision,
 		previousRevision,
@@ -124,6 +117,13 @@ function RevisionsButtons( {
 			currentUser: getCurrentUser(),
 		};
 	}, [] );
+	const blockNames = useMemo( () => {
+		const blockTypes = getBlockTypes();
+		return blockTypes.reduce( ( accumulator, { name, title } ) => {
+			accumulator[ name ] = title;
+			return accumulator;
+		}, {} );
+	}, [] );
 	const dateNowInMs = getDate().getTime();
 	const { datetimeAbbreviated } = getSettings().formats;
 
@@ -212,6 +212,7 @@ function RevisionsButtons( {
 						</Button>
 						{ isSelected && (
 							<ChangedSummary
+								blockNames={ blockNames }
 								revision={ revision }
 								previousRevision={
 									index < userRevisions.length

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -20,6 +20,7 @@ import { getBlockTypes } from '@wordpress/blocks';
 import getRevisionChanges from './get-revision-changes';
 
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
+const MAX_CHANGES = 7;
 
 function ChangedSummary( { revision, previousRevision } ) {
 	const blockNames = useMemo( () => {
@@ -29,19 +30,26 @@ function ChangedSummary( { revision, previousRevision } ) {
 			return accumulator;
 		}, {} );
 	}, [] );
-	const summary = getRevisionChanges(
+	const changes = getRevisionChanges(
 		revision,
 		previousRevision,
 		blockNames
 	);
 
-	if ( ! summary ) {
+	const changesLength = changes.length;
+
+	if ( ! changesLength ) {
 		return null;
+	}
+
+	// Truncate to `n` results.
+	if ( changesLength > MAX_CHANGES ) {
+		changes.splice( MAX_CHANGES, changesLength - MAX_CHANGES, __( '…' ) );
 	}
 
 	return (
 		<span className="edit-site-global-styles-screen-revision__changes">
-			{ summary }
+			{ changes.join( ', ' ) }
 		</span>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -171,7 +171,7 @@ function RevisionsButtons( {
 								</span>
 							) }
 						</Button>
-						{ isSelected && canApplyRevision && (
+						{ isSelected && (
 							<>
 								<p>
 									{ getRevisionChanges(
@@ -181,15 +181,22 @@ function RevisionsButtons( {
 											: {}
 									) }
 								</p>
-								<Button
-									variant="primary"
-									className="edit-site-global-styles-screen-revision__button"
-									onClick={ onSelect }
-								>
-									{ isReset
-										? __( 'Reset to defaults' )
-										: __( 'Apply' ) }
-								</Button>
+								{ canApplyRevision ? (
+									<Button
+										variant="primary"
+										className="edit-site-global-styles-screen-revision__button"
+										onClick={ onSelect }
+									>
+										{ isReset
+											? __( 'Reset to defaults' )
+											: __( 'Apply' ) }
+									</Button>
+								) : (
+									<p>
+										The revision is the same as the saved
+										state.
+									</p>
+								) }
 							</>
 						) }
 					</li>

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -19,6 +19,20 @@ import { getRevisionChanges } from './get-revision-changes';
 
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 
+function ChangedSummary( { revision, previousRevision } ) {
+	const summary = getRevisionChanges( revision, previousRevision );
+
+	if ( ! summary ) {
+		return null;
+	}
+
+	return (
+		<span className="edit-site-global-styles-screen-revision__changes">
+			{ summary }
+		</span>
+	);
+}
+
 /**
  * Returns a button label for the revision.
  *
@@ -104,9 +118,10 @@ function RevisionsButtons( {
 				const revisionAuthor = isUnsaved ? currentUser : author;
 				const authorDisplayName = revisionAuthor?.name || __( 'User' );
 				const authorAvatar = revisionAuthor?.avatar_urls?.[ '48' ];
+				const isFirstItem = index === 0;
 				const isSelected = selectedRevisionId
 					? selectedRevisionId === id
-					: index === 0;
+					: isFirstItem;
 				const isReset = 'parent' === id;
 				const modifiedDate = getDate( modified );
 				const displayDate =
@@ -173,14 +188,15 @@ function RevisionsButtons( {
 						</Button>
 						{ isSelected && (
 							<>
-								<p>
-									{ getRevisionChanges(
-										revision,
+								<ChangedSummary
+									revision={ revision }
+									previousRevision={
 										index < userRevisions.length
 											? userRevisions[ index + 1 ]
 											: {}
-									) }
-								</p>
+									}
+								/>
+								{ /* eslint-disable-next-line no-nested-ternary */ }
 								{ canApplyRevision ? (
 									<Button
 										variant="primary"
@@ -192,10 +208,11 @@ function RevisionsButtons( {
 											: __( 'Apply' ) }
 									</Button>
 								) : (
-									<p>
-										The revision is the same as the saved
-										state.
-									</p>
+									<span className="edit-site-global-styles-screen-revision__matches">
+										{ __(
+											'Revision matches current editor styles.'
+										) }
+									</span>
 								) }
 							</>
 						) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -23,11 +23,7 @@ const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 const MAX_CHANGES = 7;
 
 function ChangedSummary( { revision, previousRevision, blockNames } ) {
-	const changes = getRevisionChanges(
-		revision,
-		previousRevision,
-		blockNames
-	);
+	let changes = getRevisionChanges( revision, previousRevision, blockNames );
 
 	const changesLength = changes.length;
 
@@ -37,12 +33,14 @@ function ChangedSummary( { revision, previousRevision, blockNames } ) {
 
 	// Truncate to `n` results.
 	if ( changesLength > MAX_CHANGES ) {
-		changes.splice( MAX_CHANGES, changesLength - MAX_CHANGES, __( '…' ) );
+		changes = changes.slice( 0, MAX_CHANGES ).join( ', ' ) + __( '…' );
+	} else {
+		changes = changes.join( ', ' );
 	}
 
 	return (
 		<span className="edit-site-global-styles-screen-revision__changes">
-			{ changes.join( ', ' ) }
+			{ changes }
 		</span>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -48,7 +48,7 @@ function ChangedSummary( { revision, previousRevision, blockNames } ) {
 	return (
 		<span
 			data-testid="global-styles-revision-changes"
-			className="edit-site-global-styles-screen-revision__changes"
+			className="edit-site-global-styles-screen-revisions__changes"
 		>
 			{ changes.join( ', ' ) }
 		</span>
@@ -208,6 +208,17 @@ function RevisionsButtons( {
 											{ displayDate }
 										</time>
 									) }
+									{ isSelected && (
+										<ChangedSummary
+											blockNames={ blockNames }
+											revision={ revision }
+											previousRevision={
+												index < userRevisions.length
+													? userRevisions[ index + 1 ]
+													: {}
+											}
+										/>
+									) }
 									<span className="edit-site-global-styles-screen-revisions__meta">
 										<img
 											alt={ authorDisplayName }
@@ -218,17 +229,6 @@ function RevisionsButtons( {
 								</span>
 							) }
 						</Button>
-						{ isSelected && (
-							<ChangedSummary
-								blockNames={ blockNames }
-								revision={ revision }
-								previousRevision={
-									index < userRevisions.length
-										? userRevisions[ index + 1 ]
-										: {}
-								}
-							/>
-						) }
 					</li>
 				);
 			} ) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -23,57 +23,35 @@ const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 const MAX_CHANGES = 7;
 
 function ChangedSummary( { revision, previousRevision, blockNames } ) {
-	let changes = getRevisionChanges( revision, previousRevision, blockNames );
-
+	const changes = getRevisionChanges(
+		revision,
+		previousRevision,
+		blockNames
+	);
 	const changesLength = changes.length;
 
 	if ( ! changesLength ) {
 		return null;
 	}
 
-	// Truncate to `n` results.
+	// Truncate to `n` results if necessary.
 	if ( changesLength > MAX_CHANGES ) {
-		changes = changes.slice( 0, MAX_CHANGES );
+		const deleteCount = changesLength - MAX_CHANGES;
+		const andMoreText = sprintf(
+			// translators: %d: number of global styles changes that are not displayed in the UI.
+			_n( '…and %d more change.', '…and %d more changes.', deleteCount ),
+			deleteCount
+		);
+		changes.splice( MAX_CHANGES, deleteCount, andMoreText );
 	}
 
-	const moreChanges = changesLength - changes.length;
-
-	changes = changes.reduce( ( acc, curr ) => {
-		acc[ curr[ 0 ] ] = ! acc[ curr[ 0 ] ]
-			? [ curr[ 1 ] ]
-			: [ ...acc[ curr[ 0 ] ], curr[ 1 ] ];
-		return acc;
-	}, {} );
-
 	return (
-		<div className="edit-site-global-styles-screen-revision__changes">
-			{ Object.entries( changes )?.map( ( [ key, changeValues ] ) => (
-				<div
-					key={ key }
-					className="edit-site-global-styles-screen-revision__changes-group"
-				>
-					<span className="edit-site-global-styles-screen-revision__changes-title">
-						{ key }:
-					</span>
-					<span className="edit-site-global-styles-screen-revision__changes-list">
-						{ changeValues.join( ', ' ) }
-					</span>
-				</div>
-			) ) }
-			{ moreChanges > 0 ? (
-				<span className="edit-site-global-styles-screen-revision__more">
-					{ sprintf(
-						// translators: %d: number of global styles changes that are not displayed in the UI.
-						_n(
-							'…and %d more change.',
-							'…and %d more changes.',
-							moreChanges
-						),
-						moreChanges
-					) }
-				</span>
-			) : null }
-		</div>
+		<span
+			data-testid="global-styles-revision-changes"
+			className="edit-site-global-styles-screen-revision__changes"
+		>
+			{ changes.join( ', ' ) }
+		</span>
 	);
 }
 
@@ -98,7 +76,7 @@ function getRevisionLabel(
 
 	if ( 'unsaved' === id ) {
 		return sprintf(
-			/* translators: %s author display name */
+			/* translators: %s: author display name */
 			__( 'Unsaved changes by %s' ),
 			authorDisplayName
 		);
@@ -106,7 +84,7 @@ function getRevisionLabel(
 
 	return areStylesEqual
 		? sprintf(
-				/* translators: %1$s author display name, %2$s: revision creation date */
+				// translators: %1$s: author display name, %2$s: revision creation date.
 				__(
 					'Changes saved by %1$s on %2$s. This revision matches current editor styles.'
 				),
@@ -114,7 +92,7 @@ function getRevisionLabel(
 				formattedModifiedDate
 		  )
 		: sprintf(
-				/* translators: %1$s author display name, %2$s: revision creation date */
+				// translators: %1$s: author display name, %2$s: revision creation date.
 				__( 'Changes saved by %1$s on %2$s' ),
 				authorDisplayName,
 				formattedModifiedDate

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -22,7 +22,7 @@ import getRevisionChanges from './get-revision-changes';
 const DAY_IN_MILLISECONDS = 60 * 60 * 1000 * 24;
 const MAX_CHANGES = 7;
 
-function ChangedSummary( { revision, previousRevision, blockNames } ) {
+function ChangesSummary( { revision, previousRevision, blockNames } ) {
 	const changes = getRevisionChanges(
 		revision,
 		previousRevision,
@@ -209,7 +209,7 @@ function RevisionsButtons( {
 										</time>
 									) }
 									{ isSelected && (
-										<ChangedSummary
+										<ChangesSummary
 											blockNames={ blockNames }
 											revision={ revision }
 											previousRevision={

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -17,6 +17,10 @@
 	overflow: hidden;
 	cursor: pointer;
 
+	&.is-active {
+		box-shadow: inset 5px 0 $black;
+	}
+
 	&:hover {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		.edit-site-global-styles-screen-revisions__date {
@@ -89,16 +93,6 @@
 .edit-site-global-styles-screen-revisions__button {
 	justify-content: center;
 	width: 100%;
-	margin: 0 0 10px 10px;
-}
-
-.edit-site-global-styles-screen-revision__button {
-	justify-content: center;
-	width: 90%;
-	margin: 0 0 $grid-unit-10 $grid-unit-20;
-	&:hover {
-		background: $white;
-	}
 }
 
 .edit-site-global-styles-screen-revisions__description {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -129,26 +129,36 @@
 
 .edit-site-global-styles-screen-revision__changes {
 	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-30;
-	color: $gray-900;
-	display: block;
-	&::first-letter {
-		text-transform: uppercase;
-	}
+}
+
+.edit-site-global-styles-screen-revision__header {
+	text-transform: uppercase;
+	margin-bottom: $grid-unit-05;
+	font-weight: 700;
+	color: $gray-700;
+	font-size: 12px;
+}
+
+.edit-site-global-styles-screen-revision__changes-group {
+	margin-bottom: $grid-unit-05;
+	color: $gray-800;
 }
 
 .edit-site-global-styles-screen-revision__changes-title {
 	font-weight: 700;
-	display: inline-block;
 	margin-right: $grid-unit-05;
-	text-transform: uppercase;
 	font-size: 12px;
-	color: $gray-800;
-	margin-bottom: $grid-unit-05;
+	color: $gray-700;
 }
 
 .edit-site-global-styles-screen-revision__changes-list {
-	margin-left: $grid-unit-15;
 	font-size: 12px;
 	list-style: circle;
 	color: $gray-700;
+}
+
+.edit-site-global-styles-screen-revision__more {
+	font-style: italic;
+	color: $gray-700;
+	font-size: 12px;
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -96,6 +96,9 @@
 	justify-content: center;
 	width: 90%;
 	margin: 0 0 $grid-unit-10 $grid-unit-20;
+	&:hover {
+		background: $white;
+	}
 }
 
 .edit-site-global-styles-screen-revisions__description {
@@ -135,7 +138,7 @@
 	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-20;
 	color: $gray-900;
 	display: block;
-	&:first-letter {
+	&::first-letter {
 		text-transform: uppercase;
 	}
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -89,6 +89,13 @@
 .edit-site-global-styles-screen-revisions__button {
 	justify-content: center;
 	width: 100%;
+	margin: 0 0 10px 10px;
+}
+
+.edit-site-global-styles-screen-revision__button {
+	justify-content: center;
+	width: 90%;
+	margin: 0 0 $grid-unit-10 $grid-unit-20;
 }
 
 .edit-site-global-styles-screen-revisions__description {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -129,3 +129,19 @@
 .edit-site-global-styles-screen-revisions__loading {
 	margin: $grid-unit-30 auto !important;
 }
+
+.edit-site-global-styles-screen-revision__matches,
+.edit-site-global-styles-screen-revision__changes {
+	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-20;
+	color: $gray-900;
+	display: block;
+	&:first-letter {
+		text-transform: uppercase;
+	}
+}
+
+.edit-site-global-styles-screen-revision__matches {
+	font-style: italic;
+	font-size: 12px;
+	color: $gray-600;
+}

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -127,9 +127,8 @@
 	margin: $grid-unit-30 auto !important;
 }
 
-.edit-site-global-styles-screen-revision__matches,
 .edit-site-global-styles-screen-revision__changes {
-	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-20;
+	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-30;
 	color: $gray-900;
 	display: block;
 	&::first-letter {
@@ -137,8 +136,19 @@
 	}
 }
 
-.edit-site-global-styles-screen-revision__matches {
-	font-style: italic;
+.edit-site-global-styles-screen-revision__changes-title {
+	font-weight: 700;
+	display: inline-block;
+	margin-right: $grid-unit-05;
+	text-transform: uppercase;
 	font-size: 12px;
-	color: $gray-600;
+	color: $gray-800;
+	margin-bottom: $grid-unit-05;
+}
+
+.edit-site-global-styles-screen-revision__changes-list {
+	margin-left: $grid-unit-15;
+	font-size: 12px;
+	list-style: circle;
+	color: $gray-700;
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -129,36 +129,9 @@
 
 .edit-site-global-styles-screen-revision__changes {
 	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-30;
-}
-
-.edit-site-global-styles-screen-revision__header {
-	text-transform: uppercase;
-	margin-bottom: $grid-unit-05;
-	font-weight: 700;
-	color: $gray-700;
-	font-size: 12px;
-}
-
-.edit-site-global-styles-screen-revision__changes-group {
-	margin-bottom: $grid-unit-05;
-	color: $gray-800;
-}
-
-.edit-site-global-styles-screen-revision__changes-title {
-	font-weight: 700;
-	margin-right: $grid-unit-05;
-	font-size: 12px;
-	color: $gray-700;
-}
-
-.edit-site-global-styles-screen-revision__changes-list {
-	font-size: 12px;
-	list-style: circle;
-	color: $gray-700;
-}
-
-.edit-site-global-styles-screen-revision__more {
-	font-style: italic;
-	color: $gray-700;
-	font-size: 12px;
+	color: $gray-900;
+	display: block;
+	&::first-letter {
+		text-transform: uppercase;
+	}
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -17,10 +17,6 @@
 	overflow: hidden;
 	cursor: pointer;
 
-	&.is-active {
-		box-shadow: inset 5px 0 $black;
-	}
-
 	&:hover {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		.edit-site-global-styles-screen-revisions__date {
@@ -70,7 +66,7 @@
 		width: 100%;
 		height: auto;
 		display: block;
-		padding: $grid-unit-15 $grid-unit-15 $grid-unit-15 $grid-unit-30;
+		padding: $grid-unit-15 $grid-unit-15 $grid-unit-10 $grid-unit-30;
 		&:focus,
 		&:active {
 			outline: 0;
@@ -107,6 +103,7 @@
 	}
 }
 
+.edit-site-global-styles-screen-revisions__changes,
 .edit-site-global-styles-screen-revisions__meta {
 	color: $gray-600;
 	display: flex;
@@ -114,7 +111,6 @@
 	width: 100%;
 	align-items: center;
 	font-size: 12px;
-
 	img {
 		width: $grid-unit-20;
 		height: $grid-unit-20;
@@ -127,11 +123,10 @@
 	margin: $grid-unit-30 auto !important;
 }
 
-.edit-site-global-styles-screen-revision__changes {
-	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-30;
+.edit-site-global-styles-screen-revisions__changes {
+	margin-bottom: $grid-unit-05;
+	text-align: left;
 	color: $gray-900;
-	display: block;
-	&::first-letter {
-		text-transform: uppercase;
-	}
+	line-height: $default-line-height;
 }
+

--- a/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
@@ -136,13 +136,13 @@ describe( 'getRevisionChanges', () => {
 			blockNames
 		);
 		expect( resultA ).toEqual( [
-			'Paragraph block',
-			'background colors',
-			'font size',
-			'font family',
-			'caption element',
-			'link element',
-			'color settings',
+			[ 'Blocks', 'Paragraph' ],
+			[ 'Styles', 'Background' ],
+			[ 'Styles', 'Font size' ],
+			[ 'Styles', 'Font family' ],
+			[ 'Elements', 'Caption' ],
+			[ 'Elements', 'Link' ],
+			[ 'Settings', 'Color' ],
 		] );
 
 		const resultB = getRevisionChanges(

--- a/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
@@ -151,7 +151,7 @@ describe( 'getRevisionChanges', () => {
 			blockNames
 		);
 
-		expect( resultA ).toStrictEqual( resultB );
+		expect( resultA ).toBe( resultB );
 	} );
 
 	it( 'skips unknown keys', () => {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
@@ -129,15 +129,21 @@ describe( 'getRevisionChanges', () => {
 	const blockNames = {
 		'core/paragraph': 'Paragraph',
 	};
-	it( 'returns a comma-separated list of changes and caches them', () => {
+	it( 'returns a list of changes and caches them', () => {
 		const resultA = getRevisionChanges(
 			revision,
 			previousRevision,
 			blockNames
 		);
-		expect( resultA ).toEqual(
-			'Paragraph block, background colors, font size, font family, caption element, link element, color settings'
-		);
+		expect( resultA ).toEqual( [
+			'Paragraph block',
+			'background colors',
+			'font size',
+			'font family',
+			'caption element',
+			'link element',
+			'color settings',
+		] );
 
 		const resultB = getRevisionChanges(
 			revision,
@@ -145,17 +151,7 @@ describe( 'getRevisionChanges', () => {
 			blockNames
 		);
 
-		expect( resultA ).toBe( resultB );
-	} );
-
-	it( 'returns a comma-separated list of changes with max results', () => {
-		const result = getRevisionChanges(
-			revision,
-			previousRevision,
-			blockNames,
-			2
-		);
-		expect( result ).toEqual( 'Paragraph block, background colors' );
+		expect( resultA ).toStrictEqual( resultB );
 	} );
 
 	it( 'skips unknown keys', () => {
@@ -191,6 +187,6 @@ describe( 'getRevisionChanges', () => {
 				},
 			}
 		);
-		expect( result ).toEqual( '' );
+		expect( result ).toEqual( [] );
 	} );
 } );

--- a/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
@@ -1,0 +1,196 @@
+/**
+ * Internal dependencies
+ */
+import getRevisionChanges from '../get-revision-changes';
+
+describe( 'getRevisionChanges', () => {
+	const revision = {
+		id: 10,
+		styles: {
+			typography: {
+				fontSize: 'var(--wp--preset--font-size--potato)',
+				fontStyle: 'normal',
+				fontWeight: '600',
+				lineHeight: '1.85',
+				fontFamily: 'var(--wp--preset--font-family--asparagus)',
+			},
+			spacing: {
+				padding: {
+					top: '36px',
+					right: '89px',
+					bottom: '133px',
+					left: 'var(--wp--preset--spacing--20)',
+				},
+				blockGap: '114px',
+			},
+			elements: {
+				heading: {
+					typography: {
+						letterSpacing: '37px',
+					},
+				},
+				caption: {
+					color: {
+						text: 'var(--wp--preset--color--pineapple)',
+					},
+				},
+			},
+			color: {
+				text: 'var(--wp--preset--color--tomato)',
+			},
+			blocks: {
+				'core/paragraph': {
+					color: {
+						text: '#000000',
+					},
+				},
+			},
+		},
+		settings: {
+			color: {
+				palette: {
+					theme: [
+						{
+							slug: 'one',
+							color: 'pink',
+						},
+					],
+				},
+			},
+		},
+	};
+	const previousRevision = {
+		id: 9,
+		styles: {
+			typography: {
+				fontSize: 'var(--wp--preset--font-size--fungus)',
+				fontStyle: 'normal',
+				fontWeight: '600',
+				lineHeight: '1.85',
+				fontFamily: 'var(--wp--preset--font-family--grapes)',
+			},
+			spacing: {
+				padding: {
+					top: '36px',
+					right: '89px',
+					bottom: '133px',
+					left: 'var(--wp--preset--spacing--20)',
+				},
+				blockGap: '114px',
+			},
+			elements: {
+				heading: {
+					typography: {
+						letterSpacing: '37px',
+					},
+				},
+				caption: {
+					typography: {
+						fontSize: '1.11rem',
+						fontStyle: 'normal',
+						fontWeight: '600',
+					},
+				},
+				link: {
+					typography: {
+						lineHeight: 2,
+						textDecoration: 'line-through',
+					},
+					color: {
+						text: 'var(--wp--preset--color--egg)',
+					},
+				},
+			},
+			color: {
+				text: 'var(--wp--preset--color--tomato)',
+				background: 'var(--wp--preset--color--pumpkin)',
+			},
+			blocks: {
+				'core/paragraph': {
+					color: {
+						text: '#fff',
+					},
+				},
+			},
+		},
+		settings: {
+			color: {
+				palette: {
+					theme: [
+						{
+							slug: 'one',
+							color: 'blue',
+						},
+					],
+				},
+			},
+		},
+	};
+	const blockNames = {
+		'core/paragraph': 'Paragraph',
+	};
+	it( 'returns a comma-separated list of changes and caches them', () => {
+		const resultA = getRevisionChanges(
+			revision,
+			previousRevision,
+			blockNames
+		);
+		expect( resultA ).toEqual(
+			'Paragraph block, background colors, font size, font family, caption element, link element, color settings'
+		);
+
+		const resultB = getRevisionChanges(
+			revision,
+			previousRevision,
+			blockNames
+		);
+
+		expect( resultA ).toBe( resultB );
+	} );
+
+	it( 'returns a comma-separated list of changes with max results', () => {
+		const result = getRevisionChanges(
+			revision,
+			previousRevision,
+			blockNames,
+			2
+		);
+		expect( result ).toEqual( 'Paragraph block, background colors' );
+	} );
+
+	it( 'skips unknown keys', () => {
+		const result = getRevisionChanges(
+			{
+				styles: {
+					frogs: {
+						legs: 'green',
+					},
+					typography: {
+						owl: 'hoot',
+					},
+					settings: {
+						'': {
+							'': 'foo',
+						},
+					},
+				},
+			},
+			{
+				styles: {
+					frogs: {
+						legs: 'yellow',
+					},
+					typography: {
+						cat: 'meow',
+					},
+					settings: {
+						'': {
+							'': 'bar',
+						},
+					},
+				},
+			}
+		);
+		expect( result ).toEqual( '' );
+	} );
+} );

--- a/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/test/get-revision-changes.js
@@ -136,13 +136,12 @@ describe( 'getRevisionChanges', () => {
 			blockNames
 		);
 		expect( resultA ).toEqual( [
-			[ 'Blocks', 'Paragraph' ],
-			[ 'Styles', 'Background' ],
-			[ 'Styles', 'Font size' ],
-			[ 'Styles', 'Font family' ],
-			[ 'Elements', 'Caption' ],
-			[ 'Elements', 'Link' ],
-			[ 'Settings', 'Color' ],
+			'Colors',
+			'Typography',
+			'Paragraph block',
+			'Caption element',
+			'Link element',
+			'Color settings',
 		] );
 
 		const resultB = getRevisionChanges(
@@ -154,7 +153,7 @@ describe( 'getRevisionChanges', () => {
 		expect( resultA ).toBe( resultB );
 	} );
 
-	it( 'skips unknown keys', () => {
+	it( 'skips unknown and unchanged keys', () => {
 		const result = getRevisionChanges(
 			{
 				styles: {
@@ -162,7 +161,7 @@ describe( 'getRevisionChanges', () => {
 						legs: 'green',
 					},
 					typography: {
-						owl: 'hoot',
+						fontSize: '1rem',
 					},
 					settings: {
 						'': {
@@ -177,7 +176,7 @@ describe( 'getRevisionChanges', () => {
 						legs: 'yellow',
 					},
 					typography: {
-						cat: 'meow',
+						fontSize: '1rem',
 					},
 					settings: {
 						'': {

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -55,6 +55,11 @@ test.describe( 'Global styles revisions', () => {
 			name: /^Changes saved by /,
 		} );
 
+		// Shows changes made in the revision.
+		await expect(
+			page.getByTestId( 'global-styles-revision-changes' )
+		).toHaveText( 'Colors' );
+
 		// There should be 2 revisions not including the reset to theme defaults button.
 		await expect( revisionButtons ).toHaveCount(
 			currentRevisions.length + 1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Maybe one day resolves https://github.com/WordPress/gutenberg/issues/55647

Part of:

- https://github.com/WordPress/gutenberg/issues/55776



https://github.com/WordPress/gutenberg/assets/6458278/0c57e6f5-0cf7-40f1-a750-ec40dbbbfd92




## Why?

To give the user a short overview of the global styles revision change set, which may not be evident from the canvas preview.

Also, highlighting revisions that match current editor styles by a left-hand-side dark, border.

## TODO

- [x] Unit tests

## How?

1. Deep comparison of two objects to get changed values
2. Limiting reported changes to the second level, e.g., `Block name > style`
3. Deduping results and translating
4. Caching results 

## Testing Instructions

Make a bunch of changes to your global styles revisions, ensuring to get a decent mix of block, top-level, element styles and layout, typography and color settings. 

If the theme, e.g., 2024, has style variations, activate and save a few revision using those.

Open up the styles revisions panel and check that the change summary makes sense.