### PR TITLE
Paragraph: avoid re-rendering block controls on type

### DIFF
--- a/packages/block-library/src/paragraph/controls.js
+++ b/packages/block-library/src/paragraph/controls.js
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x, isRTL } from '@wordpress/i18n';
+import {
+	ToolbarButton,
+	ToggleControl,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import {
+	AlignmentControl,
+	BlockControls,
+	InspectorControls,
+	useSettings,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { formatLtr } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { pure } from '@wordpress/compose';
+
+function ParagraphRTLControl( { direction, setDirection } ) {
+	return (
+		isRTL() && (
+			<ToolbarButton
+				icon={ formatLtr }
+				title={ _x( 'Left to right', 'editor button' ) }
+				isActive={ direction === 'ltr' }
+				onClick={ () => {
+					setDirection( direction === 'ltr' ? undefined : 'ltr' );
+				} }
+			/>
+		)
+	);
+}
+
+export function hasDropCapDisabled( align ) {
+	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
+}
+
+function Controls( { clientId, setAttributes } ) {
+	const [ isDropCapFeatureEnabled ] = useSettings( 'typography.dropCap' );
+
+	function selector( select ) {
+		const { align, direction, dropCap } =
+			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
+		return { align, direction, dropCap };
+	}
+	const { align, direction, dropCap } = useSelect( selector, [ clientId ] );
+
+	let helpText;
+	if ( hasDropCapDisabled( align ) ) {
+		helpText = __( 'Not available for aligned text.' );
+	} else if ( dropCap ) {
+		helpText = __( 'Showing large initial letter.' );
+	} else {
+		helpText = __( 'Toggle to show a large initial letter.' );
+	}
+
+	return (
+		<>
+			<BlockControls group="block">
+				<AlignmentControl
+					value={ align }
+					onChange={ ( newAlign ) =>
+						setAttributes( {
+							align: newAlign,
+							dropCap: hasDropCapDisabled( newAlign )
+								? false
+								: dropCap,
+						} )
+					}
+				/>
+				<ParagraphRTLControl
+					direction={ direction }
+					setDirection={ ( newDirection ) =>
+						setAttributes( { direction: newDirection } )
+					}
+				/>
+			</BlockControls>
+			{ isDropCapFeatureEnabled && (
+				<InspectorControls group="typography">
+					<ToolsPanelItem
+						hasValue={ () => !! dropCap }
+						label={ __( 'Drop cap' ) }
+						onDeselect={ () =>
+							setAttributes( { dropCap: undefined } )
+						}
+						resetAllFilter={ () => ( { dropCap: undefined } ) }
+						panelId={ clientId }
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Drop cap' ) }
+							checked={ !! dropCap }
+							onChange={ () =>
+								setAttributes( { dropCap: ! dropCap } )
+							}
+							help={ helpText }
+							disabled={
+								hasDropCapDisabled( align ) ? true : false
+							}
+						/>
+					</ToolsPanelItem>
+				</InspectorControls>
+			) }
+		</>
+	);
+}
+
+export default pure( Controls );

--- a/packages/block-library/src/paragraph/controls.js
+++ b/packages/block-library/src/paragraph/controls.js
@@ -12,10 +12,8 @@ import {
 	BlockControls,
 	InspectorControls,
 	useSettings,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { formatLtr } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
 import { pure } from '@wordpress/compose';
 
 function ParagraphRTLControl( { direction, setDirection } ) {
@@ -37,15 +35,8 @@ export function hasDropCapDisabled( align ) {
 	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
 }
 
-function Controls( { clientId, setAttributes } ) {
+function Controls( { align, direction, dropCap, clientId, setAttributes } ) {
 	const [ isDropCapFeatureEnabled ] = useSettings( 'typography.dropCap' );
-
-	function selector( select ) {
-		const { align, direction, dropCap } =
-			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-		return { align, direction, dropCap };
-	}
-	const { align, direction, dropCap } = useSelect( selector, [ clientId ] );
 
 	let helpText;
 	if ( hasDropCapDisabled( align ) ) {

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -6,48 +6,16 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, _x, isRTL } from '@wordpress/i18n';
-import {
-	ToolbarButton,
-	ToggleControl,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
-import {
-	AlignmentControl,
-	BlockControls,
-	InspectorControls,
-	RichText,
-	useBlockProps,
-	useSettings,
-} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { formatLtr } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { useOnEnter } from './use-enter';
-
-const name = 'core/paragraph';
-
-function ParagraphRTLControl( { direction, setDirection } ) {
-	return (
-		isRTL() && (
-			<ToolbarButton
-				icon={ formatLtr }
-				title={ _x( 'Left to right', 'editor button' ) }
-				isActive={ direction === 'ltr' }
-				onClick={ () => {
-					setDirection( direction === 'ltr' ? undefined : 'ltr' );
-				} }
-			/>
-		)
-	);
-}
-
-function hasDropCapDisabled( align ) {
-	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
-}
+import Controls, { hasDropCapDisabled } from './controls';
+import { name } from './';
 
 function ParagraphBlock( {
 	attributes,
@@ -58,7 +26,6 @@ function ParagraphBlock( {
 	clientId,
 } ) {
 	const { align, content, direction, dropCap, placeholder } = attributes;
-	const [ isDropCapFeatureEnabled ] = useSettings( 'typography.dropCap' );
 	const blockProps = useBlockProps( {
 		ref: useOnEnter( { clientId, content } ),
 		className: classnames( {
@@ -68,62 +35,9 @@ function ParagraphBlock( {
 		style: { direction },
 	} );
 
-	let helpText;
-	if ( hasDropCapDisabled( align ) ) {
-		helpText = __( 'Not available for aligned text.' );
-	} else if ( dropCap ) {
-		helpText = __( 'Showing large initial letter.' );
-	} else {
-		helpText = __( 'Toggle to show a large initial letter.' );
-	}
-
 	return (
 		<>
-			<BlockControls group="block">
-				<AlignmentControl
-					value={ align }
-					onChange={ ( newAlign ) =>
-						setAttributes( {
-							align: newAlign,
-							dropCap: hasDropCapDisabled( newAlign )
-								? false
-								: dropCap,
-						} )
-					}
-				/>
-				<ParagraphRTLControl
-					direction={ direction }
-					setDirection={ ( newDirection ) =>
-						setAttributes( { direction: newDirection } )
-					}
-				/>
-			</BlockControls>
-			{ isDropCapFeatureEnabled && (
-				<InspectorControls group="typography">
-					<ToolsPanelItem
-						hasValue={ () => !! dropCap }
-						label={ __( 'Drop cap' ) }
-						onDeselect={ () =>
-							setAttributes( { dropCap: undefined } )
-						}
-						resetAllFilter={ () => ( { dropCap: undefined } ) }
-						panelId={ clientId }
-					>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Drop cap' ) }
-							checked={ !! dropCap }
-							onChange={ () =>
-								setAttributes( { dropCap: ! dropCap } )
-							}
-							help={ helpText }
-							disabled={
-								hasDropCapDisabled( align ) ? true : false
-							}
-						/>
-					</ToolsPanelItem>
-				</InspectorControls>
-			) }
+			<Controls clientId={ clientId } setAttributes={ setAttributes } />
 			<RichText
 				identifier="content"
 				tagName="p"

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -37,7 +37,13 @@ function ParagraphBlock( {
 
 	return (
 		<>
-			<Controls clientId={ clientId } setAttributes={ setAttributes } />
+			<Controls
+				align={ align }
+				direction={ direction }
+				dropCap={ dropCap }
+				clientId={ clientId }
+				setAttributes={ setAttributes }
+			/>
 			<RichText
 				identifier="content"
 				tagName="p"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is an experiment inspired by #56783. While the color/typography panels no longer re-render, the controls added by the block itself are still being built on every keystroke, and when visible it's even worse, they will re-render (top toolbar enabled, or drop cap option shown). I also suspect registering the fills adds additional overhead, which happens even if the control is not visible.

I'm also wondering what this means for other block Edit functions. I don't really like that the content and controls are rendered together, but that ship has sailed. Together with a new block supports API, maybe we should rethink how controls are added though, also by blocks themselves.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After running the test, it seems there's about a 9.2% improvement (30.39 ms this branch vs 33.47 ms trunk).
Also "type in container" is better by 24% (8.36 ms vs 11.03ms) and "type without inspector" by 6% (30.17 ms vs 32.11 ms).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By wrapping the controls in a separate, pure component (only re-renders from parent if the props change), subscribing itself to only the block attributes it needs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
