### PR TITLE
[Data Views] Adding `scope` to table view headers

### DIFF
--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -581,6 +581,7 @@ function ViewTable( {
 												header.column.getIsSorted()
 											]
 										}
+										scope="col"
 									>
 										<HeaderMenu
 											dataView={ dataView }


### PR DESCRIPTION
## What?
This PR adds `scope` to column headers in table view.

## Why?
Ensures that appropriate context is provided for table header and cells.

## How?
Every column header gets a `scope` prop with a `"col"` value.

## Testing Instructions
1. With the "New admin views" Gutenberg experiment enabled, navigate to a new admin view such as "Manage all pages", and check that you are using the table layout.
2. Confirm that each column header has a `scope` attribute with a value of `col`.

```html
...
<table class="dataviews-table-view">
  <thead>
    <tr>
      <th data-field-id="title" scope="col" ...>
        <button ...>Title</button>
      </th>
      <th data-field-id="author" scope="col" ...>
        <button ...>Author</button>
      </th>
      <th data-field-id="status" scope="col" ...>
        <button ...>Status</button>
      </th>
      <th data-field-id="actions" scope="col" ...>
        Actions
      </th>
    </tr>
  </thead>
  ...
</table>
...
```