### PR TITLE
Patterns: End pattern page descriptions with a period

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
@@ -95,7 +95,7 @@ export default function usePatternCategories() {
 		sortedCategories.unshift( {
 			name: PATTERN_DEFAULT_CATEGORY,
 			label: __( 'All patterns' ),
-			description: __( 'A list of all patterns from all sources' ),
+			description: __( 'A list of all patterns from all sources.' ),
 			count: themePatterns.length + userPatterns.length,
 		} );
 


### PR DESCRIPTION
## What?

This PR ends the description with a period on the site editor's pattern page.

## Why?

To increase copy consistency.

## Testing Instructions

No code impact.

## Screenshots or screencast <!-- if applicable -->

![patterns](https://github.com/WordPress/gutenberg/assets/54422211/d407e4ad-5385-482b-ae00-a711b70fb01b)
