### PR TITLE
Site Editor: Fix active edited post

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1285,6 +1285,19 @@ _Returns_
 
 -   `Object`: Action object.
 
+### setEditedPost
+
+Returns an action that sets the current post Type and post ID.
+
+_Parameters_
+
+-   _postType_ `string`: Post Type.
+-   _postId_ `string`: Post ID.
+
+_Returns_
+
+-   `Object`: Action object.
+
 ### setRenderingMode
 
 Returns an action used to set the rendering mode of the post editor. We support multiple rendering modes:
@@ -1316,15 +1329,13 @@ _Parameters_
 
 ### setupEditorState
 
-Returns an action object used to setup the editor state when first opening an editor.
+> **Deprecated**
+
+Setup the editor state.
 
 _Parameters_
 
 -   _post_ `Object`: Post object.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### showInsertionPoint
 

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -88,7 +88,7 @@ export default function DocumentBar() {
 
 function BaseDocumentActions( { postType, postId, onBack } ) {
 	const { open: openCommandCenter } = useDispatch( commandsStore );
-	const { editedRecord: document, isResolving } = useEntityRecord(
+	const { editedRecord: doc, isResolving } = useEntityRecord(
 		'postType',
 		postType,
 		postId
@@ -96,13 +96,13 @@ function BaseDocumentActions( { postType, postId, onBack } ) {
 	const { templateIcon, templateTitle } = useSelect( ( select ) => {
 		const { __experimentalGetTemplateInfo: getTemplateInfo } =
 			select( editorStore );
-		const templateInfo = getTemplateInfo( document );
+		const templateInfo = getTemplateInfo( doc );
 		return {
 			templateIcon: templateInfo.icon,
 			templateTitle: templateInfo.title,
 		};
 	} );
-	const isNotFound = ! document && ! isResolving;
+	const isNotFound = ! doc && ! isResolving;
 	const icon = icons[ postType ] ?? pageIcon;
 	const [ isAnimated, setIsAnimated ] = useState( false );
 	const isMounting = useRef( true );
@@ -123,7 +123,7 @@ function BaseDocumentActions( { postType, postId, onBack } ) {
 		isMounting.current = false;
 	}, [ postType, postId ] );
 
-	const title = isTemplate ? templateTitle : document.title;
+	const title = isTemplate ? templateTitle : doc.title;
 
 	return (
 		<div

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -164,13 +164,12 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			updatePostLock,
 			setupEditor,
 			updateEditorSettings,
-			__experimentalTearDownEditor,
 			setCurrentTemplateId,
+			setEditedPost,
 			setRenderingMode,
 		} = unlock( useDispatch( editorStore ) );
 		const { createWarningNotice } = useDispatch( noticesStore );
 
-		// Initialize and tear down the editor.
 		// Ideally this should be synced on each change and not just something you do once.
 		useLayoutEffect( () => {
 			// Assume that we don't need to initialize in the case of an error recovery.
@@ -196,17 +195,19 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					}
 				);
 			}
-
-			return () => {
-				__experimentalTearDownEditor();
-			};
 		}, [] );
+
+		// Synchronizes the active post with the state
+		useEffect( () => {
+			setEditedPost( post.type, post.id );
+		}, [ post.type, post.id ] );
 
 		// Synchronize the editor settings as they change.
 		useEffect( () => {
 			updateEditorSettings( settings );
 		}, [ settings, updateEditorSettings ] );
 
+		// Synchronizes the active template with the state.
 		useEffect( () => {
 			setCurrentTemplateId( template?.id );
 		}, [ template?.id, setCurrentTemplateId ] );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -36,7 +36,7 @@ import {
 export const setupEditor =
 	( post, edits, template ) =>
 	( { dispatch } ) => {
-		dispatch.setupEditorState( post );
+		dispatch.setEditedPost( post.type, post.id );
 		// Apply a template for new posts only, if exists.
 		const isNewPost = post.status === 'auto-draft';
 		if ( isNewPost && template ) {
@@ -70,10 +70,18 @@ export const setupEditor =
  * Returns an action object signalling that the editor is being destroyed and
  * that any necessary state or side-effect cleanup should occur.
  *
+ * @deprecated
+ *
  * @return {Object} Action object.
  */
 export function __experimentalTearDownEditor() {
-	return { type: 'TEAR_DOWN_EDITOR' };
+	deprecated(
+		"wp.data.dispatch( 'core/editor' ).__experimentalTearDownEditor",
+		{
+			since: '6.5',
+		}
+	);
+	return { type: 'DO_NOTHING' };
 }
 
 /**
@@ -109,17 +117,33 @@ export function updatePost() {
 }
 
 /**
- * Returns an action object used to setup the editor state when first opening
- * an editor.
+ * Setup the editor state.
+ *
+ * @deprecated
  *
  * @param {Object} post Post object.
+ */
+export function setupEditorState( post ) {
+	deprecated( "wp.data.dispatch( 'core/editor' ).setupEditorState", {
+		since: '6.5',
+		alternative: "wp.data.dispatch( 'core/editor' ).setEditedPost",
+	} );
+	return setEditedPost( post.type, post.id );
+}
+
+/**
+ * Returns an action that sets the current post Type and post ID.
+ *
+ * @param {string} postType Post Type.
+ * @param {string} postId   Post ID.
  *
  * @return {Object} Action object.
  */
-export function setupEditorState( post ) {
+export function setEditedPost( postType, postId ) {
 	return {
-		type: 'SETUP_EDITOR_STATE',
-		post,
+		type: 'SET_EDITED_POST',
+		postType,
+		postId,
 	};
 }
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -83,8 +83,8 @@ export function shouldOverwriteState( action, previousAction ) {
 
 export function postId( state = null, action ) {
 	switch ( action.type ) {
-		case 'SETUP_EDITOR_STATE':
-			return action.post.id;
+		case 'SET_EDITED_POST':
+			return action.postId;
 	}
 
 	return state;
@@ -101,8 +101,8 @@ export function templateId( state = null, action ) {
 
 export function postType( state = null, action ) {
 	switch ( action.type ) {
-		case 'SETUP_EDITOR_STATE':
-			return action.post.type;
+		case 'SET_EDITED_POST':
+			return action.postType;
 	}
 
 	return state;
@@ -247,28 +247,6 @@ export function postAutosavingLock( state = {}, action ) {
 }
 
 /**
- * Reducer returning whether the editor is ready to be rendered.
- * The editor is considered ready to be rendered once
- * the post object is loaded properly and the initial blocks parsed.
- *
- * @param {boolean} state
- * @param {Object}  action
- *
- * @return {boolean} Updated state.
- */
-export function isReady( state = false, action ) {
-	switch ( action.type ) {
-		case 'SETUP_EDITOR_STATE':
-			return true;
-
-		case 'TEAR_DOWN_EDITOR':
-			return false;
-	}
-
-	return state;
-}
-
-/**
  * Reducer returning the post editor setting.
  *
  * @param {Object} state  Current state.
@@ -323,7 +301,6 @@ export default combineReducers( {
 	postLock,
 	template,
 	postSavingLock,
-	isReady,
 	editorSettings,
 	postAutosavingLock,
 	renderingMode,

--- a/packages/editor/src/store/reducer.native.js
+++ b/packages/editor/src/store/reducer.native.js
@@ -13,7 +13,6 @@ import {
 	postLock,
 	postSavingLock,
 	template,
-	isReady,
 	editorSettings,
 } from './reducer.js';
 
@@ -87,7 +86,6 @@ export default combineReducers( {
 	postLock,
 	postSavingLock,
 	template,
-	isReady,
 	editorSettings,
 	clipboard,
 	notices,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1185,7 +1185,7 @@ export function getEditorSelection( state ) {
  * @return {boolean} is Ready.
  */
 export function __unstableIsEditorReady( state ) {
-	return state.isReady;
+	return !! state.postId;
 }
 
 /**


### PR DESCRIPTION
## What?

This fixes a regression introduced in #56000 where the currently edited post type and id goes out of sync in the "editor" store causing the "document bar" to show the title of a previously opened tempate/post rather than the current one.

## Testing Instructions

1- Open the site editor
2- Navigate to "template a" (random template)
3- go back and navigate to "template b"
4- on the "document bar", the title of the "template b" should be shown not "a".