### PR TITLE
Hide sibling inserter in zoomed out mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -211,11 +211,6 @@ export default function BlockTools( {
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
 				/>
-				{ isZoomOutMode && (
-					<ZoomOutModeInserters
-						__unstableContentRef={ __unstableContentRef }
-					/>
-				) }
 			</InsertionPointOpenRef.Provider>
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes the sibling inserter for the zoomed out mode experiments (#56806).

## Why?
As part of the experiments, zoomed out mode is instigated by opening patterns in the inserter. The problem is the inserter acts as a dialog, so clicking something like the sibling inserter immediately closes it and results in zoomed out mode also being exited.

For this timeboxed experiment, there isn't enough time to look at solutions, so the quick fix is to remove the inserter.

It perhaps also doesn't make sense to show the sibling inserter when the main inserter menu is already open.

## How?
Delete it

## Testing Instructions
1. Enabled the zoomed out mode experiments
2. Open the site editor and edit a template
3. Open the inserter

In trunk: Sibling inserters are displayed in the canvas
In this PR: No sibling inserters (drag and drop indicators are still shown)

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="243" alt="Screenshot 2023-12-08 at 3 28 26 pm" src="https://github.com/WordPress/gutenberg/assets/677833/c891481b-2fe4-4976-b1e0-0ebb0fe105f9">

### After
<img width="247" alt="Screenshot 2023-12-08 at 3 27 59 pm" src="https://github.com/WordPress/gutenberg/assets/677833/0e7b3a40-3c08-4881-be51-9108581710da">

