### PR TITLE
Use contextual toolbar in the zoom out mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/selected-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-tools.js
@@ -100,7 +100,7 @@ export default function SelectedBlockTools( {
 				resize={ false }
 				{ ...popoverProps }
 			>
-				{ shouldShowContextualToolbar && (
+				{ shouldShowContextualToolbar ? (
 					<BlockContextualToolbar
 						// If the toolbar is being shown because of being forced
 						// it should focus the toolbar right after the mount.
@@ -112,12 +112,13 @@ export default function SelectedBlockTools( {
 							initialToolbarItemIndexRef.current = index;
 						} }
 					/>
-				) }
-				{ shouldShowBreadcrumb && (
-					<BlockSelectionButton
-						clientId={ clientId }
-						rootClientId={ rootClientId }
-					/>
+				) : (
+					shouldShowBreadcrumb && (
+						<BlockSelectionButton
+							clientId={ clientId }
+							rootClientId={ rootClientId }
+						/>
+					)
 				) }
 			</BlockPopover>
 		);

--- a/packages/block-editor/src/utils/use-should-contextual-toolbar-show.js
+++ b/packages/block-editor/src/utils/use-should-contextual-toolbar-show.js
@@ -38,6 +38,7 @@ export function useShouldContextualToolbarShow() {
 			} = unlock( select( blockEditorStore ) );
 
 			const isEditMode = __unstableGetEditorMode() === 'edit';
+			const isZoomOutMode = __unstableGetEditorMode() === 'zoom-out';
 			const hasFixedToolbar = getSettings().hasFixedToolbar;
 			const isDistractionFree = getSettings().isDistractionFree;
 			const selectedBlockId =
@@ -49,7 +50,7 @@ export function useShouldContextualToolbarShow() {
 			);
 
 			const _shouldShowContextualToolbar =
-				isEditMode &&
+				( isEditMode || isZoomOutMode ) &&
 				! hasFixedToolbar &&
 				( ! isDistractionFree || isNavigationMode() ) &&
 				isLargeViewport &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of https://github.com/WordPress/gutenberg/pull/56806. Use contextual toolbar in the zoom-out mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allows reordering/deleting blocks in the zoom-out mode, as they are some core features we want to support in that mode. We can still use the navigation toolbar but then we'll need to add the "Delete" action back. Using the contextual toolbar is just easier at this stage.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Tweak the conditions to also allow contextual toolbar in the zoom-out mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the "Zoom out mode" gutenberg experiment.
2. Go to the Site Editor.
3. Enter the zoom-out mode (currently available when opening the inserter with the "Patterns" tab)
4. Expect to see the contextual bar when selecting blocks in the canvas.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/a4f08ea5-6209-4fb5-918e-cee4f15ea6a9


