### PR TITLE
Make `SaveButton` extensible

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -71,6 +71,15 @@ export default function SaveButton( {
 		setIsSaveViewOpened( true );
 	}, [ customizedSaveButtonAction, setIsSaveViewOpened ]);
 
+	// For testing
+	const { updateSettings } = useDispatch( editSiteStore );
+	useEffect( () => {
+		updateSettings( {
+			__experimentalSaveButtonAction: () => console.log('Customized Action'),
+			__experimentalSaveButtonLabel: 'Customized Action',
+		} );
+	}, [ updateSettings ] );
+
 	const activateSaveEnabled = isPreviewingTheme() || isDirty;
 	const disabled = isSaving || ! activateSaveEnabled;
 

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -56,26 +56,33 @@ export default function SaveButton( {
 		}, [] );
 
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
-	const { customizedSaveButtonAction, customizedSaveButtonLabel } = useSelect( ( select ) => {
-		const { getSettings } = unlock(select( editSiteStore ));
-		return {
-			customizedSaveButtonAction: getSettings().__experimentalSaveButtonAction,
-			customizedSaveButtonLabel: getSettings().__experimentalSaveButtonLabel,
-		};
-	}, []);
+	const { customizedSaveButtonAction, customizedSaveButtonLabel } = useSelect(
+		( select ) => {
+			const { getSettings } = unlock( select( editSiteStore ) );
+			return {
+				customizedSaveButtonAction:
+					getSettings().__experimentalSaveButtonAction,
+				customizedSaveButtonLabel:
+					getSettings().__experimentalSaveButtonLabel,
+			};
+		},
+		[]
+	);
 	const onClick = useCallback( () => {
 		if ( customizedSaveButtonAction ) {
 			customizedSaveButtonAction();
 			return;
 		}
 		setIsSaveViewOpened( true );
-	}, [ customizedSaveButtonAction, setIsSaveViewOpened ]);
+	}, [ customizedSaveButtonAction, setIsSaveViewOpened ] );
 
 	// For testing
 	const { updateSettings } = useDispatch( editSiteStore );
 	useEffect( () => {
 		updateSettings( {
-			__experimentalSaveButtonAction: () => console.log('Customized Action'),
+			__experimentalSaveButtonAction: () =>
+				// eslint-disable-next-line no-console
+				console.log( 'Customized Action' ),
 			__experimentalSaveButtonLabel: 'Customized Action',
 		} );
 	}, [ updateSettings ] );

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -6,7 +6,7 @@ import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { displayShortcut } from '@wordpress/keycodes';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -75,17 +75,6 @@ export default function SaveButton( {
 		}
 		setIsSaveViewOpened( true );
 	}, [ customizedSaveButtonAction, setIsSaveViewOpened ] );
-
-	// For testing
-	const { updateSettings } = useDispatch( editSiteStore );
-	useEffect( () => {
-		updateSettings( {
-			__experimentalSaveButtonAction: () =>
-				// eslint-disable-next-line no-console
-				console.log( 'Customized Action' ),
-			__experimentalSaveButtonLabel: 'Customized Action',
-		} );
-	}, [ updateSettings ] );
 
 	const activateSaveEnabled = isPreviewingTheme() || isDirty;
 	const disabled = isSaving || ! activateSaveEnabled;

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -57,13 +57,6 @@ export default function SaveButton( {
 
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
 
-	const onClick = useCallback( () => {
-		const callback = applyFilters( 'edit-site.SaveButton.onClick', () =>
-			setIsSaveViewOpened( true )
-		);
-		callback();
-	}, [ setIsSaveViewOpened ] );
-
 	const activateSaveEnabled = isPreviewingTheme() || isDirty;
 	const disabled = isSaving || ! activateSaveEnabled;
 
@@ -88,6 +81,18 @@ export default function SaveButton( {
 		}
 		return __( 'Save' );
 	};
+
+	/**
+	 * We focus on adding the customization to the SaveButton's `onClick` and `label` for now.
+	 * We will provide the customization to the other entry points (e.g., SavePanel, SaveHub) in the future if needed.
+	 * @see https://github.com/WordPress/gutenberg/pull/56807
+	 */
+	const onClick = useCallback( () => {
+		const callback = applyFilters( 'edit-site.SaveButton.onClick', () =>
+			setIsSaveViewOpened( true )
+		);
+		callback();
+	}, [ setIsSaveViewOpened ] );
 	const label = useMemo( () => {
 		return applyFilters( 'edit-site.SaveButton.label', getLabel(), {
 			isSaving,

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -9,6 +9,8 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { check } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as noticesStore } from '@wordpress/notices';
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -112,6 +114,32 @@ export default function SaveHub() {
 		} = select( coreStore );
 		return {
 			homeUrl: getUnstableBase()?.home,
+		};
+	}, [] );
+
+	// This is only for testing purposes.
+	useEffect( () => {
+		addFilter(
+			'edit-site.SaveButton.onClick',
+			'my-plugin',
+			( originalFunction ) => {
+				return () => {
+					// eslint-disable-next-line no-alert
+					window.alert( 'Custom action' );
+					originalFunction();
+				};
+			}
+		);
+		addFilter(
+			'edit-site.SaveButton.label',
+			'my-plugin',
+			( originalLabel ) => {
+				return `Custom ${ originalLabel }`;
+			}
+		);
+		return () => {
+			removeFilter( 'edit-site.SaveButton.onClick', 'my-plugin' );
+			removeFilter( 'edit-site.SaveButton.label', 'my-plugin' );
 		};
 	}, [] );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This Pull Request introduces enhancements to the `SaveButton` component, aimed at adding its extensibility within client applications of Gutenberg. Key improvements include the button label, and the action triggered when the button is clicked.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The primary goal of these enhancements is to improve the adaptability of the `SaveButton` within client applications, particularly in scenarios where user interaction necessitates a context-specific response.

### Example

An example of the necessity for these enhancements can be seen on WordPress.com. Say a user is previewing a block theme; if the user does not have the required plan for the previewing theme, `SaveButton` needs to do more than just save changes. In this case, the button should redirect the user to the plan checkout page (c.f., https://github.com/Automattic/wp-calypso/issues/79223).

This example underlines the need for a `SaveButton` that is not only context-aware but also capable of performing the actions based on the requirements of the client application. By implementing these, we enable a more responsive UX, tailored to the specific conditions of the user's interaction within the client application.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

~~The approach taken to enable these enhancements is minimalist, utilizing the existing `getSettings()` store.~~
Update: The approach is done by using `applyFilters` in `@wordpress/hooks`.

The Slot/Fill approach was considered but not used. The rationale behind this is that Slot/Fill, while appropriate for replacing entire UI elements, would be an overextension for the future use case. Our aim was to enhance, not replace, the existing `SaveButton` UI. 

Another considered approach was dynamically adding event listeners to the button (in this case, we don't change anything on the Gutenberg side). However, this was deemed less ideal compared to having a dedicated customization point within the SaveButton itself.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Go to `Appearance > Editor`
- Edit your content
- Click the customized "SaveButton"
- See the custom action and label



https://github.com/WordPress/gutenberg/assets/5287479/9513ea3c-af30-4a73-bdf1-34fa7457fcaf

