### PR TITLE
`BorderControl`: Fix button styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 -   `ToggleGroupControl`: react correctly to external controlled updates ([#56678](https://github.com/WordPress/gutenberg/pull/56678)).
 -   `ToolsPanel`: fix a performance issue ([#56770](https://github.com/WordPress/gutenberg/pull/56770)).
+-   `BorderControl`: adjust `BorderControlDropdown` Button size to fix misaligned border ([#56730](https://github.com/WordPress/gutenberg/pull/56730)).
 
 ## 25.13.0 (2023-11-29)
 

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -198,7 +198,7 @@ const BorderControlDropdown = (
 						<HStack>
 							<StyledLabel>{ __( 'Border color' ) }</StyledLabel>
 							<Button
-								isSmall
+								size="small"
 								label={ __( 'Close border color' ) }
 								icon={ closeSmall }
 								onClick={ onClose }

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -149,6 +149,7 @@ const BorderControlDropdown = (
 		popoverControlsClassName,
 		resetButtonClassName,
 		showDropdownHeader,
+		size,
 		__unstablePopoverProps,
 		...otherProps
 	} = useBorderControlDropdown( props );
@@ -170,23 +171,28 @@ const BorderControlDropdown = (
 
 	const renderToggle: DropdownComponentProps[ 'renderToggle' ] = ( {
 		onToggle,
-	} ) => (
-		<Button
-			onClick={ onToggle }
-			variant="tertiary"
-			aria-label={ toggleAriaLabel }
-			tooltipPosition={ dropdownPosition }
-			label={ __( 'Border color and style picker' ) }
-			showTooltip={ true }
-		>
-			<span className={ indicatorWrapperClassName }>
-				<ColorIndicator
-					className={ indicatorClassName }
-					colorValue={ color }
-				/>
-			</span>
-		</Button>
-	);
+	} ) => {
+		return (
+			<Button
+				onClick={ onToggle }
+				variant="tertiary"
+				aria-label={ toggleAriaLabel }
+				tooltipPosition={ dropdownPosition }
+				label={ __( 'Border color and style picker' ) }
+				showTooltip={ true }
+				__next40pxDefaultSize={
+					size === '__unstable-large' ? true : false
+				}
+			>
+				<span className={ indicatorWrapperClassName }>
+					<ColorIndicator
+						className={ indicatorClassName }
+						colorValue={ color }
+					/>
+				</span>
+			</Button>
+		);
+	};
 
 	const renderContent: DropdownComponentProps[ 'renderContent' ] = ( {
 		onClose,

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -171,28 +171,24 @@ const BorderControlDropdown = (
 
 	const renderToggle: DropdownComponentProps[ 'renderToggle' ] = ( {
 		onToggle,
-	} ) => {
-		return (
-			<Button
-				onClick={ onToggle }
-				variant="tertiary"
-				aria-label={ toggleAriaLabel }
-				tooltipPosition={ dropdownPosition }
-				label={ __( 'Border color and style picker' ) }
-				showTooltip={ true }
-				__next40pxDefaultSize={
-					size === '__unstable-large' ? true : false
-				}
-			>
-				<span className={ indicatorWrapperClassName }>
-					<ColorIndicator
-						className={ indicatorClassName }
-						colorValue={ color }
-					/>
-				</span>
-			</Button>
-		);
-	};
+	} ) => (
+		<Button
+			onClick={ onToggle }
+			variant="tertiary"
+			aria-label={ toggleAriaLabel }
+			tooltipPosition={ dropdownPosition }
+			label={ __( 'Border color and style picker' ) }
+			showTooltip={ true }
+			__next40pxDefaultSize={ size === '__unstable-large' ? true : false }
+		>
+			<span className={ indicatorWrapperClassName }>
+				<ColorIndicator
+					className={ indicatorClassName }
+					colorValue={ color }
+				/>
+			</span>
+		</Button>
+	);
 
 	const renderContent: DropdownComponentProps[ 'renderContent' ] = ( {
 		onClose,

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -95,6 +95,7 @@ export function useBorderControlDropdown(
 		popoverContentClassName,
 		popoverControlsClassName,
 		resetButtonClassName,
+		size,
 		__experimentalIsRenderedInSidebar,
 	};
 }

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -57,8 +57,8 @@ export function useBorderControlDropdown(
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx( styles.borderControlDropdown( size ), className );
-	}, [ className, cx, size ] );
+		return cx( styles.borderControlDropdown, className );
+	}, [ className, cx ] );
 
 	const indicatorClassName = useMemo( () => {
 		return cx( styles.borderColorIndicator );

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -59,18 +59,11 @@ export const wrapperHeight = ( size?: 'default' | '__unstable-large' ) => {
 	`;
 };
 
-export const borderControlDropdown = (
-	size?: 'default' | '__unstable-large'
-) => css`
+export const borderControlDropdown = css`
 	background: #fff;
 
 	&& > button {
-		/*
-		 * Override button component styles to fit within BorderControl
-		 * regardless of size.
-		 */
-		height: ${ size === '__unstable-large' ? '40px' : '30px' };
-		width: ${ size === '__unstable-large' ? '40px' : '30px' };
+		aspect-ratio: 1;
 		padding: 0;
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The size of the button in BorderControl did not match the input field so there is a slight gap between their borders. This also affects BorderBoxControl.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It looks nicer. :) 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removing the hardcoded height and width, adding an aspect-ratio of 1, and using `size="small"` instead of the deprecated `isSmall` for button.

## Testing Instructions
Ensure BorderControl and BorderBoxControl's borders and size look correct. 

## Screenshots or screencast <!-- if applicable -->

### BorderControl

| Before  | After |
| ------------- | ------------- |
|  <img width="281" alt="Screenshot 2023-12-01 at 7 36 24 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/b2f52868-7f09-4ec8-8813-1f51bb8222e4"> | <img width="274" alt="Screenshot 2023-12-01 at 7 36 44 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/54f2e494-fca3-43ac-9863-3ed11415640d"> |

### BorderBoxControl

| Before  | After |
| ------------- | ------------- |
| <img width="284" alt="Screenshot 2023-12-01 at 7 36 30 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/e9b4faaa-ba74-4bc8-b156-a04329d742a1"> | <img width="273" alt="Screenshot 2023-12-01 at 7 36 53 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/5182b309-8b17-4531-a39e-03a4afb53faf"> |



