### PR TITLE
Change the label name for the Font Selector from 'Font' to 'Font Family'

### DIFF
--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -35,7 +35,7 @@ export default function FontFamilyControl( {
 	];
 	return (
 		<SelectControl
-			label={ __( 'Font' ) }
+			label={ __( 'Font Family' ) }
 			options={ options }
 			value={ value }
 			onChange={ onChange }

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -35,7 +35,7 @@ export default function FontFamilyControl( {
 	];
 	return (
 		<SelectControl
-			label={ __( 'Font Family' ) }
+			label={ __( 'Font family' ) }
 			options={ options }
 			value={ value }
 			onChange={ onChange }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Change the label name for the Font Selector from 'Font' to 'Font Family'

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

https://github.com/WordPress/gutenberg/issues/56374

For clarity and ease of use, it would be better to align this label with the dropdown display name used in the Typography UI.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add new post
2. Select pagraph block and so on
3. Open style panel
4. Change font family

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1237" alt="スクリーンショット 2023-12-06 23 11 05" src="https://github.com/WordPress/gutenberg/assets/3272660/7a5f1f6b-e7b3-4856-9b20-7603e26cdcdb">

