### PR TITLE
[a11y][Dataviews] Fix: use span instead of heading for the template titles

### DIFF
--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -186,3 +186,8 @@
 	display: block;
 	color: $gray-700;
 }
+
+.edit-site-list-title__customized-info {
+	font-size: 1.3em;
+	font-weight: 600;
+}

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -8,7 +8,7 @@ import removeAccents from 'remove-accents';
  */
 import {
 	Icon,
-	__experimentalHeading as Heading,
+	__experimentalView as View,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -83,7 +83,7 @@ function TemplateTitle( { item } ) {
 	const { isCustomized } = useAddedBy( item.type, item.id );
 	return (
 		<VStack spacing={ 1 }>
-			<Heading as="h3" level={ 5 }>
+			<View as="h3">
 				<Link
 					params={ {
 						postId: item.id,
@@ -94,7 +94,7 @@ function TemplateTitle( { item } ) {
 					{ decodeEntities( item.title?.rendered || item.slug ) ||
 						__( '(no title)' ) }
 				</Link>
-			</Heading>
+			</View>
 			{ isCustomized && (
 				<span className="edit-site-list-added-by__customized-info">
 					{ item.type === TEMPLATE_POST_TYPE


### PR DESCRIPTION
Fixes an issue referred by @afercia where the dataviews table view uses a h3 heading in the titles cells.
This PR fixes the issue for the template view `/wp-admin/site-editor.php?path=%2Fwp_template%2Fall`.


# Testing
Verify the template UI looks the same as in the trunk.
Verify the template's title is now a span and not a heading.