### PR TITLE
Revert "feat: Add Hook to monitor network connectivity status"

### DIFF
--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -60,10 +60,6 @@ public interface GutenbergBridgeJS2Parent extends RequestExecutor {
         void onRequestBlockTypeImpressions(ReadableMap impressions);
     }
 
-    interface ConnectionStatusCallback {
-        void onRequestConnectionStatus(boolean isConnected);
-    }
-
     // Ref: https://github.com/facebook/react-native/blob/HEAD/Libraries/polyfills/console.js#L376
     enum LogLevel {
         TRACE(0),
@@ -187,6 +183,4 @@ public interface GutenbergBridgeJS2Parent extends RequestExecutor {
     void toggleUndoButton(boolean isDisabled);
 
     void toggleRedoButton(boolean isDisabled);
-
-    void requestConnectionStatus(ConnectionStatusCallback connectionStatusCallback);
 }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -23,7 +23,6 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
-import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.ConnectionStatusCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaType;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.OtherMediaOptionsReceivedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.FocalPointPickerTooltipShownCallback;
@@ -85,8 +84,6 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final String MAP_KEY_REPLACE_BLOCK_BLOCK_ID = "clientId";
 
     public static final String MAP_KEY_FEATURED_IMAGE_ID = "featuredImageId";
-
-    public static final String MAP_KEY_IS_CONNECTED = "isConnected";
 
     private boolean mIsDarkMode;
 
@@ -535,19 +532,5 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
                 vibrator.vibrate(tickEffect);
             }
         }
-    }
-
-    @ReactMethod
-    public void requestConnectionStatus(final Callback jsCallback) {
-        ConnectionStatusCallback connectionStatusCallback = requestConnectionStatusCallback(jsCallback);
-        mGutenbergBridgeJS2Parent.requestConnectionStatus(connectionStatusCallback);
-    }
-
-    private ConnectionStatusCallback requestConnectionStatusCallback(final Callback jsCallback) {
-        return new GutenbergBridgeJS2Parent.ConnectionStatusCallback() {
-            @Override public void onRequestConnectionStatus(boolean isConnected) {
-                jsCallback.invoke(isConnected);
-            }
-        };
     }
 }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/DeferredEventEmitter.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/DeferredEventEmitter.java
@@ -15,7 +15,6 @@ import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.wordpress.mobile.ReactNativeGutenbergBridge.RNReactNativeGutenbergBridgeModule.MAP_KEY_IS_CONNECTED;
 import static org.wordpress.mobile.ReactNativeGutenbergBridge.RNReactNativeGutenbergBridgeModule.MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_ID;
 import static org.wordpress.mobile.ReactNativeGutenbergBridge.RNReactNativeGutenbergBridgeModule.MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_NEW_ID;
 import static org.wordpress.mobile.ReactNativeGutenbergBridge.RNReactNativeGutenbergBridgeModule.MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_URL;
@@ -44,8 +43,6 @@ public class DeferredEventEmitter implements MediaUploadEventEmitter, MediaSaveE
     private static final String EVENT_NAME_MEDIA_REPLACE_BLOCK = "replaceBlock";
 
     private static final String EVENT_FEATURED_IMAGE_ID_NATIVE_UPDATED = "featuredImageIdNativeUpdated";
-
-    private static final String EVENT_CONNECTION_STATUS_CHANGE = "connectionStatusChange";
 
     private static final String MAP_KEY_MEDIA_FILE_STATE = "state";
     private static final String MAP_KEY_MEDIA_FILE_MEDIA_ACTION_PROGRESS = "progress";
@@ -223,12 +220,6 @@ public class DeferredEventEmitter implements MediaUploadEventEmitter, MediaSaveE
         WritableMap writableMap = new WritableNativeMap();
         writableMap.putInt(MAP_KEY_FEATURED_IMAGE_ID, mediaId);
         queueActionToJS(EVENT_FEATURED_IMAGE_ID_NATIVE_UPDATED, writableMap);
