### PR TITLE
Fix error when using a navigation block that returns an empty fallback result

### DIFF
--- a/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
+++ b/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
@@ -185,7 +185,7 @@ class WP_Navigation_Block_Renderer {
 	private static function get_inner_blocks_from_navigation_post( $attributes ) {
 		$navigation_post = get_post( $attributes['ref'] );
 		if ( ! isset( $navigation_post ) ) {
-			return '';
+			return array();
 		}
 
 		// Only published posts are valid. If this is changed then a corresponding change
@@ -214,7 +214,7 @@ class WP_Navigation_Block_Renderer {
 
 		// Fallback my have been filtered so do basic test for validity.
 		if ( empty( $fallback_blocks ) || ! is_array( $fallback_blocks ) ) {
-			return '';
+			return array();
 		}
 
 		return new WP_Block_List( $fallback_blocks, $attributes );

--- a/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
+++ b/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
@@ -185,7 +185,7 @@ class WP_Navigation_Block_Renderer {
 	private static function get_inner_blocks_from_navigation_post( $attributes ) {
 		$navigation_post = get_post( $attributes['ref'] );
 		if ( ! isset( $navigation_post ) ) {
-			return array();
+			return new WP_Block_List( array(), $attributes );
 		}
 
 		// Only published posts are valid. If this is changed then a corresponding change
@@ -214,7 +214,7 @@ class WP_Navigation_Block_Renderer {
 
 		// Fallback my have been filtered so do basic test for validity.
 		if ( empty( $fallback_blocks ) || ! is_array( $fallback_blocks ) ) {
-			return array();
+			return new WP_Block_List( array(), $attributes );
 		}
 
 		return new WP_Block_List( $fallback_blocks, $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -75,7 +75,7 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 	function block_core_navigation_get_inner_blocks_from_unstable_location( $attributes ) {
 		$menu_items = block_core_navigation_get_menu_items_at_location( $attributes['__unstableLocation'] );
 		if ( empty( $menu_items ) ) {
-			return '';
+			return array();
 		}
 
 		$menu_items_by_parent_id = block_core_navigation_sort_menu_items_by_parent_id( $menu_items );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -75,7 +75,7 @@ if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 	function block_core_navigation_get_inner_blocks_from_unstable_location( $attributes ) {
 		$menu_items = block_core_navigation_get_menu_items_at_location( $attributes['__unstableLocation'] );
 		if ( empty( $menu_items ) ) {
-			return array();
+			return new WP_Block_List( array(), $attributes );
 		}
 
 		$menu_items_by_parent_id = block_core_navigation_sort_menu_items_by_parent_id( $menu_items );

--- a/phpunit/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/class-wp-navigation-block-renderer-test.php
@@ -62,4 +62,23 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$expected = '<li class="wp-block-navigation-item"><h1 class="wp-block-site-title"><a href="http://' . WP_TESTS_DOMAIN . '" target="_self" rel="home">Test Blog</a></h1></li>';
 		$this->assertEquals( $expected, $result );
 	}
+
+	/**
+	 * Test that the `get_inner_blocks_from_navigation_post` method returns an empty block list for a non-existent post.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers WP_Navigation_Block_Renderer::get_inner_blocks_from_navigation_post
+	 */
+	public function test_gutenberg_get_inner_blocks_from_navigation_post_returns_empty_block_list() {
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer' );
+		$method     = $reflection->getMethod( 'get_inner_blocks_from_navigation_post' );
+		$method->setAccessible( true );
+		$attributes = array( 'ref' => 0 );
+
+		$actual   = $method->invoke( $reflection, $attributes );
+		$expected = new WP_Block_List( array(), $attributes );
+		$this->assertEquals( $actual, $expected );
+		$this->assertCount( 0, $actual );
+	}
 }


### PR DESCRIPTION
## What?
Fixes #56600

That issue explains how an error can trigger when navigation fallbacks return empty results.

## How?
After the refactor in #55605, some of the code was moved from the navigation block's render function (where the code returned an empty string to indicate empty block content) over to smaller helper functions that return fallback blocks.

In these new smaller helper functions, the code should return an array when there are no results, as the new calling code expects to handle arrays/iterables. Probably as a result of the copy/paste, some of them were still returning strings.

## Testing Instructions
Testing is a little challenging. I think you need to:
- Delete all wp_navigation menus (so that you don't fallback to using the first one)
- Not have a page list block registered (so that the page list fallback isn't used)
- Delete all classic menus (so that you don't fall back to those either)
- Have a navigation block that has an `__unstableLocation` attribute specified, and no `ref` attribute.

All you need to then is view the front end of the site that renders that navigation block and you should be able to trigger the error in trunk.

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screenshot 2023-11-29 at 4 35 34 pm](https://github.com/WordPress/gutenberg/assets/677833/fcc2e9ca-ef80-483a-b081-d808d1cd00d1)

#### After
![Screenshot 2023-11-29 at 4 35 45 pm](https://github.com/WordPress/gutenberg/assets/677833/38713044-bf93-4575-ba86-1f169e0fe893)
