### PR TITLE
tests: add `insertBlockAndWaitForSelector` utility

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/index.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/index.ts
@@ -28,6 +28,7 @@ import { saveSiteEditorEntities } from './site-editor';
 import { setIsFixedToolbar } from './set-is-fixed-toolbar';
 import { switchToLegacyCanvas } from './switch-to-legacy-canvas';
 import { transformBlockTo } from './transform-block-to';
+import { insertBlockAndWaitForSelector } from './insert-block-and-wait-for-selector';
 
 type EditorConstructorProps = {
 	page: Page;
@@ -61,6 +62,9 @@ export class Editor {
 		getEditedPostContent.bind( this );
 	/** @borrows insertBlock as this.insertBlock */
 	insertBlock: typeof insertBlock = insertBlock.bind( this );
+	/** @borrows insertBlockAndWaitForSelector as this.insertBlockAndWaitForSelector */
+	insertBlockAndWaitForSelector: typeof insertBlockAndWaitForSelector =
+		insertBlockAndWaitForSelector.bind( this );
 	/** @borrows openDocumentSettingsSidebar as this.openDocumentSettingsSidebar */
 	openDocumentSettingsSidebar: typeof openDocumentSettingsSidebar =
 		openDocumentSettingsSidebar.bind( this );

--- a/packages/e2e-test-utils-playwright/src/editor/insert-block-and-wait-for-selector.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/insert-block-and-wait-for-selector.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import type { Editor } from './index';
+import { insertBlock, type BlockRepresentation } from './insert-block';
+
+/**
+ * Insert a block and wait for a given selector to be visible.
+ *
+ * @param this
+ * @param blockRepresentation Inserted block representation.
+ * @param selector            Selector to wait for to be visible.
+ */
+async function insertBlockAndWaitForSelector(
+	this: Editor,
+	blockRepresentation: BlockRepresentation,
+	selector: string
+) {
+	await insertBlock.call( this, blockRepresentation );
+	await this.page.locator( selector ).isVisible();
+}
+
+export type { BlockRepresentation };
+export { insertBlockAndWaitForSelector };


### PR DESCRIPTION
## What?

Add a `insertBlockAndWaitForSelector` utility to the e2e test utils for playwright package which inserts a block and then waits for a given selector to be visible. 

## Why?

The idea came up when I started working on fixing e2e tests in #55585 which attempts to lazy load edit functions of blocks. After using `insertBlock` we have to wait for a certain selector to be visible, otherwise some of the tests fail which attempt to e.g. type something into a block which isn't there yet.

In https://github.com/WordPress/gutenberg/pull/55585/commits/50cd450f4046dc69ad125a667dc94aa7204540bd you can see this might result in a lot of repetitive code which this util tries to abstract away. It's probably not suitable for all block insertions done in those tests but should cover a fair bit.

## How?

The `@wordpress/e2e-test-utils-playwright` exports a bunch of methods and we're adding `insertBlockAndWaitForSelector` to it.

## Testing Instructions



### Testing Instructions for Keyboard

none

## Screenshots or screencast <!-- if applicable -->

none
