### PR TITLE
DataViews: document `view.layout`

### DIFF
--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -65,9 +65,8 @@ Example:
     -   `value`: the actual value selected by the user.
 -   `hiddenFields`: the `id` of the fields that are hidden in the UI.
 -   `layout`: config that is specific to a particular layout type.
-    -   `grid`: config for the `grid` layout
-        -   `mediaField`: the `id` of the field to be used for rendering each card's media.
-        -   `primaryField`: the `id` of the field to be used for rendering each card's title.
+    -   `mediaField`: used by the `grid` layout. The `id` of the field to be used for rendering each card's media.
+    -   `primaryField`: used by the `grid` layout. The `id` of the field to be used for rendering each card's title.
 
 ### View <=> data
 

--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -64,7 +64,10 @@ Example:
     -   `operator`: which type of filter it is. Only `in` available at the moment.
     -   `value`: the actual value selected by the user.
 -   `hiddenFields`: the `id` of the fields that are hidden in the UI.
--   `layout`: ...
+-   `layout`: config that is specific to a particular layout type.
+    -   `grid`: config for the `grid` layout
+        -   `mediaField`: the field name to be used for rendering each card's media.
+        -   `primaryField`: the field name to be used for rendering each card's title.
 
 ### View <=> data
 

--- a/packages/edit-site/src/components/dataviews/README.md
+++ b/packages/edit-site/src/components/dataviews/README.md
@@ -66,8 +66,8 @@ Example:
 -   `hiddenFields`: the `id` of the fields that are hidden in the UI.
 -   `layout`: config that is specific to a particular layout type.
     -   `grid`: config for the `grid` layout
-        -   `mediaField`: the field name to be used for rendering each card's media.
-        -   `primaryField`: the field name to be used for rendering each card's title.
+        -   `mediaField`: the `id` of the field to be used for rendering each card's media.
+        -   `primaryField`: the `id` of the field to be used for rendering each card's title.
 
 ### View <=> data
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

Documents the `view.layout` prop, and all existing use cases (`view.layout.grid` and its props `mediaField` and `primaryField`).
