### PR TITLE
[a11y][Dataviews] Fix: Dropdown menus with only one item.

### DIFF
--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -101,6 +101,54 @@ function ActionsDropdownMenuGroup( { actions, item } ) {
 	);
 }
 
+function PrimaryActions( { primaryActions, item } ) {
+	return primaryActions.map( ( action ) => {
+		if ( !! action.RenderModal ) {
+			return (
+				<ActionWithModal
+					key={ action.id }
+					action={ action }
+					item={ item }
+					ActionTrigger={ ButtonTrigger }
+				/>
+			);
+		}
+		return (
+			<ButtonTrigger
+				key={ action.id }
+				action={ action }
+				onClick={ () => action.callback( item ) }
+			/>
+		);
+	} );
+}
+
+function SecondaryActions( { secondaryActions, item } ) {
+	// If there is only one secondary action, it should be rendered as a primary action avoid an unnecessary dropdown.
+	if ( secondaryActions.length === 1 ) {
+		return (
+			<PrimaryActions primaryActions={ secondaryActions } item={ item } />
+		);
+	}
+	return (
+		<DropdownMenu
+			trigger={
+				<Button
+					size="compact"
+					icon={ moreVertical }
+					label={ __( 'Actions' ) }
+				/>
+			}
+			placement="bottom-end"
+		>
+			<ActionsDropdownMenuGroup
+				actions={ secondaryActions }
+				item={ item }
+			/>
+		</DropdownMenu>
+	);
+}
+
 export default function ItemActions( { item, actions, isCompact } ) {
 	const { primaryActions, secondaryActions } = useMemo( () => {
 		return actions.reduce(
@@ -141,42 +189,17 @@ export default function ItemActions( { item, actions, isCompact } ) {
 				width: 'auto',
 			} }
 		>
-			{ !! primaryActions.length &&
-				primaryActions.map( ( action ) => {
-					if ( !! action.RenderModal ) {
-						return (
-							<ActionWithModal
-								key={ action.id }
-								action={ action }
-								item={ item }
-								ActionTrigger={ ButtonTrigger }
-							/>
-						);
-					}
-					return (
-						<ButtonTrigger
-							key={ action.id }
-							action={ action }
-							onClick={ () => action.callback( item ) }
-						/>
-					);
-				} ) }
+			{ !! primaryActions.length && (
+				<PrimaryActions
+					primaryActions={ primaryActions }
+					item={ item }
+				/>
+			) }
 			{ !! secondaryActions.length && (
-				<DropdownMenu
-					trigger={
-						<Button
-							size="compact"
-							icon={ moreVertical }
-							label={ __( 'Actions' ) }
-						/>
-					}
-					placement="bottom-end"
-				>
-					<ActionsDropdownMenuGroup
-						actions={ secondaryActions }
-						item={ item }
-					/>
-				</DropdownMenu>
+				<SecondaryActions
+					item={ item }
+					secondaryActions={ secondaryActions }
+				/>
 			) }
 		</HStack>
 	);

--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { external, trash, backup } from '@wordpress/icons';
+import { external, trash, backup, edit } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -225,6 +225,7 @@ export function useEditPostAction() {
 			isEligible( { status } ) {
 				return status !== 'trash';
 			},
+			icon: edit,
 			callback( post ) {
 				history.push( {
 					postId: post.id,


### PR DESCRIPTION
When there is only one secondary action in dataviews we ended up rendering a dropdown menu with a single item which is not ideal. This PR fixes that issue reported by @afercia at https://github.com/WordPress/gutenberg/pull/56476#issuecomment-1838416628.

## Testing
Go to the pages view `/wp-admin/site-editor.php?path=%2Fpages.
Verify that if we have a single secondary item we don't render the dropdown and render the action directly.

## Screenshot

<img width="2277" alt="Screenshot 2023-12-05 at 17 05 43" src="https://github.com/WordPress/gutenberg/assets/11271197/067a594e-5a6e-47c2-81d7-2cc76b298b1c">
