### PR TITLE
Load the import map polyfill only when there is an import map

### DIFF
--- a/lib/experimental/interactivity-api/modules.php
+++ b/lib/experimental/interactivity-api/modules.php
@@ -16,18 +16,6 @@ function gutenberg_register_interactivity_module() {
 		array(),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);
-
-	// TODO: Replace with a simpler version that only provides support for import maps.
-	// TODO: Load only if the browser doesn't support import maps (https://github.com/guybedford/es-module-shims/issues/371).
-	wp_enqueue_script(
-		'es-module-shims',
-		gutenberg_url( '/build/modules/importmap-polyfill.min.js' ),
-		array(),
-		null,
-		array(
-			'strategy' => 'defer',
-		)
-	);
 }
 
 add_action( 'wp_enqueue_scripts', 'gutenberg_register_interactivity_module' );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -115,6 +115,26 @@ class Gutenberg_Modules {
 	}
 
 	/**
+	 * Prints the necessary script to load import map polyfill for browsers that
+	 * do not support import maps.
+	 *
+	 * TODO: Replace the polyfill with a simpler version that only provides
+	 * support for import maps and load it only when the browser doesn't support
+	 * import maps (https://github.com/guybedford/es-module-shims/issues/371).
+	 */
+	public static function print_import_map_polyfill() {
+		$import_map = self::get_import_map();
+		if ( ! empty( $import_map['imports'] ) ) {
+			wp_print_script_tag(
+				array(
+					'src'   => gutenberg_url( '/build/modules/importmap-polyfill.min.js' ),
+					'defer' => true,
+				)
+			);
+		}
+	}
+
+	/**
 	 * Gets the module's version. It either returns a timestamp (if SCRIPT_DEBUG
 	 * is true), the explicit version of the module if it is set and not false, or
 	 * an empty string if none of the above conditions are met.
@@ -193,3 +213,6 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 
 // Prints the preloaded modules in the head tag.
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
+
+// Prints the script that loads the import map polyfill in the footer.
+add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -215,4 +215,4 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
-add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );
+// add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -215,4 +215,4 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
-// add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );
+add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Load the import map polyfill only when there is an actual import map.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because if there is no import map, it's not needed.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By checking if the import map is empty before adding it to the HTML.

I also tried to load the polyfill conditionally by using this logic, but in my testing with iOS Safari 16.0 it didn't work.

```html
<script>
if (!(HTMLScriptElement.supports && HTMLScriptElement.supports("importmap"))) {
  const importMapPolyfill = document.createElement("script");
  importMapPolyfill.async = true;
  importMapPolyfill.src = "URL-TO-POLYFILL";
  document.head.appendChild(importMapPolyfill);
}
</script>
```

This is the related issue in the `es-module-shims` repository:

- https://github.com/guybedford/es-module-shims/issues/371

I'll investigate why it didn't work. For now, I think this fix improves the current behavior.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Go to a page that has interactive blocks.
- Check that the import map polyfill was added.
- Go to a page that doesn't have interactive blocks.
- Check that the import map polyfill was not added.

Also, in not supported browsers (Safari < 16.3):

- Go to a page that has interactive blocks.
- Check that they keep working.