### PR TITLE
Command Palette: Use getRevisions instead of deprecated selector

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -245,14 +245,13 @@ function useGlobalStylesOpenRevisionsCommands() {
 	const isEditorPage = ! getIsListPage( params, isMobileViewport );
 	const history = useHistory();
 	const hasRevisions = useSelect( ( select ) => {
-		const { getRevisions, __experimentalGetCurrentGlobalStylesId } =
+		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
 			select( coreStore );
-		const globalStylesRevisions = getRevisions(
-			'root',
-			'globalStyles',
-			__experimentalGetCurrentGlobalStylesId()
-		);
-		return !! globalStylesRevisions?.length;
+		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+		const globalStyles = globalStylesId
+			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+			: undefined;
+		return !! globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count;
 	}, [] );
 
 	const commands = useMemo( () => {

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -244,11 +244,17 @@ function useGlobalStylesOpenRevisionsCommands() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isEditorPage = ! getIsListPage( params, isMobileViewport );
 	const history = useHistory();
-	const hasRevisions = useSelect(
-		( select ) =>
-			select( coreStore ).getCurrentThemeGlobalStylesRevisions()?.length,
-		[]
-	);
+	const hasRevisions = useSelect( ( select ) => {
+		const { getRevisions, __experimentalGetCurrentGlobalStylesId } =
+			select( coreStore );
+		const globalStylesRevisions = getRevisions(
+			'root',
+			'globalStyles',
+			__experimentalGetCurrentGlobalStylesId()
+		);
+		return !! globalStylesRevisions?.length;
+	}, [] );
+
 	const commands = useMemo( () => {
 		if ( ! hasRevisions ) {
 			return [];


### PR DESCRIPTION
Related to #56349

## What?

This PR refactors the deprecated `getCurrentThemeGlobalStylesRevisions` selector into the `getRevisions` selector in the Command Palette. This will prevent warning messages from appearing in the browser console.

![browser-console](https://github.com/WordPress/gutenberg/assets/54422211/1f22cea3-f165-4c13-8d36-3edb4b348e56)

## Why?

To improve code quality.

## How?

Refactored it while keeping the logic. However, I added `!!` to explicitly return a `boolean` type.

## Testing Instructions

- If a revision is already recorded in the global style, please delete it. It would be easy to use the [WP-Optimize](https://ja.wordpress.org/plugins/wp-optimize/) plugin.
- Open the Command Palette in the Site Editor.
- If you type "revisions" there should be no results.
- Make some changes in global styles.
- Open the Command Palette in the site editor.
- Type "revisions" and you should see "Style revisions" in the results.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/5cc05b03-4bf8-44c4-86f0-1c8af4ca372b


