### PR TITLE
Components: Try disabling `NavigatorScreen` animations completely

### DIFF
--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -37,6 +37,7 @@ const animationEnterDelay = 0;
 const animationEnterDuration = 0.14;
 const animationExitDuration = 0.14;
 const animationExitDelay = 0;
+const DISABLE_ANIMATIONS = true;
 
 // Props specific to `framer-motion` can't be currently passed to `NavigatorScreen`,
 // as some of them would overlap with HTML props (e.g. `onAnimationStart`, ...)
@@ -153,7 +154,7 @@ function UnconnectedNavigatorScreen(
 		return null;
 	}
 
-	if ( prefersReducedMotion ) {
+	if ( prefersReducedMotion || DISABLE_ANIMATIONS ) {
 		return (
 			<View
 				ref={ mergedWrapperRef }


### PR DESCRIPTION
**DO NOT MERGE**

## What?
This is an experiment that allows us to try out disabling only the `NavigatorScreen` animations, without tinkering with any other existing animations or existing motion throughout the application. 

## Why?
To demonstrate that the animations of `NavigatorScreen` tend to be among the primary reasons for the slow performance of the site editor when navigating between pages and templates, as reported in https://github.com/WordPress/gutenberg/issues/55892

This hints that we might need to rewrite those animations to not use `framer-motion` but just pure CSS instead to leverage hardware acceleration and avoid the already complex painting work that the browser has to do with the editor canvas iframe. 

## How?
We're just disabling the `NavigatorScreen` enter/exit animations. 

We could alternatively try out by emulating `prefers-reduced-motion`, but this disables other animations too, which we don't want for this experiment.

## Testing Instructions
* Start with the latest WordPress
* Throttle your CPU to simulate a slower device.
* Install and activate the TT4 (Twenty Twenty-Four) theme
* Navigate between pages or templates and go back
* You'll see the UI stuck at animating the site editor sidebar.
* On slower devices, you'll see the UI unresponsive for many seconds.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None