### PR TITLE
DataViews: implement `NOT IN` operator for author filter in templates

### DIFF
--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -35,6 +35,7 @@ import {
 	TEMPLATE_POST_TYPE,
 	ENUMERATION_TYPE,
 	OPERATOR_IN,
+	OPERATOR_NOT_IN,
 	LAYOUT_GRID,
 	LAYOUT_TABLE,
 } from '../../utils/constants';
@@ -265,6 +266,14 @@ export default function DataviewsTemplates() {
 				) {
 					filteredTemplates = filteredTemplates.filter( ( item ) => {
 						return item.author_text === filter.value;
+					} );
+				} else if (
+					filter.field === 'author' &&
+					filter.operator === OPERATOR_NOT_IN &&
+					!! filter.value
+				) {
+					filteredTemplates = filteredTemplates.filter( ( item ) => {
+						return item.author_text !== filter.value;
 					} );
 				}
 			} );


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/55083

## What?

Implement the new `NOT IN` operator in the author filter for the templates page.

https://github.com/WordPress/gutenberg/assets/583546/4e1c4092-f091-4191-9f3c-bf22dfd73d2d


## Why?

The filter component gained a new `NOT IN` operator that is enabled by default. We should either disable it or implement it – right now, the operator is displayed in the filter UI, but it does nothing.

## How?

Filter templates whose author is not the given one, if the filter uses a `NOT IN` operator.

## Testing Instructions

- Enable the "new view admins" experiment and visit "Manage all templates".
- Use the different operators in the author filter and verify that work as expected.
