### PR TITLE
DataViews: set proper role for AddFilter's items

### DIFF
--- a/packages/edit-site/src/components/dataviews/add-filter.js
+++ b/packages/edit-site/src/components/dataviews/add-filter.js
@@ -81,8 +81,6 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 						{ filter.elements.map( ( element ) => (
 							<DropdownMenuItem
 								key={ element.value }
-								role="menuitemradio"
-								aria-checked={ false }
 								onSelect={ () => {
 									onChangeView( ( currentView ) => ( {
 										...currentView,

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -66,7 +66,7 @@ test.describe( 'Templates', () => {
 		// Filter by author.
 		await page.getByRole( 'button', { name: 'Add filter' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Author' } ).hover();
-		await page.getByRole( 'menuitemradio', { name: 'admin' } ).click();
+		await page.getByRole( 'menuitem', { name: 'admin' } ).click();
 		await expect( titles ).toHaveCount( 1 );
 		await expect( titles.first() ).toHaveText( 'Date Archives' );
 
@@ -77,7 +77,7 @@ test.describe( 'Templates', () => {
 		await expect( titles ).toHaveCount( 3 );
 		await page.getByRole( 'button', { name: 'Add filter' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Author' } ).hover();
-		await page.getByRole( 'menuitemradio', { name: 'Emptytheme' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Emptytheme' } ).click();
 		await expect( titles ).toHaveCount( 2 );
 	} );
 	test( 'Field visibility', async ( { admin, page } ) => {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/56676#discussion_r1412006580
