### PR TITLE
DataViews: make `Actions` styles the same as any other column header

### DIFF
--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -34,9 +34,15 @@
 	}
 	th {
 		text-align: left;
-		font-weight: normal;
-		padding: 0 $grid-unit-20 $grid-unit-20;
-		color: $gray-700;
+		/*
+		 * This makes the Actions column header to use the same styles as the other ones.
+		 * The other column headers use the .components-button styles.
+		 */
+		&[data-field-id="actions"] {
+			color: #1e1e1e;
+			font-weight: normal;
+			font-size: 13px;
+		}
 	}
 	td,
 	th {

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -39,7 +39,7 @@
 		 * The other column headers use the .components-button styles.
 		 */
 		&[data-field-id="actions"] {
-			color: #1e1e1e;
+			color: var(--wp-components-color-foreground, $gray-900);
 			font-weight: normal;
 			font-size: $default-font-size;
 		}

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -34,15 +34,9 @@
 	}
 	th {
 		text-align: left;
-		/*
-		 * This makes the Actions column header to use the same styles as the other ones.
-		 * The other column headers use the .components-button styles.
-		 */
-		&[data-field-id="actions"] {
-			color: var(--wp-components-color-foreground, $gray-900);
-			font-weight: normal;
-			font-size: $default-font-size;
-		}
+		color: var(--wp-components-color-foreground, $gray-900);
+		font-weight: normal;
+		font-size: $default-font-size;
 	}
 	td,
 	th {

--- a/packages/edit-site/src/components/dataviews/style.scss
+++ b/packages/edit-site/src/components/dataviews/style.scss
@@ -41,7 +41,7 @@
 		&[data-field-id="actions"] {
 			color: #1e1e1e;
 			font-weight: normal;
-			font-size: 13px;
+			font-size: $default-font-size;
 		}
 	}
 	td,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Makes the styles for the `Actions` column header be the same as other column headers.

|| Before | After |
| --- | --- | --- |
| Pages | <img width="1147" alt="Captura de ecrã 2023-11-29, às 17 35 51" src="https://github.com/WordPress/gutenberg/assets/583546/5366fc59-a75b-4bc1-a851-32de9eb71b7a"> | <img width="1147" alt="Captura de ecrã 2023-11-29, às 17 35 32" src="https://github.com/WordPress/gutenberg/assets/583546/a2fbdde2-038b-4c5e-8e6e-02291d35cb5f"> |
| Templates | <img width="1147" alt="Captura de ecrã 2023-11-29, às 19 40 37" src="https://github.com/WordPress/gutenberg/assets/583546/af3b4b60-5921-4475-9808-851ad6c34da0"> | <img width="1147" alt="Captura de ecrã 2023-11-29, às 19 40 25" src="https://github.com/WordPress/gutenberg/assets/583546/98726049-ee89-4bcd-a5a6-ac93ffe4fd37"> |

## Testing Instructions

- Enable the "view admin" experiment and visit "Appareance > Editor > Pages > Manage all pages".
- Verify the styles match.
