### PR TITLE
setImmutably: don't clone all objects

### DIFF
--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -72,14 +72,16 @@ export function setImmutably( object, path, value ) {
 		throw new Error( 'Path cannot be empty' );
 	}
 
-	const clonedObj = Array.isArray( object ) ? [ ...object ] : { ...object };
+	const shallowClone = Array.isArray( object )
+		? [ ...object ]
+		: { ...object };
 	const [ first, ...rest ] = path;
 
-	clonedObj[ first ] = rest.length
-		? setImmutably( clonedObj[ first ], rest, value )
+	shallowClone[ first ] = rest.length
+		? setImmutably( shallowClone[ first ], rest, value )
 		: value;
 
-	return clonedObj;
+	return shallowClone;
 }
 
 const stringToPath = memoize( ( path ) => path.split( '.' ) );

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -5,27 +5,6 @@ import { paramCase } from 'change-case';
 import memoize from 'memize';
 
 /**
- * Converts a path to an array of its fragments.
- * Supports strings, numbers and arrays:
- *
- * 'foo' => [ 'foo' ]
- * 2 => [ '2' ]
- * [ 'foo', 'bar' ] => [ 'foo', 'bar' ]
- *
- * @param {string|number|Array} path Path
- * @return {Array} Normalized path.
- */
-function normalizePath( path ) {
-	if ( Array.isArray( path ) ) {
-		return path;
-	} else if ( typeof path === 'number' ) {
-		return [ path.toString() ];
-	}
-
-	return [ path ];
-}
-
-/**
  * Converts any string to kebab case.
  * Backwards compatible with Lodash's `_.kebabCase()`.
  * Backwards compatible with `_wp_to_kebab_case()`.
@@ -66,10 +45,10 @@ export function kebabCase( str ) {
  * @return {Object} Cloned object with the new value set.
  */
 export function setImmutably( object, path, value ) {
-	path = normalizePath( path );
+	path = Array.isArray( path ) ? path : [ path ];
 
 	if ( path.length === 0 ) {
-		throw new Error( 'Path cannot be empty' );
+		return value;
 	}
 
 	const shallowClone = Array.isArray( object )
@@ -77,9 +56,7 @@ export function setImmutably( object, path, value ) {
 		: { ...object };
 	const [ first, ...rest ] = path;
 
-	shallowClone[ first ] = rest.length
-		? setImmutably( shallowClone[ first ], rest, value )
-		: value;
+	shallowClone[ first ] = setImmutably( shallowClone[ first ], rest, value );
 
 	return shallowClone;
 }

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -45,20 +45,27 @@ export function kebabCase( str ) {
  * @return {Object} Cloned object with the new value set.
  */
 export function setImmutably( object, path, value ) {
+	// Normalize path
 	path = Array.isArray( path ) ? path : [ path ];
 
-	if ( path.length === 0 ) {
-		return value;
+	// Shallowly clone the base of the object
+	object = Array.isArray( object ) ? [ ...object ] : { ...object };
+
+	// Traverse object from root to leaf, shallowly cloning at each level
+	let prev = object;
+	for ( const i in path ) {
+		const branch = path[ i ];
+		if ( i < path.length - 1 ) {
+			prev[ branch ] = Array.isArray( prev[ branch ] )
+				? [ ...prev[ branch ] ]
+				: { ...prev[ branch ] };
+		} else {
+			prev[ branch ] = value;
+		}
+		prev = prev[ branch ];
 	}
 
-	const shallowClone = Array.isArray( object )
-		? [ ...object ]
-		: { ...object };
-	const [ first, ...rest ] = path;
-
-	shallowClone[ first ] = setImmutably( shallowClone[ first ], rest, value );
-
-	return shallowClone;
+	return object;
 }
 
 const stringToPath = memoize( ( path ) => path.split( '.' ) );

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -56,33 +56,6 @@ export function kebabCase( str ) {
 }
 
 /**
- * Clones an object.
- * Arrays are also cloned as arrays.
- * Non-object values are returned unchanged.
- *
- * @param {*} object Object to clone.
- * @return {*} Cloned object, or original literal non-object value.
- */
-function cloneObject( object ) {
-	if ( Array.isArray( object ) ) {
-		return object.map( cloneObject );
-	}
-
-	if ( object && typeof object === 'object' ) {
-		return {
-			...Object.fromEntries(
-				Object.entries( object ).map( ( [ key, value ] ) => [
-					key,
-					cloneObject( value ),
-				] )
-			),
-		};
-	}
-
-	return object;
-}
-
-/**
  * Immutably sets a value inside an object. Like `lodash#set`, but returning a
  * new object. Treats nullish initial values as empty objects. Clones any
  * nested objects. Supports arrays, too.
@@ -93,24 +66,20 @@ function cloneObject( object ) {
  * @return {Object} Cloned object with the new value set.
  */
 export function setImmutably( object, path, value ) {
-	const normalizedPath = normalizePath( path );
-	const newObject = object ? cloneObject( object ) : {};
+	path = normalizePath( path );
 
-	normalizedPath.reduce( ( acc, key, i ) => {
-		if ( acc[ key ] === undefined ) {
-			if ( Number.isInteger( path[ i + 1 ] ) ) {
-				acc[ key ] = [];
-			} else {
-				acc[ key ] = {};
-			}
-		}
-		if ( i === normalizedPath.length - 1 ) {
-			acc[ key ] = value;
-		}
-		return acc[ key ];
-	}, newObject );
+	if ( path.length === 0 ) {
+		throw new Error( 'Path cannot be empty' );
+	}
 
-	return newObject;
+	const clonedObj = Array.isArray( object ) ? [ ...object ] : { ...object };
+	const [ first, ...rest ] = path;
+
+	clonedObj[ first ] = rest.length
+		? setImmutably( clonedObj[ first ], rest, value )
+		: value;
+
+	return clonedObj;
 }
 
 const stringToPath = memoize( ( path ) => path.split( '.' ) );

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -46,24 +46,21 @@ export function kebabCase( str ) {
  */
 export function setImmutably( object, path, value ) {
 	// Normalize path
-	path = Array.isArray( path ) ? path : [ path ];
+	path = Array.isArray( path ) ? [ ...path ] : [ path ];
 
 	// Shallowly clone the base of the object
 	object = Array.isArray( object ) ? [ ...object ] : { ...object };
 
+	const leaf = path.pop();
+
 	// Traverse object from root to leaf, shallowly cloning at each level
 	let prev = object;
-	for ( const i in path ) {
-		const branch = path[ i ];
-		if ( i < path.length - 1 ) {
-			prev[ branch ] = Array.isArray( prev[ branch ] )
-				? [ ...prev[ branch ] ]
-				: { ...prev[ branch ] };
-		} else {
-			prev[ branch ] = value;
-		}
-		prev = prev[ branch ];
+	for ( const key of path ) {
+		const lvl = prev[ key ];
+		prev = prev[ key ] = Array.isArray( lvl ) ? [ ...lvl ] : { ...lvl };
 	}
+
+	prev[ leaf ] = value;
 
 	return object;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently, `setImmutably` is deep cloning all objects blindly, while only the objects/arrays lying in the path to be updated should be cloned.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

* This can cause problems if you have non plain objects (since it's cloning everything blindly and doesn't even know how to clone some objects).
* You might end up re-rendering things needlessly if you clone everything.
* The new function should also be more performant since it removes a the deep cloning loops.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
