### PR TITLE
fix: Guard against a block styles crash due to null block values

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.native.js
+++ b/packages/block-editor/src/components/block-styles/index.native.js
@@ -19,14 +19,16 @@ import StylePreview from './preview';
 import containerStyles from './style.scss';
 import { store as blockEditorStore } from '../../store';
 
+const EMPTY_ARRAY = [];
+
 function BlockStyles( { clientId, url } ) {
 	const selector = ( select ) => {
 		const { getBlock } = select( blockEditorStore );
 		const { getBlockStyles } = select( blocksStore );
 		const block = getBlock( clientId );
 		return {
-			styles: getBlockStyles( block.name ),
-			className: block.attributes.className || '',
+			styles: getBlockStyles( block?.name ) || EMPTY_ARRAY,
+			className: block?.attributes?.className || '',
 		};
 	};
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,6 +12,7 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 -   [*] [internal] Move InserterButton from components package to block-editor package [#56494]
 -   [*] [internal] Move ImageLinkDestinationsScreen from components package to block-editor package [#56775]
+-   [*] Guard against an Image block styles crash due to null block values [#56903]
 
 ## 1.109.2
 -   [**] Fix issue related to text color format and receiving in rare cases an undefined ref from `RichText` component [#56686]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Guard against `null` values returned from `getBlock`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6128. Mitigate
disruptive crashes caused by accessing attributes on a `null` value.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In certain scenarios, e.g., when the editor hangs due to poor
performance, the `getBlock` value unexpectedly returns `null`. To guard
against a crash in this scenario, we now conditionally access attributes
on the block.

A ideal resolution would be improving editor performance to avoid the
scenario where a race condition causes a crash, but the fact remains
that `getBlock` _can_ return `null` values and that we should not
presume that it will not.

Additional details are shared in https://github.com/wordpress-mobile/gutenberg-mobile/issues/6128#issuecomment-1847105356. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
The real world scenario where this occurs is difficult to replicate
consistently, as it appears to depend upon a race condition prevalent during
hangs caused by  poor app performance. Therefore, a contrived testing approach
is applying the following diff with and without the proposed changes to ensure that 
the component correctly handles `null` block values.

<details><summary>Test Diff</summary>

```diff
diff --git a/packages/block-editor/src/components/block-styles/index.native.js b/packages/block-editor/src/components/block-styles/index.native.js
index 40e2947628..b4d4cb2803 100644
--- a/packages/block-editor/src/components/block-styles/index.native.js
+++ b/packages/block-editor/src/components/block-styles/index.native.js
@@ -25,7 +25,7 @@ function BlockStyles( { clientId, url } ) {
 	const selector = ( select ) => {
 		const { getBlock } = select( blockEditorStore );
 		const { getBlockStyles } = select( blocksStore );
-		const block = getBlock( clientId );
+		const block = null;
 		return {
 			styles: getBlockStyles( block?.name ) || EMPTY_ARRAY,
 			className: block?.attributes?.className || '',

```

</details>

1. Insert an Image block. 
2. Assign media for the block. 
3. Open the block settings. 
4. Verify the app does not throw an error or crash. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
n/a

## Screenshots or screencast <!-- if applicable -->

It is worth noting that guarding against the crash results in an unexpected block controls state where the block styles are missing. Hypothetically, the block styles would become visible once the block value is no longer `null`. This is unavoidable until the editor performance is addressed and the race condition is avoided. 

| Non-null value | Null value |
| - | - |
| ![block styles present with non-null value](https://github.com/WordPress/gutenberg/assets/438664/c3a631f2-dfc8-4081-b61d-9b3f923436ac) | ![block styles missing with null value](https://github.com/WordPress/gutenberg/assets/438664/15cd183b-9cf4-4881-87d0-1be61b7bba5a) |
