### PR TITLE
Post types REST API: add revisions support to view context

### DIFF
--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -140,3 +140,15 @@ function _gutenberg_register_wp_templates_additional_fields() {
 }
 
 add_action( 'rest_api_init', '_gutenberg_register_wp_templates_additional_fields' );
+
+function gutenberg_rest_prepare_post_type_add_support( $response, $post_type ) {
+	$supports = get_all_post_type_supports( $post_type->name );
+	// should it be restricted to an author or source? (e.g., site editor)?
+	if ( isset( $supports['revisions'] ) && true === $supports['revisions'] ) {
+		$response->data['supports']['revisions'] = true;
+	}
+
+	return $response;
+}
+
+add_filter( 'rest_prepare_post_type', 'gutenberg_rest_prepare_post_type_add_support', 10, 2 );

--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -141,14 +141,28 @@ function _gutenberg_register_wp_templates_additional_fields() {
 
 add_action( 'rest_api_init', '_gutenberg_register_wp_templates_additional_fields' );
 
-function gutenberg_rest_prepare_post_type_add_support( $response, $post_type ) {
-	$supports = get_all_post_type_supports( $post_type->name );
-	// should it be restricted to an author or source? (e.g., site editor)?
-	if ( isset( $supports['revisions'] ) && true === $supports['revisions'] ) {
-		$response->data['supports']['revisions'] = true;
-	}
 
+/**
+ * Returns post type supports data in the request's view context.
+ *
+ * @since 6.5.0
+ *
+ * @param WP_REST_Response $response  The response object.
+ * @param WP_Post_Type     $post_type The original post type object.
+ * @param WP_REST_Request  $request   Request used to generate the response.
+ */
+function gutenberg_rest_prepare_post_type_add_support( $response, $post_type, $request ) {
+	/*
+	 * Path to Core migration: modify  `get_item_schema()` and allow the field `supports => array( 'revisions' => true )` in view context always
+	 * when the post type supports revisions.
+	 */
+	if ( 'view' === $request['context'] ) {
+		$supports = get_all_post_type_supports( $post_type->name );
+		if ( isset( $supports['revisions'] ) && true === $supports['revisions'] ) {
+			$response->data['supports']['revisions'] = true;
+		}
+	}
 	return $response;
 }
 
-add_filter( 'rest_prepare_post_type', 'gutenberg_rest_prepare_post_type_add_support', 10, 2 );
+add_filter( 'rest_prepare_post_type', 'gutenberg_rest_prepare_post_type_add_support', 10, 3 );

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -19,18 +19,6 @@ export const DEFAULT_ENTITY_KEY = 'id';
 
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
 
-// A hardcoded list of post types that support revisions.
-// Reflects post types in Core's src/wp-includes/post.php.
-// @TODO: Ideally this should be fetched from the  `/types` REST API's view context.
-const POST_TYPE_ENTITIES_WITH_REVISIONS_SUPPORT = [
-	'post',
-	'page',
-	'wp_block',
-	'wp_navigation',
-	'wp_template',
-	'wp_template_part',
-];
-
 export const rootEntitiesConfig = [
 	{
 		label: __( 'Base' ),
@@ -299,7 +287,6 @@ async function loadPostTypeEntities() {
 	const postTypes = await apiFetch( {
 		path: '/wp/v2/types?context=view',
 	} );
-	console.log( 'postTypes', postTypes );
 	return Object.entries( postTypes ?? {} ).map( ( [ name, postType ] ) => {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name
@@ -316,11 +303,7 @@ async function loadPostTypeEntities() {
 				selection: true,
 			},
 			mergedEdits: { meta: true },
-			supports: {
-				revisions: POST_TYPE_ENTITIES_WITH_REVISIONS_SUPPORT.includes(
-					postType?.slug
-				),
-			},
+			supports: postType?.supports,
 			rawAttributes: POST_RAW_ATTRIBUTES,
 			getTitle: ( record ) =>
 				record?.title?.rendered ||

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -299,6 +299,7 @@ async function loadPostTypeEntities() {
 	const postTypes = await apiFetch( {
 		path: '/wp/v2/types?context=view',
 	} );
+	console.log( 'postTypes', postTypes );
 	return Object.entries( postTypes ?? {} ).map( ( [ name, postType ] ) => {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name

--- a/phpunit/class-gutenberg-rest-post-types-controller-test.php
+++ b/phpunit/class-gutenberg-rest-post-types-controller-test.php
@@ -64,6 +64,13 @@ class Gutenberg_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_
 	/**
 	 * @doesNotPerformAssertions
 	 */
+	public function test_get_items() {
+		// Controller does not implement this method.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function test_context_param() {
 		// Controller does not implement this method.
 	}

--- a/phpunit/class-gutenberg-rest-post-types-controller-test.php
+++ b/phpunit/class-gutenberg-rest-post-types-controller-test.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Unit tests covering WP_REST_Posts_Types_Controller functionality extensions.
+ *
+ * @package WordPress
+ * @subpackage REST API
+ */
+class Gutenberg_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcase {
+	public function set_up() {
+		register_post_type(
+			'gutenberg_types_cpt',
+			array(
+				'show_in_rest' => true,
+				'rest_base'    => 'gutenberg_types_cpt',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		unregister_post_type( 'gutenberg_types_cpt' );
+	}
+
+	public function test_get_items_revisions_support_in_view_context() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/types' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Only returns one support.
+		$this->assertCount( 1, $data['page']['supports'], 'Only one support item should be returned in view context.' );
+
+		$page_supports = get_all_post_type_supports( 'page' );
+		$this->assertSame( $page_supports['revisions'], $data['page']['supports']['revisions'], 'Revisions support should be returned for `page` post types.' );
+
+		$this->assertCount( 1, $data['post']['supports'], 'Only one support item should be returned in view context.' );
+		$post_supports = get_all_post_type_supports( 'post' );
+		$this->assertSame( $post_supports['revisions'], $data['post']['supports']['revisions'], 'Revisions support should be returned for `post` post types.' );
+
+		// Where revisions are not supported.
+		$this->assertSame( 'gutenberg_types_cpt', $data['gutenberg_types_cpt']['slug'], 'Custom post should be correctly registered.' );
+		$this->assertFalse( isset( $data['gutenberg_types_cpt']['supports'] ), 'Custom post should not return supports array in view context.' );
+	}
+
+	public function test_get_item_post_revisions_support_in_view_context() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/types/post' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		// Only returns one support.
+		$this->assertCount( 1, $data['supports'], 'Only one support item should be returned in view context.' );
+
+		$supports_revisions = post_type_supports( 'post', 'revisions' );
+		$this->assertSame( $supports_revisions, $data['supports']['revisions'], 'Revisions support should be returned for single `post` post types.' );
+
+		// Where revisions are not supported.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/types/gutenberg_types_cpt' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 'gutenberg_types_cpt', $data['slug'], 'Custom post should be correctly registered.' );
+		$this->assertFalse( isset( $data['supports'] ), 'Custom post should not return supports array in view context.' );
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_context_param() {
+		// Controller does not implement this method.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item() {
+		// Controller does not implement this method.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_create_item() {
+		// Controller does not implement this method.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_update_item() {
+		// Controller does not implement this method.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_delete_item() {
+		// Controller does not implement this method.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_prepare_item() {
+		// Controller does not implement this method.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item_schema() {
+		// Controller does not implement this method.
+	}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_register_routes() {
+		// Controller does not implement this method.
+	}
+}


### PR DESCRIPTION
In progress...

## What?
This PR adds `supports.revisions` to the post type objects returned by `WP_REST_Post_Types_Controller` and the following routes:

`/wp/v2/types`
`/wp/v2/types/post_type`

The default context for these routes in 'view'.

This allows us to remove the hardcoded `POST_TYPES_WITH_REVISIONS_SUPPORT` constant in Core Data entities.

## Why?
Supports information is only available in the "edit" context. See [WP_REST_Post_Types_Controller::get_item_schema()](https://github.com/WordPress/wordpress-develop/blob/e005108fe18e6278f4e6dd0fec030e503fe0ff46/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php#L355-L354).

The Block Editor's Core Data package fetches post types using the view context, but also needs to know about revisions support (since https://github.com/WordPress/gutenberg/pull/54046).

So far, we've been duplicating post type revisions support in a `POST_TYPES_WITH_REVISIONS_SUPPORT` constant.

Revisions is being integrated into the Block Editor UI ([example](https://github.com/WordPress/gutenberg/issues/55776)), and therefore, there is a argument that `supports.revisions` belongs to the "view" context.

It's not appropriate to fetch the post types with `context=edit` because users who do not have edit access to the post types may be using the editor.

## How?
`rest_prepare_post_type` filter to modify the response only in the view context and only when the post supports revisions.

No other supports information is added.

The path to Core migration could be to modify  `get_item_schema()` and allow the field `supports => array( 'revisions' => true )` in view context always when the post type supports revisions.

This PR does not extend the controller in this way, opting for `rest_prepare_post_type` out of convenience.

## TODO
- [ ] See if we can consolidate `supportsPagination` into the `entity.supports` config in entities.js. See https://github.com/WordPress/gutenberg/pull/54046#discussion_r1379763884 Probably a good follow up to this PR.

## Testing Instructions
Check that `getRevisions` works for supported post types.

Example:

```js
// Gets all revisions
await wp.data.resolveSelect( 'core' ).getRevisions( 'root', 'globalStyles', parentGlobalStylesId, { per_page: -1 } );

// Get a single revision
await wp.data.resolveSelect( 'core' ).getRevision( 'postType', 'page', parentId, revisionId );
```

See the test descriptions in https://github.com/WordPress/gutenberg/pull/56353 for other supported post types. 

Run the tests!

`npm run test:unit:php:base -- --filter Gutenberg_Test_REST_Post_Types_Controller`
