### PR TITLE
Fixture Tests: Correctly generate fixture files for form-related blocks

### DIFF
--- a/packages/block-library/src/form-input/save.js
+++ b/packages/block-library/src/form-input/save.js
@@ -12,6 +12,7 @@ import {
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 } from '@wordpress/block-editor';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Get the name attribute from a content string.
@@ -21,11 +22,8 @@ import {
  * @return {string} Returns the slug.
  */
 const getNameFromLabel = ( content ) => {
-	const dummyElement = document.createElement( 'div' );
-	dummyElement.innerHTML = content;
-	// Get the slug.
 	return (
-		removeAccents( dummyElement.innerText )
+		removeAccents( stripHTML( content ) )
 			// Convert anything that's not a letter or number to a hyphen.
 			.replace( /[^\p{L}\p{N}]+/gu, '-' )
 			// Convert to lowercase

--- a/phpunit/class-block-fixture-test.php
+++ b/phpunit/class-block-fixture-test.php
@@ -7,6 +7,12 @@
 
 class Block_Fixture_Test extends WP_UnitTestCase {
 
+	public function filter_allowed_html( $tags ) {
+		$tags['form']['class']   = true;
+		$tags['form']['enctype'] = true;
+		return $tags;
+	}
+
 	/**
 	 * Tests that running the serialised block content through KSES doesn't cause the
 	 * HTML to change.
@@ -20,7 +26,9 @@ class Block_Fixture_Test extends WP_UnitTestCase {
 		$block = preg_replace( "/href=['\"]data:[^'\"]+['\"]/", 'href="https://wordpress.org/foo.jpg"', $block );
 		$block = preg_replace( '/url\(data:[^)]+\)/', 'url(https://wordpress.org/foo.jpg)', $block );
 
+		add_filter( 'wp_kses_allowed_html', array( $this, 'filter_allowed_html' ) );
 		$kses_block = wp_kses_post( $block );
+		remove_filter( 'wp_kses_allowed_html', array( $this, 'filter_allowed_html' ) );
 
 		// KSES adds a space at the end of self-closing tags, add it to the original to match.
 		$block = preg_replace( '|([^ ])/>|', '$1 />', $block );

--- a/test/integration/fixtures/blocks/core__form-input.html
+++ b/test/integration/fixtures/blocks/core__form-input.html
@@ -1,3 +1,3 @@
-<!-- wp:form-input {"label":"Name","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Name</span><input class="wp-block-form-input" type="text" name="Name" required aria-required="true"/></label>
+<!-- wp:form-input -->
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Label</span><input class="wp-block-form-input__input" type="text" name="label" aria-required="false"/></label>
 <!-- /wp:form-input -->

--- a/test/integration/fixtures/blocks/core__form-input.json
+++ b/test/integration/fixtures/blocks/core__form-input.json
@@ -1,11 +1,14 @@
 [
 	{
-		"name": "core/missing",
+		"name": "core/form-input",
 		"isValid": true,
 		"attributes": {
-			"originalName": "core/form-input",
-			"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>",
-			"originalContent": "<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->"
+			"type": "text",
+			"label": "Label",
+			"inlineLabel": false,
+			"required": false,
+			"value": "",
+			"visibilityPermissions": "all"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__form-input.parsed.json
+++ b/test/integration/fixtures/blocks/core__form-input.parsed.json
@@ -1,14 +1,11 @@
 [
 	{
 		"blockName": "core/form-input",
-		"attrs": {
-			"label": "Name",
-			"required": true
-		},
+		"attrs": {},
 		"innerBlocks": [],
-		"innerHTML": "\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n",
+		"innerHTML": "\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Label</span><input class=\"wp-block-form-input__input\" type=\"text\" name=\"label\" aria-required=\"false\"/></label>\n",
 		"innerContent": [
-			"\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n"
+			"\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Label</span><input class=\"wp-block-form-input__input\" type=\"text\" name=\"label\" aria-required=\"false\"/></label>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__form-input.serialized.html
+++ b/test/integration/fixtures/blocks/core__form-input.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:form-input {"label":"Name","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Name</span><input class="wp-block-form-input" type="text" name="Name" required aria-required="true"/></label>
+<!-- wp:form-input -->
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Label</span><input class="wp-block-form-input__input" type="text" name="label" aria-required="false"/></label>
 <!-- /wp:form-input -->

--- a/test/integration/fixtures/blocks/core__form-submission-notification.html
+++ b/test/integration/fixtures/blocks/core__form-submission-notification.html
@@ -1,0 +1,5 @@
+<!-- wp:form-submission-notification -->
+<div class="wp-block-form-submission-notification form-notification-type-success"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#000000"}}}},"backgroundColor":"#00D084","textColor":"#000000"} -->
+<p class="has-000000-color has-00-d-084-background-color has-text-color has-background has-link-color">Your form has been submitted successfully.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:form-submission-notification -->

--- a/test/integration/fixtures/blocks/core__form-submission-notification.json
+++ b/test/integration/fixtures/blocks/core__form-submission-notification.json
@@ -1,0 +1,31 @@
+[
+	{
+		"name": "core/form-submission-notification",
+		"isValid": true,
+		"attributes": {
+			"type": "success"
+		},
+		"innerBlocks": [
+			{
+				"name": "core/paragraph",
+				"isValid": true,
+				"attributes": {
+					"content": "Your form has been submitted successfully.",
+					"dropCap": false,
+					"backgroundColor": "#00D084",
+					"textColor": "#000000",
+					"style": {
+						"elements": {
+							"link": {
+								"color": {
+									"text": "#000000"
+								}
+							}
+						}
+					}
+				},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__form-submission-notification.parsed.json
+++ b/test/integration/fixtures/blocks/core__form-submission-notification.parsed.json
@@ -1,0 +1,35 @@
+[
+	{
+		"blockName": "core/form-submission-notification",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "core/paragraph",
+				"attrs": {
+					"style": {
+						"elements": {
+							"link": {
+								"color": {
+									"text": "#000000"
+								}
+							}
+						}
+					},
+					"backgroundColor": "#00D084",
+					"textColor": "#000000"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n<p class=\"has-000000-color has-00-d-084-background-color has-text-color has-background has-link-color\">Your form has been submitted successfully.</p>\n",
+				"innerContent": [
+					"\n<p class=\"has-000000-color has-00-d-084-background-color has-text-color has-background has-link-color\">Your form has been submitted successfully.</p>\n"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-form-submission-notification form-notification-type-success\"></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-form-submission-notification form-notification-type-success\">",
+			null,
+			"</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__form-submission-notification.serialized.html
+++ b/test/integration/fixtures/blocks/core__form-submission-notification.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:form-submission-notification -->
+<div class="wp-block-form-submission-notification form-notification-type-success"><!-- wp:paragraph {"backgroundColor":"#00D084","textColor":"#000000","style":{"elements":{"link":{"color":{"text":"#000000"}}}}} -->
+<p class="has-000000-color has-00-d-084-background-color has-text-color has-background has-link-color">Your form has been submitted successfully.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:form-submission-notification -->

--- a/test/integration/fixtures/blocks/core__form-submit-button.html
+++ b/test/integration/fixtures/blocks/core__form-submit-button.html
@@ -1,0 +1,7 @@
+<!-- wp:form-submit-button -->
+<div class="wp-block-form-submit-button"><!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"tagName":"button","type":"submit"} -->
+<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:form-submit-button -->

--- a/test/integration/fixtures/blocks/core__form-submit-button.json
+++ b/test/integration/fixtures/blocks/core__form-submit-button.json
@@ -1,0 +1,26 @@
+[
+	{
+		"name": "core/form-submit-button",
+		"isValid": true,
+		"attributes": {},
+		"innerBlocks": [
+			{
+				"name": "core/buttons",
+				"isValid": true,
+				"attributes": {},
+				"innerBlocks": [
+					{
+						"name": "core/button",
+						"isValid": true,
+						"attributes": {
+							"tagName": "button",
+							"type": "submit",
+							"text": "Submit"
+						},
+						"innerBlocks": []
+					}
+				]
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__form-submit-button.parsed.json
+++ b/test/integration/fixtures/blocks/core__form-submit-button.parsed.json
@@ -1,0 +1,38 @@
+[
+	{
+		"blockName": "core/form-submit-button",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "core/buttons",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/button",
+						"attrs": {
+							"tagName": "button",
+							"type": "submit"
+						},
+						"innerBlocks": [],
+						"innerHTML": "\n<div class=\"wp-block-button\"><button type=\"submit\" class=\"wp-block-button__link wp-element-button\">Submit</button></div>\n",
+						"innerContent": [
+							"\n<div class=\"wp-block-button\"><button type=\"submit\" class=\"wp-block-button__link wp-element-button\">Submit</button></div>\n"
+						]
+					}
+				],
+				"innerHTML": "\n<div class=\"wp-block-buttons\"></div>\n",
+				"innerContent": [
+					"\n<div class=\"wp-block-buttons\">",
+					null,
+					"</div>\n"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-form-submit-button\"></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-form-submit-button\">",
+			null,
+			"</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__form-submit-button.serialized.html
+++ b/test/integration/fixtures/blocks/core__form-submit-button.serialized.html
@@ -1,0 +1,7 @@
+<!-- wp:form-submit-button -->
+<div class="wp-block-form-submit-button"><!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"tagName":"button","type":"submit"} -->
+<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:form-submit-button -->

--- a/test/integration/fixtures/blocks/core__form.html
+++ b/test/integration/fixtures/blocks/core__form.html
@@ -1,21 +1,27 @@
 <!-- wp:form -->
-<form><!-- wp:form-input {"label":"Name","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Name</span><input class="wp-block-form-input" type="text" name="Name" required aria-required="true"/></label>
+<form class="wp-block-form" enctype="text/plain">
+<!-- wp:form-input {"label":"Name","required":true} -->
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Name</span><input class="wp-block-form-input__input" type="text" name="name" required aria-required="true"/></label>
 <!-- /wp:form-input -->
 
 <!-- wp:form-input {"type":"email","label":"Email","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Email</span><input class="wp-block-form-input" type="email" name="Email" required aria-required="true"/></label>
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Email</span><input class="wp-block-form-input__input" type="email" name="email" required aria-required="true"/></label>
 <!-- /wp:form-input -->
 
 <!-- wp:form-input {"type":"url","label":"Website"} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Website</span><input class="wp-block-form-input" type="url" name="Website" aria-required="false"/></label>
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Website</span><input class="wp-block-form-input__input" type="url" name="website" aria-required="false"/></label>
 <!-- /wp:form-input -->
 
 <!-- wp:form-input {"type":"textarea","label":"Comment","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Comment</span><textarea class="wp-block-form-input" name="Comment" required aria-required="true"></textarea></label>
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Comment</span><textarea class="wp-block-form-input__input" name="comment" required aria-required="true"></textarea></label>
 <!-- /wp:form-input -->
 
-<!-- wp:form-input {"type":"submit","label":"Submit"} -->
-<div class="wp-block-buttons"><div class="wp-block-button"><button class="wp-block-button__link wp-element-button">Submit</button></div></div>
-<!-- /wp:form-input --></form>
+<!-- wp:form-submit-button -->
+<div class="wp-block-form-submit-button"><!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"tagName":"button","type":"submit"} -->
+<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:form-submit-button -->
+</form>
 <!-- /wp:form -->

--- a/test/integration/fixtures/blocks/core__form.json
+++ b/test/integration/fixtures/blocks/core__form.json
@@ -1,62 +1,87 @@
 [
 	{
-		"name": "core/missing",
+		"name": "core/form",
 		"isValid": true,
 		"attributes": {
-			"originalName": "core/form",
-			"originalUndelimitedContent": "<form>\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>\n<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>\n</form>",
-			"originalContent": "<!-- wp:form -->\n<form>\n<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"email\",\"label\":\"Email\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"url\",\"label\":\"Website\"} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"textarea\",\"label\":\"Comment\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>\n<!-- /wp:form-input -->\n<!-- wp:form-input {\"type\":\"submit\",\"label\":\"Submit\"} -->\n<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>\n<!-- /wp:form-input -->\n</form>\n<!-- /wp:form -->"
+			"submissionMethod": "email",
+			"method": "post"
 		},
 		"innerBlocks": [
 			{
-				"name": "core/missing",
+				"name": "core/form-input",
 				"isValid": true,
 				"attributes": {
-					"originalName": "core/form-input",
-					"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>",
-					"originalContent": "<!-- wp:form-input {\"label\":\"Name\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->"
+					"type": "text",
+					"label": "Name",
+					"inlineLabel": false,
+					"required": true,
+					"value": "",
+					"visibilityPermissions": "all"
 				},
 				"innerBlocks": []
 			},
 			{
-				"name": "core/missing",
+				"name": "core/form-input",
 				"isValid": true,
 				"attributes": {
-					"originalName": "core/form-input",
-					"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>",
-					"originalContent": "<!-- wp:form-input {\"type\":\"email\",\"label\":\"Email\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>\n<!-- /wp:form-input -->"
+					"type": "email",
+					"label": "Email",
+					"inlineLabel": false,
+					"required": true,
+					"value": "",
+					"visibilityPermissions": "all"
 				},
 				"innerBlocks": []
 			},
 			{
-				"name": "core/missing",
+				"name": "core/form-input",
 				"isValid": true,
 				"attributes": {
-					"originalName": "core/form-input",
-					"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>",
-					"originalContent": "<!-- wp:form-input {\"type\":\"url\",\"label\":\"Website\"} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>\n<!-- /wp:form-input -->"
+					"type": "url",
+					"label": "Website",
+					"inlineLabel": false,
+					"required": false,
+					"value": "",
+					"visibilityPermissions": "all"
 				},
 				"innerBlocks": []
 			},
 			{
-				"name": "core/missing",
+				"name": "core/form-input",
 				"isValid": true,
 				"attributes": {
-					"originalName": "core/form-input",
-					"originalUndelimitedContent": "<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>",
-					"originalContent": "<!-- wp:form-input {\"type\":\"textarea\",\"label\":\"Comment\",\"required\":true} -->\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>\n<!-- /wp:form-input -->"
+					"type": "textarea",
+					"label": "Comment",
+					"inlineLabel": false,
+					"required": true,
+					"value": "",
+					"visibilityPermissions": "all"
 				},
 				"innerBlocks": []
 			},
 			{
-				"name": "core/missing",
+				"name": "core/form-submit-button",
 				"isValid": true,
-				"attributes": {
-					"originalName": "core/form-input",
-					"originalUndelimitedContent": "<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>",
-					"originalContent": "<!-- wp:form-input {\"type\":\"submit\",\"label\":\"Submit\"} -->\n<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>\n<!-- /wp:form-input -->"
-				},
-				"innerBlocks": []
+				"attributes": {},
+				"innerBlocks": [
+					{
+						"name": "core/buttons",
+						"isValid": true,
+						"attributes": {},
+						"innerBlocks": [
+							{
+								"name": "core/button",
+								"isValid": true,
+								"attributes": {
+									"tagName": "button",
+									"type": "submit",
+									"text": "Submit"
+								},
+								"innerBlocks": []
+							}
+						]
+					}
+				]
 			}
 		]
 	}

--- a/test/integration/fixtures/blocks/core__form.parsed.json
+++ b/test/integration/fixtures/blocks/core__form.parsed.json
@@ -10,9 +10,9 @@
 					"required": true
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n",
+				"innerHTML": "\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Name</span><input class=\"wp-block-form-input__input\" type=\"text\" name=\"name\" required aria-required=\"true\"/></label>\n",
 				"innerContent": [
-					"\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Name</span><input class=\"wp-block-form-input\" type=\"text\" name=\"Name\" required aria-required=\"true\"/></label>\n"
+					"\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Name</span><input class=\"wp-block-form-input__input\" type=\"text\" name=\"name\" required aria-required=\"true\"/></label>\n"
 				]
 			},
 			{
@@ -23,9 +23,9 @@
 					"required": true
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>\n",
+				"innerHTML": "\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Email</span><input class=\"wp-block-form-input__input\" type=\"email\" name=\"email\" required aria-required=\"true\"/></label>\n",
 				"innerContent": [
-					"\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Email</span><input class=\"wp-block-form-input\" type=\"email\" name=\"Email\" required aria-required=\"true\"/></label>\n"
+					"\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Email</span><input class=\"wp-block-form-input__input\" type=\"email\" name=\"email\" required aria-required=\"true\"/></label>\n"
 				]
 			},
 			{
@@ -35,9 +35,9 @@
 					"label": "Website"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>\n",
+				"innerHTML": "\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Website</span><input class=\"wp-block-form-input__input\" type=\"url\" name=\"website\" aria-required=\"false\"/></label>\n",
 				"innerContent": [
-					"\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Website</span><input class=\"wp-block-form-input\" type=\"url\" name=\"Website\" aria-required=\"false\"/></label>\n"
+					"\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Website</span><input class=\"wp-block-form-input__input\" type=\"url\" name=\"website\" aria-required=\"false\"/></label>\n"
 				]
 			},
 			{
@@ -48,27 +48,51 @@
 					"required": true
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>\n",
+				"innerHTML": "\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Comment</span><textarea class=\"wp-block-form-input__input\" name=\"comment\" required aria-required=\"true\"></textarea></label>\n",
 				"innerContent": [
-					"\n<label class=\"wp-block-form-input-label\"><span class=\"wp-block-form-input-label__content\">Comment</span><textarea class=\"wp-block-form-input\" name=\"Comment\" required aria-required=\"true\"></textarea></label>\n"
+					"\n<label class=\"wp-block-form-input__label\"><span class=\"wp-block-form-input__label-content\">Comment</span><textarea class=\"wp-block-form-input__input\" name=\"comment\" required aria-required=\"true\"></textarea></label>\n"
 				]
 			},
 			{
-				"blockName": "core/form-input",
-				"attrs": {
-					"type": "submit",
-					"label": "Submit"
-				},
-				"innerBlocks": [],
-				"innerHTML": "\n<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>\n",
+				"blockName": "core/form-submit-button",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/buttons",
+						"attrs": {},
+						"innerBlocks": [
+							{
+								"blockName": "core/button",
+								"attrs": {
+									"tagName": "button",
+									"type": "submit"
+								},
+								"innerBlocks": [],
+								"innerHTML": "\n<div class=\"wp-block-button\"><button type=\"submit\" class=\"wp-block-button__link wp-element-button\">Submit</button></div>\n",
+								"innerContent": [
+									"\n<div class=\"wp-block-button\"><button type=\"submit\" class=\"wp-block-button__link wp-element-button\">Submit</button></div>\n"
+								]
+							}
+						],
+						"innerHTML": "\n<div class=\"wp-block-buttons\"></div>\n",
+						"innerContent": [
+							"\n<div class=\"wp-block-buttons\">",
+							null,
+							"</div>\n"
+						]
+					}
+				],
+				"innerHTML": "\n<div class=\"wp-block-form-submit-button\"></div>\n",
 				"innerContent": [
-					"\n<div class=\"wp-block-buttons\"><div class=\"wp-block-button\"><button class=\"wp-block-button__link wp-element-button\">Submit</button></div></div>\n"
+					"\n<div class=\"wp-block-form-submit-button\">",
+					null,
+					"</div>\n"
 				]
 			}
 		],
-		"innerHTML": "\n<form>\n\n\n\n\n\n\n\n</form>\n",
+		"innerHTML": "\n<form class=\"wp-block-form\" enctype=\"text/plain\">\n\n\n\n\n\n\n\n\n\n</form>\n",
 		"innerContent": [
-			"\n<form>",
+			"\n<form class=\"wp-block-form\" enctype=\"text/plain\">\n",
 			null,
 			"\n\n",
 			null,
@@ -78,7 +102,7 @@
 			null,
 			"\n\n",
 			null,
-			"</form>\n"
+			"\n</form>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__form.serialized.html
+++ b/test/integration/fixtures/blocks/core__form.serialized.html
@@ -1,19 +1,25 @@
 <!-- wp:form -->
-<form>
-<!-- wp:form-input {"label":"Name","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Name</span><input class="wp-block-form-input" type="text" name="Name" required aria-required="true"/></label>
+<form class="wp-block-form" enctype="text/plain"><!-- wp:form-input -->
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Name</span><input class="wp-block-form-input__input" type="text" name="name" required aria-required="true"/></label>
 <!-- /wp:form-input -->
-<!-- wp:form-input {"type":"email","label":"Email","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Email</span><input class="wp-block-form-input" type="email" name="Email" required aria-required="true"/></label>
+
+<!-- wp:form-input {"type":"email"} -->
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Email</span><input class="wp-block-form-input__input" type="email" name="email" required aria-required="true"/></label>
 <!-- /wp:form-input -->
-<!-- wp:form-input {"type":"url","label":"Website"} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Website</span><input class="wp-block-form-input" type="url" name="Website" aria-required="false"/></label>
+
+<!-- wp:form-input {"type":"url"} -->
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Website</span><input class="wp-block-form-input__input" type="url" name="website" aria-required="false"/></label>
 <!-- /wp:form-input -->
-<!-- wp:form-input {"type":"textarea","label":"Comment","required":true} -->
-<label class="wp-block-form-input-label"><span class="wp-block-form-input-label__content">Comment</span><textarea class="wp-block-form-input" name="Comment" required aria-required="true"></textarea></label>
+
+<!-- wp:form-input {"type":"textarea"} -->
+<label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Comment</span><textarea class="wp-block-form-input__input" name="comment" required aria-required="true"></textarea></label>
 <!-- /wp:form-input -->
-<!-- wp:form-input {"type":"submit","label":"Submit"} -->
-<div class="wp-block-buttons"><div class="wp-block-button"><button class="wp-block-button__link wp-element-button">Submit</button></div></div>
-<!-- /wp:form-input -->
-</form>
+
+<!-- wp:form-submit-button -->
+<div class="wp-block-form-submit-button"><!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"tagName":"button","type":"submit"} -->
+<div class="wp-block-button"><button type="submit" class="wp-block-button__link wp-element-button">Submit</button></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:form-submit-button --></form>
 <!-- /wp:form -->

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -35,6 +35,13 @@ import {
 	writeBlockFixtureSerializedHTML,
 } from '../fixtures';
 
+/* eslint-disable no-restricted-syntax */
+import * as form from '@wordpress/block-library/build-module/form';
+import * as formInput from '@wordpress/block-library/build-module/form-input';
+import * as formSubmitButton from '@wordpress/block-library/build-module/form-submit-button';
+import * as formSubmissionNotification from '@wordpress/block-library/build-module/form-submission-notification';
+/* eslint-enable no-restricted-syntax */
+
 const blockBasenames = getAvailableBlockFixturesBasenames();
 
 /**
@@ -64,6 +71,17 @@ describe( 'full post content fixture', () => {
 		);
 		unstable__bootstrapServerSideBlockDefinitions( blockDefinitions );
 		registerCoreBlocks();
+
+		// Form-related blocks will not be registered unless they are opted
+		// in on the experimental settings page. Therefore, these blocks
+		// must be explicitly registered.
+		registerCoreBlocks( [
+			form,
+			formInput,
+			formSubmitButton,
+			formSubmissionNotification,
+		] );
+
 		if ( process.env.IS_GUTENBERG_PLUGIN ) {
 			__experimentalRegisterExperimentalCoreBlocks( {
 				enableFSEBlocks: true,

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -36,10 +36,10 @@ import {
 } from '../fixtures';
 
 /* eslint-disable no-restricted-syntax */
-import * as form from '@wordpress/block-library/build-module/form';
-import * as formInput from '@wordpress/block-library/build-module/form-input';
-import * as formSubmitButton from '@wordpress/block-library/build-module/form-submit-button';
-import * as formSubmissionNotification from '@wordpress/block-library/build-module/form-submission-notification';
+import * as form from '@wordpress/block-library/src/form';
+import * as formInput from '@wordpress/block-library/src/form-input';
+import * as formSubmitButton from '@wordpress/block-library/src/form-submit-button';
+import * as formSubmissionNotification from '@wordpress/block-library/src/form-submission-notification';
 /* eslint-enable no-restricted-syntax */
 
 const blockBasenames = getAvailableBlockFixturesBasenames();


### PR DESCRIPTION
Fixes #56590
This issue was discovered in this comment: https://github.com/WordPress/gutenberg/pull/56507#issuecomment-1827856129

## What?
This PR will ensure that the fixture files for the following two blocks are generated correctly.

- `test/integration/fixtures/blocks/core__form-input.html`
- `test/integration/fixtures/blocks/core__form.html`

Additionally, this PR creates fixture files for form-related blocks that do not yet exist.

- `test/integration/fixtures/blocks/core__form-submission-notification.html`
- `test/integration/fixtures/blocks/core__form-submit-button.html`

## Why?

These blocks are not available unless you explicitly opt-in on the Experimental Settings page. In other words, in fixture tests, it is excluded from the blocks registered with the `registerBlocks()` function.

As a result, even if you create a fixture file, that block will be considered a `core/missing` block and will not generate a correct serialized file that has passed deprecation.

## How?

- Explicitly registered these blocks in fixture tests.
- In the form-input block, the `getNameFromLabel()` function no longer depends on the `document` object to avoid fixture test failures. (See the "The behavior of the save function of the Input Field block is different in the fixture test" section in [#56590](https://github.com/WordPress/gutenberg/issues/56590) for details.)
- Regarding the two existing fixture files, the original HTML markup was invalid, so I fixed it.

## Testing Instructions

Confirm that the form-input block's save function outputs exactly the same markup as before.

- Switch to trunk branch.
- Insert a form-input block.
- Decorate the label with bold text, links, etc., and save the post.
- Switch to this PR and reload the post.
- The block should not break.