### PR TITLE
Show block's custom name in the block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -100,6 +100,8 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const isSingleBlock = blocks.length === 1;
 	const isReusable = isSingleBlock && isReusableBlock( blocks[ 0 ] );
 	const isTemplate = isSingleBlock && isTemplatePart( blocks[ 0 ] );
+	const hasCustomName =
+		isSingleBlock && !! blocks[ 0 ].attributes.metadata?.name;
 
 	function selectForMultipleBlocks( insertedBlocks ) {
 		if ( insertedBlocks.length > 1 ) {
@@ -156,7 +158,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					icon={
 						<>
 							<BlockIcon icon={ icon } showColors />
-							{ ( isReusable || isTemplate ) && (
+							{ ( isReusable || isTemplate || hasCustomName ) && (
 								<span className="block-editor-block-switcher__toggle-text">
 									{ blockTitle }
 								</span>
@@ -209,7 +211,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 									className="block-editor-block-switcher__toggle"
 									showColors
 								/>
-								{ ( isReusable || isTemplate ) && (
+								{ ( isReusable ||
+									isTemplate ||
+									hasCustomName ) && (
 									<span className="block-editor-block-switcher__toggle-text">
 										{ blockTitle }
 									</span>

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -72,12 +72,14 @@ export default function useBlockDisplayTitle( {
 		? getBlockLabel( blockType, attributes, context )
 		: null;
 
+	const blockCustomName = attributes.metadata?.name;
 	const label = reusableBlockTitle || blockLabel;
 	// Label will fallback to the title if no label is defined for the current
 	// label context. If the label is defined we prioritize it over a
 	// possible block variation title match.
 	const blockTitle =
-		label && label !== blockType.title ? label : blockInformation.title;
+		blockCustomName ||
+		( label && label !== blockType.title ? label : blockInformation.title );
 
 	if (
 		maximumLength &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #56806.

Show block's custom name in the block toolbar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It'd be nice to show it for clarity.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Currently, I just add it for all editor mode, zoom-out or not, as I think it would be useful for all situations. We can limit it to only zoom-out mode though if not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to the Site Editor
2. Rename a block
3. Expect to see the custom name on the block toolbar

## Screenshots or screencast <!-- if applicable -->

<img width="255" alt="image" src="https://github.com/WordPress/gutenberg/assets/7753001/1ac6c6da-61a4-4725-9231-533048811922">
