### PR TITLE
One hook to rule them all: preparation for a block supports API

### DIFF
--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -1,45 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { store as blocksStore } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import groups from './groups';
-import { store as blockEditorStore } from '../../store';
-import { useBlockEditContext } from '../block-edit/context';
 import useDisplayBlockControls from '../use-display-block-controls';
 
 export default function useBlockControlsFill( group, shareWithChildBlocks ) {
-	const isDisplayed = useDisplayBlockControls();
-	const { clientId } = useBlockEditContext();
-	const isParentDisplayed = useSelect(
-		( select ) => {
-			if ( ! shareWithChildBlocks ) {
-				return false;
-			}
-
-			const { getBlockName, hasSelectedInnerBlock } =
-				select( blockEditorStore );
-			const { hasBlockSupport } = select( blocksStore );
-
-			return (
-				hasBlockSupport(
-					getBlockName( clientId ),
-					'__experimentalExposeControlsToChildren',
-					false
-				) && hasSelectedInnerBlock( clientId )
-			);
-		},
-		[ shareWithChildBlocks, clientId ]
-	);
-
+	const { isDisplayed, isParentDisplayed } = useDisplayBlockControls();
 	if ( isDisplayed ) {
 		return groups[ group ]?.Fill;
 	}
-	if ( isParentDisplayed ) {
+	if ( isParentDisplayed && shareWithChildBlocks ) {
 		return groups.parent.Fill;
 	}
 	return null;

--- a/packages/block-editor/src/components/block-info-slot-fill/index.js
+++ b/packages/block-editor/src/components/block-info-slot-fill/index.js
@@ -13,7 +13,7 @@ const { createPrivateSlotFill } = unlock( componentsPrivateApis );
 const { Fill, Slot } = createPrivateSlotFill( 'BlockInformation' );
 
 const BlockInfo = ( props ) => {
-	const isDisplayed = useDisplayBlockControls();
+	const { isDisplayed } = useDisplayBlockControls();
 	if ( ! isDisplayed ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -33,7 +33,7 @@ export default function InspectorControlsFill( {
 		group = __experimentalGroup;
 	}
 
-	const isDisplayed = useDisplayBlockControls();
+	const { isDisplayed } = useDisplayBlockControls();
 	const Fill = groups[ group ]?.Fill;
 	if ( ! Fill ) {
 		warning( `Unknown InspectorControls group "${ group }" provided.` );

--- a/packages/block-editor/src/components/inspector-controls/fill.native.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.native.js
@@ -35,7 +35,7 @@ export default function InspectorControlsFill( {
 		);
 		group = __experimentalGroup;
 	}
-	const isDisplayed = useDisplayBlockControls();
+	const { isDisplayed } = useDisplayBlockControls();
 
 	const Fill = groups[ group ]?.Fill;
 	if ( ! Fill ) {

--- a/packages/block-editor/src/components/use-display-block-controls/index.js
+++ b/packages/block-editor/src/components/use-display-block-controls/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -13,23 +14,28 @@ export default function useDisplayBlockControls() {
 	const { isSelected, clientId, name } = useBlockEditContext();
 	return useSelect(
 		( select ) => {
-			if ( isSelected ) {
-				return true;
-			}
-
 			const {
 				getBlockName,
 				isFirstMultiSelectedBlock,
 				getMultiSelectedBlockClientIds,
+				hasSelectedInnerBlock,
 			} = select( blockEditorStore );
+			const { hasBlockSupport } = select( blocksStore );
 
-			if ( isFirstMultiSelectedBlock( clientId ) ) {
-				return getMultiSelectedBlockClientIds().every(
-					( id ) => getBlockName( id ) === name
-				);
-			}
-
-			return false;
+			return {
+				isDisplayed:
+					isSelected ||
+					( isFirstMultiSelectedBlock( clientId ) &&
+						getMultiSelectedBlockClientIds().every(
+							( id ) => getBlockName( id ) === name
+						) ),
+				isParentDisplayed:
+					hasBlockSupport(
+						getBlockName( clientId ),
+						'__experimentalExposeControlsToChildren',
+						false
+					) && hasSelectedInnerBlock( clientId ),
+			};
 		},
 		[ clientId, isSelected, name ]
 	);

--- a/packages/block-editor/src/components/use-display-block-controls/index.native.js
+++ b/packages/block-editor/src/components/use-display-block-controls/index.native.js
@@ -26,11 +26,7 @@ export default function useDisplayBlockControls() {
 				false
 			);
 
-			if ( ! hideControls && isSelected ) {
-				return true;
-			}
-
-			return false;
+			return { isDisplayed: ! hideControls && isSelected };
 		},
 		[ clientId, isSelected, name ]
 	);

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -109,7 +109,7 @@ export function addAttribute( settings ) {
 }
 
 function BlockEditAlignmentToolbarControlsPure( {
-	blockName,
+	name: blockName,
 	align,
 	setAttributes,
 } ) {

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -159,38 +159,11 @@ const BlockEditAlignmentToolbarControls = pure(
 	BlockEditAlignmentToolbarControlsPure
 );
 
-/**
- * Override the default edit UI to include new toolbar controls for block
- * alignment, if block defines support.
- *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
- */
-export const withAlignmentControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const hasAlignmentSupport = hasBlockSupport(
-			props.name,
-			'align',
-			false
-		);
-
-		return (
-			<>
-				{ hasAlignmentSupport && (
-					<BlockEditAlignmentToolbarControls
-						blockName={ props.name }
-						// This component is pure, so only pass needed props!
-						align={ props.attributes.align }
-						setAttributes={ props.setAttributes }
-					/>
-				) }
-				<BlockEdit key="edit" { ...props } />
-			</>
-		);
-	},
-	'withAlignmentControls'
-);
+export const BlockEdit = BlockEditAlignmentToolbarControls;
+export const attributeKeys = [ 'align' ];
+export function hasSupport( blockName ) {
+	return hasBlockSupport( blockName, 'align', false );
+}
 
 function BlockListBlockWithDataAlign( { block: BlockListBlock, props } ) {
 	const { name, attributes } = props;
@@ -272,11 +245,6 @@ addFilter(
 	'editor.BlockListBlock',
 	'core/editor/align/with-data-align',
 	withDataAlign
-);
-addFilter(
-	'editor.BlockEdit',
-	'core/editor/align/with-toolbar-controls',
-	withAlignmentControls
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent, pure } from '@wordpress/compose';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
@@ -152,18 +152,13 @@ function BlockEditAlignmentToolbarControlsPure( {
 	);
 }
 
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-const BlockEditAlignmentToolbarControls = pure(
-	BlockEditAlignmentToolbarControlsPure
-);
-
-export const BlockEdit = BlockEditAlignmentToolbarControls;
-export const attributeKeys = [ 'align' ];
-export function hasSupport( blockName ) {
-	return hasBlockSupport( blockName, 'align', false );
-}
+export default {
+	edit: BlockEditAlignmentToolbarControlsPure,
+	attributeKeys: [ 'align' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'align', false );
+	},
+};
 
 function BlockListBlockWithDataAlign( { block: BlockListBlock, props } ) {
 	const { name, attributes } = props;

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -153,6 +153,7 @@ function BlockEditAlignmentToolbarControlsPure( {
 }
 
 export default {
+	shareWithChildBlocks: true,
 	edit: BlockEditAlignmentToolbarControlsPure,
 	attributeKeys: [ 'align' ],
 	hasSupport( name ) {

--- a/packages/block-editor/src/hooks/align.native.js
+++ b/packages/block-editor/src/hooks/align.native.js
@@ -8,6 +8,7 @@ import { WIDE_ALIGNMENTS } from '@wordpress/components';
 const ALIGNMENTS = [ 'left', 'center', 'right' ];
 
 export * from './align.js';
+export { default } from './align.js';
 
 // Used to filter out blocks that don't support wide/full alignment on mobile
 addFilter(

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -5,7 +5,6 @@ import { addFilter } from '@wordpress/hooks';
 import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { Platform } from '@wordpress/element';
 
 /**
@@ -116,38 +115,11 @@ function BlockEditAnchorControlPure( { blockName, anchor, setAttributes } ) {
 	);
 }
 
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-const BlockEditAnchorControl = pure( BlockEditAnchorControlPure );
-
-/**
- * Override the default edit UI to include a new block inspector control for
- * assigning the anchor ID, if block supports anchor.
- *
- * @param {Component} BlockEdit Original component.
- *
- * @return {Component} Wrapped component.
- */
-export const withAnchorControls = createHigherOrderComponent( ( BlockEdit ) => {
-	return ( props ) => {
-		return (
-			<>
-				<BlockEdit { ...props } />
-				{ props.isSelected &&
-					hasBlockSupport( props.name, 'anchor' ) && (
-						<BlockEditAnchorControl
-							blockName={ props.name }
-							// This component is pure, so only pass needed
-							// props!
-							anchor={ props.attributes.anchor }
-							setAttributes={ props.setAttributes }
-						/>
-					) }
-			</>
-		);
-	};
-}, 'withAnchorControls' );
+export const BlockEdit = BlockEditAnchorControlPure;
+export const attributeKeys = [ 'anchor' ];
+export function hasSupport( name ) {
+	return hasBlockSupport( name, 'anchor' );
+}
 
 /**
  * Override props assigned to save component to inject anchor ID, if block
@@ -169,11 +141,6 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 }
 
 addFilter( 'blocks.registerBlockType', 'core/anchor/attribute', addAttribute );
-addFilter(
-	'editor.BlockEdit',
-	'core/editor/anchor/with-inspector-controls',
-	withAnchorControls
-);
 addFilter(
 	'blocks.getSaveContent.extraProps',
 	'core/editor/anchor/save-props',

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -115,11 +115,13 @@ function BlockEditAnchorControlPure( { blockName, anchor, setAttributes } ) {
 	);
 }
 
-export const BlockEdit = BlockEditAnchorControlPure;
-export const attributeKeys = [ 'anchor' ];
-export function hasSupport( name ) {
-	return hasBlockSupport( name, 'anchor' );
-}
+export default {
+	edit: BlockEditAnchorControlPure,
+	attributeKeys: [ 'anchor' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'anchor' );
+	},
+};
 
 /**
  * Override props assigned to save component to inject anchor ID, if block

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -51,7 +51,11 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
-function BlockEditAnchorControlPure( { blockName, anchor, setAttributes } ) {
+function BlockEditAnchorControlPure( {
+	name: blockName,
+	anchor,
+	setAttributes,
+} ) {
 	const blockEditingMode = useBlockEditingMode();
 
 	const isWeb = Platform.OS === 'web';

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -19,7 +19,7 @@ import { store as blockEditorStore } from '../store';
 
 const EMPTY_OBJECT = {};
 
-function BlockHooksControlPure( props ) {
+function BlockHooksControlPure( { name, clientId } ) {
 	const blockTypes = useSelect(
 		( select ) => select( blocksStore ).getBlockTypes(),
 		[]
@@ -28,10 +28,9 @@ function BlockHooksControlPure( props ) {
 	const hookedBlocksForCurrentBlock = useMemo(
 		() =>
 			blockTypes?.filter(
-				( { blockHooks } ) =>
-					blockHooks && props.blockName in blockHooks
+				( { blockHooks } ) => blockHooks && name in blockHooks
 			),
-		[ blockTypes, props.blockName ]
+		[ blockTypes, name ]
 	);
 
 	const { blockIndex, rootClientId, innerBlocksLength } = useSelect(
@@ -40,13 +39,12 @@ function BlockHooksControlPure( props ) {
 				select( blockEditorStore );
 
 			return {
-				blockIndex: getBlockIndex( props.clientId ),
-				innerBlocksLength: getBlock( props.clientId )?.innerBlocks
-					?.length,
-				rootClientId: getBlockRootClientId( props.clientId ),
+				blockIndex: getBlockIndex( clientId ),
+				innerBlocksLength: getBlock( clientId )?.innerBlocks?.length,
+				rootClientId: getBlockRootClientId( clientId ),
 			};
 		},
-		[ props.clientId ]
+		[ clientId ]
 	);
 
 	const hookedBlockClientIds = useSelect(
@@ -63,8 +61,7 @@ function BlockHooksControlPure( props ) {
 						return clientIds;
 					}
 
-					const relativePosition =
-						block?.blockHooks?.[ props.blockName ];
+					const relativePosition = block?.blockHooks?.[ name ];
 					let candidates;
 
 					switch ( relativePosition ) {
@@ -81,12 +78,12 @@ function BlockHooksControlPure( props ) {
 							// Any of the current block's child blocks (with the right block type) qualifies
 							// as a hooked first or last child block, as the block might've been automatically
 							// inserted and then moved around a bit by the user.
-							candidates = getBlock( props.clientId ).innerBlocks;
+							candidates = getBlock( clientId ).innerBlocks;
 							break;
 					}
 
 					const hookedBlock = candidates?.find(
-						( { name } ) => name === block.name
+						( candidate ) => name === candidate.name
 					);
 
 					// If the block exists in the designated location, we consider it hooked
@@ -116,12 +113,7 @@ function BlockHooksControlPure( props ) {
 
 			return EMPTY_OBJECT;
 		},
-		[
-			hookedBlocksForCurrentBlock,
-			props.blockName,
-			props.clientId,
-			rootClientId,
-		]
+		[ hookedBlocksForCurrentBlock, name, clientId, rootClientId ]
 	);
 
 	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
@@ -167,7 +159,7 @@ function BlockHooksControlPure( props ) {
 					block,
 					// TODO: It'd be great if insertBlock() would accept negative indices for insertion.
 					relativePosition === 'first_child' ? 0 : innerBlocksLength,
-					props.clientId, // Insert as a child of the current block.
+					clientId, // Insert as a child of the current block.
 					false
 				);
 				break;
@@ -205,9 +197,7 @@ function BlockHooksControlPure( props ) {
 											if ( ! checked ) {
 												// Create and insert block.
 												const relativePosition =
-													block.blockHooks[
-														props.blockName
-													];
+													block.blockHooks[ name ];
 												insertBlockIntoDesignatedLocation(
 													createBlock( block.name ),
 													relativePosition
@@ -216,11 +206,12 @@ function BlockHooksControlPure( props ) {
 											}
 
 											// Remove block.
-											const clientId =
+											removeBlock(
 												hookedBlockClientIds[
 													block.name
-												];
-											removeBlock( clientId, false );
+												],
+												false
+											);
 										} }
 									/>
 								);

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -233,7 +233,9 @@ function BlockHooksControlPure( props ) {
 	);
 }
 
-export const BlockEdit = BlockHooksControlPure;
-export function hasSupport() {
-	return true;
-}
+export default {
+	edit: BlockHooksControlPure,
+	hasSupport() {
+		return true;
+	},
+};

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -2,14 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { addFilter } from '@wordpress/hooks';
 import { Fragment, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	PanelBody,
 	ToggleControl,
 } from '@wordpress/components';
-import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -235,32 +233,7 @@ function BlockHooksControlPure( props ) {
 	);
 }
 
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-const BlockHooksControl = pure( BlockHooksControlPure );
-
-export const withBlockHooksControls = createHigherOrderComponent(
-	( BlockEdit ) => {
-		return ( props ) => {
-			return (
-				<>
-					<BlockEdit key="edit" { ...props } />
-					{ props.isSelected && (
-						<BlockHooksControl
-							blockName={ props.name }
-							clientId={ props.clientId }
-						/>
-					) }
-				</>
-			);
-		};
-	},
-	'withBlockHooksControls'
-);
-
-addFilter(
-	'editor.BlockEdit',
-	'core/editor/block-hooks/with-inspector-controls',
-	withBlockHooksControls
-);
+export const BlockEdit = BlockHooksControlPure;
+export function hasSupport() {
+	return true;
+}

--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -3,7 +3,6 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent, pure } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
 
@@ -11,7 +10,6 @@ import { TextControl } from '@wordpress/components';
  * Internal dependencies
  */
 import { InspectorControls } from '../components';
-import { useBlockRename } from '../components/block-rename';
 
 /**
  * Filters registered block settings, adding an `__experimentalLabel` callback if one does not already exist.
@@ -47,13 +45,7 @@ export function addLabelCallback( settings ) {
 	return settings;
 }
 
-function BlockRenameControlPure( { name, metadata, setAttributes } ) {
-	const { canRename } = useBlockRename( name );
-
-	if ( ! canRename ) {
-		return null;
-	}
-
+function BlockRenameControlPure( { metadata, setAttributes } ) {
 	return (
 		<InspectorControls group="advanced">
 			<TextControl
@@ -70,36 +62,11 @@ function BlockRenameControlPure( { name, metadata, setAttributes } ) {
 	);
 }
 
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-const BlockRenameControl = pure( BlockRenameControlPure );
-
-export const withBlockRenameControl = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const { name, attributes, setAttributes, isSelected } = props;
-		return (
-			<>
-				{ isSelected && (
-					<BlockRenameControl
-						name={ name }
-						// This component is pure, so only pass needed props!
-						metadata={ attributes.metadata }
-						setAttributes={ setAttributes }
-					/>
-				) }
-				<BlockEdit key="edit" { ...props } />
-			</>
-		);
-	},
-	'withToolbarControls'
-);
-
-addFilter(
-	'editor.BlockEdit',
-	'core/block-rename-ui/with-block-rename-control',
-	withBlockRenameControl
-);
+export const BlockEdit = BlockRenameControlPure;
+export const attributeKeys = [ 'metadata' ];
+export function hasSupport( name ) {
+	return hasBlockSupport( name, 'renaming', true );
+}
 
 addFilter(
 	'blocks.registerBlockType',

--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -62,11 +62,13 @@ function BlockRenameControlPure( { metadata, setAttributes } ) {
 	);
 }
 
-export const BlockEdit = BlockRenameControlPure;
-export const attributeKeys = [ 'metadata' ];
-export function hasSupport( name ) {
-	return hasBlockSupport( name, 'renaming', true );
-}
+export default {
+	edit: BlockRenameControlPure,
+	attributeKeys: [ 'metadata' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'renaming', true );
+	},
+};
 
 addFilter(
 	'blocks.registerBlockType',

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -10,7 +10,6 @@ import { addFilter } from '@wordpress/hooks';
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent, pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -64,46 +63,11 @@ function CustomClassNameControlsPure( { className, setAttributes } ) {
 	);
 }
 
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-const CustomClassNameControls = pure( CustomClassNameControlsPure );
-
-/**
- * Override the default edit UI to include a new block inspector control for
- * assigning the custom class name, if block supports custom class name.
- * The control is displayed within the Advanced panel in the block inspector.
- *
- * @param {Component} BlockEdit Original component.
- *
- * @return {Component} Wrapped component.
- */
-export const withCustomClassNameControls = createHigherOrderComponent(
-	( BlockEdit ) => {
-		return ( props ) => {
-			const hasCustomClassName = hasBlockSupport(
-				props.name,
-				'customClassName',
-				true
-			);
-
-			return (
-				<>
-					<BlockEdit { ...props } />
-					{ hasCustomClassName && props.isSelected && (
-						<CustomClassNameControls
-							// This component is pure, so only pass needed
-							// props!
-							className={ props.attributes.className }
-							setAttributes={ props.setAttributes }
-						/>
-					) }
-				</>
-			);
-		};
-	},
-	'withCustomClassNameControls'
-);
+export const BlockEdit = CustomClassNameControlsPure;
+export const attributeKeys = [ 'className' ];
+export function hasSupport( name ) {
+	return hasBlockSupport( name, 'customClassName', true );
+}
 
 /**
  * Override props assigned to save component to inject the className, if block
@@ -173,11 +137,6 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/editor/custom-class-name/attribute',
 	addAttribute
-);
-addFilter(
-	'editor.BlockEdit',
-	'core/editor/custom-class-name/with-inspector-controls',
-	withCustomClassNameControls
 );
 addFilter(
 	'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -63,11 +63,13 @@ function CustomClassNameControlsPure( { className, setAttributes } ) {
 	);
 }
 
-export const BlockEdit = CustomClassNameControlsPure;
-export const attributeKeys = [ 'className' ];
-export function hasSupport( name ) {
-	return hasBlockSupport( name, 'customClassName', true );
-}
+export default {
+	edit: CustomClassNameControlsPure,
+	attributeKeys: [ 'className' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'customClassName', true );
+	},
+};
 
 /**
  * Override props assigned to save component to inject the className, if block

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -5,7 +5,6 @@ import { addFilter } from '@wordpress/hooks';
 import { PanelBody, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { createHigherOrderComponent, pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -91,50 +90,16 @@ function CustomFieldsControlPure( { name, connections, setAttributes } ) {
 	);
 }
 
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-const CustomFieldsControl = pure( CustomFieldsControlPure );
-
-/**
- * Override the default edit UI to include a new block inspector control for
- * assigning a connection to blocks that has support for connections.
- * Currently, only the `core/paragraph` block is supported and there is only a relation
- * between paragraph content and a custom field.
- *
- * @param {Component} BlockEdit Original component.
- *
- * @return {Component} Wrapped component.
- */
-const withCustomFieldsControls = createHigherOrderComponent( ( BlockEdit ) => {
-	return ( props ) => {
-		const hasCustomFieldsSupport = hasBlockSupport(
-			props.name,
-			'__experimentalConnections',
-			false
-		);
-
+export const BlockEdit = CustomFieldsControlPure;
+export const attributeKeys = [ 'connections' ];
+export function hasSupport( name ) {
+	return (
+		hasBlockSupport( name, '__experimentalConnections', false ) &&
 		// Check if the current block is a paragraph or image block.
 		// Currently, only these two blocks are supported.
-		if ( ! [ 'core/paragraph', 'core/image' ].includes( props.name ) ) {
-			return <BlockEdit key="edit" { ...props } />;
-		}
-
-		return (
-			<>
-				<BlockEdit key="edit" { ...props } />
-				{ hasCustomFieldsSupport && props.isSelected && (
-					<CustomFieldsControl
-						name={ props.name }
-						// This component is pure, so only pass needed props!
-						connections={ props.attributes.connections }
-						setAttributes={ props.setAttributes }
-					/>
-				) }
-			</>
-		);
-	};
-}, 'withCustomFieldsControls' );
+		[ 'core/paragraph', 'core/image' ].includes( name )
+	);
+}
 
 if (
 	window.__experimentalConnections ||
@@ -144,12 +109,5 @@ if (
 		'blocks.registerBlockType',
 		'core/editor/connections/attribute',
 		addAttribute
-	);
-}
-if ( window.__experimentalConnections ) {
-	addFilter(
-		'editor.BlockEdit',
-		'core/editor/connections/with-inspector-controls',
-		withCustomFieldsControls
 	);
 }

--- a/packages/block-editor/src/hooks/custom-fields.js
+++ b/packages/block-editor/src/hooks/custom-fields.js
@@ -90,16 +90,18 @@ function CustomFieldsControlPure( { name, connections, setAttributes } ) {
 	);
 }
 
-export const BlockEdit = CustomFieldsControlPure;
-export const attributeKeys = [ 'connections' ];
-export function hasSupport( name ) {
-	return (
-		hasBlockSupport( name, '__experimentalConnections', false ) &&
-		// Check if the current block is a paragraph or image block.
-		// Currently, only these two blocks are supported.
-		[ 'core/paragraph', 'core/image' ].includes( name )
-	);
-}
+export default {
+	edit: CustomFieldsControlPure,
+	attributeKeys: [ 'connections' ],
+	hasSupport( name ) {
+		return (
+			hasBlockSupport( name, '__experimentalConnections', false ) &&
+			// Check if the current block is a paragraph or image block.
+			// Currently, only these two blocks are supported.
+			[ 'core/paragraph', 'core/image' ].includes( name )
+		);
+	},
+};
 
 if (
 	window.__experimentalConnections ||

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -13,11 +13,7 @@ import {
 	getBlockType,
 	hasBlockSupport,
 } from '@wordpress/blocks';
-import {
-	createHigherOrderComponent,
-	useInstanceId,
-	pure,
-} from '@wordpress/compose';
+import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { useMemo, useEffect } from '@wordpress/element';
 
@@ -179,10 +175,16 @@ function DuotonePanelPure( { style, setAttributes, name } ) {
 	);
 }
 
+export const attributeKeys = [ 'style' ];
+
+export function hasSupport( name ) {
+	return hasBlockSupport( name, 'filter.duotone' );
+}
+
 // We don't want block controls to re-render when typing inside a block. `pure`
 // will prevent re-renders unless props change, so only pass the needed props
 // and not the whole attributes object.
-const DuotonePanel = pure( DuotonePanelPure );
+export const BlockEdit = DuotonePanelPure;
 
 /**
  * Filters registered block settings, extending attributes to include
@@ -211,44 +213,6 @@ function addDuotoneAttributes( settings ) {
 
 	return settings;
 }
-
-/**
- * Override the default edit UI to include toolbar controls for duotone if the
- * block supports duotone.
- *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
- */
-const withDuotoneControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		// Previous `color.__experimentalDuotone` support flag is migrated via
-		// block_type_metadata_settings filter in `lib/block-supports/duotone.php`.
-		const hasDuotoneSupport = hasBlockSupport(
-			props.name,
-			'filter.duotone'
-		);
-
-		// CAUTION: code added before this line will be executed
-		// for all blocks, not just those that support duotone. Code added
-		// above this line should be carefully evaluated for its impact on
-		// performance.
-		return (
-			<>
-				{ hasDuotoneSupport && (
-					<DuotonePanel
-						// This component is pure, so only pass needed props!
-						style={ props.attributes.style }
-						setAttributes={ props.setAttributes }
-						name={ props.name }
-					/>
-				) }
-				<BlockEdit { ...props } />
-			</>
-		);
-	},
-	'withDuotoneControls'
-);
 
 function DuotoneStyles( {
 	clientId,
@@ -437,11 +401,6 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/editor/duotone/add-attributes',
 	addDuotoneAttributes
-);
-addFilter(
-	'editor.BlockEdit',
-	'core/editor/duotone/with-editor-controls',
-	withDuotoneControls
 );
 addFilter(
 	'editor.BlockListBlock',

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -175,16 +175,13 @@ function DuotonePanelPure( { style, setAttributes, name } ) {
 	);
 }
 
-export const attributeKeys = [ 'style' ];
-
-export function hasSupport( name ) {
-	return hasBlockSupport( name, 'filter.duotone' );
-}
-
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-export const BlockEdit = DuotonePanelPure;
+export default {
+	edit: DuotonePanelPure,
+	attributeKeys: [ 'style' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'filter.duotone' );
+	},
+};
 
 /**
  * Filters registered block settings, extending attributes to include

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -176,6 +176,7 @@ function DuotonePanelPure( { style, setAttributes, name } ) {
 }
 
 export default {
+	shareWithChildBlocks: true,
 	edit: DuotonePanelPure,
 	attributeKeys: [ 'style' ],
 	hasSupport( name ) {

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -37,6 +37,7 @@ const features = [
 	'custom-class-name',
 	window.__experimentalConnections ? 'custom-fields' : null,
 	'position',
+	'style',
 ]
 	.filter( Boolean )
 	.map( ( feature ) => {
@@ -62,7 +63,7 @@ export const withBlockEditHooks = createHigherOrderComponent(
 		const shouldDisplayControls = useDisplayBlockControls();
 		return [
 			...features.map(
-				( { name, BlockEdit, hasSupport, attributeKeys } ) => {
+				( { name, BlockEdit, hasSupport, attributeKeys = [] } ) => {
 					if (
 						! shouldDisplayControls ||
 						! hasSupport( props.name )
@@ -81,6 +82,9 @@ export const withBlockEditHooks = createHigherOrderComponent(
 							name={ props.name }
 							clientId={ props.clientId }
 							setAttributes={ props.setAttributes }
+							__unstableParentLayout={
+								props.__unstableParentLayout
+							}
 							{ ...neededProps }
 						/>
 					);

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -9,43 +9,44 @@ import { addFilter } from '@wordpress/hooks';
  */
 import useDisplayBlockControls from '../components/use-display-block-controls';
 import './compat';
+import align from './align';
 import './lock';
-import './anchor';
+import anchor from './anchor';
 import './aria-label';
-import './custom-class-name';
+import customClassName from './custom-class-name';
 import './generated-class-name';
-import './style';
+import style from './style';
 import './settings';
 import './color';
+import duotone from './duotone';
 import './font-family';
 import './font-size';
 import './border';
-import './position';
+import position from './position';
+import layout from './layout';
 import './content-lock-ui';
 import './metadata';
-import './custom-fields';
-import './block-hooks';
-import './block-renaming';
+import customFields from './custom-fields';
+import blockHooks from './block-hooks';
+import blockRenaming from './block-renaming';
 
 const features = [
-	'layout',
-	'duotone',
-	'align',
-	'anchor',
-	'block-hooks',
-	'block-renaming',
-	'custom-class-name',
-	window.__experimentalConnections ? 'custom-fields' : null,
-	'position',
-	'style',
+	align,
+	anchor,
+	customClassName,
+	style,
+	duotone,
+	position,
+	layout,
+	window.__experimentalConnections ? customFields : null,
+	blockHooks,
+	blockRenaming,
 ]
 	.filter( Boolean )
-	.map( ( feature ) => {
-		const settings = require( `./${ feature }` );
+	.map( ( settings ) => {
 		return {
 			...settings,
-			name: feature,
-			BlockEdit: pure( settings.BlockEdit ),
+			Edit: pure( settings.edit ),
 		};
 	} );
 
@@ -63,7 +64,7 @@ export const withBlockEditHooks = createHigherOrderComponent(
 		const shouldDisplayControls = useDisplayBlockControls();
 		return [
 			...features.map(
-				( { name, BlockEdit, hasSupport, attributeKeys = [] } ) => {
+				( { Edit, hasSupport, attributeKeys = [] }, i ) => {
 					if (
 						! shouldDisplayControls ||
 						! hasSupport( props.name )
@@ -77,8 +78,8 @@ export const withBlockEditHooks = createHigherOrderComponent(
 						}
 					}
 					return (
-						<BlockEdit
-							key={ name }
+						<Edit
+							key={ i }
 							name={ props.name }
 							clientId={ props.clientId }
 							setAttributes={ props.setAttributes }

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -27,16 +27,26 @@ import './custom-fields';
 import './block-hooks';
 import './block-renaming';
 
-const features = [ 'layout', 'duotone', 'align', 'anchor' ].map(
-	( feature ) => {
+const features = [
+	'layout',
+	'duotone',
+	'align',
+	'anchor',
+	'block-hooks',
+	'block-renaming',
+	'custom-class-name',
+	window.__experimentalConnections ? 'custom-fields' : null,
+	'position',
+]
+	.filter( Boolean )
+	.map( ( feature ) => {
 		const settings = require( `./${ feature }` );
 		return {
 			...settings,
 			name: feature,
 			BlockEdit: pure( settings.BlockEdit ),
 		};
-	}
-);
+	} );
 
 export { useCustomSides } from './dimensions';
 export { useLayoutClasses, useLayoutStyles } from './layout';
@@ -69,6 +79,7 @@ export const withBlockEditHooks = createHigherOrderComponent(
 						<BlockEdit
 							key={ name }
 							name={ props.name }
+							clientId={ props.clientId }
 							setAttributes={ props.setAttributes }
 							{ ...neededProps }
 						/>
@@ -78,7 +89,7 @@ export const withBlockEditHooks = createHigherOrderComponent(
 			<OriginalBlockEdit key="edit" { ...props } />,
 		];
 	},
-	'withLayoutControls'
+	'withBlockEditHooks'
 );
 
 addFilter( 'editor.BlockEdit', 'core/editor/hooks', withBlockEditHooks );

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -1,8 +1,14 @@
 /**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
+import useDisplayBlockControls from '../components/use-display-block-controls';
 import './compat';
-import './align';
 import './lock';
 import './anchor';
 import './aria-label';
@@ -11,17 +17,26 @@ import './generated-class-name';
 import './style';
 import './settings';
 import './color';
-import './duotone';
 import './font-family';
 import './font-size';
 import './border';
 import './position';
-import './layout';
 import './content-lock-ui';
 import './metadata';
 import './custom-fields';
 import './block-hooks';
 import './block-renaming';
+
+const features = [ 'layout', 'duotone', 'align', 'anchor' ].map(
+	( feature ) => {
+		const settings = require( `./${ feature }` );
+		return {
+			...settings,
+			name: feature,
+			BlockEdit: pure( settings.BlockEdit ),
+		};
+	}
+);
 
 export { useCustomSides } from './dimensions';
 export { useLayoutClasses, useLayoutStyles } from './layout';
@@ -31,3 +46,39 @@ export { getSpacingClassesAndStyles } from './use-spacing-props';
 export { getTypographyClassesAndStyles } from './use-typography-props';
 export { getGapCSSValue } from './gap';
 export { useCachedTruthy } from './use-cached-truthy';
+
+export const withBlockEditHooks = createHigherOrderComponent(
+	( OriginalBlockEdit ) => ( props ) => {
+		const shouldDisplayControls = useDisplayBlockControls();
+		return [
+			...features.map(
+				( { name, BlockEdit, hasSupport, attributeKeys } ) => {
+					if (
+						! shouldDisplayControls ||
+						! hasSupport( props.name )
+					) {
+						return null;
+					}
+					const neededProps = {};
+					for ( const key of attributeKeys ) {
+						if ( props.attributes[ key ] ) {
+							neededProps[ key ] = props.attributes[ key ];
+						}
+					}
+					return (
+						<BlockEdit
+							key={ name }
+							name={ props.name }
+							setAttributes={ props.setAttributes }
+							{ ...neededProps }
+						/>
+					);
+				}
+			),
+			<OriginalBlockEdit key="edit" { ...props } />,
+		];
+	},
+	'withLayoutControls'
+);
+
+addFilter( 'editor.BlockEdit', 'core/editor/hooks', withBlockEditHooks );

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -1,13 +1,7 @@
 /**
- * WordPress dependencies
- */
-import { createHigherOrderComponent, pure } from '@wordpress/compose';
-import { addFilter } from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
-import useDisplayBlockControls from '../components/use-display-block-controls';
+import { createBlockEditFilter } from './utils';
 import './compat';
 import align from './align';
 import './lock';
@@ -30,25 +24,20 @@ import customFields from './custom-fields';
 import blockHooks from './block-hooks';
 import blockRenaming from './block-renaming';
 
-const features = [
-	align,
-	anchor,
-	customClassName,
-	style,
-	duotone,
-	position,
-	layout,
-	window.__experimentalConnections ? customFields : null,
-	blockHooks,
-	blockRenaming,
-]
-	.filter( Boolean )
-	.map( ( settings ) => {
-		return {
-			...settings,
-			Edit: pure( settings.edit ),
-		};
-	} );
+createBlockEditFilter(
+	[
+		align,
+		anchor,
+		customClassName,
+		style,
+		duotone,
+		position,
+		layout,
+		window.__experimentalConnections ? customFields : null,
+		blockHooks,
+		blockRenaming,
+	].filter( Boolean )
+);
 
 export { useCustomSides } from './dimensions';
 export { useLayoutClasses, useLayoutStyles } from './layout';
@@ -58,43 +47,3 @@ export { getSpacingClassesAndStyles } from './use-spacing-props';
 export { getTypographyClassesAndStyles } from './use-typography-props';
 export { getGapCSSValue } from './gap';
 export { useCachedTruthy } from './use-cached-truthy';
-
-export const withBlockEditHooks = createHigherOrderComponent(
-	( OriginalBlockEdit ) => ( props ) => {
-		const shouldDisplayControls = useDisplayBlockControls();
-		return [
-			...features.map(
-				( { Edit, hasSupport, attributeKeys = [] }, i ) => {
-					if (
-						! shouldDisplayControls ||
-						! hasSupport( props.name )
-					) {
-						return null;
-					}
-					const neededProps = {};
-					for ( const key of attributeKeys ) {
-						if ( props.attributes[ key ] ) {
-							neededProps[ key ] = props.attributes[ key ];
-						}
-					}
-					return (
-						<Edit
-							key={ i }
-							name={ props.name }
-							clientId={ props.clientId }
-							setAttributes={ props.setAttributes }
-							__unstableParentLayout={
-								props.__unstableParentLayout
-							}
-							{ ...neededProps }
-						/>
-					);
-				}
-			),
-			<OriginalBlockEdit key="edit" { ...props } />,
-		];
-	},
-	'withBlockEditHooks'
-);
-
-addFilter( 'editor.BlockEdit', 'core/editor/hooks', withBlockEditHooks );

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -1,15 +1,18 @@
 /**
  * Internal dependencies
  */
+import { createBlockEditFilter } from './utils';
 import './compat';
-import './align';
-import './anchor';
+import align from './align';
+import anchor from './anchor';
 import './custom-class-name';
 import './generated-class-name';
-import './style';
+import style from './style';
 import './color';
 import './font-size';
 import './layout';
+
+createBlockEditFilter( [ align, anchor, style ] );
 
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -286,16 +286,13 @@ function LayoutPanelPure( { layout, setAttributes, name: blockName } ) {
 	);
 }
 
-export const attributeKeys = [ 'layout' ];
-
-export function hasSupport( name ) {
-	return hasLayoutBlockSupport( name, layoutBlockSupportKey );
-}
-
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-export const BlockEdit = LayoutPanelPure;
+export default {
+	edit: LayoutPanelPure,
+	attributeKeys: [ 'layout' ],
+	hasSupport( name ) {
+		return hasLayoutBlockSupport( name );
+	},
+};
 
 function LayoutTypeSwitcher( { type, onChange } ) {
 	return (

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -6,11 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	createHigherOrderComponent,
-	pure,
-	useInstanceId,
-} from '@wordpress/compose';
+import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
@@ -290,10 +286,16 @@ function LayoutPanelPure( { layout, setAttributes, name: blockName } ) {
 	);
 }
 
+export const attributeKeys = [ 'layout' ];
+
+export function hasSupport( name ) {
+	return hasLayoutBlockSupport( name, layoutBlockSupportKey );
+}
+
 // We don't want block controls to re-render when typing inside a block. `pure`
 // will prevent re-renders unless props change, so only pass the needed props
 // and not the whole attributes object.
-const LayoutPanel = pure( LayoutPanelPure );
+export const BlockEdit = LayoutPanelPure;
 
 function LayoutTypeSwitcher( { type, onChange } ) {
 	return (
@@ -335,33 +337,6 @@ export function addAttribute( settings ) {
 
 	return settings;
 }
-
-/**
- * Override the default edit UI to include layout controls
- *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
- */
-export const withLayoutControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const supportLayout = hasLayoutBlockSupport( props.name );
-
-		return [
-			supportLayout && (
-				<LayoutPanel
-					key="layout"
-					// This component is pure, so only pass needed props!
-					layout={ props.attributes.layout }
-					setAttributes={ props.setAttributes }
-					name={ props.name }
-				/>
-			),
-			<BlockEdit key="edit" { ...props } />,
-		];
-	},
-	'withLayoutControls'
-);
 
 function BlockWithLayoutStyles( { block: BlockListBlock, props } ) {
 	const { name, attributes } = props;
@@ -515,9 +490,4 @@ addFilter(
 	'editor.BlockListBlock',
 	'core/editor/layout/with-child-layout-styles',
 	withChildLayoutStyles
-);
-addFilter(
-	'editor.BlockEdit',
-	'core/editor/layout/with-inspector-controls',
-	withLayoutControls
 );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -287,6 +287,7 @@ function LayoutPanelPure( { layout, setAttributes, name: blockName } ) {
 }
 
 export default {
+	shareWithChildBlocks: true,
 	edit: LayoutPanelPure,
 	attributeKeys: [ 'layout' ],
 	hasSupport( name ) {

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -12,11 +12,7 @@ import {
 	BaseControl,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import {
-	createHigherOrderComponent,
-	pure,
-	useInstanceId,
-} from '@wordpress/compose';
+import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useMemo, Platform } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
@@ -324,18 +320,13 @@ export default {
 		if ( isPositionDisabled ) {
 			return null;
 		}
-		return <PositionPanel { ...props } />;
+		return <PositionPanelPure { ...props } />;
 	},
 	attributeKeys: [ 'style' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, POSITION_SUPPORT_KEY );
 	},
 };
-
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-const PositionPanel = pure( PositionPanelPure );
 
 /**
  * Override the default block element to add the position styles.

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -318,44 +318,22 @@ export function PositionPanelPure( {
 	} );
 }
 
+export const BlockEdit = ( props ) => {
+	const isPositionDisabled = useIsPositionDisabled( props );
+	if ( isPositionDisabled ) {
+		return;
+	}
+	return <PositionPanel { ...props } />;
+};
+export const attributeKeys = [ 'style' ];
+export function hasSupport( name ) {
+	return hasBlockSupport( name, POSITION_SUPPORT_KEY );
+}
+
 // We don't want block controls to re-render when typing inside a block. `pure`
 // will prevent re-renders unless props change, so only pass the needed props
 // and not the whole attributes object.
 const PositionPanel = pure( PositionPanelPure );
-
-/**
- * Override the default edit UI to include position controls.
- *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
- */
-export const withPositionControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const { name: blockName } = props;
-		const positionSupport = hasBlockSupport(
-			blockName,
-			POSITION_SUPPORT_KEY
-		);
-		const isPositionDisabled = useIsPositionDisabled( props );
-		const showPositionControls = positionSupport && ! isPositionDisabled;
-
-		return [
-			showPositionControls && (
-				<PositionPanel
-					key="position"
-					// This component is pure, so only pass needed props!
-					style={ props.attributes.style }
-					name={ blockName }
-					setAttributes={ props.setAttributes }
-					clientId={ props.clientId }
-				/>
-			),
-			<BlockEdit key="edit" { ...props } />,
-		];
-	},
-	'withPositionControls'
-);
 
 /**
  * Override the default block element to add the position styles.
@@ -410,9 +388,4 @@ addFilter(
 	'editor.BlockListBlock',
 	'core/editor/position/with-position-styles',
 	withPositionStyles
-);
-addFilter(
-	'editor.BlockEdit',
-	'core/editor/position/with-inspector-controls',
-	withPositionControls
 );

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -318,17 +318,19 @@ export function PositionPanelPure( {
 	} );
 }
 
-export const BlockEdit = ( props ) => {
-	const isPositionDisabled = useIsPositionDisabled( props );
-	if ( isPositionDisabled ) {
-		return;
-	}
-	return <PositionPanel { ...props } />;
+export default {
+	edit: function Edit( props ) {
+		const isPositionDisabled = useIsPositionDisabled( props );
+		if ( isPositionDisabled ) {
+			return;
+		}
+		return <PositionPanel { ...props } />;
+	},
+	attributeKeys: [ 'style' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, POSITION_SUPPORT_KEY );
+	},
 };
-export const attributeKeys = [ 'style' ];
-export function hasSupport( name ) {
-	return hasBlockSupport( name, POSITION_SUPPORT_KEY );
-}
 
 // We don't want block controls to re-render when typing inside a block. `pure`
 // will prevent re-renders unless props change, so only pass the needed props

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -322,7 +322,7 @@ export default {
 	edit: function Edit( props ) {
 		const isPositionDisabled = useIsPositionDisabled( props );
 		if ( isPositionDisabled ) {
-			return;
+			return null;
 		}
 		return <PositionPanel { ...props } />;
 	},

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -376,10 +376,10 @@ function BlockStyleControls( {
 	);
 }
 
-export const BlockEdit = BlockStyleControls;
-export function hasSupport( name ) {
-	return hasStyleSupport( name );
-}
+export default {
+	edit: BlockStyleControls,
+	hasSupport: hasStyleSupport,
+};
 
 // Defines which element types are supported, including their hover styles or
 // any other elements that have been included under a single element type

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -32,7 +32,6 @@ import {
 	SPACING_SUPPORT_KEY,
 	DimensionsPanel,
 } from './dimensions';
-import useDisplayBlockControls from '../components/use-display-block-controls';
 import {
 	shouldSkipSerialization,
 	useStyleOverride,
@@ -356,12 +355,16 @@ function BlockStyleControls( {
 	__unstableParentLayout,
 } ) {
 	const settings = useBlockSettings( name, __unstableParentLayout );
+	const blockEditingMode = useBlockEditingMode();
 	const passedProps = {
 		clientId,
 		name,
 		setAttributes,
 		settings,
 	};
+	if ( blockEditingMode !== 'default' ) {
+		return null;
+	}
 	return (
 		<>
 			<ColorEdit { ...passedProps } />
@@ -373,34 +376,10 @@ function BlockStyleControls( {
 	);
 }
 
-/**
- * Override the default edit UI to include new inspector controls for
- * all the custom styles configs.
- *
- * @param {Function} BlockEdit Original component.
- *
- * @return {Function} Wrapped component.
- */
-export const withBlockStyleControls = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		if ( ! hasStyleSupport( props.name ) ) {
-			return <BlockEdit key="edit" { ...props } />;
-		}
-
-		const shouldDisplayControls = useDisplayBlockControls();
-		const blockEditingMode = useBlockEditingMode();
-
-		return (
-			<>
-				{ shouldDisplayControls && blockEditingMode === 'default' && (
-					<BlockStyleControls { ...props } />
-				) }
-				<BlockEdit key="edit" { ...props } />
-			</>
-		);
-	},
-	'withBlockStyleControls'
-);
+export const BlockEdit = BlockStyleControls;
+export function hasSupport( name ) {
+	return hasStyleSupport( name );
+}
 
 // Defines which element types are supported, including their hover styles or
 // any other elements that have been included under a single element type
@@ -540,12 +519,6 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/style/addEditProps',
 	addEditProps
-);
-
-addFilter(
-	'editor.BlockEdit',
-	'core/style/with-block-controls',
-	withBlockStyleControls
 );
 
 addFilter(

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -12,20 +12,12 @@ import {
 	registerBlockType,
 	unregisterBlockType,
 } from '@wordpress/blocks';
-import { SlotFillProvider } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import BlockControls from '../../components/block-controls';
-import BlockEdit from '../../components/block-edit';
 import BlockEditorProvider from '../../components/provider';
-import {
-	getValidAlignments,
-	withAlignmentControls,
-	withDataAlign,
-	addAssignedAlign,
-} from '../align';
+import { getValidAlignments, withDataAlign, addAssignedAlign } from '../align';
 
 const noop = () => {};
 
@@ -154,68 +146,6 @@ describe( 'align', () => {
 					false
 				)
 			).toEqual( [ 'left', 'right' ] );
-		} );
-	} );
-
-	describe( 'withAlignControls', () => {
-		const componentProps = {
-			name: 'core/foo',
-			attributes: {},
-			isSelected: true,
-		};
-
-		it( 'should do nothing if no valid alignments', () => {
-			registerBlockType( 'core/foo', blockSettings );
-
-			const EnhancedComponent = withAlignmentControls(
-				( { wrapperProps } ) => <div { ...wrapperProps } />
-			);
-
-			render(
-				<SlotFillProvider>
-					<BlockEdit { ...componentProps }>
-						<EnhancedComponent { ...componentProps } />
-					</BlockEdit>
-					<BlockControls.Slot group="block" />
-				</SlotFillProvider>
-			);
-
-			expect(
-				screen.queryByRole( 'button', {
-					name: 'Align',
-					expanded: false,
-				} )
-			).not.toBeInTheDocument();
-		} );
-
-		it( 'should render toolbar controls if valid alignments', () => {
-			registerBlockType( 'core/foo', {
-				...blockSettings,
-				supports: {
-					align: true,
-					alignWide: false,
-				},
-			} );
-
-			const EnhancedComponent = withAlignmentControls(
-				( { wrapperProps } ) => <div { ...wrapperProps } />
-			);
-
-			render(
-				<SlotFillProvider>
-					<BlockEdit { ...componentProps }>
-						<EnhancedComponent { ...componentProps } />
-					</BlockEdit>
-					<BlockControls.Slot group="block" />
-				</SlotFillProvider>
-			);
-
-			expect(
-				screen.getAllByRole( 'button', {
-					name: 'Align',
-					expanded: false,
-				} )
-			).toHaveLength( 2 );
 		} );
 	} );
 

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -375,45 +375,54 @@ export function createBlockEditFilter( features ) {
 	} );
 	const withBlockEditHooks = createHigherOrderComponent(
 		( OriginalBlockEdit ) => ( props ) => {
-			const shouldDisplayControls = useDisplayBlockControls();
+			const { isDisplayed, isParentDisplayed } =
+				useDisplayBlockControls();
 			// CAUTION: code added before this line will be executed for all
 			// blocks, not just those that support the feature! Code added
 			// above this line should be carefully evaluated for its impact on
 			// performance.
 			return [
-				...features.map(
-					( { Edit, hasSupport, attributeKeys = [] }, i ) => {
-						if (
-							! shouldDisplayControls ||
-							! hasSupport( props.name )
-						) {
-							return null;
-						}
+				...features.map( ( feature, i ) => {
+					const {
+						Edit,
+						hasSupport,
+						attributeKeys = [],
+						shareWithChildBlocks,
+					} = feature;
+					const shouldDisplayControls =
+						isDisplayed ||
+						( isParentDisplayed && shareWithChildBlocks );
 
-						const neededProps = {};
-						for ( const key of attributeKeys ) {
-							if ( props.attributes[ key ] ) {
-								neededProps[ key ] = props.attributes[ key ];
-							}
-						}
-						return (
-							<Edit
-								// We can use the index because the array length
-								// is fixed per page load right now.
-								key={ i }
-								name={ props.name }
-								clientId={ props.clientId }
-								setAttributes={ props.setAttributes }
-								__unstableParentLayout={
-									props.__unstableParentLayout
-								}
-								// This component is pure, so only pass needed
-								// props!!!
-								{ ...neededProps }
-							/>
-						);
+					if (
+						! shouldDisplayControls ||
+						! hasSupport( props.name )
+					) {
+						return null;
 					}
-				),
+
+					const neededProps = {};
+					for ( const key of attributeKeys ) {
+						if ( props.attributes[ key ] ) {
+							neededProps[ key ] = props.attributes[ key ];
+						}
+					}
+					return (
+						<Edit
+							// We can use the index because the array length
+							// is fixed per page load right now.
+							key={ i }
+							name={ props.name }
+							clientId={ props.clientId }
+							setAttributes={ props.setAttributes }
+							__unstableParentLayout={
+								props.__unstableParentLayout
+							}
+							// This component is pure, so only pass needed
+							// props!!!
+							{ ...neededProps }
+						/>
+					);
+				} ),
 				<OriginalBlockEdit key="edit" { ...props } />,
 			];
 		},

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -4,10 +4,13 @@
 import { getBlockSupport } from '@wordpress/blocks';
 import { useMemo, useEffect, useId } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
+import useDisplayBlockControls from '../components/use-display-block-controls';
 import { useSettings } from '../components';
 import { useSettingsForBlockElement } from '../components/global-styles/hooks';
 import { getValueFromObjectPath, setImmutably } from '../utils/object';
@@ -361,4 +364,60 @@ export function useBlockSettings( name, parentLayout ) {
 	] );
 
 	return useSettingsForBlockElement( rawSettings, name );
+}
+
+export function createBlockEditFilter( features ) {
+	// We don't want block controls to re-render when typing inside a block.
+	// `pure` will prevent re-renders unless props change, so only pass the
+	// needed props and not the whole attributes object.
+	features = features.map( ( settings ) => {
+		return { ...settings, Edit: pure( settings.edit ) };
+	} );
+	const withBlockEditHooks = createHigherOrderComponent(
+		( OriginalBlockEdit ) => ( props ) => {
+			const shouldDisplayControls = useDisplayBlockControls();
+			// CAUTION: code added before this line will be executed for all
+			// blocks, not just those that support the feature! Code added
+			// above this line should be carefully evaluated for its impact on
+			// performance.
+			return [
+				...features.map(
+					( { Edit, hasSupport, attributeKeys = [] }, i ) => {
+						if (
+							! shouldDisplayControls ||
+							! hasSupport( props.name )
+						) {
+							return null;
+						}
+
+						const neededProps = {};
+						for ( const key of attributeKeys ) {
+							if ( props.attributes[ key ] ) {
+								neededProps[ key ] = props.attributes[ key ];
+							}
+						}
+						return (
+							<Edit
+								// We can use the index because the array length
+								// is fixed per page load right now.
+								key={ i }
+								name={ props.name }
+								clientId={ props.clientId }
+								setAttributes={ props.setAttributes }
+								__unstableParentLayout={
+									props.__unstableParentLayout
+								}
+								// This component is pure, so only pass needed
+								// props!!!
+								{ ...neededProps }
+							/>
+						);
+					}
+				),
+				<OriginalBlockEdit key="edit" { ...props } />,
+			];
+		},
+		'withBlockEditHooks'
+	);
+	addFilter( 'editor.BlockEdit', 'core/editor/hooks', withBlockEditHooks );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR refactors to hooks to use a single filter for `editor.BlockEdit`, and with that lays the foundations for a new block supports API (the other filters remain to be done in a similar fashion).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Related to https://github.com/WordPress/gutenberg/discussions/51005.

Less code duplication.
Less higher order components and less components in a block tree.
Less opportunities for performance regressions:
* Check if controls should be rendered in a single place.
* Make the components pure in a single place.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
