### PR TITLE
DataViews: iterate on list view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55075,6 +55075,7 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/private-apis": "file:../private-apis",
 				"classnames": "^2.3.1",
 				"remove-accents": "^0.5.0"
@@ -70411,6 +70412,7 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/private-apis": "file:../private-apis",
 				"classnames": "^2.3.1",
 				"remove-accents": "^0.5.0"

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -76,7 +76,7 @@ Example:
     -   `value`: the actual value selected by the user.
 -   `hiddenFields`: the `id` of the fields that are hidden in the UI.
 -   `layout`: config that is specific to a particular layout type.
-    -   `mediaField`: used by the `grid` layout. The `id` of the field to be used for rendering each card's media.
+    -   `mediaField`: used by the `grid` and `list` layouts. The `id` of the field to be used for rendering each card's media.
     -   `primaryField`: used by the `grid` and `list` layouts. The `id` of the field to be highlighted in each card/list item.
 
 ### View <=> data

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -22,6 +22,7 @@ npm install @wordpress/dataviews --save
 	fields={ fields }
 	actions={ [ trashPostAction ] }
 	paginationInfo={ { totalItems, totalPages } }
+	onClickPreviewField={ ( item ) => { /* handle preview */ } }
 />
 ```
 
@@ -77,6 +78,7 @@ Example:
 -   `layout`: config that is specific to a particular layout type.
     -   `mediaField`: used by the `grid` layout. The `id` of the field to be used for rendering each card's media.
     -   `primaryField`: used by the `grid` layout. The `id` of the field to be used for rendering each card's title.
+    -   `previewField`: used by the `list` layout. The `id` of the field to be used for triggering the preview.
 
 ### View <=> data
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -78,7 +78,6 @@ Example:
 -   `layout`: config that is specific to a particular layout type.
     -   `mediaField`: used by the `grid` layout. The `id` of the field to be used for rendering each card's media.
     -   `primaryField`: used by the `grid` and `list` layouts. The `id` of the field to be highlighted in each card/list item.
-    -   `preview`: boolean. Only supported by the `list` view. Whether or not previews are supported.
 
 ### View <=> data
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -22,7 +22,7 @@ npm install @wordpress/dataviews --save
 	fields={ fields }
 	actions={ [ trashPostAction ] }
 	paginationInfo={ { totalItems, totalPages } }
-	onClickPreviewField={ ( item ) => { /* handle preview */ } }
+	onClickPreview={ ( item ) => { /* handle preview */ } }
 />
 ```
 
@@ -77,8 +77,8 @@ Example:
 -   `hiddenFields`: the `id` of the fields that are hidden in the UI.
 -   `layout`: config that is specific to a particular layout type.
     -   `mediaField`: used by the `grid` layout. The `id` of the field to be used for rendering each card's media.
-    -   `primaryField`: used by the `grid` layout. The `id` of the field to be used for rendering each card's title.
-    -   `previewField`: used by the `list` layout. The `id` of the field to be used for triggering the preview.
+    -   `primaryField`: used by the `grid` and `list` layouts. The `id` of the field to be highlighted in each card/list item.
+    -   `preview`: boolean. Only supported by the `list` view. Whether or not previews are supported.
 
 ### View <=> data
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -22,7 +22,7 @@ npm install @wordpress/dataviews --save
 	fields={ fields }
 	actions={ [ trashPostAction ] }
 	paginationInfo={ { totalItems, totalPages } }
