### PR TITLE
Template Part block: Fix template part path arg missing from actions

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -70,6 +70,12 @@ function render_block_core_template_part( $attributes ) {
 				if ( isset( $block_template->area ) ) {
 					$area = $block_template->area;
 				}
+
+				// Needed for the `render_block_core_template_part_file` and `render_block_core_template_part_none` actions below.
+				$block_template_file = _get_block_template_file( 'wp_template_part', $attributes['slug'] );
+				if ( $block_template_file ) {
+					$template_part_file_path = $block_template_file['path'];
+				}
 			}
 
 			if ( '' !== $content && null !== $content ) {


### PR DESCRIPTION
## What?
In the Template Part block, set the `$template_part_file_path` variable (for use by the `render_block_core_template_part_file` and `render_block_core_template_part_none` filters).

## Why?
Fixes #56013. This was broken by https://github.com/WordPress/gutenberg/pull/52892.

## How?
By calling `_get_block_template_file()` (which duplicates some logic also found deeper in the call stack of [`get_block_file_template`](https://developer.wordpress.org/reference/functions/get_block_file_template/)). But alas, the relevant information cannot be inferred from the `WP_Block_Template` object returned  by `get_block_file_template`, nor does the [eponymous filter](https://developer.wordpress.org/reference/hooks/get_block_file_template/) expose any useful information.

## Testing Instructions

Quoting #56013:

> ```php
> add_action( 'render_block_core_template_part_file', function( $template_part_id, $attributes, $template_part_file_path ) {
>     var_dump( $template_part_file_path );
> }, 10, 3 );
> ```
>
> Load the front page of a vanilla WordPress site using the Twenty Twenty Four theme and observe that [...] the template part file path [is logged].
>
> This [fix] can also be [tested] by installing the Query Monitor plugin and viewing the "Template" panel, which [should show] the path to each Template Part block that was loaded on the page.
