### PR TITLE
Site Editor: Merge the post only mode and the post editor

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -256,6 +256,18 @@ _Returns_
 
 -   `string`: Post type.
 
+### getCurrentTemplateId
+
+Returns the template ID currently being rendered/edited
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `string?`: Template ID.
+
 ### getEditedPostAttribute
 
 Returns a single attribute of the post being edited, preferring the unsaved edit if one exists, but falling back to the attribute for the last known saved state of the post.

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -111,11 +111,9 @@ export default function VisualEditor( { styles } ) {
 			...styles,
 			{
 				// We should move this in to future to the body.
-				css:
-					`.edit-post-visual-editor__post-title-wrapper{margin-top:4rem}` +
-					( paddingBottom
-						? `body{padding-bottom:${ paddingBottom }}`
-						: '' ),
+				css: paddingBottom
+					? `body{padding-bottom:${ paddingBottom }}`
+					: '',
 			},
 		],
 		[ styles ]

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -6,24 +6,21 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { PostTitle, store as editorStore } from '@wordpress/editor';
 import {
-	BlockList,
+	store as editorStore,
+	privateApis as editorPrivateApis,
+} from '@wordpress/editor';
+import {
 	BlockTools,
-	store as blockEditorStore,
 	__unstableUseTypewriter as useTypewriter,
-	__unstableUseTypingObserver as useTypingObserver,
 	__experimentalUseResizeCanvas as useResizeCanvas,
-	useSettings,
-	__experimentalRecursionProvider as RecursionProvider,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useEffect, useRef, useMemo } from '@wordpress/element';
+import { useRef, useMemo, useEffect } from '@wordpress/element';
 import { __unstableMotion as motion } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useMergeRefs } from '@wordpress/compose';
-import { parse, store as blocksStore } from '@wordpress/blocks';
-import { store as coreStore } from '@wordpress/core-data';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -31,128 +28,46 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editPostStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const {
-	LayoutStyle,
-	useLayoutClasses,
-	useLayoutStyles,
-	ExperimentalBlockCanvas: BlockCanvas,
-} = unlock( blockEditorPrivateApis );
+const { ExperimentalBlockCanvas: BlockCanvas } = unlock(
+	blockEditorPrivateApis
+);
+const { EditorCanvas } = unlock( editorPrivateApis );
 
 const isGutenbergPlugin = process.env.IS_GUTENBERG_PLUGIN ? true : false;
-
-/**
- * Given an array of nested blocks, find the first Post Content
- * block inside it, recursing through any nesting levels,
- * and return its attributes.
- *
- * @param {Array} blocks A list of blocks.
- *
- * @return {Object | undefined} The Post Content block.
- */
-function getPostContentAttributes( blocks ) {
-	for ( let i = 0; i < blocks.length; i++ ) {
-		if ( blocks[ i ].name === 'core/post-content' ) {
-			return blocks[ i ].attributes;
-		}
-		if ( blocks[ i ].innerBlocks.length ) {
-			const nestedPostContent = getPostContentAttributes(
-				blocks[ i ].innerBlocks
-			);
-
-			if ( nestedPostContent ) {
-				return nestedPostContent;
-			}
-		}
-	}
-}
-
-function checkForPostContentAtRootLevel( blocks ) {
-	for ( let i = 0; i < blocks.length; i++ ) {
-		if ( blocks[ i ].name === 'core/post-content' ) {
-			return true;
-		}
-	}
-	return false;
-}
 
 export default function VisualEditor( { styles } ) {
 	const {
 		deviceType,
 		isWelcomeGuideVisible,
 		isTemplateMode,
-		postContentAttributes,
-		editedPostTemplate = {},
-		wrapperBlockName,
-		wrapperUniqueId,
 		isBlockBasedTheme,
 		hasV3BlocksOnly,
 	} = useSelect( ( select ) => {
 		const {
 			isFeatureActive,
 			isEditingTemplate,
-			getEditedPostTemplate,
 			__experimentalGetPreviewDeviceType,
 		} = select( editPostStore );
-		const { getCurrentPostId, getCurrentPostType, getEditorSettings } =
-			select( editorStore );
+		const { getEditorSettings } = select( editorStore );
 		const { getBlockTypes } = select( blocksStore );
 		const _isTemplateMode = isEditingTemplate();
-		const postTypeSlug = getCurrentPostType();
-		let _wrapperBlockName;
-
-		if ( postTypeSlug === 'wp_block' ) {
-			_wrapperBlockName = 'core/block';
-		} else if ( ! _isTemplateMode ) {
-			_wrapperBlockName = 'core/post-content';
-		}
-
 		const editorSettings = getEditorSettings();
-		const supportsTemplateMode = editorSettings.supportsTemplateMode;
-		const postType = select( coreStore ).getPostType( postTypeSlug );
-		const canEditTemplate = select( coreStore ).canUser(
-			'create',
-			'templates'
-		);
 
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 			isTemplateMode: _isTemplateMode,
-			postContentAttributes: getEditorSettings().postContentAttributes,
-			// Post template fetch returns a 404 on classic themes, which
-			// messes with e2e tests, so check it's a block theme first.
-			editedPostTemplate:
-				postType?.viewable && supportsTemplateMode && canEditTemplate
-					? getEditedPostTemplate()
-					: undefined,
-			wrapperBlockName: _wrapperBlockName,
-			wrapperUniqueId: getCurrentPostId(),
 			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
 			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
 				return type.apiVersion >= 3;
 			} ),
 		};
 	}, [] );
