### PR TITLE
Modules: Fix import map polyfill not being copied on the generated plugin ZIP

### DIFF
--- a/lib/experimental/interactivity-api/modules.php
+++ b/lib/experimental/interactivity-api/modules.php
@@ -21,7 +21,7 @@ function gutenberg_register_interactivity_module() {
 	// TODO: Load only if the browser doesn't support import maps (https://github.com/guybedford/es-module-shims/issues/371).
 	wp_enqueue_script(
 		'es-module-shims',
-		gutenberg_url( '/build/importmap-polyfill.min.js' ),
+		gutenberg_url( '/build/modules/importmap-polyfill.min.js' ),
 		array(),
 		null,
 		array(

--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -75,7 +75,7 @@ module.exports = {
 			patterns: [
 				{
 					from: './node_modules/es-module-shims/dist/es-module-shims.wasm.js',
-					to: './build/importmap-polyfill.min.js',
+					to: './build/modules/importmap-polyfill.min.js',
 				},
 			],
 		} ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Move the `importmap-polyfill.js` file to the `modules` folder.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the build script doesn't copy anything outside folders (notice the single `*`):

`ls build/*/*.{js,js.map,css,asset.php}`

https://github.com/WordPress/gutenberg/blob/trunk/bin/build-plugin-zip.sh#L82

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I tried with `ls build/**/*.{js,js.map,css,asset.php}`, but that generated a lot of extra files. So I just moved the `importmap-polyfill.js` file to the `modules` folder to make it work with the current logic.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Go to a WordPress site (for example, using [the playground](https://playground.wordpress.net/)).
- Download the [latest plugin ZIP file](https://github.com/WordPress/gutenberg/suites/18606812694/artifacts/1081455255) from this PR.
- Unzip it and rezip it (because due to GH actions its zipped twice).
- Install it and activate it.
- Go to the frontend.
- Check that the `importmap-polyfill.js` file is downloaded correctly.

