### PR TITLE
Editor: Cleanup default editor mode handling

### DIFF
--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -9,7 +9,7 @@ import {
 	store as editorStore,
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -141,12 +141,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		updatePreferredStyleVariations,
 		keepCaretInsideBlock,
 	] );
-
-	// The default mode of the post editor is "post-only" mode.
-	const { setRenderingMode } = useDispatch( editorStore );
-	useEffect( () => {
-		setRenderingMode( 'post-only' );
-	}, [ setRenderingMode ] );
 
 	if ( ! post ) {
 		return null;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -29,7 +29,6 @@ import {
 } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -149,7 +148,6 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 			),
 		};
 	}, [] );
-	const { setRenderingMode } = useDispatch( editorStore );
 
 	const isViewMode = canvasMode === 'view';
 	const isEditMode = canvasMode === 'edit';
@@ -191,16 +189,6 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 		! isLoading &&
 		( ( postWithTemplate && !! contextPost && !! editedPost ) ||
 			( ! postWithTemplate && !! editedPost ) );
-
-	// This is the only reliable way I've found to reinitialize the rendering mode
-	// when the canvas mode or the edited entity changes.
-	useEffect( () => {
-		if ( canvasMode === 'edit' && postWithTemplate ) {
-			setRenderingMode( 'template-locked' );
-		} else {
-			setRenderingMode( 'all' );
-		}
-	}, [ canvasMode, postWithTemplate, setRenderingMode ] );
 
 	return (
 		<>

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -199,6 +199,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			updateEditorSettings,
 			__experimentalTearDownEditor,
 			setCurrentTemplateId,
+			setRenderingMode,
 		} = unlock( useDispatch( editorStore ) );
 		const { createWarningNotice } = useDispatch( noticesStore );
 
@@ -242,6 +243,11 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		useEffect( () => {
 			setCurrentTemplateId( template?.id );
 		}, [ template?.id, setCurrentTemplateId ] );
+
+		// Sets the right rendering mode when loading the editor.
+		useEffect( () => {
+			setRenderingMode( settings.defaultRenderingMode ?? 'post-only' );
+		}, [ settings.defaultRenderingMode, setRenderingMode ] );
 
 		if ( ! isReady ) {
 			return null;


### PR DESCRIPTION
Follow-up to #56778 

## What?

Just a small cleanup function, now that we have a setting that indicates the "default editor mode". I believe the "EditorProvider" should set that mode when the setting changes. This allows us to remove some effects from the initialization code of both post and site editors.

## Testing instructions

Just ensure that opening the edit templates, template parts, pages... in the site editor lands you in the right mode (you can only edit the right things) 