### PR TITLE
Doc: Search Control - add Storybook link

### DIFF
--- a/packages/components/src/search-control/README.md
+++ b/packages/components/src/search-control/README.md
@@ -8,7 +8,7 @@ SearchControl components let users display a search control.
 1. [Development guidelines](#development-guidelines)
 2. [Related components](#related-components)
 
-Check out also the [Storybook page](https://wordpress.github.io/gutenberg/?path=/docs/components-searchcontrol--docs) for a visual exploration of this component.
+Check out the [Storybook page](https://wordpress.github.io/gutenberg/?path=/docs/components-searchcontrol--docs) for a visual exploration of this component.
 
 ## Development guidelines
 

--- a/packages/components/src/search-control/README.md
+++ b/packages/components/src/search-control/README.md
@@ -8,6 +8,8 @@ SearchControl components let users display a search control.
 1. [Development guidelines](#development-guidelines)
 2. [Related components](#related-components)
 
+Check out also the [Storybook page for this component](https://wordpress.github.io/gutenberg/?path=/docs/components-searchcontrol--docs) a visual exploration
+
 ## Development guidelines
 
 ### Usage

--- a/packages/components/src/search-control/README.md
+++ b/packages/components/src/search-control/README.md
@@ -8,7 +8,7 @@ SearchControl components let users display a search control.
 1. [Development guidelines](#development-guidelines)
 2. [Related components](#related-components)
 
-Check out also the [Storybook page for this component](https://wordpress.github.io/gutenberg/?path=/docs/components-searchcontrol--docs) a visual exploration
+Check out also the [Storybook page](https://wordpress.github.io/gutenberg/?path=/docs/components-searchcontrol--docs) for a visual exploration of this component.
 
 ## Development guidelines
 


### PR DESCRIPTION
## What?
[Documentation page for Search Control ](https://developer.wordpress.org/block-editor/reference-guides/components/search-control/) is linked in [Data Layer Course](https://learn.wordpress.org/course/using-the-wordpress-data-layer/) on Learn.WordPress and need a link to the Storybook space. 

## Why?
It would help a learner to know about Storybook space for more visual exploration of components. 

## How?
added the link to the readme.md for the component

## Testing Instructions
Use the View file feature
