### PR TITLE
Font Library: fix font uninstallation

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -229,7 +229,7 @@ function FontLibraryProvider( { children } ) {
 			// Uninstall the font (remove the font files from the server and the post from the database).
 			const response = await fetchUninstallFonts( [ font ] );
 			// Deactivate the font family (remove the font family from the global styles).
-			if ( ! response.errors ) {
+			if ( 0 === response.errors.length ) {
 				deactivateFontFamily( font );
 				// Save the global styles to the database.
 				await saveSpecifiedEntityEdits(


### PR DESCRIPTION
## What?
This PR fixes a bug in the `uninstallFont` function of the FontLibraryProvider class. 

~It also adds some logic to ensure that only custom fonts that are actually installed are ever rendered to the client.~

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/56166

## How?
In the uninstallFonts function, check the response errors array for length.

~In the context, filter out fonts that are not installed.~

## Testing Instructions
- Install some custom fonts
- Go to each font, select "Delete" followed by "Yes, uninstall."
- Verify those fonts do not appear in the fonts modal or Typography sidebar preview.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
