### PR TITLE
Unification of labels in global style settings to singular form

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -435,7 +435,7 @@ export default function ColorPanel( {
 	const elements = [
 		{
 			name: 'caption',
-			label: __( 'Captions' ),
+			label: __( 'Caption' ),
 			showPanel: useHasCaptionPanel( settings ),
 		},
 		{

--- a/packages/edit-site/src/components/global-styles/screen-typography-element.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography-element.js
@@ -23,19 +23,19 @@ const elements = {
 	},
 	link: {
 		description: __( 'Manage the fonts and typography used on the links.' ),
-		title: __( 'Links' ),
+		title: __( 'Link' ),
 	},
 	heading: {
 		description: __( 'Manage the fonts and typography used on headings.' ),
-		title: __( 'Headings' ),
+		title: __( 'Heading' ),
 	},
 	caption: {
 		description: __( 'Manage the fonts and typography used on captions.' ),
-		title: __( 'Captions' ),
+		title: __( 'Caption' ),
 	},
 	button: {
 		description: __( 'Manage the fonts and typography used on buttons.' ),
-		title: __( 'Buttons' ),
+		title: __( 'Button' ),
 	},
 };
 

--- a/packages/edit-site/src/components/global-styles/typogrphy-elements.js
+++ b/packages/edit-site/src/components/global-styles/typogrphy-elements.js
@@ -85,22 +85,22 @@ function TypographyElements() {
 				<ElementItem
 					parentMenu={ parentMenu }
 					element="link"
-					label={ __( 'Links' ) }
+					label={ __( 'Link' ) }
 				/>
 				<ElementItem
 					parentMenu={ parentMenu }
 					element="heading"
-					label={ __( 'Headings' ) }
+					label={ __( 'Heading' ) }
 				/>
 				<ElementItem
 					parentMenu={ parentMenu }
 					element="caption"
-					label={ __( 'Captions' ) }
+					label={ __( 'Caption' ) }
 				/>
 				<ElementItem
 					parentMenu={ parentMenu }
 					element="button"
-					label={ __( 'Buttons' ) }
+					label={ __( 'Button' ) }
 				/>
 			</ItemGroup>
 		</VStack>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
#56733
To resolve mixed plural and singular forms in global styling setting's labels.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I felt uncomfortable with the mixing of plural and singular forms.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I have unified it into singular form.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Dashboard → Appearance → Editor
2. Styles → Edit styles（Pencil Icon）
3. Typography  or Colors from right panel
4. Visually check that each label is unified into a singular form and that plural forms are not mixed.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/1205958/083958ec-472b-4523-b805-79eb0a813963)
![image](https://github.com/WordPress/gutenberg/assets/1205958/f1062a7d-7c7d-4898-8620-28462be4d74f)

![image](https://github.com/WordPress/gutenberg/assets/1205958/1c673c84-35e7-4fbf-ae3c-6d42bfab808b)