-    }
-
-    public void onConnectionStatusChange(boolean isConnected) {
-        WritableMap writableMap = new WritableNativeMap();
-        writableMap.putBoolean(MAP_KEY_IS_CONNECTED, isConnected);
-        queueActionToJS(EVENT_CONNECTION_STATUS_CHANGE, writableMap);
     }
 
     @Override public void onReplaceMediaFilesEditedBlock(String mediaFiles, String blockId) {

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -112,7 +112,6 @@ public class WPAndroidGlueCode {
     private OnToggleUndoButtonListener mOnToggleUndoButtonListener;
 
     private OnToggleRedoButtonListener mOnToggleRedoButtonListener;
-    private OnConnectionStatusEventListener mOnConnectionStatusEventListener;
     private boolean mIsEditorMounted;
 
     private String mContentHtml = "";
@@ -258,10 +257,6 @@ public class WPAndroidGlueCode {
 
     public interface OnToggleRedoButtonListener {
         void onToggleRedoButton(boolean isDisabled);
-    }
-
-    public interface OnConnectionStatusEventListener {
-        boolean onRequestConnectionStatus();
     }
 
     public void mediaSelectionCancelled() {
@@ -599,12 +594,6 @@ public class WPAndroidGlueCode {
             public void toggleRedoButton(boolean isDisabled) {
                 mOnToggleRedoButtonListener.onToggleRedoButton(isDisabled);
             }
-
-            @Override
-            public void requestConnectionStatus(ConnectionStatusCallback connectionStatusCallback) {
-                boolean isConnected = mOnConnectionStatusEventListener.onRequestConnectionStatus();
-                connectionStatusCallback.onRequestConnectionStatus(isConnected);
-            }
         }, mIsDarkMode);
 
         return Arrays.asList(
@@ -699,7 +688,6 @@ public class WPAndroidGlueCode {
                                   OnSendEventToHostListener onSendEventToHostListener,
                                   OnToggleUndoButtonListener onToggleUndoButtonListener,
                                   OnToggleRedoButtonListener onToggleRedoButtonListener,
-                                  OnConnectionStatusEventListener onConnectionStatusEventListener,
                                   boolean isDarkMode) {
         MutableContextWrapper contextWrapper = (MutableContextWrapper) mReactRootView.getContext();
         contextWrapper.setBaseContext(viewGroup.getContext());
@@ -725,7 +713,6 @@ public class WPAndroidGlueCode {
         mOnSendEventToHostListener = onSendEventToHostListener;
         mOnToggleUndoButtonListener = onToggleUndoButtonListener;
         mOnToggleRedoButtonListener = onToggleRedoButtonListener;
-        mOnConnectionStatusEventListener = onConnectionStatusEventListener;
 
         sAddCookiesInterceptor.setOnAuthHeaderRequestedListener(onAuthHeaderRequestedListener);
 
@@ -1160,10 +1147,6 @@ public class WPAndroidGlueCode {
 
     public void sendToJSFeaturedImageId(int mediaId) {
         mDeferredEventEmitter.sendToJSFeaturedImageId(mediaId);
-    }
-
-    public void connectionStatusChange(boolean isConnected) {
-        mDeferredEventEmitter.onConnectionStatusChange(isConnected);
     }
 
     public void replaceUnsupportedBlock(String content, String blockId) {

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -3,11 +3,6 @@
  */
 import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
 
-/**
- * WordPress dependencies
- */
-import { useEffect, useState } from '@wordpress/element';
-
 const { RNReactNativeGutenbergBridge } = NativeModules;
 const isIOS = Platform.OS === 'ios';
 const isAndroid = Platform.OS === 'android';
@@ -188,49 +183,6 @@ export function subscribeOnUndoPressed( callback ) {
 
 export function subscribeOnRedoPressed( callback ) {
 	return gutenbergBridgeEvents.addListener( 'onRedoPressed', callback );
-}
-
-export function useIsConnected() {
-	const [ isConnected, setIsConnected ] = useState( null );
-
-	useEffect( () => {
-		let isCurrent = true;
-
-		RNReactNativeGutenbergBridge.requestConnectionStatus(
-			( isBridgeConnected ) => {
-				if ( ! isCurrent ) {
-					return;
-				}
-
-				setIsConnected( isBridgeConnected );
-			}
-		);
-
-		return () => {
-			isCurrent = false;
-		};
-	}, [] );
-
-	useEffect( () => {
-		const subscription = subscribeConnectionStatus(
-			( { isConnected: isBridgeConnected } ) => {
-				setIsConnected( isBridgeConnected );
-			}
-		);
-
-		return () => {
-			subscription.remove();
-		};
-	}, [] );
-
-	return { isConnected };
-}
-
-function subscribeConnectionStatus( callback ) {
-	return gutenbergBridgeEvents.addListener(
-		'connectionStatusChange',
-		callback
-	);
 }
 
 /**

--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -210,11 +210,6 @@ public class Gutenberg: UIResponder {
         bridgeModule.sendEventIfNeeded(.onRedoPressed, body: nil)
     }
 
-    public func connectionStatusChange(isConnected: Bool) {
-        var data: [String: Any] = ["isConnected": isConnected]
-        bridgeModule.sendEventIfNeeded(.connectionStatusChange, body: data)
-    }
-
     private func properties(from editorSettings: GutenbergEditorSettings?) -> [String : Any] {
         var settingsUpdates = [String : Any]()
         settingsUpdates["isFSETheme"] = editorSettings?.isFSETheme ?? false

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -283,8 +283,6 @@ public protocol GutenbergBridgeDelegate: AnyObject {
     func gutenbergDidRequestToggleUndoButton(_ isDisabled: Bool)
     
     func gutenbergDidRequestToggleRedoButton(_ isDisabled: Bool)
-
-    func gutenbergDidRequestConnectionStatus() -> Bool
 }
 
 // MARK: - Optional GutenbergBridgeDelegate methods

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -42,6 +42,5 @@ RCT_EXTERN_METHOD(sendEventToHost:(NSString)eventName properties:(NSDictionary *
 RCT_EXTERN_METHOD(generateHapticFeedback)
 RCT_EXTERN_METHOD(toggleUndoButton:(BOOL)isDisabled)
 RCT_EXTERN_METHOD(toggleRedoButton:(BOOL)isDisabled)
-RCT_EXTERN_METHOD(requestConnectionStatus:(RCTResponseSenderBlock)callback)
 
 @end

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -421,11 +421,6 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     func toggleRedoButton(_ isDisabled: Bool) {
         self.delegate?.gutenbergDidRequestToggleRedoButton(isDisabled)
     }
-
-	@objc
-	func requestConnectionStatus(_ callback: @escaping RCTResponseSenderBlock) {
-		callback([self.delegate?.gutenbergDidRequestConnectionStatus() ?? true])
-	}
 }
 
 // MARK: - RCTBridgeModule delegate
@@ -455,7 +450,6 @@ extension RNReactNativeGutenbergBridge {
         case showEditorHelp
         case onUndoPressed
         case onRedoPressed
-        case connectionStatusChange
     }
 
     public override func supportedEvents() -> [String]! {

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -308,11 +308,6 @@ public class MainApplication extends Application implements ReactApplication, Gu
                     mainActivity.updateRedoItem(isDisabled);
                 }
             }
-
-            @Override
-            public void requestConnectionStatus(ConnectionStatusCallback connectionStatusCallback) {
-                connectionStatusCallback.onRequestConnectionStatus(true);
-            }
         }, isDarkMode());
 
         return new DefaultReactNativeHost(this) {

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -345,10 +345,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             }
         }
     }
-
-    func gutenbergDidRequestConnectionStatus() -> Bool {
-        return true
-    }
 }
 
 extension GutenbergViewController: GutenbergWebDelegate {


### PR DESCRIPTION
Reverts WordPress/gutenberg#56609 to avoid merging changes into the WordPress host app, as the app is frozen to new changes at the end of the calendar year. 

I will follow up with a PR to reintroduce these changes later. 