### PR TITLE
[RNMobile] Address `NullPointerException` crash in `AztecHeadingSpan`

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         espressoVersion = '3.0.1'
 
         // libs
-        aztecVersion = 'v1.8.0'
+        aztecVersion = '1071-6dd6bc5768a6e8eb60945171a1ee65346bf921b4'
         wordpressUtilsVersion = '3.3.0'
 
         // main

--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         espressoVersion = '3.0.1'
 
         // libs
-        aztecVersion = '1071-6dd6bc5768a6e8eb60945171a1ee65346bf921b4'
+        aztecVersion = 'v1.9.0'
         wordpressUtilsVersion = '3.3.0'
 
         // main

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -16,6 +16,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [***] Fix issue when backspacing in an empty Paragraph block [#56496]
 -   [**] Fix issue related to text color format and receiving in rare cases an undefined ref from `RichText` component [#56686]
 -   [**] Fixes a crash on pasting MS Word list markup [#56653]
+-   [**] Address rare cases where a null value is passed to a heading block, causing a crash [#56757]
 
 ## 1.109.0
 -   [*] Audio block: Improve legibility of audio file details on various background colors [#55627]


### PR DESCRIPTION
## Related PRs

* `Gutenberg Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6435
* `Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/19724
* `Aztec Android`: https://github.com/wordpress-mobile/AztecEditor-Android/pull/1071

## What?

This PR updates the referenced version of Aztec for Android. That referenced version includes a potential fix for the crash described at https://github.com/wordpress-mobile/WordPress-Android/issues/18657.

## Why?

It's necessary to update the reference in order to include the potential crash fix in Gutenberg.

## How?

Full details of the changes to Aztec can be found at https://github.com/wordpress-mobile/AztecEditor-Android/pull/1071. It is the changes in that PR that will be included in Gutenberg. 

## Testing Instructions

1. Using the installable build available from https://github.com/wordpress-mobile/WordPress-Android/pull/19724, install the app and navigate to the post editor.
2. Add some heading blocks and ensure there are no unexpected side effects when performing tasks. Example tasks to test include splitting the block, applying new font sizes and line heights, etc. 