### PR TITLE
Codify editor focus mode concept

### DIFF
--- a/packages/edit-site/src/components/block-editor/back-button.js
+++ b/packages/edit-site/src/components/block-editor/back-button.js
@@ -5,26 +5,29 @@ import { Button } from '@wordpress/components';
 import { arrowLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import {
-	TEMPLATE_PART_POST_TYPE,
-	NAVIGATION_POST_TYPE,
-} from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
+import { store as editSiteStore } from '../../store';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 function BackButton() {
 	const location = useLocation();
 	const history = useHistory();
-	const isTemplatePart = location.params.postType === TEMPLATE_PART_POST_TYPE;
-	const isNavigationMenu = location.params.postType === NAVIGATION_POST_TYPE;
+
 	const previousTemplateId = location.state?.fromTemplateId;
 
-	const isFocusMode = isTemplatePart || isNavigationMenu;
+	const { isFocusMode } = useSelect( ( select ) => {
+		const { isEntityFocusMode } = unlock( select( editSiteStore ) );
+
+		return {
+			isFocusMode: isEntityFocusMode(),
+		};
+	}, [] );
 
 	if ( ! isFocusMode || ! previousTemplateId ) {
 		return null;

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -22,10 +22,7 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
  */
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
-import {
-	FOCUSABLE_ENTITIES,
-	NAVIGATION_POST_TYPE,
-} from '../../utils/constants';
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 
 const { ExperimentalBlockCanvas: BlockCanvas } = unlock(
 	blockEditorPrivateApis
@@ -53,12 +50,13 @@ function EditorCanvas( {
 			getEditedPostType,
 			__experimentalGetPreviewDeviceType,
 			getCanvasMode,
+			isEntityFocusMode,
 		} = unlock( select( editSiteStore ) );
 		const _templateType = getEditedPostType();
 
 		return {
 			templateType: _templateType,
-			isFocusMode: FOCUSABLE_ENTITIES.includes( _templateType ),
+			isFocusMode: isEntityFocusMode(),
 			deviceType: __experimentalGetPreviewDeviceType(),
 			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
 			canvasMode: getCanvasMode(),
@@ -93,6 +91,7 @@ function EditorCanvas( {
 	};
 	const isTemplateTypeNavigation = templateType === NAVIGATION_POST_TYPE;
 	const isNavigationFocusMode = isTemplateTypeNavigation && isFocusMode;
+
 	// Hide the appender when:
 	// - In navigation focus mode (should only allow the root Nav block).
 	// - In view mode (i.e. not editing).

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -41,14 +41,12 @@ import {
 	useHasEditorCanvasContainer,
 } from '../editor-canvas-container';
 import { unlock } from '../../lock-unlock';
-import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
 const { BlockContextualToolbar } = unlock( blockEditorPrivateApis );
 
 export default function HeaderEditMode( { setListViewToggleElement } ) {
 	const {
 		deviceType,
-		templateType,
 		isDistractionFree,
 		blockEditorMode,
 		blockSelectionStart,
@@ -57,11 +55,14 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 		editorCanvasView,
 		hasFixedToolbar,
 		isZoomOutMode,
+		isFocusMode,
 	} = useSelect( ( select ) => {
 		const { __experimentalGetPreviewDeviceType, getEditedPostType } =
 			select( editSiteStore );
 		const { getBlockSelectionStart, __unstableGetEditorMode } =
 			select( blockEditorStore );
+
+		const { isEntityFocusMode } = unlock( select( editSiteStore ) );
 
 		const postType = getEditedPostType();
 
@@ -93,6 +94,7 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 				'distractionFree'
 			),
 			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+			isFocusMode: isEntityFocusMode(),
 		};
 	}, [] );
 
@@ -105,8 +107,6 @@ export default function HeaderEditMode( { setListViewToggleElement } ) {
 	const disableMotion = useReducedMotion();
 
 	const hasDefaultEditorCanvasView = ! useHasEditorCanvasContainer();
-
-	const isFocusMode = FOCUSABLE_ENTITIES.includes( templateType );
 
 	const isZoomedOutView = blockEditorMode === 'zoom-out';
 

--- a/packages/edit-site/src/store/private-selectors.js
+++ b/packages/edit-site/src/store/private-selectors.js
@@ -1,4 +1,11 @@
 /**
+ * Internal dependencies
+ */
+import { FOCUSABLE_ENTITIES } from '../utils/constants';
+
+import { getEditedPostType } from './selectors';
+
+/**
  * Returns the current canvas mode.
  *
  * @param {Object} state Global application state.
@@ -18,4 +25,9 @@ export function getCanvasMode( state ) {
  */
 export function getEditorCanvasContainerView( state ) {
 	return state.editorCanvasContainerView;
+}
+
+export function isEntityFocusMode( state ) {
+	const postType = getEditedPostType( state );
+	return FOCUSABLE_ENTITIES.includes( postType );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Codifies the concept of "focus mode" by implementing a selector which you can call to determine whether the editor is in focus mode.

"Focus mode" means the different layout and visual state the editor moves to when editing a particular post instance, for example:

- a Navigation Menu
- a Template Part
- a Synced Pattern

**Note**: the name "focus mode" feels a little vague. There are far too many "modes" floating around. I'm open to better suggestions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Templates are becoming littered with inline calls to check for this concept. The odd call was acceptable but the proliferation of this concept means it's now time to codify it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Implements an experimental selector to determine whether the editor is in focus mode.

There's no need for new state because focus mode is determine purely by whether we are editing an individual post type.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Edit the following entities in the editor and see if everything functions as per `trunk`.
    - Navigation Menu
    - Template Part
    - Synced Pattern

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
