### PR TITLE
Only show pattern results when searching in zoomed out mode

### DIFF
--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -53,14 +53,17 @@ function InserterSearchResults( {
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
-	const { prioritizedBlocks } = useSelect(
+	const { prioritizedBlocks, isZoomOutMode } = useSelect(
 		( select ) => {
 			const blockListSettings =
 				select( blockEditorStore ).getBlockListSettings( rootClientId );
+			const editorMode =
+				select( blockEditorStore ).__unstableGetEditorMode();
 
 			return {
 				prioritizedBlocks:
 					blockListSettings?.prioritizedInserterBlocks || EMPTY_ARRAY,
+				isZoomOutMode: editorMode === 'zoom-out',
 			};
 		},
 		[ rootClientId ]
@@ -198,6 +201,15 @@ function InserterSearchResults( {
 			</div>
 		</InserterPanel>
 	);
+
+	if ( isZoomOutMode ) {
+		return (
+			<InserterListbox>
+				{ ! hasItems && <InserterNoResults /> }
+				{ patternsUI }
+			</InserterListbox>
+		);
+	}
 
 	return (
 		<InserterListbox>

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -205,8 +205,7 @@ function InserterSearchResults( {
 	if ( isZoomOutMode ) {
 		return (
 			<InserterListbox>
-				{ ! hasItems && <InserterNoResults /> }
-				{ patternsUI }
+				{ patternsUI || <InserterNoResults /> }
 			</InserterListbox>
 		);
 	}


### PR DESCRIPTION
## What?
As part of the zoomed out mode experiments, shows only pattern results when searching in the pattern tab (with zoomed out mode active).

## Why?
In this mode we want to see whether it's useful for users to explore using patterns to build the top level of their site

## How?
When zoomed out mode is active, only shows pattern results.

## Testing Instructions
1. Activate the Zoomed Out Mode experiment
2. Open the site editor and edit a template
3. Use the + global inserter menu
4. Search for something like 'headers'

## Screenshots or screencast <!-- if applicable -->
<img width="328" alt="Screenshot 2023-12-08 at 4 13 05 pm" src="https://github.com/WordPress/gutenberg/assets/677833/b3dcc61d-22f8-469c-a469-abfa26982d00">
