### PR TITLE
Scripts: Enable skipping Playwright browser installation

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -88,6 +88,8 @@ jobs:
                   npm run wp-env start
 
             - name: Run the tests
+              env:
+                  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
               run: |
                   xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test:e2e:playwright -- --shard=${{ matrix.part }}/${{ matrix.totalParts }}
 

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -87,6 +87,7 @@ async function runTestSuite( testSuite, testRunnerDir, runKey ) {
 		testRunnerDir,
 		{
 			...process.env,
+			PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
 			WP_ARTIFACTS_PATH: ARTIFACTS_PATH,
 			RESULTS_ID: runKey,
 		}

--- a/packages/scripts/scripts/test-playwright.js
+++ b/packages/scripts/scripts/test-playwright.js
@@ -26,7 +26,7 @@ const {
 	getArgsFromCLI,
 } = require( '../utils' );
 
-if ( ! process.env.CI ) {
+if ( process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD !== '1' ) {
 	const result = spawn(
 		'node',
 		[

--- a/packages/scripts/scripts/test-playwright.js
+++ b/packages/scripts/scripts/test-playwright.js
@@ -24,9 +24,10 @@ const {
 	hasProjectFile,
 	hasArgInCLI,
 	getArgsFromCLI,
+	getAsBooleanFromENV,
 } = require( '../utils' );
 
-if ( process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD !== '1' ) {
+if ( ! getAsBooleanFromENV( 'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD' ) ) {
 	const result = spawn(
 		'node',
 		[

--- a/packages/scripts/scripts/test-playwright.js
+++ b/packages/scripts/scripts/test-playwright.js
@@ -26,19 +26,25 @@ const {
 	getArgsFromCLI,
 } = require( '../utils' );
 
-const result = spawn(
-	'node',
-	[
-		path.resolve( require.resolve( 'playwright-core' ), '..', 'cli.js' ),
-		'install',
-	],
-	{
-		stdio: 'inherit',
-	}
-);
+if ( ! process.env.CI ) {
+	const result = spawn(
+		'node',
+		[
+			path.resolve(
+				require.resolve( 'playwright-core' ),
+				'..',
+				'cli.js'
+			),
+			'install',
+		],
+		{
+			stdio: 'inherit',
+		}
+	);
 
-if ( result.status > 0 ) {
-	process.exit( result.status );
+	if ( result.status > 0 ) {
+		process.exit( result.status );
+	}
 }
 
 const config =

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+const { getAsBooleanFromENV } = require( './process' );
 const {
 	getArgFromCLI,
 	getArgsFromCLI,
@@ -28,6 +29,7 @@ const { getPackageProp, hasPackageProp } = require( './package' );
 module.exports = {
 	fromProjectRoot,
 	fromConfigRoot,
+	getAsBooleanFromENV,
 	getArgFromCLI,
 	getArgsFromCLI,
 	getFileArgsFromCLI,

--- a/packages/scripts/utils/process.js
+++ b/packages/scripts/utils/process.js
@@ -1,3 +1,8 @@
+const getAsBooleanFromENV = ( name ) => {
+	const value = process.env[ name ];
+	return !! value && value !== 'false' && value !== '0';
+};
+
 const getArgsFromCLI = ( excludePrefixes ) => {
 	const args = process.argv.slice( 2 );
 	if ( excludePrefixes ) {
@@ -12,6 +17,7 @@ const getArgsFromCLI = ( excludePrefixes ) => {
 
 module.exports = {
 	exit: process.exit,
+	getAsBooleanFromENV,
 	getArgsFromCLI,
 	getCurrentWorkingDirectory: process.cwd,
 };


### PR DESCRIPTION
## What?

Closes #56588

Dependencies in CI should be explicitly defined for the sake of saving time. For example, performance tests only run against Chromium, but all browsers are installed anyway because [we're running](https://github.com/WordPress/gutenberg/blob/trunk/packages/scripts/scripts/test-playwright.js#L33) `playwright install` before each test run. Adding a `CI` check should be sufficient to address this. 

To make sure we're not breaking anything, I've checked the following workflows to ensure they install Playwright deps explicitly:

- https://github.com/WordPress/wordpress-develop/blob/trunk/.github/workflows/end-to-end-tests.yml#L97
- https://github.com/WordPress/wordpress-develop/blob/trunk/.github/workflows/performance.yml#L127
- https://github.com/WordPress/gutenberg/blob/trunk/.github/workflows/end2end-test.yml#L84
- https://github.com/WordPress/gutenberg/blob/trunk/bin/plugin/commands/performance.js#L212

## Testing Instructions
1. Uninstall Playwright deps via `node packages/scripts/node_modules/playwright-core/cli.js uninstall`
2. Try running e2e tests with the `CI` var added: `CI=true npm run test:e2e:playwright`
3. All the tests should fail.
4. Now try running without the CI var: `npm run test:e2e:playwright`
5. Browsers should be installed, and tests should be passing.