### PR TITLE
DataViews: export the view components as defaults

### DIFF
--- a/packages/edit-site/src/components/dataviews/dataviews.js
+++ b/packages/edit-site/src/components/dataviews/dataviews.js
@@ -10,13 +10,13 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import ViewList from './view-list';
 import Pagination from './pagination';
 import ViewActions from './view-actions';
 import Filters from './filters';
 import Search from './search';
-import { ViewGrid } from './view-grid';
-import { ViewSideBySide } from './view-side-by-side';
+import ViewList from './view-list';
+import ViewGrid from './view-grid';
+import ViewSideBySide from './view-side-by-side';
 
 // To do: convert to view type registry.
 export const viewTypeSupportsMap = {

--- a/packages/edit-site/src/components/dataviews/view-grid.js
+++ b/packages/edit-site/src/components/dataviews/view-grid.js
@@ -13,7 +13,7 @@ import { useAsyncList } from '@wordpress/compose';
  */
 import ItemActions from './item-actions';
 
-export function ViewGrid( { data, fields, view, actions, getItemId } ) {
+export default function ViewGrid( { data, fields, view, actions, getItemId } ) {
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField
 	);

--- a/packages/edit-site/src/components/dataviews/view-side-by-side.js
+++ b/packages/edit-site/src/components/dataviews/view-side-by-side.js
@@ -3,7 +3,7 @@
  */
 import ViewList from './view-list';
 
-export function ViewSideBySide( props ) {
+export default function ViewSideBySide( props ) {
 	// To do: change to email-like preview list.
 	return <ViewList { ...props } />;
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Export the default components as default.

## Why?

For code consistency:

| Before | After | 
| --- | --- |
| <img width="466" alt="Captura de ecrã 2023-11-30, às 12 21 11" src="https://github.com/WordPress/gutenberg/assets/583546/58864bef-35a9-4043-ac20-685796fdb586"> | <img width="436" alt="Captura de ecrã 2023-11-30, às 12 20 52" src="https://github.com/WordPress/gutenberg/assets/583546/81dd5458-8985-47c9-a3bf-a18085ef0d0d"> |

## How?

Make the view component a default export.

## Testing Instructions

- Enable the "view admin" Gutenberg experiment and visit "Manage all pages" or "Manage all templates".
- Use the grid or side-by-side layout and verify that they still work as expected.
