### PR TITLE
Fix order of typography sizes and families

### DIFF
--- a/packages/block-editor/src/components/use-settings/index.js
+++ b/packages/block-editor/src/components/use-settings/index.js
@@ -103,7 +103,7 @@ const removeCustomPrefixes = ( path ) => {
  * @param {Object} value Object to merge
  * @return {Array} Array of merged items
  */
-function mergeOrigins( value ) {
+export function mergeOrigins( value ) {
 	let result = mergeCache.get( value );
 	if ( ! result ) {
 		result = [ 'default', 'theme', 'custom' ].flatMap(
@@ -114,6 +114,20 @@ function mergeOrigins( value ) {
 	return result;
 }
 const mergeCache = new WeakMap();
+
+/**
+ * For settings like `color.palette`, which have a value that is an object
+ * with `default`, `theme`, `custom`, with field values that are arrays of
+ * items, see if any of the three origins have values.
+ *
+ * @param {Object} value Object to check
+ * @return {boolean} Whether the object has values in any of the three origins
+ */
+export function hasMergedOrigins( value ) {
+	return [ 'default', 'theme', 'custom' ].some(
+		( key ) => value?.[ key ]?.length
+	);
+}
 
 /**
  * Hook that retrieves the given settings for the block instance in use.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Having the order different caused some confusion in #52200 of which values are present.

This fixes the order to be the same in all places for the typography panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Fix order of values in global styles to match block settings by using the same `mergeOrigins` function to concatenate them.
- Minor performance optimizations:
  - Don't `concat` if we only need to check `length > 0`.
  - The `mergeOrigins` function caches results for subsequent calls.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Ensure that the order is the same in all three places.

1. Site editor > Styles > Typography > Text > Typography > Size
2. Site editor > Settings > Block > Styles > Typography > Size
3. Block editor > Block > Typography > Size

Do the same for … > Typography > FontFamilies

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

### Before

| 1 | 2 | 3 |
| - | - | - |
| <img width="280" alt="1 before" src="https://github.com/WordPress/gutenberg/assets/5129775/8cd2780e-c67d-4054-a13e-a650aef8d215"> | <img width="280" alt="2 before" src="https://github.com/WordPress/gutenberg/assets/5129775/98d54f3b-9992-4266-ab6b-18c5566ceef0"> | <img width="280" alt="3 before" src="https://github.com/WordPress/gutenberg/assets/5129775/8dccded4-a41f-4cff-80e3-9bd194f6da5d"> |

### After

| 1 | 2 | 3 |
| - | - | - |
| <img width="280" alt="1 after" src="https://github.com/WordPress/gutenberg/assets/5129775/5f025573-8caf-4bf5-b810-24284bd8f77b"> | <img width="280" alt="2 after" src="https://github.com/WordPress/gutenberg/assets/5129775/81cea233-b15b-4433-ab5b-2bf347064df3"> | <img width="280" alt="3 after" src="https://github.com/WordPress/gutenberg/assets/5129775/dd7f4ccd-3d65-4811-a8df-8fdc5a41a4f8"> |
