### PR TITLE
Link to Dashicons

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -197,7 +197,7 @@ The `ancestor` property makes a block available inside the specified block types
 { "icon": "smile" }
 ```
 
-An icon property should be specified to make it easier to identify a block. These can be any of WordPress' Dashicons (slug serving also as a fallback in non-js contexts).
+An icon property should be specified to make it easier to identify a block. These can be any of [WordPress' Dashicons](https://developer.wordpress.org/resource/dashicons/) (slug serving also as a fallback in non-js contexts).
 
 **Note:** It's also possible to override this property on the client-side with the source of the SVG element. In addition, this property can be defined with JavaScript as an object containing background and foreground colors. This colors will appear with the icon when they are applicable e.g.: in the inserter. Custom SVG icons are automatically wrapped in the [wp.primitives.SVG](/packages/primitives/README.md) component to add accessibility attributes (aria-hidden, role, and focusable).
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Link "WordPress’ Dashicons" to https://developer.wordpress.org/resource/dashicons/ on https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/.

## Why?
So readers don't have to leave and google it.

## How?
I added the link.

## Testing Instructions
1. Click the link.

### Testing Instructions for Keyboard
1. Tab to the link and hit Enter.

## Screenshots or screencast
I'm hoping shouldn't be necessary.
