### PR TITLE
DataViews: rename view components 

### DIFF
--- a/packages/edit-site/src/components/dataviews/constants.js
+++ b/packages/edit-site/src/components/dataviews/constants.js
@@ -7,7 +7,7 @@ import { blockTable, category, drawerLeft } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import ViewList from './view-list';
+import ViewTable from './view-table';
 import ViewGrid from './view-grid';
 import ViewSideBySide from './view-side-by-side';
 
@@ -26,7 +26,7 @@ export const VIEW_LAYOUTS = [
 	{
 		type: LAYOUT_TABLE,
 		label: __( 'Table' ),
-		component: ViewList,
+		component: ViewTable,
 		icon: blockTable,
 		supports: {
 			preview: false,

--- a/packages/edit-site/src/components/dataviews/constants.js
+++ b/packages/edit-site/src/components/dataviews/constants.js
@@ -9,7 +9,7 @@ import { blockTable, category, drawerLeft } from '@wordpress/icons';
  */
 import ViewTable from './view-table';
 import ViewGrid from './view-grid';
-import ViewSideBySide from './view-side-by-side';
+import ViewList from './view-list';
 
 // Field types.
 export const ENUMERATION_TYPE = 'enumeration';
@@ -44,7 +44,7 @@ export const VIEW_LAYOUTS = [
 	{
 		type: LAYOUT_LIST,
 		label: __( 'List' ),
-		component: ViewSideBySide,
+		component: ViewList,
 		icon: drawerLeft,
 		supports: {
 			preview: true,

--- a/packages/edit-site/src/components/dataviews/view-list.js
+++ b/packages/edit-site/src/components/dataviews/view-list.js
@@ -3,7 +3,7 @@
  */
 import ViewTable from './view-table';
 
-export default function ViewSideBySide( props ) {
+export default function ViewList( props ) {
 	// To do: change to email-like preview list.
 	return <ViewTable { ...props } />;
 }

--- a/packages/edit-site/src/components/dataviews/view-side-by-side.js
+++ b/packages/edit-site/src/components/dataviews/view-side-by-side.js
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import ViewList from './view-list';
+import ViewTable from './view-table';
 
 export default function ViewSideBySide( props ) {
 	// To do: change to email-like preview list.
-	return <ViewList { ...props } />;
+	return <ViewTable { ...props } />;
 }

--- a/packages/edit-site/src/components/dataviews/view-table.js
+++ b/packages/edit-site/src/components/dataviews/view-table.js
@@ -229,7 +229,7 @@ function WithSeparators( { children } ) {
 		) );
 }
 
-function ViewList( {
+function ViewTable( {
 	view,
 	onChangeView,
 	fields,
@@ -509,4 +509,4 @@ function ViewList( {
 	);
 }
 
-export default ViewList;
+export default ViewTable;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/56693

## What?

This PR renames the view components:

- `ViewList` to `ViewTable`
- `ViewSideBySide` to `ViewList`

## Why?

To follow-up on the new names introduced in https://github.com/WordPress/gutenberg/pull/56693. The component rename wasn't done there to make reviews easier.

## How?

Rename the components and the corresponding imports/exports.

## Testing Instructions

- Enable the "admin views" experiment and visit "Manage all pages" and/or "Manage all templates".
- Switch layouts and verify that everything still works properly.
