### PR TITLE
Enter zoom-out mode when selecting patterns in the inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useDebouncedInput } from '@wordpress/compose';
 
 /**
@@ -57,6 +57,8 @@ function InserterMenu(
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
 	const [ selectedTab, setSelectedTab ] = useState( null );
+	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {
@@ -228,6 +230,14 @@ function InserterMenu(
 		if ( value !== 'patterns' ) {
 			setSelectedPatternCategory( null );
 		}
+
+		// Enter the zoom-out mode when selecting the patterns tab and exit otherwise.
+		if ( value === 'patterns' ) {
+			__unstableSetEditorMode( 'zoom-out' );
+		} else if ( __unstableGetEditorMode() === 'zoom-out' ) {
+			__unstableSetEditorMode( 'edit' );
+		}
+
 		setSelectedTab( value );
 	};
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -150,6 +150,10 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 		};
 	}, [] );
 	const { setRenderingMode } = useDispatch( editorStore );
+	const { __unstableGetEditorMode: getBlockEditorMode } =
+		useSelect( blockEditorStore );
+	const { __unstableSetEditorMode: setBlockEditorMode } =
+		useDispatch( blockEditorStore );
 
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
@@ -201,6 +205,15 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 			setRenderingMode( 'all' );
 		}
 	}, [ canvasMode, postWithTemplate, setRenderingMode ] );
+
+	useEffect(
+		function ExitZoomOutModeWhenInserterClosed() {
+			if ( ! shouldShowInserter && getBlockEditorMode() === 'zoom-out' ) {
+				setBlockEditorMode( 'edit' );
+			}
+		},
+		[ getBlockEditorMode, setBlockEditorMode, shouldShowInserter ]
+	);
 
 	return (
 		<>

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -29,6 +29,14 @@ export default function InserterSidebar() {
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 		focusOnMount: null,
+		// Don't close the inserter on focus outside.
+		// This is a temporary hack as we figure out the expected interactions
+		// in the zoom-out mode.
+		__unstableOnClose: ( eventName ) => {
+			if ( eventName === 'focus-outside' ) {
+				// Do nothing.
+			}
+		},
 	} );
 
 	const libraryRef = useRef();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Addresses https://github.com/WordPress/gutenberg/issues/44585.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/44585.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Due to that the inserter works as a dialog, it closes itself if the focus changes. It conflicts with the vision of (only) auto-enabling zoom-out mode when the inserter is opened, because interacting with anything in the zoom-out mode will change the focus and thus close the inserter (and exit zoom-out mode).

This PR disables the close on focus outside feature for now, until we find a better interactions for the zoom-out mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the Zoom Out mode gutenberg experiment
2. Go to the Site Editor
3. Open the inserter, expect to enter the zoom-out mode when selecting the "Patterns" tab.
4. Otherwise, exit the zoom-out mode for other tabs. Closing the inserter also exits the zoom-out mode.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/83f57356-abb4-4dd4-a1b2-e284a4f0a07e

