### PR TITLE
Fix Restore Post title placeholder

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -168,7 +168,7 @@ function PostTitle( _, forwardedRef ) {
 	const { ref: richTextRef } = useRichText( {
 		value: title,
 		onChange,
-		decodedPlaceholder,
+		placeholder: decodedPlaceholder,
 		selectionStart: selection.start,
 		selectionEnd: selection.end,
 		onSelectionChange( newStart, newEnd ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Restores the Post Title placeholder that went missing after https://github.com/WordPress/gutenberg/pull/54718

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Placeholder is required.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Provide `placeholder` prop to rich text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Create new Post
- See that post title field shows `Add title` placeholder.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
