### PR TITLE
Fix input not showing when switching to "Fixed" width

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -465,28 +465,6 @@ function BlockWithChildLayoutStyles( { block: BlockListBlock, props } ) {
  */
 export const withChildLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const layout = props.attributes.style?.layout ?? {};
-		const { selfStretch, flexSize } = layout;
-		const hasChildLayout =
-			selfStretch === 'fill' || ( selfStretch === 'fixed' && flexSize );
-
-		const shouldRenderChildLayoutStyles = useSelect(
-			( select ) => {
-				// The callback returns early to avoid block editor subscription.
-				if ( ! hasChildLayout ) {
-					return false;
-				}
-
-				return ! select( blockEditorStore ).getSettings()
-					.disableLayoutStyles;
-			},
-			[ hasChildLayout ]
-		);
-
-		if ( ! shouldRenderChildLayoutStyles ) {
-			return <BlockListBlock { ...props } />;
-		}
-
 		return (
 			<BlockWithChildLayoutStyles
 				block={ BlockListBlock }

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -467,7 +467,8 @@ export const withChildLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const layout = props.attributes.style?.layout ?? {};
 		const { selfStretch, flexSize } = layout;
-		const hasChildLayout = selfStretch || flexSize;
+		const hasChildLayout =
+			selfStretch === 'fill' || ( selfStretch === 'fixed' && flexSize );
 
 		const shouldRenderChildLayoutStyles = useSelect(
 			( select ) => {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -465,6 +465,15 @@ function BlockWithChildLayoutStyles( { block: BlockListBlock, props } ) {
  */
 export const withChildLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
+		const shouldRenderChildLayoutStyles = useSelect( ( select ) => {
+			return ! select( blockEditorStore ).getSettings()
+				.disableLayoutStyles;
+		} );
+
+		if ( ! shouldRenderChildLayoutStyles ) {
+			return <BlockListBlock { ...props } />;
+		}
+
 		return (
 			<BlockWithChildLayoutStyles
 				block={ BlockListBlock }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the regression described [here](https://github.com/WordPress/gutenberg/pull/55762#issuecomment-1831206750). The refactor of the layout rendering logic indirectly caused a bug in the child layout controls component, as detailed [here](https://github.com/WordPress/gutenberg/pull/55762#issuecomment-1831413092). 

~~This fix makes sure that the check for rendering child layout styles inside `withChildLayoutStyles` is consistent with the logic in `BlockWithChildLayoutStyles`, so that component will only render when there is CSS to output.~~

Update: this fix removes the check inside `withChildLayoutStyles` altogether so that `BlockWithChildLayoutStyles` is always rendered, and it decides whether there are styles to render or not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Row block with some children to a post or template;
2. Select one of the children, and in the sidebar, under Dimensions (in the Styles tab if the tabs appear), try changing width to "Fixed".
3. Check that the input appears under the width controls and setting a width works as expected.

TODO: the "Fixed" toggle should reset to "Fit" on page reload if there's no actual value set.

Edit: the toggle reset issue is described [here](https://github.com/WordPress/gutenberg/pull/55762#issuecomment-1832891483) and might need a separate fix.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
