### PR TITLE
Interactivity API: update TS/JSDocs after migrating to the new `store()` API

### DIFF
--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -255,7 +255,7 @@ const getEvaluate: GetEvaluate =
 		}
 		// If path starts with !, remove it and save a flag.
 		const hasNegationOperator =
-			path[ 0 ] === '!' && !! ( path = path!.slice( 1 ) );
+			path[ 0 ] === '!' && !! ( path = path.slice( 1 ) );
 		setScope( scope );
 		const value = resolve( path, namespace );
 		const result = typeof value === 'function' ? value( ...args ) : value;

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -71,7 +71,7 @@ interface DirectivesProps {
 }
 
 // Main context.
-const context = createContext( {} );
+const context = createContext< any >( {} );
 
 // Wrap the element props to prevent modifications.
 const immutableMap = new WeakMap();
@@ -272,7 +272,7 @@ const Directives = ( {
 	// element ref, state and props.
 	const scope = useRef< Scope >( {} as Scope ).current;
 	scope.evaluate = useCallback( getEvaluate( { scope } ), [] );
-	scope.context = useContext< any >( context );
+	scope.context = useContext( context );
 	/* eslint-disable react-hooks/rules-of-hooks */
 	scope.ref = previousScope.ref || useRef( null );
 	scope.state = previousScope.state || useRef( deepSignal( {} ) ).current;

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -101,9 +101,25 @@ const deepImmutable = < T extends Object = {} >( target: T ): T => {
 const scopeStack: Scope[] = [];
 const namespaceStack: string[] = [];
 
+/**
+ * Retrieves the context inherited by the element evaluating a function from the
+ * store. The returned value depends on the element and the namespace where the
+ * function calling `getContext()` exists.
+ *
+ * @param namespace Store namespace. By default, the namespace where the calling
+ *                  function exists is used.
+ * @return The context content.
+ */
 export const getContext = < T extends object >( namespace?: string ): T =>
 	getScope()?.context[ namespace || namespaceStack.slice( -1 )[ 0 ] ];
 
+/**
+ * Retrieves a representation of the element where a function from the store
+ * is being evalutated. Such representation is read-only, and contains a
+ * reference to the DOM element, its props and a local reactive state.
+ *
+ * @return Element representation.
+ */
 export const getElement = () => {
 	if ( ! getScope() ) {
 		throw Error(

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -296,8 +296,8 @@ const Directives = ( {
 	scope.evaluate = useCallback( getEvaluate( { scope } ), [] );
 	scope.context = useContext( context );
 	/* eslint-disable react-hooks/rules-of-hooks */
-	scope.ref = previousScope.ref || useRef( null );
-	scope.state = previousScope.state || useRef( deepSignal( {} ) ).current;
+	scope.ref = previousScope?.ref || useRef( null );
+	scope.state = previousScope?.state || useRef( deepSignal( {} ) ).current;
 	/* eslint-enable react-hooks/rules-of-hooks */
 
 	// Create a fresh copy of the vnode element and add the props to the scope.

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -19,10 +19,26 @@ interface DirectiveEntry {
 type DirectiveEntries = Record< string, DirectiveEntry[] >;
 
 interface DirectiveArgs {
+	/**
+	 * Object map with the defined directives of the element being evaluated.
+	 */
 	directives: DirectiveEntries;
+	/**
+	 * Props present in the current element.
+	 */
 	props: Object;
+	/**
+	 * Virtual node representing the element.
+	 */
 	element: VNode;
+	/**
+	 * The inherited context.
+	 */
 	context: Context< any >;
+	/**
+	 * Function that resolves a given path to a value either in the store or the
+	 * context.
+	 */
 	evaluate: Evaluate;
 }
 

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -176,8 +176,8 @@ const directivePriorities: Record< string, number > = {};
  * @example
  * ```js
  * directive(
- *   'alert', // Name without the `data-wp-` prefix. ( {
- *   directives: { alert }, element, evaluate }) => {
+ *   'alert', // Name without the `data-wp-` prefix.
+ *   ( { directives: { alert }, element, evaluate } ) => {
  *     const defaultEntry = alert.find( entry => entry.suffix === 'default' );
  *     element.props.onclick = () => { alert( evaluate( defaultEntry ) ); }
  *   }

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -154,7 +154,7 @@ const directivePriorities: Record< string, number > = {};
  *
  * The previous code registers a custom directive type for displaying an alert
  * message whenever an element using it is clicked. The message text is obtained
- * from the store using `evaluate`.
+ * from the store under the inherited namespace, using `evaluate`.
  *
  * When the HTML is processed by the Interactivity API, any element containing
  * the `data-wp-alert` directive will have the `onclick` event handler, e.g.,
@@ -164,10 +164,10 @@ const directivePriorities: Record< string, number > = {};
  *   <button data-wp-alert="state.alert">Click me!</button>
  * </div>
  * ```
- * Note that, in the previous example, you access `alert.default` in order to
- * retrieve the `state.alert` value passed to the directive. You can
- * also define custom names by appending `--` to the directive attribute,
- * followed by a suffix, like in the following HTML snippet:
+ * Note that, in the previous example, the directive callback gets the path
+ * value (`state.alert`) from the directive entry with suffix `default`. A
+ * custom suffix can also be specified by appending `--` to the directive
+ * attribute, followed by the suffix, like in the following HTML snippet:
  *
  * ```html
  * <div data-wp-interactive='{ "namespace": "myblock" }'>
@@ -185,19 +185,21 @@ const directivePriorities: Record< string, number > = {};
  * ```js
  * directive(
  *   'color', // Name without prefix and suffix.
- *   ( { directives: { color }, ref, evaluate }) => {
- *     if ( color.text ) {
- *       ref.style.setProperty(
- *         'color',
- *         evaluate( color.text )
- *       );
- *     }
- *     if ( color.background ) {
- *       ref.style.setProperty(
- *         'background-color',
- *         evaluate( color.background )
- *       );
- *     }
+ *   ( { directives: { color }, ref, evaluate } ) =>
+ *     colors.forEach( ( color ) => {
+ *       if ( color.suffix = 'text' ) {
+ *         ref.style.setProperty(
+ *           'color',
+ *           evaluate( color.text )
+ *         );
+ *       }
+ *       if ( color.suffix = 'background' ) {
+ *         ref.style.setProperty(
+ *           'background-color',
+ *           evaluate( color.background )
+ *         );
+ *       }
+ *     } );
  *   }
  * )
  * ```

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -27,7 +27,7 @@ interface DirectiveArgs {
 }
 
 interface DirectiveCallback {
-	( params: DirectiveArgs ): VNode | void;
+	( args: DirectiveArgs ): VNode | void;
 }
 
 interface DirectiveOptions {
@@ -145,9 +145,9 @@ const directivePriorities: Record< string, number > = {};
  * ```js
  * directive(
  *   'alert', // Name without the `data-wp-` prefix. ( {
- *   directives: { alert }, element, evaluate }) => { element.props.onclick = ()
- *   => { alert( evaluate( alert.default ) );
- *     }
+ *   directives: { alert }, element, evaluate }) => {
+ *     const defaultEntry = alert.find( entry => entry.suffix === 'default' );
+ *     element.props.onclick = () => { alert( evaluate( defaultEntry ) ); }
  *   }
  * )
  * ```
@@ -160,18 +160,22 @@ const directivePriorities: Record< string, number > = {};
  * the `data-wp-alert` directive will have the `onclick` event handler, e.g.,
  *
  * ```html
- * <button data-wp-alert="state.messages.alert">Click me!</button>
+ * <div data-wp-interactive='{ "namespace": "messages" }'>
+ *   <button data-wp-alert="state.alert">Click me!</button>
+ * </div>
  * ```
  * Note that, in the previous example, you access `alert.default` in order to
- * retrieve the `state.messages.alert` value passed to the directive. You can
+ * retrieve the `state.alert` value passed to the directive. You can
  * also define custom names by appending `--` to the directive attribute,
  * followed by a suffix, like in the following HTML snippet:
  *
  * ```html
- * <button
- *   data-wp-color--text="state.theme.text"
- *   data-wp-color--background="state.theme.background"
- * >Click me!</button>
+ * <div data-wp-interactive='{ "namespace": "myblock" }'>
+ *   <button
+ *     data-wp-color--text="state.text"
+ *     data-wp-color--background="state.background"
+ *   >Click me!</button>
+ * </div>
  * ```
  *
  * This could be an hypothetical implementation of the custom directive used in

--- a/packages/interactivity/src/router.js
+++ b/packages/interactivity/src/router.js
@@ -59,8 +59,18 @@ const regionsToVdom = ( dom ) => {
 	return { regions, title };
 };
 
-// Prefetch a page. We store the promise to avoid triggering a second fetch for
-// a page if a fetching has already started.
+/**
+ * Prefetchs the page with the passed URL.
+ *
+ * The function normalizes the URL and stores internally the fetch promise, to
+ * avoid triggering a second fetch for an ongoing request.
+ *
+ * @param {string}  url             The page URL.
+ * @param {Object}  [options]       Options object.
+ * @param {boolean} [options.force] Force fetching the URL again.
+ * @param {string}  [options.html]  HTML string to be used instead of fetching
+ *                                  the requested URL.
+ */
 export const prefetch = ( url, options = {} ) => {
 	url = cleanUrl( url );
 	if ( options.force || ! pages.has( url ) ) {
@@ -84,7 +94,26 @@ const renderRegions = ( page ) => {
 // Variable to store the current navigation.
 let navigatingTo = '';
 
-// Navigate to a new page.
+/**
+ * Navigates to the specified page.
+ *
+ * This function normalizes the passed href, fetchs the page HTML if needed, and
+ * updates any interactive regions whose contents have changed. It also creates
+ * a new entry in the browser session history.
+ *
+ * @param {string}  href              The page href.
+ * @param {Object}  [options]         Options object.
+ * @param {boolean} [options.force]   If true, it forces re-fetching the URL.
+ * @param {string}  [options.html]    HTML string to be used instead of fetching
+ *                                    the requested URL.
+ * @param {boolean} [options.replace] If true, it replaces the current entry in
+ *                                    the browser session history.
+ * @param {number}  [options.timeout] Time until the navigation is aborted, in
+ *                                    milliseconds. Default is 10000.
+ *
+ * @return {Promise} Promise that resolves once the navigation is completed or
+ *                   aborted.
+ */
 export const navigate = async ( href, options = {} ) => {
 	const url = cleanUrl( href );
 	navigatingTo = href;

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -164,71 +164,88 @@ const handlers = {
 		return result;
 	},
 };
-
-/**
- * @typedef StoreProps Properties object passed to `store`.
- * @property {Object} state State to be added to the global store. All the
- *                          properties included here become reactive.
- */
-
-/**
- * @typedef StoreOptions Options object.
- */
-
-/**
- * Extends the Interactivity API global store with the passed properties.
- *
- * These props typically consist of `state`, which is reactive, and other
- * properties like `selectors`, `actions`, `effects`, etc. which can store
- * callbacks and derived state. These props can then be referenced by any
- * directive to make the HTML interactive.
- *
- * @example
- * ```js
- *  store({
- *    state: {
- *      counter: { value: 0 },
- *    },
- *    actions: {
- *      counter: {
- *        increment: ({ state }) => {
- *          state.counter.value += 1;
- *        },
- *      },
- *    },
- *  });
- * ```
- *
- * The code from the example above allows blocks to subscribe and interact with
- * the store by using directives in the HTML, e.g.:
- *
- * ```html
- * <div data-wp-interactive>
- *   <button
- *     data-wp-text="state.counter.value"
- *     data-wp-on--click="actions.counter.increment"
- *   >
- *     0
- *   </button>
- * </div>
- * ```
- *
- * @param {StoreProps}   properties Properties to be added to the global store.
- * @param {StoreOptions} [options]  Options passed to the `store` call.
- */
-
 interface StoreOptions {
+	/**
+	 * Property to block/unblock private store namespaces.
+	 *
+	 * If the passed value is `true`, it blocks the given namespace, making it
+	 * accessible only trough the returned variables of the `store()` call. In
+	 * the case a lock string is passed, it also blocks the namespace, but can
+	 * be unblocked for other `store()` calls using the same lock string.
+	 *
+	 * @example
+	 * ```
+	 * // The store can only be accessed where the `state` const can.
+	 * const { state } = store( 'myblock/private', { ... }, { lock: true } );
+	 * ```
+	 *
+	 * @example
+	 * ```
+	 * // Other modules knowing `SECRET_LOCK_STRING` can access the namespace.
+	 * const { state } = store(
+	 *   'myblock/private',
+	 *   { ... },
+	 *   { lock: 'SECRET_LOCK_STRING' }
+	 * );
+	 * ```
+	 */
 	lock?: boolean | string;
 }
 
 const universalUnlock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
+/**
+ * Extends the Interactivity API global store adding the passed properties to
+ * the given namespace. It also returns stable references to the namespace
+ * content.
+ *
+ * These props typically consist of `state`, which is the reactive part of the
+ * store ― which means that any directive referencing a state property will be
+ * re-rendered anytime it changes ― and function properties like `actions` and
+ * `callbacks`, mostly used for event handlers. These props can then be
+ * referenced by any directive to make the HTML interactive.
+ *
+ * @example
+ * ```js
+ *  const { state } = store( 'counter', {
+ *    state: {
+ *      value: 0,
+ *      get double() { return state.value * 2; },
+ *    },
+ *    actions: {
+ *      increment() {
+ *        state.value += 1;
+ *      },
+ *    },
+ *  } );
+ * ```
+ *
+ * The code from the example above allows blocks to subscribe and interact with
+ * the store by using directives in the HTML, e.g.:
+ *
+ * ```html
+ * <div data-wp-interactive='{ "namespace": "counter" }'>
+ *   <button
+ *     data-wp-text="state.double"
+ *     data-wp-on--click="actions.increment"
+ *   >
+ *     0
+ *   </button>
+ * </div>
+ * ```
+ * @param namespace The store namespace to interact with.
+ * @param storePart Properties to add to the store namespace.
+ * @param options   Options for the given namespace.
+ *
+ * @return A reference to the namespace content.
+ */
 export function store< S extends object = {} >(
 	namespace: string,
 	storePart?: S,
 	options?: StoreOptions
 ): S;
+
 export function store< T extends object >(
 	namespace: string,
 	storePart?: T,


### PR DESCRIPTION
## What?

Tracking issue: https://github.com/WordPress/gutenberg/issues/53740

Update comments describing the public API of the Interactivity API package. More precisely, these function comments have been updated:

- [x] Fixed outdated docs: [`store()`](https://github.com/WordPress/gutenberg/blob/53ffc0b1ba97ca13355cfd81be3b85b58d7d9920/packages/interactivity/src/store.ts#L178-L218), [`directive()`](https://github.com/WordPress/gutenberg/blob/53ffc0b1ba97ca13355cfd81be3b85b58d7d9920/packages/interactivity/src/hooks.tsx#L108-L172)
- [x] Added missing docs: `getContext()`, `getElement()`, `navigate()`, `prefetch()`

## Why?

The migration to the new `store()` API introduced breaking changes, making these APIs different.

## How?

Updating docs to reflect the new API usage.
