### PR TITLE
HeadingLevelDropdown: Remove unnecessary isPressed prop

### DIFF
--- a/packages/block-editor/src/components/block-heading-level-dropdown/index.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/index.js
@@ -46,31 +46,23 @@ export default function HeadingLevelDropdown( {
 			icon={ <HeadingLevelIcon level={ value } /> }
 			label={ __( 'Change level' ) }
 			controls={ options.map( ( targetLevel ) => {
-				{
-					const isActive = targetLevel === value;
-
-					return {
-						icon: (
-							<HeadingLevelIcon
-								level={ targetLevel }
-								isPressed={ isActive }
-							/>
-						),
-						title:
-							targetLevel === 0
-								? __( 'Paragraph' )
-								: sprintf(
-										// translators: %s: heading level e.g: "1", "2", "3"
-										__( 'Heading %d' ),
-										targetLevel
-								  ),
-						isActive,
-						onClick() {
-							onChange( targetLevel );
-						},
-						role: 'menuitemradio',
-					};
-				}
+				const isActive = targetLevel === value;
+				return {
+					icon: <HeadingLevelIcon level={ targetLevel } />,
+					title:
+						targetLevel === 0
+							? __( 'Paragraph' )
+							: sprintf(
+									// translators: %s: heading level e.g: "1", "2", "3"
+									__( 'Heading %d' ),
+									targetLevel
+							  ),
+					isActive,
+					onClick() {
+						onChange( targetLevel );
+					},
+					role: 'menuitemradio',
+				};
 			} ) }
 		/>
 	);


### PR DESCRIPTION
## What?
This PR removes the `isPressed` property from the dropdown menu icon of the `HeadingLevelDropdown` component.

## Why?
`HeadingLevelIcon` [does not receive `isPressed` prop](https://github.com/WordPress/gutenberg/blob/00ccb8b18ea45295bf5edc74f94b7197c768cb96/packages/block-editor/src/components/block-heading-level-dropdown/heading-level-icon.js#L42).

## Testing Instructions
Insert a Heading block that uses this component and confirm that changing the heading level works as before.
