### PR TITLE
Restore Post Title visual styles in Code View mode

### DIFF
--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -5,7 +5,8 @@
 	flex-grow: 1;
 
 	// Post title.
-	.editor-post-title {
+	.editor-post-title:not(.is-raw-text),
+	.editor-post-title.is-raw-text textarea {
 		max-width: none;
 		line-height: $default-line-height;
 
@@ -14,6 +15,7 @@
 		font-weight: normal;
 
 		border: $border-width solid $gray-600;
+		border-radius: 0;
 
 		// Same padding as body.
 		padding: $grid-unit-20;

--- a/packages/editor/src/components/post-title/post-title-raw.js
+++ b/packages/editor/src/components/post-title/post-title-raw.js
@@ -73,6 +73,7 @@ function PostTitleRaw( _, forwardedRef ) {
 			hideLabelFromVision={ true }
 			autoComplete="off"
 			dir="auto"
+			rows={ 1 }
 			__nextHasNoMarginBottom
 		/>
 	);

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -1,16 +1,5 @@
 // Raw Text Variant
 .edit-post-text-editor__body .editor-post-title.is-raw-text {
-	padding: 0;
 	margin-bottom: $grid-unit-30;
-
-	textarea {
-		padding: $grid-unit-20;
-
-		@include break-small() {
-			padding: $grid-unit-30;
-		}
-		font-size: inherit;
-		font-family: inherit;
-		line-height: inherit;
-	}
+	margin-top: 2px; // space for focus outline to appear.
 }

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -1,4 +1,16 @@
-.edit-post-text-editor__body .is-raw-text textarea {
-	font-size: inherit;
-	line-height: inherit;
+// Raw Text Variant
+.edit-post-text-editor__body .editor-post-title.is-raw-text {
+	padding: 0;
+	margin-bottom: $grid-unit-30;
+
+	textarea {
+		padding: $grid-unit-20;
+
+		@include break-small() {
+			padding: $grid-unit-30;
+		}
+		font-size: inherit;
+		font-family: inherit;
+		line-height: inherit;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Restores the visual styles to the Post Title field that were lost as part of https://github.com/WordPress/gutenberg/pull/54718/

Closes https://github.com/WordPress/gutenberg/issues/56581

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should retain the previous visual styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

These styles were lost due to the usage of a new component. Update the post title styles for the "raw" variant to match the previous design.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add a title (try something that might stress test the field - lots of text...etc)
- Switch editor to Code View mode
- See title field and check it's visual styles against the reference screenshot below. It should be as close as possible to that visual.

#### Reference screenshot

This is how the field looked on `trunk` prior to the merge of https://github.com/WordPress/gutenberg/pull/54718/.

<img width="1231" alt="Screenshot 2023-11-28 at 05 38 36" src="https://github.com/WordPress/gutenberg/assets/444434/57de8fc6-0cfd-4d1d-970d-d7cf84aa8a96">




### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

#### Before (current trunk)

![trunk](https://github.com/WordPress/gutenberg/assets/54422211/fd6d9697-38a6-40ce-9687-29adf61ec45f)

#### After (this PR)

The following screenshot is how the field looks as a result of _this PR_:

<img width="1228" alt="Screenshot 2023-11-28 at 06 02 40" src="https://github.com/WordPress/gutenberg/assets/444434/34d64a9e-4195-435f-bddd-a49bc578ac9b">



