### PR TITLE
Post Editor: Use the post-only mode introduced by the site editor

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -6,24 +6,19 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { PostTitle, store as editorStore } from '@wordpress/editor';
+import { store as editorStore } from '@wordpress/editor';
 import {
 	BlockList,
 	BlockTools,
-	store as blockEditorStore,
 	__unstableUseTypewriter as useTypewriter,
-	__unstableUseTypingObserver as useTypingObserver,
 	__experimentalUseResizeCanvas as useResizeCanvas,
-	useSettings,
-	__experimentalRecursionProvider as RecursionProvider,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useMemo } from '@wordpress/element';
 import { __unstableMotion as motion } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useMergeRefs } from '@wordpress/compose';
-import { parse, store as blocksStore } from '@wordpress/blocks';
-import { store as coreStore } from '@wordpress/core-data';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -31,106 +26,40 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editPostStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const {
-	LayoutStyle,
-	useLayoutClasses,
-	useLayoutStyles,
-	ExperimentalBlockCanvas: BlockCanvas,
-} = unlock( blockEditorPrivateApis );
+const { ExperimentalBlockCanvas: BlockCanvas } = unlock(
+	blockEditorPrivateApis
+);
 
 const isGutenbergPlugin = process.env.IS_GUTENBERG_PLUGIN ? true : false;
