### PR TITLE
DropdownMenuV2Ariakit: prevent prefix collapsing if all radios or checkboxes are unselected

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,10 @@
 -   `ToolsPanel`: fix a performance issue ([#56770](https://github.com/WordPress/gutenberg/pull/56770)).
 -   `BorderControl`: adjust `BorderControlDropdown` Button size to fix misaligned border ([#56730](https://github.com/WordPress/gutenberg/pull/56730)).
 
+### Internal
+
+-   `DropdownMenuV2Ariakit`: prevent prefix collapsing if all radios or checkboxes are unselected ([#56720](https://github.com/WordPress/gutenberg/pull/56720)).
+
 ## 25.13.0 (2023-11-29)
 
 ### Enhancements

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -212,6 +212,16 @@ export const ItemPrefixWrapper = styled.span`
 	/* Always occupy the first column, even when auto-collapsing */
 	grid-column: 1;
 
+	/*
+	 * Even when the item is not checked, occupy the same screen space to avoid
+	 * the space collapside when no items are checked.
+	 */
+	${ DropdownMenuCheckboxItem } > &,
+	${ DropdownMenuRadioItem } > & {
+		min-width: ${ space( 6 ) };
+		margin-inline-end: ${ space( 2 ) };
+	}
+
 	&:not( :empty ) {
 		margin-inline-end: ${ space( 2 ) };
 	}

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -218,10 +218,12 @@ export const ItemPrefixWrapper = styled.span`
 	 */
 	${ DropdownMenuCheckboxItem } > &,
 	${ DropdownMenuRadioItem } > & {
+		/* Same width as the check icons */
 		min-width: ${ space( 6 ) };
-		margin-inline-end: ${ space( 2 ) };
 	}
 
+	${ DropdownMenuCheckboxItem } > &,
+	${ DropdownMenuRadioItem } > &,
 	&:not( :empty ) {
 		margin-inline-end: ${ space( 2 ) };
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improves spacing in radio and checkbox menu items, so that the prefix space doesn't collapse if all items are unchecked

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the whole menu can "jump" when selecting an item (as reported in https://github.com/WordPress/gutenberg/pull/55625#issuecomment-1836128184), which is a poor user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By making sure that the prefix has a minimum width for radio and checkbox menu items

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the "With Checkboxes" Storybook example for the `DropdownMenuV2Ariakit` component
- Uncheck all checkboxes
- Make sure that all checkboxes are still showing some empty space as their prefix, and that the menu's width doesn't change
- To test with radios, manually tweak the "With Radios" storybook example to remove any initial selection

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2023-12-01 at 17 46 18](https://github.com/WordPress/gutenberg/assets/1083581/a06c6433-2f6b-4ead-a2bc-c6dbd3c97ea0) | ![Screenshot 2023-12-01 at 18 09 12](https://github.com/WordPress/gutenberg/assets/1083581/2ef607c1-186a-49bc-b0d3-641fe4f8f258) |
