### PR TITLE
Tabs: sync browser focus to selected tab in controlled mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,10 @@
 -   `ToggleGroupControl`: react correctly to external controlled updates ([#56678](https://github.com/WordPress/gutenberg/pull/56678)).
 -   `ToolsPanel`: fix a performance issue ([#56770](https://github.com/WordPress/gutenberg/pull/56770)).
 
+### Experimental
+
+-   `Tabs`: improve focus handling in controlled mode ([#56658](https://github.com/WordPress/gutenberg/pull/56658)).
+
 ## 25.13.0 (2023-11-29)
 
 ### Enhancements

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -42,10 +42,7 @@ function Tabs( {
 		selectedId: selectedTabId && `${ instanceId }-${ selectedTabId }`,
 	} );
 
-	const isControlled = useMemo(
-		() => selectedTabId !== undefined,
-		[ selectedTabId ]
-	);
+	const isControlled = selectedTabId !== undefined;
 
 	const { items, selectedId } = store.useState();
 	const { setSelectedId, move } = store;

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -164,7 +164,7 @@ function Tabs( {
 	// In controlled mode, make sure browser focus follows the selected tab if
 	// the selection is changed while a tab is already being focused.
 	useLayoutEffect( () => {
-		if ( ! isControlled ) {
+		if ( ! isControlled || ! selectOnMove ) {
 			return;
 		}
 
@@ -174,7 +174,7 @@ function Tabs( {
 		) {
 			move( selectedId );
 		}
-	}, [ isControlled, move, selectedId, tabsHasFocus ] );
+	}, [ isControlled, move, selectOnMove, selectedId, tabsHasFocus ] );
 
 	const contextValue = useMemo(
 		() => ( {

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -170,7 +170,6 @@ function Tabs( {
 
 		if (
 			tabsHasFocus &&
-			tabsRef.current?.ownerDocument.activeElement !== null &&
 			selectedId !== tabsRef.current?.ownerDocument.activeElement.id
 		) {
 			move( selectedId );

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -47,13 +47,6 @@ function Tabs( {
 	const { items, selectedId } = store.useState();
 	const { setSelectedId, move } = store;
 
-	const tabsRef = useRef< HTMLDivElement >( null );
-	const tabsHasFocus =
-		!! tabsRef.current?.ownerDocument.activeElement &&
-		items
-			.map( ( item ) => item.id )
-			.includes( tabsRef.current?.ownerDocument.activeElement.id );
-
 	// Keep track of whether tabs have been populated. This is used to prevent
 	// certain effects from firing too early while tab data and relevant
 	// variables are undefined during the initial render.
@@ -167,14 +160,20 @@ function Tabs( {
 		if ( ! isControlled || ! selectOnMove ) {
 			return;
 		}
+		const currentItem = items.find( ( item ) => item.id === selectedId );
+		const activeElement = currentItem?.element?.ownerDocument.activeElement;
+		const tabsHasFocus = items.some( ( item ) => {
+			return activeElement && activeElement === item.element;
+		} );
 
 		if (
+			activeElement &&
 			tabsHasFocus &&
-			selectedId !== tabsRef.current?.ownerDocument.activeElement.id
+			selectedId !== activeElement.id
 		) {
 			move( selectedId );
 		}
-	}, [ isControlled, move, selectOnMove, selectedId, tabsHasFocus ] );
+	}, [ isControlled, items, move, selectOnMove, selectedId ] );
 
 	const contextValue = useMemo(
 		() => ( {
@@ -185,11 +184,9 @@ function Tabs( {
 	);
 
 	return (
-		<div ref={ tabsRef }>
-			<TabsContext.Provider value={ contextValue }>
-				{ children }
-			</TabsContext.Provider>
-		</div>
+		<TabsContext.Provider value={ contextValue }>
+			{ children }
+		</TabsContext.Provider>
 	);
 }
 

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -801,17 +801,15 @@ describe( 'Tabs', () => {
 
 		describe( 'When `selectOnMove` is `true`', () => {
 			it( 'should automatically select a newly focused tab', async () => {
-				const user = userEvent.setup();
-
 				render( <UncontrolledTabs tabs={ TABS } /> );
 
 				// Tab should focus the currently selected tab, which is Alpha.
-				await user.keyboard( '[Tab]' );
+				await press.Tab();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 				expect( await getSelectedTab() ).toHaveFocus();
 
 				// Arrow keys should select and move focus to the next tab.
-				await user.keyboard( '[ArrowRight]' );
+				await press.ArrowRight();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 				expect( await getSelectedTab() ).toHaveFocus();
 			} );
@@ -819,37 +817,35 @@ describe( 'Tabs', () => {
 
 		describe( 'When `selectOnMove` is `false`', () => {
 			it( 'should apply focus without automatically changing the selected tab', async () => {
-				const user = userEvent.setup();
-
 				render(
 					<UncontrolledTabs tabs={ TABS } selectOnMove={ false } />
 				);
 
 				// Tab should focus the currently selected tab, which is Alpha.
-				await user.keyboard( '[Tab]' );
+				await press.Tab();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 				expect( await getSelectedTab() ).toHaveFocus();
 
 				// Arrow key should move focus but not automatically change the selected tab.
-				await user.keyboard( '[ArrowRight]' );
+				await press.ArrowRight();
 				expect(
 					screen.getByRole( 'tab', { name: 'Beta' } )
 				).toHaveFocus();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 
 				// Pressing the spacebar should select the focused tab.
-				await user.keyboard( '[Space]' );
+				await press.Space();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 
 				// Arrow key should move focus but not automatically change the selected tab.
-				await user.keyboard( '[ArrowRight]' );
+				await press.ArrowRight();
 				expect(
 					screen.getByRole( 'tab', { name: 'Gamma' } )
 				).toHaveFocus();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 
 				// Pressing the enter/return should select the focused tab.
-				await user.keyboard( '[Enter]' );
+				await press.Enter();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
 			} );
 		} );
@@ -1230,48 +1226,26 @@ describe( 'Tabs', () => {
 
 		describe( 'When `selectOnMove` is `true`', () => {
 			it( 'should automatically select a newly focused tab', async () => {
-				const user = userEvent.setup();
-
 				render( <ControlledTabs tabs={ TABS } selectedTabId="beta" /> );
 
-				// This assertion ensures the component has had time to fully
-				// render, preventing flakiness.
-				// see https://github.com/WordPress/gutenberg/pull/55950
-				await waitFor( async () =>
-					expect(
-						await screen.findByRole( 'tab', { name: 'Beta' } )
-					).toHaveAttribute( 'aria-selected', 'true' )
-				);
-
-				await user.keyboard( '[Tab]' );
+				await press.Tab();
 
 				// Tab key should focus the currently selected tab, which is Beta.
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 				expect( await getSelectedTab() ).toHaveFocus();
 
 				// Arrow keys should select and move focus to the next tab.
-				await user.keyboard( '[ArrowRight]' );
+				await press.ArrowRight();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
 				expect( await getSelectedTab() ).toHaveFocus();
 			} );
 			it( 'should automatically update focus when the selected tab is changed by the controlling component', async () => {
-				const user = userEvent.setup();
-
 				const { rerender } = render(
 					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
 				);
 
-				// This assertion ensures the component has had time to fully
-				// render, preventing flakiness.
-				// see https://github.com/WordPress/gutenberg/pull/55950
-				await waitFor( async () =>
-					expect(
-						await screen.findByRole( 'tab', { name: 'Beta' } )
-					).toHaveAttribute( 'aria-selected', 'true' )
-				);
-
 				// Tab key should focus the currently selected tab, which is Beta.
-				await user.keyboard( '[Tab]' );
+				await press.Tab();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 				expect( await getSelectedTab() ).toHaveFocus();
 
@@ -1286,8 +1260,6 @@ describe( 'Tabs', () => {
 		} );
 		describe( 'When `selectOnMove` is `false`', () => {
 			it( 'should apply focus without automatically changing the selected tab', async () => {
-				const user = userEvent.setup();
-
 				render(
 					<ControlledTabs
 						tabs={ TABS }
@@ -1296,48 +1268,37 @@ describe( 'Tabs', () => {
 					/>
 				);
 
-				// This assertion ensures the component has had time to fully
-				// render, preventing flakiness.
-				// see https://github.com/WordPress/gutenberg/pull/55950
-				await waitFor( async () =>
-					expect(
-						await screen.findByRole( 'tab', { name: 'Beta' } )
-					).toHaveAttribute( 'aria-selected', 'true' )
-				);
-
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 
 				// Tab key should focus the currently selected tab, which is Beta.
-				await user.keyboard( '[Tab]' );
+				await press.Tab();
 				expect(
 					await screen.findByRole( 'tab', { name: 'Beta' } )
 				).toHaveFocus();
 
 				// Arrow key should move focus but not automatically change the selected tab.
-				await user.keyboard( '[ArrowRight]' );
+				await press.ArrowRight();
 				expect(
 					screen.getByRole( 'tab', { name: 'Gamma' } )
 				).toHaveFocus();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 
 				// Pressing the spacebar should select the focused tab.
-				await user.keyboard( '[Space]' );
+				await press.Space();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
 
 				// Arrow key should move focus but not automatically change the selected tab.
-				await user.keyboard( '[ArrowRight]' );
+				await press.ArrowRight();
 				expect(
 					screen.getByRole( 'tab', { name: 'Alpha' } )
 				).toHaveFocus();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
 
 				// Pressing the enter/return should select the focused tab.
-				await user.keyboard( '[Enter]' );
+				await press.Enter();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			} );
 			it( 'should not automatically update focus when the selected tab is changed by the controlling component', async () => {
-				const user = userEvent.setup();
-
 				const { rerender } = render(
 					<ControlledTabs
 						tabs={ TABS }
@@ -1346,19 +1307,10 @@ describe( 'Tabs', () => {
 					/>
 				);
 
-				// This assertion ensures the component has had time to fully
-				// render, preventing flakiness.
-				// see https://github.com/WordPress/gutenberg/pull/55950
-				await waitFor( async () =>
-					expect(
-						await screen.findByRole( 'tab', { name: 'Beta' } )
-					).toHaveAttribute( 'aria-selected', 'true' )
-				);
-
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 
 				// Tab key should focus the currently selected tab, which is Beta.
-				await user.keyboard( '[Tab]' );
+				await press.Tab();
 				expect( await getSelectedTab() ).toHaveFocus();
 
 				rerender(
@@ -1371,13 +1323,9 @@ describe( 'Tabs', () => {
 
 				// When the selected tab is changed, it should not automatically receive focus.
 				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-				// `waitFor` is needed here to prevent testing library from
-				// throwing a 'not wrapped in `act()`' error.
-				await waitFor( () =>
-					expect(
-						screen.getByRole( 'tab', { name: 'Beta' } )
-					).toHaveFocus()
-				);
+				expect(
+					screen.getByRole( 'tab', { name: 'Beta' } )
+				).toHaveFocus();
 			} );
 		} );
 	} );

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -799,57 +799,6 @@ describe( 'Tabs', () => {
 			} );
 		} );
 
-		describe( 'When `selectOnMove` is `true`', () => {
-			it( 'should automatically select a newly focused tab', async () => {
-				render( <UncontrolledTabs tabs={ TABS } /> );
-
-				// Tab should focus the currently selected tab, which is Alpha.
-				await press.Tab();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect( await getSelectedTab() ).toHaveFocus();
-
-				// Arrow keys should select and move focus to the next tab.
-				await press.ArrowRight();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-				expect( await getSelectedTab() ).toHaveFocus();
-			} );
-		} );
-
-		describe( 'When `selectOnMove` is `false`', () => {
-			it( 'should apply focus without automatically changing the selected tab', async () => {
-				render(
-					<UncontrolledTabs tabs={ TABS } selectOnMove={ false } />
-				);
-
-				// Tab should focus the currently selected tab, which is Alpha.
-				await press.Tab();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect( await getSelectedTab() ).toHaveFocus();
-
-				// Arrow key should move focus but not automatically change the selected tab.
-				await press.ArrowRight();
-				expect(
-					screen.getByRole( 'tab', { name: 'Beta' } )
-				).toHaveFocus();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-
-				// Pressing the spacebar should select the focused tab.
-				await press.Space();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				// Arrow key should move focus but not automatically change the selected tab.
-				await press.ArrowRight();
-				expect(
-					screen.getByRole( 'tab', { name: 'Gamma' } )
-				).toHaveFocus();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				// Pressing the enter/return should select the focused tab.
-				await press.Enter();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-			} );
-		} );
-
 		describe( 'Disabled tab', () => {
 			it( 'should disable the tab when `disabled` is `true`', async () => {
 				const mockOnSelect = jest.fn();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In controlled mode, make browser focus follow any changes in tab selection that occur while a rendered tab currently has browser focus.

## Why?
In some cases, it's possible for focus to be passed to the selected tab, only to have that selection change immediately afterwards. This could leave keyboard navigation and/or assistive tech in a confusing state where the focused tab does not reflect the content actually being displayed.

Real life example in the editor when [tabbing to the sidebar without having a block actively selected](https://github.com/WordPress/gutenberg/pull/55360#issuecomment-1828420884).

## How?
The main `Tabs` component now wraps its content provider in a div that we can attach a ref to. Using that ref, we can identify what DOM element currently has focus in the browser. Comparing that element's id to our tabs ids, we can then then make sure that the focus remains on the selected tab at the right times (specifically, only if a tab was actively focused when the change occurred).

I wasn't able to use Ariakit's `activeId` value for this, because it appears to already follow the selected tab, which can leave it out of sync with browser focus if conditions are right as in the example above

## Testing Instructions

<details>
<summary>
Apply the following diff to perform this test in Storybook:</summary>

```diff
diff --git a/packages/components/src/tabs/stories/index.story.tsx b/packages/components/src/tabs/stories/index.story.tsx
index ce8c8324ed..2a724c0171 100644
--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -273,17 +273,29 @@ const ControlledModeTemplate: StoryFn< typeof Tabs > = ( props ) => {
 					<DropdownMenu
 						controls={ [
 							{
-								onClick: () => setSelectedTabId( 'tab1' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab1' ),
+										3000
+									),
 								title: 'Tab 1',
 								isActive: selectedTabId === 'tab1',
 							},
 							{
-								onClick: () => setSelectedTabId( 'tab2' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab2' ),
+										3000
+									),
 								title: 'Tab 2',
 								isActive: selectedTabId === 'tab2',
 							},
 							{
-								onClick: () => setSelectedTabId( 'tab3' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab3' ),
+										3000
+									),
 								title: 'Tab 3',
 								isActive: selectedTabId === 'tab3',
 							},

```

</details>
The above diff adds a delay to the controlled-mode selection changes. This will allow you to simulate the tab changing on you while it's already focused.

1. Launch Storybook and open the "Controlled Mode" story
2. Using the dropdown, choose a tab to switch to
3. Before it updates (you have three seconds) click somewhere on the canvas, and press [Tab] to focus the currently selected tab.
4. Note that when the controlled selection takes effect, the newly selected tab receives browser focus.
5. Repeat this test, but skip step three. Don't force the focus onto a tab.
6. Confirm that the focus doesn't move when the selection kicks in (in this case, it stays on the dropdown toggle)

## Notes

In most implementations, if a tab has focus it will automatically be the selected tab, because by default focusing a tab selects it. The exception to this is when `selectOnMove = false`. This means that in controlled mode, with that prop set to `false` it is possible for a user to be navigating tabs with their arrow keys at the same time that a controlling component forces a selection change. I expect that to be pretty rare, and this change will mostly take effect during race conditions like the one in the example above. I don't anticipate it happening often while someone's casually navigating a bit of UI. It is technically possible though, and with this PR in effect that would move the focus to the newly selected tab. I went back and forth on how to approach that.

On the one hand, we could limit this change to only fire when `selectOnMove = true`, or fine-tune it a bit to only take effect if the selected tab specifically was focused when the controlled selection change took effect.

On the other hand, I thought the change in focus might be a good way to notify assistive tech that something had just happened, rather than letting it happen silently in the background with no warning. Very much open to feedback on this point! cc @andrewhayward in case you have thoughts.
