### PR TITLE
Keycodes: avoid regex for capital case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55865,8 +55865,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "file:../i18n",
-				"change-case": "^4.1.2"
+				"@wordpress/i18n": "file:../i18n"
 			},
 			"engines": {
 				"node": ">=12"
@@ -70957,8 +70956,7 @@
 			"version": "file:packages/keycodes",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "file:../i18n",
-				"change-case": "^4.1.2"
+				"@wordpress/i18n": "file:../i18n"
 			}
 		},
 		"@wordpress/lazy-import": {

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -898,7 +898,7 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
               class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
             >
               <kbd
-                aria-label="Shift + Alt + 1 6"
+                aria-label="Shift + Alt + 1-6"
                 class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
               >
                 <kbd

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -28,8 +28,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"@wordpress/i18n": "file:../i18n",
-		"change-case": "^4.1.2"
+		"@wordpress/i18n": "file:../i18n"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -10,11 +10,6 @@
  */
 
 /**
- * External dependencies
- */
-import { capitalCase } from 'change-case';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -149,6 +144,17 @@ export const ZERO = 48;
 export { isAppleOS };
 
 /**
+ * Capitalise the first character of a string.
+ * @param {string} string String to capitalise.
+ * @return {string} Capitalised string.
+ */
+function capitaliseFirstCharacter( string ) {
+	return string.length < 2
+		? string.toUpperCase()
+		: string.charAt( 0 ).toUpperCase() + string.slice( 1 );
+}
+
+/**
  * Map the values of an object with a specified callback and return the result object.
  *
  * @template {{ [s: string]: any; } | ArrayLike<any>} T
@@ -260,14 +266,7 @@ export const displayShortcutList = mapValues(
 				/** @type {string[]} */ ( [] )
 			);
 
-			// Symbols (~`,.) are removed by the default regular expression,
-			// so override the rule to allow symbols used for shortcuts.
-			// see: https://github.com/blakeembrey/change-case#options
-			const capitalizedCharacter = capitalCase( character, {
-				stripRegexp: /[^A-Z0-9~`,\.\\\-]/gi,
-			} );
-
-			return [ ...modifierKeys, capitalizedCharacter ];
+			return [ ...modifierKeys, capitaliseFirstCharacter( character ) ];
 		};
 	}
 );
@@ -335,7 +334,7 @@ export const shortcutAriaLabel = mapValues(
 
 			return [ ...modifier( _isApple ), character ]
 				.map( ( key ) =>
-					capitalCase( replacementKeyMap[ key ] ?? key )
+					capitaliseFirstCharacter( replacementKeyMap[ key ] ?? key )
 				)
 				.join( isApple ? ' ' : ' + ' );
 		};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I saw `capitalCase` pop up in the performance graph, probably because of the regex, so I thought I'd quickly address it. It seems way overkill to pull in a package for this, and add a regex on top of that. Let's just use `toUpperCase`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
