### PR TITLE
Docs: Fix {% end %} tab position to show the text

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -103,9 +103,9 @@ body {
 }
 ```
 
--   **Custom properties**: there's also a mechanism to create your own CSS Custom Properties.
-
 {% end %}
+
+-   **Custom properties**: there's also a mechanism to create your own CSS Custom Properties.
 
 {% codetabs %}
 {% Input %}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
#56561 has broght back non-js tabs, but one insertion point is wrong, obscuring a needed explanation.

This line of text describing the example below is embedded in the previous example's Output tab because of the wrong `{% end %}` tab position.
> Custom properties: there’s also a mechanism to create your own CSS Custom Properties.

Refer 1st example's Input/Output tab of https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/

cc: @ryanwelcher 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
