### PR TITLE
DataViews: Fix dropdown menu actions with modal

### DIFF
--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -37,7 +37,10 @@ function ButtonTrigger( { action, onClick } ) {
 
 function DropdownMenuItemTrigger( { action, onClick } ) {
 	return (
-		<DropdownMenuItem onClick={ onClick }>
+		<DropdownMenuItem
+			onClick={ onClick }
+			hideOnClick={ ! action.RenderModal }
+		>
 			<DropdownMenuItemLabel>{ action.label }</DropdownMenuItemLabel>
 		</DropdownMenuItem>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes a bug where actions with modal in the dropdown menu wouldn't render because we were unmounting the dropdown on click.

## Testing Instructions
1. In templates list test the `rename` action in templates
2. In pages list select the `grid` view and test that the `delete` action renders the modal.

