### PR TITLE
Components: replace `TabPanel` with `Tabs` in the editor's `ColorPanel`

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -272,6 +272,7 @@ function ColorPanelDropdown( {
 											<Tabs.TabPanel
 												key={ tab.key }
 												id={ tab.key }
+												focusable={ false }
 											>
 												<ColorPanelTab
 													{ ...tab }

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -12,12 +12,12 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalZStack as ZStack,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
-	TabPanel,
 	ColorIndicator,
 	Flex,
 	FlexItem,
 	Dropdown,
 	Button,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -29,6 +29,9 @@ import ColorGradientControl from '../colors-gradients/control';
 import { useColorsPerOrigin, useGradientsPerOrigin } from './hooks';
 import { getValueFromVariable } from './utils';
 import { setImmutably } from '../../utils/object';
+import { unlock } from '../../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 export function useHasColorPanel( settings ) {
 	const hasTextPanel = useHasTextPanel( settings );
@@ -203,13 +206,6 @@ function ColorPanelDropdown( {
 	colorGradientControlSettings,
 	panelId,
 } ) {
-	const tabConfigs = tabs.map( ( { key, label: tabLabel } ) => {
-		return {
-			name: key,
-			title: tabLabel,
-		};
-	} );
-
 	return (
 		<ToolsPanelItem
 			className="block-editor-tools-panel-color-gradient-settings__item"
@@ -258,26 +254,34 @@ function ColorPanelDropdown( {
 								/>
 							) }
 							{ tabs.length > 1 && (
-								<TabPanel tabs={ tabConfigs }>
-									{ ( tab ) => {
-										const selectedTab = tabs.find(
-											( t ) => t.key === tab.name
-										);
+								<Tabs>
+									<Tabs.TabList>
+										{ tabs.map( ( tab ) => (
+											<Tabs.Tab
+												key={ tab.key }
+												id={ tab.key }
+											>
+												{ tab.label }
+											</Tabs.Tab>
+										) ) }
+									</Tabs.TabList>
 
-										if ( ! selectedTab ) {
-											return null;
-										}
-
+									{ tabs.map( ( tab ) => {
 										return (
-											<ColorPanelTab
-												{ ...selectedTab }
-												colorGradientControlSettings={
-													colorGradientControlSettings
-												}
-											/>
+											<Tabs.TabPanel
+												key={ tab.key }
+												id={ tab.key }
+											>
+												<ColorPanelTab
+													{ ...tab }
+													colorGradientControlSettings={
+														colorGradientControlSettings
+													}
+												/>
+											</Tabs.TabPanel>
 										);
-									} }
-								</TabPanel>
+									} ) }
+								</Tabs>
 							) }
 						</div>
 					</DropdownContentWrapper>

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -31,8 +31,6 @@ import { getValueFromVariable } from './utils';
 import { setImmutably } from '../../utils/object';
 import { unlock } from '../../lock-unlock';
 
-const { Tabs } = unlock( componentsPrivateApis );
-
 export function useHasColorPanel( settings ) {
 	const hasTextPanel = useHasTextPanel( settings );
 	const hasBackgroundPanel = useHasBackgroundPanel( settings );
@@ -207,6 +205,11 @@ function ColorPanelDropdown( {
 	panelId,
 } ) {
 	const currentTab = tabs.find( ( tab ) => tab.userValue !== undefined );
+	// Unlocking `Tabs` too early causes the `unlock` method to receive an empty
+	// object, due to circular dependencies.
+	// See https://github.com/WordPress/gutenberg/issues/52692
+	const { Tabs } = unlock( componentsPrivateApis );
+
 	return (
 		<ToolsPanelItem
 			className="block-editor-tools-panel-color-gradient-settings__item"

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -206,6 +206,7 @@ function ColorPanelDropdown( {
 	colorGradientControlSettings,
 	panelId,
 } ) {
+	const currentTab = tabs.find( ( tab ) => tab.userValue !== undefined );
 	return (
 		<ToolsPanelItem
 			className="block-editor-tools-panel-color-gradient-settings__item"
@@ -254,7 +255,7 @@ function ColorPanelDropdown( {
 								/>
 							) }
 							{ tabs.length > 1 && (
-								<Tabs>
+								<Tabs initialTabId={ currentTab?.key }>
 									<Tabs.TabList>
 										{ tabs.map( ( tab ) => (
 											<Tabs.Tab


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Replaces the legacy TabPanel component with the new Tabs component.
- Adds a check to make sure the currently relevant tab is automatically selected (ie, "solid" or "gradient" for background selections, based on what the current setting is)

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

Adding an `initialTabId` value makes this implementation more consistent with the `ColorPanel` usages in the editor, as those already follow this pattern.

## How?
`TabPanel` is swapped out for `Tabs` and its sub-components. A small abstraction re-labeling some of the tab data was removed to simplify things. We now need to map through the `tabs` data twice, and the `tabConfigs` abstraction didn't work for both of them.

For the initial tab selection, the component now checks to confirm that a given tab has a value and selects that tab.

Note: How exactly this manifests depends a bit on how the tabs are being used. For example:

With background colors, the **Solid** and **Gradient** tabs are mutually exclusive, and one will always cancel the other out. It behaves like a toggle, so whatever tab you used last is the only one with a value, so it opens automatically.

With something like **Button** colors in the Site Editor, there are three tabs:
1. Text
2. Background (aka "solid background")
3. Gradient (aka "gradient background")

In this case, the **Text** tab is an independent value. **Background** and **Gradient** are once again behaving as a toggle, one always resetting the other. **Text** being a different setting will retain its own value even when one of the other tabs is used.

This means, if a custom **Text** color is set, that's the tab the user will get, regardless of what kind of custom background is in effect. There are two tabs with a defined value, and **Text** is just the first one in this instance. If **Text** isn't set (or gets cleared) the appropriate button background tab will open as expected.

Side note: that all has me feeling a little weird about some of this UI, but I won't clutter up this PR with my thoughts on that!

## Testing Instructions
**Post/Page editor:**
1. Create a new post or page
5. Select a paragraph block
6. In the editor sidebar, confirm that you are able to update the background and text colors normally
7. For the background color, confirm that the `ColorPanel` renders the correct content based on the current selection. If you set a gradient, that tab should open automatically next time you open the `ColorPanel`.

**Site editor**
1. Launch the site editor
2. Select styles and open the editor
3. Open the Styles sidebar and select the `Colors` style settings
8. Confirm you're about to update colors and backgrounds as expected
9. For background color, confirm that the `ColorPanel` renders the correct content based on the current selection. If you set a gradient, that tab should open automatically next time you open the `ColorPanel`.

## Keyboard Testing Instructions

1. Create a new post
2. Use the [Tab] key to navigate to title field and then the default paragraph block
3. Press [Tab] to navigate to the settings sidebar, and continue using [Tab] until you reach the **Background** setting
4. Press [Enter/Return]
5. Focus should automatically go to the selected tab
6. Press [Tab] one more time to confirm focus travels to the first element within the panel, and that focus does not pass to the panel itself.
