### PR TITLE
Perf: reopen inspector for remaining tests

### DIFF
--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -159,7 +159,13 @@ test.describe( 'Post Editor Performance', () => {
 			draftId = await perfUtils.saveDraft();
 		} );
 
-		test( 'Run the test', async ( { admin, perfUtils, metrics, page } ) => {
+		test( 'Run the test', async ( {
+			admin,
+			perfUtils,
+			metrics,
+			page,
+			editor,
+		} ) => {
 			await admin.editPost( draftId );
 			await perfUtils.disableAutosave();
 			const toggleButton = page
@@ -173,6 +179,9 @@ test.describe( 'Post Editor Performance', () => {
 			} );
 
 			await type( paragraph, metrics, 'typeWithoutInspector' );
+
+			// Open the inspector again.
+			await editor.openDocumentSettingsSidebar();
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In https://github.com/WordPress/gutenberg/pull/56753 a test was added that types with the inspector sidebar closed, but this closing is persisted and affects the remaining tests, so we should open it again at the end.

See the drop for `Block Select`: https://www.codevitals.run/project/gutenberg

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
