### PR TITLE
EditorProvider: Use an internal post content block to keep the global core/block-editor store attached to post content

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -605,6 +605,15 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** 
 
+## Content
+
+Displays the contents of a post or page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-content-internal))
+
+-	**Name:** core/post-content-internal
+-	**Category:** theme
+-	**Supports:** align (full, wide), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~
+-	**Attributes:** registry
+
 ## Date
 
 Display the publish date for an entry such as a post or page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-date))

--- a/packages/block-editor/src/components/provider/with-registry-provider.js
+++ b/packages/block-editor/src/components/provider/with-registry-provider.js
@@ -18,22 +18,41 @@ import { STORE_NAME as blockEditorStoreName } from '../../store/constants';
 const withRegistryProvider = createHigherOrderComponent(
 	( WrappedComponent ) => {
 		return withRegistry(
-			( { useSubRegistry = true, registry, ...props } ) => {
-				if ( ! useSubRegistry ) {
-					return (
-						<WrappedComponent registry={ registry } { ...props } />
-					);
-				}
-
+			( {
+				useSubRegistry = true,
+				forceRegistry,
+				registry,
+				...props
+			} ) => {
 				const [ subRegistry, setSubRegistry ] = useState( null );
 				useEffect( () => {
+					if ( forceRegistry || ! useSubRegistry ) {
+						return;
+					}
 					const newRegistry = createRegistry( {}, registry );
 					newRegistry.registerStore(
 						blockEditorStoreName,
 						storeConfig
 					);
 					setSubRegistry( newRegistry );
-				}, [ registry ] );
+				}, [ registry, useSubRegistry, forceRegistry ] );
+
+				if ( forceRegistry ) {
+					return (
+						<RegistryProvider value={ forceRegistry }>
+							<WrappedComponent
+								registry={ forceRegistry }
+								{ ...props }
+							/>
+						</RegistryProvider>
+					);
+				}
+
+				if ( ! useSubRegistry ) {
+					return (
+						<WrappedComponent registry={ registry } { ...props } />
+					);
+				}
 
 				if ( ! subRegistry ) {
 					return null;

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -82,6 +82,7 @@ import * as postCommentsCount from './post-comments-count';
 import * as postCommentsForm from './post-comments-form';
 import * as postCommentsLink from './post-comments-link';
 import * as postContent from './post-content';
+import * as postContentInternal from './post-content-internal';
 import * as postDate from './post-date';
 import * as postExcerpt from './post-excerpt';
 import * as postFeaturedImage from './post-featured-image';
@@ -196,6 +197,7 @@ const getAllBlocks = () => {
 		postExcerpt,
 		postFeaturedImage,
 		postContent,
+		postContentInternal,
 		postAuthor,
 		postAuthorName,
 		postComment,

--- a/packages/block-library/src/post-content-internal/block.json
+++ b/packages/block-library/src/post-content-internal/block.json
@@ -1,0 +1,49 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/post-content-internal",
+	"title": "Content",
+	"category": "theme",
+	"description": "Displays the contents of a post or page.",
+	"textdomain": "default",
+	"usesContext": [ "postId", "postType", "queryId" ],
+	"attributes": {
+		"registry": {
+			"type": "object"
+		}
+	},
+	"supports": {
+		"inserter": false,
+		"align": [ "wide", "full" ],
+		"html": false,
+		"layout": true,
+		"dimensions": {
+			"minHeight": true
+		},
+		"spacing": {
+			"blockGap": true
+		},
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": false,
+				"text": false
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
+	},
+	"editorStyle": "wp-block-post-content-internal-editor"
+}

--- a/packages/block-library/src/post-content-internal/edit.js
+++ b/packages/block-library/src/post-content-internal/edit.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	__experimentalRecursionProvider as RecursionProvider,
+	__experimentalUseHasRecursion as useHasRecursion,
+	Warning,
+	BlockEditorProvider,
+	BlockList,
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { useEntityBlockEditor } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { LayoutStyle } = unlock( blockEditorPrivateApis );
+
+function Content( { context: { postType, postId } = {}, attributes } ) {
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		postType,
+		{ id: postId }
+	);
+
+	const settings = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings();
+	}, [] );
+
+	const initialBlocks = useMemo( () => {
+		return [ createBlock( 'core/paragraph' ) ];
+	}, [] );
+
+	const blockProps = useBlockProps();
+	return (
+		<BlockEditorProvider
+			value={ blocks.length !== 0 ? blocks : initialBlocks }
+			onInput={ onInput }
+			onChange={ onChange }
+			settings={ settings }
+			forceRegistry={ attributes.registry }
+		>
+			<LayoutStyle
+				selector=".wp-block-post-content-internal > div"
+				layout={ attributes.layout }
+			/>
+			<div { ...blockProps }>
+				<BlockList layout={ attributes.layout } />
+			</div>
+		</BlockEditorProvider>
+	);
+}
+
+function RecursionError() {
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			<Warning>
+				{ __( 'Block cannot be rendered inside itself.' ) }
+			</Warning>
+		</div>
+	);
+}
+
+export default function PostContentEdit( { context, ...props } ) {
+	const { postId: contextPostId, postType: contextPostType } = context;
+	const hasAlreadyRendered = useHasRecursion( contextPostId );
+
+	if ( contextPostId && contextPostType && hasAlreadyRendered ) {
+		return <RecursionError />;
+	}
+
+	return (
+		<RecursionProvider uniqueId={ contextPostId }>
+			{ contextPostId && contextPostType && (
+				<Content context={ context } { ...props } />
+			) }
+		</RecursionProvider>
+	);
+}

--- a/packages/block-library/src/post-content-internal/index.js
+++ b/packages/block-library/src/post-content-internal/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { postContent as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-content-internal/init.js
+++ b/packages/block-library/src/post-content-internal/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/editor/src/components/provider/constants.js
+++ b/packages/editor/src/components/provider/constants.js
@@ -2,4 +2,5 @@ export const PAGE_CONTENT_BLOCK_TYPES = [
 	'core/post-title',
 	'core/post-featured-image',
 	'core/post-content',
+	'core/post-content-internal',
 ];


### PR DESCRIPTION
Builds on top of #56542 
Related to #56586

## What?

While trying to unify the post and site editor code bases to both use the "post-only" mode instead of duplicating the same logic in both places, we found that it would be very hard to keep backward compatibility this way. The main reason is because "core/block-editor" store is expected to only contain the "post content blocks" in the post editor by all plugins and third-party developers. 

The current PR tries to explore the idea mentioned here https://github.com/WordPress/gutenberg/pull/56586#issuecomment-1829729916

which basically means we have a block editor within a block editor (instead of using the regular post content block) and the internal block editor still points to the global registry (so the global core/block-editor store).

This PR tries this in the site editor first (disable template previewing) and you can verify this by opening the browser console in that mode and typing `wp.data.select( 'core/block-editor' ).getBlocks()`

**Note** The code here is a bit "clever" and I'm not a huge fan. So while I'll keep this PR around to consider it, I'm thinking about exploring another simpler approach maybe: Instead of having two nested block editors, have multiple (or two) block editors around each post block (post title, post content and post featured image). The `BlockEditorProvider` that wraps the `post content` blocks would be the only one that has `useSubRegistry=false`. In other words, this alternative approach would be very close to the post editor, only difference is it would use blocks rather than a `PostTitle` component to render the post title. A third approach (might be the easiest to start with) would be to instead copy the post editor in the post-only mode of the site editor rather than doing the opposite.