### PR TITLE
Avoid to show unnecessary Tooltip for the Post Schedule button.

### DIFF
--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -49,7 +49,7 @@ export default function PostSchedulePanel() {
 								label
 							) }
 							label={ fullLabel }
-							showTooltip
+							showTooltip={ label !== fullLabel }
 							aria-expanded={ isOpen }
 						>
 							{ label }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/56755

## What?
<!-- In a few words, what is the PR actually doing? -->
The Post Schedule button may show a tooltip that just repeats the visible text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Unnecessary tooltips should be avoided as they just clutter the UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Only shows the Tooltip when it actually contains expanded information compared to the visible text by checking whether `label` and `fullLabel` are not the same.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post.
- Set the publish date / time to:
  - Immediately.
  - Later today.
  - A date in the future.
  - A date in the past.
- For each of the cases above test with different time zone settings:
  - Go to the WordPress admin, Settings > General Settings > Timezone.
  - Set the Timezone value to a value other than your time zone.
  - Test again after setting the Timezone value to your actual time zone.
- For all the above cases, check that when hovering or focusing the button, the Tooltip appears only when it contains text that is different from the visible text.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
