### PR TITLE
Close the pattern category when the right sidebar is open in zoom-out mode

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -126,7 +126,7 @@ function InserterMenu(
 		( patternCategory, filter ) => {
 			setSelectedPatternCategory( patternCategory );
 			setPatternFilter( filter );
-			__experimentalOnPatternCategorySelection?.();
+			__experimentalOnPatternCategorySelection?.( patternCategory );
 		},
 		[ setSelectedPatternCategory, __experimentalOnPatternCategorySelection ]
 	);
@@ -213,6 +213,8 @@ function InserterMenu(
 		focusSearch: () => {
 			searchRef.current.focus();
 		},
+		getSelectedPatternCategory: () => selectedPatternCategory,
+		selectPatternCategory: onClickPatternCategory,
 	} ) );
 
 	const showPatternPanel =

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -15,6 +15,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useCallback } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -38,6 +39,13 @@ export default function InserterSidebar() {
 			select( editSiteStore ).getEditedPostType()
 		)
 	);
+	const isRightSidebarOpen = useSelect(
+		( select ) =>
+			!! select( interfaceStore ).getActiveComplementaryArea(
+				editSiteStore.name
+			),
+		[]
+	);
 	const { __unstableSetEditorMode: setEditorMode } =
 		useDispatch( blockEditorStore );
 	const { __unstableGetEditorMode: getEditorMode } =
@@ -59,6 +67,15 @@ export default function InserterSidebar() {
 			}
 		},
 	} );
+
+	const onSelectPatternCategory = useCallback(
+		( category ) => {
+			if ( !! category ) {
+				closeGeneralSidebar();
+			}
+		},
+		[ closeGeneralSidebar ]
+	);
 
 	const libraryRef = useRef();
 	useEffect( () => {
@@ -91,6 +108,19 @@ export default function InserterSidebar() {
 		[ location, setIsInserterOpened ]
 	);
 
+	useEffect(
+		function closePatternCategoryOnRightSidebarOpenInZoomOut() {
+			if (
+				getEditorMode() === 'zoom-out' &&
+				isRightSidebarOpen &&
+				!! libraryRef.current.getSelectedPatternCategory()
+			) {
+				libraryRef.current.selectPatternCategory( null );
+			}
+		},
+		[ getEditorMode, isRightSidebarOpen ]
+	);
+
 	return (
 		<div
 			ref={ inserterDialogRef }
@@ -114,7 +144,7 @@ export default function InserterSidebar() {
 					}
 					__experimentalFilterValue={ insertionPoint.filterValue }
 					__experimentalOnPatternCategorySelection={
-						closeGeneralSidebar
+						onSelectPatternCategory
 					}
 					__experimentalShouldZoomPatterns
 					ref={ libraryRef }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #56806.

Close the pattern category when the right sidebar is open in zoom-out mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The pattern category panel is inlined when entering the zoom-out mode so the canvas has limited space for the right sidebar to be opened.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add some hacky imperative methods to the library ref.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the Zoomed Out Mode gutenberg experiment
2. Go to the Site Editor
3. Open the inserter and select "Patterns" -> a random category
4. Open the Block Inspector
5. Expect the category to be reset and the pattern category panel to be closed

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/ae9d6e54-cee9-489c-a55e-13d499a18493


