### PR TITLE
Fix errant scrollbar when zoomed out mode is activated

### DIFF
--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -102,7 +102,11 @@ function EditorCanvas( {
 					canvasMode === 'view'
 						? 'cursor: pointer; min-height: 100vh;'
 						: ''
-				}}}`
+				} ${
+					// In zoomed out mode, hide the normal canvas scrollbar,
+					// as this results in a double-scrollbar
+					isZoomOutMode ? 'overflow: hidden;' : ''
+				}}`
 			}</style>
 			{ children }
 		</BlockCanvas>


### PR DESCRIPTION
## What?
When activating zoomed out mode, the editor canvas scroll bar can still be displayed which results in a double scrollbar (zoomed out mode has its own scrollbar).

## Why?
Users don't need that many scrollbars.

## How?
Adds an `overflow: hidden` style to the editor canvas body, only when zoomed out mode is active.

Also removes a stray `}` in the style declarations.

## Testing Instructions
Note: It's easier to see the scrollbar when the Mac OS setting "Scrollbars always on" is active.

1. Ensure the 'Zoomed Out Mode' experiment is active using the `wp-admin/admin.php?page=gutenberg-experiments` page.
2. Open up the site editor and visit a template like Blog Home
3. Toggle on zoomed out mode
4. Resize your browser viewport

Expected: The canvas shouldn't have a scrollbar
On trunk: At some viewport sizes the canvas has a scrolllbar

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="366" alt="Screenshot 2023-12-05 at 11 24 07 am" src="https://github.com/WordPress/gutenberg/assets/677833/16780f93-4b5f-4d8c-b094-3e0f7e558484">

### After
<img width="372" alt="Screenshot 2023-12-05 at 11 24 48 am" src="https://github.com/WordPress/gutenberg/assets/677833/177f8a1e-a2b4-44aa-8752-297ed260c408">
