### PR TITLE
RN: Add watch mode for native tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,6 +322,7 @@
 		"test:e2e:storybook": "playwright test --config test/storybook-playwright/playwright.config.ts",
 		"test:e2e:watch": "npm run test:e2e -- --watch",
 		"test:native": "cross-env NODE_ENV=test jest --config test/native/jest.config.js",
+		"test:native:watch": "npm run test:native -- --watch",
 		"test:native:clean": "jest --clearCache --config test/native/jest.config.js; rm -rf $TMPDIR/jest_*",
 		"test:native:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand --verbose --config test/native/jest.config.js",
 		"test:native:perf": "cross-env TEST_RUNNER_ARGS='--runInBand --config test/native/jest.config.js --testMatch \"**/performance/*.native.[jt]s?(x)\"' reassure",


### PR DESCRIPTION
## What?
While working on https://github.com/WordPress/gutenberg/pull/56758 I noticed that the RN tests don't come with a watch mode. This PR introduces one.

## Why?
So you'd be able to run React native tests in watch mode, rather than re-running them every time.

## How?
We're adding a new script that runs `test:native` in `jest` `--watch` mode.

## Testing Instructions
* Verify `npm run test:native:watch` correctly runs React native tests in Jest watch mode.
* Verify `npm run test:native` still works well.
* All checks should be green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None