### PR TITLE
Global styles: keep custom CSS when switching between style variations

### DIFF
--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -44,7 +44,7 @@ function Variation( { variation, preserveAdditionalCSS } ) {
 	}, [ variation, base ] );
 
 	const selectVariation = () => {
-		const blockStyles = variation?.styles?.blocks || {};
+		const blockStyles = { ...variation?.styles?.blocks } || {};
 		if ( user?.styles?.blocks && preserveAdditionalCSS ) {
 			Object.keys( user.styles.blocks ).forEach( ( blockName ) => {
 				if ( user.styles.blocks[ blockName ].css ) {
@@ -66,6 +66,7 @@ function Variation( { variation, preserveAdditionalCSS } ) {
 					},
 			  }
 			: variation.styles;
+
 		setUserConfig( () => {
 			return {
 				settings: variation.settings,

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -41,11 +41,15 @@ function Variation( { variation } ) {
 	}, [ variation, base ] );
 
 	const selectVariation = () => {
-		const blockCSS = {};
+		const blockStyles = {};
 		if ( user?.styles?.blocks ) {
 			Object.keys( user.styles.blocks ).forEach( ( blockName ) => {
 				if ( user.styles.blocks[ blockName ].css ) {
-					blockCSS[ blockName ] = {
+					blockStyles[ blockName ] = {
+						...( variation?.styles?.blocks &&
+						variation.styles.blocks[ blockName ]
+							? variation.styles.blocks[ blockName ]
+							: {} ),
 						css: user.styles.blocks[ blockName ].css,
 					};
 				}
@@ -59,8 +63,7 @@ function Variation( { variation } ) {
 					...variation.styles,
 					...( user?.styles?.css ? { css: user.styles.css } : {} ),
 					blocks: {
-						...variation.styles.blocks,
-						...blockCSS,
+						...blockStyles,
 					},
 				},
 			};

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -41,12 +41,27 @@ function Variation( { variation } ) {
 	}, [ variation, base ] );
 
 	const selectVariation = () => {
+		const blockCSS = {};
+		if ( user?.styles?.blocks ) {
+			Object.keys( user.styles.blocks ).forEach( ( blockName ) => {
+				if ( user.styles.blocks[ blockName ].css ) {
+					blockCSS[ blockName ] = {
+						css: user.styles.blocks[ blockName ].css,
+					};
+				}
+			} );
+		}
+
 		setUserConfig( () => {
 			return {
 				settings: variation.settings,
 				styles: {
 					...variation.styles,
 					...( user?.styles?.css ? { css: user.styles.css } : {} ),
+					blocks: {
+						...variation.styles.blocks,
+						...blockCSS,
+					},
 				},
 			};
 		} );

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useContext, useState } from '@wordpress/element';
+import { useMemo, useContext, useState, useEffect } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import {
 	__experimentalGrid as Grid,
@@ -28,9 +28,9 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
 
-function Variation( { variation } ) {
+function Variation( { variation, setCurrentVariation, variationId } ) {
 	const [ isFocused, setIsFocused ] = useState( false );
-	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
+	const { base, user } = useContext( GlobalStylesContext );
 	const context = useMemo( () => {
 		return {
 			user: {
@@ -44,12 +44,7 @@ function Variation( { variation } ) {
 	}, [ variation, base ] );
 
 	const selectVariation = () => {
-		setUserConfig( () => {
-			return {
-				settings: variation.settings,
-				styles: variation.styles,
-			};
-		} );
+		setCurrentVariation( variationId );
 	};
 
 	const selectOnEnter = ( event ) => {
@@ -104,8 +99,9 @@ function Variation( { variation } ) {
 }
 
 export default function StyleVariationsContainer() {
-	const { user } = useContext( GlobalStylesContext );
+	const { user, setUserConfig } = useContext( GlobalStylesContext );
 	const [ currentUserStyles ] = useState( { ...user } );
+	const [ currentVariation, setCurrentVariation ] = useState();
 
 	const [ preserveAdditionalCSS, setPreserveAdditionalCSS ] =
 		useState( true );
@@ -182,6 +178,22 @@ export default function StyleVariationsContainer() {
 		preserveAdditionalCSS,
 	] );
 
+	useEffect( () => {
+		if ( currentVariation ) {
+			setUserConfig( () => {
+				return {
+					settings: withEmptyVariation[ currentVariation ]?.settings,
+					styles: withEmptyVariation[ currentVariation ]?.styles,
+				};
+			} );
+		}
+	}, [
+		currentVariation,
+		preserveAdditionalCSS,
+		setUserConfig,
+		withEmptyVariation,
+	] );
+
 	return (
 		<>
 			<Grid
@@ -192,7 +204,8 @@ export default function StyleVariationsContainer() {
 					<Variation
 						key={ index }
 						variation={ variation }
-						preserveAdditionalCSS={ preserveAdditionalCSS }
+						variationId={ index }
+						setCurrentVariation={ setCurrentVariation }
 					/>
 				) ) }
 			</Grid>

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -44,7 +44,10 @@ function Variation( { variation } ) {
 		setUserConfig( () => {
 			return {
 				settings: variation.settings,
-				styles: variation.styles,
+				styles: {
+					...variation.styles,
+					...( user?.styles?.css ? { css: user.styles.css } : {} ),
+				},
 			};
 		} );
 	};

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -45,7 +45,7 @@ function Variation( { variation, preserveAdditionalCSS } ) {
 
 	const selectVariation = () => {
 		const blockStyles = variation?.styles?.blocks || {};
-		if ( user?.styles?.blocks ) {
+		if ( user?.styles?.blocks && preserveAdditionalCSS ) {
 			Object.keys( user.styles.blocks ).forEach( ( blockName ) => {
 				if ( user.styles.blocks[ blockName ].css ) {
 					blockStyles[ blockName ] = {

--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -41,14 +41,13 @@ function Variation( { variation } ) {
 	}, [ variation, base ] );
 
 	const selectVariation = () => {
-		const blockStyles = {};
+		const blockStyles = variation?.styles?.blocks || {};
 		if ( user?.styles?.blocks ) {
 			Object.keys( user.styles.blocks ).forEach( ( blockName ) => {
 				if ( user.styles.blocks[ blockName ].css ) {
 					blockStyles[ blockName ] = {
-						...( variation?.styles?.blocks &&
-						variation.styles.blocks[ blockName ]
-							? variation.styles.blocks[ blockName ]
+						...( blockStyles[ blockName ]
+							? blockStyles[ blockName ]
 							: {} ),
 						css: user.styles.blocks[ blockName ].css,
 					};

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -104,6 +104,10 @@
 	}
 }
 
+.edit-site-global-styles-style-variations-preserve-css {
+	margin-top: $grid-unit-20;
+}
+
 .edit-site-sidebar-navigation-screen__footer {
 	position: sticky;
 	bottom: 0;


### PR DESCRIPTION
## What?
Preserves user custom CSS when switching between style variations

## Why?
User can find it surprising that their custom CSS is lost when they switch to a different theme variation.

Fixes: https://github.com/WordPress/gutenberg/issues/47433

## How?
Adds a toggle to specify if any existing custom CSS should be copied over to the new style variation CSS

## Testing Instructions

- Add some global custom CSS to a theme including block custom CSS
- Go to the site editor style variation picker, pick another style and check that your custom CSS is preserved
- Toggle off `Keep additional CSS` and check that the custom CSS is wiped

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/5a19f288-4606-499d-89e8-a716d1864c4b

After:

https://github.com/WordPress/gutenberg/assets/3629020/0d4ebec7-76a3-463f-afde-41e6af082c16




