### PR TITLE
Add basic test coverage for Navigation Menu editing mode

### DIFF
--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -33,7 +33,7 @@ test.describe( 'Editing Navigation Menus', () => {
 		//
 		await admin.visitSiteEditor();
 
-		// create a Navigation Menu called "Test Menu" usinf the REST API helpers
+		// create a Navigation Menu called "Test Menu" using the REST API helpers
 		const createdMenu = await requestUtils.createNavigationMenu( {
 			title: 'Primary Menu',
 			content:

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -58,10 +58,12 @@ test.describe( 'Editing Navigation Menus', () => {
 			.click();
 
 		// Wait for list of Navigations to appear.
-		editorSidebar.getByRole( 'heading', {
-			name: 'Navigation',
-			level: 1,
-		} );
+		await expect(
+			editorSidebar.getByRole( 'heading', {
+				name: 'Navigation',
+				level: 1,
+			} )
+		).toBeVisible();
 
 		await editorSidebar
 			.getByRole( 'button', {

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -123,7 +123,9 @@ test.describe( 'Editing Navigation Menus', () => {
 		// Open the document settings sidebar
 		await editor.openDocumentSettingsSidebar();
 
-		const sidebar = page.getByLabel( 'Editor settings' );
+		const sidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
 
 		await expect( sidebar ).toBeVisible();
 

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -19,131 +19,137 @@ test.describe( 'Editing Navigation Menus', () => {
 		requestUtils,
 		editor,
 	} ) => {
-		// We could Navigate directly to editing the Navigation Menu but we intentionally do not do this.
-		//
-		// Why? To provide coverage for a bug that caused the Navigation Editor behaviours to fail
-		// only when navigating through the editor screens (rather than going directly to the editor by URL).
-		// See: https://github.com/WordPress/gutenberg/pull/56856.
-		//
-		// Example (what we could do):
-		// await admin.visitSiteEditor( {
-		// 	postId: createdMenu?.id,
-		// 	postType: 'wp_navigation',
-		// } );
-		//
-		await admin.visitSiteEditor();
+		await test.step( 'Manually browse to focus mode for a Navigation Menu', async () => {
+			// We could Navigate directly to editing the Navigation Menu but we intentionally do not do this.
+			//
+			// Why? To provide coverage for a bug that caused the Navigation Editor behaviours to fail
+			// only when navigating through the editor screens (rather than going directly to the editor by URL).
+			// See: https://github.com/WordPress/gutenberg/pull/56856.
+			//
+			// Example (what we could do):
+			// await admin.visitSiteEditor( {
+			// 	postId: createdMenu?.id,
+			// 	postType: 'wp_navigation',
+			// } );
+			//
+			await admin.visitSiteEditor();
 
-		// create a Navigation Menu called "Test Menu" using the REST API helpers
-		const createdMenu = await requestUtils.createNavigationMenu( {
-			title: 'Primary Menu',
-			content:
-				'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
-		} );
-
-		// Add another so we get a list of Navigation menus in the editor.
-		await requestUtils.createNavigationMenu( {
-			title: 'Another One',
-			content:
-				'<!-- wp:navigation-link {"label":"Another Item","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
-		} );
-
-		const editorSidebar = page.getByRole( 'region', {
-			name: 'Navigation',
-		} );
-
-		await editorSidebar
-			.getByRole( 'button', {
-				name: 'Navigation',
-			} )
-			.click();
-
-		// Wait for list of Navigations to appear.
-		await expect(
-			editorSidebar.getByRole( 'heading', {
-				name: 'Navigation',
-				level: 1,
-			} )
-		).toBeVisible();
-
-		await editorSidebar
-			.getByRole( 'button', {
-				name: 'Primary Menu',
-			} )
-			.click();
-
-		await expect( page ).toHaveURL(
-			`wp-admin/site-editor.php?postId=${ createdMenu?.id }&postType=wp_navigation`
-		);
-
-		// Wait for list of Navigations to appear.
-		editorSidebar.getByRole( 'heading', {
-			name: 'Primary Menu',
-			level: 1,
-		} );
-
-		// Switch to editing the Navigation Menu
-		await editorSidebar
-			.getByRole( 'link', {
-				name: 'Edit',
-			} )
-			.click();
-
-		// Open List View.
-		await pageUtils.pressKeys( 'access+o' );
-
-		const listView = page
-			.getByRole( 'region', {
-				name: 'List View',
-			} )
-			.getByRole( 'treegrid', {
-				name: 'Block navigation structure',
+			// create a Navigation Menu called "Test Menu" using the REST API helpers
+			const createdMenu = await requestUtils.createNavigationMenu( {
+				title: 'Primary Menu',
+				content:
+					'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
 			} );
 
-		await expect( listView ).toBeVisible();
+			// Add another so we get a list of Navigation menus in the editor.
+			await requestUtils.createNavigationMenu( {
+				title: 'Another One',
+				content:
+					'<!-- wp:navigation-link {"label":"Another Item","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
+			} );
 
-		const navBlockNode = listView.getByRole( 'link', {
-			name: 'Navigation (locked)',
-			exact: true,
+			const editorSidebar = page.getByRole( 'region', {
+				name: 'Navigation',
+			} );
+
+			await editorSidebar
+				.getByRole( 'button', {
+					name: 'Navigation',
+				} )
+				.click();
+
+			// Wait for list of Navigations to appear.
+			await expect(
+				editorSidebar.getByRole( 'heading', {
+					name: 'Navigation',
+					level: 1,
+				} )
+			).toBeVisible();
+
+			await editorSidebar
+				.getByRole( 'button', {
+					name: 'Primary Menu',
+				} )
+				.click();
+
+			await expect( page ).toHaveURL(
+				`wp-admin/site-editor.php?postId=${ createdMenu?.id }&postType=wp_navigation`
+			);
+
+			// Wait for list of Navigations to appear.
+			editorSidebar.getByRole( 'heading', {
+				name: 'Primary Menu',
+				level: 1,
+			} );
+
+			// Switch to editing the Navigation Menu
+			await editorSidebar
+				.getByRole( 'link', {
+					name: 'Edit',
+				} )
+				.click();
 		} );
 
-		// The Navigation block should be present and locked.
-		await expect( navBlockNode ).toBeVisible();
+		await test.step( 'Check Navigation block is present and locked', async () => {
+			// Open List View.
+			await pageUtils.pressKeys( 'access+o' );
 
-		// The block should have no options menu.
-		await expect(
-			listView.getByRole( 'button', {
-				name: 'Options for Navigation',
+			const listView = page
+				.getByRole( 'region', {
+					name: 'List View',
+				} )
+				.getByRole( 'treegrid', {
+					name: 'Block navigation structure',
+				} );
+
+			await expect( listView ).toBeVisible();
+
+			const navBlockNode = listView.getByRole( 'link', {
+				name: 'Navigation (locked)',
 				exact: true,
-			} )
-		).toBeHidden();
+			} );
 
-		// Select the Navigation block.
-		await navBlockNode.click();
+			// The Navigation block should be present and locked.
+			await expect( navBlockNode ).toBeVisible();
 
-		// Open the document settings sidebar
-		await editor.openDocumentSettingsSidebar();
+			// The block should have no options menu.
+			await expect(
+				listView.getByRole( 'button', {
+					name: 'Options for Navigation',
+					exact: true,
+				} )
+			).toBeHidden();
 
-		const sidebar = page.getByRole( 'region', {
-			name: 'Editor settings',
+			// Select the Navigation block.
+			await navBlockNode.click();
 		} );
 
-		await expect( sidebar ).toBeVisible();
+		await test.step( 'Check Navigation block has no controls other than editable list view', async () => {
+			// Open the document settings sidebar
+			await editor.openDocumentSettingsSidebar();
 
-		// Check that the `Menu` control is visible.
-		// This is effectively the contents of the "List View" tab.
-		await expect(
-			sidebar.getByRole( 'heading', { name: 'Menu', exact: true } )
-		).toBeVisible();
+			const sidebar = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
 
-		// Check the standard tabs are not present.
-		await expect(
-			sidebar.getByRole( 'tab', { name: 'List View' } )
-		).toBeHidden();
-		await expect(
-			sidebar.getByRole( 'tab', { name: 'Settings' } )
-		).toBeHidden();
-		await expect(
-			sidebar.getByRole( 'tab', { name: 'Styles' } )
-		).toBeHidden();
+			await expect( sidebar ).toBeVisible();
+
+			// Check that the `Menu` control is visible.
+			// This is effectively the contents of the "List View" tab.
+			await expect(
+				sidebar.getByRole( 'heading', { name: 'Menu', exact: true } )
+			).toBeVisible();
+
+			// Check the standard tabs are not present.
+			await expect(
+				sidebar.getByRole( 'tab', { name: 'List View' } )
+			).toBeHidden();
+			await expect(
+				sidebar.getByRole( 'tab', { name: 'Settings' } )
+			).toBeHidden();
+			await expect(
+				sidebar.getByRole( 'tab', { name: 'Styles' } )
+			).toBeHidden();
+		} );
 	} );
 } );

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -1,0 +1,145 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Editing Navigation Menus', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMenus();
+	} );
+
+	test( 'it should lock the root Navigation block in the editor', async ( {
+		admin,
+		page,
+		pageUtils,
+		requestUtils,
+		editor,
+	} ) => {
+		// We could Navigate directly to editing the Navigation Menu but we intentionally do not do this.
+		//
+		// Why? To provide coverage for a bug that caused the Navigation Editor behaviours to fail
+		// only when navigating through the editor screens (rather than going directly to the editor by URL).
+		// See: https://github.com/WordPress/gutenberg/pull/56856.
+		//
+		// Example (what we could do):
+		// await admin.visitSiteEditor( {
+		// 	postId: createdMenu?.id,
+		// 	postType: 'wp_navigation',
+		// } );
+		//
+		await admin.visitSiteEditor();
+
+		// create a Navigation Menu called "Test Menu" usinf the REST API helpers
+		const createdMenu = await requestUtils.createNavigationMenu( {
+			title: 'Primary Menu',
+			content:
+				'<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
+		} );
+
+		// Add another so we get a list of Navigation menus in the editor.
+		await requestUtils.createNavigationMenu( {
+			title: 'Another One',
+			content:
+				'<!-- wp:navigation-link {"label":"Another Item","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
+		} );
+
+		const editorSidebar = page.getByRole( 'region', {
+			name: 'Navigation',
+		} );
+
+		await editorSidebar
+			.getByRole( 'button', {
+				name: 'Navigation',
+			} )
+			.click();
+
+		// Wait for list of Navigations to appear.
+		editorSidebar.getByRole( 'heading', {
+			name: 'Navigation',
+			level: 1,
+		} );
+
+		await editorSidebar
+			.getByRole( 'button', {
+				name: 'Primary Menu',
+			} )
+			.click();
+
+		await expect( page ).toHaveURL(
+			`wp-admin/site-editor.php?postId=${ createdMenu?.id }&postType=wp_navigation`
+		);
+
+		// Wait for list of Navigations to appear.
+		editorSidebar.getByRole( 'heading', {
+			name: 'Primary Menu',
+			level: 1,
+		} );
+
+		// Switch to editing the Navigation Menu
+		await editorSidebar
+			.getByRole( 'link', {
+				name: 'Edit',
+			} )
+			.click();
+
+		// Open List View.
+		await pageUtils.pressKeys( 'access+o' );
+
+		const listView = page
+			.getByRole( 'region', {
+				name: 'List View',
+			} )
+			.getByRole( 'treegrid', {
+				name: 'Block navigation structure',
+			} );
+
+		await expect( listView ).toBeVisible();
+
+		const navBlockNode = listView.getByRole( 'link', {
+			name: 'Navigation (locked)',
+			exact: true,
+		} );
+
+		// The Navigation block should be present and locked.
+		await expect( navBlockNode ).toBeVisible();
+
+		// The block should have no options menu.
+		await expect(
+			listView.getByRole( 'button', {
+				name: 'Options for Navigation',
+				exact: true,
+			} )
+		).toBeHidden();
+
+		// Select the Navigation block.
+		await navBlockNode.click();
+
+		// Open the document settings sidebar
+		await editor.openDocumentSettingsSidebar();
+
+		const sidebar = page.getByLabel( 'Editor settings' );
+
+		await expect( sidebar ).toBeVisible();
+
+		// Check that the `Menu` control is visible.
+		// This is effectively the contents of the "List View" tab.
+		await expect(
+			sidebar.getByRole( 'heading', { name: 'Menu', exact: true } )
+		).toBeVisible();
+
+		// Check the standard tabs are not present.
+		await expect(
+			sidebar.getByRole( 'tab', { name: 'List View' } )
+		).toBeHidden();
+		await expect(
+			sidebar.getByRole( 'tab', { name: 'Settings' } )
+		).toBeHidden();
+		await expect(
+			sidebar.getByRole( 'tab', { name: 'Styles' } )
+		).toBeHidden();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Provided some high level tests for the key features that distinguish the Navigation Menu editing mode from editing other content types.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Guard against regressions such as that which occurred in https://github.com/WordPress/gutenberg/pull/56856.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Basic e2e test.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Run the test below and make sure it makes sense and covers the key features.

```
npm run test:e2e:playwright -- -g "Editing Navigation Menus" 
```



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
