### PR TITLE
[Data Views] Adding `aria-sort` to table view headers

### DIFF
--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -545,6 +545,9 @@ function ViewTable( {
 		// TODO:Add spinner or progress bar..
 		return <h3>{ __( 'Loading' ) }</h3>;
 	}
+
+	const sortValues = { asc: 'ascending', desc: 'descending' };
+
 	return (
 		<div className="dataviews-table-view-wrapper">
 			{ hasRows && (
@@ -568,6 +571,11 @@ function ViewTable( {
 													.maxWidth || undefined,
 										} }
 										data-field-id={ header.id }
+										aria-sort={
+											sortValues[
+												header.column.getIsSorted()
+											]
+										}
 									>
 										<HeaderMenu
 											dataView={ dataView }


### PR DESCRIPTION
## What?

This PR adds `aria-sort` to column headers in table view. Resolves #56853.


## Why?

Ensures sorting semantics are not just communicated visually


## How?

Every column header gets an `aria-sort` prop with a value appropriate for the sort status of the column (`"ascending"`/`"descending"`/`undefined`).


## Testing Instructions

1. With the "New admin views" Gutenberg experiment enabled, navigate to a new admin view such as "Manage all pages".
2. Sort a column, either from the 'view options' menu button, or from a column header.
3. Confirm that the generated HTML has an `aria-sort` on the correct `<th>`, either `ascending` or `descending` as appropriate, and that `aria-sort` does not appear on any other `<th>`.

![The new 'Pages' admin view, showing a data table surrounded by various controls. The "Title" column header is visually indicated as being sorted with a downward-pointing chevron.](https://github.com/WordPress/gutenberg/assets/159848/edfa558a-6df3-4ef2-8cd6-38cf0f96558c)


```html
...
<table class="dataviews-table-view">
  <thead>
    <tr>
      <th data-field-id="title" aria-sort="descending" ...>
        <button ...>Title ⏷</button>
      </th>
      <th data-field-id="author" ...>
        <button ...>Author</button>
      </th>
      <th data-field-id="status" ...>
        <button ...>Status</button>
      </th>
      <th data-field-id="actions" ...>Actions</th>
    </tr>
  </thead>
  ...
</table>
...
```