### PR TITLE
Core data revisions: remove hardcoded supports constant

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -19,18 +19,6 @@ export const DEFAULT_ENTITY_KEY = 'id';
 
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
 
-// A hardcoded list of post types that support revisions.
-// Reflects post types in Core's src/wp-includes/post.php.
-// @TODO: Ideally this should be fetched from the  `/types` REST API's view context.
-const POST_TYPE_ENTITIES_WITH_REVISIONS_SUPPORT = [
-	'post',
-	'page',
-	'wp_block',
-	'wp_navigation',
-	'wp_template',
-	'wp_template_part',
-];
-
 export const rootEntitiesConfig = [
 	{
 		label: __( 'Base' ),
@@ -223,9 +211,6 @@ export const rootEntitiesConfig = [
 			`/wp/v2/global-styles/${ parentId }/revisions${
 				revisionId ? '/' + revisionId : ''
 			}`,
-		supports: {
-			revisions: true,
-		},
 		supportsPagination: true,
 	},
 	{
@@ -315,11 +300,6 @@ async function loadPostTypeEntities() {
 				selection: true,
 			},
 			mergedEdits: { meta: true },
-			supports: {
-				revisions: POST_TYPE_ENTITIES_WITH_REVISIONS_SUPPORT.includes(
-					postType?.slug
-				),
-			},
 			rawAttributes: POST_RAW_ATTRIBUTES,
 			getTitle: ( record ) =>
 				record?.title?.rendered ||

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -355,51 +355,37 @@ function entity( entityConfig ) {
 				return state;
 			},
 
-			// Add revisions to the state tree if the post type supports it.
-			...( entityConfig?.supports?.revisions
-				? {
-						revisions: ( state = {}, action ) => {
-							// Use the same queriedDataReducer shape for revisions.
-							if ( action.type === 'RECEIVE_ITEM_REVISIONS' ) {
-								const recordKey = action.recordKey;
-								delete action.recordKey;
-								const newState = queriedDataReducer(
-									state[ recordKey ],
-									{
-										...action,
-										type: 'RECEIVE_ITEMS',
+			revisions: ( state = {}, action ) => {
+				// Use the same queriedDataReducer shape for revisions.
+				if ( action.type === 'RECEIVE_ITEM_REVISIONS' ) {
+					const recordKey = action.recordKey;
+					delete action.recordKey;
+					const newState = queriedDataReducer( state[ recordKey ], {
+						...action,
+						type: 'RECEIVE_ITEMS',
+					} );
+					return {
+						...state,
+						[ recordKey ]: newState,
+					};
+				}
+
+				if ( action.type === 'REMOVE_ITEMS' ) {
+					return Object.fromEntries(
+						Object.entries( state ).filter(
+							( [ id ] ) =>
+								! action.itemIds.some( ( itemId ) => {
+									if ( Number.isInteger( itemId ) ) {
+										return itemId === +id;
 									}
-								);
-								return {
-									...state,
-									[ recordKey ]: newState,
-								};
-							}
+									return itemId === id;
+								} )
+						)
+					);
+				}
 
-							if ( action.type === 'REMOVE_ITEMS' ) {
-								return Object.fromEntries(
-									Object.entries( state ).filter(
-										( [ id ] ) =>
-											! action.itemIds.some(
-												( itemId ) => {
-													if (
-														Number.isInteger(
-															itemId
-														)
-													) {
-														return itemId === +id;
-													}
-													return itemId === id;
-												}
-											)
-									)
-								);
-							}
-
-							return state;
-						},
-				  }
-				: {} ),
+				return state;
+			},
 		} )
 	);
 }


### PR DESCRIPTION
Alternative to: 

- https://github.com/WordPress/gutenberg/pull/56624#issuecomment-1832937295

Part of:

- https://github.com/WordPress/gutenberg/issues/56413

## What?
This PR:
- removes the hardcoded `POST_TYPES_WITH_REVISIONS_SUPPORT` constant in Core Data entities in order to let the server deal with permissions
- Wraps the `apiFetch` in a try/catch and only dispatch a response if there is one.

## Why?
So far, we've been duplicating post type revisions support in a `POST_TYPES_WITH_REVISIONS_SUPPORT` constant.

This removes that maintenance burden.

## How?



## Testing Instructions
Check that `getRevision(s)` works for supported post types.

Example:

```js
// Gets all revisions
await wp.data.resolveSelect( 'core' ).getRevisions( 'root', 'globalStyles', parentGlobalStylesId, { per_page: -1 } );

// Get a single revision
await wp.data.resolveSelect( 'core' ).getRevision( 'postType', 'page', parentId, revisionId );
```

See the test descriptions in https://github.com/WordPress/gutenberg/pull/56353 for other supported post types. 


Test with some invalid API calls, e.g., 

```js
await wp.data.resolveSelect( 'core' ).getRevisions( 'postType', 'attachment', 25 )
```
