### PR TITLE
[Experiment] Patterns: Allow the heading block and the button block to be partially synced

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -100,14 +100,17 @@ if ( $gutenberg_experiments && (
 		// Allowlist of blocks that support block connections.
 		// Currently, we only allow the following blocks and attributes:
 		// - Paragraph: content.
+		// - Heading: content.
+		// - Button: text.
 		// - Image: url.
 		$blocks_attributes_allowlist = array(
 			'core/paragraph' => array( 'content' ),
+			'core/heading'   => array( 'content' ),
+			'core/button'    => array( 'text' ),
 			'core/image'     => array( 'url' ),
 		);
 
 		// Whitelist of the block types that support block connections.
-		// Currently, we only allow the Paragraph and Image blocks to use block connections.
 		if ( ! in_array( $block['blockName'], array_keys( $blocks_attributes_allowlist ), true ) ) {
 			return $block_content;
 		}
@@ -168,14 +171,14 @@ if ( $gutenberg_experiments && (
 				continue;
 			}
 
-			$tags  = new WP_HTML_Tag_Processor( $block_content );
-			$found = $tags->next_tag(
-				array(
-					// TODO: In the future, when blocks other than Paragraph and Image are
-					// supported, we should build the full query from CSS selector.
-					'tag_name' => $block_type->attributes[ $attribute_name ]['selector'],
-				)
-			);
+			$selectors = explode( ',', $block_type->attributes[ $attribute_name ]['selector'] );
+			$found     = false;
+			while ( ! $found && count( $selectors ) > 0 ) {
+				$tags = new WP_HTML_Tag_Processor( $block_content );
+				// TODO: In the future, when blocks are supported,
+				// we should build the full query from CSS selector.
+				$found = $tags->next_tag( trim( array_shift( $selectors ) ) );
+			}
 			if ( ! $found ) {
 				return $block_content;
 			}

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -175,7 +175,7 @@ if ( $gutenberg_experiments && (
 			$found     = false;
 			while ( ! $found && count( $selectors ) > 0 ) {
 				$tags = new WP_HTML_Tag_Processor( $block_content );
-				// TODO: In the future, when blocks are supported,
+				// TODO: In the future, to support connecting more block attributes,
 				// we should build the full query from CSS selector.
 				$found = $tags->next_tag( trim( array_shift( $selectors ) ) );
 			}

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -118,7 +118,8 @@
 				"width": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-button .wp-block-button__link"
+		"__experimentalSelector": ".wp-block-button .wp-block-button__link",
+		"__experimentalConnections": true
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -63,7 +63,8 @@
 			}
 		},
 		"__unstablePasteTextInline": true,
-		"__experimentalSlashInserter": true
+		"__experimentalSlashInserter": true,
+		"__experimentalConnections": true
 	},
 	"editorStyle": "wp-block-heading-editor",
 	"style": "wp-block-heading"

--- a/packages/editor/src/hooks/pattern-partial-syncing.js
+++ b/packages/editor/src/hooks/pattern-partial-syncing.js
@@ -23,7 +23,6 @@ const {
 /**
  * Override the default edit UI to include a new block inspector control for
  * assigning a partial syncing controls to supported blocks in the pattern editor.
- * Currently, only the `core/paragraph` block is supported.
  *
  * @param {Component} BlockEdit Original component.
  *

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -23,4 +23,6 @@ export const PATTERN_SYNC_TYPES = {
 // TODO: This should not be hardcoded. Maybe there should be a config and/or an UI.
 export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 	'core/paragraph': { content: __( 'Content' ) },
+	'core/heading': { content: __( 'Content' ) },
+	'core/button': { text: __( 'Text' ) },
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Based on #56235. Allow the `core/heading` block and the `core/button` block to be partially synced.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To have more blocks to test the feature.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I had to refactor a part of the block connections code to support `,`-separated attributes' selectors. It'd be nice to get a sanity check that it doesn't break or block the work on the block connections side. (c.c. @SantosGuillamot)

Note that the solution here is likely just a temporary solution. Ideally, we might want to support arbitrary CSS selectors in the `WP_HTML_Tag_Processor` API.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the "Test partially synced patterns" gutenberg experiment.
2. Go to Editor -> Patterns -> create a new synced pattern.
3. Add some blocks that include the paragraph, heading, and button blocks.
4. For each block above, open the block inspector and check the "Synced attributes" checkbox under "Advanced".
5. Save the (partially) synced pattern.
6. Open a post editor and insert a couple of the just-created synced patterns.
7. Edit the contents of the abovementioned blocks on the pattern instance and save the post.
8. Visit the saved post (the frontend) and expect the content to be synced to each instance separately.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/85d45633-4f40-49cb-a7c0-6adbfb17712c

