### PR TITLE
Block editor: make all BlockEdit hooks pure

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
@@ -108,9 +108,9 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
-function BlockEditAlignmentToolbarControls( {
+function BlockEditAlignmentToolbarControlsPure( {
 	blockName,
-	attributes,
+	align,
 	setAttributes,
 } ) {
 	// Compute the block valid alignments by taking into account,
@@ -144,13 +144,17 @@ function BlockEditAlignmentToolbarControls( {
 	return (
 		<BlockControls group="block" __experimentalShareWithChildBlocks>
 			<BlockAlignmentControl
-				value={ attributes.align }
+				value={ align }
 				onChange={ updateAlignment }
 				controls={ validAlignments }
 			/>
 		</BlockControls>
 	);
 }
+
+const BlockEditAlignmentToolbarControls = pure(
+	BlockEditAlignmentToolbarControlsPure
+);
 
 /**
  * Override the default edit UI to include new toolbar controls for block
@@ -173,7 +177,8 @@ export const withAlignmentControls = createHigherOrderComponent(
 				{ hasAlignmentSupport && (
 					<BlockEditAlignmentToolbarControls
 						blockName={ props.name }
-						attributes={ props.attributes }
+						// This component is pure, so only pass needed props!
+						align={ props.attributes.align }
 						setAttributes={ props.setAttributes }
 					/>
 				) }

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -152,6 +152,9 @@ function BlockEditAlignmentToolbarControlsPure( {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const BlockEditAlignmentToolbarControls = pure(
 	BlockEditAlignmentToolbarControlsPure
 );

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -137,7 +137,7 @@ export const withAnchorControls = createHigherOrderComponent( ( BlockEdit ) => {
 							blockName={ props.name }
 							// This component is pure, so only pass needed
 							// props!
-							attributes={ props.attributes.anchor }
+							anchor={ props.attributes.anchor }
 							setAttributes={ props.setAttributes }
 						/>
 					) }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -116,6 +116,9 @@ function BlockEditAnchorControlPure( { blockName, anchor, setAttributes } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const BlockEditAnchorControl = pure( BlockEditAnchorControlPure );
 
 /**

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -5,7 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { Platform } from '@wordpress/element';
 
 /**
@@ -52,7 +52,7 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
-function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
+function BlockEditAnchorControlPure( { blockName, anchor, setAttributes } ) {
 	const blockEditingMode = useBlockEditingMode();
 
 	const isWeb = Platform.OS === 'web';
@@ -79,7 +79,7 @@ function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
 					) }
 				</>
 			}
-			value={ attributes.anchor || '' }
+			value={ anchor || '' }
 			placeholder={ ! isWeb ? __( 'Add an anchor' ) : null }
 			onChange={ ( nextValue ) => {
 				nextValue = nextValue.replace( ANCHOR_REGEX, '-' );
@@ -116,6 +116,8 @@ function BlockEditAnchorControl( { blockName, attributes, setAttributes } ) {
 	);
 }
 
+const BlockEditAnchorControl = pure( BlockEditAnchorControlPure );
+
 /**
  * Override the default edit UI to include a new block inspector control for
  * assigning the anchor ID, if block supports anchor.
@@ -133,7 +135,9 @@ export const withAnchorControls = createHigherOrderComponent( ( BlockEdit ) => {
 					hasBlockSupport( props.name, 'anchor' ) && (
 						<BlockEditAnchorControl
 							blockName={ props.name }
-							attributes={ props.attributes }
+							// This component is pure, so only pass needed
+							// props!
+							attributes={ props.attributes.anchor }
 							setAttributes={ props.setAttributes }
 						/>
 					) }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -318,4 +318,7 @@ function BackgroundImagePanelPure( props ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 export const BackgroundImagePanel = pure( BackgroundImagePanelPure );

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -9,7 +9,7 @@ import {
 	PanelBody,
 	ToggleControl,
 } from '@wordpress/components';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -21,7 +21,7 @@ import { store as blockEditorStore } from '../store';
 
 const EMPTY_OBJECT = {};
 
-function BlockHooksControl( props ) {
+function BlockHooksControlPure( props ) {
 	const blockTypes = useSelect(
 		( select ) => select( blocksStore ).getBlockTypes(),
 		[]
@@ -234,6 +234,8 @@ function BlockHooksControl( props ) {
 		</InspectorControls>
 	);
 }
+
+const BlockHooksControl = pure( BlockHooksControlPure );
 
 export const withBlockHooksControls = createHigherOrderComponent(
 	( BlockEdit ) => {

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -235,6 +235,9 @@ function BlockHooksControlPure( props ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const BlockHooksControl = pure( BlockHooksControlPure );
 
 export const withBlockHooksControls = createHigherOrderComponent(

--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -3,7 +3,7 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
 
@@ -47,30 +47,43 @@ export function addLabelCallback( settings ) {
 	return settings;
 }
 
+function BlockRenameControlPure( { name, metadata, setAttributes } ) {
+	const { canRename } = useBlockRename( name );
+
+	if ( ! canRename ) {
+		return null;
+	}
+
+	return (
+		<InspectorControls group="advanced">
+			<TextControl
+				__nextHasNoMarginBottom
+				label={ __( 'Block name' ) }
+				value={ metadata?.name || '' }
+				onChange={ ( newName ) => {
+					setAttributes( {
+						metadata: { ...metadata, name: newName },
+					} );
+				} }
+			/>
+		</InspectorControls>
+	);
+}
+
+const BlockRenameControl = pure( BlockRenameControlPure );
+
 export const withBlockRenameControl = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name, attributes, setAttributes, isSelected } = props;
-
-		const { canRename } = useBlockRename( name );
-
 		return (
 			<>
-				{ isSelected && canRename && (
-					<InspectorControls group="advanced">
-						<TextControl
-							__nextHasNoMarginBottom
-							label={ __( 'Block name' ) }
-							value={ attributes?.metadata?.name || '' }
-							onChange={ ( newName ) => {
-								setAttributes( {
-									metadata: {
-										...attributes?.metadata,
-										name: newName,
-									},
-								} );
-							} }
-						/>
-					</InspectorControls>
+				{ isSelected && (
+					<BlockRenameControl
+						name={ name }
+						// This component is pure, so only pass needed props!
+						metadata={ attributes.metadata }
+						setAttributes={ setAttributes }
+					/>
 				) }
 				<BlockEdit key="edit" { ...props } />
 			</>

--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -70,6 +70,9 @@ function BlockRenameControlPure( { name, metadata, setAttributes } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const BlockRenameControl = pure( BlockRenameControlPure );
 
 export const withBlockRenameControl = createHigherOrderComponent(

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -175,6 +175,9 @@ function BorderPanelPure( { clientId, name, setAttributes } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 export const BorderPanel = pure( BorderPanelPure );
 
 /**

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -361,6 +361,9 @@ function ColorEditPure( { clientId, name, setAttributes } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 export const ColorEdit = pure( ColorEditPure );
 
 /**

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { ToolbarButton, MenuItem } from '@wordpress/components';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -37,120 +37,126 @@ function StopEditingAsBlocksOnOutsideSelect( {
 	return null;
 }
 
+function ContentLockControlsPure( { clientId, isSelected } ) {
+	const { getBlockListSettings, getSettings } = useSelect( blockEditorStore );
+	const focusModeToRevert = useRef();
+	const { templateLock, isLockedByParent, isEditingAsBlocks } = useSelect(
+		( select ) => {
+			const {
+				__unstableGetContentLockingParent,
+				getTemplateLock,
+				__unstableGetTemporarilyEditingAsBlocks,
+			} = select( blockEditorStore );
+			return {
+				templateLock: getTemplateLock( clientId ),
+				isLockedByParent:
+					!! __unstableGetContentLockingParent( clientId ),
+				isEditingAsBlocks:
+					__unstableGetTemporarilyEditingAsBlocks() === clientId,
+			};
+		},
+		[ clientId ]
+	);
+
+	const {
+		updateSettings,
+		updateBlockListSettings,
+		__unstableSetTemporarilyEditingAsBlocks,
+	} = useDispatch( blockEditorStore );
+	const isContentLocked =
+		! isLockedByParent && templateLock === 'contentOnly';
+	const { __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
+		useDispatch( blockEditorStore );
+
+	const stopEditingAsBlock = useCallback( () => {
+		__unstableMarkNextChangeAsNotPersistent();
+		updateBlockAttributes( clientId, {
+			templateLock: 'contentOnly',
+		} );
+		updateBlockListSettings( clientId, {
+			...getBlockListSettings( clientId ),
+			templateLock: 'contentOnly',
+		} );
+		updateSettings( { focusMode: focusModeToRevert.current } );
+		__unstableSetTemporarilyEditingAsBlocks();
+	}, [
+		clientId,
+		updateSettings,
+		updateBlockListSettings,
+		getBlockListSettings,
+		__unstableMarkNextChangeAsNotPersistent,
+		updateBlockAttributes,
+		__unstableSetTemporarilyEditingAsBlocks,
+	] );
+
+	if ( ! isContentLocked && ! isEditingAsBlocks ) {
+		return null;
+	}
+
+	const showStopEditingAsBlocks = isEditingAsBlocks && ! isContentLocked;
+	const showStartEditingAsBlocks =
+		! isEditingAsBlocks && isContentLocked && isSelected;
+
+	return (
+		<>
+			{ showStopEditingAsBlocks && (
+				<>
+					<StopEditingAsBlocksOnOutsideSelect
+						clientId={ clientId }
+						stopEditingAsBlock={ stopEditingAsBlock }
+					/>
+					<BlockControls group="other">
+						<ToolbarButton
+							onClick={ () => {
+								stopEditingAsBlock();
+							} }
+						>
+							{ __( 'Done' ) }
+						</ToolbarButton>
+					</BlockControls>
+				</>
+			) }
+			{ showStartEditingAsBlocks && (
+				<BlockSettingsMenuControls>
+					{ ( { onClose } ) => (
+						<MenuItem
+							onClick={ () => {
+								__unstableMarkNextChangeAsNotPersistent();
+								updateBlockAttributes( clientId, {
+									templateLock: undefined,
+								} );
+								updateBlockListSettings( clientId, {
+									...getBlockListSettings( clientId ),
+									templateLock: false,
+								} );
+								focusModeToRevert.current =
+									getSettings().focusMode;
+								updateSettings( { focusMode: true } );
+								__unstableSetTemporarilyEditingAsBlocks(
+									clientId
+								);
+								onClose();
+							} }
+						>
+							{ __( 'Modify' ) }
+						</MenuItem>
+					) }
+				</BlockSettingsMenuControls>
+			) }
+		</>
+	);
+}
+
+const ContentLockControls = pure( ContentLockControlsPure );
+
 export const withContentLockControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const { getBlockListSettings, getSettings } =
-			useSelect( blockEditorStore );
-		const focusModeToRevert = useRef();
-		const { templateLock, isLockedByParent, isEditingAsBlocks } = useSelect(
-			( select ) => {
-				const {
-					__unstableGetContentLockingParent,
-					getTemplateLock,
-					__unstableGetTemporarilyEditingAsBlocks,
-				} = select( blockEditorStore );
-				return {
-					templateLock: getTemplateLock( props.clientId ),
-					isLockedByParent: !! __unstableGetContentLockingParent(
-						props.clientId
-					),
-					isEditingAsBlocks:
-						__unstableGetTemporarilyEditingAsBlocks() ===
-						props.clientId,
-				};
-			},
-			[ props.clientId ]
-		);
-
-		const {
-			updateSettings,
-			updateBlockListSettings,
-			__unstableSetTemporarilyEditingAsBlocks,
-		} = useDispatch( blockEditorStore );
-		const isContentLocked =
-			! isLockedByParent && templateLock === 'contentOnly';
-		const {
-			__unstableMarkNextChangeAsNotPersistent,
-			updateBlockAttributes,
-		} = useDispatch( blockEditorStore );
-
-		const stopEditingAsBlock = useCallback( () => {
-			__unstableMarkNextChangeAsNotPersistent();
-			updateBlockAttributes( props.clientId, {
-				templateLock: 'contentOnly',
-			} );
-			updateBlockListSettings( props.clientId, {
-				...getBlockListSettings( props.clientId ),
-				templateLock: 'contentOnly',
-			} );
-			updateSettings( { focusMode: focusModeToRevert.current } );
-			__unstableSetTemporarilyEditingAsBlocks();
-		}, [
-			props.clientId,
-			updateSettings,
-			updateBlockListSettings,
-			getBlockListSettings,
-			__unstableMarkNextChangeAsNotPersistent,
-			updateBlockAttributes,
-			__unstableSetTemporarilyEditingAsBlocks,
-		] );
-
-		if ( ! isContentLocked && ! isEditingAsBlocks ) {
-			return <BlockEdit key="edit" { ...props } />;
-		}
-
-		const showStopEditingAsBlocks = isEditingAsBlocks && ! isContentLocked;
-		const showStartEditingAsBlocks =
-			! isEditingAsBlocks && isContentLocked && props.isSelected;
-
 		return (
 			<>
-				{ showStopEditingAsBlocks && (
-					<>
-						<StopEditingAsBlocksOnOutsideSelect
-							clientId={ props.clientId }
-							stopEditingAsBlock={ stopEditingAsBlock }
-						/>
-						<BlockControls group="other">
-							<ToolbarButton
-								onClick={ () => {
-									stopEditingAsBlock();
-								} }
-							>
-								{ __( 'Done' ) }
-							</ToolbarButton>
-						</BlockControls>
-					</>
-				) }
-				{ showStartEditingAsBlocks && (
-					<BlockSettingsMenuControls>
-						{ ( { onClose } ) => (
-							<MenuItem
-								onClick={ () => {
-									__unstableMarkNextChangeAsNotPersistent();
-									updateBlockAttributes( props.clientId, {
-										templateLock: undefined,
-									} );
-									updateBlockListSettings( props.clientId, {
-										...getBlockListSettings(
-											props.clientId
-										),
-										templateLock: false,
-									} );
-									focusModeToRevert.current =
-										getSettings().focusMode;
-									updateSettings( { focusMode: true } );
-									__unstableSetTemporarilyEditingAsBlocks(
-										props.clientId
-									);
-									onClose();
-								} }
-							>
-								{ __( 'Modify' ) }
-							</MenuItem>
-						) }
-					</BlockSettingsMenuControls>
-				) }
+				<ContentLockControls
+					clientId={ props.clientId }
+					isSelected={ props.isSelected }
+				/>
 				<BlockEdit key="edit" { ...props } />
 			</>
 		);

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -147,6 +147,9 @@ function ContentLockControlsPure( { clientId, isSelected } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const ContentLockControls = pure( ContentLockControlsPure );
 
 export const withContentLockControls = createHigherOrderComponent(

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -10,7 +10,7 @@ import { addFilter } from '@wordpress/hooks';
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
-function CustomClassNameControls( { attributes, setAttributes } ) {
+function CustomClassNameControlsPure( { className, setAttributes } ) {
 	const blockEditingMode = useBlockEditingMode();
 	if ( blockEditingMode !== 'default' ) {
 		return null;
@@ -52,7 +52,7 @@ function CustomClassNameControls( { attributes, setAttributes } ) {
 				__next40pxDefaultSize
 				autoComplete="off"
 				label={ __( 'Additional CSS class(es)' ) }
-				value={ attributes.className || '' }
+				value={ className || '' }
 				onChange={ ( nextValue ) => {
 					setAttributes( {
 						className: nextValue !== '' ? nextValue : undefined,
@@ -63,6 +63,8 @@ function CustomClassNameControls( { attributes, setAttributes } ) {
 		</InspectorControls>
 	);
 }
+
+const CustomClassNameControls = pure( CustomClassNameControlsPure );
 
 /**
  * Override the default edit UI to include a new block inspector control for
@@ -87,7 +89,9 @@ export const withCustomClassNameControls = createHigherOrderComponent(
 					<BlockEdit { ...props } />
 					{ hasCustomClassName && props.isSelected && (
 						<CustomClassNameControls
-							attributes={ props.attributes }
+							// This component is pure, so only pass needed
+							// props!
+							attributes={ props.attributes.className }
 							setAttributes={ props.setAttributes }
 						/>
 					) }

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -64,6 +64,9 @@ function CustomClassNameControlsPure( { className, setAttributes } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const CustomClassNameControls = pure( CustomClassNameControlsPure );
 
 /**

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -91,7 +91,7 @@ export const withCustomClassNameControls = createHigherOrderComponent(
 						<CustomClassNameControls
 							// This component is pure, so only pass needed
 							// props!
-							attributes={ props.attributes.className }
+							className={ props.attributes.className }
 							setAttributes={ props.setAttributes }
 						/>
 					) }

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -91,6 +91,9 @@ function CustomFieldsControlPure( { name, connections, setAttributes } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const CustomFieldsControl = pure( CustomFieldsControlPure );
 
 /**

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -5,7 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 import { PanelBody, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ function addAttribute( settings ) {
 	return settings;
 }
 
-function CustomFieldsControl( props ) {
+function CustomFieldsControlPure( { name, connections, setAttributes } ) {
 	const blockEditingMode = useBlockEditingMode();
 	if ( blockEditingMode !== 'default' ) {
 		return null;
@@ -44,8 +44,8 @@ function CustomFieldsControl( props ) {
 	// attribute to use for the connection. Only the `content` attribute
 	// of the paragraph block and the `url` attribute of the image block are supported.
 	let attributeName;
-	if ( props.name === 'core/paragraph' ) attributeName = 'content';
-	if ( props.name === 'core/image' ) attributeName = 'url';
+	if ( name === 'core/paragraph' ) attributeName = 'content';
+	if ( name === 'core/image' ) attributeName = 'url';
 
 	return (
 		<InspectorControls>
@@ -55,19 +55,17 @@ function CustomFieldsControl( props ) {
 					autoComplete="off"
 					label={ __( 'Custom field meta_key' ) }
 					value={
-						props.attributes?.connections?.attributes?.[
-							attributeName
-						]?.value || ''
+						connections?.attributes?.[ attributeName ]?.value || ''
 					}
 					onChange={ ( nextValue ) => {
 						if ( nextValue === '' ) {
-							props.setAttributes( {
+							setAttributes( {
 								connections: undefined,
 								[ attributeName ]: undefined,
 								placeholder: undefined,
 							} );
 						} else {
-							props.setAttributes( {
+							setAttributes( {
 								connections: {
 									attributes: {
 										// The attributeName will be either `content` or `url`.
@@ -92,6 +90,8 @@ function CustomFieldsControl( props ) {
 		</InspectorControls>
 	);
 }
+
+const CustomFieldsControl = pure( CustomFieldsControlPure );
 
 /**
  * Override the default edit UI to include a new block inspector control for
@@ -121,7 +121,12 @@ const withCustomFieldsControls = createHigherOrderComponent( ( BlockEdit ) => {
 			<>
 				<BlockEdit key="edit" { ...props } />
 				{ hasCustomFieldsSupport && props.isSelected && (
-					<CustomFieldsControl { ...props } />
+					<CustomFieldsControl
+						name={ props.name }
+						// This component is pure, so only pass needed props!
+						connections={ props.attributes.connections }
+						setAttributes={ props.setAttributes }
+					/>
 				) }
 			</>
 		);

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -132,6 +132,9 @@ function DimensionsPanelPure( {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 export const DimensionsPanel = pure( DimensionsPanelPure );
 
 /**

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -13,7 +13,11 @@ import {
 	getBlockType,
 	hasBlockSupport,
 } from '@wordpress/blocks';
-import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
+import {
+	createHigherOrderComponent,
+	useInstanceId,
+	pure,
+} from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { useMemo, useEffect } from '@wordpress/element';
 
@@ -95,8 +99,7 @@ export function getDuotonePresetFromColors( colors, duotonePalette ) {
 	return preset ? `var:preset|duotone|${ preset.slug }` : undefined;
 }
 
-function DuotonePanel( { attributes, setAttributes, name } ) {
-	const style = attributes?.style;
+function DuotonePanelPure( { style, setAttributes, name } ) {
 	const duotoneStyle = style?.color?.duotone;
 	const settings = useBlockSettings( name );
 	const blockEditingMode = useBlockEditingMode();
@@ -176,6 +179,8 @@ function DuotonePanel( { attributes, setAttributes, name } ) {
 	);
 }
 
+const DuotonePanel = pure( DuotonePanelPure );
+
 /**
  * Filters registered block settings, extending attributes to include
  * the `duotone` attribute.
@@ -227,7 +232,14 @@ const withDuotoneControls = createHigherOrderComponent(
 		// performance.
 		return (
 			<>
-				{ hasDuotoneSupport && <DuotonePanel { ...props } /> }
+				{ hasDuotoneSupport && (
+					<DuotonePanel
+						// This component is pure, so only pass needed props!
+						style={ props.attributes.style }
+						setAttributes={ props.setAttributes }
+						name={ props.name }
+					/>
+				) }
 				<BlockEdit { ...props } />
 			</>
 		);

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -179,6 +179,9 @@ function DuotonePanelPure( { style, setAttributes, name } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const DuotonePanel = pure( DuotonePanelPure );
 
 /**

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -6,7 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
+import {
+	createHigherOrderComponent,
+	pure,
+	useInstanceId,
+} from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
@@ -133,12 +137,11 @@ export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 	return css;
 }
 
-function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
+function LayoutPanelPure( { layout, setAttributes, name: blockName } ) {
 	const settings = useBlockSettings( blockName );
 	// Block settings come from theme.json under settings.[blockName].
 	const { layout: layoutSettings } = settings;
 	// Layout comes from block attributes.
-	const { layout } = attributes;
 	const [ defaultThemeLayout ] = useSettings( 'layout' );
 	const { themeSupportsLayout } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
@@ -287,6 +290,8 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	);
 }
 
+const LayoutPanel = pure( LayoutPanelPure );
+
 function LayoutTypeSwitcher( { type, onChange } ) {
 	return (
 		<ButtonGroup>
@@ -340,7 +345,14 @@ export const withLayoutControls = createHigherOrderComponent(
 		const supportLayout = hasLayoutBlockSupport( props.name );
 
 		return [
-			supportLayout && <LayoutPanel key="layout" { ...props } />,
+			supportLayout && (
+				<LayoutPanel
+					key="layout"
+					layout={ props.attributes.layout }
+					setAttributes={ props.setAttributes }
+					name={ props.name }
+				/>
+			),
 			<BlockEdit key="edit" { ...props } />,
 		];
 	},

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -348,6 +348,7 @@ export const withLayoutControls = createHigherOrderComponent(
 			supportLayout && (
 				<LayoutPanel
 					key="layout"
+					// This component is pure, so only pass needed props!
 					layout={ props.attributes.layout }
 					setAttributes={ props.setAttributes }
 					name={ props.name }

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -290,6 +290,9 @@ function LayoutPanelPure( { layout, setAttributes, name: blockName } ) {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const LayoutPanel = pure( LayoutPanelPure );
 
 function LayoutTypeSwitcher( { type, onChange } ) {

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -12,7 +12,11 @@ import {
 	BaseControl,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
+import {
+	createHigherOrderComponent,
+	pure,
+	useInstanceId,
+} from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useMemo, Platform } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
@@ -207,14 +211,12 @@ export function useIsPositionDisabled( { name: blockName } = {} ) {
  *
  * @return {Element} Position panel.
  */
-export function PositionPanel( props ) {
-	const {
-		attributes: { style = {} },
-		clientId,
-		name: blockName,
-		setAttributes,
-	} = props;
-
+export function PositionPanelPure( {
+	style = {},
+	clientId,
+	name: blockName,
+	setAttributes,
+} ) {
 	const allowFixed = hasFixedPositionSupport( blockName );
 	const allowSticky = hasStickyPositionSupport( blockName );
 	const value = style?.position?.type;
@@ -316,6 +318,8 @@ export function PositionPanel( props ) {
 	} );
 }
 
+const PositionPanel = pure( PositionPanelPure );
+
 /**
  * Override the default edit UI to include position controls.
  *
@@ -335,7 +339,14 @@ export const withPositionControls = createHigherOrderComponent(
 
 		return [
 			showPositionControls && (
-				<PositionPanel key="position" { ...props } />
+				<PositionPanel
+					key="position"
+					// This component is pure, so only pass needed props!
+					style={ props.attributes.style }
+					name={ blockName }
+					setAttributes={ props.setAttributes }
+					clientId={ props.clientId }
+				/>
 			),
 			<BlockEdit key="edit" { ...props } />,
 		];

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -318,6 +318,9 @@ export function PositionPanelPure( {
 	} );
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 const PositionPanel = pure( PositionPanelPure );
 
 /**

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -153,6 +153,9 @@ function TypographyPanelPure( {
 	);
 }
 
+// We don't want block controls to re-render when typing inside a block. `pure`
+// will prevent re-renders unless props change, so only pass the needed props
+// and not the whole attributes object.
 export const TypographyPanel = pure( TypographyPanelPure );
 
 export const hasTypographySupport = ( blockName ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A continuation of #56783, which is relevant for all controls added by all hooks: don't re-render panels/controls when irrelevant attributes change, especially content attributes.

Edit: even for paragraph it seems to shave off a couple of %, perhaps because of the content locking and/or anchor/block renaming?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
