### PR TITLE
List View: Try expanding over collapsed blocks while dragging

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -132,6 +132,8 @@ function ListViewComponent(
 
 	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone( {
 		dropZoneElement,
+		expandedState,
+		setExpandedState,
 	} );
 	const elementRef = useRef();
 	const treeGridRef = useMergeRefs( [ elementRef, dropZoneRef, ref ] );

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -307,7 +307,6 @@ export function getListViewDropTarget( blocksData, position, rtl = false ) {
 			rootClientId: candidateBlockData.clientId,
 			blockIndex: newBlockIndex,
 			dropPosition: 'inside',
-			cursorPosition: position,
 		};
 	}
 

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -476,6 +476,7 @@ export default function useListViewDropZone( {
 			previousRootClientId !== target?.rootClientId
 		) {
 			throttledMaybeExpandBlock.cancel();
+			return;
 		}
 		throttledMaybeExpandBlock( expandedState, target );
 	}, [

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -2,10 +2,11 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import {
 	useThrottle,
 	__experimentalUseDropZone as useDropZone,
+	usePrevious,
 } from '@wordpress/compose';
 import { isRTL } from '@wordpress/i18n';
 
@@ -306,6 +307,7 @@ export function getListViewDropTarget( blocksData, position, rtl = false ) {
 			rootClientId: candidateBlockData.clientId,
 			blockIndex: newBlockIndex,
 			dropPosition: 'inside',
+			cursorPosition: position,
 		};
 	}
 
@@ -396,15 +398,30 @@ export function getListViewDropTarget( blocksData, position, rtl = false ) {
 	};
 }
 
+// Throttle options need to be defined outside of the hook to avoid
+// re-creating the object on every render. This is due to a limitation
+// of the `useThrottle` hook, where the options object is included
+// in the dependency array for memoization.
+const EXPAND_THROTTLE_OPTIONS = {
+	leading: false, // Don't call the function immediately on the first call.
+	trailing: true, // Do call the function on the last call.
+};
+
 /**
  * A react hook for implementing a drop zone in list view.
  *
- * @param {Object}       props                   Named parameters.
- * @param {?HTMLElement} [props.dropZoneElement] Optional element to be used as the drop zone.
+ * @param {Object}       props                    Named parameters.
+ * @param {?HTMLElement} [props.dropZoneElement]  Optional element to be used as the drop zone.
+ * @param {Object}       [props.expandedState]    The expanded state of the blocks in the list view.
+ * @param {Function}     [props.setExpandedState] Function to set the expanded state of a list of block clientIds.
  *
  * @return {WPListViewDropZoneTarget} The drop target.
  */
-export default function useListViewDropZone( { dropZoneElement } ) {
+export default function useListViewDropZone( {
+	dropZoneElement,
+	expandedState,
+	setExpandedState,
+} ) {
 	const {
 		getBlockRootClientId,
 		getBlockIndex,
@@ -419,6 +436,54 @@ export default function useListViewDropZone( { dropZoneElement } ) {
 	const onBlockDrop = useOnBlockDrop( targetRootClientId, targetBlockIndex );
 
 	const rtl = isRTL();
+
+	const previousRootClientId = usePrevious( targetRootClientId );
+
+	const maybeExpandBlock = useCallback(
+		( _expandedState, _target ) => {
+			// If the user is attempting to drop a block inside a collapsed block,
+			// that is, using a nesting gesture flagged by 'inside' dropPosition,
+			// expand the block within the list view, if it isn't already.
+			const { rootClientId } = _target || {};
+			if ( ! rootClientId ) {
+				return;
+			}
+			if (
+				_target?.dropPosition === 'inside' &&
+				! _expandedState[ rootClientId ]
+			) {
+				setExpandedState( {
+					type: 'expand',
+					clientIds: [ rootClientId ],
+				} );
+			}
+		},
+		[ setExpandedState ]
+	);
+
+	// Throttle the maybeExpandBlock function to avoid expanding the block
+	// too quickly when the user is dragging over the block. This is to
+	// avoid expanding the block when the user is just passing over it.
+	const throttledMaybeExpandBlock = useThrottle(
+		maybeExpandBlock,
+		750,
+		EXPAND_THROTTLE_OPTIONS
+	);
+
+	useEffect( () => {
+		if (
+			target?.dropPosition !== 'inside' ||
+			previousRootClientId !== target?.rootClientId
+		) {
+			throttledMaybeExpandBlock.cancel();
+		}
+		throttledMaybeExpandBlock( expandedState, target );
+	}, [
+		expandedState,
+		previousRootClientId,
+		target,
+		throttledMaybeExpandBlock,
+	] );
 
 	const draggedBlockClientIds = getDraggedBlockClientIds();
 	const throttled = useThrottle(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/33684

This PR explores expanding list view items within the list view while dragging over collapsed blocks.

It seeks to strike a balance between allowing a user to drag quickly over collapsed blocks, but if they linger over the bottom right side of a collapsed block (same position as if nesting within a collapsed block in `trunk`), then we expand the collapsed block. It's fairly nuanced to find the right balance for this interaction, so I'm very happy for feedback on how this all works!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Once a user has started dragging blocks, it can be frustrating if you have to stop dragging and go and manually click on a collapsed block in the list view in order to expand it. Also, this behaviour (expanding collapsed blocks on drag) is a prerequisite for further explorations into moving blocks out of the way while dragging, as raised in https://github.com/WordPress/gutenberg/issues/56539

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Re-use the `inside` dropPosition (this is the state for a nesting gesture in drag and drop terms) to flag that a block should be expanded.
* Throttle the callback to update the expanded state so that it will only update after the wait time is elapsed.
* Wait time is currently set to `750ms` and is easy to change if we'd like to go with something different.
* 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a post with many nested blocks, open up the list view
2. Try dragging a block into one of the nested blocks, and wait for the block to expand. How does that feel to use?
3. Try dragging quickly over collapsed blocks (when you don't wish to expand them). Did that feel natural, or did you find blocks expanded unexpectedly?

## Feedback requested

* How does this feel to use?
* Does it feel natural to drag over the bottom right of a block in order to expand it? Or should the expand behaviour be more permissive than that?
* Is the delay (750ms) before expanding too short, too long, or just right?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/14988353/61a36b8c-943b-42a9-bfdb-3b97ec71a8be


