### PR TITLE
`DimensionControl`: Add __next40pxDefaultSize prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `CheckboxControl`: Add option to not render label ([#56158](https://github.com/WordPress/gutenberg/pull/56158)).
 -   `PaletteEdit`: Gradient pickers to use same width as color pickers ([#56801](https://github.com/WordPress/gutenberg/pull/56801)).
 -   `FocalPointPicker`: Add opt-in prop for 40px default size ([#56021](https://github.com/WordPress/gutenberg/pull/56021)).
+-   `DimensionControl`: Add opt-in prop for 40px default size ([#56805](https://github.com/WordPress/gutenberg/pull/56805)).
 
 ### Bug Fix
 

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -42,6 +42,7 @@ import type { SelectControlSingleSelectionProps } from '../select-control/types'
  */
 export function DimensionControl( props: DimensionControlProps ) {
 	const {
+		__next40pxDefaultSize = false,
 		label,
 		value,
 		sizes = sizesTable,
@@ -85,6 +86,7 @@ export function DimensionControl( props: DimensionControlProps ) {
 
 	return (
 		<SelectControl
+			__next40pxDefaultSize={ __next40pxDefaultSize }
 			className={ classnames(
 				className,
 				'block-editor-dimension-control'

--- a/packages/components/src/dimension-control/types.ts
+++ b/packages/components/src/dimension-control/types.ts
@@ -45,4 +45,10 @@ export type DimensionControlProps = {
 	 * @default ''
 	 */
 	className?: string;
+	/**
+	 * Start opting into the larger default height that will become the default size in a future version.
+	 *
+	 * @default false
+	 */
+	__next40pxDefaultSize?: boolean;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/46741

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a new opt-in prop `__next40pxDefaultSize` to DimensionControl, following the plan outlined in above mentioned PR. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For more consistency in styling. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A new, temporary `__next40pxDefaultSize` prop. When the prop is set to `true`, the inputs will have a height of 40px. 

## Testing Instructions

### In Storybook: 

1. `npm run storybook:dev`
2. Set `__next40pxDefaultSize` to `true` for DimensionControl
3. The input height of the component should now be 40px

### In the editor

Smoke test the component in the editor; DimensionControl shouldn't have any visible changes for now. 
