### PR TITLE
Try adding edit template part button in zoom mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { dragHandle } from '@wordpress/icons';
+import { dragHandle, pencil } from '@wordpress/icons';
 import { Button, Flex, FlexItem } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -29,6 +29,7 @@ import {
 import { speak } from '@wordpress/a11y';
 import { focus } from '@wordpress/dom';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -293,6 +294,20 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 						/>
 					</Button>
 				</FlexItem>
+				{ editorMode === 'zoom-out' &&
+					blockType.name === 'core/template-part' && (
+						<FlexItem>
+							<Button
+								icon={ pencil }
+								className="block-selection-button_edit-button"
+								label={ __( 'Edit' ) }
+								href={ addQueryArgs( 'site-editor.php', {
+									postType: 'wp_template_part',
+									postId: `${ attributes.theme }//${ attributes.slug }`,
+								} ) }
+							/>
+						</FlexItem>
+					) }
 			</Flex>
 		</div>
 	);


### PR DESCRIPTION
**This is for experimental purposes only as it hardcodes URL to site-editor**

## What?
Adds an edit button for template parts to the block toolbar in zoomed-out mode.

## Why?
It's a handy thing to be able to do when working in zoomed out mode.

## How?
Checks the block type and editor mode in the block selection button component and adds a button to the template part editor if appropriate.

## Testing Instructions
1. Open the site editor, edit a template, switch to zoomed-out mode
2. Select a template part and confirm the presence of an edit button
3. Click the edit button and confirm you are taken to the template part editor
4. Click the browser's back button (**Note: for the moment the sidebar back button won't work**)
5. On the zoomed-out mode view again, confirm non template part blocks do not have the edit button.


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/2f797724-9016-4ec7-84e5-c8907ee5c18a


