### PR TITLE
Restrict available block actions in zoomed out mode

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -96,6 +96,7 @@ export function BlockSettingsDropdown( {
 	const firstBlockClientId = blockClientIds[ 0 ];
 	const {
 		firstParentClientId,
+		isZoomOutMode,
 		onlyBlock,
 		parentBlockType,
 		previousBlockClientId,
@@ -109,6 +110,7 @@ export function BlockSettingsDropdown( {
 				getPreviousBlockClientId,
 				getSelectedBlockClientIds,
 				getBlockAttributes,
+				__unstableGetEditorMode,
 			} = select( blockEditorStore );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -120,6 +122,7 @@ export function BlockSettingsDropdown( {
 
 			return {
 				firstParentClientId: _firstParentClientId,
+				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
 				onlyBlock: 1 === getBlockCount( _firstParentClientId ),
 				parentBlockType:
 					_firstParentClientId &&
@@ -291,7 +294,8 @@ export function BlockSettingsDropdown( {
 									'core/block-editor/insert-after',
 									event
 								) &&
-								canInsertDefaultBlock
+								canInsertDefaultBlock &&
+								! isZoomOutMode
 							) {
 								event.preventDefault();
 								setOpenedBlockSettingsMenu( undefined );
@@ -301,7 +305,8 @@ export function BlockSettingsDropdown( {
 									'core/block-editor/insert-before',
 									event
 								) &&
-								canInsertDefaultBlock
+								canInsertDefaultBlock &&
+								! isZoomOutMode
 							) {
 								event.preventDefault();
 								setOpenedBlockSettingsMenu( undefined );
@@ -347,7 +352,7 @@ export function BlockSettingsDropdown( {
 										{ __( 'Duplicate' ) }
 									</MenuItem>
 								) }
-								{ canInsertDefaultBlock && (
+								{ canInsertDefaultBlock && ! isZoomOutMode && (
 									<>
 										<MenuItem
 											onClick={ pipe(
@@ -382,25 +387,31 @@ export function BlockSettingsDropdown( {
 									</MenuItem>
 								</MenuGroup>
 							) }
-							<BlockSettingsMenuControls.Slot
-								fillProps={ {
-									onClose,
-									canMove,
-									onMoveTo,
-									onlyBlock,
-									count,
-									firstBlockClientId,
-								} }
-								clientIds={ clientIds }
-								__unstableDisplayLocation={
-									__unstableDisplayLocation
-								}
-							/>
-							{ typeof children === 'function'
-								? children( { onClose } )
-								: Children.map( ( child ) =>
-										cloneElement( child, { onClose } )
-								  ) }
+							{ ! isZoomOutMode && (
+								<>
+									<BlockSettingsMenuControls.Slot
+										fillProps={ {
+											onClose,
+											canMove,
+											onMoveTo,
+											onlyBlock,
+											count,
+											firstBlockClientId,
+										} }
+										clientIds={ clientIds }
+										__unstableDisplayLocation={
+											__unstableDisplayLocation
+										}
+									/>
+									{ typeof children === 'function'
+										? children( { onClose } )
+										: Children.map( ( child ) =>
+												cloneElement( child, {
+													onClose,
+												} )
+										  ) }
+								</>
+							) }
 							{ canRemove && (
 								<MenuGroup>
 									<MenuItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Restricts block actions while in zoomed-out mode. 

Note: Adding a zoomed-out mode slot or further tweaks to managing the existing toolbar slots will be explored separately.

## Why?

Not all the existing block actions make sense while operating in zoomed-out mode.

## How?

Scope the inclusion of block actions and primary slot with a check against if we are in zoomed-out mode.

## Testing Instructions

1. Navigate to Site Editor > Template 
2. Edit a template and open the inserter
3. Select the patterns tab to enter zoomed-out mode
4. Select a block in the zoomed-out canvas and confirm reduced number of block actions
5. Check they all still work as before

### Testing Instructions for Keyboard

1. Same as above but also check keyboard shortcuts are working or restricted based on zoomed-out mode.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="400" alt="Screenshot 2023-12-08 at 12 27 34 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/e54d9047-5c1f-4e17-873f-c952ed160ecf"> | <img width="393" alt="Screenshot 2023-12-08 at 12 26 02 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/331f263f-04fc-4516-bcca-8640cde98e00"> |

