### PR TITLE
Zoomed Out Mode experiments

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -1,14 +1,9 @@
 name: Build Gutenberg Plugin Zip
 
 on:
-    pull_request:
+    pull_request_target:
+        types: [opened]
     push:
-        branches: [trunk]
-    workflow_dispatch:
-        inputs:
-            version:
-                description: 'rc or stable?'
-                required: true
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -7,7 +7,6 @@
 	// The preview component measures the pixel width of this item, so as to calculate the scale factor.
 	// But without this baseline width, it collapses to 0.
 	width: 100%;
-	height: 100%;
 
 	overflow: hidden;
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -96,6 +96,7 @@ export function BlockSettingsDropdown( {
 	const firstBlockClientId = blockClientIds[ 0 ];
 	const {
 		firstParentClientId,
+		isZoomOutMode,
 		onlyBlock,
 		parentBlockType,
 		previousBlockClientId,
@@ -109,6 +110,7 @@ export function BlockSettingsDropdown( {
 				getPreviousBlockClientId,
 				getSelectedBlockClientIds,
 				getBlockAttributes,
+				__unstableGetEditorMode,
 			} = select( blockEditorStore );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -120,6 +122,7 @@ export function BlockSettingsDropdown( {
 
 			return {
 				firstParentClientId: _firstParentClientId,
+				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
 				onlyBlock: 1 === getBlockCount( _firstParentClientId ),
 				parentBlockType:
 					_firstParentClientId &&
@@ -291,7 +294,8 @@ export function BlockSettingsDropdown( {
 									'core/block-editor/insert-after',
 									event
 								) &&
-								canInsertDefaultBlock
+								canInsertDefaultBlock &&
+								! isZoomOutMode
 							) {
 								event.preventDefault();
 								setOpenedBlockSettingsMenu( undefined );
@@ -301,7 +305,8 @@ export function BlockSettingsDropdown( {
 									'core/block-editor/insert-before',
 									event
 								) &&
-								canInsertDefaultBlock
+								canInsertDefaultBlock &&
+								! isZoomOutMode
 							) {
 								event.preventDefault();
 								setOpenedBlockSettingsMenu( undefined );
@@ -347,7 +352,7 @@ export function BlockSettingsDropdown( {
 										{ __( 'Duplicate' ) }
 									</MenuItem>
 								) }
-								{ canInsertDefaultBlock && (
+								{ canInsertDefaultBlock && ! isZoomOutMode && (
 									<>
 										<MenuItem
 											onClick={ pipe(
@@ -382,25 +387,31 @@ export function BlockSettingsDropdown( {
 									</MenuItem>
 								</MenuGroup>
 							) }
-							<BlockSettingsMenuControls.Slot
-								fillProps={ {
-									onClose,
-									canMove,
-									onMoveTo,
-									onlyBlock,
-									count,
-									firstBlockClientId,
-								} }
-								clientIds={ clientIds }
-								__unstableDisplayLocation={
-									__unstableDisplayLocation
-								}
-							/>
-							{ typeof children === 'function'
-								? children( { onClose } )
-								: Children.map( ( child ) =>
-										cloneElement( child, { onClose } )
-								  ) }
+							{ ! isZoomOutMode && (
+								<>
+									<BlockSettingsMenuControls.Slot
+										fillProps={ {
+											onClose,
+											canMove,
+											onMoveTo,
+											onlyBlock,
+											count,
+											firstBlockClientId,
+										} }
+										clientIds={ clientIds }
+										__unstableDisplayLocation={
+											__unstableDisplayLocation
+										}
+									/>
+									{ typeof children === 'function'
+										? children( { onClose } )
+										: Children.map( ( child ) =>
+												cloneElement( child, {
+													onClose,
+												} )
+										  ) }
+								</>
+							) }
 							{ canRemove && (
 								<MenuGroup>
 									<MenuItem

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -38,6 +38,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 		canRemove,
 		hasBlockStyles,
 		icon,
+		isZoomOutMode,
 		patterns,
 	} = useSelect(
 		( select ) => {
@@ -48,6 +49,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 				canRemoveBlocks,
 			} = select( blockEditorStore );
 			const { getBlockStyles, getBlockType } = select( blocksStore );
+			const { __unstableGetEditorMode } = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId(
 				Array.isArray( clientIds ) ? clientIds[ 0 ] : clientIds
 			);
@@ -75,6 +77,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 				canRemove: canRemoveBlocks( clientIds, rootClientId ),
 				hasBlockStyles: !! styles?.length,
 				icon: _icon,
+				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
 				patterns: __experimentalGetPatternTransformItems(
 					blocks,
 					rootClientId
@@ -138,11 +141,12 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;
-	if (
+	const hasNoMenu =
 		! hasBlockStyles &&
 		! hasPossibleBlockTransformations &&
-		! hasPossibleBlockVariationTransformations
-	) {
+		! hasPossibleBlockVariationTransformations;
+
+	if ( hasNoMenu || isZoomOutMode ) {
 		return (
 			<ToolbarGroup>
 				<ToolbarButton

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -100,6 +100,8 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const isSingleBlock = blocks.length === 1;
 	const isReusable = isSingleBlock && isReusableBlock( blocks[ 0 ] );
 	const isTemplate = isSingleBlock && isTemplatePart( blocks[ 0 ] );
+	const hasCustomName =
+		isSingleBlock && !! blocks[ 0 ].attributes.metadata?.name;
 
 	function selectForMultipleBlocks( insertedBlocks ) {
 		if ( insertedBlocks.length > 1 ) {
@@ -156,7 +158,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					icon={
 						<>
 							<BlockIcon icon={ icon } showColors />
-							{ ( isReusable || isTemplate ) && (
+							{ ( isReusable || isTemplate || hasCustomName ) && (
 								<span className="block-editor-block-switcher__toggle-text">
 									{ blockTitle }
 								</span>
@@ -209,7 +211,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 									className="block-editor-block-switcher__toggle"
 									showColors
 								/>
-								{ ( isReusable || isTemplate ) && (
+								{ ( isReusable ||
+									isTemplate ||
+									hasCustomName ) && (
 									<span className="block-editor-block-switcher__toggle-text">
 										{ blockTitle }
 									</span>

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -72,12 +72,14 @@ export default function useBlockDisplayTitle( {
 		? getBlockLabel( blockType, attributes, context )
 		: null;
 
+	const blockCustomName = attributes.metadata?.name;
 	const label = reusableBlockTitle || blockLabel;
 	// Label will fallback to the title if no label is defined for the current
 	// label context. If the label is defined we prioritize it over a
 	// possible block variation title match.
 	const blockTitle =
-		label && label !== blockType.title ? label : blockInformation.title;
+		blockCustomName ||
+		( label && label !== blockType.title ? label : blockInformation.title );
 
 	if (
 		maximumLength &&

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -290,6 +290,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 						<BlockTitle
 							clientId={ clientId }
 							maximumLength={ 35 }
+							context="list-view"
 						/>
 					</Button>
 				</FlexItem>

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -211,11 +211,6 @@ export default function BlockTools( {
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
 				/>
-				{ isZoomOutMode && (
-					<ZoomOutModeInserters
-						__unstableContentRef={ __unstableContentRef }
-					/>
-				) }
 			</InsertionPointOpenRef.Provider>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -100,7 +100,7 @@ export default function SelectedBlockTools( {
 				resize={ false }
 				{ ...popoverProps }
 			>
-				{ shouldShowContextualToolbar && (
+				{ shouldShowContextualToolbar ? (
 					<BlockContextualToolbar
 						// If the toolbar is being shown because of being forced
 						// it should focus the toolbar right after the mount.
@@ -112,12 +112,13 @@ export default function SelectedBlockTools( {
 							initialToolbarItemIndexRef.current = index;
 						} }
 					/>
-				) }
-				{ shouldShowBreadcrumb && (
-					<BlockSelectionButton
-						clientId={ clientId }
-						rootClientId={ rootClientId }
-					/>
+				) : (
+					shouldShowBreadcrumb && (
+						<BlockSelectionButton
+							clientId={ clientId }
+							rootClientId={ rootClientId }
+						/>
+					)
 				) }
 			</BlockPopover>
 		);

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -46,7 +46,7 @@ const defaultRenderToggle = ( {
 			blockTitle
 		);
 	} else if ( ! label && prioritizePatterns ) {
-		label = __( 'Add pattern' );
+		label = __( 'Add section' );
 	} else if ( ! label ) {
 		label = _x( 'Add block', 'Generic label for block inserter button' );
 	}

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -21,6 +21,8 @@ function InserterLibrary(
 		showMostUsedBlocks = false,
 		__experimentalInsertionIndex,
 		__experimentalFilterValue,
+		__experimentalOnPatternCategorySelection,
+		__experimentalShouldZoomPatterns = false,
 		onSelect = noop,
 		shouldFocusBlock = false,
 	},
@@ -53,6 +55,12 @@ function InserterLibrary(
 			showMostUsedBlocks={ showMostUsedBlocks }
 			__experimentalInsertionIndex={ __experimentalInsertionIndex }
 			__experimentalFilterValue={ __experimentalFilterValue }
+			__experimentalOnPatternCategorySelection={
+				__experimentalOnPatternCategorySelection
+			}
+			__experimentalShouldZoomPatterns={
+				__experimentalShouldZoomPatterns
+			}
 			shouldFocusBlock={ shouldFocusBlock }
 			prioritizePatterns={ prioritizePatterns }
 			ref={ ref }

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -25,6 +25,7 @@ function InserterLibrary(
 		__experimentalShouldZoomPatterns = false,
 		onSelect = noop,
 		shouldFocusBlock = false,
+		onSelectTab,
 	},
 	ref
 ) {
@@ -48,6 +49,7 @@ function InserterLibrary(
 	return (
 		<InserterMenu
 			onSelect={ onSelect }
+			onSelectTab={ onSelectTab }
 			rootClientId={ destinationRootClientId }
 			clientId={ clientId }
 			isAppender={ isAppender }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useDebouncedInput } from '@wordpress/compose';
 
 /**
@@ -57,6 +57,8 @@ function InserterMenu(
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
 	const [ selectedTab, setSelectedTab ] = useState( null );
+	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {
@@ -228,6 +230,14 @@ function InserterMenu(
 		if ( value !== 'patterns' ) {
 			setSelectedPatternCategory( null );
 		}
+
+		// Enter the zoom-out mode when selecting the patterns tab and exit otherwise.
+		if ( value === 'patterns' ) {
+			__unstableSetEditorMode( 'zoom-out' );
+		} else if ( __unstableGetEditorMode() === 'zoom-out' ) {
+			__unstableSetEditorMode( 'edit' );
+		}
+
 		setSelectedTab( value );
 	};
 

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -45,6 +45,8 @@ function InserterMenu(
 		__experimentalFilterValue = '',
 		shouldFocusBlock = true,
 		prioritizePatterns,
+		__experimentalOnPatternCategorySelection,
+		__experimentalShouldZoomPatterns = false,
 	},
 	ref
 ) {
@@ -125,8 +127,9 @@ function InserterMenu(
 		( patternCategory, filter ) => {
 			setSelectedPatternCategory( patternCategory );
 			setPatternFilter( filter );
+			__experimentalOnPatternCategorySelection?.();
 		},
-		[ setSelectedPatternCategory ]
+		[ setSelectedPatternCategory, __experimentalOnPatternCategorySelection ]
 	);
 
 	const blocksTab = useMemo(
@@ -241,8 +244,12 @@ function InserterMenu(
 		setSelectedTab( value );
 	};
 
+	const className = classnames( 'block-editor-inserter__menu', {
+		'has-inline-patterns': __experimentalShouldZoomPatterns,
+	} );
+
 	return (
-		<div className="block-editor-inserter__menu">
+		<div className={ className }>
 			<div
 				className={ classnames( 'block-editor-inserter__main-area', {
 					'show-as-tabs': showAsTabs,

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -126,7 +126,7 @@ function InserterMenu(
 		( patternCategory, filter ) => {
 			setSelectedPatternCategory( patternCategory );
 			setPatternFilter( filter );
-			__experimentalOnPatternCategorySelection?.();
+			__experimentalOnPatternCategorySelection?.( patternCategory );
 		},
 		[ setSelectedPatternCategory, __experimentalOnPatternCategorySelection ]
 	);
@@ -213,6 +213,8 @@ function InserterMenu(
 		focusSearch: () => {
 			searchRef.current.focus();
 		},
+		getSelectedPatternCategory: () => selectedPatternCategory,
+		selectPatternCategory: onClickPatternCategory,
 	} ) );
 
 	const showPatternPanel =

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useDebouncedInput } from '@wordpress/compose';
 
 /**
@@ -47,6 +47,7 @@ function InserterMenu(
 		prioritizePatterns,
 		__experimentalOnPatternCategorySelection,
 		__experimentalShouldZoomPatterns = false,
+		onSelectTab,
 	},
 	ref
 ) {
@@ -59,8 +60,6 @@ function InserterMenu(
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
 	const [ selectedTab, setSelectedTab ] = useState( null );
-	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {
@@ -234,14 +233,8 @@ function InserterMenu(
 			setSelectedPatternCategory( null );
 		}
 
-		// Enter the zoom-out mode when selecting the patterns tab and exit otherwise.
-		if ( value === 'patterns' ) {
-			__unstableSetEditorMode( 'zoom-out' );
-		} else if ( __unstableGetEditorMode() === 'zoom-out' ) {
-			__unstableSetEditorMode( 'edit' );
-		}
-
 		setSelectedTab( value );
+		onSelectTab?.( value );
 	};
 
 	const className = classnames( 'block-editor-inserter__menu', {

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -53,14 +53,17 @@ function InserterSearchResults( {
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
-	const { prioritizedBlocks } = useSelect(
+	const { prioritizedBlocks, isZoomOutMode } = useSelect(
 		( select ) => {
 			const blockListSettings =
 				select( blockEditorStore ).getBlockListSettings( rootClientId );
+			const editorMode =
+				select( blockEditorStore ).__unstableGetEditorMode();
 
 			return {
 				prioritizedBlocks:
 					blockListSettings?.prioritizedInserterBlocks || EMPTY_ARRAY,
+				isZoomOutMode: editorMode === 'zoom-out',
 			};
 		},
 		[ rootClientId ]
@@ -198,6 +201,14 @@ function InserterSearchResults( {
 			</div>
 		</InserterPanel>
 	);
+
+	if ( isZoomOutMode ) {
+		return (
+			<InserterListbox>
+				{ patternsUI || <InserterNoResults /> }
+			</InserterListbox>
+		);
+	}
 
 	return (
 		<InserterListbox>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -92,6 +92,14 @@ $block-inserter-tabs-height: 44px;
 	overflow: visible;
 }
 
+.block-editor-inserter__menu.has-inline-patterns {
+	display: flex;
+
+	.block-editor-inserter__patterns-category-dialog {
+		position: static;
+	}
+}
+
 .block-editor-inserter__inline-elements {
 	margin-top: -1px;
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -237,6 +237,10 @@ $block-inserter-tabs-height: 44px;
 		display: block;
 	}
 
+	.block-editor-block-preview__container {
+		height: 100%;
+	}
+
 	.block-editor-block-card {
 		padding-left: 0;
 		padding-right: 0;

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -105,12 +105,17 @@ function ListViewBranch( props ) {
 	const parentBlockInformation = useBlockDisplayInformation( parentId );
 	const syncedBranch = isSyncedBranch || !! parentBlockInformation?.isSynced;
 
-	const canParentExpand = useSelect(
+	const { canParentExpand, getBlockById } = useSelect(
 		( select ) => {
-			if ( ! parentId ) {
-				return true;
-			}
-			return select( blockEditorStore ).canEditBlock( parentId );
+			const { canEditBlock, getBlockParents, getBlockName, getBlock } =
+				select( blockEditorStore );
+
+			return {
+				canParentExpand: canEditBlock( parentId ),
+				getBlocksParents: getBlockParents,
+				getName: getBlockName,
+				getBlockById: getBlock,
+			};
 		},
 		[ parentId ]
 	);
@@ -132,6 +137,10 @@ function ListViewBranch( props ) {
 	return (
 		<>
 			{ filteredBlocks.map( ( block, index ) => {
+				const isContentSection =
+					getBlockById( block.clientId )?.attributes?.tagName ===
+					'main';
+
 				const { clientId, innerBlocks } = block;
 
 				if ( index > 0 ) {
@@ -154,7 +163,8 @@ function ListViewBranch( props ) {
 				const hasNestedBlocks = !! innerBlocks?.length;
 
 				const shouldExpand =
-					hasNestedBlocks && shouldShowInnerBlocks
+					hasNestedBlocks &&
+					( shouldShowInnerBlocks || isContentSection )
 						? expandedState[ clientId ] ?? isExpanded
 						: undefined;
 
@@ -221,6 +231,7 @@ function ListViewBranch( props ) {
 								selectedClientIds={ selectedClientIds }
 								isExpanded={ isExpanded }
 								isSyncedBranch={ syncedBranch }
+								shouldShowInnerBlocks={ shouldShowInnerBlocks }
 							/>
 						) }
 					</AsyncModeProvider>

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2846,9 +2846,14 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 
 	// In zoom-out mode, the block overlay is always active for top level blocks.
 	if (
-		editorMode === 'zoom-out' &&
-		clientId &&
-		! getBlockRootClientId( state, clientId )
+		( editorMode === 'zoom-out' &&
+			clientId &&
+			! getBlockRootClientId( state, clientId ) &&
+			! getBlock( state, clientId )?.attributes?.tagName === 'main' ) ||
+		getBlockParents( state, clientId )?.find(
+			( parentId ) =>
+				getBlock( state, parentId )?.attributes?.tagName === 'main'
+		)
 	) {
 		return true;
 	}

--- a/packages/block-editor/src/utils/use-should-contextual-toolbar-show.js
+++ b/packages/block-editor/src/utils/use-should-contextual-toolbar-show.js
@@ -38,6 +38,7 @@ export function useShouldContextualToolbarShow() {
 			} = unlock( select( blockEditorStore ) );
 
 			const isEditMode = __unstableGetEditorMode() === 'edit';
+			const isZoomOutMode = __unstableGetEditorMode() === 'zoom-out';
 			const hasFixedToolbar = getSettings().hasFixedToolbar;
 			const isDistractionFree = getSettings().isDistractionFree;
 			const selectedBlockId =
@@ -49,7 +50,7 @@ export function useShouldContextualToolbarShow() {
 			);
 
 			const _shouldShowContextualToolbar =
-				isEditMode &&
+				( isEditMode || isZoomOutMode ) &&
 				! hasFixedToolbar &&
 				( ! isDistractionFree || isNavigationMode() ) &&
 				isLargeViewport &&

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -102,7 +102,11 @@ function EditorCanvas( {
 					canvasMode === 'view'
 						? 'cursor: pointer; min-height: 100vh;'
 						: ''
-				}}}`
+				} ${
+					// In zoomed out mode, hide the normal canvas scrollbar,
+					// as this results in a double-scrollbar
+					isZoomOutMode ? 'overflow: hidden;' : ''
+				}}`
 			}</style>
 			{ children }
 		</BlockCanvas>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -150,6 +150,10 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 		};
 	}, [] );
 	const { setRenderingMode } = useDispatch( editorStore );
+	const { __unstableGetEditorMode: getBlockEditorMode } =
+		useSelect( blockEditorStore );
+	const { __unstableSetEditorMode: setBlockEditorMode } =
+		useDispatch( blockEditorStore );
 
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
@@ -201,6 +205,15 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 			setRenderingMode( 'all' );
 		}
 	}, [ canvasMode, postWithTemplate, setRenderingMode ] );
+
+	useEffect(
+		function ExitZoomOutModeWhenInserterClosed() {
+			if ( ! shouldShowInserter && getBlockEditorMode() === 'zoom-out' ) {
+				setBlockEditorMode( 'edit' );
+			}
+		},
+		[ getBlockEditorMode, setBlockEditorMode, shouldShowInserter ]
+	);
 
 	return (
 		<>

--- a/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
@@ -6,12 +6,11 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	ToolSelector,
 	NavigableToolbar,
-	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { _x, __ } from '@wordpress/i18n';
-import { listView, plus, chevronUpDown } from '@wordpress/icons';
+import { listView, plus } from '@wordpress/icons';
 import { Button, ToolbarItem } from '@wordpress/components';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
@@ -60,12 +59,8 @@ export default function DocumentTools( {
 			};
 		}, [] );
 
-	const {
-		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
-		setIsInserterOpened,
-		setIsListViewOpened,
-	} = useDispatch( editSiteStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { setIsInserterOpened, setIsListViewOpened } =
+		useDispatch( editSiteStore );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
@@ -105,8 +100,6 @@ export default function DocumentTools( {
 	);
 	const shortLabel = ! isInserterOpen ? __( 'Add' ) : __( 'Close' );
 
-	const isZoomedOutViewExperimentEnabled =
-		window?.__experimentalEnableZoomedOutView && isVisualMode;
 	const isZoomedOutView = blockEditorMode === 'zoom-out';
 
 	return (
@@ -178,27 +171,6 @@ export default function DocumentTools( {
 								size="compact"
 							/>
 						) }
-						{ isZoomedOutViewExperimentEnabled &&
-							! isDistractionFree &&
-							! hasFixedToolbar && (
-								<ToolbarItem
-									as={ Button }
-									className="edit-site-header-edit-mode__zoom-out-view-toggle"
-									icon={ chevronUpDown }
-									isPressed={ isZoomedOutView }
-									/* translators: button label text should, if possible, be under 16 characters. */
-									label={ __( 'Zoom-out View' ) }
-									onClick={ () => {
-										setPreviewDeviceType( 'Desktop' );
-										__unstableSetEditorMode(
-											isZoomedOutView
-												? 'edit'
-												: 'zoom-out'
-										);
-									} }
-									size="compact"
-								/>
-							) }
 					</>
 				) }
 			</div>

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -29,6 +29,14 @@ export default function InserterSidebar() {
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 		focusOnMount: null,
+		// Don't close the inserter on focus outside.
+		// This is a temporary hack as we figure out the expected interactions
+		// in the zoom-out mode.
+		__unstableOnClose: ( eventName ) => {
+			if ( eventName === 'focus-outside' ) {
+				// Do nothing.
+			}
+		},
 	} );
 
 	const libraryRef = useRef();

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -18,7 +18,8 @@ import { useEffect, useRef } from '@wordpress/element';
 import { store as editSiteStore } from '../../store';
 
 export default function InserterSidebar() {
-	const { setIsInserterOpened } = useDispatch( editSiteStore );
+	const { closeGeneralSidebar, setIsInserterOpened } =
+		useDispatch( editSiteStore );
 	const insertionPoint = useSelect(
 		( select ) => select( editSiteStore ).__experimentalGetInsertionPoint(),
 		[]
@@ -66,6 +67,10 @@ export default function InserterSidebar() {
 						insertionPoint.insertionIndex
 					}
 					__experimentalFilterValue={ insertionPoint.filterValue }
+					__experimentalOnPatternCategorySelection={
+						closeGeneralSidebar
+					}
+					__experimentalShouldZoomPatterns
 					ref={ libraryRef }
 				/>
 			</div>

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -15,6 +15,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useCallback } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -38,6 +39,13 @@ export default function InserterSidebar() {
 			select( editSiteStore ).getEditedPostType()
 		)
 	);
+	const isRightSidebarOpen = useSelect(
+		( select ) =>
+			!! select( interfaceStore ).getActiveComplementaryArea(
+				editSiteStore.name
+			),
+		[]
+	);
 	const { __unstableSetEditorMode: setEditorMode } =
 		useDispatch( blockEditorStore );
 	const { __unstableGetEditorMode: getEditorMode } =
@@ -59,6 +67,15 @@ export default function InserterSidebar() {
 			}
 		},
 	} );
+
+	const onSelectPatternCategory = useCallback(
+		( category ) => {
+			if ( !! category ) {
+				closeGeneralSidebar();
+			}
+		},
+		[ closeGeneralSidebar ]
+	);
 
 	const libraryRef = useRef();
 	useEffect( () => {
@@ -91,6 +108,19 @@ export default function InserterSidebar() {
 		[ location, setIsInserterOpened ]
 	);
 
+	useEffect(
+		function closePatternCategoryOnRightSidebarOpenInZoomOut() {
+			if (
+				getEditorMode() === 'zoom-out' &&
+				isRightSidebarOpen &&
+				!! libraryRef.current.getSelectedPatternCategory()
+			) {
+				libraryRef.current.selectPatternCategory( null );
+			}
+		},
+		[ getEditorMode, isRightSidebarOpen ]
+	);
+
 	return (
 		<div
 			ref={ inserterDialogRef }
@@ -114,7 +144,7 @@ export default function InserterSidebar() {
 					}
 					__experimentalFilterValue={ insertionPoint.filterValue }
 					__experimentalOnPatternCategorySelection={
-						closeGeneralSidebar
+						onSelectPatternCategory
 					}
 					__experimentalShouldZoomPatterns
 					ref={ libraryRef }


### PR DESCRIPTION
*This is an experimental (pretty hacky) PR, not intended to be merged.*

## What?
A few of us (see assignees) are experimenting with Zoomed Out mode in the site editor.

See https://github.com/WordPress/gutenberg/issues/50739

## Why?
The basic version of zoomed out view was originally implemented a while ago, and exists behind an experimental flag.

There's a wishlist of features at #50739 that have never been implemented depsite a few attempts.

## How?
Several sub PRs have been merged into this branch with more detail:
- #56771
- #56769
- #56773
- #56772
- https://github.com/WordPress/gutenberg/pull/56808
- https://github.com/WordPress/gutenberg/pull/56885
- #56888
- https://github.com/WordPress/gutenberg/pull/56886
- https://github.com/WordPress/gutenberg/pull/56889
- https://github.com/WordPress/gutenberg/pull/56890
- https://github.com/WordPress/gutenberg/pull/56891
- https://github.com/WordPress/gutenberg/pull/56814
- https://github.com/WordPress/gutenberg/pull/56893
- https://github.com/WordPress/gutenberg/pull/56894
- https://github.com/WordPress/gutenberg/pull/56892

## Issues Encountered
- #44585 proposes activating zoomed out mode when viewing patterns in the inserter. The problem with this is that the inserter acts as a dialog, clicking outside of it closes the inserter and deactivates zoomed out mode. The current situation makes it difficult to add any canvas interactions for zoomed out view. For this experiment, the inserter has been hacked (in #56772) so that it doesn't close when clicking outside.
- Zoomed out mode considers any top-level blocks as 'sections' and locks all inner blocks. The problem is that most templates only have three top level blocks. A header, a group that acts as the `<main>` element and a footer. Usually most body sections for a page are within the `<main>` group. Somehow we need to ignore the `<main>` group and only consider its direct children. There's a fix in this PR (see #56890 for more detail).
- It'd be nice to be able to drag and drop the blocks themselves rather than using a drag handle on the toolbar (like #23497). There doesn't seem to be a way to attach drag/drop event handlers to a block. Using an element that overlays blocks as a draggable might be possible, but would need some more exploration.
- The bug with VH units in patterns (#50449) also happens in the editor canvas in zoomed out mode for some patterns, which can break the experience.

## Testing Instructions
1. Open the site editor and choose a template
2. Click the Main Inserter + button, observe that zoomed out mode initiates in the canvas when the 'Pattern' tab is active
3. Experiment with editing blocks as sections

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/677833/64f00697-6799-4ddd-9fdf-23d2bda599ef

