### PR TITLE
Pattern inserter: fix Broken preview layout

### DIFF
--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -7,7 +7,6 @@
 	// The preview component measures the pixel width of this item, so as to calculate the scale factor.
 	// But without this baseline width, it collapses to 0.
 	width: 100%;
-	height: 100%;
 
 	overflow: hidden;
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -229,6 +229,10 @@ $block-inserter-tabs-height: 44px;
 		display: block;
 	}
 
+	.block-editor-block-preview__container {
+		height: 100%;
+	}
+
 	.block-editor-block-card {
 		padding-left: 0;
 		padding-right: 0;


### PR DESCRIPTION
Fixes #56812
Related to #56011

## What?

This PR fixes an issue where the pattern layout is broken in the main inserter and quick inserter.

![patterns-inserter](https://github.com/WordPress/gutenberg/assets/54422211/76673c78-9621-4132-8ca6-510548f41d88)
![quick-inserter](https://github.com/WordPress/gutenberg/assets/54422211/09b57e60-adf6-44bc-a7e6-ede8e1faf955)

## Why?
In #56011, the following styles have been added to center the block in the block preview vertically.

```css
.block-editor-block-preview__container {
  height: 100%;
}
```

However, this selector also affects the pattern preview in the pattern list.

The pattern preview consists of the following hierarchy.

```html
<div class="block-editor-block-patterns-list__list-item">
	<div class="block-editor-block-patterns-list__item">
		<div class="block-editor-block-preview__container"> // ← has `height:100%`
			<div class="block-editor-block-preview__content">
				<iframe />
			</div>
		</div>
		<div class="block-editor-patterns__pattern-details">Pattern Name</div>
	</div>
</div>
```

If the preview element (`.block-editor-block-preview__container`) has a height of 100%, the element will extend to the full height of the parent element, and the pattern name (`.block-editor-patterns__pattern-details`) that exists in parallel will jump out from the parent element.

## How?

Applies `height:100%` style to the block preview and the block style preview only (`.block-editor-inserter__preview-container .block-editor-block-preview__container`).

## Testing Instructions

- Open the editor.
- Enter characters in the main inserter search box.
- Check the displayed pattern layout.
- Open the editor.
- Enter characters in the quick inserter search box.
- Check the displayed pattern layout.
- Make sure that the block is centered vertically in the preview that appears when you hover over the block from the main inserter.
- Inserts a block with block style.
- From the block sidebar, hover over the block style.
- Check that the block is centered vertically in the preview.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/66de014e-56c7-4200-860e-fee5b7bc84fd


