### PR TITLE
DataViews: Open a new tab when the View action button is clicked

### DIFF
--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -212,7 +212,7 @@ export const viewPostAction = {
 		return post.status !== 'trash';
 	},
 	callback( post ) {
-		document.location.href = post.link;
+		window.open( post.link, '_blank' );
 	},
 };
 


### PR DESCRIPTION
## What?

This PR will open the page in a new tab when the View button is clicked in the data view.

![view](https://github.com/WordPress/gutenberg/assets/54422211/cf8c7a8b-4d90-4c19-9e1d-0dc33858108e)

## Why?

As this icon indicates, the link is expected to open in a new tab. The "View post" button in the Post Editor and the "View site" button in the Site Editor also open a new tab.

## How?
Updated `viewPostAction` callback processing. For now, I think this action should always be OK to open in a new window.

## Testing Instructions

- Enable "New admin views" from the Experimental settings.
- Go to the Site Editor > Pages > Manage all pages.
- Click the "View" button.
- The page should open in a new window or tab.