### PR TITLE
DataViews: Render data async conditionally

### DIFF
--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -29,6 +29,7 @@ export default function DataViews( {
 	paginationInfo,
 	supportedLayouts,
 	onSelectionChange,
+	isRenderedAsync,
 } ) {
 	const [ selection, setSelection ] = useState( [] );
 
@@ -82,6 +83,7 @@ export default function DataViews( {
 					isLoading={ isLoading }
 					onSelectionChange={ onSetSelection }
 					selection={ selection }
+					isRenderedAsync={ isRenderedAsync }
 				/>
 				<Pagination
 					view={ view }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -29,7 +29,7 @@ export default function DataViews( {
 	paginationInfo,
 	supportedLayouts,
 	onSelectionChange,
-	isRenderedAsync,
+	deferredRendering,
 } ) {
 	const [ selection, setSelection ] = useState( [] );
 
@@ -83,7 +83,7 @@ export default function DataViews( {
 					isLoading={ isLoading }
 					onSelectionChange={ onSetSelection }
 					selection={ selection }
-					isRenderedAsync={ isRenderedAsync }
+					deferredRendering={ deferredRendering }
 				/>
 				<Pagination
 					view={ view }

--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -156,7 +156,10 @@ function FieldsVisibilityMenu( { view, onChangeView, fields } ) {
 									? view.hiddenFields.filter(
 											( id ) => id !== field.id
 									  )
-									: [ ...view.hiddenFields, field.id ],
+									: [
+											...( view.hiddenFields || [] ),
+											field.id,
+									  ],
 							} );
 						} }
 					>

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -14,7 +14,14 @@ import { useAsyncList } from '@wordpress/compose';
  */
 import ItemActions from './item-actions';
 
-export default function ViewGrid( { data, fields, view, actions, getItemId } ) {
+export default function ViewGrid( {
+	data,
+	fields,
+	view,
+	actions,
+	getItemId,
+	isRenderedAsync,
+} ) {
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField
 	);
@@ -29,6 +36,7 @@ export default function ViewGrid( { data, fields, view, actions, getItemId } ) {
 			)
 	);
 	const shownData = useAsyncList( data, { step: 3 } );
+	const usedData = isRenderedAsync ? shownData : data;
 	return (
 		<Grid
 			gap={ 8 }
@@ -36,7 +44,7 @@ export default function ViewGrid( { data, fields, view, actions, getItemId } ) {
 			alignment="top"
 			className="dataviews-grid-view"
 		>
-			{ shownData.map( ( item, index ) => (
+			{ usedData.map( ( item, index ) => (
 				<VStack
 					spacing={ 3 }
 					key={ getItemId?.( item ) || index }

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -20,7 +20,7 @@ export default function ViewGrid( {
 	view,
 	actions,
 	getItemId,
-	isRenderedAsync,
+	deferredRendering,
 } ) {
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField
@@ -36,7 +36,7 @@ export default function ViewGrid( {
 			)
 	);
 	const shownData = useAsyncList( data, { step: 3 } );
-	const usedData = isRenderedAsync ? shownData : data;
+	const usedData = deferredRendering ? shownData : data;
 	return (
 		<Grid
 			gap={ 8 }

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -20,8 +20,10 @@ export default function ViewList( {
 	getItemId,
 	onSelectionChange,
 	selection,
+	isRenderedAsync,
 } ) {
 	const shownData = useAsyncList( data, { step: 3 } );
+	const usedData = isRenderedAsync ? shownData : data;
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField
 	);
@@ -45,7 +47,7 @@ export default function ViewList( {
 
 	return (
 		<ul className="dataviews-list-view">
-			{ shownData.map( ( item, index ) => {
+			{ usedData.map( ( item, index ) => {
 				return (
 					<li key={ getItemId?.( item ) || index }>
 						<div

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -20,10 +20,10 @@ export default function ViewList( {
 	getItemId,
 	onSelectionChange,
 	selection,
-	isRenderedAsync,
+	deferredRendering,
 } ) {
 	const shownData = useAsyncList( data, { step: 3 } );
-	const usedData = isRenderedAsync ? shownData : data;
+	const usedData = deferredRendering ? shownData : data;
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout.mediaField
 	);

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -340,6 +340,7 @@ function ViewTable( {
 	getItemId,
 	isLoading = false,
 	paginationInfo,
+	isRenderedAsync,
 } ) {
 	const columns = useMemo( () => {
 		const _columns = fields.map( ( field ) => {
@@ -367,7 +368,7 @@ function ViewTable( {
 		}
 
 		return _columns;
-	}, [ fields, actions, view ] );
+	}, [ fields, actions ] );
 
 	const columnVisibility = useMemo( () => {
 		if ( ! view.hiddenFields?.length ) {
@@ -435,8 +436,9 @@ function ViewTable( {
 		} );
 
 	const shownData = useAsyncList( data );
+	const usedData = isRenderedAsync ? shownData : data;
 	const dataView = useReactTable( {
-		data: shownData,
+		data: usedData,
 		columns,
 		manualSorting: true,
 		manualFiltering: true,

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -340,7 +340,7 @@ function ViewTable( {
 	getItemId,
 	isLoading = false,
 	paginationInfo,
-	isRenderedAsync,
+	deferredRendering,
 } ) {
 	const columns = useMemo( () => {
 		const _columns = fields.map( ( field ) => {
@@ -436,7 +436,7 @@ function ViewTable( {
 		} );
 
 	const shownData = useAsyncList( data );
-	const usedData = isRenderedAsync ? shownData : data;
+	const usedData = deferredRendering ? shownData : data;
 	const dataView = useReactTable( {
 		data: usedData,
 		columns,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -331,7 +331,7 @@ export default function PagePages() {
 					view={ view }
 					onChangeView={ onChangeView }
 					onSelectionChange={ onSelectionChange }
-					isRenderedAsync={ false }
+					deferredRendering={ false }
 				/>
 			</Page>
 			{ view.type === LAYOUT_LIST && (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -331,6 +331,7 @@ export default function PagePages() {
 					view={ view }
 					onChangeView={ onChangeView }
 					onSelectionChange={ onSelectionChange }
+					isRenderedAsync={ false }
 				/>
 			</Page>
 			{ view.type === LAYOUT_LIST && (

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -353,7 +353,7 @@ export default function DataviewsTemplates() {
 				view={ view }
 				onChangeView={ onChangeView }
 				supportedLayouts={ [ LAYOUT_TABLE, LAYOUT_GRID ] }
-				isRenderedAsync={ ! view.hiddenFields?.includes( 'preview' ) }
+				deferredRendering={ ! view.hiddenFields?.includes( 'preview' ) }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -353,6 +353,7 @@ export default function DataviewsTemplates() {
 				view={ view }
 				onChangeView={ onChangeView }
 				supportedLayouts={ [ LAYOUT_TABLE, LAYOUT_GRID ] }
+				isRenderedAsync={ ! view.hiddenFields?.includes( 'preview' ) }
 			/>
 		</Page>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds a new prop that conditionally render data async. This way when we don't have some heavy rendering functions for fields, we don't need to show them few at the time, which produces a visual 'waterfall' effect.

## Testing Instructions
1. Everything should render synchronously  with the exception in templates list when the `preview` field is visible.

