### PR TITLE
Rich Text: Update the regex to allow underscores in Format Type class name format

### DIFF
--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -71,9 +71,9 @@ export function registerFormatType( name, settings ) {
 		return;
 	}
 
-	if ( ! /^[_a-zA-Z]+[a-zA-Z0-9-]*$/.test( settings.className ) ) {
+	if ( ! /^[_a-zA-Z]+[a-zA-Z0-9_-]*$/.test( settings.className ) ) {
 		window.console.error(
-			'A class name must begin with a letter, followed by any number of hyphens, letters, or numbers.'
+			'A class name must begin with a letter, followed by any number of hyphens, underscores, letters, or numbers.'
 		);
 		return;
 	}

--- a/packages/rich-text/src/test/register-format-type.js
+++ b/packages/rich-text/src/test/register-format-type.js
@@ -171,7 +171,7 @@ describe( 'registerFormatType', () => {
 			className: 'invalid class name',
 		} );
 		expect( console ).toHaveErroredWith(
-			'A class name must begin with a letter, followed by any number of hyphens, letters, or numbers.'
+			'A class name must begin with a letter, followed by any number of hyphens, underscores, letters, or numbers.'
 		);
 		expect( format ).toBeUndefined();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This allows underscores in Format Type class name format.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, Format Types that apply a class containing underscores are not registered correctly and cause the following error in the console: `A class name must begin with a letter, followed by any number of hyphens, letters, or numbers.`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR fixes #56571 by adding `_` (underscore) character to the regular expression used when checking the className format in the registerFormatType function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Declare a new "My Format" Format Type via `registerFormatType` in a JS file a enqueue it in editor like so: 
```
/**
 * WordPress dependencies
 */
import { __, _x } from "@wordpress/i18n";
import { toggleFormat, registerFormatType } from "@wordpress/rich-text";
import { RichTextToolbarButton } from "@wordpress/block-editor";
import { wordpress } from "@wordpress/icons";

const name = "test-format-type/my-format";
const title = __("My Format");

registerFormatType(name, {
    title: title,
    icon: wordpress,
    tagName: "span",
    className: "my-format-class__with-underscore",
    attributes: {
        class: "class"
    },
    edit({ isActive, value, onChange, onFocus }) {
        function onClick() {
            onChange(toggleFormat(value, { type: name }));
            onFocus();
        }

        return (
            <>
                <RichTextToolbarButton icon={wordpress} title={title} onClick={onClick} isActive={isActive} />
            </>
        );
    }
});
```
- In admin, open editor adding a page, apply "My Format" format to a text selection in a Paragraph for example
- Open the browser console and check for error
- Save the page and check for the `<span class="my-format-class__with-underscore">` in the paragraph markup
