### PR TITLE
Font Library: add font family and font face preview keys to schema

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -188,7 +188,7 @@ Settings related to typography.
 | textTransform | boolean | true |  |
 | dropCap | boolean | true |  |
 | fontSizes | array |  | fluid, name, size, slug |
-| fontFamilies | array |  | fontFace, fontFamily, name, slug |
+| fontFamilies | array |  | fontFace, fontFamily, name, preview, slug |
 
 ---
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -431,6 +431,7 @@ class WP_Theme_JSON_Gutenberg {
 			'fontFamily' => null,
 			'name'       => null,
 			'slug'       => null,
+			'preview'    => null,
 			'fontFace'   => array(
 				array(
 					'ascentOverride'        => null,
@@ -446,6 +447,7 @@ class WP_Theme_JSON_Gutenberg {
 					'sizeAdjust'            => null,
 					'src'                   => null,
 					'unicodeRange'          => null,
+					'preview'               => null,
 				),
 			),
 		),

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -719,7 +719,7 @@
 													"type": "string"
 												},
 												"preview": {
-													"description": "URL to a preview image of the font family.",
+													"description": "URL to a preview image of the font face.",
 													"type": "string"
 												}
 											},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -623,6 +623,10 @@
 										"description": "CSS font-family value.",
 										"type": "string"
 									},
+									"preview": {
+										"description": "URL to a preview image of the font family.",
+										"type": "string"
+									},
 									"fontFace": {
 										"description": "Array of font-face declarations.",
 										"type": "array",
@@ -712,6 +716,10 @@
 												},
 												"unicodeRange": {
 													"description": "CSS unicode-range value.",
+													"type": "string"
+												},
+												"preview": {
+													"description": "URL to a preview image of the font family.",
 													"type": "string"
 												}
 											},


### PR DESCRIPTION
## What?
Font Library: add font family and font face preview keys to schema.
The preview property is optional and it's used to store a reference to a preview of the font asset.

Example:
In the Font Library default font collection is used to store an image preview in SVG format.

## Why?
To avoid using a non-documented key `preview`.
To avoid wiping the `preview` data during sanitization. 

## How?
Add to theme.json schema to document this key.
Add to PHP sanitization schema to avoid the preview data being removed by the sanitization process.

## Testing Instructions
- Install a font from the Google Fonts collection.
- Check that the font preview data is not removed when saved to the database.