-	onClickPreview={ ( item ) => { /* handle preview */ } }
+	onSelectionChange={ ( items ) => { /* ... */ } }
 />
 ```
 

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/private-apis": "file:../private-apis",
 		"classnames": "^2.3.1",
 		"remove-accents": "^0.5.0"

--- a/packages/dataviews/src/constants.js
+++ b/packages/dataviews/src/constants.js
@@ -29,26 +29,17 @@ export const VIEW_LAYOUTS = [
 		label: __( 'Table' ),
 		component: ViewTable,
 		icon: blockTable,
-		supports: {
-			preview: false,
-		},
 	},
 	{
 		type: LAYOUT_GRID,
 		label: __( 'Grid' ),
 		component: ViewGrid,
 		icon: category,
-		supports: {
-			preview: false,
-		},
 	},
 	{
 		type: LAYOUT_LIST,
 		label: __( 'List' ),
 		component: ViewList,
 		icon: drawerLeft,
-		supports: {
-			preview: true,
-		},
 	},
 ];

--- a/packages/dataviews/src/constants.js
+++ b/packages/dataviews/src/constants.js
@@ -1,8 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { blockTable, category, drawerLeft } from '@wordpress/icons';
+import { __, isRTL } from '@wordpress/i18n';
+import {
+	blockTable,
+	category,
+	formatListBullets,
+	formatListBulletsRTL,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -40,6 +45,6 @@ export const VIEW_LAYOUTS = [
 		type: LAYOUT_LIST,
 		label: __( 'List' ),
 		component: ViewList,
-		icon: drawerLeft,
+		icon: isRTL() ? formatListBulletsRTL : formatListBullets,
 	},
 ];

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -28,7 +28,7 @@ export default function DataViews( {
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
-	onClickPreview,
+	onSelectionChange,
 } ) {
 	const ViewComponent = VIEW_LAYOUTS.find(
 		( v ) => v.type === view.type
@@ -73,7 +73,7 @@ export default function DataViews( {
 					data={ data }
 					getItemId={ getItemId }
 					isLoading={ isLoading }
-					onClickPreview={ onClickPreview }
+					onSelectionChange={ onSelectionChange }
 				/>
 				<Pagination
 					view={ view }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -28,7 +28,7 @@ export default function DataViews( {
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
-	onClickPreviewField,
+	onClickPreview,
 } ) {
 	const ViewComponent = VIEW_LAYOUTS.find(
 		( v ) => v.type === view.type
@@ -73,7 +73,7 @@ export default function DataViews( {
 					data={ data }
 					getItemId={ getItemId }
 					isLoading={ isLoading }
-					onClickPreviewField={ onClickPreviewField }
+					onClickPreview={ onClickPreview }
 				/>
 				<Pagination
 					view={ view }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -5,7 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,6 +30,13 @@ export default function DataViews( {
 	supportedLayouts,
 	onSelectionChange,
 } ) {
+	const [ selection, setSelection ] = useState( [] );
+
+	const onSetSelection = ( items ) => {
+		setSelection( items.map( ( item ) => item.id ) );
+		onSelectionChange( items );
+	};
+
 	const ViewComponent = VIEW_LAYOUTS.find(
 		( v ) => v.type === view.type
 	).component;
@@ -73,7 +80,8 @@ export default function DataViews( {
 					data={ data }
 					getItemId={ getItemId }
 					isLoading={ isLoading }
-					onSelectionChange={ onSelectionChange }
+					onSelectionChange={ onSetSelection }
+					selection={ selection }
 				/>
 				<Pagination
 					view={ view }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -28,6 +28,7 @@ export default function DataViews( {
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
+	onClickPreviewField,
 } ) {
 	const ViewComponent = VIEW_LAYOUTS.find(
 		( v ) => v.type === view.type
@@ -72,6 +73,7 @@ export default function DataViews( {
 					data={ data }
 					getItemId={ getItemId }
 					isLoading={ isLoading }
+					onClickPreviewField={ onClickPreviewField }
 				/>
 				<Pagination
 					view={ view }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -143,6 +143,9 @@
 		&:hover {
 			background-color: lighten($gray-100, 3%);
 		}
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
 		h3 {
 			overflow: hidden;
 			text-overflow: ellipsis;
@@ -151,9 +154,12 @@
 	}
 
 	.dataviews-list-view__item-selected,
-	.dataviews-list-view__item-selected:hover,
-	.dataviews-list-view__item-selected:focus {
+	.dataviews-list-view__item-selected:hover {
 		background-color: $gray-100;
+
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
 	}
 
 	.dataviews-list-view__media-wrapper {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -138,7 +138,12 @@
 			background-color: $gray-100;
 		}
 	}
+
+	.dataviews-list-view__fields {
+		color: $gray-700;
+	}
 }
+
 .dataviews-action-modal {
 	z-index: z-index(".dataviews-action-modal");
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -129,13 +129,17 @@
 
 .dataviews-list-view {
 	li {
-		padding: $grid-unit-15 $grid-unit-40;
 		border-bottom: $border-width solid $gray-100;
-		margin: 0;
 		&:last-child {
 			border-bottom: 0;
 		}
-		&:hover {
+	}
+
+	.dataviews-list-view__item {
+		padding: $grid-unit-15 $grid-unit-40;
+		margin: 0;
+		&:hover,
+		&:focus {
 			background-color: $gray-100;
 		}
 		h3 {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -127,6 +127,18 @@
 	}
 }
 
+.dataviews-list-view {
+	li {
+		padding: $grid-unit-20 $grid-unit-40;
+		border-bottom: $border-width solid $gray-100;
+		&:last-child {
+			border-bottom: 0;
+		}
+		&:hover {
+			background-color: $gray-100;
+		}
+	}
+}
 .dataviews-action-modal {
 	z-index: z-index(".dataviews-action-modal");
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -130,6 +130,7 @@
 .dataviews-list-view {
 	li {
 		border-bottom: $border-width solid $gray-100;
+		margin: 0;
 		&:last-child {
 			border-bottom: 0;
 		}
@@ -137,7 +138,6 @@
 
 	.dataviews-list-view__item {
 		padding: $grid-unit-15 $grid-unit-40;
-		margin: 0;
 		&:hover,
 		&:focus {
 			background-color: $gray-100;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -140,7 +140,7 @@
 		padding: $grid-unit-15 $grid-unit-40;
 		cursor: default;
 		&:hover {
-			background-color: lighten($gray-100,3%);
+			background-color: lighten($gray-100, 3%);
 		}
 		h3 {
 			overflow: hidden;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -139,6 +139,7 @@
 	.dataviews-list-view__item {
 		padding: $grid-unit-15 $grid-unit-40;
 		cursor: default;
+		&:focus,
 		&:hover {
 			background-color: lighten($gray-100, 3%);
 		}
@@ -150,7 +151,8 @@
 	}
 
 	.dataviews-list-view__item-selected,
-	.dataviews-list-view__item-selected:hover {
+	.dataviews-list-view__item-selected:hover,
+	.dataviews-list-view__item-selected:focus {
 		background-color: $gray-100;
 	}
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -138,9 +138,9 @@
 
 	.dataviews-list-view__item {
 		padding: $grid-unit-15 $grid-unit-40;
-		&:hover,
-		&:focus {
-			background-color: $gray-100;
+		cursor: default;
+		&:hover {
+			background-color: lighten($gray-100,3%);
 		}
 		h3 {
 			overflow: hidden;
@@ -149,8 +149,9 @@
 		}
 	}
 
-	.dataviews-list-view__item-selected {
-		background-color: $gray-200;
+	.dataviews-list-view__item-selected,
+	.dataviews-list-view__item-selected:hover {
+		background-color: $gray-100;
 	}
 
 	.dataviews-list-view__media-wrapper {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -129,30 +129,64 @@
 
 .dataviews-list-view {
 	li {
-		padding: $grid-unit-20 $grid-unit-40;
+		padding: $grid-unit-15 $grid-unit-40;
 		border-bottom: $border-width solid $gray-100;
+		margin: 0;
 		&:last-child {
 			border-bottom: 0;
 		}
 		&:hover {
 			background-color: $gray-100;
 		}
+		h3 {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
+
+	.dataviews-list-view__media-wrapper {
+		min-width: $grid-unit-40;
+		height: $grid-unit-40;
+		border-radius: $grid-unit-05;
+		overflow: hidden;
+		position: relative;
+
+		&:after {
+			content: "";
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			box-shadow: inset 0 0 0 $border-width rgba(0,0,0,0.1);
+			border-radius: $grid-unit-05;
+		}
 	}
 
 	.edit-site-page-pages__featured-image,
 	.dataviews-list-view__media-placeholder {
-		width: 45px;
-		height: 45px;
-		margin-right: 1em;
+		min-width: $grid-unit-40;
+		height: $grid-unit-40;
 	}
 
 	.dataviews-list-view__media-placeholder {
 		background-color: $gray-200;
-		border-radius: $radius-block-ui;
 	}
 
 	.dataviews-list-view__fields {
 		color: $gray-700;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		.dataviews-list-view__field {
+			margin-right: $grid-unit-15;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
 	}
 }
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -149,6 +149,10 @@
 		}
 	}
 
+	.dataviews-list-view__item-selected {
+		background-color: $gray-200;
+	}
+
 	.dataviews-list-view__media-wrapper {
 		min-width: $grid-unit-40;
 		height: $grid-unit-40;
@@ -156,14 +160,14 @@
 		overflow: hidden;
 		position: relative;
 
-		&:after {
+		&::after {
 			content: "";
 			position: absolute;
 			top: 0;
 			left: 0;
 			width: 100%;
 			height: 100%;
-			box-shadow: inset 0 0 0 $border-width rgba(0,0,0,0.1);
+			box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);
 			border-radius: $grid-unit-05;
 		}
 	}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -139,6 +139,18 @@
 		}
 	}
 
+	.edit-site-page-pages__featured-image,
+	.dataviews-list-view__media-placeholder {
+		width: 45px;
+		height: 45px;
+		margin-right: 1em;
+	}
+
+	.dataviews-list-view__media-placeholder {
+		background-color: $gray-200;
+		border-radius: $radius-block-ui;
+	}
+
 	.dataviews-list-view__fields {
 		color: $gray-700;
 	}

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -43,14 +43,14 @@ export default function ViewGrid( { data, fields, view, actions, getItemId } ) {
 					className="dataviews-view-grid__card"
 				>
 					<div className="dataviews-view-grid__media">
-						{ mediaField?.render( { item, view } ) }
+						{ mediaField?.render( { item } ) }
 					</div>
 					<HStack
 						className="dataviews-view-grid__primary-field"
 						justify="space-between"
 					>
 						<FlexBlock>
-							{ primaryField?.render( { item, view } ) }
+							{ primaryField?.render( { item } ) }
 						</FlexBlock>
 						<ItemActions
 							item={ item }
@@ -65,7 +65,6 @@ export default function ViewGrid( { data, fields, view, actions, getItemId } ) {
 						{ visibleFields.map( ( field ) => {
 							const renderedValue = field.render( {
 								item,
-								view,
 							} );
 							if ( ! renderedValue ) {
 								return null;
@@ -80,7 +79,7 @@ export default function ViewGrid( { data, fields, view, actions, getItemId } ) {
 										{ field.header }
 									</div>
 									<div className="dataviews-view-grid__field-value">
-										{ field.render( { item, view } ) }
+										{ field.render( { item } ) }
 									</div>
 								</VStack>
 							);

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -51,6 +51,7 @@ export default function ViewList( {
 						<div
 							role="button"
 							tabIndex={ 0 }
+							aria-pressed={ selection.includes( item.id ) }
 							onKeyDown={ onEnter( item ) }
 							className={ classNames(
 								'dataviews-list-view__item',

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -11,7 +11,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { ENTER } from '@wordpress/keycodes';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 
 export default function ViewList( {
 	view,
@@ -38,7 +38,7 @@ export default function ViewList( {
 
 	const onEnter = ( item ) => ( event ) => {
 		const { keyCode } = event;
-		if ( keyCode === ENTER ) {
+		if ( [ ENTER, SPACE ].includes( keyCode ) ) {
 			onSelectionChange( [ item ] );
 		}
 	};

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -39,25 +39,25 @@ export default function ViewList( {
 						key={ getItemId?.( item ) || index }
 						onClick={ () => onSelectionChange( [ item ] ) }
 					>
-						<HStack>
+						<HStack spacing={ 3 }>
 							{ mediaField?.render( { item } ) || (
 								<div className="dataviews-list-view__media-placeholder"></div>
 							) }
 							<HStack>
-								<VStack>
+								<VStack spacing={ 1 }>
 									{ primaryField?.render( { item } ) }
-									<HStack
-										alignment="left"
-										className="dataviews-list-view__fields"
-									>
+									<div className="dataviews-list-view__fields">
 										{ visibleFields.map( ( field ) => {
 											return (
-												<span key={ field.id }>
+												<span
+													key={ field.id }
+													className="dataviews-list-view__field"
+												>
 													{ field.render( { item } ) }
 												</span>
 											);
 										} ) }
-									</HStack>
+									</div>
 								</VStack>
 							</HStack>
 						</HStack>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -1,13 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalHeading as Heading } from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import Link from '../routes/link';
+import { Icon,
+	__experimentalHStack as HStack,} from '@wordpress/components';
+import { chevronRight } from '@wordpress/icons';
 
 export default function ViewList( {
 	view,
@@ -21,25 +18,16 @@ export default function ViewList( {
 		( field ) => field.id === view.layout.previewField
 	);
 	return (
-		<ul>
+		<ul className="dataviews-list-view">
 			{ shownData.map( ( item, index ) => {
 				return (
-					<li key={ getItemId?.( item ) || index }>
-						<Heading as="h3" level={ 5 }>
-							<Link
-								params={ {
-									postId: item.id,
-									postType: item.type,
-									canvas: 'edit',
-								} }
-								onClick={ ( event ) => {
-									event.preventDefault();
-									onClickPreviewField( item );
-								} }
-							>
-								{ previewField.getValue( { item } ) }
-							</Link>
-						</Heading>
+					<li key={ getItemId?.( item ) || index } onClick={ () => {
+						onClickPreviewField( item );
+					}}>
+						<HStack>
+						{ previewField?.render( { item } ) }
+						<Icon icon={ chevronRight } />
+						</HStack>
 					</li>
 				);
 			} ) }

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -1,9 +1,48 @@
 /**
+ * WordPress dependencies
+ */
+import { __experimentalHeading as Heading } from '@wordpress/components';
+import { useAsyncList } from '@wordpress/compose';
+
+/**
  * Internal dependencies
  */
-import ViewTable from './view-table';
+import Link from '../routes/link';
 
-export default function ViewList( props ) {
-	// To do: change to email-like preview list.
-	return <ViewTable { ...props } />;
+export default function ViewList( {
+	view,
+	fields,
+	data,
+	getItemId,
+	onClickPreviewField,
+} ) {
+	const shownData = useAsyncList( data, { step: 3 } );
+	const previewField = fields.find(
+		( field ) => field.id === view.layout.previewField
+	);
+	return (
+		<ul>
+			{ shownData.map( ( item, index ) => {
+				return (
+					<li key={ getItemId?.( item ) || index }>
+						<Heading as="h3" level={ 5 }>
+							<Link
+								params={ {
+									postId: item.id,
+									postType: item.type,
+									canvas: 'edit',
+								} }
+								onClick={ ( event ) => {
+									event.preventDefault();
+									onClickPreviewField( item );
+								} }
+							>
+								{ previewField.getValue( { item } ) }
+							</Link>
+						</Heading>
+					</li>
+				);
+			} ) }
+		</ul>
+	);
 }

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useAsyncList } from '@wordpress/compose';
@@ -14,6 +19,7 @@ export default function ViewList( {
 	data,
 	getItemId,
 	onSelectionChange,
+	selection,
 } ) {
 	const shownData = useAsyncList( data, { step: 3 } );
 	const mediaField = fields.find(
@@ -46,7 +52,13 @@ export default function ViewList( {
 							role="button"
 							tabIndex={ 0 }
 							onKeyDown={ onEnter( item ) }
-							className="dataviews-list-view__item"
+							className={ classNames(
+								'dataviews-list-view__item',
+								{
+									'dataviews-list-view__item-selected':
+										selection.includes( item.id ),
+								}
+							) }
 							onClick={ () => onSelectionChange( [ item ] ) }
 						>
 							<HStack spacing={ 3 }>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { useAsyncList } from '@wordpress/compose';
-import { Icon,
-	__experimentalHStack as HStack,} from '@wordpress/components';
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
 import { chevronRight } from '@wordpress/icons';
 
 export default function ViewList( {
@@ -23,17 +22,19 @@ export default function ViewList( {
 			{ shownData.map( ( item, index ) => {
 				return (
 					// TODO: make li interactive.
-					// fix jsx-a11y/click-events-have-key-events and jsx-a11y/no-noninteractive-element-interactions
-					<li key={ getItemId?.( item ) || index } onClick={ () => {
-						if (view.layout.preview) {
+					/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
+					<li
+						key={ getItemId?.( item ) || index }
+						onClick={ () => {
 							onClickPreview( item );
-						}
-					}}>
+						} }
+					>
 						<HStack>
-						{ primaryField?.render( { item } ) }
-						{ view.layout.preview && <Icon icon={ chevronRight } /> }
+							{ primaryField?.render( { item } ) }
+							<Icon icon={ chevronRight } />
 						</HStack>
 					</li>
+					/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
 				);
 			} ) }
 		</ul>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -62,9 +62,11 @@ export default function ViewList( {
 							onClick={ () => onSelectionChange( [ item ] ) }
 						>
 							<HStack spacing={ 3 }>
-								{ mediaField?.render( { item } ) || (
-									<div className="dataviews-list-view__media-placeholder"></div>
-								) }
+								<div className="dataviews-list-view__media-wrapper">
+									{ mediaField?.render( { item } ) || (
+										<div className="dataviews-list-view__media-placeholder"></div>
+									) }
+								</div>
 								<HStack>
 									<VStack spacing={ 1 }>
 										{ primaryField?.render( { item } ) }

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -11,21 +11,23 @@ export default function ViewList( {
 	fields,
 	data,
 	getItemId,
-	onClickPreviewField,
+	onClickPreview,
 } ) {
 	const shownData = useAsyncList( data, { step: 3 } );
-	const previewField = fields.find(
-		( field ) => field.id === view.layout.previewField
+	const primaryField = fields.find(
+		( field ) => field.id === view.layout.primaryField
 	);
 	return (
 		<ul className="dataviews-list-view">
 			{ shownData.map( ( item, index ) => {
 				return (
+					// TODO: make li interactive.
+					// fix jsx-a11y/click-events-have-key-events and jsx-a11y/no-noninteractive-element-interactions
 					<li key={ getItemId?.( item ) || index } onClick={ () => {
-						onClickPreviewField( item );
+						onClickPreview( item );
 					}}>
 						<HStack>
-						{ previewField?.render( { item } ) }
+						{ primaryField?.render( { item } ) }
 						<Icon icon={ chevronRight } />
 						</HStack>
 					</li>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { useAsyncList } from '@wordpress/compose';
-import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
-import { chevronRight } from '@wordpress/icons';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 
 export default function ViewList( {
 	view,
@@ -27,10 +26,7 @@ export default function ViewList( {
 						key={ getItemId?.( item ) || index }
 						onClick={ () => onSelectionChange( [ item ] ) }
 					>
-						<HStack>
-							{ primaryField?.render( { item } ) }
-							<Icon icon={ chevronRight } />
-						</HStack>
+						<HStack>{ primaryField?.render( { item } ) }</HStack>
 					</li>
 					/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
 				);

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -17,6 +17,7 @@ export default function ViewList( {
 	const primaryField = fields.find(
 		( field ) => field.id === view.layout.primaryField
 	);
+
 	return (
 		<ul className="dataviews-list-view">
 			{ shownData.map( ( item, index ) => {
@@ -24,11 +25,13 @@ export default function ViewList( {
 					// TODO: make li interactive.
 					// fix jsx-a11y/click-events-have-key-events and jsx-a11y/no-noninteractive-element-interactions
 					<li key={ getItemId?.( item ) || index } onClick={ () => {
-						onClickPreview( item );
+						if (view.layout.preview) {
+							onClickPreview( item );
+						}
 					}}>
 						<HStack>
 						{ primaryField?.render( { item } ) }
-						<Icon icon={ chevronRight } />
+						{ view.layout.preview && <Icon icon={ chevronRight } /> }
 						</HStack>
 					</li>
 				);

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useAsyncList } from '@wordpress/compose';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 
 export default function ViewList( {
 	view,
@@ -15,6 +18,11 @@ export default function ViewList( {
 	const primaryField = fields.find(
 		( field ) => field.id === view.layout.primaryField
 	);
+	const visibleFields = fields.filter(
+		( field ) =>
+			! view.hiddenFields.includes( field.id ) &&
+			view.layout.primaryField !== field.id
+	);
 
 	return (
 		<ul className="dataviews-list-view">
@@ -26,7 +34,21 @@ export default function ViewList( {
 						key={ getItemId?.( item ) || index }
 						onClick={ () => onSelectionChange( [ item ] ) }
 					>
-						<HStack>{ primaryField?.render( { item } ) }</HStack>
+						<VStack>
+							{ primaryField?.render( { item } ) }
+							<HStack
+								alignment="left"
+								className="dataviews-list-view__fields"
+							>
+								{ visibleFields.map( ( field ) => {
+									return (
+										<span key={ field.id }>
+											{ field.render( { item } ) }
+										</span>
+									);
+								} ) }
+							</HStack>
+						</VStack>
 					</li>
 					/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
 				);

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -15,13 +15,18 @@ export default function ViewList( {
 	onSelectionChange,
 } ) {
 	const shownData = useAsyncList( data, { step: 3 } );
+	const mediaField = fields.find(
+		( field ) => field.id === view.layout.mediaField
+	);
 	const primaryField = fields.find(
 		( field ) => field.id === view.layout.primaryField
 	);
 	const visibleFields = fields.filter(
 		( field ) =>
 			! view.hiddenFields.includes( field.id ) &&
-			view.layout.primaryField !== field.id
+			! [ view.layout.primaryField, view.layout.mediaField ].includes(
+				field.id
+			)
 	);
 
 	return (
@@ -34,21 +39,28 @@ export default function ViewList( {
 						key={ getItemId?.( item ) || index }
 						onClick={ () => onSelectionChange( [ item ] ) }
 					>
-						<VStack>
-							{ primaryField?.render( { item } ) }
-							<HStack
-								alignment="left"
-								className="dataviews-list-view__fields"
-							>
-								{ visibleFields.map( ( field ) => {
-									return (
-										<span key={ field.id }>
-											{ field.render( { item } ) }
-										</span>
-									);
-								} ) }
+						<HStack>
+							{ mediaField?.render( { item } ) || (
+								<div className="dataviews-list-view__media-placeholder"></div>
+							) }
+							<HStack>
+								<VStack>
+									{ primaryField?.render( { item } ) }
+									<HStack
+										alignment="left"
+										className="dataviews-list-view__fields"
+									>
+										{ visibleFields.map( ( field ) => {
+											return (
+												<span key={ field.id }>
+													{ field.render( { item } ) }
+												</span>
+											);
+										} ) }
+									</HStack>
+								</VStack>
 							</HStack>
-						</VStack>
+						</HStack>
 					</li>
 					/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
 				);

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -10,7 +10,7 @@ export default function ViewList( {
 	fields,
 	data,
 	getItemId,
-	onClickPreview,
+	onSelectionChange,
 } ) {
 	const shownData = useAsyncList( data, { step: 3 } );
 	const primaryField = fields.find(
@@ -26,7 +26,7 @@ export default function ViewList( {
 					<li
 						key={ getItemId?.( item ) || index }
 						onClick={ () => {
-							onClickPreview( item );
+							onSelectionChange( [ item ] );
 						} }
 					>
 						<HStack>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -6,6 +6,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { ENTER } from '@wordpress/keycodes';
 
 export default function ViewList( {
 	view,
@@ -29,40 +30,51 @@ export default function ViewList( {
 			)
 	);
 
+	const onEnter = ( item ) => ( event ) => {
+		const { keyCode } = event;
+		if ( keyCode === ENTER ) {
+			onSelectionChange( [ item ] );
+		}
+	};
+
 	return (
 		<ul className="dataviews-list-view">
 			{ shownData.map( ( item, index ) => {
 				return (
-					// TODO: make li interactive.
-					/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
-					<li
-						key={ getItemId?.( item ) || index }
-						onClick={ () => onSelectionChange( [ item ] ) }
-					>
-						<HStack spacing={ 3 }>
-							{ mediaField?.render( { item } ) || (
-								<div className="dataviews-list-view__media-placeholder"></div>
-							) }
-							<HStack>
-								<VStack spacing={ 1 }>
-									{ primaryField?.render( { item } ) }
-									<div className="dataviews-list-view__fields">
-										{ visibleFields.map( ( field ) => {
-											return (
-												<span
-													key={ field.id }
-													className="dataviews-list-view__field"
-												>
-													{ field.render( { item } ) }
-												</span>
-											);
-										} ) }
-									</div>
-								</VStack>
+					<li key={ getItemId?.( item ) || index }>
+						<div
+							role="button"
+							tabIndex={ 0 }
+							onKeyDown={ onEnter( item ) }
+							className="dataviews-list-view__item"
+							onClick={ () => onSelectionChange( [ item ] ) }
+						>
+							<HStack spacing={ 3 }>
+								{ mediaField?.render( { item } ) || (
+									<div className="dataviews-list-view__media-placeholder"></div>
+								) }
+								<HStack>
+									<VStack spacing={ 1 }>
+										{ primaryField?.render( { item } ) }
+										<div className="dataviews-list-view__fields">
+											{ visibleFields.map( ( field ) => {
+												return (
+													<span
+														key={ field.id }
+														className="dataviews-list-view__field"
+													>
+														{ field.render( {
+															item,
+														} ) }
+													</span>
+												);
+											} ) }
+										</div>
+									</VStack>
+								</HStack>
 							</HStack>
-						</HStack>
+						</div>
 					</li>
-					/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
 				);
 			} ) }
 		</ul>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -25,9 +25,7 @@ export default function ViewList( {
 					/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
 					<li
 						key={ getItemId?.( item ) || index }
-						onClick={ () => {
-							onSelectionChange( [ item ] );
-						} }
+						onClick={ () => onSelectionChange( [ item ] ) }
 					>
 						<HStack>
 							{ primaryField?.render( { item } ) }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -344,8 +344,7 @@ function ViewTable( {
 	const columns = useMemo( () => {
 		const _columns = fields.map( ( field ) => {
 			const { render, getValue, ...column } = field;
-			column.cell = ( props ) =>
-				render( { item: props.row.original, view } );
+			column.cell = ( props ) => render( { item: props.row.original } );
 			if ( getValue ) {
 				column.accessorFn = ( item ) => getValue( { item } );
 			}

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -216,7 +216,7 @@ export default function PagePages() {
 				render: ( { item } ) => {
 					return (
 						<VStack spacing={ 1 }>
-							<Heading as="h3" level={ 5 }>
+							<Heading as="h3" level={ 5 } weight={ 500 }>
 								{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
 									view.type
 								) ? (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -129,7 +129,7 @@ export default function PagePages() {
 	const [ view, setView ] = useView( postType );
 	const [ previewItem, setPreview ] = useState();
 
-	const onClickPreview = ( item ) => setPreview( item.id );
+	const onSelectionChange = ( item ) => setPreview( item.id );
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
@@ -319,7 +319,7 @@ export default function PagePages() {
 					isLoading={ isLoadingPages || isLoadingAuthors }
 					view={ view }
 					onChangeView={ onChangeView }
-					onClickPreview={ onClickPreview }
+					onSelectionChange={ onSelectionChange }
 				/>
 			</Page>
 			{ view.type === LAYOUT_LIST && (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -24,6 +24,7 @@ import {
 	ENUMERATION_TYPE,
 	LAYOUT_GRID,
 	LAYOUT_TABLE,
+	LAYOUT_LIST,
 	OPERATOR_IN,
 	OPERATOR_NOT_IN,
 } from '../../utils/constants';

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -12,7 +12,7 @@ import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { DataViews, VIEW_LAYOUTS } from '@wordpress/dataviews';
+import { DataViews } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
@@ -127,9 +127,9 @@ const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'tra
 export default function PagePages() {
 	const postType = 'page';
 	const [ view, setView ] = useView( postType );
-	const [ selection, setSelection ] = useState( [] );
+	const [ previewItem, setPreview ] = useState();
 
-	const onClickPreviewField = ( item ) => setSelection( [ item.id ] );
+	const onClickPreviewField = ( item ) => setPreview( item.id );
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
@@ -322,17 +322,16 @@ export default function PagePages() {
 					onClickPreviewField={ onClickPreviewField }
 				/>
 			</Page>
-			{ VIEW_LAYOUTS.find( ( v ) => v.type === view.type )?.supports
-				?.preview && (
+			{ view.layout.previewField && (
 				<Page>
 					<div className="edit-site-page-pages-preview">
-						{ selection.length === 1 && (
+						{ previewItem && (
 							<SideEditor
-								postId={ selection[ 0 ] }
+								postId={ previewItem }
 								postType={ postType }
 							/>
 						) }
-						{ selection.length !== 1 && (
+						{ ! previewItem && (
 							<div
 								style={ {
 									display: 'flex',

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -51,6 +51,7 @@ const defaultConfigPerViewType = {
 	},
 	[ LAYOUT_LIST ]: {
 		primaryField: 'title',
+		mediaField: 'featured-image',
 	},
 };
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -194,13 +194,13 @@ export default function PagePages() {
 				id: 'featured-image',
 				header: __( 'Featured Image' ),
 				getValue: ( { item } ) => item.featured_media,
-				render: ( { item, view: currentView } ) =>
+				render: ( { item } ) =>
 					!! item.featured_media ? (
 						<Media
 							className="edit-site-page-pages__featured-image"
 							id={ item.featured_media }
 							size={
-								currentView.type === 'list'
+								view.type === 'list'
 									? [ 'thumbnail', 'medium', 'large', 'full' ]
 									: [ 'large', 'full', 'medium', 'thumbnail' ]
 							}
@@ -271,7 +271,7 @@ export default function PagePages() {
 				},
 			},
 		],
-		[ authors ]
+		[ authors, view ]
 	);
 
 	const permanentlyDeletePostAction = usePermanentlyDeletePostAction();

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -50,7 +50,6 @@ const defaultConfigPerViewType = {
 	},
 	[ LAYOUT_LIST ]: {
 		primaryField: 'title',
-		preview: true,
 	},
 };
 
@@ -323,7 +322,7 @@ export default function PagePages() {
 					onClickPreview={ onClickPreview }
 				/>
 			</Page>
-			{ view.layout.preview && (
+			{ view.type === LAYOUT_LIST && (
 				<Page>
 					<div className="edit-site-page-pages-preview">
 						{ previewItem && (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -200,9 +200,9 @@ export default function PagePages() {
 							className="edit-site-page-pages__featured-image"
 							id={ item.featured_media }
 							size={
-								view.type === 'list'
-									? [ 'thumbnail', 'medium', 'large', 'full' ]
-									: [ 'large', 'full', 'medium', 'thumbnail' ]
+								view.type === LAYOUT_GRID
+									? [ 'large', 'full', 'medium', 'thumbnail' ]
+									: [ 'thumbnail', 'medium', 'large', 'full' ]
 							}
 						/>
 					) : null,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -48,6 +48,9 @@ const defaultConfigPerViewType = {
 		mediaField: 'featured-image',
 		primaryField: 'title',
 	},
+	[ LAYOUT_LIST ]: {
+		previewField: 'title',
+	},
 };
 
 function useView( type ) {
@@ -125,6 +128,8 @@ export default function PagePages() {
 	const postType = 'page';
 	const [ view, setView ] = useView( postType );
 	const [ selection, setSelection ] = useState( [] );
+
+	const onClickPreviewField = ( item ) => setSelection( [ item.id ] );
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
@@ -205,7 +210,7 @@ export default function PagePages() {
 				header: __( 'Title' ),
 				id: 'title',
 				getValue: ( { item } ) => item.title?.rendered || item.slug,
-				render: ( { item, view: { type } } ) => {
+				render: ( { item } ) => {
 					return (
 						<VStack spacing={ 1 }>
 							<Heading as="h3" level={ 5 }>
@@ -214,16 +219,6 @@ export default function PagePages() {
 										postId: item.id,
 										postType: item.type,
 										canvas: 'edit',
-									} }
-									onClick={ ( event ) => {
-										if (
-											VIEW_LAYOUTS.find(
-												( v ) => v.type === type
-											)?.supports?.preview
-										) {
-											event.preventDefault();
-											setSelection( [ item.id ] );
-										}
 									} }
 								>
 									{ decodeEntities(
@@ -324,6 +319,7 @@ export default function PagePages() {
 					isLoading={ isLoadingPages || isLoadingAuthors }
 					view={ view }
 					onChangeView={ onChangeView }
+					onClickPreviewField={ onClickPreviewField }
 				/>
 			</Page>
 			{ VIEW_LAYOUTS.find( ( v ) => v.type === view.type )?.supports

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -49,7 +49,8 @@ const defaultConfigPerViewType = {
 		primaryField: 'title',
 	},
 	[ LAYOUT_LIST ]: {
-		previewField: 'title',
+		primaryField: 'title',
+		preview: true,
 	},
 };
 
@@ -129,7 +130,7 @@ export default function PagePages() {
 	const [ view, setView ] = useView( postType );
 	const [ previewItem, setPreview ] = useState();
 
-	const onClickPreviewField = ( item ) => setPreview( item.id );
+	const onClickPreview = ( item ) => setPreview( item.id );
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
@@ -319,10 +320,10 @@ export default function PagePages() {
 					isLoading={ isLoadingPages || isLoadingAuthors }
 					view={ view }
 					onChangeView={ onChangeView }
-					onClickPreviewField={ onClickPreviewField }
+					onClickPreview={ onClickPreview }
 				/>
 			</Page>
-			{ view.layout.previewField && (
+			{ view.layout.preview && (
 				<Page>
 					<div className="edit-site-page-pages-preview">
 						{ previewItem && (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -217,17 +217,25 @@ export default function PagePages() {
 					return (
 						<VStack spacing={ 1 }>
 							<Heading as="h3" level={ 5 }>
-								<Link
-									params={ {
-										postId: item.id,
-										postType: item.type,
-										canvas: 'edit',
-									} }
-								>
-									{ decodeEntities(
+								{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
+									view.type
+								) ? (
+									<Link
+										params={ {
+											postId: item.id,
+											postType: item.type,
+											canvas: 'edit',
+										} }
+									>
+										{ decodeEntities(
+											item.title?.rendered || item.slug
+										) || __( '(no title)' ) }
+									</Link>
+								) : (
+									decodeEntities(
 										item.title?.rendered || item.slug
-									) || __( '(no title)' ) }
-								</Link>
+									) || __( '(no title)' )
+								) }
 							</Heading>
 						</VStack>
 					);

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -128,9 +128,10 @@ const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'tra
 export default function PagePages() {
 	const postType = 'page';
 	const [ view, setView ] = useView( postType );
-	const [ previewItem, setPreview ] = useState();
+	const [ pageId, setPageId ] = useState( null );
 
-	const onSelectionChange = ( item ) => setPreview( item.id );
+	const onSelectionChange = ( items ) =>
+		setPageId( items?.length === 1 ? items[ 0 ].id : null );
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
@@ -326,13 +327,12 @@ export default function PagePages() {
 			{ view.type === LAYOUT_LIST && (
 				<Page>
 					<div className="edit-site-page-pages-preview">
-						{ previewItem && (
+						{ pageId !== null ? (
 							<SideEditor
-								postId={ previewItem }
+								postId={ pageId }
 								postType={ postType }
 							/>
-						) }
-						{ ! previewItem && (
+						) : (
 							<div
 								style={ {
 									display: 'flex',

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -176,11 +176,11 @@ export default function DataviewsTemplates() {
 			{
 				header: __( 'Preview' ),
 				id: 'preview',
-				render: ( { item, view: { type: viewType } } ) => {
+				render: ( { item } ) => {
 					return (
 						<TemplatePreview
 							content={ item.content.raw }
-							viewType={ viewType }
+							viewType={ view.type }
 						/>
 					);
 				},
@@ -229,7 +229,7 @@ export default function DataviewsTemplates() {
 				elements: authors,
 			},
 		],
-		[ authors ]
+		[ authors, view ]
 	);
 
 	const { shownTemplates, paginationInfo } = useMemo( () => {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/pull/56476#discussion_r1413629329

## What?

This PR iterates on the API and design of the list view:

https://github.com/WordPress/gutenberg/assets/583546/31fd1220-15a2-4e28-9e55-da8a61e1d837

## Why?

- API wise, we need to define how the consumer work with previews.
- At the moment, the list view is using the table layout – it needs its own. Target design:

![274858864-cf194048-01a3-4410-8025-4ab1f6354fd2](https://github.com/WordPress/gutenberg/assets/583546/9c7655cc-5c34-40df-8900-98871fc0107c)

## How?

- The `render` prop of the field API only takes an `item` as parameter, no longer takes the view, mimicking how `getValue` works.
- Let the consumer configure the list view by setting the primary & media fields.
- We don't plan to have a `list` view that works with and without preview, so it's not necessary to export whether the view supports previews or not.

```js
{
  [ LAYOUT_LIST ]: {
    primaryField: 'title',
    mediaField: 'featured-image',
  }
}
```

- The selection affordance is no longer provided by a field (link), but by the view itself. Expose a `onSelectionChange` prop to `DataViews` component that relays the selection to the consumer, to update the preview.

```js
<DataViews
  onSelectionChange={ ( items ) => { /* consumer instantiates the preview * / } }
/>
``` 

## Testing Instructions

- Enable the "new admin view" experiment and visit "Manage all pages" or "Manage all templates".
- Select the "list" layout and interact with it.

## Follow-ups

- Filters: display them condensed, in a dropdown + reduce the width of the view frame.
- Button to trigger the page details (chrevon right in list items).
- Action items: could be added after the buttor to trigger the page details (see [mockup](https://github.com/WordPress/gutenberg/pull/56746#issuecomment-1840500851)).
- Keyboard navigation: potentially use arrow up/down to navigate through the list (to revisit when the items have buttons within).
- Preview should be a toggle-able field.
- Enable list view for templates.
- Clicking the Frame should go to edit view.
