### PR TITLE
Fix wrong type for `receiveNavigationFallbackId`

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -733,7 +733,7 @@ Returns an action object signalling that the fallback Navigation Menu id has bee
 
 _Parameters_
 
--   _fallbackId_ `integer`: the id of the fallback Navigation Menu
+-   _fallbackId_ `number`: the id of the fallback Navigation Menu
 
 _Returns_
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -242,7 +242,7 @@ Returns an action object signalling that the fallback Navigation Menu id has bee
 
 _Parameters_
 
--   _fallbackId_ `integer`: the id of the fallback Navigation Menu
+-   _fallbackId_ `number`: the id of the fallback Navigation Menu
 
 _Returns_
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -908,7 +908,7 @@ export function receiveAutosaves( postId, autosaves ) {
  * Returns an action object signalling that the fallback Navigation
  * Menu id has been received.
  *
- * @param {integer} fallbackId the id of the fallback Navigation Menu
+ * @param {number} fallbackId the id of the fallback Navigation Menu
  * @return {Object} Action object.
  */
 export function receiveNavigationFallbackId( fallbackId ) {


### PR DESCRIPTION
The `integer` type does not exists on TypeScript.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixing TypeScript type for the function `receiveNavigationFallbackId` where the type for the `fallbackId` is specified as `integer` but it shall be `number` since the former does not exists in TypeScript.

## Why?
Correctly type the function

## How?
Correct the function signature

## Testing Instructions
Nothing to specify

### Testing Instructions for Keyboard
Nothing to specify

## Screenshots or screencast <!-- if applicable -->
