### PR TITLE
Zoomed out mode: show content container children

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -290,6 +290,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 						<BlockTitle
 							clientId={ clientId }
 							maximumLength={ 35 }
+							context="list-view"
 						/>
 					</Button>
 				</FlexItem>

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -46,7 +46,7 @@ const defaultRenderToggle = ( {
 			blockTitle
 		);
 	} else if ( ! label && prioritizePatterns ) {
-		label = __( 'Add pattern' );
+		label = __( 'Add section' );
 	} else if ( ! label ) {
 		label = _x( 'Add block', 'Generic label for block inserter button' );
 	}

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -105,12 +105,17 @@ function ListViewBranch( props ) {
 	const parentBlockInformation = useBlockDisplayInformation( parentId );
 	const syncedBranch = isSyncedBranch || !! parentBlockInformation?.isSynced;
 
-	const canParentExpand = useSelect(
+	const { canParentExpand, getBlockById } = useSelect(
 		( select ) => {
-			if ( ! parentId ) {
-				return true;
-			}
-			return select( blockEditorStore ).canEditBlock( parentId );
+			const { canEditBlock, getBlockParents, getBlockName, getBlock } =
+				select( blockEditorStore );
+
+			return {
+				canParentExpand: canEditBlock( parentId ),
+				getBlocksParents: getBlockParents,
+				getName: getBlockName,
+				getBlockById: getBlock,
+			};
 		},
 		[ parentId ]
 	);
@@ -132,6 +137,10 @@ function ListViewBranch( props ) {
 	return (
 		<>
 			{ filteredBlocks.map( ( block, index ) => {
+				const isContentSection =
+					getBlockById( block.clientId )?.attributes?.tagName ===
+					'main';
+
 				const { clientId, innerBlocks } = block;
 
 				if ( index > 0 ) {
@@ -154,7 +163,8 @@ function ListViewBranch( props ) {
 				const hasNestedBlocks = !! innerBlocks?.length;
 
 				const shouldExpand =
-					hasNestedBlocks && shouldShowInnerBlocks
+					hasNestedBlocks &&
+					( shouldShowInnerBlocks || isContentSection )
 						? expandedState[ clientId ] ?? isExpanded
 						: undefined;
 
@@ -221,6 +231,7 @@ function ListViewBranch( props ) {
 								selectedClientIds={ selectedClientIds }
 								isExpanded={ isExpanded }
 								isSyncedBranch={ syncedBranch }
+								shouldShowInnerBlocks={ shouldShowInnerBlocks }
 							/>
 						) }
 					</AsyncModeProvider>

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2846,9 +2846,14 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 
 	// In zoom-out mode, the block overlay is always active for top level blocks.
 	if (
-		editorMode === 'zoom-out' &&
-		clientId &&
-		! getBlockRootClientId( state, clientId )
+		( editorMode === 'zoom-out' &&
+			clientId &&
+			! getBlockRootClientId( state, clientId ) &&
+			! getBlock( state, clientId )?.attributes?.tagName === 'main' ) ||
+		getBlockParents( state, clientId )?.find(
+			( parentId ) =>
+				getBlock( state, parentId )?.attributes?.tagName === 'main'
+		)
 	) {
 		return true;
 	}


### PR DESCRIPTION
## What?
Shows the children of the `main` section in the list view, and allows selection of these in editor canvas when in zoomed out mode.

## Why?
Currently it is not very easy to work with the body content in zoomed out view as it just appears as one big section.

## How?
Detects a top level group container with tag of `main` and  removes the editor overlay of it and shows direct children of this in the list view.

## Testing Instructions

- In a page template assign the html tag `main` to the top level body content group
- Add children group containers to this - naming them makes zoomed out mode and list view more meaningful
- Enter zoomed out view and make sure the top level content group can be expanded in list view and that the child sections can be selected in editor canvas

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/9ac07ca0-7176-4d48-b14a-f32b8f368a7e



