### PR TITLE
Global styles welcome guide: add a space between translated strings

### DIFF
--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -118,7 +118,7 @@ export default function WelcomeGuideStyles() {
 							<p className="edit-site-welcome-guide__text">
 								{ __(
 									'New to block themes and styling your site?'
-								) }
+								) }{ ' ' }
 								<ExternalLink
 									href={ __(
 										'https://wordpress.org/documentation/article/styles-overview/'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/56816

### Before

<img width="284" alt="Screenshot 2023-12-07 at 9 22 11 am" src="https://github.com/WordPress/gutenberg/assets/6458278/e4b2c92e-2ae6-4c2a-92a1-3662ebb775fe">


### After

<img width="281" alt="Screenshot 2023-12-07 at 9 21 50 am" src="https://github.com/WordPress/gutenberg/assets/6458278/a265470c-7256-4b15-8670-e03b983adea5">



## How?

`{ ' ' }`

## Testing Instructions

In the site editor, open up the welcome guide for global styles. 

Click on the styles icon in the right hand column and then, from the options menu, click on the **Welcome Guide**.

<img width="273" alt="Screenshot 2023-12-07 at 9 22 22 am" src="https://github.com/WordPress/gutenberg/assets/6458278/322676c1-c2ab-45b6-ae7c-ea83c83baf41">

The copy in question is on the fourth slide.


<img width="318" alt="Screenshot 2023-12-07 at 9 25 08 am" src="https://github.com/WordPress/gutenberg/assets/6458278/39072e53-151f-484b-834c-c9612fc14fb4">
