### PR TITLE
getValueFromObjectPath: remove memize

### DIFF
--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { paramCase } from 'change-case';
-import memoize from 'memize';
 
 /**
  * Converts any string to kebab case.
@@ -65,8 +64,6 @@ export function setImmutably( object, path, value ) {
 	return object;
 }
 
-const stringToPath = memoize( ( path ) => path.split( '.' ) );
-
 /**
  * Helper util to return a value from a certain path of the object.
  * Path is specified as either:
@@ -80,9 +77,9 @@ const stringToPath = memoize( ( path ) => path.split( '.' ) );
  * @return {*} Value of the object property at the specified path.
  */
 export const getValueFromObjectPath = ( object, path, defaultValue ) => {
-	const normalizedPath = Array.isArray( path ) ? path : stringToPath( path );
+	const arrayPath = Array.isArray( path ) ? path : path.split( '.' );
 	let value = object;
-	normalizedPath.forEach( ( fieldName ) => {
+	arrayPath.forEach( ( fieldName ) => {
 		value = value?.[ fieldName ];
 	} );
 	return value ?? defaultValue;


### PR DESCRIPTION
Removes memoization of the string-to-path code when getting a nested value from object. As suggested in https://github.com/WordPress/gutenberg/pull/55337#discussion_r1409914932. I added the memoization only because Lodash `get` also does it internally. But even when measuring performance in the original #55337 I didn't see any improvements.

The `memize` package continues to be used in `block-editor` by one of React Native components.