### PR TITLE
copy/fix capitalization of WordPress

### DIFF
--- a/docs/getting-started/fundamentals/javascript-in-the-block-editor.md
+++ b/docs/getting-started/fundamentals/javascript-in-the-block-editor.md
@@ -44,7 +44,7 @@ Use [`enqueue_block_editor_assets`](https://developer.wordpress.org/reference/ho
 
 - [Get started with wp-scripts](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-scripts/) 
 - [Enqueueing assets in the Editor](https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/) 
-- [Wordpress Packages handles](https://developer.wordpress.org/block-editor/contributors/code/scripts/) 
+- [WordPress Packages handles](https://developer.wordpress.org/block-editor/contributors/code/scripts/) 
 - [Javascript Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript) | MDN Web Docs
 - [block-development-examples](https://github.com/WordPress/block-development-examples) | GitHub repository
 - [block-theme-examples](https://github.com/wptrainingteam/block-theme-examples) | GitHub repository

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2140,7 +2140,7 @@ describe( 'Post types', () => {
 describe( 'Rich link previews', () => {
 	const selectedLink = {
 		id: '1',
-		title: 'Wordpress.org', // Customize this for differentiation in assertions.
+		title: 'WordPress.org', // Customize this for differentiation in assertions.
 		url: 'https://www.wordpress.org',
 		type: 'URL',
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7831341</samp>

### Summary
📝🖊️🐛

<!--
1.  📝 This emoji can be used to indicate a minor text or documentation edit, such as fixing a typo or capitalizing a word.
2.  🖊️ This emoji can be used to indicate a more significant text or documentation edit, such as rewriting a sentence or adding a new section.
3.  🐛 This emoji can be used to indicate a bug fix or a code improvement, such as correcting a variable name or updating a function.
-->
This pull request fixes a minor typo in the documentation of the block editor, by capitalizing `WordPress` correctly in two files: `docs/getting-started/fundamentals/javascript-in-the-block-editor.md` and `packages/block-editor/src/components/link-control/test/index.js`.

> _`WordPress` is right_
> _Capitalizing the name_
> _Shows respect in spring_

### Walkthrough
* Capitalize `Wordpress` to `WordPress` in documentation and code examples ([link](https://github.com/WordPress/gutenberg/pull/56834/files?diff=unified&w=0#diff-75754153b4b07dc3f9bc539b4ddd9b50a963d495a8931fbc50d1a1cc03023efdL47-R47), [link](https://github.com/WordPress/gutenberg/pull/56834/files?diff=unified&w=0#diff-f133ef8bc484506e19d14be3b9f281b93b657b7fc472b757569e9b3548329483L2143-R2143))

