### PR TITLE
Fix top position and height of Pattern Modal Sidebar

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -268,14 +268,10 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__block-patterns-tabs-container,
-.block-editor-block-patterns-explorer__sidebar {
+.block-editor-inserter__block-patterns-tabs-container {
 	height: 100%;
 	nav {
 		height: 100%;
-	}
-	.block-editor-block-patterns__source-filter select.components-select-control__input {
-		height: 40px;
 	}
 }
 
@@ -445,7 +441,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-block-patterns-explorer {
 	&__sidebar {
 		position: absolute;
-		top: $header-height + $grid-unit-20;
+		top: $header-height + $grid-unit-15;
 		left: 0;
 		bottom: 0;
 		width: $sidebar-width;


### PR DESCRIPTION
Contains fix for #56740

## What?

This PR fixes the following two issues in the Pattern Modal Sidebar.

- Sidebar is slightly offset from the modal header
- Categories at the back will be cut (Reported by [#56740](https://github.com/WordPress/gutenberg/issues/56740))

![trunk](https://github.com/WordPress/gutenberg/assets/54422211/b566c5d1-5ad6-4b41-8177-450222255c55)


## Why?

> Sidebar is slightly offset from the modal header

I suspected that #51829, which added 4px padding to the top of the modal content, was the cause, but it doesn't seem to be the direct cause.

This might have been a pre-existing problem, or some change may have caused this problem.

> Categories at the back will be cut (Reported by [#56740](https://github.com/WordPress/gutenberg/issues/56740))

This sidebar (`.block-editor-block-patterns-explorer__sidebar`) is absolutely positioned, with `bottom: 0` applied. However, since `height:100%` is also applied at the same time, the height will protrude.

## How?

> Sidebar is slightly offset from the modal header

I moved the top position of the sidebar up 4px.

> Categories at the back will be cut (Reported by [#56740](https://github.com/WordPress/gutenberg/issues/56740))

I removed the unused code at the same time as the affecting code.

## Testing Instructions

- Open the editor.
- Click on the Pattern tab from the main inserter.
- Click the "Explore all patterns" button.
- Scroll the sidebar.
- No matter what browser size you use, make sure that the top position stays the same and that you can scroll to the bottom.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/54422211/2741bc0d-6f7a-4b2b-abf8-9f77a46ad213

