### PR TITLE
Add typing test when top toolbar is mounted

### DIFF
--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -26,6 +26,7 @@ export interface WPRawPerformanceResults {
 	firstContentfulPaint: number[];
 	firstBlock: number[];
 	type: number[];
+	typeWithTopToolbar: number[];
 	typeWithoutInspector: number[];
 	typeContainer: number[];
 	focus: number[];
@@ -49,6 +50,7 @@ export interface WPPerformanceResults {
 	type?: number;
 	minType?: number;
 	maxType?: number;
+	typeWithTopToolbar: number;
 	typeWithoutInspector?: number;
 	typeContainer?: number;
 	minTypeContainer?: number;
@@ -94,6 +96,9 @@ export function curateResults(
 		type: average( results.type ),
 		minType: minimum( results.type ),
 		maxType: maximum( results.type ),
+		typeWithTopToolbar: average( results.typeWithTopToolbar ),
+		minWithTopToolbarType: minimum( results.typeWithTopToolbar ),
+		maxWithTopToolbarType: maximum( results.typeWithTopToolbar ),
 		typeWithoutInspector: average( results.typeWithoutInspector ),
 		typeContainer: average( results.typeContainer ),
 		minTypeContainer: minimum( results.typeContainer ),

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -22,6 +22,7 @@ const results = {
 	firstContentfulPaint: [],
 	firstBlock: [],
 	type: [],
+	typeWithTopToolbar: [],
 	typeWithoutInspector: [],
 	typeContainer: [],
 	focus: [],
@@ -146,6 +147,30 @@ test.describe( 'Post Editor Performance', () => {
 			} );
 
 			await type( paragraph, metrics, 'type' );
+		} );
+	} );
+
+	test.describe( 'Typing with Top Toolbar', () => {
+		let draftId = null;
+
+		test( 'Setup the test post', async ( { admin, perfUtils, editor } ) => {
+			await admin.createNewPost();
+			await editor.setIsFixedToolbar( true );
+			await perfUtils.loadBlocksForLargePost();
+			await editor.insertBlock( { name: 'core/paragraph' } );
+			draftId = await perfUtils.saveDraft();
+		} );
+
+		test( 'Run the test', async ( { admin, perfUtils, metrics } ) => {
+			await admin.editPost( draftId );
+			await perfUtils.disableAutosave();
+			const canvas = await perfUtils.getCanvas();
+
+			const paragraph = canvas.getByRole( 'document', {
+				name: /Empty block/i,
+			} );
+
+			await type( paragraph, metrics, 'typeWithTopToolbar' );
 		} );
 	} );
 


### PR DESCRIPTION
Ideally, this metric should be similar to the performance of the typing metric of when the toolbar is not mounted (typing perf results). This gives us a decent proxy for how much the `<BlockToolbar />` is doing on each keypress. At the moment, there seems to be a lot of unnecessary rendering happening on each keypress, especially with `<BlockSwitcher />`.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a performance test for typing with the top toolbar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To measure performance of typing without the toolbar mounted (default typing metric) vs mounted (top toolbar).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Duplicates the typing test, but sets the Top Toolbar option.

## Testing Instructions
Performance Tests for this PR should pass. Check for `typeWithTopToolbar`.
