### PR TITLE
Global styles revisions: add pagination 

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -3,13 +3,11 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import {
-	Button,
 	__experimentalUseNavigator as useNavigator,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Spinner,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { useContext, useState, useEffect } from '@wordpress/element';
 import {
 	privateApis as blockEditorPrivateApis,
@@ -27,47 +25,39 @@ import { store as editSiteStore } from '../../../store';
 import useGlobalStylesRevisions from './use-global-styles-revisions';
 import RevisionsButtons from './revisions-buttons';
 import StyleBook from '../../style-book';
+import Pagination from '../../pagination';
 
 const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
 
+const PAGE_SIZE = 10;
+
 function ScreenRevisions() {
 	const { goTo } = useNavigator();
 	const { user: currentEditorGlobalStyles, setUserConfig } =
 		useContext( GlobalStylesContext );
-	const { blocks, editorCanvasContainerView, revisionsCount } = useSelect(
-		( select ) => {
-			const {
-				getEntityRecord,
-				__experimentalGetCurrentGlobalStylesId,
-				__experimentalGetDirtyEntityRecords,
-			} = select( coreStore );
-			const isDirty = __experimentalGetDirtyEntityRecords().length > 0;
-			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-			const globalStyles = globalStylesId
-				? getEntityRecord( 'root', 'globalStyles', globalStylesId )
-				: undefined;
-			let _revisionsCount =
-				globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count || 0;
-			// one for the reset item.
-			_revisionsCount++;
-			// one for any dirty changes (unsaved).
-			if ( isDirty ) {
-				_revisionsCount++;
-			}
-			return {
-				editorCanvasContainerView: unlock(
-					select( editSiteStore )
-				).getEditorCanvasContainerView(),
-				blocks: select( blockEditorStore ).getBlocks(),
-				revisionsCount: _revisionsCount,
-			};
-		},
+	const { blocks, editorCanvasContainerView } = useSelect(
+		( select ) => ( {
+			editorCanvasContainerView: unlock(
+				select( editSiteStore )
+			).getEditorCanvasContainerView(),
+			blocks: select( blockEditorStore ).getBlocks(),
+		} ),
 		[]
 	);
-	const { revisions, isLoading, hasUnsavedChanges } =
-		useGlobalStylesRevisions();
+	const [ currentPage, setCurrentPage ] = useState( 1 );
+	const [ currentRevisions, setCurrentRevisions ] = useState( [] );
+	const { revisions, isLoading, hasUnsavedChanges, revisionsCount } =
+		useGlobalStylesRevisions( {
+			query: {
+				per_page: PAGE_SIZE,
+				page: currentPage,
+			},
+		} );
+
+	const numPages = Math.ceil( revisionsCount / PAGE_SIZE );
+
 	const [ currentlySelectedRevision, setCurrentlySelectedRevision ] =
 		useState( currentEditorGlobalStyles );
 	const [
@@ -114,6 +104,12 @@ function ScreenRevisions() {
 		}
 	}, [ editorCanvasContainerView ] );
 
+	useEffect( () => {
+		if ( ! isLoading && revisions.length ) {
+			setCurrentRevisions( revisions );
+		}
+	}, [ revisions, isLoading ] );
+
 	const firstRevision = revisions[ 0 ];
 	const currentlySelectedRevisionId = currentlySelectedRevision?.id;
 	const shouldSelectFirstItem =
@@ -141,8 +137,10 @@ function ScreenRevisions() {
 	// Only display load button if there is a revision to load,
 	// and it is different from the current editor styles.
 	const isLoadButtonEnabled =
-		!! currentlySelectedRevisionId && ! selectedRevisionMatchesEditorStyles;
-	const shouldShowRevisions = ! isLoading && revisions.length;
+		!! currentlySelectedRevisionId &&
+		currentlySelectedRevisionId !== 'unsaved' &&
+		! selectedRevisionMatchesEditorStyles;
+	const hasRevisions = !! currentRevisions.length;
 
 	return (
 		<>
@@ -157,83 +155,74 @@ function ScreenRevisions() {
 				) }
 				onBack={ onCloseRevisions }
 			/>
-			{ isLoading && (
+			{ ! hasRevisions && (
 				<Spinner className="edit-site-global-styles-screen-revisions__loading" />
 			) }
-			{ editorCanvasContainerView ===
-			'global-styles-revisions:style-book' ? (
-				<StyleBook
-					userConfig={ currentlySelectedRevision }
-					isSelected={ () => {} }
-					onClose={ () => {
-						setEditorCanvasContainerView(
-							'global-styles-revisions'
-						);
-					} }
-				/>
-			) : (
-				<Revisions
-					blocks={ blocks }
-					userConfig={ currentlySelectedRevision }
-					closeButtonLabel={ __( 'Close revisions' ) }
-				/>
-			) }
-			{ shouldShowRevisions && (
-				<>
-					<div className="edit-site-global-styles-screen-revisions">
-						<RevisionsButtons
-							onChange={ selectRevision }
-							selectedRevisionId={ currentlySelectedRevisionId }
-							userRevisions={ revisions }
-							canApplyRevision={ isLoadButtonEnabled }
+			<>
+				{ hasRevisions &&
+					( editorCanvasContainerView ===
+					'global-styles-revisions:style-book' ? (
+						<StyleBook
+							userConfig={ currentlySelectedRevision }
+							isSelected={ () => {} }
+							onClose={ () => {
+								setEditorCanvasContainerView(
+									'global-styles-revisions'
+								);
+							} }
 						/>
-						{ isLoadButtonEnabled && (
-							<SidebarFixedBottom>
-								<Button
-									variant="primary"
-									className="edit-site-global-styles-screen-revisions__button"
-									disabled={
-										! currentlySelectedRevisionId ||
-										currentlySelectedRevisionId ===
-											'unsaved'
-									}
-									onClick={ () => {
-										if ( hasUnsavedChanges ) {
-											setIsLoadingRevisionWithUnsavedChanges(
-												true
-											);
-										} else {
-											restoreRevision(
-												currentlySelectedRevision
-											);
-										}
-									} }
-								>
-									{ currentlySelectedRevisionId === 'parent'
-										? __( 'Reset to defaults' )
-										: __( 'Apply' ) }
-								</Button>
-							</SidebarFixedBottom>
-						) }
-					</div>
-					{ isLoadingRevisionWithUnsavedChanges && (
-						<ConfirmDialog
-							isOpen={ isLoadingRevisionWithUnsavedChanges }
-							confirmButtonText={ __( 'Apply' ) }
-							onConfirm={ () =>
-								restoreRevision( currentlySelectedRevision )
-							}
-							onCancel={ () =>
-								setIsLoadingRevisionWithUnsavedChanges( false )
-							}
-						>
-							{ __(
-								'Any unsaved changes will be lost when you apply this revision.'
+					) : (
+						<Revisions
+							blocks={ blocks }
+							userConfig={ currentlySelectedRevision }
+							closeButtonLabel={ __( 'Close revisions' ) }
+						/>
+					) ) }
+				<div className="edit-site-global-styles-screen-revisions">
+					<RevisionsButtons
+						onChange={ selectRevision }
+						selectedRevisionId={ currentlySelectedRevisionId }
+						userRevisions={ currentRevisions }
+						canApplyRevision={ isLoadButtonEnabled }
+						onApplyRevision={ () =>
+							hasUnsavedChanges
+								? setIsLoadingRevisionWithUnsavedChanges( true )
+								: restoreRevision( currentlySelectedRevision )
+						}
+					/>
+				</div>
+				{ numPages > 1 && (
+					<SidebarFixedBottom className="edit-site-global-styles-screen-revisions__footer">
+						<Pagination
+							className="edit-site-global-styles-screen-revisions__pagination"
+							currentPage={ currentPage }
+							numPages={ numPages }
+							changePage={ setCurrentPage }
+							totalItems={ revisionsCount }
+							disabled={ isLoading }
+							label={ __(
+								'Global Styles pagination navigation'
 							) }
-						</ConfirmDialog>
-					) }
-				</>
-			) }
+						/>
+					</SidebarFixedBottom>
+				) }
+				{ isLoadingRevisionWithUnsavedChanges && (
+					<ConfirmDialog
+						isOpen={ isLoadingRevisionWithUnsavedChanges }
+						confirmButtonText={ __( 'Apply' ) }
+						onConfirm={ () =>
+							restoreRevision( currentlySelectedRevision )
+						}
+						onCancel={ () =>
+							setIsLoadingRevisionWithUnsavedChanges( false )
+						}
+					>
+						{ __(
+							'Any unsaved changes will be lost when you apply this revision.'
+						) }
+					</ConfirmDialog>
+				) }
+			</>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -114,7 +114,8 @@ function RevisionsButtons( {
 	userRevisions,
 	selectedRevisionId,
 	onChange,
-	canApplyRevision,
+	canSelectedRevisionBeRestored,
+	onApplyRevision,
 } ) {
 	const { currentThemeName, currentUser } = useSelect( ( select ) => {
 		const { getCurrentTheme, getCurrentUser } = select( coreStore );
@@ -148,22 +149,26 @@ function RevisionsButtons( {
 				const revisionAuthor = isUnsaved ? currentUser : author;
 				const authorDisplayName = revisionAuthor?.name || __( 'User' );
 				const authorAvatar = revisionAuthor?.avatar_urls?.[ '48' ];
-				const isFirstItem = index === 0;
 				const isSelected = selectedRevisionId
 					? selectedRevisionId === id
-					: isFirstItem;
-				const areStylesEqual = ! canApplyRevision && isSelected;
-				const isReset = 'parent' === id;
+					: index === 0;
+				const areStylesEqual =
+					! canSelectedRevisionBeRestored && isSelected;
+				const isParent = 'parent' === id;
 				const modifiedDate = getDate( modified );
+				const formattedModifiedDate = dateI18n(
+					datetimeAbbreviated,
+					modifiedDate
+				);
 				const displayDate =
 					modified &&
 					dateNowInMs - modifiedDate.getTime() > DAY_IN_MILLISECONDS
-						? dateI18n( datetimeAbbreviated, modifiedDate )
+						? formattedModifiedDate
 						: humanTimeDiff( modified );
 				const revisionLabel = getRevisionLabel(
 					id,
 					authorDisplayName,
-					dateI18n( datetimeAbbreviated, modifiedDate ),
+					formattedModifiedDate,
 					areStylesEqual
 				);
 
@@ -174,7 +179,7 @@ function RevisionsButtons( {
 							{
 								'is-selected': isSelected,
 								'is-active': areStylesEqual,
-								'is-reset': isReset,
+								'is-reset': isParent,
 							}
 						) }
 						key={ id }
@@ -187,7 +192,7 @@ function RevisionsButtons( {
 							} }
 							aria-label={ revisionLabel }
 						>
-							{ isReset ? (
+							{ isParent ? (
 								<span className="edit-site-global-styles-screen-revisions__description">
 									{ __( 'Default styles' ) }
 									<span className="edit-site-global-styles-screen-revisions__meta">
@@ -229,6 +234,17 @@ function RevisionsButtons( {
 								</span>
 							) }
 						</Button>
+						{ isSelected && canSelectedRevisionBeRestored && (
+							<Button
+								variant="primary"
+								className="edit-site-global-styles-screen-revisions__button"
+								onClick={ onApplyRevision }
+							>
+								{ isParent
+									? __( 'Reset to defaults' )
+									: __( 'Apply' ) }
+							</Button>
+						) }
 					</li>
 				);
 			} ) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -114,8 +114,7 @@ function RevisionsButtons( {
 	userRevisions,
 	selectedRevisionId,
 	onChange,
-	canSelectedRevisionBeRestored,
-	onApplyRevision,
+	canApplyRevision,
 } ) {
 	const { currentThemeName, currentUser } = useSelect( ( select ) => {
 		const { getCurrentTheme, getCurrentUser } = select( coreStore );
@@ -149,26 +148,22 @@ function RevisionsButtons( {
 				const revisionAuthor = isUnsaved ? currentUser : author;
 				const authorDisplayName = revisionAuthor?.name || __( 'User' );
 				const authorAvatar = revisionAuthor?.avatar_urls?.[ '48' ];
+				const isFirstItem = index === 0;
 				const isSelected = selectedRevisionId
 					? selectedRevisionId === id
-					: index === 0;
-				const areStylesEqual =
-					! canSelectedRevisionBeRestored && isSelected;
-				const isParent = 'parent' === id;
+					: isFirstItem;
+				const areStylesEqual = ! canApplyRevision && isSelected;
+				const isReset = 'parent' === id;
 				const modifiedDate = getDate( modified );
-				const formattedModifiedDate = dateI18n(
-					datetimeAbbreviated,
-					modifiedDate
-				);
 				const displayDate =
 					modified &&
 					dateNowInMs - modifiedDate.getTime() > DAY_IN_MILLISECONDS
-						? formattedModifiedDate
+						? dateI18n( datetimeAbbreviated, modifiedDate )
 						: humanTimeDiff( modified );
 				const revisionLabel = getRevisionLabel(
 					id,
 					authorDisplayName,
-					formattedModifiedDate,
+					dateI18n( datetimeAbbreviated, modifiedDate ),
 					areStylesEqual
 				);
 
@@ -179,7 +174,7 @@ function RevisionsButtons( {
 							{
 								'is-selected': isSelected,
 								'is-active': areStylesEqual,
-								'is-reset': isParent,
+								'is-reset': isReset,
 							}
 						) }
 						key={ id }
@@ -192,7 +187,7 @@ function RevisionsButtons( {
 							} }
 							aria-label={ revisionLabel }
 						>
-							{ isParent ? (
+							{ isReset ? (
 								<span className="edit-site-global-styles-screen-revisions__description">
 									{ __( 'Default styles' ) }
 									<span className="edit-site-global-styles-screen-revisions__meta">
@@ -234,17 +229,6 @@ function RevisionsButtons( {
 								</span>
 							) }
 						</Button>
-						{ isSelected && canSelectedRevisionBeRestored && (
-							<Button
-								variant="primary"
-								className="edit-site-global-styles-screen-revisions__button"
-								onClick={ onApplyRevision }
-							>
-								{ isParent
-									? __( 'Reset to defaults' )
-									: __( 'Apply' ) }
-							</Button>
-						) }
 					</li>
 				);
 			} ) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -179,6 +179,7 @@ function RevisionsButtons( {
 							}
 						) }
 						key={ id }
+						aria-current={ isSelected }
 					>
 						<Button
 							className="edit-site-global-styles-screen-revisions__revision-button"
@@ -232,13 +233,13 @@ function RevisionsButtons( {
 						</Button>
 						{ canApplyRevision && isSelected && (
 							<Button
-								variant="secondary"
+								variant="primary"
 								className="edit-site-global-styles-screen-revisions__apply-button"
 								onClick={ onApplyRevision }
 							>
 								{ isReset
 									? __( 'Reset to defaults' )
-									: __( 'Apply changes' ) }
+									: __( 'Apply' ) }
 							</Button>
 						) }
 					</li>

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -115,6 +115,7 @@ function RevisionsButtons( {
 	selectedRevisionId,
 	onChange,
 	canApplyRevision,
+	onApplyRevision,
 } ) {
 	const { currentThemeName, currentUser } = useSelect( ( select ) => {
 		const { getCurrentTheme, getCurrentUser } = select( coreStore );
@@ -208,6 +209,13 @@ function RevisionsButtons( {
 											{ displayDate }
 										</time>
 									) }
+									<span className="edit-site-global-styles-screen-revisions__meta">
+										<img
+											alt={ authorDisplayName }
+											src={ authorAvatar }
+										/>
+										{ authorDisplayName }
+									</span>
 									{ isSelected && (
 										<ChangesSummary
 											blockNames={ blockNames }
@@ -219,16 +227,20 @@ function RevisionsButtons( {
 											}
 										/>
 									) }
-									<span className="edit-site-global-styles-screen-revisions__meta">
-										<img
-											alt={ authorDisplayName }
-											src={ authorAvatar }
-										/>
-										{ authorDisplayName }
-									</span>
 								</span>
 							) }
 						</Button>
+						{ canApplyRevision && isSelected && (
+							<Button
+								variant="secondary"
+								className="edit-site-global-styles-screen-revisions__apply-button"
+								onClick={ onApplyRevision }
+							>
+								{ isReset
+									? __( 'Reset to defaults' )
+									: __( 'Apply changes' ) }
+							</Button>
+						) }
 					</li>
 				);
 			} ) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -231,17 +231,25 @@ function RevisionsButtons( {
 								</span>
 							) }
 						</Button>
-						{ canApplyRevision && isSelected && (
-							<Button
-								variant="primary"
-								className="edit-site-global-styles-screen-revisions__apply-button"
-								onClick={ onApplyRevision }
-							>
-								{ isReset
-									? __( 'Reset to defaults' )
-									: __( 'Apply' ) }
-							</Button>
-						) }
+						{ isSelected &&
+							( areStylesEqual ? (
+								<p className="edit-site-global-styles-screen-revisions__applied-text">
+									{ __(
+										'These styles are already applied to your site.'
+									) }
+								</p>
+							) : (
+								<Button
+									disabled={ areStylesEqual }
+									variant="primary"
+									className="edit-site-global-styles-screen-revisions__apply-button"
+									onClick={ onApplyRevision }
+								>
+									{ isReset
+										? __( 'Reset to defaults' )
+										: __( 'Apply' ) }
+								</Button>
+							) ) }
 					</li>
 				);
 			} ) }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -95,15 +95,10 @@
 	}
 }
 
-.edit-site-global-styles-screen-revisions__apply-button.is-secondary {
-	justify-content: center;
-	height: $button-size-small;
-	background: $white;
-	margin: 0 $grid-unit-15 $grid-unit-15 $grid-unit-30;
-	padding: $grid-unit-15 $grid-unit-20;
-	&:hover:not(:disabled) {
-		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-	}
+.edit-site-global-styles-screen-revisions__apply-button.is-primary {
+	align-self: flex-start;
+	// Left margin = left padding of .edit-site-global-styles-screen-revisions__revision-button.
+	margin: 0 $grid-unit-15 $grid-unit-15 $grid-unit-50;
 }
 
 .edit-site-global-styles-screen-revisions__description {
@@ -146,15 +141,6 @@
 	line-height: $default-line-height;
 }
 
-.edit-site-global-styles-screen-revisions__footer {
-	padding: $grid-unit-20 $grid-unit-20 $grid-unit-15 $grid-unit-20;
-	position: sticky;
-	bottom: 0;
-	background: $white;
-	z-index: 10;
-	border-top: 1px solid $gray-400;
-}
-
 .edit-site-global-styles-screen-revisions__pagination.edit-site-global-styles-screen-revisions__pagination {
 	justify-content: space-between;
 	gap: 2px;
@@ -172,6 +158,15 @@
 	.components-button.is-tertiary {
 		width: $button-size-small;
 		height: $button-size-small;
-		outline: 1px solid;
+		font-size: 28px;
+		font-weight: 200;
+		color: $gray-900;
+		margin-bottom: $grid-unit-05;
+	}
+	.components-button.is-tertiary:disabled {
+		color: $gray-600;
+	}
+	.components-button.is-tertiary:hover {
+		background: transparent;
 	}
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -1,6 +1,7 @@
 
 .edit-site-global-styles-screen-revisions {
 	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-20;
+	padding-bottom: $grid-unit-60;
 }
 
 .edit-site-global-styles-screen-revisions__revisions-list {
@@ -181,3 +182,6 @@
 	}
 }
 
+.edit-site-global-styles-screen-revisions__footer {
+	height: $grid-unit-60;
+}

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -161,6 +161,9 @@
 
 	.components-text {
 		font-size: 12px;
+		// `will-change` is required because something about flex props prevents
+		// Safari from rendering the page / total text.
+		will-change: opacity;
 	}
 	.components-button.is-tertiary {
 		width: $button-size-small;
@@ -177,3 +180,4 @@
 		background: transparent;
 	}
 }
+

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -11,10 +11,6 @@
 	}
 }
 
-.edit-site-global-styles-header__description {
-	margin-bottom: 0;
-}
-
 .edit-site-global-styles-screen-revisions__revision-item {
 	position: relative;
 	cursor: pointer;
@@ -99,9 +95,8 @@
 
 .edit-site-global-styles-screen-revisions__button {
 	justify-content: center;
-	width: 80%;
-	margin-left: 10%;
-	margin-bottom: $grid-unit-10;
+	width: 100%;
+	margin-bottom: $grid-unit-20;
 }
 
 .edit-site-global-styles-screen-revisions__description {
@@ -143,19 +138,24 @@
 	line-height: $default-line-height;
 }
 
+.edit-site-global-styles-screen-revisions__footer {
+	padding: $grid-unit-20 $grid-unit-20 $grid-unit-15 $grid-unit-20;
+	position: sticky;
+	bottom: 0;
+	background: $white;
+	z-index: 10;
+	border-top: 1px solid $gray-400;
+}
+
 .edit-site-global-styles-screen-revisions__pagination.edit-site-global-styles-screen-revisions__pagination {
 	justify-content: space-between;
 	gap: 2px;
-	padding: $grid-unit-20 $grid-unit-20 $grid-unit-15 $grid-unit-20;
-	position: sticky;
-	top: 0;
-	background: $white;
-	z-index: 10;
-	border-bottom: 1px solid $gray-400;
-
 	.edit-site-pagination__total {
-		font-weight: 600;
-		font-color: $gray-900;
+		position: absolute;
+		left: -1000px;
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
 	}
 
 	.components-text {
@@ -176,6 +176,3 @@
 		}
 	}
 }
-
-
-

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -95,7 +95,9 @@
 
 .edit-site-global-styles-screen-revisions__button {
 	justify-content: center;
-	width: 100%;
+	width: 80%;
+	margin-left: 10%;
+	margin-bottom: $grid-unit-10;
 }
 
 .edit-site-global-styles-screen-revisions__description {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -14,6 +14,8 @@
 .edit-site-global-styles-screen-revisions__revision-item {
 	position: relative;
 	cursor: pointer;
+	display: flex;
+	flex-direction: column;
 
 	&:hover {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -93,10 +93,15 @@
 	}
 }
 
-.edit-site-global-styles-screen-revisions__button {
+.edit-site-global-styles-screen-revisions__apply-button.is-secondary {
 	justify-content: center;
-	width: 100%;
-	margin-bottom: $grid-unit-20;
+	height: $button-size-small;
+	background: $white;
+	margin: 0 $grid-unit-15 $grid-unit-15 $grid-unit-30;
+	padding: $grid-unit-15 $grid-unit-20;
+	&:hover:not(:disabled) {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+	}
 }
 
 .edit-site-global-styles-screen-revisions__description {
@@ -117,8 +122,9 @@
 	display: flex;
 	justify-content: start;
 	width: 100%;
-	align-items: center;
+	align-items: flex-start;
 	font-size: 12px;
+	text-align: left;
 	img {
 		width: $grid-unit-20;
 		height: $grid-unit-20;
@@ -165,14 +171,5 @@
 		width: $button-size-small;
 		height: $button-size-small;
 		outline: 1px solid;
-
-		&:disabled {
-			color: $gray-600;
-			background: none;
-		}
-
-		&:hover:not(:disabled) {
-			background-color: $gray-700;
-		}
 	}
 }

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -1,6 +1,6 @@
 
 .edit-site-global-styles-screen-revisions {
-	margin: $grid-unit-20;
+	margin: 0 $grid-unit-20 $grid-unit-20 $grid-unit-20;
 }
 
 .edit-site-global-styles-screen-revisions__revisions-list {
@@ -9,6 +9,10 @@
 	li {
 		margin-bottom: 0;
 	}
+}
+
+.edit-site-global-styles-header__description {
+	margin-bottom: 0;
 }
 
 .edit-site-global-styles-screen-revisions__revision-item {
@@ -138,4 +142,40 @@
 	color: $gray-900;
 	line-height: $default-line-height;
 }
+
+.edit-site-global-styles-screen-revisions__pagination.edit-site-global-styles-screen-revisions__pagination {
+	justify-content: space-between;
+	gap: 2px;
+	padding: $grid-unit-20 $grid-unit-20 $grid-unit-15 $grid-unit-20;
+	position: sticky;
+	top: 0;
+	background: $white;
+	z-index: 10;
+	border-bottom: 1px solid $gray-400;
+
+	.edit-site-pagination__total {
+		font-weight: 600;
+		font-color: $gray-900;
+	}
+
+	.components-text {
+		font-size: 12px;
+	}
+	.components-button.is-tertiary {
+		width: $button-size-small;
+		height: $button-size-small;
+		outline: 1px solid;
+
+		&:disabled {
+			color: $gray-600;
+			background: none;
+		}
+
+		&:hover:not(:disabled) {
+			background-color: $gray-700;
+		}
+	}
+}
+
+
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -95,10 +95,17 @@
 	}
 }
 
-.edit-site-global-styles-screen-revisions__apply-button.is-primary {
+.edit-site-global-styles-screen-revisions__apply-button.is-primary,
+.edit-site-global-styles-screen-revisions__applied-text {
 	align-self: flex-start;
 	// Left margin = left padding of .edit-site-global-styles-screen-revisions__revision-button.
 	margin: 0 $grid-unit-15 $grid-unit-15 $grid-unit-50;
+}
+
+.edit-site-global-styles-screen-revisions__applied-text {
+	color: $gray-600;
+	font-size: 12px;
+	font-style: italic;
 }
 
 .edit-site-global-styles-screen-revisions__description {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/test/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/test/use-global-styles-revisions.js
@@ -50,6 +50,7 @@ describe( 'useGlobalStylesRevisions', () => {
 			},
 		],
 		isLoadingGlobalStylesRevisions: false,
+		revisionsCount: 1,
 	};
 
 	it( 'returns loaded revisions with no unsaved changes', () => {
@@ -157,5 +158,71 @@ describe( 'useGlobalStylesRevisions', () => {
 		expect( isLoading ).toBe( true );
 		expect( hasUnsavedChanges ).toBe( false );
 		expect( revisions ).toEqual( [] );
+	} );
+
+	it( 'should prepend unsaved changes item and append reset item to paginated results', () => {
+		useSelect.mockImplementation( () => ( {
+			...selectValue,
+			revisionsCount: 2,
+			isDirty: true,
+		} ) );
+
+		// Prepend unsaved changes item to paginated results.
+		const { result: resultPrepend } = renderHook( () =>
+			useGlobalStylesRevisions( {
+				query: {
+					per_page: 1,
+					page: 1,
+				},
+			} )
+		);
+		expect( resultPrepend.current.revisions ).toEqual( [
+			{
+				author: {
+					avatar_urls: {},
+					name: 'fred',
+				},
+				id: 'unsaved',
+				modified: resultPrepend.current.revisions[ 0 ].modified,
+				settings: 'cake',
+				styles: 'ice-cream',
+			},
+			{
+				author: {
+					id: 4,
+					name: 'sam',
+				},
+				id: 1,
+				isLatest: true,
+				settings: {},
+				styles: {},
+			},
+		] );
+
+		// Append reset item to paginated results.
+		const { result: resultAppend } = renderHook( () =>
+			useGlobalStylesRevisions( {
+				query: {
+					per_page: 1,
+					page: 2,
+				},
+			} )
+		);
+		expect( resultAppend.current.revisions ).toEqual( [
+			{
+				author: {
+					id: 4,
+					name: 'sam',
+				},
+				id: 1,
+				settings: {},
+				styles: {},
+			},
+			{
+				id: 'parent',
+				settings: {},
+				styles: {},
+			},
+		] );
 	} );
 } );

--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -19,7 +19,9 @@ const SITE_EDITOR_AUTHORS_QUERY = {
 };
 const EMPTY_ARRAY = [];
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
-export default function useGlobalStylesRevisions() {
+export default function useGlobalStylesRevisions( {
+	query = { per_page: 100, page: 1 },
+} ) {
 	const { user: userConfig } = useContext( GlobalStylesContext );
 	const {
 		authors,
@@ -27,47 +29,64 @@ export default function useGlobalStylesRevisions() {
 		isDirty,
 		revisions,
 		isLoadingGlobalStylesRevisions,
-	} = useSelect( ( select ) => {
-		const {
-			__experimentalGetDirtyEntityRecords,
-			getCurrentUser,
-			getUsers,
-			getRevisions,
-			__experimentalGetCurrentGlobalStylesId,
-			isResolving,
-		} = select( coreStore );
-		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-		const _currentUser = getCurrentUser();
-		const _isDirty = dirtyEntityRecords.length > 0;
-		const query = {
-			per_page: 100,
-		};
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStylesRevisions =
-			getRevisions( 'root', 'globalStyles', globalStylesId, query ) ||
-			EMPTY_ARRAY;
-		const _authors = getUsers( SITE_EDITOR_AUTHORS_QUERY ) || EMPTY_ARRAY;
-		const _isResolving = isResolving( 'getRevisions', [
-			'root',
-			'globalStyles',
-			globalStylesId,
-			query,
-		] );
-		return {
-			authors: _authors,
-			currentUser: _currentUser,
-			isDirty: _isDirty,
-			revisions: globalStylesRevisions,
-			isLoadingGlobalStylesRevisions: _isResolving,
-		};
-	}, [] );
+		revisionsCount,
+	} = useSelect(
+		( select ) => {
+			const {
+				__experimentalGetDirtyEntityRecords,
+				getCurrentUser,
+				getUsers,
+				getRevisions,
+				__experimentalGetCurrentGlobalStylesId,
+				getEntityRecord,
+				isResolving,
+			} = select( coreStore );
+			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+			const _currentUser = getCurrentUser();
+			const _isDirty = dirtyEntityRecords.length > 0;
+			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+			const globalStyles = globalStylesId
+				? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+				: undefined;
+			let _revisionsCount =
+				globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
+			// one for the reset item.
+			_revisionsCount++;
+			// one for any dirty changes (unsaved).
+			if ( _isDirty ) {
+				_revisionsCount++;
+			}
+			const globalStylesRevisions =
+				getRevisions( 'root', 'globalStyles', globalStylesId, query ) ||
+				EMPTY_ARRAY;
+			const _authors =
+				getUsers( SITE_EDITOR_AUTHORS_QUERY ) || EMPTY_ARRAY;
+			const _isResolving = isResolving( 'getRevisions', [
+				'root',
+				'globalStyles',
+				globalStylesId,
+				query,
+			] );
+			return {
+				authors: _authors,
+				currentUser: _currentUser,
+				isDirty: _isDirty,
+				revisions: globalStylesRevisions,
+				isLoadingGlobalStylesRevisions: _isResolving,
+				revisionsCount: _revisionsCount,
+			};
+		},
+		[ query ]
+	);
 	return useMemo( () => {
 		let _modifiedRevisions = [];
+		// Add 1 for the "reset to theme defaults" revision we tack onto the last page.
 		if ( ! authors.length || isLoadingGlobalStylesRevisions ) {
 			return {
 				revisions: _modifiedRevisions,
 				hasUnsavedChanges: isDirty,
 				isLoading: true,
+				revisionsCount: 0,
 			};
 		}
 
@@ -81,9 +100,14 @@ export default function useGlobalStylesRevisions() {
 			};
 		} );
 
-		if ( _modifiedRevisions.length ) {
+		const fetchedRevisionsCount = revisions.length;
+
+		if ( fetchedRevisionsCount ) {
 			// Flags the most current saved revision.
-			if ( _modifiedRevisions[ 0 ].id !== 'unsaved' ) {
+			if (
+				_modifiedRevisions[ 0 ].id !== 'unsaved' &&
+				query.page === 1
+			) {
 				_modifiedRevisions[ 0 ].isLatest = true;
 			}
 
@@ -92,7 +116,8 @@ export default function useGlobalStylesRevisions() {
 				isDirty &&
 				userConfig &&
 				Object.keys( userConfig ).length > 0 &&
-				currentUser
+				currentUser &&
+				query.page === 1
 			) {
 				const unsavedRevision = {
 					id: 'unsaved',
@@ -108,17 +133,21 @@ export default function useGlobalStylesRevisions() {
 				_modifiedRevisions.unshift( unsavedRevision );
 			}
 
-			_modifiedRevisions.push( {
-				id: 'parent',
-				styles: {},
-				settings: {},
-			} );
+			if ( query.page === Math.ceil( revisionsCount / query.per_page ) ) {
+				// Adds an item for the default theme styles.
+				_modifiedRevisions.push( {
+					id: 'parent',
+					styles: {},
+					settings: {},
+				} );
+			}
 		}
 
 		return {
 			revisions: _modifiedRevisions,
 			hasUnsavedChanges: isDirty,
 			isLoading: false,
+			revisionsCount,
 		};
 	}, [
 		isDirty,

--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -79,11 +79,12 @@ export default function useGlobalStylesRevisions( {
 		[ query ]
 	);
 	return useMemo( () => {
-		let _modifiedRevisions = [];
-		// Add 1 for the "reset to theme defaults" revision we tack onto the last page.
-		if ( ! authors.length || isLoadingGlobalStylesRevisions ) {
+		if (
+			! authors.length ||
+			( isLoadingGlobalStylesRevisions && ! revisions?.length )
+		) {
 			return {
-				revisions: _modifiedRevisions,
+				revisions: EMPTY_ARRAY,
 				hasUnsavedChanges: isDirty,
 				isLoading: true,
 				revisionsCount: 0,
@@ -91,7 +92,7 @@ export default function useGlobalStylesRevisions( {
 		}
 
 		// Adds author details to each revision.
-		_modifiedRevisions = revisions.map( ( revision ) => {
+		const _modifiedRevisions = revisions.map( ( revision ) => {
 			return {
 				...revision,
 				author: authors.find(

--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -87,7 +87,7 @@ export default function useGlobalStylesRevisions( {
 				revisions: EMPTY_ARRAY,
 				hasUnsavedChanges: isDirty,
 				isLoading: true,
-				revisionsCount: 0,
+				revisionsCount,
 			};
 		}
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/use-global-styles-revisions.js
@@ -48,14 +48,19 @@ export default function useGlobalStylesRevisions( {
 			const globalStyles = globalStylesId
 				? getEntityRecord( 'root', 'globalStyles', globalStylesId )
 				: undefined;
-			let _revisionsCount =
+			const _revisionsCount =
 				globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
-			// one for the reset item.
-			_revisionsCount++;
-			// one for any dirty changes (unsaved).
-			if ( _isDirty ) {
-				_revisionsCount++;
-			}
+			// Commenting out for now as we need to ensure
+			// that the right revisionsCount is use to calculate numPages.
+			// E.g., there might be a single, trailing 'reset' item, tricking the
+			// pagination into thinking there's an extra page,
+			// but there are no more revisions in the database.
+			// // one for the reset item.
+			// _revisionsCount++;
+			// // one for any dirty changes (unsaved).
+			// if ( _isDirty ) {
+			// 	_revisionsCount++;
+			// }
 			const globalStylesRevisions =
 				getRevisions( 'root', 'globalStyles', globalStylesId, query ) ||
 				EMPTY_ARRAY;

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -217,6 +217,7 @@ export default function PatternsList( { categoryId, type } ) {
 			</VStack>
 			{ numPages > 1 && (
 				<Pagination
+					className="edit-site-patterns__pagination"
 					currentPage={ currentPage }
 					numPages={ numPages }
 					changePage={ changePage }

--- a/packages/edit-site/src/components/page-patterns/patterns-list.js
+++ b/packages/edit-site/src/components/page-patterns/patterns-list.js
@@ -31,7 +31,7 @@ import usePatterns from './use-patterns';
 import SidebarButton from '../sidebar-button';
 import { unlock } from '../../lock-unlock';
 import { PATTERN_SYNC_TYPES, PATTERN_TYPES } from '../../utils/constants';
-import Pagination from './pagination';
+import Pagination from '../pagination';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -67,32 +67,6 @@
 		background: $gray-700;
 		color: $gray-100;
 	}
-
-	.edit-site-patterns__grid-pagination {
-		border-top: 1px solid $gray-800;
-		background: $gray-900;
-		padding: $grid-unit-30 $grid-unit-40;
-		position: sticky;
-		bottom: 0;
-		z-index: z-index(".edit-site-patterns__grid-pagination");
-
-		.components-button.is-tertiary {
-			width: $button-size-compact;
-			height: $button-size-compact;
-			color: $gray-100;
-			background-color: $gray-800;
-			justify-content: center;
-
-			&:disabled {
-				color: $gray-600;
-				background: none;
-			}
-
-			&:hover:not(:disabled) {
-				background-color: $gray-700;
-			}
-		}
-	}
 }
 
 .edit-site-patterns__header {

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -200,3 +200,16 @@
 .edit-site-patterns__delete-modal {
 	width: $modal-width-small;
 }
+
+.edit-site-patterns__pagination {
+	padding: $grid-unit-30 $grid-unit-40;
+	border-top: 1px solid $gray-800;
+	background: $gray-900;
+	position: sticky;
+	bottom: 0;
+	color: $gray-100;
+	z-index: z-index(".edit-site-patterns__grid-pagination");
+	.components-button.is-tertiary {
+		background-color: $gray-800;
+	}
+}

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -211,5 +211,15 @@
 	z-index: z-index(".edit-site-patterns__grid-pagination");
 	.components-button.is-tertiary {
 		background-color: $gray-800;
+		color: $gray-100;
+
+		&:disabled {
+			color: $gray-600;
+			background: none;
+		}
+
+		&:hover:not(:disabled) {
+			background-color: $gray-700;
+		}
 	}
 }

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -13,13 +18,14 @@ export default function Pagination( {
 	numPages,
 	changePage,
 	totalItems,
+	className,
 } ) {
 	return (
 		<HStack
 			expanded={ false }
 			spacing={ 3 }
 			justify="flex-start"
-			className="edit-site-patterns__grid-pagination"
+			className={ classnames( 'edit-site--pagination', className ) }
 		>
 			<Text variant="muted">
 				{

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -19,15 +19,16 @@ export default function Pagination( {
 	changePage,
 	totalItems,
 	className,
+	disabled = false,
 } ) {
 	return (
 		<HStack
 			expanded={ false }
 			spacing={ 3 }
 			justify="flex-start"
-			className={ classnames( 'edit-site--pagination', className ) }
+			className={ classnames( 'edit-site-pagination', className ) }
 		>
-			<Text variant="muted">
+			<Text variant="muted" className="edit-site-pagination__total">
 				{
 					// translators: %s: Total number of patterns.
 					sprintf(
@@ -41,7 +42,7 @@ export default function Pagination( {
 				<Button
 					variant="tertiary"
 					onClick={ () => changePage( 1 ) }
-					disabled={ currentPage === 1 }
+					disabled={ disabled || currentPage === 1 }
 					aria-label={ __( 'First page' ) }
 				>
 					«
@@ -49,7 +50,7 @@ export default function Pagination( {
 				<Button
 					variant="tertiary"
 					onClick={ () => changePage( currentPage - 1 ) }
-					disabled={ currentPage === 1 }
+					disabled={ disabled || currentPage === 1 }
 					aria-label={ __( 'Previous page' ) }
 				>
 					‹
@@ -67,7 +68,7 @@ export default function Pagination( {
 				<Button
 					variant="tertiary"
 					onClick={ () => changePage( currentPage + 1 ) }
-					disabled={ currentPage === numPages }
+					disabled={ disabled || currentPage === numPages }
 					aria-label={ __( 'Next page' ) }
 				>
 					›
@@ -75,7 +76,7 @@ export default function Pagination( {
 				<Button
 					variant="tertiary"
 					onClick={ () => changePage( numPages ) }
-					disabled={ currentPage === numPages }
+					disabled={ disabled || currentPage === numPages }
 					aria-label={ __( 'Last page' ) }
 				>
 					»

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -20,6 +20,7 @@ export default function Pagination( {
 	totalItems,
 	className,
 	disabled = false,
+	buttonVariant = 'tertiary',
 } ) {
 	return (
 		<HStack
@@ -40,7 +41,7 @@ export default function Pagination( {
 			</Text>
 			<HStack expanded={ false } spacing={ 1 }>
 				<Button
-					variant="tertiary"
+					variant={ buttonVariant }
 					onClick={ () => changePage( 1 ) }
 					disabled={ disabled || currentPage === 1 }
 					aria-label={ __( 'First page' ) }
@@ -48,7 +49,7 @@ export default function Pagination( {
 					«
 				</Button>
 				<Button
-					variant="tertiary"
+					variant={ buttonVariant }
 					onClick={ () => changePage( currentPage - 1 ) }
 					disabled={ disabled || currentPage === 1 }
 					aria-label={ __( 'Previous page' ) }
@@ -66,7 +67,7 @@ export default function Pagination( {
 			</Text>
 			<HStack expanded={ false } spacing={ 1 }>
 				<Button
-					variant="tertiary"
+					variant={ buttonVariant }
 					onClick={ () => changePage( currentPage + 1 ) }
 					disabled={ disabled || currentPage === numPages }
 					aria-label={ __( 'Next page' ) }
@@ -74,7 +75,7 @@ export default function Pagination( {
 					›
 				</Button>
 				<Button
-					variant="tertiary"
+					variant={ buttonVariant }
 					onClick={ () => changePage( numPages ) }
 					disabled={ disabled || currentPage === numPages }
 					aria-label={ __( 'Last page' ) }

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -25,6 +25,8 @@ export default function Pagination( {
 	return (
 		<HStack
 			expanded={ false }
+			as="nav"
+			aria-label="Pagination Navigation"
 			spacing={ 3 }
 			justify="flex-start"
 			className={ classnames( 'edit-site-pagination', className ) }

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -21,12 +21,13 @@ export default function Pagination( {
 	className,
 	disabled = false,
 	buttonVariant = 'tertiary',
+	label = __( 'Pagination Navigation' ),
 } ) {
 	return (
 		<HStack
 			expanded={ false }
 			as="nav"
-			aria-label="Pagination Navigation"
+			aria-label={ label }
 			spacing={ 3 }
 			justify="flex-start"
 			className={ classnames( 'edit-site-pagination', className ) }

--- a/packages/edit-site/src/components/pagination/style.scss
+++ b/packages/edit-site/src/components/pagination/style.scss
@@ -1,16 +1,7 @@
 .edit-site--pagination {
-  border-top: 1px solid $gray-800;
-  background: $gray-900;
-  padding: $grid-unit-30 $grid-unit-40;
-  position: sticky;
-  bottom: 0;
-  z-index: z-index(".edit-site-patterns__grid-pagination");
-
   .components-button.is-tertiary {
 	width: $button-size-compact;
 	height: $button-size-compact;
-	color: $gray-100;
-	background-color: $gray-800;
 	justify-content: center;
 
 	&:disabled {

--- a/packages/edit-site/src/components/pagination/style.scss
+++ b/packages/edit-site/src/components/pagination/style.scss
@@ -1,0 +1,25 @@
+.edit-site--pagination {
+  border-top: 1px solid $gray-800;
+  background: $gray-900;
+  padding: $grid-unit-30 $grid-unit-40;
+  position: sticky;
+  bottom: 0;
+  z-index: z-index(".edit-site-patterns__grid-pagination");
+
+  .components-button.is-tertiary {
+	width: $button-size-compact;
+	height: $button-size-compact;
+	color: $gray-100;
+	background-color: $gray-800;
+	justify-content: center;
+
+	&:disabled {
+	  color: $gray-600;
+	  background: none;
+	}
+
+	&:hover:not(:disabled) {
+	  background-color: $gray-700;
+	}
+  }
+}

--- a/packages/edit-site/src/components/pagination/style.scss
+++ b/packages/edit-site/src/components/pagination/style.scss
@@ -1,16 +1,16 @@
-.edit-site--pagination {
-  .components-button.is-tertiary {
-	width: $button-size-compact;
-	height: $button-size-compact;
-	justify-content: center;
+.edit-site-pagination {
+	.components-button.is-tertiary {
+		width: $button-size-compact;
+		height: $button-size-compact;
+		justify-content: center;
 
-	&:disabled {
-	  color: $gray-600;
-	  background: none;
-	}
+		&:disabled {
+			color: $gray-600;
+			background: none;
+		}
 
-	&:hover:not(:disabled) {
-	  background-color: $gray-700;
+		&:hover:not(:disabled) {
+			background-color: $gray-700;
+		}
 	}
-  }
 }

--- a/packages/edit-site/src/components/pagination/style.scss
+++ b/packages/edit-site/src/components/pagination/style.scss
@@ -1,16 +1,5 @@
-.edit-site-pagination {
-	.components-button.is-tertiary {
-		width: $button-size-compact;
-		height: $button-size-compact;
-		justify-content: center;
-
-		&:disabled {
-			color: $gray-600;
-			background: none;
-		}
-
-		&:hover:not(:disabled) {
-			background-color: $gray-700;
-		}
-	}
+.edit-site-pagination .components-button.is-tertiary {
+	width: $button-size-compact;
+	height: $button-size-compact;
+	justify-content: center;
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/sidebar-fixed-bottom.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/sidebar-fixed-bottom.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
@@ -13,10 +18,15 @@ const SIDEBAR_FIXED_BOTTOM_SLOT_FILL_NAME = 'SidebarFixedBottom';
 const { Slot: SidebarFixedBottomSlot, Fill: SidebarFixedBottomFill } =
 	createPrivateSlotFill( SIDEBAR_FIXED_BOTTOM_SLOT_FILL_NAME );
 
-export default function SidebarFixedBottom( { children } ) {
+export default function SidebarFixedBottom( { className, children } ) {
 	return (
 		<SidebarFixedBottomFill>
-			<div className="edit-site-sidebar-fixed-bottom-slot">
+			<div
+				className={ classnames(
+					'edit-site-sidebar-fixed-bottom-slot',
+					className
+				) }
+			>
 				{ children }
 			</div>
 		</SidebarFixedBottomFill>

--- a/packages/edit-site/src/components/sidebar-edit-mode/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/style.scss
@@ -104,8 +104,7 @@
 	position: sticky;
 	bottom: 0;
 	background: $white;
-	display: flex;
-	padding: $grid-unit-20;
+	padding: $grid-unit-15;
 	border-top: $border-width solid $gray-300;
 	box-sizing: content-box;
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/style.scss
@@ -101,7 +101,8 @@
 }
 
 .edit-site-sidebar-fixed-bottom-slot {
-	position: sticky;
+	position: absolute;
+	min-width: 100%;
 	bottom: 0;
 	background: $white;
 	padding: $grid-unit-15;

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -48,6 +48,7 @@
 @import "./components/resizable-frame/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";
 @import "./components/global-styles/font-library-modal/style.scss";
+@import "./components/pagination/style.scss";
 
 body.js #wpadminbar {
 	display: none;

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -4,18 +4,25 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.use( {
-	userGlobalStylesRevisions: async ( { page, requestUtils }, use ) => {
-		await use( new UserGlobalStylesRevisions( { page, requestUtils } ) );
+	userGlobalStylesRevisions: async (
+		{ editor, page, requestUtils },
+		use
+	) => {
+		await use(
+			new UserGlobalStylesRevisions( { editor, page, requestUtils } )
+		);
 	},
 } );
 
 test.describe( 'Global styles revisions', () => {
+	let stylesPostId;
 	test.beforeAll( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.activateTheme( 'emptytheme' ),
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 			requestUtils.deleteAllTemplates( 'wp_template_part' ),
 		] );
+		stylesPostId = await requestUtils.getCurrentThemeGlobalStylesPostId();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
@@ -34,19 +41,11 @@ test.describe( 'Global styles revisions', () => {
 		await editor.canvas.locator( 'body' ).click();
 		const currentRevisions =
 			await userGlobalStylesRevisions.getGlobalStylesRevisions();
+		// Create a revision: change a style and save it.
+		await userGlobalStylesRevisions.saveRevision( stylesPostId, {
+			color: { background: 'blue' },
+		} );
 		await userGlobalStylesRevisions.openStylesPanel();
-
-		// Change a style and save it.
-		await page.getByRole( 'button', { name: 'Colors styles' } ).click();
-
-		await page
-			.getByRole( 'button', { name: 'Color Background styles' } )
-			.click();
-		await page
-			.getByRole( 'option', { name: 'Color: Cyan bluish gray' } )
-			.click( { force: true } );
-
-		await editor.saveSiteEditorEntities();
 
 		// Now there should be enough revisions to show the revisions UI.
 		await page.getByRole( 'button', { name: 'Revisions' } ).click();
@@ -189,11 +188,34 @@ test.describe( 'Global styles revisions', () => {
 			page.getByLabel( 'Global styles revisions list' )
 		).toBeHidden();
 	} );
+
+	test( 'should paginate', async ( {
+		page,
+		editor,
+		userGlobalStylesRevisions,
+	} ) => {
+		await editor.canvas.locator( 'body' ).click();
+		// Create > 10 revisions to display pagination navigation component.
+		for ( let i = 9; i < 21; i++ ) {
+			await userGlobalStylesRevisions.saveRevision( stylesPostId, {
+				typography: { fontSize: `${ i }px` },
+			} );
+		}
+		await userGlobalStylesRevisions.openStylesPanel();
+		await page.getByRole( 'button', { name: 'Revisions' } ).click();
+		const pagination = page.getByLabel(
+			'Global Styles pagination navigation'
+		);
+		await expect( pagination ).toContainText( '1 of 2' );
+		await pagination.getByRole( 'button', { name: 'Next page' } ).click();
+		await expect( pagination ).toContainText( '2 of 2' );
+	} );
 } );
 
 class UserGlobalStylesRevisions {
-	constructor( { page, requestUtils } ) {
+	constructor( { editor, page, requestUtils } ) {
 		this.page = page;
+		this.editor = editor;
 		this.requestUtils = requestUtils;
 	}
 
@@ -213,5 +235,21 @@ class UserGlobalStylesRevisions {
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Styles' } )
 			.click();
+	}
+
+	async saveRevision( stylesPostId, styles = {}, settings = {} ) {
+		await this.page.evaluate(
+			async ( [ _stylesPostId, _styles, _settings ] ) => {
+				window.wp.data
+					.dispatch( 'core' )
+					.editEntityRecord( 'root', 'globalStyles', _stylesPostId, {
+						id: _stylesPostId,
+						settings: _settings,
+						styles: _styles,
+					} );
+			},
+			[ stylesPostId, styles, settings ]
+		);
+		await this.editor.saveSiteEditorEntities();
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/53621

Part of:

- https://github.com/WordPress/gutenberg/issues/55776

## What?

Now that we have a [revisions API in Core Data](https://github.com/WordPress/gutenberg/pull/54046), let's add paginated results to global styles revisions!

Uploading 2023-12-19 15.40.44.mp4…

## Why?

Good question. Because currently, there is a hard limit of 100 results for global styles revisions coming straight from the  REST response.

Paginated results not only reduces the amount of space revisions take up in the sidebar, but allows users to access any number of revisions.

## How?
- Passing query parameters with `per_page` and `page` values to `useGlobalStylesRevisions()` to get paginated results.
- Adding a pagination component at the footer of the revisions panel.

## Testing Instructions

Requires a block theme like 2024.

In the Site Editor:

1. Check that the pagination navigation does not appear with < 10 revisions. A "revision" is classed as a saved revision record in the database (not any unsaved changes or "Reset" items in the revisions list).
2. Add 10+ revisions. Witness how the pagination now appears, and sits, at the bottom of the revision panel. Navigate through the results!
3. Select some revisions to preview them. Test that the "Apply" button works to apply revisions to the editor and close the revisions panel. (There shouldn't be any regression in the way folks can preview and apply revisions).
4. Make sure a "Reset" item is appended to the last page of the revisions results and not on any other page.
5. Make some changes to styles in the editor, but don't save. Now make sure an "Unsaved" item is prepended to the first page of the revisions results and not on any other page.

Because I've abstracted the pagination component from the Patterns page, check that there are no regressions between trunk and this PR:

| This PR  | Trunk |
| ------------- | ------------- |
| <img width="311" alt="Screenshot 2023-12-19 at 2 20 19 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/9761d7a6-eba9-4678-9f1e-056b8dc495b9">  | <img width="315" alt="Screenshot 2023-12-19 at 2 20 52 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/3c7373d9-c39c-4f7f-8739-cc94d90265f4">  |



### Testing Instructions for Keyboard
It should be possible to tab down the revision items and access the pagination navigation buttons.

<img width="283" alt="Screenshot 2023-12-19 at 2 18 49 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/57fe9807-8aab-4062-bf26-9d816c3e9e63">


## TODO
- [x] Style pagination component
- [x] Position pagination component, maybe in the sticky footer? Would require moving "Apply" button, perhaps inside every individual button?
- [x] Prevent full render when fetching uncached results (i.e., not already in store) - just need to remove condition renders on `shouldShowRevisions`
- [x] Update tests
