### PR TITLE
Block editor: hooks: subscribe only to relevant attributes

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -42,13 +42,13 @@ export const IMAGE_BACKGROUND_TYPE = 'image';
  * Checks if there is a current value in the background image block support
  * attributes.
  *
- * @param {Object} props Block props.
+ * @param {Object} style Style attribute.
  * @return {boolean}     Whether or not the block has a background image value set.
  */
-export function hasBackgroundImageValue( props ) {
+export function hasBackgroundImageValue( style ) {
 	const hasValue =
-		!! props.attributes.style?.background?.backgroundImage?.id ||
-		!! props.attributes.style?.background?.backgroundImage?.url;
+		!! style?.background?.backgroundImage?.id ||
+		!! style?.background?.backgroundImage?.url;
 
 	return hasValue;
 }
@@ -83,13 +83,10 @@ export function hasBackgroundSupport( blockName, feature = 'any' ) {
  * Resets the background image block support attributes. This can be used when disabling
  * the background image controls for a block via a `ToolsPanel`.
  *
- * @param {Object} props               Block props.
- * @param {Object} props.attributes    Block's attributes.
- * @param {Object} props.setAttributes Function to set block's attributes.
+ * @param {Object}   style         Style attribute.
+ * @param {Function} setAttributes Function to set block's attributes.
  */
-export function resetBackgroundImage( { attributes = {}, setAttributes } ) {
-	const { style = {} } = attributes;
-
+export function resetBackgroundImage( style = {}, setAttributes ) {
 	setAttributes( {
 		style: cleanEmptyObject( {
 			...style,
@@ -146,8 +143,7 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 	);
 }
 
-function BackgroundImagePanelItem( props ) {
-	const { clientId, setAttributes } = props;
+function BackgroundImagePanelItem( { clientId, setAttributes } ) {
 	const style = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
@@ -248,14 +244,14 @@ function BackgroundImagePanelItem( props ) {
 		};
 	}, [] );
 
-	const hasValue = hasBackgroundImageValue( props );
+	const hasValue = hasBackgroundImageValue( style );
 
 	return (
 		<ToolsPanelItem
 			className="single-column"
 			hasValue={ () => hasValue }
 			label={ __( 'Background image' ) }
-			onDeselect={ () => resetBackgroundImage( props ) }
+			onDeselect={ () => resetBackgroundImage( style, setAttributes ) }
 			isShownByDefault={ true }
 			resetAllFilter={ resetAllFilter }
 			panelId={ clientId }
@@ -290,7 +286,7 @@ function BackgroundImagePanelItem( props ) {
 								// closed and focus is redirected to the dropdown toggle button.
 								toggleButton?.focus();
 								toggleButton?.click();
-								resetBackgroundImage( props );
+								resetBackgroundImage( style, setAttributes );
 							} }
 						>
 							{ __( 'Reset ' ) }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -24,6 +24,7 @@ import { Platform, useCallback, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
+import { pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -146,10 +147,13 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 }
 
 function BackgroundImagePanelItem( props ) {
-	const { attributes, clientId, setAttributes } = props;
-
-	const { id, title, url } =
-		attributes.style?.background?.backgroundImage || {};
+	const { clientId, setAttributes } = props;
+	const style = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId ).style,
+		[ clientId ]
+	);
+	const { id, title, url } = style?.background?.backgroundImage || {};
 
 	const replaceContainerRef = useRef();
 
@@ -167,9 +171,9 @@ function BackgroundImagePanelItem( props ) {
 	const onSelectMedia = ( media ) => {
 		if ( ! media || ! media.url ) {
 			const newStyle = {
-				...attributes.style,
+				...style,
 				background: {
-					...attributes.style?.background,
+					...style?.background,
 					backgroundImage: undefined,
 				},
 			};
@@ -201,9 +205,9 @@ function BackgroundImagePanelItem( props ) {
 		}
 
 		const newStyle = {
-			...attributes.style,
+			...style,
 			background: {
-				...attributes.style?.background,
+				...style?.background,
 				backgroundImage: {
 					url: media.url,
 					id: media.id,
@@ -302,7 +306,7 @@ function BackgroundImagePanelItem( props ) {
 	);
 }
 
-export function BackgroundImagePanel( props ) {
+function BackgroundImagePanelPure( props ) {
 	const [ backgroundImage ] = useSettings( 'background.backgroundImage' );
 	if (
 		! backgroundImage ||
@@ -317,3 +321,5 @@ export function BackgroundImagePanel( props ) {
 		</InspectorControls>
 	);
 }
+
+export const BackgroundImagePanel = pure( BackgroundImagePanelPure );

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -150,7 +150,7 @@ function BackgroundImagePanelItem( props ) {
 	const { clientId, setAttributes } = props;
 	const style = useSelect(
 		( select ) =>
-			select( blockEditorStore ).getBlockAttributes( clientId ).style,
+			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
 		[ clientId ]
 	);
 	const { id, title, url } = style?.background?.backgroundImage || {};

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -143,7 +143,7 @@ function BorderPanelPure( props ) {
 	const isEnabled = useHasBorderPanel( settings );
 	function selector( select ) {
 		const { style, borderColor } =
-			select( blockEditorStore ).getBlockAttributes( clientId );
+			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 		return { style, borderColor };
 	}
 	const { style, borderColor } = useSelect( selector, [ clientId ] );

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -137,8 +137,7 @@ function BordersInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-function BorderPanelPure( props ) {
-	const { clientId, name, setAttributes } = props;
+function BorderPanelPure( { clientId, name, setAttributes } ) {
 	const settings = useBlockSettings( name );
 	const isEnabled = useHasBorderPanel( settings );
 	function selector( select ) {
@@ -148,10 +147,7 @@ function BorderPanelPure( props ) {
 	}
 	const { style, borderColor } = useSelect( selector, [ clientId ] );
 	const value = useMemo( () => {
-		return attributesToStyle( {
-			style,
-			borderColor,
-		} );
+		return attributesToStyle( { style, borderColor } );
 	}, [ style, borderColor ] );
 
 	const onChange = ( newStyle ) => {
@@ -162,7 +158,7 @@ function BorderPanelPure( props ) {
 		return null;
 	}
 
-	const defaultControls = getBlockSupport( props.name, [
+	const defaultControls = getBlockSupport( name, [
 		BORDER_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -9,7 +9,8 @@ import classnames from 'classnames';
 import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport } from '@wordpress/blocks';
 import { useMemo, Platform, useCallback } from '@wordpress/element';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -32,6 +33,7 @@ import {
 	default as StylesColorPanel,
 } from '../components/global-styles/color-panel';
 import BlockColorContrastChecker from './contrast-checker';
+import { store as blockEditorStore } from '../store';
 
 export const COLOR_SUPPORT_KEY = 'color';
 
@@ -289,23 +291,27 @@ function ColorInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function ColorEdit( props ) {
-	const { clientId, name, attributes, setAttributes } = props;
+function ColorEditPure( props ) {
+	const { clientId, name, setAttributes } = props;
 	const settings = useBlockSettings( name );
 	const isEnabled = useHasColorPanel( settings );
+	function selector( select ) {
+		const { style, textColor, backgroundColor, gradient } =
+			select( blockEditorStore ).getBlockAttributes( clientId );
+		return { style, textColor, backgroundColor, gradient };
+	}
+	const { style, textColor, backgroundColor, gradient } = useSelect(
+		selector,
+		[ clientId ]
+	);
 	const value = useMemo( () => {
 		return attributesToStyle( {
-			style: attributes.style,
-			textColor: attributes.textColor,
-			backgroundColor: attributes.backgroundColor,
-			gradient: attributes.gradient,
+			style,
+			textColor,
+			backgroundColor,
+			gradient,
 		} );
-	}, [
-		attributes.style,
-		attributes.textColor,
-		attributes.backgroundColor,
-		attributes.gradient,
-	] );
+	}, [ style, textColor, backgroundColor, gradient ] );
 
 	const onChange = ( newStyle ) => {
 		setAttributes( styleToAttributes( newStyle ) );
@@ -355,6 +361,8 @@ export function ColorEdit( props ) {
 		</StylesColorPanel>
 	);
 }
+
+export const ColorEdit = pure( ColorEditPure );
 
 /**
  * This adds inline styles for color palette colors.

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -291,8 +291,7 @@ function ColorInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-function ColorEditPure( props ) {
-	const { clientId, name, setAttributes } = props;
+function ColorEditPure( { clientId, name, setAttributes } ) {
 	const settings = useBlockSettings( name );
 	const isEnabled = useHasColorPanel( settings );
 	function selector( select ) {
@@ -321,7 +320,7 @@ function ColorEditPure( props ) {
 		return null;
 	}
 
-	const defaultControls = getBlockSupport( props.name, [
+	const defaultControls = getBlockSupport( name, [
 		COLOR_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );
@@ -334,7 +333,7 @@ function ColorEditPure( props ) {
 		// Deactivating it requires `enableContrastChecker` to have
 		// an explicit value of `false`.
 		false !==
-			getBlockSupport( props.name, [
+			getBlockSupport( name, [
 				COLOR_SUPPORT_KEY,
 				'enableContrastChecker',
 			] );
@@ -349,7 +348,7 @@ function ColorEditPure( props ) {
 			defaultControls={ defaultControls }
 			enableContrastChecker={
 				false !==
-				getBlockSupport( props.name, [
+				getBlockSupport( name, [
 					COLOR_SUPPORT_KEY,
 					'enableContrastChecker',
 				] )

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -297,7 +297,7 @@ function ColorEditPure( props ) {
 	const isEnabled = useHasColorPanel( settings );
 	function selector( select ) {
 		const { style, textColor, backgroundColor, gradient } =
-			select( blockEditorStore ).getBlockAttributes( clientId );
+			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 		return { style, textColor, backgroundColor, gradient };
 	}
 	const { style, textColor, backgroundColor, gradient } = useSelect(

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -5,6 +5,7 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
+import { pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -65,7 +66,7 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function DimensionsPanel( props ) {
+function DimensionsPanelPure( props ) {
 	const { clientId, name, setAttributes, __unstableParentLayout } = props;
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const isEnabled = useHasDimensionsPanel( settings );
@@ -124,6 +125,8 @@ export function DimensionsPanel( props ) {
 		</>
 	);
 }
+
+export const DimensionsPanel = pure( DimensionsPanelPure );
 
 /**
  * @deprecated

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -71,7 +71,7 @@ export function DimensionsPanel( props ) {
 	const isEnabled = useHasDimensionsPanel( settings );
 	const value = useSelect(
 		( select ) =>
-			select( blockEditorStore ).getBlockAttributes( clientId ).style,
+			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
 		[ clientId ]
 	);
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -66,8 +66,12 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-function DimensionsPanelPure( props ) {
-	const { clientId, name, setAttributes, __unstableParentLayout } = props;
+function DimensionsPanelPure( {
+	clientId,
+	name,
+	setAttributes,
+	__unstableParentLayout,
+} ) {
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const isEnabled = useHasDimensionsPanel( settings );
 	const value = useSelect(
@@ -86,11 +90,11 @@ function DimensionsPanelPure( props ) {
 		return null;
 	}
 
-	const defaultDimensionsControls = getBlockSupport( props.name, [
+	const defaultDimensionsControls = getBlockSupport( name, [
 		DIMENSIONS_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );
-	const defaultSpacingControls = getBlockSupport( props.name, [
+	const defaultSpacingControls = getBlockSupport( name, [
 		SPACING_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );
@@ -113,13 +117,15 @@ function DimensionsPanelPure( props ) {
 			{ !! settings?.spacing?.padding && (
 				<PaddingVisualizer
 					forceShow={ visualizedProperty === 'padding' }
-					{ ...props }
+					clientId={ clientId }
+					value={ value }
 				/>
 			) }
 			{ !! settings?.spacing?.margin && (
 				<MarginVisualizer
 					forceShow={ visualizedProperty === 'margin' }
-					{ ...props }
+					clientId={ clientId }
+					value={ value }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState, useEffect, useCallback } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 
@@ -66,16 +66,14 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 }
 
 export function DimensionsPanel( props ) {
-	const {
-		clientId,
-		name,
-		attributes,
-		setAttributes,
-		__unstableParentLayout,
-	} = props;
+	const { clientId, name, setAttributes, __unstableParentLayout } = props;
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const isEnabled = useHasDimensionsPanel( settings );
-	const value = attributes.style;
+	const value = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId ).style,
+		[ clientId ]
+	);
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 	const onChange = ( newStyle ) => {
 		setAttributes( {

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -16,11 +16,11 @@ function getComputedCSS( element, property ) {
 		.getPropertyValue( property );
 }
 
-export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
+export function PaddingVisualizer( { clientId, value, forceShow } ) {
 	const blockElement = useBlockElement( clientId );
 	const [ style, setStyle ] = useState();
 
-	const padding = attributes?.style?.spacing?.padding;
+	const padding = value?.spacing?.padding;
 
 	useEffect( () => {
 		if (

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -361,41 +361,38 @@ export const withBlockStyleControls = createHigherOrderComponent(
 
 		const shouldDisplayControls = useDisplayBlockControls();
 		const blockEditingMode = useBlockEditingMode();
+		const { clientId, name, setAttributes, __unstableParentLayout } = props;
 
 		return (
 			<>
 				{ shouldDisplayControls && blockEditingMode === 'default' && (
 					<>
 						<ColorEdit
-							clientId={ props.clientId }
-							name={ props.name }
-							setAttributes={ props.setAttributes }
+							clientId={ clientId }
+							name={ name }
+							setAttributes={ setAttributes }
 						/>
 						<BackgroundImagePanel
-							clientId={ props.clientId }
-							name={ props.name }
-							setAttributes={ props.setAttributes }
+							clientId={ clientId }
+							name={ name }
+							setAttributes={ setAttributes }
 						/>
 						<TypographyPanel
-							clientId={ props.clientId }
-							name={ props.name }
-							setAttributes={ props.setAttributes }
-							__unstableParentLayout={
-								props.__unstableParentLayout
-							}
+							clientId={ clientId }
+							name={ name }
+							setAttributes={ setAttributes }
+							__unstableParentLayout={ __unstableParentLayout }
 						/>
 						<BorderPanel
-							clientId={ props.clientId }
-							name={ props.name }
-							setAttributes={ props.setAttributes }
+							clientId={ clientId }
+							name={ name }
+							setAttributes={ setAttributes }
 						/>
 						<DimensionsPanel
-							clientId={ props.clientId }
-							name={ props.name }
-							setAttributes={ props.setAttributes }
-							__unstableParentLayout={
-								props.__unstableParentLayout
-							}
+							clientId={ clientId }
+							name={ name }
+							setAttributes={ setAttributes }
+							__unstableParentLayout={ __unstableParentLayout }
 						/>
 					</>
 				) }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -366,11 +366,37 @@ export const withBlockStyleControls = createHigherOrderComponent(
 			<>
 				{ shouldDisplayControls && blockEditingMode === 'default' && (
 					<>
-						<ColorEdit { ...props } />
-						<BackgroundImagePanel { ...props } />
-						<TypographyPanel { ...props } />
-						<BorderPanel { ...props } />
-						<DimensionsPanel { ...props } />
+						<ColorEdit
+							clientId={ props.clientId }
+							name={ props.name }
+							setAttributes={ props.setAttributes }
+						/>
+						<BackgroundImagePanel
+							clientId={ props.clientId }
+							name={ props.name }
+							setAttributes={ props.setAttributes }
+						/>
+						<TypographyPanel
+							clientId={ props.clientId }
+							name={ props.name }
+							setAttributes={ props.setAttributes }
+							__unstableParentLayout={
+								props.__unstableParentLayout
+							}
+						/>
+						<BorderPanel
+							clientId={ props.clientId }
+							name={ props.name }
+							setAttributes={ props.setAttributes }
+						/>
+						<DimensionsPanel
+							clientId={ props.clientId }
+							name={ props.name }
+							setAttributes={ props.setAttributes }
+							__unstableParentLayout={
+								props.__unstableParentLayout
+							}
+						/>
 					</>
 				) }
 				<BlockEdit key="edit" { ...props } />

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -117,7 +117,7 @@ function TypographyPanelPure( {
 } ) {
 	function selector( select ) {
 		const { style, fontFamily, fontSize } =
-			select( blockEditorStore ).getBlockAttributes( clientId );
+			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
 		return { style, fontFamily, fontSize };
 	}
 	const { style, fontFamily, fontSize } = useSelect( selector, [ clientId ] );

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -3,6 +3,8 @@
  */
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useMemo, useCallback } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -17,6 +19,7 @@ import { LINE_HEIGHT_SUPPORT_KEY } from './line-height';
 import { FONT_FAMILY_SUPPORT_KEY } from './font-family';
 import { FONT_SIZE_SUPPORT_KEY } from './font-size';
 import { cleanEmptyObject, useBlockSettings } from './utils';
+import { store as blockEditorStore } from '../store';
 
 function omit( object, keys ) {
 	return Object.fromEntries(
@@ -106,22 +109,24 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function TypographyPanel( {
+function TypographyPanelPure( {
 	clientId,
 	name,
-	attributes,
 	setAttributes,
 	__unstableParentLayout,
 } ) {
+	function selector( select ) {
+		const { style, fontFamily, fontSize } =
+			select( blockEditorStore ).getBlockAttributes( clientId );
+		return { style, fontFamily, fontSize };
+	}
+	const { style, fontFamily, fontSize } = useSelect( selector, [ clientId ] );
 	const settings = useBlockSettings( name, __unstableParentLayout );
 	const isEnabled = useHasTypographyPanel( settings );
-	const value = useMemo( () => {
-		return attributesToStyle( {
-			style: attributes.style,
-			fontFamily: attributes.fontFamily,
-			fontSize: attributes.fontSize,
-		} );
-	}, [ attributes.style, attributes.fontSize, attributes.fontFamily ] );
+	const value = useMemo(
+		() => attributesToStyle( { style, fontFamily, fontSize } ),
+		[ style, fontSize, fontFamily ]
+	);
 
 	const onChange = ( newStyle ) => {
 		setAttributes( styleToAttributes( newStyle ) );
@@ -147,6 +152,8 @@ export function TypographyPanel( {
 		/>
 	);
 }
+
+export const TypographyPanel = pure( TypographyPanelPure );
 
 export const hasTypographySupport = ( blockName ) => {
 	return TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR depends on #56770 to see the improvement better, but otherwise not technically.

Currently BlockEdit functions added by hooks implicitly subscribe to all attributes because they are children of the main BlockEdit function. In this PR, I make some of these pure and explicitly subscribe only to the relevant attributes.

I expect a performance benefit on typing because now these controls shouldn't re-render when the paragraph content attribute changes.

The more panels you have open, or the more controls show, the worse it is. By default, we only have color and typography open on paragraph.

Also:
* Using the store allows us to decouple these controls in the future when we design a block supports API.
* We should look into replacing `setAttributes` etc. as well and use the store instead.
* There’s potentially further improvements we can make when these controls read from the store: use AsyncProvider when the panel is not focussed, although I think the gain would be smaller since the amount of subscriptions is probably low.
* The inspector slot/fills should be investigated because they still render excessively.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

|Before|After #56770|After this PR|
|-|-|-|
|![before](https://github.com/WordPress/gutenberg/assets/4710635/e4e7994f-b3c8-40f3-8eea-daeabe3b20b7)|![after](https://github.com/WordPress/gutenberg/assets/4710635/ea99660c-3c8d-41f0-b84d-caeeb5a74ee1)|![after-2](https://github.com/WordPress/gutenberg/assets/4710635/b027475d-22d7-48e6-9d58-32eece7ad621)|
|Panels 🔴|Panels 🟢|Panels 🟢|
|Controls 🔴|Controls 🔴|Controls 🟢|
|Slot/Fill 🔴|Slot/Fill 🔴|Slot/Fill 🔴(*)|

(*) To be investigated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
