### PR TITLE
Docs: Selectors API merged into core, callouts no longer needed

### DIFF
--- a/docs/reference-guides/block-api/block-selectors.md
+++ b/docs/reference-guides/block-api/block-selectors.md
@@ -1,24 +1,14 @@
 # Selectors
 
-<div class="callout callout-alert">
-	This API was stabilized in Gutenberg 15.5 and is planned for core release
-	in WordPress 6.3. To use this prior to WordPress 6.3, you will need to
-	install and activate Gutenberg >= 15.5.
-</div>
+Block Selectors is the API that allows blocks to customize the CSS selector used when their styles are generated.
 
-Block Selectors is the API that allows blocks to customize the CSS selector used
-when their styles are generated.
-
-A block may customize its CSS selectors at three levels: root, feature, and
-subfeature.
+A block may customize its CSS selectors at three levels: root, feature, and subfeature.
 
 ## Root Selector
 
 The root selector is the block's primary CSS selector.
 
-All blocks require a primary CSS selector for their style declarations to be
-included under. If one is not provided through the Block Selectors API, a
-default is generated in the form of `.wp-block-<name>`.
+All blocks require a primary CSS selector for their style declarations to be included under. If one is not provided through the Block Selectors API, a default is generated in the form of `.wp-block-<name>`.
 
 ### Example
 
@@ -33,12 +23,9 @@ default is generated in the form of `.wp-block-<name>`.
 
 ## Feature Selectors
 
-Feature selectors relate to styles for a block support, e.g. border, color,
-typography, etc.
+Feature selectors relate to styles for a block support, e.g. border, color, typography, etc.
 
-A block may wish to apply the styles for specific features to different
-elements within a block. An example might be using colors on the block's wrapper
-but applying the typography styles to an inner heading only.
+A block may wish to apply the styles for specific features to different elements within a block. An example might be using colors on the block's wrapper but applying the typography styles to an inner heading only.
 
 ### Example
 
@@ -55,17 +42,11 @@ but applying the typography styles to an inner heading only.
 
 ## Subfeature Selectors
 
-These selectors relate to individual styles provided by a block support e.g.
-`background-color`
+These selectors relate to individual styles provided by a block support e.g. `background-color`
 
-A subfeature can have styles generated under its own unique selector. This is
-especially useful where one block support subfeature can't be applied to the
-same element as the support's other subfeatures.
+A subfeature can have styles generated under its own unique selector. This is especially useful where one block support subfeature can't be applied to the same element as the support's other subfeatures.
 
-A great example of this is `text-decoration`. Web browsers render this style
-differently, making it difficult to override if added to a wrapper element. By
-assigning `text-decoration` a custom selector, its style can target only the
-elements to which it should be applied.
+A great example of this is `text-decoration`. Web browsers render this style differently, making it difficult to override if added to a wrapper element. By assigning `text-decoration` a custom selector, its style can target only the elements to which it should be applied.
 
 ### Example
 
@@ -85,19 +66,13 @@ elements to which it should be applied.
 
 ## Shorthand
 
-Rather than specify a CSS selector for every subfeature, you can set a single
-selector as a string value for the relevant feature. This is the approach
-demonstrated for the `color` feature in the earlier examples above.
+Rather than specify a CSS selector for every subfeature, you can set a single selector as a string value for the relevant feature. This is the approach demonstrated for the `color` feature in the earlier examples above.
 
 ## Fallbacks
 
-A selector that hasn't been configured for a specific feature will fall back to
-the block's root selector. Similarly, if a subfeature hasn't had a custom
-selector set, it will fall back to its parent feature's selector and, if unavailable, fall back further to the block's root selector.
+A selector that hasn't been configured for a specific feature will fall back to the block's root selector. Similarly, if a subfeature hasn't had a custom selector set, it will fall back to its parent feature's selector and, if unavailable, fall back further to the block's root selector.
 
-Rather than repeating selectors for multiple subfeatures, you can set the
-common selector as the parent feature's `root` selector and only define the
-unique selectors for the subfeatures that differ.
+Rather than repeating selectors for multiple subfeatures, you can set the common selector as the parent feature's `root` selector and only define the unique selectors for the subfeatures that differ.
 
 ### Example
 
@@ -117,10 +92,6 @@ unique selectors for the subfeatures that differ.
 }
 ```
 
-The `color.background-color` subfeature isn't explicitly set in the above
-example. As the `color` feature also doesn't define a `root` selector,
-`color.background-color` would be included under the block's primary root
-selector, `.my-custom-block-selector`.
+The `color.background-color` subfeature isn't explicitly set in the above example. As the `color` feature also doesn't define a `root` selector, `color.background-color` would be included under the block's primary root selector, `.my-custom-block-selector`.
 
-For a subfeature such as `typography.font-size`, it would fallback to its parent
-feature's selector given that is present, i.e. `.my-custom-block-selector > h2`.
+For a subfeature such as `typography.font-size`, it would fallback to its parent feature's selector given that is present, i.e. `.my-custom-block-selector > h2`.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Gutenberg 15.5, which stabilized the Selectors API, has been merged into WordPress 6.3.
Callouts are no longer needed.

Also, all text on this page contains line breaks.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
