### PR TITLE
Prevent block switcher menu while in zoomed out mode

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -38,6 +38,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 		canRemove,
 		hasBlockStyles,
 		icon,
+		isZoomOutMode,
 		patterns,
 	} = useSelect(
 		( select ) => {
@@ -48,6 +49,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 				canRemoveBlocks,
 			} = select( blockEditorStore );
 			const { getBlockStyles, getBlockType } = select( blocksStore );
+			const { __unstableGetEditorMode } = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId(
 				Array.isArray( clientIds ) ? clientIds[ 0 ] : clientIds
 			);
@@ -75,6 +77,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 				canRemove: canRemoveBlocks( clientIds, rootClientId ),
 				hasBlockStyles: !! styles?.length,
 				icon: _icon,
+				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
 				patterns: __experimentalGetPatternTransformItems(
 					blocks,
 					rootClientId
@@ -138,11 +141,12 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;
-	if (
+	const hasNoMenu =
 		! hasBlockStyles &&
 		! hasPossibleBlockTransformations &&
-		! hasPossibleBlockVariationTransformations
-	) {
+		! hasPossibleBlockVariationTransformations;
+
+	if ( hasNoMenu || isZoomOutMode ) {
 		return (
 			<ToolbarGroup>
 				<ToolbarButton


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/56806

## What?

Prevents the block switcher menu while operating in zoomd out mode.

## Why?

After switching to the contextual toolbar menu for zoomed out mode, there's a lot we don't need at that point and things like transforms don't make a lot of sense for zoomed out mode.

## How?

Checks if the editor is in zoomed out mode and if so renders a basic icon rather than a dropdown menu for the block switcher.

## Testing Instructions
1. Navigate to the Site Editor > Templates 
2. Select a template to edit
3. Select several blocks at different levels and confirm the block switcher displays and behaves as normal
4. Open the inserter to the patterns tab which will trigger zoomed out mode
5. Select the available blocks and template parts and confirm none show the block switcher menu


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/gutenberg/assets/60436221/e6b66992-a7be-4282-a49d-ec619397db30" /> | <video src="https://github.com/WordPress/gutenberg/assets/60436221/a6c882e0-4642-456a-b27b-5bc0ac216309" /> |

