### PR TITLE
Simplify page list edit warning

### DIFF
--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -8,7 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
 
 export const convertDescription = createInterpolateElement(
 	__(
-		"The page list displays your site's published pages. If you choose to independently edit, your navigation will no longer <em>automatically</em> update when your pages change."
+		"This menu is currently displaying your website's pages. Editing it will allow you to add, delete, or reorder pages, but new pages will no longer be <em>automatically</em> added to this navigation."
 	),
 	{
 		em: <em />,

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -4,8 +4,15 @@
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export const convertDescription = __(
-	'This page list is synced with the published pages on your site. Detach the page list to add, delete, or reorder pages yourself.'
+import { createInterpolateElement } from '@wordpress/element';
+
+export const convertDescription = createInterpolateElement(
+	__(
+		"The page list displays your site's published pages. If you choose to independently edit, your navigation will no longer <em>automatically</em> update when your pages change."
+	),
+	{
+		em: <em />,
+	}
 );
 
 export function ConvertToLinksModal( { onClick, onClose, disabled } ) {

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -37,7 +37,7 @@ export function ConvertToLinksModal( { onClick, onClose, disabled } ) {
 					disabled={ disabled }
 					onClick={ onClick }
 				>
-					{ __( 'Detach' ) }
+					{ __( 'Edit' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -4,15 +4,8 @@
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-import { createInterpolateElement } from '@wordpress/element';
-
-export const convertDescription = createInterpolateElement(
-	__(
-		"This navigation menu is currently displaying your website's pages. Editing it will allow you to add, delete, or reorder pages, but new pages will no longer be <em>automatically</em> added."
-	),
-	{
-		em: <em />,
-	}
+export const convertDescription = __(
+	"The navigation menu displays your website's pages. Editing it will enable you to add, delete, or reorder pages. However, new pages will no longer be added automatically."
 );
 
 export function ConvertToLinksModal( { onClick, onClose, disabled } ) {

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -5,7 +5,7 @@ import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export const convertDescription = __(
-	"The navigation menu displays your website's pages. Editing it will enable you to add, delete, or reorder pages. However, new pages will no longer be added automatically."
+	"This navigation menu displays your website's pages. Editing it will enable you to add, delete, or reorder pages. However, new pages will no longer be added automatically."
 );
 
 export function ConvertToLinksModal( { onClick, onClose, disabled } ) {

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -8,7 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
 
 export const convertDescription = createInterpolateElement(
 	__(
-		"This menu is currently displaying your website's pages. Editing it will allow you to add, delete, or reorder pages, but new pages will no longer be <em>automatically</em> added to this navigation."
+		"This navigation menu is currently displaying your website's pages. Editing it will allow you to add, delete, or reorder pages, but new pages will no longer be <em>automatically</em> added."
 	),
 	{
 		em: <em />,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Simplifies the wording of the modal that appears once you "Edit" a Page List block inside a Navigation block.

I'm totally open to alternative suggestions, but we need something that is succinct and avoids technically complex words.

Closes https://github.com/WordPress/gutenberg/issues/54625

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the wording is very technical and can be hard to appreciate what will happen when you click affirmative.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses more user-facing terminology that is more specific to Navigation Menus.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Create a Navigation block containing a Page List - I did this by:
    - go to Post Editor
    - switch editor to Code View
    - Paste in the following:
```
<!-- wp:navigation -->
<!-- wp:page-list /-->
<!-- /wp:navigation -->
```
    - Return to visual mode and see Nav block with Page List
- Toggle List view to open and select the Page List _inside_ the Navigation block.
- Go to the block toolbar and find the "Edit" button.
- Click it.
- See Modal appear with new text.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="496" alt="Screenshot 2023-12-06 at 15 05 26" src="https://github.com/WordPress/gutenberg/assets/444434/23225ada-07be-440d-a7e8-28e89debc7de">


