### PR TITLE
Improve text and design of the block removal warnings

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -48,13 +48,13 @@ export function BlockRemovalWarningModal( { rules } ) {
 
 	return (
 		<Modal
-			title={ __( 'Are you sure?' ) }
+			title={ __( 'Be careful!' ) }
 			onRequestClose={ clearBlockRemovalPrompt }
 		>
 			<p>
 				{ _n(
-					'Be careful! Post or page content will not be displayed if you delete this block.',
-					'Be careful! Post or page content will not be displayed if you delete these blocks.',
+					'Post or page content will not be displayed if you delete this block.',
+					'Post or page content will not be displayed if you delete these blocks.',
 					blockNamesForPrompt.length
 				) }
 			</p>

--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -8,7 +8,7 @@ import {
 	Button,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -51,19 +51,12 @@ export function BlockRemovalWarningModal( { rules } ) {
 			title={ __( 'Are you sure?' ) }
 			onRequestClose={ clearBlockRemovalPrompt }
 		>
-			{ blockNamesForPrompt.length === 1 ? (
-				<p>{ rules[ blockNamesForPrompt[ 0 ] ] }</p>
-			) : (
-				<ul style={ { listStyleType: 'disc', paddingLeft: '1rem' } }>
-					{ blockNamesForPrompt.map( ( name ) => (
-						<li key={ name }>{ rules[ name ] }</li>
-					) ) }
-				</ul>
-			) }
 			<p>
-				{ blockNamesForPrompt.length > 1
-					? __( 'Removing these blocks is not advised.' )
-					: __( 'Removing this block is not advised.' ) }
+				{ _n(
+					'Be careful! Post or page content will not be displayed if you delete this block.',
+					'Be careful! Post or page content will not be displayed if you delete these blocks.',
+					blockNamesForPrompt.length
+				) }
 			</p>
 			<HStack justify="right">
 				<Button variant="tertiary" onClick={ clearBlockRemovalPrompt }>

--- a/test/e2e/specs/site-editor/block-removal.spec.js
+++ b/test/e2e/specs/site-editor/block-removal.spec.js
@@ -35,7 +35,7 @@ test.describe( 'Site editor block removal prompt', () => {
 		// Expect the block removal prompt to have appeared
 		await expect(
 			page.getByText(
-				'Post or page content will not be displayed if you delete this block.'
+				'Post or page content will not be displayed if you delete these blocks.'
 			)
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/site-editor/block-removal.spec.js
+++ b/test/e2e/specs/site-editor/block-removal.spec.js
@@ -34,7 +34,9 @@ test.describe( 'Site editor block removal prompt', () => {
 
 		// Expect the block removal prompt to have appeared
 		await expect(
-			page.getByText( 'Query Loop displays a list of posts or pages.' )
+			page.getByText(
+				'Post or page content will not be displayed if you delete this block.'
+			)
 		).toBeVisible();
 	} );
 
@@ -57,7 +59,7 @@ test.describe( 'Site editor block removal prompt', () => {
 		// Expect the block removal prompt to have appeared
 		await expect(
 			page.getByText(
-				'Post Template displays each post or page in a Query Loop.'
+				'Post or page content will not be displayed if you delete this block.'
 			)
 		).toBeVisible();
 	} );


### PR DESCRIPTION
## What?
Updates the text for the block removal warnings.

Fixes #52392.

## Why?
The goal is to improve the UX and have a clearer message/copy.

## How?
1. Update the copy of the notice
2. Remove block specific warnings
3. Use the `_n` function so that we don't need to fork the code for translations.

## Testing Instructions
1. Open the Site Editor on a template that contains a query loop or a post content block
2. Try to remove the query/post template/post content block
3. Confirm that the text on the warning matches says:
> Be careful! Post or page content will not be displayed if you delete this block.

if you are removing one block and
> Be careful! Post or page content will not be displayed if you delete these blocks.

If you are removing more than one block,

## Screenshots or screencast <!-- if applicable -->

<img width="609" alt="Screenshot 2023-12-07 at 14 56 51" src="https://github.com/WordPress/gutenberg/assets/275961/cbf0a56e-2d76-4af4-ae7d-3c1ee5db7216">
<img width="609" alt="Screenshot 2023-12-07 at 14 56 28" src="https://github.com/WordPress/gutenberg/assets/275961/44062e36-7d95-4c10-a5c7-983f96dad60d">

