### PR TITLE
Interactivity API: Add missing changelog entry for the new `store()` API

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   Implement the new `store()` API as specified in the [proposal](https://github.com/WordPress/gutenberg/discussions/53586). ([#55459](https://github.com/WordPress/gutenberg/pull/55459))
+
 ## 2.7.0 (2023-11-16)
 
 ## 2.6.0 (2023-11-02)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR simply adds a `Breaking change` to the changelog's `Unreleased` section.

## Why?
I forgot to add it in https://github.com/WordPress/gutenberg/pull/55459. 😅 
