### PR TITLE
Navigation editor: Fix content mode

### DIFF
--- a/packages/editor/src/components/provider/navigation-block-editing-mode.js
+++ b/packages/editor/src/components/provider/navigation-block-editing-mode.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * For the Navigation block editor, we need to force the block editor to contentOnly for that block.
+ *
+ * Set block editing mode to contentOnly when entering Navigation focus mode.
+ * this ensures that non-content controls on the block will be hidden and thus
+ * the user can focus on editing the Navigation Menu content only.
+ */
+
+export default function NavigationBlockEditingMode() {
+	// In the navigation block editor,
+	// the navigation block is the only root block.
+	const blockClientId = useSelect(
+		( select ) => select( blockEditorStore ).getBlockOrder()?.[ 0 ],
+		[]
+	);
+	const { setBlockEditingMode, unsetBlockEditingMode } =
+		useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( ! blockClientId ) {
+			return;
+		}
+
+		setBlockEditingMode( blockClientId, 'contentOnly' );
+
+		return () => {
+			unsetBlockEditingMode( blockClientId );
+		};
+	}, [ blockClientId, unsetBlockEditingMode, setBlockEditingMode ] );
+}


### PR DESCRIPTION
In #56000 we move the "content mode" enabling of the navigation block editor from the site editor to the editor provider but we introduced a subtle race condition, where the "content mode" was not set properly if the "blocks" were not set yet in the "BlockEditorProvider".

This PR fixes that by moving that hook under the "BlockEditorProvider" in the block tree and also updates to be reactive, as soon as the root block clientId changes, it retrievers the "content mode".

**Testing instructions**

 - Open the site editor
 - Navigate to the "navigation" page
 - Click the "edit icon"
 - You should see the navigation block "locked" in the list view and also it shouldn't have a "more menu"