### PR TITLE
Remove unnecessary isDisabled option on useShortcut for BlockToolbarPopover

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -38,16 +38,10 @@ export default function BlockToolbarPopover( {
 	const { stopTyping } = useDispatch( blockEditorStore );
 	const isToolbarForced = useRef( false );
 
-	useShortcut(
-		'core/block-editor/focus-toolbar',
-		() => {
-			isToolbarForced.current = true;
-			stopTyping( true );
-		},
-		{
-			isDisabled: false,
-		}
-	);
+	useShortcut( 'core/block-editor/focus-toolbar', () => {
+		isToolbarForced.current = true;
+		stopTyping( true );
+	} );
 
 	useEffect( () => {
 		isToolbarForced.current = false;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes the `isDisabled` option on `useShortcut` within `<BlockToolbarPopover />`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
[`useShortcut` already uses a default of `isDisabled`](https://github.com/WordPress/gutenberg/blob/trunk/packages/keyboard-shortcuts/src/hooks/use-shortcut.js#L23), so this code is redundant.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Deletes the `isDisabled` object option.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
`alt+F10` shortcut should work on the block toolbar popover.
