### PR TITLE
Site Editor: show back button when editing navigation and template area in-place with no URL params

### DIFF
--- a/packages/edit-site/src/components/block-editor/back-button.js
+++ b/packages/edit-site/src/components/block-editor/back-button.js
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { arrowLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import {
 	NAVIGATION_POST_TYPE,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
+import { store as editSiteStore } from '../../store';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
@@ -22,25 +24,25 @@ function BackButton() {
 	const history = useHistory();
 	const isTemplatePart = location.params.postType === TEMPLATE_PART_POST_TYPE;
 	const isNavigationMenu = location.params.postType === NAVIGATION_POST_TYPE;
-	const previousTemplateId = location.state?.fromTemplateId;
+	// Only show the back button when editing a template part or navigation menu.
+	const canShowBackButton = isTemplatePart || isNavigationMenu;
+	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 
-	const isFocusMode = isTemplatePart || isNavigationMenu;
-
-	if ( ! isFocusMode || ! previousTemplateId ) {
-		return null;
-	}
-
-	return (
+	return canShowBackButton ? (
 		<Button
 			className="edit-site-visual-editor__back-button"
 			icon={ arrowLeft }
 			onClick={ () => {
-				history.back();
+				if ( location.state?.fromTemplateId ) {
+					history.back();
+				} else {
+					setCanvasMode( 'view' );
+				}
 			} }
 		>
 			{ __( 'Back' ) }
 		</Button>
-	);
+	) : null;
 }
 
 export default BackButton;

--- a/packages/edit-site/src/components/block-editor/back-button.js
+++ b/packages/edit-site/src/components/block-editor/back-button.js
@@ -27,18 +27,19 @@ function BackButton() {
 	// Only show the back button when editing a template part or navigation menu.
 	const canShowBackButton = isTemplatePart || isNavigationMenu;
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+	const onClickHandler = () => {
+		if ( location.state?.fromTemplateId ) {
+			history.back();
+		} else {
+			setCanvasMode( 'view' );
+		}
+	};
 
 	return canShowBackButton ? (
 		<Button
 			className="edit-site-visual-editor__back-button"
 			icon={ arrowLeft }
-			onClick={ () => {
-				if ( location.state?.fromTemplateId ) {
-					history.back();
-				} else {
-					setCanvasMode( 'view' );
-				}
-			} }
+			onClick={ onClickHandler }
 		>
 			{ __( 'Back' ) }
 		</Button>

--- a/packages/edit-site/src/components/block-editor/back-button.js
+++ b/packages/edit-site/src/components/block-editor/back-button.js
@@ -5,7 +5,6 @@ import { Button } from '@wordpress/components';
 import { arrowLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,7 +14,6 @@ import {
 	NAVIGATION_POST_TYPE,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
-import { store as editSiteStore } from '../../store';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
@@ -24,26 +22,25 @@ function BackButton() {
 	const history = useHistory();
 	const isTemplatePart = location.params.postType === TEMPLATE_PART_POST_TYPE;
 	const isNavigationMenu = location.params.postType === NAVIGATION_POST_TYPE;
-	// Only show the back button when editing a template part or navigation menu.
-	const canShowBackButton = isTemplatePart || isNavigationMenu;
-	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
-	const onClickHandler = () => {
-		if ( location.state?.fromTemplateId ) {
-			history.back();
-		} else {
-			setCanvasMode( 'view' );
-		}
-	};
+	const previousTemplateId = location.state?.fromTemplateId;
 
-	return canShowBackButton ? (
+	const isFocusMode = isTemplatePart || isNavigationMenu;
+
+	if ( ! isFocusMode || ! previousTemplateId ) {
+		return null;
+	}
+
+	return (
 		<Button
 			className="edit-site-visual-editor__back-button"
 			icon={ arrowLeft }
-			onClick={ onClickHandler }
+			onClick={ () => {
+				history.back();
+			} }
 		>
 			{ __( 'Back' ) }
 		</Button>
-	) : null;
+	);
 }
 
 export default BackButton;

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -96,9 +96,9 @@
 	}
 }
 
+// The toolbar header in distraction mode sits over the back button, which renders it unreachable.
 .is-distraction-free .edit-site-visual-editor__back-button {
-	top: auto;
-	bottom: $grid-unit-10;
+	display: none;
 }
 
 .resizable-editor__drag-handle {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -96,6 +96,11 @@
 	}
 }
 
+.is-distraction-free .edit-site-visual-editor__back-button {
+	top: auto;
+	bottom: $grid-unit-10;
+}
+
 .resizable-editor__drag-handle {
 	position: absolute;
 	top: 0;

--- a/packages/edit-site/src/hooks/navigation-menu-edit.js
+++ b/packages/edit-site/src/hooks/navigation-menu-edit.js
@@ -43,7 +43,7 @@ function NavigationMenuEdit( { attributes } ) {
 		},
 		{
 			// this applies to Navigation Menus as well.
-			fromTemplateId: params.postId,
+			fromTemplateId: params.postId || navigationMenu?.id,
 		}
 	);
 

--- a/packages/edit-site/src/hooks/template-part-edit.js
+++ b/packages/edit-site/src/hooks/template-part-edit.js
@@ -43,7 +43,7 @@ function EditTemplatePartMenuItem( { attributes } ) {
 			canvas: 'edit',
 		},
 		{
-			fromTemplateId: params.postId,
+			fromTemplateId: params.postId || templatePart?.id,
 		}
 	);
 


### PR DESCRIPTION
Not sure about this one, but here goes...

Possibly resolves https://github.com/WordPress/gutenberg/issues/56150 (I'll let @getdave decide 😄 )

## What?

- Adds a fallback to `fromTemplateId` added by the "Edit" button in the toolbar for navigation and template part post types, so that the back button recognizes it has a valid path "back" to something.
- Hides `<BackButton />`  in distraction free mode. 

## Why?

1. Without a `postId` in the URL params, the back button will not display. This is inconvenient when navigating to a template part from `/wp-admin/site-editor.php` (no params): a template has been loaded, but its params are not in the URL.
2. Because `<BackButton />` is completely unreachable in distraction free mode


https://github.com/WordPress/gutenberg/assets/6458278/b1edb5e4-4411-43b3-9320-d1aa8321343f


## Testing Instructions
1. Open the site editor and edit the home page immediately. Check that a back button appears for "focused"[^1] navigation and template part areas. So, choose a template or page, then "Edit" a template area.
2. Enter distraction-free mode in the top right Options menu. Make sure you can access the Back button. It'll be under the editor canvas. 



[^1]: What is focus mode anyway? Apparently it's a label to describe when a template can be isolated from a larger context, or "focussed", and then festooned with horizontal drag handles. 🤷🏻 

