### PR TITLE
Image: Fix resetting behaviour for alt image text

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -380,6 +380,7 @@ export default function Image( {
 
 	const resetAll = () => {
 		setAttributes( {
+			alt: undefined,
 			width: undefined,
 			height: undefined,
 			scale: undefined,
@@ -463,7 +464,7 @@ export default function Image( {
 						>
 							<TextareaControl
 								label={ __( 'Alternative text' ) }
-								value={ alt }
+								value={ alt || '' }
 								onChange={ updateAlt }
 								help={
 									<>
@@ -481,11 +482,13 @@ export default function Image( {
 						</ToolsPanelItem>
 					) }
 					{ isResizable && dimensionsControl }
-					<ResolutionTool
-						value={ sizeSlug }
-						onChange={ updateImage }
-						options={ imageSizeOptions }
-					/>
+					{ !! imageSizeOptions.length && (
+						<ResolutionTool
+							value={ sizeSlug }
+							onChange={ updateImage }
+							options={ imageSizeOptions }
+						/>
+					) }
 					{ showLightboxToggle && (
 						<ToolsPanelItem
 							hasValue={ () => !! lightbox }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -457,7 +457,7 @@ export default function Image( {
 						<ToolsPanelItem
 							label={ __( 'Alternative text' ) }
 							isShownByDefault={ true }
-							hasValue={ () => alt !== '' }
+							hasValue={ () => !! alt }
 							onDeselect={ () =>
 								setAttributes( { alt: undefined } )
 							}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix resetting behaviour for the alt image text field in the Image block, when accessed via the tools panel menu. I think the logic was previously updated in https://github.com/WordPress/gutenberg/pull/51545, so might want to double check with @ajlende if this approach looks okay.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I noticed that if you go to reset the alt image text it doesn't appear to immediately update the text area control. This appears to be because the `TextareaControl` component expects a string. Additionally, when going to "reset all", the alt text wasn't being cleared out.

I've also added a check before rendering the resolution controls, as the "Resolution" menu item was appearing in the tools panel menu when it shouldn't.

> [!NOTE]
> I noticed that the Resolution item will sometimes appear to have a value when you don't think it should, and also isn't properly covered by the `resetAll` behaviour. I haven't handled those issues in this PR, and I don't think this PR makes any difference to them — to fix those, I think something would likely need to be done using the [imageDefaultSize](https://github.com/WordPress/gutenberg/blob/6e532f444a72d997b09441197caade90c49f19f3/packages/block-library/src/image/edit.js#L143) value so that resetting would reset back to that value perhaps instead of just clearing out the `sizeSlug` attribute. In any case, that can be explored separately if need be.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `alt` to the list of properties cleared by `resetAll`
* Update `hasValue` check to see if `alt` is truthy (as both an empty string and `undefined` are valid empty states)
* Pass a fallback of an empty string to `TextareaControl` for its controlled value, so that a cleared out `alt` text field is reflected in the UI
* Only render the `ResolutionTool` if there are available size options

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This should hopefully be fairly straightforward to test with TwentyTwentyFour:

1. Open the Blog Home template and click on the Image block of the building and sky
2. In the Settings panel in the inspector controls, click on the ellipsis menu and go to reset the alt text
3. In the dropdown menu, you _shouldn't_ see an option for Resolution
4. Clicking the `Alternative text` button in the menu should clear the field
5. Add some alt text
6. Open the menu again, and click `Reset all`, and it should clear the field again
7. Add some other image blocks to the template using images from your media library. The Resolution option should behave as on trunk (note that the Resolution control in the ToolsPanel appears to be a little buggy... as far as I can tell this PR should otherwise behave as it does currently on trunk)

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/14988353/45a6a76b-eb71-4cfd-aa68-d4a2f8d73da8

### After

https://github.com/WordPress/gutenberg/assets/14988353/b32314d8-cc62-40e3-90f6-aefaf415df7a