### PR TITLE
Block editor: hooks: early returns for getEditWrapperProps filters

### DIFF
--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -265,6 +265,12 @@ function addAttributes( settings ) {
  * @return {Object} Filtered props to apply to save element.
  */
 function addSaveProps( props, blockType, attributes ) {
+	const { borderColor, style } = attributes;
+
+	if ( ! borderColor && ! style?.border?.color ) {
+		return props;
+	}
+
 	if (
 		! hasBorderSupport( blockType, 'color' ) ||
 		shouldSkipSerialization( blockType, BORDER_SUPPORT_KEY, 'color' )

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -133,6 +133,13 @@ function addAttributes( settings ) {
  * @return {Object} Filtered props applied to save element.
  */
 export function addSaveProps( props, blockType, attributes ) {
+	// I'd have preferred to avoid the "style" attribute usage here
+	const { backgroundColor, textColor, gradient, style } = attributes;
+
+	if ( ! backgroundColor && ! textColor && ! gradient && ! style ) {
+		return props;
+	}
+
 	if (
 		! hasColorSupport( blockType ) ||
 		shouldSkipSerialization( blockType, COLOR_SUPPORT_KEY )
@@ -141,9 +148,6 @@ export function addSaveProps( props, blockType, attributes ) {
 	}
 
 	const hasGradient = hasGradientSupport( blockType );
-
-	// I'd have preferred to avoid the "style" attribute usage here
-	const { backgroundColor, textColor, gradient, style } = attributes;
 
 	const shouldSerialize = ( feature ) =>
 		! shouldSkipSerialization( blockType, COLOR_SUPPORT_KEY, feature );

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -66,6 +66,10 @@ function addAttributes( settings ) {
  * @return {Object} Filtered props applied to save element.
  */
 function addSaveProps( props, blockType, attributes ) {
+	if ( ! attributes.fontSize ) {
+		return props;
+	}
+
 	if ( ! hasBlockSupport( blockType, FONT_SIZE_SUPPORT_KEY ) ) {
 		return props;
 	}
@@ -285,6 +289,10 @@ function addEditPropsForFluidCustomFontSizes( blockType ) {
 
 		const fontSize = wrapperProps?.style?.fontSize;
 
+		if ( ! fontSize ) {
+			return wrapperProps;
+		}
+
 		// TODO: This sucks! We should be using useSetting( 'typography.fluid' )
 		// or even useSelect( blockEditorStore ). We can't do either here
 		// because getEditWrapperProps is a plain JavaScript function called by
@@ -295,12 +303,10 @@ function addEditPropsForFluidCustomFontSizes( blockType ) {
 		const fluidTypographySettings = getFluidTypographyOptionsFromSettings(
 			select( blockEditorStore ).getSettings().__experimentalFeatures
 		);
-		const newFontSize = fontSize
-			? getTypographyFontSizeValue(
-					{ size: fontSize },
-					fluidTypographySettings
-			  )
-			: null;
+		const newFontSize = getTypographyFontSizeValue(
+			{ size: fontSize },
+			fluidTypographySettings
+		);
 
 		if ( newFontSize === null ) {
 			return wrapperProps;

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -292,6 +292,11 @@ export function addSaveProps(
 	}
 
 	let { style } = attributes;
+
+	if ( ! style ) {
+		return props;
+	}
+
 	Object.entries( skipPaths ).forEach( ( [ indicator, path ] ) => {
 		const skipSerialization =
 			skipSerializationPathsSaveChecks[ indicator ] ||


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

If the relevant attribute is not present, return early.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
 These filters run on every block on type.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
