### PR TITLE
Zoomed out mode: remove button in toolbar

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
@@ -6,12 +6,11 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	ToolSelector,
 	NavigableToolbar,
-	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { _x, __ } from '@wordpress/i18n';
-import { listView, plus, chevronUpDown } from '@wordpress/icons';
+import { listView, plus } from '@wordpress/icons';
 import { Button, ToolbarItem } from '@wordpress/components';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
@@ -60,12 +59,8 @@ export default function DocumentTools( {
 			};
 		}, [] );
 
-	const {
-		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
-		setIsInserterOpened,
-		setIsListViewOpened,
-	} = useDispatch( editSiteStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { setIsInserterOpened, setIsListViewOpened } =
+		useDispatch( editSiteStore );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
@@ -105,8 +100,6 @@ export default function DocumentTools( {
 	);
 	const shortLabel = ! isInserterOpen ? __( 'Add' ) : __( 'Close' );
 
-	const isZoomedOutViewExperimentEnabled =
-		window?.__experimentalEnableZoomedOutView && isVisualMode;
 	const isZoomedOutView = blockEditorMode === 'zoom-out';
 
 	return (
@@ -178,27 +171,6 @@ export default function DocumentTools( {
 								size="compact"
 							/>
 						) }
-						{ isZoomedOutViewExperimentEnabled &&
-							! isDistractionFree &&
-							! hasFixedToolbar && (
-								<ToolbarItem
-									as={ Button }
-									className="edit-site-header-edit-mode__zoom-out-view-toggle"
-									icon={ chevronUpDown }
-									isPressed={ isZoomedOutView }
-									/* translators: button label text should, if possible, be under 16 characters. */
-									label={ __( 'Zoom-out View' ) }
-									onClick={ () => {
-										setPreviewDeviceType( 'Desktop' );
-										__unstableSetEditorMode(
-											isZoomedOutView
-												? 'edit'
-												: 'zoom-out'
-										);
-									} }
-									size="compact"
-								/>
-							) }
 					</>
 				) }
 			</div>


### PR DESCRIPTION
## What?

Removes the zoomed out mode toggle button from the site editor header

## Why?
Part of the work to look at make the zoomed out mode instead be invoked automatically when the pattern inserter is opened.

## How?
Deletes the toggle button code from header bar in site editor.

## Testing Instructions
Enable the Zoomed out view experiment
Go to the site editor and make sure zoomed out toggle does not appear in header

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="350" alt="Screenshot 2023-12-05 at 10 52 07 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/4a432a33-36ce-492c-95a8-95695f408a6d">

After:
<img width="446" alt="Screenshot 2023-12-05 at 10 51 13 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/40218de5-3c6b-4722-8710-e2d762db6716">