-
-/**
- * Given an array of nested blocks, find the first Post Content
- * block inside it, recursing through any nesting levels,
- * and return its attributes.
- *
- * @param {Array} blocks A list of blocks.
- *
- * @return {Object | undefined} The Post Content block.
- */
-function getPostContentAttributes( blocks ) {
-	for ( let i = 0; i < blocks.length; i++ ) {
-		if ( blocks[ i ].name === 'core/post-content' ) {
-			return blocks[ i ].attributes;
-		}
-		if ( blocks[ i ].innerBlocks.length ) {
-			const nestedPostContent = getPostContentAttributes(
-				blocks[ i ].innerBlocks
-			);
-
-			if ( nestedPostContent ) {
-				return nestedPostContent;
-			}
-		}
-	}
-}
-
-function checkForPostContentAtRootLevel( blocks ) {
-	for ( let i = 0; i < blocks.length; i++ ) {
-		if ( blocks[ i ].name === 'core/post-content' ) {
-			return true;
-		}
-	}
-	return false;
-}
 
 export default function VisualEditor( { styles } ) {
 	const {
 		deviceType,
 		isWelcomeGuideVisible,
 		isTemplateMode,
-		postContentAttributes,
-		editedPostTemplate = {},
-		wrapperBlockName,
-		wrapperUniqueId,
 		isBlockBasedTheme,
 		hasV3BlocksOnly,
+		shouldDisableLayoutStyles,
 	} = useSelect( ( select ) => {
 		const {
 			isFeatureActive,
 			isEditingTemplate,
-			getEditedPostTemplate,
 			__experimentalGetPreviewDeviceType,
 		} = select( editPostStore );
-		const { getCurrentPostId, getCurrentPostType, getEditorSettings } =
-			select( editorStore );
+		const { getEditorSettings } = select( editorStore );
 		const { getBlockTypes } = select( blocksStore );
-		const _isTemplateMode = isEditingTemplate();
-		const postTypeSlug = getCurrentPostType();
-		let _wrapperBlockName;
-
-		if ( postTypeSlug === 'wp_block' ) {
-			_wrapperBlockName = 'core/block';
-		} else if ( ! _isTemplateMode ) {
-			_wrapperBlockName = 'core/post-content';
-		}
-
-		const editorSettings = getEditorSettings();
-		const supportsTemplateMode = editorSettings.supportsTemplateMode;
-		const postType = select( coreStore ).getPostType( postTypeSlug );
-		const canEditTemplate = select( coreStore ).canUser(
-			'create',
-			'templates'
-		);
+		const settings = getEditorSettings();
 
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
-			isTemplateMode: _isTemplateMode,
-			postContentAttributes: getEditorSettings().postContentAttributes,
-			// Post template fetch returns a 404 on classic themes, which
-			// messes with e2e tests, so check it's a block theme first.
-			editedPostTemplate:
-				postType?.viewable && supportsTemplateMode && canEditTemplate
-					? getEditedPostTemplate()
-					: undefined,
-			wrapperBlockName: _wrapperBlockName,
-			wrapperUniqueId: getCurrentPostId(),
-			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
+			isTemplateMode: isEditingTemplate(),
+			isBlockBasedTheme: settings.__unstableIsBlockBasedTheme,
 			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
 				return type.apiVersion >= 3;
 			} ),
+			shouldDisableLayoutStyles:
+				! settings.supportsLayout || settings.disableLayoutStyles,
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -138,21 +67,7 @@ export default function VisualEditor( { styles } ) {
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
-	const {
-		hasRootPaddingAwareAlignments,
-		isFocusMode,
-		themeHasDisabledLayoutStyles,
-		themeSupportsLayout,
-	} = useSelect( ( select ) => {
-		const _settings = select( blockEditorStore ).getSettings();
-		return {
-			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
-			themeSupportsLayout: _settings.supportsLayout,
-			isFocusMode: _settings.focusMode,
-			hasRootPaddingAwareAlignments:
-				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
-		};
-	}, [] );
+	const { setRenderingMode } = useDispatch( editorStore );
 	const desktopCanvasStyles = {
 		height: '100%',
 		width: '100%',
@@ -171,7 +86,6 @@ export default function VisualEditor( { styles } ) {
 		borderBottom: 0,
 	};
 	const resizedCanvasStyles = useResizeCanvas( deviceType, isTemplateMode );
-	const [ globalLayoutSettings ] = useSettings( 'layout' );
 	const previewMode = 'is-' + deviceType.toLowerCase() + '-preview';
 
 	let animatedStyles = isTemplateMode
@@ -192,114 +106,6 @@ export default function VisualEditor( { styles } ) {
 	const ref = useRef();
 	const contentRef = useMergeRefs( [ ref, useTypewriter() ] );
 
-	// fallbackLayout is used if there is no Post Content,
-	// and for Post Title.
-	const fallbackLayout = useMemo( () => {
-		if ( isTemplateMode ) {
-			return { type: 'default' };
-		}
-
-		if ( themeSupportsLayout ) {
-			// We need to ensure support for wide and full alignments,
-			// so we add the constrained type.
-			return { ...globalLayoutSettings, type: 'constrained' };
-		}
-		// Set default layout for classic themes so all alignments are supported.
-		return { type: 'default' };
-	}, [ isTemplateMode, themeSupportsLayout, globalLayoutSettings ] );
-
-	const newestPostContentAttributes = useMemo( () => {
-		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
-			return postContentAttributes;
-		}
-		// When in template editing mode, we can access the blocks directly.
-		if ( editedPostTemplate?.blocks ) {
-			return getPostContentAttributes( editedPostTemplate?.blocks );
-		}
-		// If there are no blocks, we have to parse the content string.
-		// Best double-check it's a string otherwise the parse function gets unhappy.
-		const parseableContent =
-			typeof editedPostTemplate?.content === 'string'
-				? editedPostTemplate?.content
-				: '';
-
-		return getPostContentAttributes( parse( parseableContent ) ) || {};
-	}, [
-		editedPostTemplate?.content,
-		editedPostTemplate?.blocks,
-		postContentAttributes,
-	] );
-
-	const hasPostContentAtRootLevel = useMemo( () => {
-		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
-			return false;
-		}
-		// When in template editing mode, we can access the blocks directly.
-		if ( editedPostTemplate?.blocks ) {
-			return checkForPostContentAtRootLevel( editedPostTemplate?.blocks );
-		}
-		// If there are no blocks, we have to parse the content string.
-		// Best double-check it's a string otherwise the parse function gets unhappy.
-		const parseableContent =
-			typeof editedPostTemplate?.content === 'string'
-				? editedPostTemplate?.content
-				: '';
-
-		return (
-			checkForPostContentAtRootLevel( parse( parseableContent ) ) || false
-		);
-	}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
-
-	const { layout = {}, align = '' } = newestPostContentAttributes || {};
-
-	const postContentLayoutClasses = useLayoutClasses(
-		newestPostContentAttributes,
-		'core/post-content'
-	);
-
-	const blockListLayoutClass = classnames(
-		{
-			'is-layout-flow': ! themeSupportsLayout,
-		},
-		themeSupportsLayout && postContentLayoutClasses,
-		align && `align${ align }`
-	);
-
-	const postContentLayoutStyles = useLayoutStyles(
-		newestPostContentAttributes,
-		'core/post-content',
-		'.block-editor-block-list__layout.is-root-container'
-	);
-
-	// Update type for blocks using legacy layouts.
-	const postContentLayout = useMemo( () => {
-		return layout &&
-			( layout?.type === 'constrained' ||
-				layout?.inherit ||
-				layout?.contentSize ||
-				layout?.wideSize )
-			? { ...globalLayoutSettings, ...layout, type: 'constrained' }
-			: { ...globalLayoutSettings, ...layout, type: 'default' };
-	}, [
-		layout?.type,
-		layout?.inherit,
-		layout?.contentSize,
-		layout?.wideSize,
-		globalLayoutSettings,
-	] );
-
-	// If there is a Post Content block we use its layout for the block list;
-	// if not, this must be a classic theme, in which case we use the fallback layout.
-	const blockListLayout = postContentAttributes
-		? postContentLayout
-		: fallbackLayout;
-
-	const postEditorLayout =
-		blockListLayout?.type === 'default' && ! hasPostContentAtRootLevel
-			? fallbackLayout
-			: blockListLayout;
-
-	const observeTypingRef = useTypingObserver();
 	const titleRef = useRef();
 	useEffect( () => {
 		if ( isWelcomeGuideVisible || ! isCleanNewPost() ) {
@@ -307,27 +113,33 @@ export default function VisualEditor( { styles } ) {
 		}
 		titleRef?.current?.focus();
 	}, [ isWelcomeGuideVisible, isCleanNewPost ] );
+	useEffect( () => {
+		if ( isTemplateMode ) {
+			setRenderingMode( 'all' );
+		} else {
+			setRenderingMode( 'post-only' );
+		}
+	}, [ isTemplateMode, setRenderingMode ] );
 
 	styles = useMemo(
 		() => [
 			...styles,
 			{
+				// Themes apply a max width to wp-block class,
+				// this resets that max width for the top level blocks added by the framework (post content, post title)
+				css: shouldDisableLayoutStyles
+					? '.wp-site-blocks > .wp-block { max-width: none !important; width: 100% !important; }'
+					: '',
+			},
+			{
 				// We should move this in to future to the body.
-				css:
-					`.edit-post-visual-editor__post-title-wrapper{margin-top:4rem}` +
-					( paddingBottom
-						? `body{padding-bottom:${ paddingBottom }}`
-						: '' ),
+				css: paddingBottom
+					? `body{padding-bottom:${ paddingBottom }}`
+					: '',
 			},
 		],
-		[ styles ]
+		[ styles, shouldDisableLayoutStyles, paddingBottom ]
 	);
-
-	// Add some styles for alignwide/alignfull Post Content and its children.
-	const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
-		.is-root-container.alignwide:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
-		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
-		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
 	const isToBeIframed =
 		( ( hasV3BlocksOnly || ( isGutenbergPlugin && isBlockBasedTheme ) ) &&
@@ -361,65 +173,16 @@ export default function VisualEditor( { styles } ) {
 						styles={ styles }
 						height="100%"
 					>
-						{ themeSupportsLayout &&
-							! themeHasDisabledLayoutStyles &&
-							! isTemplateMode && (
-								<>
-									<LayoutStyle
-										selector=".edit-post-visual-editor__post-title-wrapper"
-										layout={ fallbackLayout }
-									/>
-									<LayoutStyle
-										selector=".block-editor-block-list__layout.is-root-container"
-										layout={ postEditorLayout }
-									/>
-									{ align && (
-										<LayoutStyle css={ alignCSS } />
-									) }
-									{ postContentLayoutStyles && (
-										<LayoutStyle
-											layout={ postContentLayout }
-											css={ postContentLayoutStyles }
-										/>
-									) }
-								</>
-							) }
-						{ ! isTemplateMode && (
-							<div
-								className={ classnames(
-									'edit-post-visual-editor__post-title-wrapper',
-									{
-										'is-focus-mode': isFocusMode,
-										'has-global-padding':
-											hasRootPaddingAwareAlignments,
-									}
-								) }
-								contentEditable={ false }
-								ref={ observeTypingRef }
-							>
-								<PostTitle ref={ titleRef } />
-							</div>
-						) }
-						<RecursionProvider
-							blockName={ wrapperBlockName }
-							uniqueId={ wrapperUniqueId }
-						>
-							<BlockList
-								className={
-									isTemplateMode
-										? 'wp-site-blocks'
-										: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
-								}
-								layout={ blockListLayout }
-								dropZoneElement={
-									// When iframed, pass in the html element of the iframe to
-									// ensure the drop zone extends to the edges of the iframe.
-									isToBeIframed
-										? ref.current?.parentNode
-										: ref.current
-								}
-							/>
-						</RecursionProvider>
+						<BlockList
+							className="wp-site-blocks"
+							dropZoneElement={
+								// When iframed, pass in the html element of the iframe to
+								// ensure the drop zone extends to the edges of the iframe.
+								isToBeIframed
+									? ref.current?.parentNode
+									: ref.current
+							}
+						/>
 					</BlockCanvas>
 				</motion.div>
 			</motion.div>

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -36,13 +36,12 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		hiddenBlockTypes,
 		blockTypes,
 		keepCaretInsideBlock,
-		isTemplateMode,
+		hasTemplate,
 		template,
 	} = useSelect(
 		( select ) => {
 			const {
 				isFeatureActive,
-				isEditingTemplate,
 				getEditedPostTemplate,
 				getHiddenBlockTypes,
 			} = select( editPostStore );
@@ -68,6 +67,8 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				getEditorSettings().supportsTemplateMode;
 			const isViewable = getPostType( postType )?.viewable ?? false;
 			const canEditTemplate = canUser( 'create', 'templates' );
+			const _hasTemplate =
+				supportsTemplateMode && isViewable && canEditTemplate;
 
 			return {
 				hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
@@ -81,11 +82,8 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				hiddenBlockTypes: getHiddenBlockTypes(),
 				blockTypes: getBlockTypes(),
 				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
-				isTemplateMode: isEditingTemplate(),
-				template:
-					supportsTemplateMode && isViewable && canEditTemplate
-						? getEditedPostTemplate()
-						: null,
+				hasTemplate: _hasTemplate,
+				template: _hasTemplate ? getEditedPostTemplate() : null,
 				post: postObject,
 			};
 		},
@@ -145,7 +143,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		keepCaretInsideBlock,
 	] );
 
-	if ( ! post ) {
+	if ( ! post || ( hasTemplate && ! template ) ) {
 		return null;
 	}
 
@@ -156,7 +154,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				post={ post }
 				initialEdits={ initialEdits }
 				useSubRegistry={ false }
-				__unstableTemplate={ isTemplateMode ? template : undefined }
+				__unstableTemplate={ template }
 				{ ...props }
 			>
 				<ErrorBoundary>

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -105,6 +105,9 @@ function extractPostContentBlockFromTemplateBlocks( blocks ) {
  */
 function extractPageContentBlockTypesFromTemplateBlocks( blocks ) {
 	const result = [];
+	if ( ! blocks ) {
+		return result;
+	}
 	for ( let i = 0; i < blocks.length; i++ ) {
 		// Since the Query Block could contain PAGE_CONTENT_BLOCK_TYPES block types,
 		// we skip it because we only want to render stand-alone page content blocks in the block list.
@@ -178,37 +181,35 @@ function useBlockEditorProps( post, template, mode ) {
 					createBlock( 'core/post-title' ),
 					createBlock( 'core/post-content' ),
 			  ];
-		const innerBlocksWithLayout = innerBlocks.map( ( block ) => {
+		const innerBlocksWithLayout = innerBlocks.map( ( block, index ) => {
+			// Leave some space at the top of the canvas.
+			const style =
+				index === 0
+					? {
+							spacing: {
+								margin: {
+									top: '4em',
+								},
+							},
+					  }
+					: undefined;
 			if ( block.name === 'core/post-content' ) {
 				return createBlock( 'core/post-content', {
 					layout: postContentLayout,
+					style,
 				} );
 			}
 			return createBlock(
 				'core/group',
 				{
 					layout: postContentLayout,
+					style,
 				},
 				[ block ]
 			);
 		} );
 
-		// This group block is only here to leave some space at the top of the canvas.
-		return [
-			createBlock(
-				'core/group',
-				{
-					style: {
-						spacing: {
-							margin: {
-								top: '4em',
-							},
-						},
-					},
-				},
-				innerBlocksWithLayout
-			),
-		];
+		return innerBlocksWithLayout;
 	}, [ mode, templateBlocks, postContentLayout ] );
 
 	// It is important that we don't create a new instance of blocks on every change
@@ -242,10 +243,10 @@ function useBlockEditorProps( post, template, mode ) {
 	const navigationBlockClientId =
 		post.type === 'wp_navigation' && blocks && blocks[ 0 ]?.clientId;
 	useForceFocusModeForNavigation( navigationBlockClientId );
+
 	if ( disableRootLevelChanges ) {
 		return [ blocks, noop, noop ];
 	}
-
 	return [
 		blocks,
 		rootLevelPost === 'post' ? onInput : onInputTemplate,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -63,7 +63,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'locale',
 	'maxWidth',
 	'onUpdateDefaultBlockStyles',
-	'postContentAttributes',
 	'postsPerPage',
 	'readOnly',
 	'styles',


### PR DESCRIPTION
Related #52632 
Follow-up to #56542 (can't be merged before that one)

## What?

In previous PRs we updated the "post-only" mode of the site editor to be able to guess the layout to apply from the template (similar to the post editor). With this, we're ready to unify the post and site editor template modes by actually removing the custom logic from the post editor and just using the "post-only" mode instead.

This is an impactful PR thought because it means that:

 - The post editor won't just show "post title" and "post content", it will try to guess what the post is using as a template and render the blocks that are present in the template. (for instance if there's a featured image, it will show it)
 - Removes all the layout specific code from the post editor, this means that we need to check the impact of these removals and whether all kind of themes continue to work (check alignments and styles essentially) (themes with theme.json, themes without theme.json, classic, block themes...)
 - Potential Writing flow changes: The canvas of the post editor now shows actual post title and post content blocks instead of using a PostTitle component. This probably means some changes to writing flow and some more updates that are needed (revealed by e2e tests)

I'm really satisfied that we were able to have this work pretty quickly without substantial changes and it will open the door for even more "unification" between site and post editors going forward.

## Testing Instructions

Open the post editor in different kind of themes and check how this PR impacts the styling, the alignments and things like that.
