### PR TITLE
Performance: measure typing without inspector

### DIFF
--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -26,6 +26,7 @@ export interface WPRawPerformanceResults {
 	firstContentfulPaint: number[];
 	firstBlock: number[];
 	type: number[];
+	typeWithoutInspector: number[];
 	typeContainer: number[];
 	focus: number[];
 	inserterOpen: number[];
@@ -48,6 +49,9 @@ export interface WPPerformanceResults {
 	type?: number;
 	minType?: number;
 	maxType?: number;
+	typeWithoutInspector?: number;
+	minTypeWithoutInspector?: number;
+	maxTypeWithoutInspector?: number;
 	typeContainer?: number;
 	minTypeContainer?: number;
 	maxTypeContainer?: number;
@@ -92,6 +96,9 @@ export function curateResults(
 		type: average( results.type ),
 		minType: minimum( results.type ),
 		maxType: maximum( results.type ),
+		typeWithoutInspector: average( results.typeWithoutInspector ),
+		minTypeWithoutInspector: minimum( results.typeWithoutInspector ),
+		maxTypeWithoutInspector: maximum( results.typeWithoutInspector ),
 		typeContainer: average( results.typeContainer ),
 		minTypeContainer: minimum( results.typeContainer ),
 		maxTypeContainer: maximum( results.typeContainer ),

--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -50,8 +50,6 @@ export interface WPPerformanceResults {
 	minType?: number;
 	maxType?: number;
 	typeWithoutInspector?: number;
-	minTypeWithoutInspector?: number;
-	maxTypeWithoutInspector?: number;
 	typeContainer?: number;
 	minTypeContainer?: number;
 	maxTypeContainer?: number;
@@ -97,8 +95,6 @@ export function curateResults(
 		minType: minimum( results.type ),
 		maxType: maximum( results.type ),
 		typeWithoutInspector: average( results.typeWithoutInspector ),
-		minTypeWithoutInspector: minimum( results.typeWithoutInspector ),
-		maxTypeWithoutInspector: maximum( results.typeWithoutInspector ),
 		typeContainer: average( results.typeContainer ),
 		minTypeContainer: minimum( results.typeContainer ),
 		maxTypeContainer: maximum( results.typeContainer ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a typing perf metric with the inspector panel closed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

* We are trying promote the isolated block editor, which is often used without an inspector panel, so excellent performance would be great here (I believe we can get this metric even further down).
* Catch regressions: for example creating react trees for inspector controls that won't be rendered is bad.
* The difference in metrics gives us a good picture of how much of the performance issues are coming from the inspector.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
