### PR TITLE
DataViews: make `mediaField` not hidable

### DIFF
--- a/packages/edit-site/src/components/dataviews/view-actions.js
+++ b/packages/edit-site/src/components/dataviews/view-actions.js
@@ -139,7 +139,8 @@ function PageSizeMenu( { view, onChangeView } ) {
 
 function FieldsVisibilityMenu( { view, onChangeView, fields } ) {
 	const hidableFields = fields.filter(
-		( field ) => field.enableHiding !== false
+		( field ) =>
+			field.enableHiding !== false && field.id !== view.layout.mediaField
 	);
 	if ( ! hidableFields?.length ) {
 		return null;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What

This PR makes the `mediaField` not hidable.

https://github.com/WordPress/gutenberg/assets/583546/27d05892-b01a-48d5-a89b-544448be7b82

## Why

Right now, on `trunk`, the media field is displayed on the field visibility, even though it cannot be hidden.

## How

Take into account the `view.layout.mediaField` into the logic for listing hidable fields.

## Testing

- Enable the "admin views" experiment and visit "Appareance > Editor > Pages > Manage all pages".
- Interact with the field visibility menu.
