### PR TITLE
Editor: Fix issue where createBlock in block template caused list view collapse

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -111,7 +111,7 @@ function useBlockEditorProps( post, template, mode ) {
 		useEntityBlockEditor( 'postType', template?.type, {
 			id: template?.id,
 		} );
-	const blocks = useMemo( () => {
+	const overriddenBlocks = useMemo( () => {
 		if ( post.type === 'wp_navigation' ) {
 			return [
 				createBlock( 'core/navigation', {
@@ -156,15 +156,13 @@ function useBlockEditorProps( post, template, mode ) {
 			return templateBlocks;
 		}
 
-		return postBlocks;
-	}, [
-		templateBlocks,
-		postBlocks,
-		rootLevelPost,
-		post.type,
-		post.id,
-		mode,
-	] );
+		return null;
+	}, [ templateBlocks, rootLevelPost, post.type, post.id, mode ] );
+
+	// Handle fallback to postBlocks outside of the above useMemo, to ensure
+	// that constructed block templates that call `createBlock` are not generated
+	// too frequently. This ensures that clientIds are stable.
+	const blocks = overriddenBlocks !== null ? overriddenBlocks : postBlocks;
 	const disableRootLevelChanges =
 		( !! template && mode === 'template-locked' ) ||
 		post.type === 'wp_navigation' ||


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/56662, related to https://github.com/WordPress/gutenberg/issues/56000

This fixes an issue when editing Navigation entities in the site editor, or when editing content within the post-only mode — in both cases, rearranging blocks will cause the list view to collapse on `trunk`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Within `useBlockEditorProps`, `createBlock` was called too frequently (every time a change was made in `postBlocks`), resulting in a new `clientId` for the wrapping Navigation block, or the wrapping Post Content block in the Navigation editor or the post-only mode, respectively.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By updating the `useMemo` to remove `postBlocks` from the dependency array, and moving the fallback to `postBlocks` to outside of the `useMemo`, we ensure that `createBlock` is only called when switching a mode, template, or post. This means that the `clientId` of the Navigation or Post Content blocks should now be stable when editing within the Navigation editor in the site editor, or in post only mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. On trunk, go to edit a Navigation entity in the Site Editor (Select a menu from the Navigation menu on the left hand side in browse mode).
2. Within the Navigation editor, with the list view open, go to rearrange items within the Navigation menu. On trunk, the list view will immediately collapse when finishing dragging. The same will happen if you use the list view in the right-hand block inspector.
3. With this PR applied, the list views should not collapse when rearranging items.
4. Similarly, test editing a page within the site editor, using the post only mode (by toggling off the template preview for an individual page). On trunk, if you rearrange blocks within the page, the list view will collapse. With this PR applied, they should not collapse.
5. Double-check that otherwise editing templates and post content is otherwise unaffected.

## Screenshots or screencast <!-- if applicable -->

### Before (Navigation)

https://github.com/WordPress/gutenberg/assets/14988353/18bef316-916c-41d2-ab0f-8b81043070c7

### After (Navigation)

https://github.com/WordPress/gutenberg/assets/14988353/0eab713a-92bd-4610-8f7d-62e47a4a2c95

### Before (editing Page content)

Notice how rearranging paragraph blocks within Content unexpectedly collapses the Content block:

https://github.com/WordPress/gutenberg/assets/14988353/bfc3a3d4-f29f-4d70-9e7e-e960afc574f8

### After (editing Page content)

https://github.com/WordPress/gutenberg/assets/14988353/f6eb0989-9fc6-419a-b53c-757f8ad816da