### PR TITLE
Prevent overlapping patterns menu in Site Editor

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -21,6 +21,8 @@ function InserterLibrary(
 		showMostUsedBlocks = false,
 		__experimentalInsertionIndex,
 		__experimentalFilterValue,
+		__experimentalOnPatternCategorySelection,
+		__experimentalShouldZoomPatterns = false,
 		onSelect = noop,
 		shouldFocusBlock = false,
 	},
@@ -53,6 +55,12 @@ function InserterLibrary(
 			showMostUsedBlocks={ showMostUsedBlocks }
 			__experimentalInsertionIndex={ __experimentalInsertionIndex }
 			__experimentalFilterValue={ __experimentalFilterValue }
+			__experimentalOnPatternCategorySelection={
+				__experimentalOnPatternCategorySelection
+			}
+			__experimentalShouldZoomPatterns={
+				__experimentalShouldZoomPatterns
+			}
 			shouldFocusBlock={ shouldFocusBlock }
 			prioritizePatterns={ prioritizePatterns }
 			ref={ ref }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -45,6 +45,8 @@ function InserterMenu(
 		__experimentalFilterValue = '',
 		shouldFocusBlock = true,
 		prioritizePatterns,
+		__experimentalOnPatternCategorySelection,
+		__experimentalShouldZoomPatterns = false,
 	},
 	ref
 ) {
@@ -123,8 +125,9 @@ function InserterMenu(
 		( patternCategory, filter ) => {
 			setSelectedPatternCategory( patternCategory );
 			setPatternFilter( filter );
+			__experimentalOnPatternCategorySelection?.();
 		},
-		[ setSelectedPatternCategory ]
+		[ setSelectedPatternCategory, __experimentalOnPatternCategorySelection ]
 	);
 
 	const blocksTab = useMemo(
@@ -231,8 +234,12 @@ function InserterMenu(
 		setSelectedTab( value );
 	};
 
+	const className = classnames( 'block-editor-inserter__menu', {
+		'has-inline-patterns': __experimentalShouldZoomPatterns,
+	} );
+
 	return (
-		<div className="block-editor-inserter__menu">
+		<div className={ className }>
 			<div
 				className={ classnames( 'block-editor-inserter__main-area', {
 					'show-as-tabs': showAsTabs,

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -92,6 +92,14 @@ $block-inserter-tabs-height: 44px;
 	overflow: visible;
 }
 
+.block-editor-inserter__menu.has-inline-patterns {
+	display: flex;
+
+	.block-editor-inserter__patterns-category-dialog {
+		position: static;
+	}
+}
+
 .block-editor-inserter__inline-elements {
 	margin-top: -1px;
 }

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -18,7 +18,8 @@ import { useEffect, useRef } from '@wordpress/element';
 import { store as editSiteStore } from '../../store';
 
 export default function InserterSidebar() {
-	const { setIsInserterOpened } = useDispatch( editSiteStore );
+	const { closeGeneralSidebar, setIsInserterOpened } =
+		useDispatch( editSiteStore );
 	const insertionPoint = useSelect(
 		( select ) => select( editSiteStore ).__experimentalGetInsertionPoint(),
 		[]
@@ -58,6 +59,10 @@ export default function InserterSidebar() {
 						insertionPoint.insertionIndex
 					}
 					__experimentalFilterValue={ insertionPoint.filterValue }
+					__experimentalOnPatternCategorySelection={
+						closeGeneralSidebar
+					}
+					__experimentalShouldZoomPatterns
 					ref={ libraryRef }
 				/>
 			</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Prevent pattern list overlay in inserter for site editor in preparation for zooming out when selecting patterns.

## Why?

When switching to zoomed out mode for pattern selection, the current pattern list dialog floats over the canvas.

## How?
- Removes absolute positioning of the pattern list.
- Closes the general sidebar when selecting a pattern category.

## Testing Instructions

1. Open site editor and open the general righthand sidebar
2. Open the inserter panel via the plus icon at the top left
3. Select the Patterns tab
4. Confirm selecting pattern category closes the general sidebar and the pattern list does not overlap the main canvas
5. Confirm that in the post editor the UI is unchanged.


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/d9773741-21fb-4b87-8cb8-e674194c66a3


