### PR TITLE
Add zoom out mode only block toolbar slot

### DIFF
--- a/packages/block-editor/src/components/block-controls/groups.js
+++ b/packages/block-editor/src/components/block-controls/groups.js
@@ -8,6 +8,7 @@ const BlockControlsBlock = createSlotFill( 'BlockControlsBlock' );
 const BlockControlsInline = createSlotFill( 'BlockFormatControls' );
 const BlockControlsOther = createSlotFill( 'BlockControlsOther' );
 const BlockControlsParent = createSlotFill( 'BlockControlsParent' );
+const BlockControlsZoom = createSlotFill( 'BlockControlsZoom' );
 
 const groups = {
 	default: BlockControlsDefault,
@@ -15,6 +16,7 @@ const groups = {
 	inline: BlockControlsInline,
 	other: BlockControlsOther,
 	parent: BlockControlsParent,
+	zoom: BlockControlsZoom,
 };
 
 export default groups;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -34,36 +34,42 @@ import { store as blockEditorStore } from '../../store';
 import __unstableBlockNameContext from './block-name-context';
 
 const BlockToolbar = ( { hideDragHandle } ) => {
-	const { blockClientIds, blockType, isValid, isVisual, blockEditingMode } =
-		useSelect( ( select ) => {
-			const {
-				getBlockName,
-				getBlockMode,
-				getSelectedBlockClientIds,
-				isBlockValid,
-				getBlockRootClientId,
-				getBlockEditingMode,
-			} = select( blockEditorStore );
-			const selectedBlockClientIds = getSelectedBlockClientIds();
-			const selectedBlockClientId = selectedBlockClientIds[ 0 ];
-			const blockRootClientId = getBlockRootClientId(
-				selectedBlockClientId
-			);
-			return {
-				blockClientIds: selectedBlockClientIds,
-				blockType:
-					selectedBlockClientId &&
-					getBlockType( getBlockName( selectedBlockClientId ) ),
-				rootClientId: blockRootClientId,
-				isValid: selectedBlockClientIds.every( ( id ) =>
-					isBlockValid( id )
-				),
-				isVisual: selectedBlockClientIds.every(
-					( id ) => getBlockMode( id ) === 'visual'
-				),
-				blockEditingMode: getBlockEditingMode( selectedBlockClientId ),
-			};
-		}, [] );
+	const {
+		blockClientIds,
+		blockType,
+		isValid,
+		isVisual,
+		isZoomOutMode,
+		blockEditingMode,
+	} = useSelect( ( select ) => {
+		const {
+			getBlockName,
+			getBlockMode,
+			getSelectedBlockClientIds,
+			isBlockValid,
+			getBlockRootClientId,
+			getBlockEditingMode,
+			__unstableGetEditorMode,
+		} = select( blockEditorStore );
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
+		const blockRootClientId = getBlockRootClientId( selectedBlockClientId );
+		return {
+			blockClientIds: selectedBlockClientIds,
+			blockType:
+				selectedBlockClientId &&
+				getBlockType( getBlockName( selectedBlockClientId ) ),
+			rootClientId: blockRootClientId,
+			isValid: selectedBlockClientIds.every( ( id ) =>
+				isBlockValid( id )
+			),
+			isVisual: selectedBlockClientIds.every(
+				( id ) => getBlockMode( id ) === 'visual'
+			),
+			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+			blockEditingMode: getBlockEditingMode( selectedBlockClientId ),
+		};
+	}, [] );
 
 	const toolbarWrapperRef = useRef( null );
 
@@ -136,6 +142,12 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 						group="inline"
 						className="block-editor-block-toolbar__slot"
 					/>
+					{ isZoomOutMode && (
+						<BlockControls.Slot
+							group="zoom"
+							className="block-editor-block-toolbar__slot"
+						/>
+					) }
 					<BlockControls.Slot
 						group="other"
 						className="block-editor-block-toolbar__slot"


### PR DESCRIPTION

## What?
Adds a new zoom out mode only slot to the block toolbar.

## Why?

There's a need to be able to inject some custom controls to the block toolbar for blocks but only in zoomed out mode.

## How?

Adds a new block controls group and only renders its slot when in zoom out mode.

## Testing Instructions

1. Check out this PR and apply the diff below to add a fill for the new zoom out mode only slot
2. Open the site editor and edit a template
3. Select a Group block and make sure you don't see the new fill in the toolbar
4. Open the inserter on the patterns tab to trigger zoom out mode
5. Select a group block and confirm the new fill is rendered

```diff
diff --git a/packages/block-library/src/group/edit.js b/packages/block-library/src/group/edit.js
index 9c8690c4e0e..16330118e4e 100644
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	InnerBlocks,
 	useBlockProps,
+	BlockControls,
 	InspectorControls,
 	useInnerBlocksProps,
 	store as blockEditorStore,
@@ -146,6 +147,11 @@ function GroupEdit( { attributes, name, setAttributes, clientId } ) {
 					setAttributes( { tagName: value } )
 				}
 			/>
+			<BlockControls group="zoom">
+				<div style={ { display: 'flex', alignItems: 'center' } }>
+					Hola!
+				</div>
+			</BlockControls>
 			{ showPlaceholder && (
 				<View>
 					{ innerBlocksProps.children }

```
