### PR TITLE
Fix labeling of the command palette.

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -46,34 +46,29 @@ function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 
 	return (
 		<>
-			<Command.List>
-				{ commands.map( ( command ) => (
-					<Command.Item
-						key={ command.name }
-						value={ command.searchLabel ?? command.label }
-						onSelect={ () => command.callback( { close } ) }
-						id={ command.name }
+			{ commands.map( ( command ) => (
+				<Command.Item
+					key={ command.name }
+					value={ command.searchLabel ?? command.label }
+					onSelect={ () => command.callback( { close } ) }
+					id={ command.name }
+				>
+					<HStack
+						alignment="left"
+						className={ classnames( 'commands-command-menu__item', {
+							'has-icon': command.icon,
+						} ) }
 					>
-						<HStack
-							alignment="left"
-							className={ classnames(
-								'commands-command-menu__item',
-								{
-									'has-icon': command.icon,
-								}
-							) }
-						>
-							{ command.icon && <Icon icon={ command.icon } /> }
-							<span>
-								<TextHighlight
-									text={ command.label }
-									highlight={ search }
-								/>
-							</span>
-						</HStack>
-					</Command.Item>
-				) ) }
-			</Command.List>
+						{ command.icon && <Icon icon={ command.icon } /> }
+						<span>
+							<TextHighlight
+								text={ command.label }
+								highlight={ search }
+							/>
+						</span>
+					</HStack>
+				</Command.Item>
+			) ) }
 		</>
 	);
 }

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -32,6 +32,8 @@ import { Icon, search as inputIcon } from '@wordpress/icons';
  */
 import { store as commandsStore } from '../store';
 
+const inputLabel = __( 'Search for commands' );
+
 function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 	const { isLoading, commands = [] } = hook( { search } ) ?? {};
 	useEffect( () => {
@@ -176,7 +178,7 @@ function CommandInput( { isOpen, search, setSearch } ) {
 			ref={ commandMenuInput }
 			value={ search }
 			onValueChange={ setSearch }
-			placeholder={ __( 'Search for commands' ) }
+			placeholder={ inputLabel }
 			aria-activedescendant={ selectedItemId }
 			icon={ search }
 		/>
@@ -195,6 +197,7 @@ export function CommandMenu() {
 	);
 	const { open, close } = useDispatch( commandsStore );
 	const [ loaders, setLoaders ] = useState( {} );
+	const commandListRef = useRef();
 
 	useEffect( () => {
 		registerShortcut( {
@@ -207,6 +210,16 @@ export function CommandMenu() {
 			},
 		} );
 	}, [ registerShortcut ] );
+
+	// Temporary fix for the suggestions Listbox labeling.
+	// See https://github.com/pacocoursey/cmdk/issues/196
+	useEffect( () => {
+		commandListRef.current?.removeAttribute( 'aria-labelledby' );
+		commandListRef.current?.setAttribute(
+			'aria-label',
+			__( 'Command suggestions' )
+		);
+	}, [ commandListRef.current ] );
 
 	useShortcut(
 		'core/commands',
@@ -265,12 +278,10 @@ export function CommandMenu() {
 			overlayClassName="commands-command-menu__overlay"
 			onRequestClose={ closeAndReset }
 			__experimentalHideHeader
+			contentLabel={ __( 'Command palette' ) }
 		>
 			<div className="commands-command-menu__container">
-				<Command
-					label={ __( 'Command palette' ) }
-					onKeyDown={ onKeyDown }
-				>
+				<Command label={ inputLabel } onKeyDown={ onKeyDown }>
 					<div className="commands-command-menu__header">
 						<Icon icon={ inputIcon } />
 						<CommandInput
@@ -279,7 +290,7 @@ export function CommandMenu() {
 							isOpen={ isOpen }
 						/>
 					</div>
-					<Command.List>
+					<Command.List ref={ commandListRef }>
 						{ search && ! isLoading && (
 							<Command.Empty>
 								{ __( 'No results found.' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Partially fixes this issue: https://github.com/WordPress/gutenberg/issues/54502

## What?
<!-- In a few words, what is the PR actually doing? -->
- The placeholder and actual label of the input field mismatch. While the placeholder should not be used for visual labeling, we need to fix the mismatch.
- The modal dialog is unlabelled.
- The Listbox with suggestions is unlabelled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Correct labelling of ARIA widgets and form controls is fundamental for basic accessibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Uses the correct props.
- Adds a workaround for the Listbox labelling. The root issue should be fixed upstream, see https://github.com/pacocoursey/cmdk/issues/196

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open the Command palette.
- Inspect the source and:
- Observe the element with `role="dialog"` is labeled `Command palette`.
- Observe the visually hidden label element of the input field has text `Search for commands`.
- Search for some command.
- Observe suggestion container element with `role="listbox"` is labeled `Command suggestions`.
- Note: there are nested Listbox within the suggestions, those need to be fixed separately.
- Search for some other command and check again the Listbox labeling.
- Close the command palette, open it again and repeat the steps above.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
