### PR TITLE
Workflows: Update 'days-before-stale' for flaky test report issues

### DIFF
--- a/.github/workflows/stale-issue-gardening.yml
+++ b/.github/workflows/stale-issue-gardening.yml
@@ -27,8 +27,8 @@ jobs:
                       remove-stale-when-updated: true
                       stale-issue-label: '[Status] Stale'
                     - name: 'Flaky test issues without activity'
-                      message: 'This issue has gone 30 days without any activity.'
-                      days-before-stale: 30
+                      message: 'This issue has gone 15 days without any activity.'
+                      days-before-stale: 15
                       days-before-close: 1
                       only-labels: '[Type] Flaky Test'
                       remove-stale-when-updated: true


### PR DESCRIPTION
## What?
PR changes `days-before-stale` for flaky test report issues from 30 to 15.

## Why?
Faux reports can be created for various reasons. A feature is being refactored, the test hasn't been updated yet, or PRs for release branches where flakiness hasn't been fixed.

Triaging these issues manually is hard, and I think reducing automated management time will help us single out the actual bugs.

## Testing Instructions
It is hard to test this, like any other workflow changes manually. Confirm that the new parameters are correct.