### PR TITLE
Docs: Fundamentals of Block Development - add links

### DIFF
--- a/docs/getting-started/fundamentals/block-json.md
+++ b/docs/getting-started/fundamentals/block-json.md
@@ -38,7 +38,7 @@ The [`script`](https://developer.wordpress.org/block-editor/reference-guides/blo
 
 The [`viewScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script) property allow us to define the Javascript file or files to be enqueued and loaded **only in the front end**.
 
-All these properties (`editorScript`, `editorStyle`, `script` `style`,`viewScript`) accept as a value a path for the file, a handle registered with `wp_register_script` or `wp_register_style`, or an array with a mix of both. Paths values in `block.json` are prefixed with `file:`.
+All these properties (`editorScript`, `editorStyle`, `script` `style`,`viewScript`) accept as a value a [path for the file](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedpath) (prefixed with `file:`), a [handle registered with `wp_register_script` or `wp_register_style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset), or an array with a mix of both.
 
 The [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property ([introduced on WordPress 6.1](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/)) sets the path of a `.php` template file that will render the markup returned to the front end. This only method will be used to return the markup for the block on request only if `$render_callback` function has not been passed to the `register_block_type` function.
 

--- a/docs/getting-started/fundamentals/block-json.md
+++ b/docs/getting-started/fundamentals/block-json.md
@@ -21,30 +21,30 @@ At [**Metadata in block.json**](https://developer.wordpress.org/block-editor/ref
 
 Through properties of the `block.json`, we can define how the block will be uniquely identified, how it can be found, and the info displayed for the block in the Block Editor. Some of these properties are:
 
-- `apiVersion`: the version of [the API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/) used by the block (current version is 2).
-- `name`:  a unique identifier for a block, including a namespace.
-- `title`:  a display title for a block.
-- `category`:  a block category for the block in the Inserter panel.
-- `icon`:  a [Dashicon](https://developer.wordpress.org/resource/dashicons) slug or a custom SVG icon.
-- `description`:  a short description visible in the block inspector.
-- `keywords`: to locate the block in the inserter.
-- `textdomain`: the plugin text-domain (important for things such as translations).
+- [`apiVersion`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#api-version): the version of [the API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/) used by the block (current version is 2).
+- [`name`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#name):  a unique identifier for a block, including a namespace.
+- [`title`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#title):  a display title for a block.
+- [`category`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#category):  a block category for the block in the Inserter panel.
+- [`icon`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#icon):  a [Dashicon](https://developer.wordpress.org/resource/dashicons) slug or a custom SVG icon.
+- [`description`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#description):  a short description visible in the block inspector.
+- [`keywords`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#keywords): to locate the block in the inserter.
+- [`textdomain`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#text-domain): the plugin text-domain (important for things such as translations).
 
 ## Files for the block's behavior, output, or style 
 
-The `editorScript` and `editorStyle` properties allow defining Javascript and CSS files to be enqueued and loaded **only in the editor**.
+The [`editorScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-script) and [`editorStyle`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style) properties allow defining Javascript and CSS files to be enqueued and loaded **only in the editor**.
 
-The `script` and `style` properties allow the definition of Javascript and CSS files to be enqueued and loaded **in both the editor and the front end**.
+The [`script`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script) and [`style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style) properties allow the definition of Javascript and CSS files to be enqueued and loaded **in both the editor and the front end**.
 
-The `viewScript` property allow us to define the Javascript file or files to be enqueued and loaded **only in the front end**.
+The [`viewScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script) property allow us to define the Javascript file or files to be enqueued and loaded **only in the front end**.
 
 All these properties (`editorScript`, `editorStyle`, `script` `style`,`viewScript`) accept as a value a path for the file, a handle registered with `wp_register_script` or `wp_register_style`, or an array with a mix of both. Paths values in `block.json` are prefixed with `file:`.
 
-The `render` property ([introduced on WordPress 6.1](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/)) sets the path of a `.php` template file that will render the markup returned to the front end. This only method will be used to return the markup for the block on request only if `$render_callback` function has not been passed to the `register_block_type` function.
+The [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property ([introduced on WordPress 6.1](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/)) sets the path of a `.php` template file that will render the markup returned to the front end. This only method will be used to return the markup for the block on request only if `$render_callback` function has not been passed to the `register_block_type` function.
 
 ## Data Storage in the Block with `attributes`
 
-The [`attributes` property](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/) allows a block to declare "variables" that store data or content for the block.
+The [`attributes` property](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#attributes) allows a block to declare "variables" that store data or content for the block.
 
 _Example: Attributes as defined in block.json_
 ```json
@@ -69,9 +69,9 @@ _Example: Atributes stored in the Markup representation of the block_
 <!-- /wp:block-development-examples/copyright-date-block-09aac3 -->x
 ```
 
-These attributes are passed to the React component `Edit`(to display in the Block Editor) and the `save` function (to return the markup saved to the DB) of the block, and to any server-side render definition for the block (see `render` prop above). 
+These [`attributes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#attributes) are passed to the React component `Edit`(to display in the Block Editor) and the `save` function (to return the markup saved to the DB) of the block, and to any server-side render definition for the block (see `render` prop above). 
 
-The `Edit` component receives exclusively the capability of updating the attributes via the `setAttributes` function.
+The `Edit` component receives exclusively the capability of updating the attributes via the [`setAttributes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#setattributes) function.
 
 _See how the attributes are passed to the [`Edit` component](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/edit.js), [the `save` function](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/save.js) and [the `render.php`](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/render.php) in this [full block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/copyright-date-block-09aac3) of the  code above_
 
@@ -84,7 +84,7 @@ Check the <a href="https://developer.wordpress.org/block-editor/reference-guides
 
 ## Enable UI settings panels for the block with `supports`
 
-The `supports` property allows a block to declare support for certain features, enabling users to customize specific settings (like colors or margins) from the Settings Sidebar.
+The [`supports`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#supports) property allows a block to declare support for certain features, enabling users to customize specific settings (like colors or margins) from the Settings Sidebar.
 
 _Example: Supports as defined in block.json_
 

--- a/docs/getting-started/fundamentals/block-wrapper.md
+++ b/docs/getting-started/fundamentals/block-wrapper.md
@@ -10,18 +10,18 @@ The use of <code>supports</code> generates a set of properties that need to be m
 
 A block can have three sets of markup defined, each one of them with a specific target and purpose:
 
-- The one for the **Block Editor**, defined through a `edit` React component passed to `registerBlockType` when registering the block in the client. 
+- The one for the **Block Editor**, defined through a `edit` React component passed to [`registerBlockType`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#registerblocktype) when registering the block in the client. 
 - The one used to **save the block in the DB**, defined through a `save` function passed to `registerBlockType` when registering the block in the client. 
     - This markup will be returned to the front end on request if no dynamic render has been defined for the block.
-- The one used to **dynamically render the markup of the block** returned to the front end on request, defined through the `render_callback` on `register_block_type` or the `render` PHP file in `block.json`
+- The one used to **dynamically render the markup of the block** returned to the front end on request, defined through the `render_callback` on [`register_block_type`](https://developer.wordpress.org/reference/functions/register_block_type/) or the [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) PHP file in `block.json`
     - If defined, this server-side generated markup will be returned to the front end, ignoring the markup stored in DB.
 
-For the React component `edit` and the `save` function, the block wrapper element should be a native DOM element (like `<div>`) or a React component that forwards any additional props to native DOM elements. Using a <Fragment> or <ServerSideRender> component, for instance, would be invalid.
+For the [`edit` React component and the `save` function](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/), the block wrapper element should be a native DOM element (like `<div>`) or a React component that forwards any additional props to native DOM elements. Using a <Fragment> or <ServerSideRender> component, for instance, would be invalid.
 
 
 ## The Edit component's markup
 
-The `useBlockProps()` hook available on the `@wordpress/block-editor` allows passing the required attributes for the Block Editor to the `edit` block's outer wrapper. 
+The [`useBlockProps()`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops) hook available on the [`@wordpress/block-editor`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor) allows passing the required attributes for the Block Editor to the `edit` block's outer wrapper. 
 
 Among other things, the `useBlockProps()` hook takes care of including in this wrapper:
 - An `id` for the block's markup 

--- a/docs/getting-started/fundamentals/file-structure-of-a-block.md
+++ b/docs/getting-started/fundamentals/file-structure-of-a-block.md
@@ -20,20 +20,20 @@ For more on creating a WordPress plugin see <a href="https://developer.wordpress
 
 ### `src` folder
 
-In a standard project you'll place your block files in the `src` folder. By default, the build process with `wp-scripts `will take files from this folder and will generate the bundled files in the `build` folder. 
+In a standard project you'll place your block files in the `src` folder. By default, [the build process with `wp-scripts`](https://developer.wordpress.org/block-editor/getting-started/fundamentals/javascript-in-the-block-editor/#javascript-build-process) will take files from this folder and will generate the bundled files in the `build` folder. 
 
 ### `block.json`
 
-This file contains the metadata of the block, and it's used to simplify the definition and registration of the block both in the client and on the server. 
+This file contains the [metadata of the block](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/), and it's used to simplify the definition and registration of the block both in the client and on the server. 
 
 Among other data it provides properties to define the paths of the files involved in the block's behaviour, output and style. If there's a build process involved, this `block.json` along with the generated files are placed into a destination folder (usually the `build` folder) so the paths provided target to the bundled versions of these files.
 
 The most relevant properties that can be defined in a `block.json` to set the files involved in the block's behaviour, output or style are:
-- The `editorScript` property, usually set with the path of a bundled `index.js` file (output build from `src/index.js`).
-- The `style` property, usually set with the path of a bundled `style-index.css` file (output build from `src/style.(css|scss|sass)`).
-- The `editorStyle` property, usually set with the path of a bundled `index.css` (output build from `src/editor.(css|scss|sass)`).
-- The `render` property, usually set with the path of a bundled `render.php` (output copied from `src/render.php`).
-- The `viewScript` property, usually set with the path of a bundled `view.js` (output copied from `src/view.php`).
+- The [`editorScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-script) property, usually set with the path of a bundled `index.js` file (output build from `src/index.js`).
+- The [`style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style) property, usually set with the path of a bundled `style-index.css` file (output build from `src/style.(css|scss|sass)`).
+- The [`editorStyle`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style) property, usually set with the path of a bundled `index.css` (output build from `src/editor.(css|scss|sass)`).
+- The [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property, usually set with the path of a bundled `render.php` (output copied from `src/render.php`).
+- The [`viewScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script) property, usually set with the path of a bundled `view.js` (output copied from `src/view.php`).
 
 [![Open Build Output Diagram in excalidraw](https://developer.wordpress.org/files/2023/11/file-structure-build-output.png)](https://excalidraw.com/#json=c22LROgcG4JkD-7SkuE-N,rQW_ViJBq0Yk3qhCgqD6zQ "Open Build Output Diagram in excalidraw")
 
@@ -43,15 +43,15 @@ The `index.js` file (or any other file defined in the `editorScript` property of
 
 ### `edit.js`
 
-The `edit.js` commonly gets used to contain the React component that gets used in the editor for our block. It usually exports a single component that then gets passed to the `edit` property of the `registerBlockType` function in the `index.js` file.
+The `edit.js` commonly gets used to contain the React component that gets used in the editor for our block. It usually exports a single component that then gets passed to the [`edit` property of the `registerBlockType`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit) function in the `index.js` file.
 
 ### `save.js`
 
-The `save.js` exports the function that returns the static HTML markup that gets saved to the Database. 
+The `save.js` exports the function that returns the static HTML markup that gets saved to the Database and that is passed to the [`save` property of the `registerBlockType`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#save) function in the `index.js` file.
 
 ### `style.(css|scss|sass)`
 
-A `style` file with any of the extensions `.css`, `.scss` or `.sass`, contains the styles of the block that will be loaded in both the editor and the frontend. In the build process this file is converted into `style-index.css` which is usually defined at `style` property in `block.json`
+A `style` file with any of the extensions `.css`, `.scss` or `.sass`, contains the styles of the block that will be loaded in both the editor and the frontend. In the build process this file is converted into `style-index.css` which is usually defined at [`style`]([`style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style)) property in `block.json`
 
 <div class="callout callout-info">
     The webpack config used internally by <code>wp-scripts</code> includes a <a href="https://webpack.js.org/loaders/css-loader/">css-loader</a> chained with <a herf="https://webpack.js.org/loaders/postcss-loader/">postcss-loader</a> and <a href="https://webpack.js.org/loaders/sass-loader/">sass-loader</a> that allows it to process CSS, SASS or SCSS files. Check <a href="https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#default-webpack-config">Default webpack config</a> for more info
@@ -60,19 +60,19 @@ A `style` file with any of the extensions `.css`, `.scss` or `.sass`, contains t
 
 ### `editor.(css|scss|sass)`
 
-An `editor` file with any of the extensions `.css`, `.scss` or `.sass`, contains the additional styles applied to the block only in the editor’s context. In the build process this file is converted into `index.css` which is usually defined at `editorStyle` property in `block.json`
+An `editor` file with any of the extensions `.css`, `.scss` or `.sass`, contains the additional styles applied to the block only in the editor’s context. In the build process this file is converted into `index.css` which is usually defined at [`editorStyle`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style) property in `block.json`
 
 ### `render.php`
 
-The `render.php` file (or any other file defined in the `render` property of `block.json`) defines the server side process that returns the markup for the block when there is a request from the frontend. If this file is defined, it will take precedence over any other ways to render the block's markup for the frontend.
+The `render.php` file (or any other file defined in the [`render`]([`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render)) property of `block.json`) defines the server side process that returns the markup for the block when there is a request from the frontend. If this file is defined, it will take precedence over any other ways to render the block's markup for the frontend.
 
 ### `view.js`
 
-The `view.js` file (or any other file defined in the `viewScript` property of `block.json`) will be loaded in the front-end when the block is displayed.
+The `view.js` file (or any other file defined in the [`viewScript`]([`viewScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script) ) property of `block.json`) will be loaded in the front-end when the block is displayed.
 
 ### `build` folder
 
-In a standard project, the `build` folder contains the generated files in the build process triggered by the `build` or `start` commands of `wp-scripts`. 
+In a standard project, the `build` folder contains the generated files in [the build process triggered by the `build` or `start` commands of `wp-scripts`](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts/#the-build-process-with-wp-scripts). 
 
 <div class="callout callout-tip">
     You can use <code>webpack-src-dir</code> and <code>output-path</code> option of <code>wp-scripts</code> build commands to <a href="https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#automatic-block-json-detection-and-the-source-code-directory">customize the entry and output points</a>

--- a/docs/getting-started/fundamentals/file-structure-of-a-block.md
+++ b/docs/getting-started/fundamentals/file-structure-of-a-block.md
@@ -51,7 +51,7 @@ The `save.js` exports the function that returns the static HTML markup that gets
 
 ### `style.(css|scss|sass)`
 
-A `style` file with any of the extensions `.css`, `.scss` or `.sass`, contains the styles of the block that will be loaded in both the editor and the frontend. In the build process this file is converted into `style-index.css` which is usually defined at [`style`]([`style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style)) property in `block.json`
+A `style` file with any of the extensions `.css`, `.scss` or `.sass`, contains the styles of the block that will be loaded in both the editor and the frontend. In the build process this file is converted into `style-index.css` which is usually defined at [`style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style) property in `block.json`
 
 <div class="callout callout-info">
     The webpack config used internally by <code>wp-scripts</code> includes a <a href="https://webpack.js.org/loaders/css-loader/">css-loader</a> chained with <a herf="https://webpack.js.org/loaders/postcss-loader/">postcss-loader</a> and <a href="https://webpack.js.org/loaders/sass-loader/">sass-loader</a> that allows it to process CSS, SASS or SCSS files. Check <a href="https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#default-webpack-config">Default webpack config</a> for more info

--- a/docs/getting-started/fundamentals/file-structure-of-a-block.md
+++ b/docs/getting-started/fundamentals/file-structure-of-a-block.md
@@ -68,7 +68,7 @@ The `render.php` file (or any other file defined in the [`render`](https://devel
 
 ### `view.js`
 
-The `view.js` file (or any other file defined in the [`viewScript`]([`viewScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script) ) property of `block.json`) will be loaded in the front-end when the block is displayed.
+The `view.js` file (or any other file defined in the [`viewScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script) property of `block.json`) will be loaded in the front-end when the block is displayed.
 
 ### `build` folder
 

--- a/docs/getting-started/fundamentals/file-structure-of-a-block.md
+++ b/docs/getting-started/fundamentals/file-structure-of-a-block.md
@@ -64,7 +64,7 @@ An `editor` file with any of the extensions `.css`, `.scss` or `.sass`, contains
 
 ### `render.php`
 
-The `render.php` file (or any other file defined in the [`render`]([`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render)) property of `block.json`) defines the server side process that returns the markup for the block when there is a request from the frontend. If this file is defined, it will take precedence over any other ways to render the block's markup for the frontend.
+The `render.php` file (or any other file defined in the [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property of `block.json`) defines the server side process that returns the markup for the block when there is a request from the frontend. If this file is defined, it will take precedence over any other ways to render the block's markup for the frontend.
 
 ### `view.js`
 


### PR DESCRIPTION
Add links to some pages of [Fundamentals of Block Development](https://developer.wordpress.org/block-editor/getting-started/fundamentals/)