### PR TITLE
Only enter the zoom-out mode when not in the focus mode

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -25,6 +25,7 @@ function InserterLibrary(
 		__experimentalShouldZoomPatterns = false,
 		onSelect = noop,
 		shouldFocusBlock = false,
+		onSelectTab,
 	},
 	ref
 ) {
@@ -48,6 +49,7 @@ function InserterLibrary(
 	return (
 		<InserterMenu
 			onSelect={ onSelect }
+			onSelectTab={ onSelectTab }
 			rootClientId={ destinationRootClientId }
 			clientId={ clientId }
 			isAppender={ isAppender }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useDebouncedInput } from '@wordpress/compose';
 
 /**
@@ -47,6 +47,7 @@ function InserterMenu(
 		prioritizePatterns,
 		__experimentalOnPatternCategorySelection,
 		__experimentalShouldZoomPatterns = false,
+		onSelectTab,
 	},
 	ref
 ) {
@@ -59,8 +60,6 @@ function InserterMenu(
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
 	const [ selectedTab, setSelectedTab ] = useState( null );
-	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {
@@ -234,14 +233,8 @@ function InserterMenu(
 			setSelectedPatternCategory( null );
 		}
 
-		// Enter the zoom-out mode when selecting the patterns tab and exit otherwise.
-		if ( value === 'patterns' ) {
-			__unstableSetEditorMode( 'zoom-out' );
-		} else if ( __unstableGetEditorMode() === 'zoom-out' ) {
-			__unstableSetEditorMode( 'edit' );
-		}
-
 		setSelectedTab( value );
+		onSelectTab?.( value );
 	};
 
 	const className = classnames( 'block-editor-inserter__menu', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #56806.

Do not enter the `zoom-out` mode when opening the patterns inserter when we're in the focus mode (template-part, patterns, etc).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The zoom-out mode is designed to be used in the templates/pages so that it can _zoom_ out to a wider view, which is not suitable for the focus mode where we want more granular controls.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Move around some APIs and only invoke `setEditorMode` when it's not in the zoom-out mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the zoomed out mode gutenberg experiment
2. Go to the Site Editor
3. Expect to enter the zoom-out mode when opening the inserter with the Patterns tab active
4. Select a template part in the editor canvas
5. Click "Edit" to go to the template part focus mode
6. Expect the inserter to be closed and exit the zoom-out mode.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/9c31358b-ed51-4b82-92db-daa2445a52ec

