### PR TITLE
[Mobile] - Global Styles - Fix issue with custom color variables not being parsed

### DIFF
--- a/packages/components/src/mobile/global-styles-context/test/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/test/utils.native.js
@@ -108,6 +108,28 @@ describe( 'parseStylesVariables', () => {
 			expect.objectContaining( PARSED_GLOBAL_STYLES )
 		);
 	} );
+
+	it( 'returns the parsed custom color values correctly', () => {
+		const defaultStyles = {
+			...DEFAULT_GLOBAL_STYLES,
+			color: {
+				text: 'var(--wp--custom--color--blue)',
+				background: 'var(--wp--custom--color--green)',
+			},
+		};
+		const customValues = parseStylesVariables(
+			JSON.stringify( RAW_FEATURES.custom ),
+			MAPPED_VALUES
+		);
+		const styles = parseStylesVariables(
+			JSON.stringify( defaultStyles ),
+			MAPPED_VALUES,
+			customValues
+		);
+		expect( styles ).toEqual(
+			expect.objectContaining( PARSED_GLOBAL_STYLES )
+		);
+	} );
 } );
 
 describe( 'getGlobalStyles', () => {

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -248,6 +248,20 @@ export function parseStylesVariables( styles, mappedValues, customValues ) {
 			const customValuesData = customValues ?? JSON.parse( stylesBase );
 			stylesBase = stylesBase.replace( regex, ( _$1, $2 ) => {
 				const path = $2.split( '--' );
+
+				// Supports cases for variables like var(--wp--custom--color--background)
+				if ( path[ 0 ] === 'color' ) {
+					const colorKey = path[ path.length - 1 ];
+					if ( mappedValues?.color ) {
+						const matchedValue = mappedValues.color?.values?.find(
+							( { slug } ) => slug === colorKey
+						);
+						if ( matchedValue ) {
+							return `${ matchedValue?.color }`;
+						}
+					}
+				}
+
 				if (
 					path.reduce(
 						( prev, curr ) => prev && prev[ curr ],


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6434

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6431

## What?
This PR fixes issues related to some themes not being parsed correctly in the editor. It looks like it's happening to some legacy theme implementations.

## Why?
To prevent rendering the editor with the wrong colors and affecting the writing flow.

## How?
It updates the `parseStylesVariables` function to take into account custom variables like `--wp--custom--color--background` to avoid having `undefined` colors.

## Testing Instructions
- Change your site's theme to `Russel`
- Open the host apps with metro running
- Open the editor
- Expect to see the right colors for both light and dark mode

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

Android Placeholders (Light)|Android Placeholders (Dark)
-|-
<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/9df0e15e-fc7e-4d8e-b434-55867cd94843" width=250 /></kbd>|<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/c65a6659-a784-4a19-b418-724fe6da4133" width=250 /></kbd>

Android Text (Light)|Android Text (Dark)
-|-
<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/11c6e3cc-f4cc-441f-a71a-e76d50030249" width=250 /></kbd>|<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/e1633b5b-507a-46e0-aa19-49910de066c1" width=250 /></kbd>

iOS Placeholders (Light)|iOS Placeholders (Dark)
-|-
<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/e227fff0-4da9-4cab-bd9e-778dbb107641" width=250 /></kbd>|<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/2ccaa843-4759-4970-959c-5304308622c6" width=250 /></kbd>

iOS Text (Light)|iOS Text (Dark)
-|-
<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/6eefba1c-bb56-4755-8967-810e66c09946" width=250 /></kbd>|<kbd><img src="https://github.com/WordPress/gutenberg/assets/4885740/938a6c39-f829-4e87-b8b6-c9e9a80d797c" width=250 /></kbd>