### PR TITLE
Editor: Move the BlockCanvas component within the EditorCanvas component

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -141,7 +141,7 @@ export default function VisualEditor( { styles } ) {
 				>
 					<EditorCanvas
 						ref={ ref }
-						disableIframe={ isToBeIframed }
+						disableIframe={ ! isToBeIframed }
 						styles={ styles }
 						// We should auto-focus the canvas (title) on load.
 						// eslint-disable-next-line jsx-a11y/no-autofocus

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -12,14 +12,11 @@ import {
 } from '@wordpress/editor';
 import {
 	BlockTools,
-	__unstableUseTypewriter as useTypewriter,
 	__experimentalUseResizeCanvas as useResizeCanvas,
-	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useRef, useMemo } from '@wordpress/element';
 import { __unstableMotion as motion } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useMergeRefs } from '@wordpress/compose';
 import { store as blocksStore } from '@wordpress/blocks';
 
 /**
@@ -28,9 +25,6 @@ import { store as blocksStore } from '@wordpress/blocks';
 import { store as editPostStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const { ExperimentalBlockCanvas: BlockCanvas } = unlock(
-	blockEditorPrivateApis
-);
 const { EditorCanvas } = unlock( editorPrivateApis );
 
 const isGutenbergPlugin = process.env.IS_GUTENBERG_PLUGIN ? true : false;
@@ -104,7 +98,6 @@ export default function VisualEditor( { styles } ) {
 	}
 
 	const ref = useRef();
-	const contentRef = useMergeRefs( [ ref, useTypewriter() ] );
 
 	styles = useMemo(
 		() => [
@@ -146,25 +139,14 @@ export default function VisualEditor( { styles } ) {
 					initial={ desktopCanvasStyles }
 					className={ previewMode }
 				>
-					<BlockCanvas
-						shouldIframe={ isToBeIframed }
-						contentRef={ contentRef }
+					<EditorCanvas
+						ref={ ref }
+						disableIframe={ isToBeIframed }
 						styles={ styles }
-						height="100%"
-					>
-						<EditorCanvas
-							dropZoneElement={
-								// When iframed, pass in the html element of the iframe to
-								// ensure the drop zone extends to the edges of the iframe.
-								isToBeIframed
-									? ref.current?.parentNode
-									: ref.current
-							}
-							// We should auto-focus the canvas (title) on load.
-							// eslint-disable-next-line jsx-a11y/no-autofocus
-							autoFocus={ ! isWelcomeGuideVisible }
-						/>
-					</BlockCanvas>
+						// We should auto-focus the canvas (title) on load.
+						// eslint-disable-next-line jsx-a11y/no-autofocus
+						autoFocus={ ! isWelcomeGuideVisible }
+					/>
 				</motion.div>
 			</motion.div>
 		</BlockTools>

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -8,12 +8,11 @@ import classnames from 'classnames';
  */
 import {
 	__experimentalUseResizeCanvas as useResizeCanvas,
-	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { ENTER, SPACE } from '@wordpress/keycodes';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
@@ -27,9 +26,6 @@ import {
 	NAVIGATION_POST_TYPE,
 } from '../../utils/constants';
 
-const { ExperimentalBlockCanvas: BlockCanvas } = unlock(
-	blockEditorPrivateApis
-);
 const { EditorCanvas: EditorCanvasRoot } = unlock( editorPrivateApis );
 
 function EditorCanvas( {
@@ -101,9 +97,35 @@ function EditorCanvas( {
 			? false
 			: undefined;
 
+	const styles = useMemo(
+		() => [
+			...settings.styles,
+			{
+				// Forming a "block formatting context" to prevent margin collapsing.
+				// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
+
+				css: `.is-root-container{display:flow-root;${
+					// Some themes will have `min-height: 100vh` for the root container,
+					// which isn't a requirement in auto resize mode.
+					enableResizing ? 'min-height:0!important;' : ''
+				}}body{position:relative; ${
+					canvasMode === 'view'
+						? 'cursor: pointer; min-height: 100vh;'
+						: ''
+				}}}`,
+			},
+		],
+		[ settings.styles, enableResizing, canvasMode ]
+	);
+
 	return (
-		<BlockCanvas
-			height="100%"
+		<EditorCanvasRoot
+			ref={ contentRef }
+			className={ classnames( 'edit-site-editor-canvas__block-list', {
+				'is-navigation-block': isTemplateTypeNavigation,
+			} ) }
+			renderAppender={ showBlockAppender }
+			styles={ styles }
 			iframeProps={ {
 				expand: isZoomOutMode,
 				scale: isZoomOutMode ? 0.45 : undefined,
@@ -118,31 +140,9 @@ function EditorCanvas( {
 				...props,
 				...( canvasMode === 'view' ? viewModeProps : {} ),
 			} }
-			styles={ settings.styles }
-			contentRef={ contentRef }
 		>
-			<style>{
-				// Forming a "block formatting context" to prevent margin collapsing.
-				// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-				`.is-root-container{display:flow-root;${
-					// Some themes will have `min-height: 100vh` for the root container,
-					// which isn't a requirement in auto resize mode.
-					enableResizing ? 'min-height:0!important;' : ''
-				}}body{position:relative; ${
-					canvasMode === 'view'
-						? 'cursor: pointer; min-height: 100vh;'
-						: ''
-				}}}`
-			}</style>
-			<EditorCanvasRoot
-				dropZoneElement={ contentRef.current?.parentNode }
-				className={ classnames( 'edit-site-editor-canvas__block-list', {
-					'is-navigation-block': isTemplateTypeNavigation,
-				} ) }
-				renderAppender={ showBlockAppender }
-			/>
 			{ children }
-		</BlockCanvas>
+		</EditorCanvasRoot>
 	);
 }
 

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -70,314 +70,301 @@ function checkForPostContentAtRootLevel( blocks ) {
 	return false;
 }
 
-const EditorCanvas = forwardRef(
-	(
-		{
-			// Ideally as we unify post and site editors, we won't need these props.
-			autoFocus,
-			className,
-			renderAppender,
-			styles,
-			disableIframe = false,
-			iframeProps,
-			children,
-		},
-		ref
-	) => {
+function EditorCanvas(
+	{
+		// Ideally as we unify post and site editors, we won't need these props.
+		autoFocus,
+		className,
+		renderAppender,
+		styles,
+		disableIframe = false,
+		iframeProps,
+		children,
+	},
+	ref
+) {
+	const {
+		renderingMode,
+		postContentAttributes,
+		editedPostTemplate = {},
+		wrapperBlockName,
+		wrapperUniqueId,
+	} = useSelect( ( select ) => {
 		const {
-			renderingMode,
-			postContentAttributes,
-			editedPostTemplate = {},
-			wrapperBlockName,
-			wrapperUniqueId,
-		} = useSelect( ( select ) => {
-			const {
-				getCurrentPostId,
-				getCurrentPostType,
-				getCurrentTemplateId,
-				getEditorSettings,
-				getRenderingMode,
-			} = select( editorStore );
-			const postTypeSlug = getCurrentPostType();
-			const _renderingMode = getRenderingMode();
-			let _wrapperBlockName;
+			getCurrentPostId,
+			getCurrentPostType,
+			getCurrentTemplateId,
+			getEditorSettings,
+			getRenderingMode,
+		} = select( editorStore );
+		const postTypeSlug = getCurrentPostType();
+		const _renderingMode = getRenderingMode();
+		let _wrapperBlockName;
 
-			if ( postTypeSlug === 'wp_block' ) {
-				_wrapperBlockName = 'core/block';
-			} else if ( ! _renderingMode === 'post-only' ) {
-				_wrapperBlockName = 'core/post-content';
-			}
+		if ( postTypeSlug === 'wp_block' ) {
+			_wrapperBlockName = 'core/block';
+		} else if ( ! _renderingMode === 'post-only' ) {
+			_wrapperBlockName = 'core/post-content';
+		}
 
-			const editorSettings = getEditorSettings();
-			const supportsTemplateMode = editorSettings.supportsTemplateMode;
-			const postType = select( coreStore ).getPostType( postTypeSlug );
-			const canEditTemplate = select( coreStore ).canUser(
-				'create',
-				'templates'
-			);
-			const currentTemplateId = getCurrentTemplateId();
-			const template = currentTemplateId
-				? select( coreStore ).getEditedEntityRecord(
-						'postType',
-						'wp_template',
-						currentTemplateId
-				  )
-				: undefined;
+		const editorSettings = getEditorSettings();
+		const supportsTemplateMode = editorSettings.supportsTemplateMode;
+		const postType = select( coreStore ).getPostType( postTypeSlug );
+		const canEditTemplate = select( coreStore ).canUser(
+			'create',
+			'templates'
+		);
+		const currentTemplateId = getCurrentTemplateId();
+		const template = currentTemplateId
+			? select( coreStore ).getEditedEntityRecord(
+					'postType',
+					'wp_template',
+					currentTemplateId
+			  )
+			: undefined;
 
-			return {
-				renderingMode: _renderingMode,
-				postContentAttributes:
-					getEditorSettings().postContentAttributes,
-				// Post template fetch returns a 404 on classic themes, which
-				// messes with e2e tests, so check it's a block theme first.
-				editedPostTemplate:
-					postType?.viewable &&
-					supportsTemplateMode &&
-					canEditTemplate
-						? template
-						: undefined,
-				wrapperBlockName: _wrapperBlockName,
-				wrapperUniqueId: getCurrentPostId(),
-			};
-		}, [] );
-		const { isCleanNewPost } = useSelect( editorStore );
-		const {
-			hasRootPaddingAwareAlignments,
-			themeHasDisabledLayoutStyles,
-			themeSupportsLayout,
-		} = useSelect( ( select ) => {
-			const _settings = select( blockEditorStore ).getSettings();
-			return {
-				themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
-				themeSupportsLayout: _settings.supportsLayout,
-				hasRootPaddingAwareAlignments:
-					_settings.__experimentalFeatures
-						?.useRootPaddingAwareAlignments,
-			};
-		}, [] );
+		return {
+			renderingMode: _renderingMode,
+			postContentAttributes: getEditorSettings().postContentAttributes,
+			// Post template fetch returns a 404 on classic themes, which
+			// messes with e2e tests, so check it's a block theme first.
+			editedPostTemplate:
+				postType?.viewable && supportsTemplateMode && canEditTemplate
+					? template
+					: undefined,
+			wrapperBlockName: _wrapperBlockName,
+			wrapperUniqueId: getCurrentPostId(),
+		};
+	}, [] );
+	const { isCleanNewPost } = useSelect( editorStore );
+	const {
+		hasRootPaddingAwareAlignments,
+		themeHasDisabledLayoutStyles,
+		themeSupportsLayout,
+	} = useSelect( ( select ) => {
+		const _settings = select( blockEditorStore ).getSettings();
+		return {
+			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
+			themeSupportsLayout: _settings.supportsLayout,
+			hasRootPaddingAwareAlignments:
+				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
+		};
+	}, [] );
 
-		const [ globalLayoutSettings ] = useSettings( 'layout' );
+	const [ globalLayoutSettings ] = useSettings( 'layout' );
 
-		// fallbackLayout is used if there is no Post Content,
-		// and for Post Title.
-		const fallbackLayout = useMemo( () => {
-			if ( renderingMode !== 'post-only' ) {
-				return { type: 'default' };
-			}
-
-			if ( themeSupportsLayout ) {
-				// We need to ensure support for wide and full alignments,
-				// so we add the constrained type.
-				return { ...globalLayoutSettings, type: 'constrained' };
-			}
-			// Set default layout for classic themes so all alignments are supported.
+	// fallbackLayout is used if there is no Post Content,
+	// and for Post Title.
+	const fallbackLayout = useMemo( () => {
+		if ( renderingMode !== 'post-only' ) {
 			return { type: 'default' };
-		}, [ renderingMode, themeSupportsLayout, globalLayoutSettings ] );
+		}
 
-		const newestPostContentAttributes = useMemo( () => {
-			if (
-				! editedPostTemplate?.content &&
-				! editedPostTemplate?.blocks &&
-				postContentAttributes
-			) {
-				return postContentAttributes;
-			}
-			// When in template editing mode, we can access the blocks directly.
-			if ( editedPostTemplate?.blocks ) {
-				return getPostContentAttributes( editedPostTemplate?.blocks );
-			}
-			// If there are no blocks, we have to parse the content string.
-			// Best double-check it's a string otherwise the parse function gets unhappy.
-			const parseableContent =
-				typeof editedPostTemplate?.content === 'string'
-					? editedPostTemplate?.content
-					: '';
+		if ( themeSupportsLayout ) {
+			// We need to ensure support for wide and full alignments,
+			// so we add the constrained type.
+			return { ...globalLayoutSettings, type: 'constrained' };
+		}
+		// Set default layout for classic themes so all alignments are supported.
+		return { type: 'default' };
+	}, [ renderingMode, themeSupportsLayout, globalLayoutSettings ] );
 
-			return getPostContentAttributes( parse( parseableContent ) ) || {};
-		}, [
-			editedPostTemplate?.content,
-			editedPostTemplate?.blocks,
-			postContentAttributes,
-		] );
+	const newestPostContentAttributes = useMemo( () => {
+		if (
+			! editedPostTemplate?.content &&
+			! editedPostTemplate?.blocks &&
+			postContentAttributes
+		) {
+			return postContentAttributes;
+		}
+		// When in template editing mode, we can access the blocks directly.
+		if ( editedPostTemplate?.blocks ) {
+			return getPostContentAttributes( editedPostTemplate?.blocks );
+		}
+		// If there are no blocks, we have to parse the content string.
+		// Best double-check it's a string otherwise the parse function gets unhappy.
+		const parseableContent =
+			typeof editedPostTemplate?.content === 'string'
+				? editedPostTemplate?.content
+				: '';
 
-		const hasPostContentAtRootLevel = useMemo( () => {
-			if (
-				! editedPostTemplate?.content &&
-				! editedPostTemplate?.blocks
-			) {
-				return false;
-			}
-			// When in template editing mode, we can access the blocks directly.
-			if ( editedPostTemplate?.blocks ) {
-				return checkForPostContentAtRootLevel(
-					editedPostTemplate?.blocks
-				);
-			}
-			// If there are no blocks, we have to parse the content string.
-			// Best double-check it's a string otherwise the parse function gets unhappy.
-			const parseableContent =
-				typeof editedPostTemplate?.content === 'string'
-					? editedPostTemplate?.content
-					: '';
+		return getPostContentAttributes( parse( parseableContent ) ) || {};
+	}, [
+		editedPostTemplate?.content,
+		editedPostTemplate?.blocks,
+		postContentAttributes,
+	] );
 
-			return (
-				checkForPostContentAtRootLevel( parse( parseableContent ) ) ||
-				false
-			);
-		}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
+	const hasPostContentAtRootLevel = useMemo( () => {
+		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
+			return false;
+		}
+		// When in template editing mode, we can access the blocks directly.
+		if ( editedPostTemplate?.blocks ) {
+			return checkForPostContentAtRootLevel( editedPostTemplate?.blocks );
+		}
+		// If there are no blocks, we have to parse the content string.
+		// Best double-check it's a string otherwise the parse function gets unhappy.
+		const parseableContent =
+			typeof editedPostTemplate?.content === 'string'
+				? editedPostTemplate?.content
+				: '';
 
-		const { layout = {}, align = '' } = newestPostContentAttributes || {};
-
-		const postContentLayoutClasses = useLayoutClasses(
-			newestPostContentAttributes,
-			'core/post-content'
+		return (
+			checkForPostContentAtRootLevel( parse( parseableContent ) ) || false
 		);
+	}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
 
-		const blockListLayoutClass = classnames(
-			{
-				'is-layout-flow': ! themeSupportsLayout,
-			},
-			themeSupportsLayout && postContentLayoutClasses,
-			align && `align${ align }`
-		);
+	const { layout = {}, align = '' } = newestPostContentAttributes || {};
 
-		const postContentLayoutStyles = useLayoutStyles(
-			newestPostContentAttributes,
-			'core/post-content',
-			'.block-editor-block-list__layout.is-root-container'
-		);
+	const postContentLayoutClasses = useLayoutClasses(
+		newestPostContentAttributes,
+		'core/post-content'
+	);
 
-		// Update type for blocks using legacy layouts.
-		const postContentLayout = useMemo( () => {
-			return layout &&
-				( layout?.type === 'constrained' ||
-					layout?.inherit ||
-					layout?.contentSize ||
-					layout?.wideSize )
-				? { ...globalLayoutSettings, ...layout, type: 'constrained' }
-				: { ...globalLayoutSettings, ...layout, type: 'default' };
-		}, [
-			layout?.type,
-			layout?.inherit,
-			layout?.contentSize,
-			layout?.wideSize,
-			globalLayoutSettings,
-		] );
+	const blockListLayoutClass = classnames(
+		{
+			'is-layout-flow': ! themeSupportsLayout,
+		},
+		themeSupportsLayout && postContentLayoutClasses,
+		align && `align${ align }`
+	);
 
-		// If there is a Post Content block we use its layout for the block list;
-		// if not, this must be a classic theme, in which case we use the fallback layout.
-		const blockListLayout = postContentAttributes
-			? postContentLayout
-			: fallbackLayout;
+	const postContentLayoutStyles = useLayoutStyles(
+		newestPostContentAttributes,
+		'core/post-content',
+		'.block-editor-block-list__layout.is-root-container'
+	);
 
-		const postEditorLayout =
-			blockListLayout?.type === 'default' && ! hasPostContentAtRootLevel
-				? fallbackLayout
-				: blockListLayout;
+	// Update type for blocks using legacy layouts.
+	const postContentLayout = useMemo( () => {
+		return layout &&
+			( layout?.type === 'constrained' ||
+				layout?.inherit ||
+				layout?.contentSize ||
+				layout?.wideSize )
+			? { ...globalLayoutSettings, ...layout, type: 'constrained' }
+			: { ...globalLayoutSettings, ...layout, type: 'default' };
+	}, [
+		layout?.type,
+		layout?.inherit,
+		layout?.contentSize,
+		layout?.wideSize,
+		globalLayoutSettings,
+	] );
 
-		const observeTypingRef = useTypingObserver();
-		const titleRef = useRef();
-		useEffect( () => {
-			if ( ! autoFocus || ! isCleanNewPost() ) {
-				return;
-			}
-			titleRef?.current?.focus();
-		}, [ autoFocus, isCleanNewPost ] );
+	// If there is a Post Content block we use its layout for the block list;
+	// if not, this must be a classic theme, in which case we use the fallback layout.
+	const blockListLayout = postContentAttributes
+		? postContentLayout
+		: fallbackLayout;
 
-		// Add some styles for alignwide/alignfull Post Content and its children.
-		const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
+	const postEditorLayout =
+		blockListLayout?.type === 'default' && ! hasPostContentAtRootLevel
+			? fallbackLayout
+			: blockListLayout;
+
+	const observeTypingRef = useTypingObserver();
+	const titleRef = useRef();
+	useEffect( () => {
+		if ( ! autoFocus || ! isCleanNewPost() ) {
+			return;
+		}
+		titleRef?.current?.focus();
+	}, [ autoFocus, isCleanNewPost ] );
+
+	// Add some styles for alignwide/alignfull Post Content and its children.
+	const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
 		.is-root-container.alignwide:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
 		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
 		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
-		const localRef = useRef();
-		const typewriterRef = useTypewriter();
-		const contentRef = useMergeRefs(
-			[
-				ref,
-				localRef,
-				renderingMode === 'post-only' ? typewriterRef : undefined,
-			].filter( ( r ) => !! r )
-		);
+	const localRef = useRef();
+	const typewriterRef = useTypewriter();
+	const contentRef = useMergeRefs(
+		[
+			ref,
+			localRef,
+			renderingMode === 'post-only' ? typewriterRef : undefined,
+		].filter( ( r ) => !! r )
+	);
 
-		return (
-			<BlockCanvas
-				shouldIframe={ ! disableIframe }
-				contentRef={ contentRef }
-				styles={ styles }
-				height="100%"
-				iframeProps={ iframeProps }
-			>
-				{ themeSupportsLayout &&
-					! themeHasDisabledLayoutStyles &&
-					renderingMode === 'post-only' && (
-						<>
+	return (
+		<BlockCanvas
+			shouldIframe={ ! disableIframe }
+			contentRef={ contentRef }
+			styles={ styles }
+			height="100%"
+			iframeProps={ iframeProps }
+		>
+			{ themeSupportsLayout &&
+				! themeHasDisabledLayoutStyles &&
+				renderingMode === 'post-only' && (
+					<>
+						<LayoutStyle
+							selector=".editor-editor-canvas__post-title-wrapper"
+							layout={ fallbackLayout }
+						/>
+						<LayoutStyle
+							selector=".block-editor-block-list__layout.is-root-container"
+							layout={ postEditorLayout }
+						/>
+						{ align && <LayoutStyle css={ alignCSS } /> }
+						{ postContentLayoutStyles && (
 							<LayoutStyle
-								selector=".editor-editor-canvas__post-title-wrapper"
-								layout={ fallbackLayout }
+								layout={ postContentLayout }
+								css={ postContentLayoutStyles }
 							/>
-							<LayoutStyle
-								selector=".block-editor-block-list__layout.is-root-container"
-								layout={ postEditorLayout }
-							/>
-							{ align && <LayoutStyle css={ alignCSS } /> }
-							{ postContentLayoutStyles && (
-								<LayoutStyle
-									layout={ postContentLayout }
-									css={ postContentLayoutStyles }
-								/>
-							) }
-						</>
-					) }
-				{ renderingMode === 'post-only' && (
-					<div
-						className={ classnames(
-							'editor-editor-canvas__post-title-wrapper',
-							// The following class is only here for backward comapatibility
-							// some themes might be using it to style the post title.
-							'edit-post-visual-editor__post-title-wrapper',
-							{
-								'has-global-padding':
-									hasRootPaddingAwareAlignments,
-							}
 						) }
-						contentEditable={ false }
-						ref={ observeTypingRef }
-						style={ {
-							// This is using inline styles
-							// so it's applied for both iframed and non iframed editors.
-							marginTop: '4rem',
-						} }
-					>
-						<PostTitle ref={ titleRef } />
-					</div>
+					</>
 				) }
-				<RecursionProvider
-					blockName={ wrapperBlockName }
-					uniqueId={ wrapperUniqueId }
-				>
-					<BlockList
-						className={ classnames(
-							className,
-							renderingMode !== 'post-only'
-								? 'wp-site-blocks'
-								: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
-						) }
-						layout={ blockListLayout }
-						dropZoneElement={
-							// When iframed, pass in the html element of the iframe to
-							// ensure the drop zone extends to the edges of the iframe.
-							disableIframe
-								? localRef.current
-								: localRef.current?.parentNode
+			{ renderingMode === 'post-only' && (
+				<div
+					className={ classnames(
+						'editor-editor-canvas__post-title-wrapper',
+						// The following class is only here for backward comapatibility
+						// some themes might be using it to style the post title.
+						'edit-post-visual-editor__post-title-wrapper',
+						{
+							'has-global-padding': hasRootPaddingAwareAlignments,
 						}
-						renderAppender={ renderAppender }
-					/>
-				</RecursionProvider>
-				{ children }
-			</BlockCanvas>
-		);
-	}
-);
+					) }
+					contentEditable={ false }
+					ref={ observeTypingRef }
+					style={ {
+						// This is using inline styles
+						// so it's applied for both iframed and non iframed editors.
+						marginTop: '4rem',
+					} }
+				>
+					<PostTitle ref={ titleRef } />
+				</div>
+			) }
+			<RecursionProvider
+				blockName={ wrapperBlockName }
+				uniqueId={ wrapperUniqueId }
+			>
+				<BlockList
+					className={ classnames(
+						className,
+						renderingMode !== 'post-only'
+							? 'wp-site-blocks'
+							: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
+					) }
+					layout={ blockListLayout }
+					dropZoneElement={
+						// When iframed, pass in the html element of the iframe to
+						// ensure the drop zone extends to the edges of the iframe.
+						disableIframe
+							? localRef.current
+							: localRef.current?.parentNode
+					}
+					renderAppender={ renderAppender }
+				/>
+			</RecursionProvider>
+			{ children }
+		</BlockCanvas>
+	);
+}
 
-export default EditorCanvas;
+export default forwardRef( EditorCanvas );

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -9,15 +9,17 @@ import classnames from 'classnames';
 import {
 	BlockList,
 	store as blockEditorStore,
+	__unstableUseTypewriter as useTypewriter,
 	__unstableUseTypingObserver as useTypingObserver,
 	useSettings,
 	__experimentalRecursionProvider as RecursionProvider,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useEffect, useRef, useMemo } from '@wordpress/element';
+import { useEffect, useRef, useMemo, forwardRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -26,9 +28,12 @@ import PostTitle from '../post-title';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const { LayoutStyle, useLayoutClasses, useLayoutStyles } = unlock(
-	blockEditorPrivateApis
-);
+const {
+	LayoutStyle,
+	useLayoutClasses,
+	useLayoutStyles,
+	ExperimentalBlockCanvas: BlockCanvas,
+} = unlock( blockEditorPrivateApis );
 
 /**
  * Given an array of nested blocks, find the first Post Content
@@ -65,270 +70,314 @@ function checkForPostContentAtRootLevel( blocks ) {
 	return false;
 }
 
-export default function EditorCanvas( {
-	// Ideally as we unify post and site editors, we won't need these props.
-	autoFocus,
-	dropZoneElement,
-	className,
-	renderAppender,
-} ) {
-	const {
-		renderingMode,
-		postContentAttributes,
-		editedPostTemplate = {},
-		wrapperBlockName,
-		wrapperUniqueId,
-	} = useSelect( ( select ) => {
-		const {
-			getCurrentPostId,
-			getCurrentPostType,
-			getCurrentTemplateId,
-			getEditorSettings,
-			getRenderingMode,
-		} = select( editorStore );
-		const postTypeSlug = getCurrentPostType();
-		const _renderingMode = getRenderingMode();
-		let _wrapperBlockName;
-
-		if ( postTypeSlug === 'wp_block' ) {
-			_wrapperBlockName = 'core/block';
-		} else if ( ! _renderingMode === 'post-only' ) {
-			_wrapperBlockName = 'core/post-content';
-		}
-
-		const editorSettings = getEditorSettings();
-		const supportsTemplateMode = editorSettings.supportsTemplateMode;
-		const postType = select( coreStore ).getPostType( postTypeSlug );
-		const canEditTemplate = select( coreStore ).canUser(
-			'create',
-			'templates'
-		);
-		const currentTemplateId = getCurrentTemplateId();
-		const template = currentTemplateId
-			? select( coreStore ).getEditedEntityRecord(
-					'postType',
-					'wp_template',
-					currentTemplateId
-			  )
-			: undefined;
-
-		return {
-			renderingMode: _renderingMode,
-			postContentAttributes: getEditorSettings().postContentAttributes,
-			// Post template fetch returns a 404 on classic themes, which
-			// messes with e2e tests, so check it's a block theme first.
-			editedPostTemplate:
-				postType?.viewable && supportsTemplateMode && canEditTemplate
-					? template
-					: undefined,
-			wrapperBlockName: _wrapperBlockName,
-			wrapperUniqueId: getCurrentPostId(),
-		};
-	}, [] );
-	const { isCleanNewPost } = useSelect( editorStore );
-	const {
-		hasRootPaddingAwareAlignments,
-		themeHasDisabledLayoutStyles,
-		themeSupportsLayout,
-	} = useSelect( ( select ) => {
-		const _settings = select( blockEditorStore ).getSettings();
-		return {
-			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
-			themeSupportsLayout: _settings.supportsLayout,
-			hasRootPaddingAwareAlignments:
-				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
-		};
-	}, [] );
-
-	const [ globalLayoutSettings ] = useSettings( 'layout' );
-
-	// fallbackLayout is used if there is no Post Content,
-	// and for Post Title.
-	const fallbackLayout = useMemo( () => {
-		if ( renderingMode !== 'post-only' ) {
-			return { type: 'default' };
-		}
-
-		if ( themeSupportsLayout ) {
-			// We need to ensure support for wide and full alignments,
-			// so we add the constrained type.
-			return { ...globalLayoutSettings, type: 'constrained' };
-		}
-		// Set default layout for classic themes so all alignments are supported.
-		return { type: 'default' };
-	}, [ renderingMode, themeSupportsLayout, globalLayoutSettings ] );
-
-	const newestPostContentAttributes = useMemo( () => {
-		if (
-			! editedPostTemplate?.content &&
-			! editedPostTemplate?.blocks &&
-			postContentAttributes
-		) {
-			return postContentAttributes;
-		}
-		// When in template editing mode, we can access the blocks directly.
-		if ( editedPostTemplate?.blocks ) {
-			return getPostContentAttributes( editedPostTemplate?.blocks );
-		}
-		// If there are no blocks, we have to parse the content string.
-		// Best double-check it's a string otherwise the parse function gets unhappy.
-		const parseableContent =
-			typeof editedPostTemplate?.content === 'string'
-				? editedPostTemplate?.content
-				: '';
-
-		return getPostContentAttributes( parse( parseableContent ) ) || {};
-	}, [
-		editedPostTemplate?.content,
-		editedPostTemplate?.blocks,
-		postContentAttributes,
-	] );
-
-	const hasPostContentAtRootLevel = useMemo( () => {
-		if ( ! editedPostTemplate?.content && ! editedPostTemplate?.blocks ) {
-			return false;
-		}
-		// When in template editing mode, we can access the blocks directly.
-		if ( editedPostTemplate?.blocks ) {
-			return checkForPostContentAtRootLevel( editedPostTemplate?.blocks );
-		}
-		// If there are no blocks, we have to parse the content string.
-		// Best double-check it's a string otherwise the parse function gets unhappy.
-		const parseableContent =
-			typeof editedPostTemplate?.content === 'string'
-				? editedPostTemplate?.content
-				: '';
-
-		return (
-			checkForPostContentAtRootLevel( parse( parseableContent ) ) || false
-		);
-	}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
-
-	const { layout = {}, align = '' } = newestPostContentAttributes || {};
-
-	const postContentLayoutClasses = useLayoutClasses(
-		newestPostContentAttributes,
-		'core/post-content'
-	);
-
-	const blockListLayoutClass = classnames(
+const EditorCanvas = forwardRef(
+	(
 		{
-			'is-layout-flow': ! themeSupportsLayout,
+			// Ideally as we unify post and site editors, we won't need these props.
+			autoFocus,
+			className,
+			renderAppender,
+			styles,
+			disableIframe = false,
+			iframeProps,
+			children,
 		},
-		themeSupportsLayout && postContentLayoutClasses,
-		align && `align${ align }`
-	);
+		ref
+	) => {
+		const {
+			renderingMode,
+			postContentAttributes,
+			editedPostTemplate = {},
+			wrapperBlockName,
+			wrapperUniqueId,
+		} = useSelect( ( select ) => {
+			const {
+				getCurrentPostId,
+				getCurrentPostType,
+				getCurrentTemplateId,
+				getEditorSettings,
+				getRenderingMode,
+			} = select( editorStore );
+			const postTypeSlug = getCurrentPostType();
+			const _renderingMode = getRenderingMode();
+			let _wrapperBlockName;
 
-	const postContentLayoutStyles = useLayoutStyles(
-		newestPostContentAttributes,
-		'core/post-content',
-		'.block-editor-block-list__layout.is-root-container'
-	);
+			if ( postTypeSlug === 'wp_block' ) {
+				_wrapperBlockName = 'core/block';
+			} else if ( ! _renderingMode === 'post-only' ) {
+				_wrapperBlockName = 'core/post-content';
+			}
 
-	// Update type for blocks using legacy layouts.
-	const postContentLayout = useMemo( () => {
-		return layout &&
-			( layout?.type === 'constrained' ||
-				layout?.inherit ||
-				layout?.contentSize ||
-				layout?.wideSize )
-			? { ...globalLayoutSettings, ...layout, type: 'constrained' }
-			: { ...globalLayoutSettings, ...layout, type: 'default' };
-	}, [
-		layout?.type,
-		layout?.inherit,
-		layout?.contentSize,
-		layout?.wideSize,
-		globalLayoutSettings,
-	] );
+			const editorSettings = getEditorSettings();
+			const supportsTemplateMode = editorSettings.supportsTemplateMode;
+			const postType = select( coreStore ).getPostType( postTypeSlug );
+			const canEditTemplate = select( coreStore ).canUser(
+				'create',
+				'templates'
+			);
+			const currentTemplateId = getCurrentTemplateId();
+			const template = currentTemplateId
+				? select( coreStore ).getEditedEntityRecord(
+						'postType',
+						'wp_template',
+						currentTemplateId
+				  )
+				: undefined;
 
-	// If there is a Post Content block we use its layout for the block list;
-	// if not, this must be a classic theme, in which case we use the fallback layout.
-	const blockListLayout = postContentAttributes
-		? postContentLayout
-		: fallbackLayout;
+			return {
+				renderingMode: _renderingMode,
+				postContentAttributes:
+					getEditorSettings().postContentAttributes,
+				// Post template fetch returns a 404 on classic themes, which
+				// messes with e2e tests, so check it's a block theme first.
+				editedPostTemplate:
+					postType?.viewable &&
+					supportsTemplateMode &&
+					canEditTemplate
+						? template
+						: undefined,
+				wrapperBlockName: _wrapperBlockName,
+				wrapperUniqueId: getCurrentPostId(),
+			};
+		}, [] );
+		const { isCleanNewPost } = useSelect( editorStore );
+		const {
+			hasRootPaddingAwareAlignments,
+			themeHasDisabledLayoutStyles,
+			themeSupportsLayout,
+		} = useSelect( ( select ) => {
+			const _settings = select( blockEditorStore ).getSettings();
+			return {
+				themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
+				themeSupportsLayout: _settings.supportsLayout,
+				hasRootPaddingAwareAlignments:
+					_settings.__experimentalFeatures
+						?.useRootPaddingAwareAlignments,
+			};
+		}, [] );
 
-	const postEditorLayout =
-		blockListLayout?.type === 'default' && ! hasPostContentAtRootLevel
-			? fallbackLayout
-			: blockListLayout;
+		const [ globalLayoutSettings ] = useSettings( 'layout' );
 
-	const observeTypingRef = useTypingObserver();
-	const titleRef = useRef();
-	useEffect( () => {
-		if ( ! autoFocus || ! isCleanNewPost() ) {
-			return;
-		}
-		titleRef?.current?.focus();
-	}, [ autoFocus, isCleanNewPost ] );
+		// fallbackLayout is used if there is no Post Content,
+		// and for Post Title.
+		const fallbackLayout = useMemo( () => {
+			if ( renderingMode !== 'post-only' ) {
+				return { type: 'default' };
+			}
 
-	// Add some styles for alignwide/alignfull Post Content and its children.
-	const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
+			if ( themeSupportsLayout ) {
+				// We need to ensure support for wide and full alignments,
+				// so we add the constrained type.
+				return { ...globalLayoutSettings, type: 'constrained' };
+			}
+			// Set default layout for classic themes so all alignments are supported.
+			return { type: 'default' };
+		}, [ renderingMode, themeSupportsLayout, globalLayoutSettings ] );
+
+		const newestPostContentAttributes = useMemo( () => {
+			if (
+				! editedPostTemplate?.content &&
+				! editedPostTemplate?.blocks &&
+				postContentAttributes
+			) {
+				return postContentAttributes;
+			}
+			// When in template editing mode, we can access the blocks directly.
+			if ( editedPostTemplate?.blocks ) {
+				return getPostContentAttributes( editedPostTemplate?.blocks );
+			}
+			// If there are no blocks, we have to parse the content string.
+			// Best double-check it's a string otherwise the parse function gets unhappy.
+			const parseableContent =
+				typeof editedPostTemplate?.content === 'string'
+					? editedPostTemplate?.content
+					: '';
+
+			return getPostContentAttributes( parse( parseableContent ) ) || {};
+		}, [
+			editedPostTemplate?.content,
+			editedPostTemplate?.blocks,
+			postContentAttributes,
+		] );
+
+		const hasPostContentAtRootLevel = useMemo( () => {
+			if (
+				! editedPostTemplate?.content &&
+				! editedPostTemplate?.blocks
+			) {
+				return false;
+			}
+			// When in template editing mode, we can access the blocks directly.
+			if ( editedPostTemplate?.blocks ) {
+				return checkForPostContentAtRootLevel(
+					editedPostTemplate?.blocks
+				);
+			}
+			// If there are no blocks, we have to parse the content string.
+			// Best double-check it's a string otherwise the parse function gets unhappy.
+			const parseableContent =
+				typeof editedPostTemplate?.content === 'string'
+					? editedPostTemplate?.content
+					: '';
+
+			return (
+				checkForPostContentAtRootLevel( parse( parseableContent ) ) ||
+				false
+			);
+		}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
+
+		const { layout = {}, align = '' } = newestPostContentAttributes || {};
+
+		const postContentLayoutClasses = useLayoutClasses(
+			newestPostContentAttributes,
+			'core/post-content'
+		);
+
+		const blockListLayoutClass = classnames(
+			{
+				'is-layout-flow': ! themeSupportsLayout,
+			},
+			themeSupportsLayout && postContentLayoutClasses,
+			align && `align${ align }`
+		);
+
+		const postContentLayoutStyles = useLayoutStyles(
+			newestPostContentAttributes,
+			'core/post-content',
+			'.block-editor-block-list__layout.is-root-container'
+		);
+
+		// Update type for blocks using legacy layouts.
+		const postContentLayout = useMemo( () => {
+			return layout &&
+				( layout?.type === 'constrained' ||
+					layout?.inherit ||
+					layout?.contentSize ||
+					layout?.wideSize )
+				? { ...globalLayoutSettings, ...layout, type: 'constrained' }
+				: { ...globalLayoutSettings, ...layout, type: 'default' };
+		}, [
+			layout?.type,
+			layout?.inherit,
+			layout?.contentSize,
+			layout?.wideSize,
+			globalLayoutSettings,
+		] );
+
+		// If there is a Post Content block we use its layout for the block list;
+		// if not, this must be a classic theme, in which case we use the fallback layout.
+		const blockListLayout = postContentAttributes
+			? postContentLayout
+			: fallbackLayout;
+
+		const postEditorLayout =
+			blockListLayout?.type === 'default' && ! hasPostContentAtRootLevel
+				? fallbackLayout
+				: blockListLayout;
+
+		const observeTypingRef = useTypingObserver();
+		const titleRef = useRef();
+		useEffect( () => {
+			if ( ! autoFocus || ! isCleanNewPost() ) {
+				return;
+			}
+			titleRef?.current?.focus();
+		}, [ autoFocus, isCleanNewPost ] );
+
+		// Add some styles for alignwide/alignfull Post Content and its children.
+		const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
 		.is-root-container.alignwide:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
 		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
 		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
-	return (
-		<>
-			{ themeSupportsLayout &&
-				! themeHasDisabledLayoutStyles &&
-				renderingMode === 'post-only' && (
-					<>
-						<LayoutStyle
-							selector=".editor-editor-canvas__post-title-wrapper"
-							layout={ fallbackLayout }
-						/>
-						<LayoutStyle
-							selector=".block-editor-block-list__layout.is-root-container"
-							layout={ postEditorLayout }
-						/>
-						{ align && <LayoutStyle css={ alignCSS } /> }
-						{ postContentLayoutStyles && (
-							<LayoutStyle
-								layout={ postContentLayout }
-								css={ postContentLayoutStyles }
-							/>
-						) }
-					</>
-				) }
-			{ renderingMode === 'post-only' && (
-				<div
-					className={ classnames(
-						'editor-editor-canvas__post-title-wrapper',
-						// The following class is only here for backward comapatibility
-						// some themes might be using it to style the post title.
-						'edit-post-visual-editor__post-title-wrapper',
-						{
-							'has-global-padding': hasRootPaddingAwareAlignments,
-						}
-					) }
-					contentEditable={ false }
-					ref={ observeTypingRef }
-					style={ {
-						// This is using inline styles
-						// so it's applied for both iframed and non iframed editors.
-						marginTop: '4rem',
-					} }
-				>
-					<PostTitle ref={ titleRef } />
-				</div>
-			) }
-			<RecursionProvider
-				blockName={ wrapperBlockName }
-				uniqueId={ wrapperUniqueId }
+		const localRef = useRef();
+		const typewriterRef = useTypewriter();
+		const contentRef = useMergeRefs(
+			[
+				ref,
+				localRef,
+				renderingMode === 'post-only' ? typewriterRef : undefined,
+			].filter( ( r ) => !! r )
+		);
+
+		return (
+			<BlockCanvas
+				shouldIframe={ ! disableIframe }
+				contentRef={ contentRef }
+				styles={ styles }
+				height="100%"
+				iframeProps={ iframeProps }
 			>
-				<BlockList
-					className={ classnames(
-						className,
-						renderingMode !== 'post-only'
-							? 'wp-site-blocks'
-							: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
+				{ themeSupportsLayout &&
+					! themeHasDisabledLayoutStyles &&
+					renderingMode === 'post-only' && (
+						<>
+							<LayoutStyle
+								selector=".editor-editor-canvas__post-title-wrapper"
+								layout={ fallbackLayout }
+							/>
+							<LayoutStyle
+								selector=".block-editor-block-list__layout.is-root-container"
+								layout={ postEditorLayout }
+							/>
+							{ align && <LayoutStyle css={ alignCSS } /> }
+							{ postContentLayoutStyles && (
+								<LayoutStyle
+									layout={ postContentLayout }
+									css={ postContentLayoutStyles }
+								/>
+							) }
+						</>
 					) }
-					layout={ blockListLayout }
-					dropZoneElement={ dropZoneElement }
-					renderAppender={ renderAppender }
-				/>
-			</RecursionProvider>
-		</>
-	);
-}
+				{ renderingMode === 'post-only' && (
+					<div
+						className={ classnames(
+							'editor-editor-canvas__post-title-wrapper',
+							// The following class is only here for backward comapatibility
+							// some themes might be using it to style the post title.
+							'edit-post-visual-editor__post-title-wrapper',
+							{
+								'has-global-padding':
+									hasRootPaddingAwareAlignments,
+							}
+						) }
+						contentEditable={ false }
+						ref={ observeTypingRef }
+						style={ {
+							// This is using inline styles
+							// so it's applied for both iframed and non iframed editors.
+							marginTop: '4rem',
+						} }
+					>
+						<PostTitle ref={ titleRef } />
+					</div>
+				) }
+				<RecursionProvider
+					blockName={ wrapperBlockName }
+					uniqueId={ wrapperUniqueId }
+				>
+					<BlockList
+						className={ classnames(
+							className,
+							renderingMode !== 'post-only'
+								? 'wp-site-blocks'
+								: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
+						) }
+						layout={ blockListLayout }
+						dropZoneElement={
+							// When iframed, pass in the html element of the iframe to
+							// ensure the drop zone extends to the edges of the iframe.
+							disableIframe
+								? localRef.current
+								: localRef.current?.parentNode
+						}
+						renderAppender={ renderAppender }
+					/>
+				</RecursionProvider>
+				{ children }
+			</BlockCanvas>
+		);
+	}
+);
+
+export default EditorCanvas;


### PR DESCRIPTION
Related #52632 

## What?

In my quest to unify the post and site editor code bases, one of the steps is to unify the "canvas" of the editor. In this PR, I just move the `BlockCanvas` rendering to the unified `EditorCanvas` component.

In the process, it allowed me to remove the "dropzoneElement" prop but forced me to add some other temporary props (styles, iframeProps) which I hope to remove later with further unification. 

## Testing Instructions

Nothing really, just ensures the editors continues to render as before.