### PR TITLE
Move mobile ImageLinkDestinationsScreen from components package to block-editor package

### DIFF
--- a/packages/block-editor/src/components/block-settings/container.native.js
+++ b/packages/block-editor/src/components/block-settings/container.native.js
@@ -3,13 +3,13 @@
  */
 import {
 	InspectorControls,
+	ImageLinkDestinationsScreen,
 	useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
 import {
 	BottomSheet,
 	ColorSettings,
 	FocalPointSettingsPanel,
-	ImageLinkDestinationsScreen,
 	LinkPickerScreen,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';

--- a/packages/block-editor/src/components/block-settings/container.native.js
+++ b/packages/block-editor/src/components/block-settings/container.native.js
@@ -2,11 +2,6 @@
  * WordPress dependencies
  */
 import {
-	InspectorControls,
-	ImageLinkDestinationsScreen,
-	useMultipleOriginColorsAndGradients,
-} from '@wordpress/block-editor';
-import {
 	BottomSheet,
 	ColorSettings,
 	FocalPointSettingsPanel,
@@ -18,6 +13,9 @@ import { useDispatch, useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import styles from './container.native.scss';
+import InspectorControls from '../inspector-controls';
+import ImageLinkDestinationsScreen from '../image-link-destinations';
+import useMultipleOriginColorsAndGradients from '../colors-gradients/use-multiple-origin-colors-and-gradients';
 
 export const blockSettingsScreens = {
 	settings: 'Settings',

--- a/packages/block-editor/src/components/image-link-destinations/index.native.js
+++ b/packages/block-editor/src/components/image-link-destinations/index.native.js
@@ -11,13 +11,12 @@ import { __ } from '@wordpress/i18n';
 import { Icon, check, chevronRight } from '@wordpress/icons';
 import { blockSettingsScreens } from '@wordpress/block-editor';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
+import { BottomSheet, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import styles from './style.scss';
-import PanelBody from '../../panel/body';
-import BottomSheet from '../bottom-sheet';
+import styles from './style.native.scss';
 
 const LINK_DESTINATION_NONE = 'none';
 const LINK_DESTINATION_MEDIA = 'media';
@@ -36,6 +35,7 @@ function LinkDestination( {
 		styles.optionIcon,
 		styles.optionIconDark
 	);
+
 	return (
 		<BottomSheet.Cell
 			icon={ check }

--- a/packages/block-editor/src/components/image-link-destinations/index.native.js
+++ b/packages/block-editor/src/components/image-link-destinations/index.native.js
@@ -9,7 +9,6 @@ import { StyleSheet } from 'react-native';
  */
 import { __ } from '@wordpress/i18n';
 import { Icon, check, chevronRight } from '@wordpress/icons';
-import { blockSettingsScreens } from '@wordpress/block-editor';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { BottomSheet, PanelBody } from '@wordpress/components';
 
@@ -17,6 +16,7 @@ import { BottomSheet, PanelBody } from '@wordpress/components';
  * Internal dependencies
  */
 import styles from './style.native.scss';
+import { blockSettingsScreens } from '../block-settings';
 
 const LINK_DESTINATION_NONE = 'none';
 const LINK_DESTINATION_MEDIA = 'media';

--- a/packages/block-editor/src/components/image-link-destinations/style.native.scss
+++ b/packages/block-editor/src/components/image-link-destinations/style.native.scss
@@ -1,0 +1,16 @@
+// used in both light and dark modes
+.placeholderTextColor {
+	color: #87a6bc;
+}
+
+.optionIcon {
+	color: $blue-50;
+}
+
+.optionIconDark {
+	color: $blue-30;
+}
+
+.unselectedOptionIcon {
+	opacity: 0;
+}

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -91,6 +91,7 @@ export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
 export { default as InserterButton } from './inserter-button';
+export { default as ImageLinkDestinationsScreen } from './image-link-destinations';
 export { useBlockProps } from './block-list/use-block-props';
 export { default as FloatingToolbar } from './floating-toolbar';
 

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -91,7 +91,6 @@ export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
 export { default as InserterButton } from './inserter-button';
-export { default as ImageLinkDestinationsScreen } from './image-link-destinations';
 export { useBlockProps } from './block-list/use-block-props';
 export { default as FloatingToolbar } from './floating-toolbar';
 

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -106,7 +106,6 @@ export { default as LinkPickerScreen } from './mobile/link-picker/link-picker-sc
 export { default as LinkSettings } from './mobile/link-settings';
 export { default as LinkSettingsScreen } from './mobile/link-settings/link-settings-screen';
 export { default as LinkSettingsNavigation } from './mobile/link-settings/link-settings-navigation';
-export { default as ImageLinkDestinationsScreen } from './mobile/link-settings/image-link-destinations-screen';
 export { default as SegmentedControl } from './mobile/segmented-control';
 export { default as Image, IMAGE_DEFAULT_FOCAL_POINT } from './mobile/image';
 export { default as ImageEditingButton } from './mobile/image/image-editing-button';

--- a/packages/components/src/mobile/link-settings/style.native.scss
+++ b/packages/components/src/mobile/link-settings/style.native.scss
@@ -2,20 +2,3 @@
 	padding-left: 0;
 	padding-right: 0;
 }
-
-// used in both light and dark modes
-.placeholderTextColor {
-	color: #87a6bc;
-}
-
-.optionIcon {
-	color: $blue-50;
-}
-
-.optionIconDark {
-	color: $blue-30;
-}
-
-.unselectedOptionIcon {
-	opacity: 0;
-}

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] [internal] Move InserterButton from components package to block-editor package [#56494]
+-   [*] [internal] Move ImageLinkDestinationsScreen from components package to block-editor package [#56775]
 
 ## 1.109.1
 -   [***] Fix issue when backspacing in an empty Paragraph block [#56496]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR moves the mobile `ImageLinkDestinationsScreen ` from the components package to the block-editor package.

Related PRs:
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6440

## Why?
There is an ongoing effort to remove block-editor package dependencies in native files from the components package in order to eliminate cyclic dependencies:

* https://github.com/WordPress/gutenberg/issues/52692
* https://github.com/WordPress/gutenberg/issues/56072
* https://github.com/WordPress/gutenberg/issues/27751

## How?
Moves code and code references to `ImageLinkDestinationsScreen ` from the components package to the block-editor package.

## Testing Instructions
1. Create a post and add an Image block.
2. Use the Settings button (gear icon in the bottom toolbar) to open the settings BottomSheet.
3. In the Link Settings section, select Link To to display the ImageLinkDestinationsScreen component.
4. ImageLinkDestinationsScreen behavior should not be changed, and match production. 