### PR TITLE
Increase right padding of URL field to take the Submit button into account

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -74,7 +74,7 @@ $preview-image-height: 140px;
 		border-radius: $radius-block-ui;
 		height: $button-size-next-default-40px; // components do not properly support unstable-large yet.
 		margin: 0;
-		padding: $grid-unit-10 $grid-unit-20;
+		padding: $grid-unit-10 $button-size-next-default-40px $grid-unit-10 $grid-unit-20;
 		position: relative;
 		width: 100%;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/56591

## What?
<!-- In a few words, what is the PR actually doing? -->
In the link control URL field, long URLs show behind the Submit button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The link control URL should always be fully displayed and not show behind the Submit button.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Increases the right padding of the URL field by making it the same as the button width

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Edit a post.
- Select some text and click the button in the block toolbar to add a link.
- Search for a post to link, make sure the post has a long URL e.g. `http://localhost:8889/title-should-not-overflow-the-content-area/`
- Highlight the post in the suggestions dropdown by using the keyboard.
- Once the suggested post is highlighted, press the Tab key to select it and move focus to the Submit button.
- Alternatively:
- Manually enter a long URL e.g. `https://my-awesome-site.org/this-is-a-very-long-url-to-test-the-link-input-field`
- Observe the long URL fully shows and it does not appear behind the Submit button.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/WordPress/gutenberg/assets/1682452/565a8ef0-3040-4bf0-b955-01555f4e23fc)

After:

![Screenshot 2023-11-30 at 14 01 54](https://github.com/WordPress/gutenberg/assets/1682452/5e5dca00-3acf-4cc1-8744-e7b16aa1f0d7)