-	const { isCleanNewPost } = useSelect( editorStore );
 	const hasMetaBoxes = useSelect(
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
-	const {
-		hasRootPaddingAwareAlignments,
-		isFocusMode,
-		themeHasDisabledLayoutStyles,
-		themeSupportsLayout,
-	} = useSelect( ( select ) => {
-		const _settings = select( blockEditorStore ).getSettings();
-		return {
-			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
-			themeSupportsLayout: _settings.supportsLayout,
-			isFocusMode: _settings.focusMode,
-			hasRootPaddingAwareAlignments:
-				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
-		};
-	}, [] );
+	const { setRenderingMode } = useDispatch( editorStore );
 	const desktopCanvasStyles = {
 		height: '100%',
 		width: '100%',
@@ -171,7 +86,6 @@ export default function VisualEditor( { styles } ) {
 		borderBottom: 0,
 	};
 	const resizedCanvasStyles = useResizeCanvas( deviceType, isTemplateMode );
-	const [ globalLayoutSettings ] = useSettings( 'layout' );
 	const previewMode = 'is-' + deviceType.toLowerCase() + '-preview';
 
 	let animatedStyles = isTemplateMode
@@ -192,122 +106,6 @@ export default function VisualEditor( { styles } ) {
 	const ref = useRef();
 	const contentRef = useMergeRefs( [ ref, useTypewriter() ] );
 
-	// fallbackLayout is used if there is no Post Content,
-	// and for Post Title.
-	const fallbackLayout = useMemo( () => {
-		if ( isTemplateMode ) {
-			return { type: 'default' };
-		}
-
-		if ( themeSupportsLayout ) {
-			// We need to ensure support for wide and full alignments,
-			// so we add the constrained type.
-			return { ...globalLayoutSettings, type: 'constrained' };
-		}
-		// Set default layout for classic themes so all alignments are supported.
-		return { type: 'default' };
-	}, [ isTemplateMode, themeSupportsLayout, globalLayoutSettings ] );
-
-	const newestPostContentAttributes = useMemo( () => {
-		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
-			return postContentAttributes;
-		}
-		// When in template editing mode, we can access the blocks directly.
-		if ( editedPostTemplate?.blocks ) {
-			return getPostContentAttributes( editedPostTemplate?.blocks );
-		}
-		// If there are no blocks, we have to parse the content string.
-		// Best double-check it's a string otherwise the parse function gets unhappy.
-		const parseableContent =
-			typeof editedPostTemplate?.content === 'string'
-				? editedPostTemplate?.content
-				: '';
-
-		return getPostContentAttributes( parse( parseableContent ) ) || {};
-	}, [
-		editedPostTemplate?.content,
-		editedPostTemplate?.blocks,
-		postContentAttributes,
-	] );
-
-	const hasPostContentAtRootLevel = useMemo( () => {
-		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
-			return false;
-		}
-		// When in template editing mode, we can access the blocks directly.
-		if ( editedPostTemplate?.blocks ) {
-			return checkForPostContentAtRootLevel( editedPostTemplate?.blocks );
-		}
-		// If there are no blocks, we have to parse the content string.
-		// Best double-check it's a string otherwise the parse function gets unhappy.
-		const parseableContent =
-			typeof editedPostTemplate?.content === 'string'
-				? editedPostTemplate?.content
-				: '';
-
-		return (
-			checkForPostContentAtRootLevel( parse( parseableContent ) ) || false
-		);
-	}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
-
-	const { layout = {}, align = '' } = newestPostContentAttributes || {};
-
-	const postContentLayoutClasses = useLayoutClasses(
-		newestPostContentAttributes,
-		'core/post-content'
-	);
-
-	const blockListLayoutClass = classnames(
-		{
-			'is-layout-flow': ! themeSupportsLayout,
-		},
-		themeSupportsLayout && postContentLayoutClasses,
-		align && `align${ align }`
-	);
-
-	const postContentLayoutStyles = useLayoutStyles(
-		newestPostContentAttributes,
-		'core/post-content',
-		'.block-editor-block-list__layout.is-root-container'
-	);
-
-	// Update type for blocks using legacy layouts.
-	const postContentLayout = useMemo( () => {
-		return layout &&
-			( layout?.type === 'constrained' ||
-				layout?.inherit ||
-				layout?.contentSize ||
-				layout?.wideSize )
-			? { ...globalLayoutSettings, ...layout, type: 'constrained' }
-			: { ...globalLayoutSettings, ...layout, type: 'default' };
-	}, [
-		layout?.type,
-		layout?.inherit,
-		layout?.contentSize,
-		layout?.wideSize,
-		globalLayoutSettings,
-	] );
-
-	// If there is a Post Content block we use its layout for the block list;
-	// if not, this must be a classic theme, in which case we use the fallback layout.
-	const blockListLayout = postContentAttributes
-		? postContentLayout
-		: fallbackLayout;
-
-	const postEditorLayout =
-		blockListLayout?.type === 'default' && ! hasPostContentAtRootLevel
-			? fallbackLayout
-			: blockListLayout;
-
-	const observeTypingRef = useTypingObserver();
-	const titleRef = useRef();
-	useEffect( () => {
-		if ( isWelcomeGuideVisible || ! isCleanNewPost() ) {
-			return;
-		}
-		titleRef?.current?.focus();
-	}, [ isWelcomeGuideVisible, isCleanNewPost ] );
-
 	styles = useMemo(
 		() => [
 			...styles,
@@ -323,18 +121,20 @@ export default function VisualEditor( { styles } ) {
 		[ styles ]
 	);
 
-	// Add some styles for alignwide/alignfull Post Content and its children.
-	const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
-		.is-root-container.alignwide:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
-		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
-		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
-
 	const isToBeIframed =
 		( ( hasV3BlocksOnly || ( isGutenbergPlugin && isBlockBasedTheme ) ) &&
 			! hasMetaBoxes ) ||
 		isTemplateMode ||
 		deviceType === 'Tablet' ||
 		deviceType === 'Mobile';
+
+	useEffect( () => {
+		if ( isTemplateMode ) {
+			setRenderingMode( 'all' );
+		} else {
+			setRenderingMode( 'post-only' );
+		}
+	}, [ isTemplateMode, setRenderingMode ] );
 
 	return (
 		<BlockTools
@@ -361,65 +161,18 @@ export default function VisualEditor( { styles } ) {
 						styles={ styles }
 						height="100%"
 					>
-						{ themeSupportsLayout &&
-							! themeHasDisabledLayoutStyles &&
-							! isTemplateMode && (
-								<>
-									<LayoutStyle
-										selector=".edit-post-visual-editor__post-title-wrapper"
-										layout={ fallbackLayout }
-									/>
-									<LayoutStyle
-										selector=".block-editor-block-list__layout.is-root-container"
-										layout={ postEditorLayout }
-									/>
-									{ align && (
-										<LayoutStyle css={ alignCSS } />
-									) }
-									{ postContentLayoutStyles && (
-										<LayoutStyle
-											layout={ postContentLayout }
-											css={ postContentLayoutStyles }
-										/>
-									) }
-								</>
-							) }
-						{ ! isTemplateMode && (
-							<div
-								className={ classnames(
-									'edit-post-visual-editor__post-title-wrapper',
-									{
-										'is-focus-mode': isFocusMode,
-										'has-global-padding':
-											hasRootPaddingAwareAlignments,
-									}
-								) }
-								contentEditable={ false }
-								ref={ observeTypingRef }
-							>
-								<PostTitle ref={ titleRef } />
-							</div>
-						) }
-						<RecursionProvider
-							blockName={ wrapperBlockName }
-							uniqueId={ wrapperUniqueId }
-						>
-							<BlockList
-								className={
-									isTemplateMode
-										? 'wp-site-blocks'
-										: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
-								}
-								layout={ blockListLayout }
-								dropZoneElement={
-									// When iframed, pass in the html element of the iframe to
-									// ensure the drop zone extends to the edges of the iframe.
-									isToBeIframed
-										? ref.current?.parentNode
-										: ref.current
-								}
-							/>
-						</RecursionProvider>
+						<EditorCanvas
+							dropZoneElement={
+								// When iframed, pass in the html element of the iframe to
+								// ensure the drop zone extends to the edges of the iframe.
+								isToBeIframed
+									? ref.current?.parentNode
+									: ref.current
+							}
+							// We should auto-focus the canvas (title) on load.
+							// eslint-disable-next-line jsx-a11y/no-autofocus
+							autoFocus={ ! isWelcomeGuideVisible }
+						/>
 					</BlockCanvas>
 				</motion.div>
 			</motion.div>

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -38,21 +38,6 @@
 	// See also https://www.w3.org/TR/CSS22/visudet.html#the-height-property.
 }
 
-// Ideally this wrapper div is not needed but if we want to match the positioning of blocks
-// .block-editor-block-list__layout and block-editor-block-list__block
-// We need to have two DOM elements.
-.edit-post-visual-editor__post-title-wrapper {
-	.editor-post-title {
-		// Center.
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	// Add extra margin at the top, to push down the Title area in the post editor.
-	margin-top: 4rem;
-	margin-bottom: var(--wp--style--block-gap);
-}
-
 .edit-post-visual-editor__content-area {
 	width: 100%;
 	height: 100%;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -36,7 +36,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		hiddenBlockTypes,
 		blockTypes,
 		keepCaretInsideBlock,
-		hasTemplate,
 		template,
 	} = useSelect(
 		( select ) => {
@@ -67,8 +66,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				getEditorSettings().supportsTemplateMode;
 			const isViewable = getPostType( postType )?.viewable ?? false;
 			const canEditTemplate = canUser( 'create', 'templates' );
-			const _hasTemplate =
-				supportsTemplateMode && isViewable && canEditTemplate;
 
 			return {
 				hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
@@ -82,8 +79,10 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				hiddenBlockTypes: getHiddenBlockTypes(),
 				blockTypes: getBlockTypes(),
 				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
-				hasTemplate: _hasTemplate,
-				template: _hasTemplate ? getEditedPostTemplate() : null,
+				template:
+					supportsTemplateMode && isViewable && canEditTemplate
+						? getEditedPostTemplate()
+						: null,
 				post: postObject,
 			};
 		},
@@ -143,7 +142,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		keepCaretInsideBlock,
 	] );
 
-	if ( ! post || ( hasTemplate && ! template ) ) {
+	if ( ! post ) {
 		return null;
 	}
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -36,13 +36,12 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		hiddenBlockTypes,
 		blockTypes,
 		keepCaretInsideBlock,
-		isTemplateMode,
+		hasTemplate,
 		template,
 	} = useSelect(
 		( select ) => {
 			const {
 				isFeatureActive,
-				isEditingTemplate,
 				getEditedPostTemplate,
 				getHiddenBlockTypes,
 			} = select( editPostStore );
@@ -68,6 +67,8 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				getEditorSettings().supportsTemplateMode;
 			const isViewable = getPostType( postType )?.viewable ?? false;
 			const canEditTemplate = canUser( 'create', 'templates' );
+			const _hasTemplate =
+				supportsTemplateMode && isViewable && canEditTemplate;
 
 			return {
 				hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
@@ -81,11 +82,8 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				hiddenBlockTypes: getHiddenBlockTypes(),
 				blockTypes: getBlockTypes(),
 				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
-				isTemplateMode: isEditingTemplate(),
-				template:
-					supportsTemplateMode && isViewable && canEditTemplate
-						? getEditedPostTemplate()
-						: null,
+				hasTemplate: _hasTemplate,
+				template: _hasTemplate ? getEditedPostTemplate() : null,
 				post: postObject,
 			};
 		},
@@ -145,7 +143,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		keepCaretInsideBlock,
 	] );
 
-	if ( ! post ) {
+	if ( ! post || ( hasTemplate && ! template ) ) {
 		return null;
 	}
 
@@ -156,7 +154,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 				post={ post }
 				initialEdits={ initialEdits }
 				useSubRegistry={ false }
-				__unstableTemplate={ isTemplateMode ? template : undefined }
+				__unstableTemplate={ template }
 				{ ...props }
 			>
 				<ErrorBoundary>

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -7,12 +7,9 @@ import classnames from 'classnames';
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
-import {
-	BlockList,
-	BlockTools,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { BlockTools, store as blockEditorStore } from '@wordpress/block-editor';
 import { useViewportMatch, useResizeObserver } from '@wordpress/compose';
+
 /**
  * Internal dependencies
  */
@@ -28,12 +25,6 @@ import {
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import PageContentFocusNotifications from '../page-content-focus-notifications';
-
-const LAYOUT = {
-	type: 'default',
-	// At the root level of the site editor, no alignments should be allowed.
-	alignments: [],
-};
 
 export default function SiteEditorCanvas() {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
@@ -56,16 +47,6 @@ export default function SiteEditorCanvas() {
 
 	const settings = useSiteEditorSettings();
 
-	const { hasBlocks } = useSelect( ( select ) => {
-		const { getBlockCount } = select( blockEditorStore );
-
-		const blocks = getBlockCount();
-
-		return {
-			hasBlocks: !! blocks,
-		};
-	}, [] );
-
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const enableResizing =
 		isFocusMode &&
@@ -75,17 +56,7 @@ export default function SiteEditorCanvas() {
 
 	const contentRef = useRef();
 	const isTemplateTypeNavigation = templateType === NAVIGATION_POST_TYPE;
-
 	const isNavigationFocusMode = isTemplateTypeNavigation && isFocusMode;
-
-	// Hide the appender when:
-	// - In navigation focus mode (should only allow the root Nav block).
-	// - In view mode (i.e. not editing).
-	const showBlockAppender =
-		( isNavigationFocusMode && hasBlocks ) || isViewMode
-			? false
-			: undefined;
-
 	const forceFullHeight = isNavigationFocusMode;
 
 	return (
@@ -126,23 +97,6 @@ export default function SiteEditorCanvas() {
 									contentRef={ contentRef }
 								>
 									{ resizeObserver }
-									<BlockList
-										className={ classnames(
-											'edit-site-block-editor__block-list wp-site-blocks',
-											{
-												'is-navigation-block':
-													isTemplateTypeNavigation,
-											}
-										) }
-										dropZoneElement={
-											// Pass in the html element of the iframe to ensure that
-											// the drop zone extends to the very edges of the iframe,
-											// even if the template is shorter than the viewport.
-											contentRef.current?.parentNode
-										}
-										layout={ LAYOUT }
-										renderAppender={ showBlockAppender }
-									/>
 								</EditorCanvas>
 							</ResizableEditor>
 						</BlockTools>

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -14,7 +14,7 @@
 
 // Navigation focus mode requires padding around the root Navigation block
 // for presentational purposes.
-.edit-site-block-editor__block-list.is-navigation-block {
+.edit-site-editor-canvas__block-list.is-navigation-block {
 	padding: $grid-unit-30;
 }
 

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -138,6 +138,7 @@ export function useSpecificEditorSettings() {
 		return {
 			...settings,
 
+			supportsTemplateMode: true,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
 			isDistractionFree,

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -12,6 +12,7 @@ import { humanTimeDiff } from '@wordpress/date';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -22,28 +23,39 @@ import PageContent from './page-content';
 import PageSummary from './page-summary';
 
 export default function PagePanels() {
-	const { id, type, hasResolved, status, date, password, title, modified } =
-		useSelect( ( select ) => {
-			const { getEditedPostContext } = select( editSiteStore );
-			const { getEditedEntityRecord, hasFinishedResolution } =
-				select( coreStore );
-			const context = getEditedPostContext();
-			const queryArgs = [ 'postType', context.postType, context.postId ];
-			const page = getEditedEntityRecord( ...queryArgs );
-			return {
-				hasResolved: hasFinishedResolution(
-					'getEditedEntityRecord',
-					queryArgs
-				),
-				title: page?.title,
-				id: page?.id,
-				type: page?.type,
-				status: page?.status,
-				date: page?.date,
-				password: page?.password,
-				modified: page?.modified,
-			};
-		}, [] );
+	const {
+		id,
+		type,
+		hasResolved,
+		status,
+		date,
+		password,
+		title,
+		modified,
+		renderingMode,
+	} = useSelect( ( select ) => {
+		const { getEditedPostContext } = select( editSiteStore );
+		const { getEditedEntityRecord, hasFinishedResolution } =
+			select( coreStore );
+		const { getRenderingMode } = select( editorStore );
+		const context = getEditedPostContext();
+		const queryArgs = [ 'postType', context.postType, context.postId ];
+		const page = getEditedEntityRecord( ...queryArgs );
+		return {
+			hasResolved: hasFinishedResolution(
+				'getEditedEntityRecord',
+				queryArgs
+			),
+			title: page?.title,
+			id: page?.id,
+			type: page?.type,
+			status: page?.status,
+			date: page?.date,
+			password: page?.password,
+			modified: page?.modified,
+			renderingMode: getRenderingMode(),
+		};
+	}, [] );
 
 	if ( ! hasResolved ) {
 		return null;
@@ -77,9 +89,11 @@ export default function PagePanels() {
 					postType={ type }
 				/>
 			</PanelBody>
-			<PanelBody title={ __( 'Content' ) }>
-				<PageContent />
-			</PanelBody>
+			{ renderingMode !== 'post-only' && (
+				<PanelBody title={ __( 'Content' ) }>
+					<PageContent />
+				</PanelBody>
+			) }
 		</>
 	);
 }

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -295,7 +295,7 @@ export default function EditorCanvas( {
 				<div
 					className={ classnames(
 						'editor-editor-canvas__post-title-wrapper',
-						// The following class is only hear for backward comapatibility
+						// The following class is only here for backward comapatibility
 						// some themes might be using it to style the post title.
 						'edit-post-visual-editor__post-title-wrapper',
 						{
@@ -307,7 +307,7 @@ export default function EditorCanvas( {
 					style={ {
 						// This is using inline styles
 						// so it's applied for both iframed and non iframed editors.
-						marginTop: '4em',
+						marginTop: '4rem',
 					} }
 				>
 					<PostTitle ref={ titleRef } />

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -1,0 +1,325 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	BlockList,
+	store as blockEditorStore,
+	__unstableUseTypingObserver as useTypingObserver,
+	useSettings,
+	__experimentalRecursionProvider as RecursionProvider,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { useEffect, useRef, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { parse } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import PostTitle from '../post-title';
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { LayoutStyle, useLayoutClasses, useLayoutStyles } = unlock(
+	blockEditorPrivateApis
+);
+
+/**
+ * Given an array of nested blocks, find the first Post Content
+ * block inside it, recursing through any nesting levels,
+ * and return its attributes.
+ *
+ * @param {Array} blocks A list of blocks.
+ *
+ * @return {Object | undefined} The Post Content block.
+ */
+function getPostContentAttributes( blocks ) {
+	for ( let i = 0; i < blocks.length; i++ ) {
+		if ( blocks[ i ].name === 'core/post-content' ) {
+			return blocks[ i ].attributes;
+		}
+		if ( blocks[ i ].innerBlocks.length ) {
+			const nestedPostContent = getPostContentAttributes(
+				blocks[ i ].innerBlocks
+			);
+
+			if ( nestedPostContent ) {
+				return nestedPostContent;
+			}
+		}
+	}
+}
+
+function checkForPostContentAtRootLevel( blocks ) {
+	for ( let i = 0; i < blocks.length; i++ ) {
+		if ( blocks[ i ].name === 'core/post-content' ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export default function EditorCanvas( {
+	// Ideally as we unify post and site editors, we won't need these props.
+	autoFocus,
+	dropZoneElement,
+	className,
+	renderAppender,
+} ) {
+	const {
+		renderingMode,
+		postContentAttributes,
+		editedPostTemplate = {},
+		wrapperBlockName,
+		wrapperUniqueId,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentPostId,
+			getCurrentPostType,
+			getCurrentTemplateId,
+			getEditorSettings,
+			getRenderingMode,
+		} = select( editorStore );
+		const postTypeSlug = getCurrentPostType();
+		const _renderingMode = getRenderingMode();
+		let _wrapperBlockName;
+
+		if ( postTypeSlug === 'wp_block' ) {
+			_wrapperBlockName = 'core/block';
+		} else if ( ! _renderingMode === 'post-only' ) {
+			_wrapperBlockName = 'core/post-content';
+		}
+
+		const editorSettings = getEditorSettings();
+		const supportsTemplateMode = editorSettings.supportsTemplateMode;
+		const postType = select( coreStore ).getPostType( postTypeSlug );
+		const canEditTemplate = select( coreStore ).canUser(
+			'create',
+			'templates'
+		);
+		const currentTemplateId = getCurrentTemplateId();
+		const template = currentTemplateId
+			? select( coreStore ).getEditedEntityRecord(
+					'postType',
+					'wp_template',
+					currentTemplateId
+			  )
+			: undefined;
+
+		return {
+			renderingMode: _renderingMode,
+			postContentAttributes: getEditorSettings().postContentAttributes,
+			// Post template fetch returns a 404 on classic themes, which
+			// messes with e2e tests, so check it's a block theme first.
+			editedPostTemplate:
+				postType?.viewable && supportsTemplateMode && canEditTemplate
+					? template
+					: undefined,
+			wrapperBlockName: _wrapperBlockName,
+			wrapperUniqueId: getCurrentPostId(),
+		};
+	}, [] );
+	const { isCleanNewPost } = useSelect( editorStore );
+	const {
+		hasRootPaddingAwareAlignments,
+		isFocusMode,
+		themeHasDisabledLayoutStyles,
+		themeSupportsLayout,
+	} = useSelect( ( select ) => {
+		const _settings = select( blockEditorStore ).getSettings();
+		return {
+			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
+			themeSupportsLayout: _settings.supportsLayout,
+			isFocusMode: _settings.focusMode,
+			hasRootPaddingAwareAlignments:
+				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
+		};
+	}, [] );
+
+	const [ globalLayoutSettings ] = useSettings( 'layout' );
+
+	// fallbackLayout is used if there is no Post Content,
+	// and for Post Title.
+	const fallbackLayout = useMemo( () => {
+		if ( renderingMode !== 'post-only' ) {
+			return { type: 'default' };
+		}
+
+		if ( themeSupportsLayout ) {
+			// We need to ensure support for wide and full alignments,
+			// so we add the constrained type.
+			return { ...globalLayoutSettings, type: 'constrained' };
+		}
+		// Set default layout for classic themes so all alignments are supported.
+		return { type: 'default' };
+	}, [ renderingMode, themeSupportsLayout, globalLayoutSettings ] );
+
+	const newestPostContentAttributes = useMemo( () => {
+		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
+			return postContentAttributes;
+		}
+		// When in template editing mode, we can access the blocks directly.
+		if ( editedPostTemplate?.blocks ) {
+			return getPostContentAttributes( editedPostTemplate?.blocks );
+		}
+		// If there are no blocks, we have to parse the content string.
+		// Best double-check it's a string otherwise the parse function gets unhappy.
+		const parseableContent =
+			typeof editedPostTemplate?.content === 'string'
+				? editedPostTemplate?.content
+				: '';
+
+		return getPostContentAttributes( parse( parseableContent ) ) || {};
+	}, [
+		editedPostTemplate?.content,
+		editedPostTemplate?.blocks,
+		postContentAttributes,
+	] );
+
+	const hasPostContentAtRootLevel = useMemo( () => {
+		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
+			return false;
+		}
+		// When in template editing mode, we can access the blocks directly.
+		if ( editedPostTemplate?.blocks ) {
+			return checkForPostContentAtRootLevel( editedPostTemplate?.blocks );
+		}
+		// If there are no blocks, we have to parse the content string.
+		// Best double-check it's a string otherwise the parse function gets unhappy.
+		const parseableContent =
+			typeof editedPostTemplate?.content === 'string'
+				? editedPostTemplate?.content
+				: '';
+
+		return (
+			checkForPostContentAtRootLevel( parse( parseableContent ) ) || false
+		);
+	}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
+
+	const { layout = {}, align = '' } = newestPostContentAttributes || {};
+
+	const postContentLayoutClasses = useLayoutClasses(
+		newestPostContentAttributes,
+		'core/post-content'
+	);
+
+	const blockListLayoutClass = classnames(
+		{
+			'is-layout-flow': ! themeSupportsLayout,
+		},
+		themeSupportsLayout && postContentLayoutClasses,
+		align && `align${ align }`
+	);
+
+	const postContentLayoutStyles = useLayoutStyles(
+		newestPostContentAttributes,
+		'core/post-content',
+		'.block-editor-block-list__layout.is-root-container'
+	);
+
+	// Update type for blocks using legacy layouts.
+	const postContentLayout = useMemo( () => {
+		return layout &&
+			( layout?.type === 'constrained' ||
+				layout?.inherit ||
+				layout?.contentSize ||
+				layout?.wideSize )
+			? { ...globalLayoutSettings, ...layout, type: 'constrained' }
+			: { ...globalLayoutSettings, ...layout, type: 'default' };
+	}, [
+		layout?.type,
+		layout?.inherit,
+		layout?.contentSize,
+		layout?.wideSize,
+		globalLayoutSettings,
+	] );
+
+	// If there is a Post Content block we use its layout for the block list;
+	// if not, this must be a classic theme, in which case we use the fallback layout.
+	const blockListLayout = postContentAttributes
+		? postContentLayout
+		: fallbackLayout;
+
+	const postEditorLayout =
+		blockListLayout?.type === 'default' && ! hasPostContentAtRootLevel
+			? fallbackLayout
+			: blockListLayout;
+
+	const observeTypingRef = useTypingObserver();
+	const titleRef = useRef();
+	useEffect( () => {
+		if ( autoFocus || ! isCleanNewPost() ) {
+			return;
+		}
+		titleRef?.current?.focus();
+	}, [ autoFocus, isCleanNewPost ] );
+
+	// Add some styles for alignwide/alignfull Post Content and its children.
+	const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
+		.is-root-container.alignwide:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
+		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
+		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
+
+	return (
+		<>
+			{ themeSupportsLayout &&
+				! themeHasDisabledLayoutStyles &&
+				renderingMode === 'post-only' && (
+					<>
+						<LayoutStyle
+							selector=".edit-post-visual-editor__post-title-wrapper"
+							layout={ fallbackLayout }
+						/>
+						<LayoutStyle
+							selector=".block-editor-block-list__layout.is-root-container"
+							layout={ postEditorLayout }
+						/>
+						{ align && <LayoutStyle css={ alignCSS } /> }
+						{ postContentLayoutStyles && (
+							<LayoutStyle
+								layout={ postContentLayout }
+								css={ postContentLayoutStyles }
+							/>
+						) }
+					</>
+				) }
+			{ renderingMode === 'post-only' && (
+				<div
+					className={ classnames(
+						'edit-post-visual-editor__post-title-wrapper',
+						{
+							'is-focus-mode': isFocusMode,
+							'has-global-padding': hasRootPaddingAwareAlignments,
+						}
+					) }
+					contentEditable={ false }
+					ref={ observeTypingRef }
+				>
+					<PostTitle ref={ titleRef } />
+				</div>
+			) }
+			<RecursionProvider
+				blockName={ wrapperBlockName }
+				uniqueId={ wrapperUniqueId }
+			>
+				<BlockList
+					className={ classnames(
+						className,
+						renderingMode !== 'post-only'
+							? 'wp-site-blocks'
+							: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
+					) }
+					layout={ blockListLayout }
+					dropZoneElement={ dropZoneElement }
+					renderAppender={ renderAppender }
+				/>
+			</RecursionProvider>
+		</>
+	);
+}

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -295,6 +295,9 @@ export default function EditorCanvas( {
 				<div
 					className={ classnames(
 						'editor-editor-canvas__post-title-wrapper',
+						// The following class is only hear for backward comapatibility
+						// some themes might be using it to style the post title.
+						'edit-post-visual-editor__post-title-wrapper',
 						{
 							'has-global-padding': hasRootPaddingAwareAlignments,
 						}

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -128,7 +128,6 @@ export default function EditorCanvas( {
 	const { isCleanNewPost } = useSelect( editorStore );
 	const {
 		hasRootPaddingAwareAlignments,
-		isFocusMode,
 		themeHasDisabledLayoutStyles,
 		themeSupportsLayout,
 	} = useSelect( ( select ) => {
@@ -136,7 +135,6 @@ export default function EditorCanvas( {
 		return {
 			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
 			themeSupportsLayout: _settings.supportsLayout,
-			isFocusMode: _settings.focusMode,
 			hasRootPaddingAwareAlignments:
 				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
 		};
@@ -273,7 +271,7 @@ export default function EditorCanvas( {
 				renderingMode === 'post-only' && (
 					<>
 						<LayoutStyle
-							selector=".edit-post-visual-editor__post-title-wrapper"
+							selector=".editor-editor-canvas__post-title-wrapper"
 							layout={ fallbackLayout }
 						/>
 						<LayoutStyle
@@ -292,14 +290,18 @@ export default function EditorCanvas( {
 			{ renderingMode === 'post-only' && (
 				<div
 					className={ classnames(
-						'edit-post-visual-editor__post-title-wrapper',
+						'editor-editor-canvas__post-title-wrapper',
 						{
-							'is-focus-mode': isFocusMode,
 							'has-global-padding': hasRootPaddingAwareAlignments,
 						}
 					) }
 					contentEditable={ false }
 					ref={ observeTypingRef }
+					style={ {
+						// This is using inline styles
+						// so it's applied for both iframed and non iframed editors.
+						marginTop: '4em',
+					} }
 				>
 					<PostTitle ref={ titleRef } />
 				</div>

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -159,7 +159,11 @@ export default function EditorCanvas( {
 	}, [ renderingMode, themeSupportsLayout, globalLayoutSettings ] );
 
 	const newestPostContentAttributes = useMemo( () => {
-		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
+		if (
+			! editedPostTemplate?.content &&
+			! editedPostTemplate?.blocks &&
+			postContentAttributes
+		) {
 			return postContentAttributes;
 		}
 		// When in template editing mode, we can access the blocks directly.

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -254,7 +254,7 @@ export default function EditorCanvas( {
 	const observeTypingRef = useTypingObserver();
 	const titleRef = useRef();
 	useEffect( () => {
-		if ( autoFocus || ! isCleanNewPost() ) {
+		if ( ! autoFocus || ! isCleanNewPost() ) {
 			return;
 		}
 		titleRef?.current?.focus();

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import EditorCanvas from './components/editor-canvas';
 import { ExperimentalEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
 import { EntitiesSavedStatesExtensible } from './components/entities-saved-states';
@@ -9,6 +10,7 @@ import PostPanelRow from './components/post-panel-row';
 
 export const privateApis = {};
 lock( privateApis, {
+	EditorCanvas,
 	ExperimentalEditorProvider,
 	EntitiesSavedStatesExtensible,
 	PostPanelRow,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -560,8 +560,12 @@ export function updateEditorSettings( settings ) {
  */
 export const setRenderingMode =
 	( mode ) =>
-	( { dispatch, registry } ) => {
-		registry.dispatch( blockEditorStore ).clearSelectedBlock();
+	( { dispatch, registry, select } ) => {
+		if ( select.__unstableIsEditorReady() ) {
+			// We clear the block selection but we also need to clear the selection from the core store.
+			registry.dispatch( blockEditorStore ).clearSelectedBlock();
+			dispatch.editPost( { selection: undefined }, { undoIgnore: true } );
+		}
 
 		dispatch( {
 			type: 'SET_RENDERING_MODE',

--- a/packages/editor/src/store/index.js
+++ b/packages/editor/src/store/index.js
@@ -9,7 +9,9 @@ import { createReduxStore, register } from '@wordpress/data';
 import reducer from './reducer';
 import * as selectors from './selectors';
 import * as actions from './actions';
+import * as privateActions from './private-actions';
 import { STORE_NAME } from './constants';
+import { unlock } from '../lock-unlock';
 
 /**
  * Post editor data store configuration.
@@ -36,3 +38,4 @@ export const store = createReduxStore( STORE_NAME, {
 } );
 
 register( store );
+unlock( store ).registerPrivateActions( privateActions );

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -1,0 +1,13 @@
+/**
+ * Returns an action object used to set which template is currently being used/edited.
+ *
+ * @param {string} id Template Id.
+ *
+ * @return {Object} Action object.
+ */
+export function setCurrentTemplateId( id ) {
+	return {
+		type: 'SET_CURRENT_TEMPLATE_ID',
+		id,
+	};
+}

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -90,6 +90,15 @@ export function postId( state = null, action ) {
 	return state;
 }
 
+export function templateId( state = null, action ) {
+	switch ( action.type ) {
+		case 'SET_CURRENT_TEMPLATE_ID':
+			return action.id;
+	}
+
+	return state;
+}
+
 export function postType( state = null, action ) {
 	switch ( action.type ) {
 		case 'SETUP_EDITOR_STATE':
@@ -291,6 +300,7 @@ export function renderingMode( state = 'all', action ) {
 export default combineReducers( {
 	postId,
 	postType,
+	templateId,
 	saving,
 	deleting,
 	postLock,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -206,6 +206,17 @@ export function getCurrentPostId( state ) {
 }
 
 /**
+ * Returns the template ID currently being rendered/edited
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string?} Template ID.
+ */
+export function getCurrentTemplateId( state ) {
+	return state.templateId;
+}
+
+/**
  * Returns the number of revisions of the post currently being edited.
  *
  * @param {Object} state Global application state.

--- a/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/editor-style-overrides.css
@@ -8,7 +8,7 @@
     display: none;
 }
 
-.edit-post-visual-editor__post-title-wrapper {
+.editor-editor-canvas__post-title-wrapper {
     display: none;
 }
 

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -215,23 +215,12 @@ test.describe( 'Pages', () => {
 			} )
 		).toBeHidden();
 
-		// Content blocks are wrapped in a Group block by default.
+		// Ensure post title component to be visible.
 		await expect(
-			editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Group',
-				} )
-				.getByRole( 'document', {
-					name: 'Block: Content',
-				} )
+			editor.canvas.getByRole( 'textbox', {
+				name: 'Add Title',
+			} )
 		).toBeVisible();
-
-		// Ensure order is preserved between toggling.
-		await page
-			.locator(
-				'[aria-label="Block: Content"] + [aria-label="Block: Title"]'
-			)
-			.isVisible();
 
 		// Remove focus from templateOptionsButton button.
 		await editor.canvas.locator( 'body' ).click();


### PR DESCRIPTION
Related #52632 
Alternative to #56542 and #56586 and #56631

## What?

This PR merges the "canvas" of both the site editor and post editor under a unique component, and also makes the "post-only" mode of the site editor strictly equivalent to the default mode of the post editor as well.

Only potential downside of this PR is that we had some logic in the "post-only" mode of the site editor where we try to guess which "post content block" to render based on the template. This PR removes that and just applies the post editor logic (render post title and post content). I think the advantages of this PR greatly outweigh the potential downsides of this removal. (see the three linked alternative PRs that tried to do the same while keeping the template logic) .

For example this PR brings some niceties of the post editor to the site editor post only mode like hitting "Enter" from the post title to go to the post content.

## Testing Instructions

1- Test the post editor: creating, saving posts, switching to template mode...
2- Test the site editor: especially the "post-only" mode (disabling template preview)