### PR TITLE
DataViews: update sorting semantics

### DIFF
--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -232,22 +232,13 @@ function SortMenu( { fields, view, onChangeView } ) {
 										}
 										onSelect={ ( event ) => {
 											event.preventDefault();
-											if (
-												sortedDirection === direction
-											) {
-												onChangeView( {
-													...view,
-													sort: undefined,
-												} );
-											} else {
-												onChangeView( {
-													...view,
-													sort: {
-														field: field.id,
-														direction,
-													},
-												} );
-											}
+											onChangeView( {
+												...view,
+												sort: {
+													field: field.id,
+													direction,
+												},
+											} );
 										} }
 									>
 										{ info.label }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -118,24 +118,13 @@ function HeaderMenu( { field, view, onChangeView } ) {
 										}
 										onSelect={ ( event ) => {
 											event.preventDefault();
-											if (
-												isSorted &&
-												view.sort.direction ===
-													direction
-											) {
-												onChangeView( {
-													...view,
-													sort: undefined,
-												} );
-											} else {
-												onChangeView( {
-													...view,
-													sort: {
-														field: field.id,
-														direction,
-													},
-												} );
-											}
+											onChangeView( {
+												...view,
+												sort: {
+													field: field.id,
+													direction,
+												},
+											} );
 										} }
 									>
 										{ info.label }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

This PR updates the sorting semantics so that once the dataset is sorted, it cannot be "unsorted":

https://github.com/WordPress/gutenberg/assets/583546/38a55a4f-b743-4cfc-ae96-05cd82cc9851

## Why?

What does it mean to "unsort" something that's already sorted? It means that it's up to the dataset _source_ (pages endpoint, templates endpoint, etc.) to provide the data in whatever default sorting it provides – the dataset is sorted, we just don't know _how_.

By aligning sorting semantics with the other view configs that have a single option (pagination or layouts), its UI representation also becomes clear (see [refactoring to new components and discussion about checkboxes/radios](https://github.com/WordPress/gutenberg/pull/55625#issuecomment-1836128184)). 

## How?

Update `ViewActions` and `ViewTable` so that sorting cannot be unset, once it is set.

## Testing Instructions

- Enable the "new admin views" experiment and visit "Manage all pages" or "Manage all templates".
- Test sorting (both from the view actions menu and column sorting).
