### PR TITLE
Performance: skip inspector panel logic when not visible

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -194,8 +194,7 @@ const DEFAULT_CONTROLS = {
 	childLayout: true,
 };
 
-export default function DimensionsPanel( {
-	as: Wrapper = DimensionsToolsPanel,
+function DimensionsPanelWithinWrapper( {
 	value,
 	onChange,
 	inheritedValue = value,
@@ -376,39 +375,10 @@ export default function DimensionsPanel( {
 		} );
 	};
 	const hasChildLayoutValue = () => !! value?.layout;
-
-	const resetAllFilter = useCallback( ( previousValue ) => {
-		return {
-			...previousValue,
-			layout: cleanEmptyObject( {
-				...previousValue?.layout,
-				contentSize: undefined,
-				wideSize: undefined,
-				selfStretch: undefined,
-				flexSize: undefined,
-			} ),
-			spacing: {
-				...previousValue?.spacing,
-				padding: undefined,
-				margin: undefined,
-				blockGap: undefined,
-			},
-			dimensions: {
-				...previousValue?.dimensions,
-				minHeight: undefined,
-			},
-		};
-	}, [] );
-
 	const onMouseLeaveControls = () => onVisualize( false );
 
 	return (
-		<Wrapper
-			resetAllFilter={ resetAllFilter }
-			value={ value }
-			onChange={ onChange }
-			panelId={ panelId }
-		>
+		<>
 			{ ( showContentSizeControl || showWideSizeControl ) && (
 				<span className="span-columns">
 					{ __( 'Set the width of the main content area.' ) }
@@ -636,6 +606,64 @@ export default function DimensionsPanel( {
 					/>
 				</VStack>
 			) }
+		</>
+	);
+}
+
+export default function DimensionsPanel( {
+	as: Wrapper = DimensionsToolsPanel,
+	value,
+	onChange,
+	inheritedValue = value,
+	settings,
+	panelId,
+	defaultControls = DEFAULT_CONTROLS,
+	onVisualize = () => {},
+	// Special case because the layout controls are not part of the dimensions panel
+	// in global styles but not in block inspector.
+	includeLayoutControls = false,
+} ) {
+	const resetAllFilter = useCallback( ( previousValue ) => {
+		return {
+			...previousValue,
+			layout: cleanEmptyObject( {
+				...previousValue?.layout,
+				contentSize: undefined,
+				wideSize: undefined,
+				selfStretch: undefined,
+				flexSize: undefined,
+			} ),
+			spacing: {
+				...previousValue?.spacing,
+				padding: undefined,
+				margin: undefined,
+				blockGap: undefined,
+			},
+			dimensions: {
+				...previousValue?.dimensions,
+				minHeight: undefined,
+			},
+		};
+	}, [] );
+
+	return (
+		<Wrapper
+			resetAllFilter={ resetAllFilter }
+			value={ value }
+			onChange={ onChange }
+			panelId={ panelId }
+		>
+			<DimensionsPanelWithinWrapper
+				as={ Wrapper }
+				value={ value }
+				onChange={ onChange }
+				inheritedValue={ inheritedValue }
+				settings={ settings }
+				panelId={ panelId }
+				defaultControls={ defaultControls }
+				onVisualize={ onVisualize }
+				includeLayoutControls={ includeLayoutControls }
+			/>
 		</Wrapper>
 	);
 }

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -147,8 +147,7 @@ const DEFAULT_CONTROLS = {
 	textColumns: true,
 };
 
-export default function TypographyPanel( {
-	as: Wrapper = TypographyToolsPanel,
+function TypographyPanelWithinWrapper( {
 	value,
 	onChange,
 	inheritedValue = value,
@@ -325,20 +324,8 @@ export default function TypographyPanel( {
 	const hasWritingMode = () => !! value?.typography?.writingMode;
 	const resetWritingMode = () => setWritingMode( undefined );
 
-	const resetAllFilter = useCallback( ( previousValue ) => {
-		return {
-			...previousValue,
-			typography: {},
-		};
-	}, [] );
-
 	return (
-		<Wrapper
-			resetAllFilter={ resetAllFilter }
-			value={ value }
-			onChange={ onChange }
-			panelId={ panelId }
-		>
+		<>
 			{ hasFontFamilyEnabled && (
 				<ToolsPanelItem
 					label={ __( 'Font family' ) }
@@ -506,6 +493,41 @@ export default function TypographyPanel( {
 					/>
 				</ToolsPanelItem>
 			) }
+		</>
+	);
+}
+
+export default function TypographyPanel( {
+	as: Wrapper = TypographyToolsPanel,
+	value,
+	onChange,
+	inheritedValue = value,
+	settings,
+	panelId,
+	defaultControls = DEFAULT_CONTROLS,
+} ) {
+	const resetAllFilter = useCallback( ( previousValue ) => {
+		return {
+			...previousValue,
+			typography: {},
+		};
+	}, [] );
+
+	return (
+		<Wrapper
+			resetAllFilter={ resetAllFilter }
+			value={ value }
+			onChange={ onChange }
+			panelId={ panelId }
+		>
+			<TypographyPanelWithinWrapper
+				value={ value }
+				onChange={ onChange }
+				inheritedValue={ inheritedValue }
+				settings={ settings }
+				defaultControls={ defaultControls }
+				panelId={ panelId }
+			/>
 		</Wrapper>
 	);
 }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -52,11 +52,9 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
-function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
-	const blockEditingMode = useBlockEditingMode();
-
+function BlockEditAnchorControl( { attributes, setAttributes } ) {
 	const isWeb = Platform.OS === 'web';
-	const textControl = (
+	return (
 		<TextControl
 			__nextHasNoMarginBottom
 			__next40pxDefaultSize
@@ -91,12 +89,19 @@ function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
 			autoComplete="off"
 		/>
 	);
+}
 
+function BlockEditAnchor( { blockName, attributes, setAttributes } ) {
+	const blockEditingMode = useBlockEditingMode();
+	const isWeb = Platform.OS === 'web';
 	return (
 		<>
 			{ isWeb && blockEditingMode === 'default' && (
 				<InspectorControls group="advanced">
-					{ textControl }
+					<BlockEditAnchorControl
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+					/>
 				</InspectorControls>
 			) }
 			{ /*
@@ -108,7 +113,10 @@ function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
 			{ ! isWeb && blockName === 'core/heading' && (
 				<InspectorControls>
 					<PanelBody title={ __( 'Heading settings' ) }>
-						{ textControl }
+						<BlockEditAnchorControl
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+						/>
 					</PanelBody>
 				</InspectorControls>
 			) }
@@ -131,7 +139,7 @@ export const withAnchorControls = createHigherOrderComponent( ( BlockEdit ) => {
 				<BlockEdit { ...props } />
 				{ props.isSelected &&
 					hasBlockSupport( props.name, 'anchor' ) && (
-						<BlockEditAnchorControl
+						<BlockEditAnchor
 							blockName={ props.name }
 							attributes={ props.attributes }
 							setAttributes={ props.setAttributes }

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -341,13 +341,6 @@ export function ColorEdit( props ) {
 			value={ value }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			enableContrastChecker={
-				false !==
-				getBlockSupport( props.name, [
-					COLOR_SUPPORT_KEY,
-					'enableContrastChecker',
-				] )
-			}
 		>
 			{ enableContrastChecking && (
 				<BlockColorContrastChecker clientId={ clientId } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently the logic inside `ColorPanel` is being run for every keystroke while this panel may not even be visible (inspector controls hidden).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
