### PR TITLE
WIP: navigation block fluid breakpoint

### DIFF
--- a/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
+++ b/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
@@ -495,6 +495,8 @@ class WP_Navigation_Block_Renderer {
 		$is_responsive_menu      = static::is_responsive( $attributes );
 		$style                   = static::get_styles( $attributes );
 		$class                   = static::get_classes( $attributes );
+		$has_flexible_breakpoint = $attributes['flexibleBreakpoint'] ? 'true' : 'false';
+
 		$wrapper_attributes      = get_block_wrapper_attributes(
 			array(
 				'class'      => $class,
@@ -504,7 +506,7 @@ class WP_Navigation_Block_Renderer {
 		);
 
 		if ( $is_responsive_menu ) {
-			$nav_element_directives = static::get_nav_element_directives( $should_load_view_script );
+			$nav_element_directives = static::get_nav_element_directives( $should_load_view_script, $has_flexible_breakpoint );
 			$wrapper_attributes    .= ' ' . $nav_element_directives;
 		}
 
@@ -517,7 +519,7 @@ class WP_Navigation_Block_Renderer {
 	 * @param bool $should_load_view_script Whether or not the view script should be loaded.
 	 * @return string the directives for the navigation element.
 	 */
-	private static function get_nav_element_directives( $should_load_view_script ) {
+	private static function get_nav_element_directives( $should_load_view_script, $has_flexible_breakpoint ) {
 		if ( ! $should_load_view_script ) {
 			return '';
 		}
@@ -528,6 +530,7 @@ class WP_Navigation_Block_Renderer {
 				'type'            => 'overlay',
 				'roleAttribute'   => '',
 				'ariaLabel'       => __( 'Menu' ),
+				'has_flexible_breakpoint'   => $has_flexible_breakpoint,
 			),
 			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP
 		);

--- a/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
+++ b/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php
@@ -60,6 +60,16 @@ class WP_Navigation_Block_Renderer {
 	}
 
 	/**
+	 * Returns whether or not the navigation has a flexible breakpoint.
+	 *
+	 * @param array $attributes The block attributes.
+	 * @return bool Returns whether or not this is responsive navigation.
+	 */
+	private static function has_flexible_breakpoint( $attributes ) {
+		return $attributes['flexibleBreakpoint'] ? 'true' : 'false';
+	}
+
+	/**
 	 * Returns whether or not a navigation has a submenu.
 	 *
 	 * @param WP_Block_List $inner_blocks The list of inner blocks.
@@ -495,9 +505,9 @@ class WP_Navigation_Block_Renderer {
 		$is_responsive_menu      = static::is_responsive( $attributes );
 		$style                   = static::get_styles( $attributes );
 		$class                   = static::get_classes( $attributes );
-		$has_flexible_breakpoint = $attributes['flexibleBreakpoint'] ? 'true' : 'false';
+		$has_flexible_breakpoint = static::has_flexible_breakpoint( $attributes );
 
-		$wrapper_attributes      = get_block_wrapper_attributes(
+		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
 				'class'      => $class,
 				'style'      => $style,
@@ -517,6 +527,7 @@ class WP_Navigation_Block_Renderer {
 	 * Get the nav element directives
 	 *
 	 * @param bool $should_load_view_script Whether or not the view script should be loaded.
+	 * @param bool $has_flexible_breakpoint Whether or not the nav block will have a flexible breakpoint.
 	 * @return string the directives for the navigation element.
 	 */
 	private static function get_nav_element_directives( $should_load_view_script, $has_flexible_breakpoint ) {
@@ -526,17 +537,25 @@ class WP_Navigation_Block_Renderer {
 		// When adding to this array be mindful of security concerns.
 		$nav_element_context = wp_json_encode(
 			array(
-				'overlayOpenedBy' => array(),
-				'type'            => 'overlay',
-				'roleAttribute'   => '',
-				'ariaLabel'       => __( 'Menu' ),
-				'has_flexible_breakpoint'   => $has_flexible_breakpoint,
+				'overlayOpenedBy'         => array(),
+				'type'                    => 'overlay',
+				'roleAttribute'           => '',
+				'ariaLabel'               => __( 'Menu' ),
+				'has_flexible_breakpoint' => $has_flexible_breakpoint,
 			),
 			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP
 		);
+
+		$flexible_breakpoint_directives = '';
+
+		if ( $has_flexible_breakpoint ) {
+			$flexible_breakpoint_directives = 'data-wp-init--overlay="actions.isNavCollapsed"';
+		}
+
 		return '
 			data-wp-interactive=\'{"namespace":"core/navigation"}\'
-			data-wp-context=\'' . $nav_element_context . '\'
+			data-wp-context=\'' . $nav_element_context . '\' 
+			' . $flexible_breakpoint_directives . '
 		';
 	}
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -33,6 +33,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"flexibleBreakpoint": {
+			"type": "boolean",
+			"default": false
+		},
 		"openSubmenusOnClick": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -98,6 +98,7 @@ function Navigation( {
 		openSubmenusOnClick,
 		overlayMenu,
 		showSubmenuIcon,
+		flexibleBreakpoint,
 		templateLock,
 		layout: {
 			justifyContent,
@@ -522,6 +523,8 @@ function Navigation( {
 		`overlay-menu-preview`
 	);
 
+	const needsBreakpoint = isResponsive && 'mobile' === overlayMenu;
+
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 	const stylingInspectorControls = (
 		<>
@@ -621,6 +624,22 @@ function Navigation( {
 									disabled={ attributes.openSubmenusOnClick }
 									label={ __( 'Show arrow' ) }
 								/>
+
+								{ needsBreakpoint && (
+									<ToggleControl
+										__nextHasNoMarginBottom
+										checked={ flexibleBreakpoint }
+										onChange={ ( value ) => {
+											setAttributes( {
+												flexibleBreakpoint: value,
+											} );
+										} }
+										disabled={
+											attributes.openSubmenusOnClick
+										}
+										label={ __( 'Flexible breakpoint' ) }
+									/>
+								) }
 
 								{ submenuAccessibilityNotice && (
 									<div>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -596,6 +596,21 @@ function Navigation( {
 								label={ __( 'Always' ) }
 							/>
 						</ToggleGroupControl>
+
+						{ needsBreakpoint && (
+							<ToggleControl
+								__nextHasNoMarginBottom
+								checked={ flexibleBreakpoint }
+								onChange={ ( value ) => {
+									setAttributes( {
+										flexibleBreakpoint: value,
+									} );
+								} }
+								disabled={ attributes.openSubmenusOnClick }
+								label={ __( 'Flexible breakpoint' ) }
+							/>
+						) }
+
 						{ hasSubmenus && (
 							<>
 								<h3>{ __( 'Submenus' ) }</h3>
@@ -624,22 +639,6 @@ function Navigation( {
 									disabled={ attributes.openSubmenusOnClick }
 									label={ __( 'Show arrow' ) }
 								/>
-
-								{ needsBreakpoint && (
-									<ToggleControl
-										__nextHasNoMarginBottom
-										checked={ flexibleBreakpoint }
-										onChange={ ( value ) => {
-											setAttributes( {
-												flexibleBreakpoint: value,
-											} );
-										} }
-										disabled={
-											attributes.openSubmenusOnClick
-										}
-										label={ __( 'Flexible breakpoint' ) }
-									/>
-								) }
 
 								{ submenuAccessibilityNotice && (
 									<div>

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -475,6 +475,17 @@ button.wp-block-navigation-item__content {
 	right: 0;
 	bottom: 0;
 
+	&:not(.hidden-by-default):not(.is-menu-open):not(.is-mobile) {
+		display: block;
+		position: static;
+	}
+
+	.is-mobile &:not(.hidden-by-default):not(.is-menu-open) {
+		display: none;
+		position: fixed;
+	}
+
+
 	// Low specificity so that themes can override.
 	& :where(.wp-block-navigation-item a) {
 		color: inherit;
@@ -611,7 +622,7 @@ button.wp-block-navigation-item__content {
 		}
 	}
 
-	@include break-small() {
+	/*@include break-small() {
 		&:not(.hidden-by-default) {
 			&:not(.is-menu-open) {
 				display: block;
@@ -632,7 +643,7 @@ button.wp-block-navigation-item__content {
 				left: 0;
 			}
 		}
-	}
+	}*/
 }
 
 // Default menu background and font color.
@@ -690,6 +701,10 @@ button.wp-block-navigation-item__content {
 		@include break-small {
 			display: none;
 		}
+	}
+
+	.is-mobile & {
+		display: block !important;
 	}
 }
 

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -176,8 +176,7 @@ const { state, actions, callbacks } = store( 'core/navigation', {
 				ctx.lastFocusableElement =
 					focusableElements[ focusableElements.length - 1 ];
 			}
-			window.addEventListener(
-				'resize',
+			window.addEventListener( 'resize', () =>
 				callbacks.isNavCollapsed( ref )
 			);
 		},
@@ -192,14 +191,17 @@ const { state, actions, callbacks } = store( 'core/navigation', {
 		},
 
 		isNavCollapsed( ref ) {
-			//test if the nav items are wrapping before testing if the actual nav is wrapping inside its parent to avoid the recursive function if possible
+			// remove the is-mobile class to avoid false positives.
+			ref.closest( 'nav' ).classList.remove( 'is-mobile' );
+
+			// test if the nav items are wrapping before testing if the actual nav is wrapping inside its parent to avoid the recursive function if possible
 			if (
 				areItemsWrapping( ref ) === true ||
 				isNavWrapping( ref ) === true
 			) {
-				//console.log( 'is mobile' );
+				ref.closest( 'nav' ).classList.add( 'is-mobile' );
 			} else {
-				//console.log( 'is not mobile' );
+				ref.closest( 'nav' ).classList.remove( 'is-mobile' );
 			}
 		},
 	},
@@ -235,19 +237,26 @@ function isNavWrapping( ref ) {
 	let isWrapping = false;
 	//how can we check if the nav element is wrapped inside its parent if we don't know anything about it (the parent)?
 	//for debugging purposes
-	const container = getFlexParent( ref );
+	const container = ref.closest( 'nav' ); //getFlexParent( ref );
 	if ( container !== null ) {
-		isWrapping = areItemsWrapping(
-			container,
-			Array.from(
-				container.querySelector( 'ul.wp-block-navigation' ).children
-			)
+		const childrenWrapper = container.querySelector(
+			'ul.wp-block-navigation'
 		);
+		isWrapping =
+			childrenWrapper &&
+			childrenWrapper.children &&
+			areItemsWrapping(
+				container,
+				Array.from(
+					container.querySelector( 'ul.wp-block-navigation' ).children
+				)
+			);
 	}
 
 	return isWrapping;
 }
 
+/* I'm not sure we still need this - can we just get the nearest nav element?
 function getFlexParent( elem ) {
 	if ( elem === document.body ) {
 		// Base case: Stop recursion once we go all the way to the body to avoid infinite recursion
@@ -261,7 +270,7 @@ function getFlexParent( elem ) {
 		return parent;
 	}
 	return getFlexParent( parent );
-}
+}*/
 
 function getItemWidths( items ) {
 	const itemsWidths = [];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a WIP

Addresses https://github.com/WordPress/gutenberg/issues/45040

https://codepen.io/Marga-Cabrera/pen/WNPjYYw

This PR intends to introduce a new option for the nav block when the overlay option is set to "Mobile" called flexible breakpoint (I already hate that name, maybe smart breakpoint? Please help). When this option is toggled (this is an opt-in situation), a script will detect if the nav block can fit within its own container. If it detects that it's wrapping, it will toggle the overlay burger automatically, instead of using the fixed breakpoint that we are using these days.

We do two checks here:

- First we check if the elements within our known block are wrapping. This is done simply by comparing the width of the elements with the width of the container, but this is not the only case, in fact this is the least common occurrence
- Most of the time, the nav block will be inside a group or column block and appear alongside other blocks such as the site logo or site title/tagline which could cause the wrapping to occur. We can't predict those, and I'm only making one assumption here that I think is valid (but could change in the future): the wrapping will be cause from a parent that is using `flex-wrap`. Based on that assumption I look for said parent recursively and apply the same principle to verify if the children inside it are wrapping or not. In my personal opinion, if we are not covering this case, there is very little use in continuing this path, since 90% of the time, this is what's causing the nav block to wrap ahead of time and not the amount of items inside it.

To do:

- [ ] Refactor the CSS so that we can change between the manual breakpoint and the smart one.
- [ ] Everything is very rough. The interactivity API stuff is not properly implemented yet.
- [ ] The "Allow to wrap to multiple lines" control doesn't make sense in this context, we should hide it (can be a follow-up)
- [ ] Check that the menu is horizontal before showing the breakpoint 
- [ ] Test on multiple header styles

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After the discussion over at https://github.com/WordPress/gutenberg/discussions/54388 and some first explorations, it becomes really clear that we either allow our users to set a breakpoint manually or we need to use JavaScript to detect when. Given the complexity of the nav block and how many combinations of layouts it can be wrapped in, there is no way CSS can only give a solution that will work for most of the use cases.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
