### PR TITLE
Clean up header toolbar metrics and responsive break points

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -21,7 +21,7 @@ export default function PreviewOptions( {
 	label,
 	showIconLabels,
 } ) {
-	const isMobile = useViewportMatch( 'small', '<' );
+	const isMobile = useViewportMatch( 'medium', '<' );
 	if ( isMobile ) return null;
 
 	const popoverProps = {

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -83,7 +83,7 @@
 	display: inline-flex;
 	align-items: center;
 	padding-left: $grid-unit-20;
-	gap: $grid-unit-05;
+	gap: $grid-unit-10;
 
 	// Some plugins add buttons here despite best practices.
 	// Push them a bit rightwards to fit the top toolbar.
@@ -99,8 +99,6 @@
 }
 
 .edit-post-header-toolbar .edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle.has-icon {
-	margin-right: $grid-unit-10;
-	// Special dimensions for this button.
 	min-width: $button-size-compact;
 	width: $button-size-compact;
 	height: $button-size-compact;
@@ -108,7 +106,7 @@
 
 	.show-icon-labels & {
 		width: auto;
-		height: 36px;
+		height: $button-size-compact;
 		padding: 0 $grid-unit-10;
 	}
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -82,14 +82,15 @@
 .edit-post-header-toolbar__left {
 	display: inline-flex;
 	align-items: center;
-	padding-left: $grid-unit-10;
+	padding-left: $grid-unit-20;
+	gap: $grid-unit-05;
 
 	// Some plugins add buttons here despite best practices.
 	// Push them a bit rightwards to fit the top toolbar.
 	margin-right: $grid-unit-10;
 
-	@include break-small() {
-		padding-left: $grid-unit-30;
+	@include break-medium() {
+		padding-left: $grid-unit-50 * 0.5;
 	}
 
 	@include break-wide() {

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -93,11 +93,7 @@
 		padding-right: $grid-unit-20 - ($grid-unit-15 * 0.5);
 	}
 
-	gap: $grid-unit-05;
-
-	@include break-small() {
-		gap: $grid-unit-10;
-	}
+	gap: $grid-unit-10;
 }
 
 .edit-post-header-preview__grouping-external {

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -93,7 +93,8 @@
 	color: $gray-800;
 	min-width: $grid-unit-40;
 	display: none;
-	@include break-small() {
+
+	@include break-medium() {
 		display: initial;
 	}
 }

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -216,41 +216,43 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 					variants={ toolbarVariants }
 					transition={ toolbarTransition }
 				>
-					<div
-						className={ classnames(
-							'edit-site-header-edit-mode__preview-options',
-							{ 'is-zoomed-out': isZoomedOutView }
-						) }
-					>
-						<PreviewOptions
-							deviceType={ deviceType }
-							setDeviceType={ setPreviewDeviceType }
-							label={ __( 'View' ) }
-							isEnabled={
-								! isFocusMode && hasDefaultEditorCanvasView
-							}
-							showIconLabels={ showIconLabels }
-						>
-							{ ( { onClose } ) => (
-								<MenuGroup>
-									<MenuItem
-										href={ homeUrl }
-										target="_blank"
-										icon={ external }
-										onClick={ onClose }
-									>
-										{ __( 'View site' ) }
-										<VisuallyHidden as="span">
-											{
-												/* translators: accessibility text */
-												__( '(opens in a new tab)' )
-											}
-										</VisuallyHidden>
-									</MenuItem>
-								</MenuGroup>
+					{ isLargeViewport && (
+						<div
+							className={ classnames(
+								'edit-site-header-edit-mode__preview-options',
+								{ 'is-zoomed-out': isZoomedOutView }
 							) }
-						</PreviewOptions>
-					</div>
+						>
+							<PreviewOptions
+								deviceType={ deviceType }
+								setDeviceType={ setPreviewDeviceType }
+								label={ __( 'View' ) }
+								isEnabled={
+									! isFocusMode && hasDefaultEditorCanvasView
+								}
+								showIconLabels={ showIconLabels }
+							>
+								{ ( { onClose } ) => (
+									<MenuGroup>
+										<MenuItem
+											href={ homeUrl }
+											target="_blank"
+											icon={ external }
+											onClick={ onClose }
+										>
+											{ __( 'View site' ) }
+											<VisuallyHidden as="span">
+												{
+													/* translators: accessibility text */
+													__( '(opens in a new tab)' )
+												}
+											</VisuallyHidden>
+										</MenuItem>
+									</MenuGroup>
+								) }
+							</PreviewOptions>
+						</div>
+					) }
 					<SaveButton />
 					{ ! isDistractionFree && (
 						<PinnedItems.Slot scope="core/edit-site" />

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -25,7 +25,9 @@ $header-toolbar-min-width: 335px;
 		// is visible on toolbar buttons.
 		height: 100%;
 		// Allow focus ring to be fully visible on furthest right button.
-		padding-right: 2px;
+		@include break-medium() {
+			padding-right: 2px;
+		}
 	}
 
 	.edit-site-header-edit-mode__end {
@@ -55,10 +57,11 @@ $header-toolbar-min-width: 335px;
 .edit-site-header-edit-mode__toolbar {
 	display: flex;
 	align-items: center;
-	padding-left: $grid-unit-10;
+	padding-left: $grid-unit-20;
+	gap: $grid-unit-05;
 
-	@include break-small() {
-		padding-left: $grid-unit-30;
+	@include break-medium() {
+		padding-left: $grid-unit-50 * 0.5;
 	}
 
 	@include break-wide() {
@@ -92,17 +95,8 @@ $header-toolbar-min-width: 335px;
 .edit-site-header-edit-mode__actions {
 	display: inline-flex;
 	align-items: center;
-	padding-right: $grid-unit-05;
-
-	@include break-small () {
-		padding-right: $grid-unit-20 - ($grid-unit-15 * 0.5);
-	}
-
-	gap: $grid-unit-05;
-
-	@include break-small() {
-		gap: $grid-unit-10;
-	}
+	padding-right: $grid-unit-20 - ($grid-unit-15 * 0.5);
+	gap: $grid-unit-10;
 }
 
 .edit-site-header-edit-mode__preview-options {

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -58,7 +58,7 @@ $header-toolbar-min-width: 335px;
 	display: flex;
 	align-items: center;
 	padding-left: $grid-unit-20;
-	gap: $grid-unit-05;
+	gap: $grid-unit-10;
 
 	@include break-medium() {
 		padding-left: $grid-unit-50 * 0.5;
@@ -69,12 +69,6 @@ $header-toolbar-min-width: 335px;
 	}
 
 	.edit-site-header-edit-mode__inserter-toggle {
-		margin-right: $grid-unit-10;
-		min-width: $grid-unit-40;
-		width: $grid-unit-40;
-		height: $grid-unit-40;
-		padding: 0;
-
 		svg {
 			transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) 0.2s;
 			@include reduce-motion("transition");
@@ -138,7 +132,6 @@ $header-toolbar-min-width: 335px;
 	}
 
 	.edit-site-header-edit-mode__toolbar > .edit-site-header-edit-mode__inserter-toggle.has-icon {
-		margin-right: $grid-unit-10;
 		// Special dimensions for this button.
 		min-width: $button-size-compact;
 		width: $button-size-compact;

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -40,7 +40,7 @@ $header-toolbar-min-width: 335px;
 		align-items: center;
 		height: 100%;
 		flex-grow: 1;
-		margin: 0 $grid-unit-10;
+		margin: 0 $grid-unit-20;
 		justify-content: center;
 		// Flex items will, by default, refuse to shrink below a minimum
 		// intrinsic width. In order to shrink this flexbox item, and
@@ -89,7 +89,7 @@ $header-toolbar-min-width: 335px;
 .edit-site-header-edit-mode__actions {
 	display: inline-flex;
 	align-items: center;
-	padding-right: $grid-unit-20 - ($grid-unit-15 * 0.5);
+	padding-right: $grid-unit-10;
 	gap: $grid-unit-10;
 }
 

--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -26,8 +26,5 @@
 	}
 
 	// Gap between pinned items.
-	gap: $grid-unit-05;
-
-	// Account for larger grid from parent container gap.
-	margin-right: -$grid-unit-05;
+	gap: $grid-unit-10;
 }

--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -27,4 +27,7 @@
 
 	// Gap between pinned items.
 	gap: $grid-unit-10;
+
+	// Account for larger grid from parent container gap.
+	margin-right: -$grid-unit-05;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A follow-up to #56635, adding the missing gap between the document tool icons and tightening up the mobile views by consolidating breakpoint changes and applying more consistent metrics on mobile. 

## How?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Resize the window to see changes. 
3. Do the same for the site editor.

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/1813435/d84314aa-99a7-4df9-856a-053f7c4116a5
