### PR TITLE
Improve Styles for Social Icons list placeholders

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -89,7 +89,7 @@ export function SocialLinksEdit( props ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ logosOnly ] );
 
-	const placeholderClasses = classNames( 'wp-social-link', {
+	const placeholderClasses = clsx( 'wp-social-link', {
 		[ `has-${ iconColor.slug }-color` ]: iconColor.slug,
 		[ `has-${ iconBackgroundColor.slug }-background-color` ]:
 			iconBackgroundColor.slug,
@@ -104,21 +104,21 @@ export function SocialLinksEdit( props ) {
 		<li className="wp-block-social-links__social-placeholder">
 			<div className="wp-block-social-links__social-placeholder-icons">
 				<div
-					className={ classNames(
+					className={ clsx(
 						'wp-social-link-twitter',
 						placeholderClasses
 					) }
 					style={ placeholderStyles }
 				></div>
 				<div
-					className={ classNames(
+					className={ clsx(
 						'wp-social-link-facebook',
 						placeholderClasses
 					) }
 					style={ placeholderStyles }
 				></div>
 				<div
-					className={ classNames(
+					className={ clsx(
 						'wp-social-link-instagram',
 						placeholderClasses
 					) }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -89,12 +89,41 @@ export function SocialLinksEdit( props ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ logosOnly ] );
 
+	const placeholderClasses = classNames( 'wp-social-link', {
+		[ `has-${ iconColor.slug }-color` ]: iconColor.slug,
+		[ `has-${ iconBackgroundColor.slug }-background-color` ]:
+			iconBackgroundColor.slug,
+	} );
+
+	const placeholderStyles = {
+		color: iconColor.color,
+		backgroundColor: iconBackgroundColor.color,
+	};
+
 	const SocialPlaceholder = (
 		<li className="wp-block-social-links__social-placeholder">
 			<div className="wp-block-social-links__social-placeholder-icons">
-				<div className="wp-social-link wp-social-link-twitter"></div>
-				<div className="wp-social-link wp-social-link-facebook"></div>
-				<div className="wp-social-link wp-social-link-instagram"></div>
+				<div
+					className={ classNames(
+						'wp-social-link-twitter',
+						placeholderClasses
+					) }
+					style={ placeholderStyles }
+				></div>
+				<div
+					className={ classNames(
+						'wp-social-link-facebook',
+						placeholderClasses
+					) }
+					style={ placeholderStyles }
+				></div>
+				<div
+					className={ classNames(
+						'wp-social-link-instagram',
+						placeholderClasses
+					) }
+					style={ placeholderStyles }
+				></div>
 			</div>
 		</li>
 	);

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -44,6 +44,7 @@
 	// Wrap the remaining placeholders in a container so the plus can overlap.
 	> .wp-block-social-links__social-placeholder-icons {
 		display: flex;
+		gap: var(--wp--style--block-gap);
 	}
 
 	.wp-social-link::before {
@@ -55,6 +56,14 @@
 
 		.is-style-logos-only & {
 			background: currentColor;
+			height: 1.25em;
+			width: 1.25em;
+			padding: 0;
+		}
+		.is-style-pill-shape & {
+			padding-left: calc((2/3) * 1em);
+			padding-right: calc((2/3) * 1em);
+			border-radius: 9999px;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Improves the appearance of the placeholders shown on the Social Icons list block.

## Why?
https://github.com/WordPress/gutenberg/issues/55296
The squares for the placeholders don't completely represent how the block will look once a user add actual social icons to the container block.

## How?
A few minor style updates.

## Testing Instructions
Insert a new Social Icons block. Remove focus from the block and observe that the placeholders have the correct gap between them. 
You can also apply the the logos only and pill shape block style variations and the placeholders will appare the same size and shape as actual inner blocks.

Note that setting the icon color will not change the colors of the placeholders.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
