### PR TITLE
Start using modules in the interactive create-block template 

### DIFF
--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Update template to use modules instead of scripts. [#56694](https://github.com/WordPress/gutenberg/pull/56694)
+
 ## 1.10.0 (2023-11-29)
 
 ### Enhancement

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -11,7 +11,11 @@
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
+// Generate unique id for aria-controls.
 $unique_id = wp_unique_id( 'p-' );
+
+// Enqueue the view file.
+gutenberg_enqueue_module( '{{namespace}}-view' );
 ?>
 
 <div

--- a/packages/create-block-interactive-template/index.js
+++ b/packages/create-block-interactive-template/index.js
@@ -14,7 +14,6 @@ module.exports = {
 			interactivity: true,
 		},
 		render: 'file:./render.php',
-		viewScript: 'file:./view.js',
 		example: {},
 	},
 	variants: {

--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -43,5 +43,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 	register_block_type( __DIR__ . '/build' );
+
+	gutenberg_register_module(
+		'{{namespace}}-view',
+		plugin_dir_url( __FILE__ ) . 'src/view.js',
+		array( '@wordpress/interactivity' ),
+		'{{version}}'
+	);
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the interactive create-block template (`create-block-interactive-template`) to start using modules instead of scripts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because, starting from Gutenberg 17.2, the Interactivity API will only be available using modules:

- https://github.com/WordPress/gutenberg/pull/56143

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For now, I've just removed the `viewScript` and registered/enqueued the `view.js` file directly to make it work. I think that should be enough until we change `wp-scripts` to support modules.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Go to the `create-block` folder
- Run `node index.js --template ../create-block-interactive-template interactive-block`
- Edit the `.wp-env.override.json` file
- Add this line to load both Gutenberg and the new plugin: `"plugins": [ ".", "./packages/create-block/interactive-block" ],`
- Start `wp-env`
- Go to a post, add an "Interactive Block" block
- Go to the frontend, check that the toggle works, and that the `view.js` file was loaded using modules (`<script type="module" src="...src/view.js">`)
