### PR TITLE
Show/Hide BlockToolbarPopover via CSS

### DIFF
--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -22,6 +22,11 @@
 			pointer-events: all;
 		}
 	}
+
+	&.is-hidden {
+		opacity: 0;
+		z-index: -1;
+	}
 }
 
 .components-popover.block-editor-block-popover__inbetween {

--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -3,19 +3,12 @@
  */
 import classnames from 'classnames';
 /**
- * WordPress dependencies
- */
-import { useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
-import { useShortcut } from '@wordpress/keyboard-shortcuts';
-/**
  * Internal dependencies
  */
 import BlockPopover from '../block-popover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
-import { store as blockEditorStore } from '../../store';
-import { PrivateBlockToolbar } from '../block-toolbar';
+import BlockToolbar from '../block-toolbar';
 
 export default function BlockToolbarPopover( {
 	clientId,
@@ -25,66 +18,23 @@ export default function BlockToolbarPopover( {
 	const { capturingClientId, isInsertionPointVisible, lastClientId } =
 		useSelectedBlockToolProps( clientId );
 
-	// Stores the active toolbar item index so the block toolbar can return focus
-	// to it when re-mounting.
-	const initialToolbarItemIndexRef = useRef();
-
-	useEffect( () => {
-		// Resets the index whenever the active block changes so this is not
-		// persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-		initialToolbarItemIndexRef.current = undefined;
-	}, [ clientId ] );
-
-	const { stopTyping } = useDispatch( blockEditorStore );
-	const isToolbarForced = useRef( false );
-
-	useShortcut(
-		'core/block-editor/focus-toolbar',
-		() => {
-			isToolbarForced.current = true;
-			stopTyping( true );
-		},
-		{
-			isDisabled: false,
-		}
-	);
-
-	useEffect( () => {
-		isToolbarForced.current = false;
-	} );
-
 	const popoverProps = useBlockToolbarPopoverProps( {
 		contentElement: __unstableContentRef?.current,
 		clientId,
 	} );
 
 	return (
-		! isTyping && (
-			<BlockPopover
-				clientId={ capturingClientId || clientId }
-				bottomClientId={ lastClientId }
-				className={ classnames(
-					'block-editor-block-list__block-popover',
-					{
-						'is-insertion-point-visible': isInsertionPointVisible,
-					}
-				) }
-				resize={ false }
-				{ ...popoverProps }
-			>
-				<PrivateBlockToolbar
-					// If the toolbar is being shown because of being forced
-					// it should focus the toolbar right after the mount.
-					focusOnMount={ isToolbarForced.current }
-					__experimentalInitialIndex={
-						initialToolbarItemIndexRef.current
-					}
-					__experimentalOnIndexChange={ ( index ) => {
-						initialToolbarItemIndexRef.current = index;
-					} }
-					variant="toolbar"
-				/>
-			</BlockPopover>
-		)
+		<BlockPopover
+			clientId={ capturingClientId || clientId }
+			bottomClientId={ lastClientId }
+			className={ classnames( 'block-editor-block-list__block-popover', {
+				'is-insertion-point-visible': isInsertionPointVisible,
+				'is-hidden': isTyping, // Leave the toolbar in the DOM so it can be focused at the same roving tabindex it was previously at
+			} ) }
+			resize={ false }
+			{ ...popoverProps }
+		>
+			<BlockToolbar variant="toolbar" />
+		</BlockPopover>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -2,28 +2,19 @@
  * External dependencies
  */
 import classnames from 'classnames';
-
-/**
- * WordPress dependencies
- */
-import { useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
-import { useShortcut } from '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
 import BlockPopover from '../block-popover';
-import { PrivateBlockToolbar } from '../block-toolbar';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
-import { store as blockEditorStore } from '../../store';
+import BlockToolbar from '../block-toolbar';
 
 export default function BlockToolbarPopover( {
 	clientId,
 	isTyping,
 	__unstableContentRef,
 } ) {
-	const { stopTyping } = useDispatch( blockEditorStore );
 	const { capturingClientId, isInsertionPointVisible, lastClientId } =
 		useSelectedBlockToolProps( clientId );
 
@@ -32,64 +23,18 @@ export default function BlockToolbarPopover( {
 		clientId,
 	} );
 
-	/**
-	 * This is necessary to prevent the toolbar from being in the DOM until a user has stopped typing.
-	 * Ideally this is all unnecessary if we can get the toolbar to not impact typing performance, as it
-	 * should not. However, once it's mounted, we don't want to remount it again until the block changes.
-	 * This is both a bit of a hack and a performance improvement.
-	 */
-	// Store a ref to always return true once the user has stopped typing. We don't want to remount the toolbar until the clientID changes to avoid doing unnecessary remounting work.
-	const hasStoppedTyping = useRef( false );
-
-	useEffect( () => {
-		if ( hasStoppedTyping.current ) {
-			return;
-		}
-
-		if ( ! hasStoppedTyping.current && ! isTyping ) {
-			hasStoppedTyping.current = true;
-		}
-	}, [ isTyping ] );
-
-	// The shortcut doing the work lives in the NavigableToolbar component.
-	// It doesn't exist until it's mounted, so we need to dispatch `stopTyping`
-	// when the shortcut is pressed to cause a rerender, which mounts the
-	// NavigableToolbar and sends focus to the toolbar.
-	const isToolbarForced = useRef( false );
-	useShortcut( 'core/block-editor/focus-toolbar', () => {
-		hasStoppedTyping.current = true;
-		isToolbarForced.current = true;
-		stopTyping();
-	} );
-
-	// Force the component to unmount when the clientID changes.
-	useEffect( () => {
-		hasStoppedTyping.current = false;
-		isToolbarForced.current = false;
-	}, [ clientId ] );
-
-	// isTyping will cause a rerender since it's a state change.
-	// After that, we can rely on hasStoppedTyping to keep the toolbar in the DOM until the clientID changes.
 	return (
-		( ! isTyping || hasStoppedTyping.current ) && (
-			<BlockPopover
-				clientId={ capturingClientId || clientId }
-				bottomClientId={ lastClientId }
-				className={ classnames(
-					'block-editor-block-list__block-popover',
-					{
-						'is-insertion-point-visible': isInsertionPointVisible,
-						'is-hidden': isTyping, // Leave the toolbar in the DOM so it can be focused at the same roving tabindex it was previously at
-					}
-				) }
-				resize={ false }
-				{ ...popoverProps }
-			>
-				<PrivateBlockToolbar
-					focusOnMount={ isToolbarForced.current }
-					variant="toolbar"
-				/>
-			</BlockPopover>
-		)
+		<BlockPopover
+			clientId={ capturingClientId || clientId }
+			bottomClientId={ lastClientId }
+			className={ classnames( 'block-editor-block-list__block-popover', {
+				'is-insertion-point-visible': isInsertionPointVisible,
+				'is-hidden': isTyping, // Leave the toolbar in the DOM so it can be focused at the same roving tabindex it was previously at
+			} ) }
+			resize={ false }
+			{ ...popoverProps }
+		>
+			<BlockToolbar variant="toolbar" />
+		</BlockPopover>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -2,19 +2,28 @@
  * External dependencies
  */
 import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
 import BlockPopover from '../block-popover';
+import { PrivateBlockToolbar } from '../block-toolbar';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
-import BlockToolbar from '../block-toolbar';
+import { store as blockEditorStore } from '../../store';
 
 export default function BlockToolbarPopover( {
 	clientId,
 	isTyping,
 	__unstableContentRef,
 } ) {
+	const { stopTyping } = useDispatch( blockEditorStore );
 	const { capturingClientId, isInsertionPointVisible, lastClientId } =
 		useSelectedBlockToolProps( clientId );
 
@@ -23,18 +32,64 @@ export default function BlockToolbarPopover( {
 		clientId,
 	} );
 
+	/**
+	 * This is necessary to prevent the toolbar from being in the DOM until a user has stopped typing.
+	 * Ideally this is all unnecessary if we can get the toolbar to not impact typing performance, as it
+	 * should not. However, once it's mounted, we don't want to remount it again until the block changes.
+	 * This is both a bit of a hack and a performance improvement.
+	 */
+	// Store a ref to always return true once the user has stopped typing. We don't want to remount the toolbar until the clientID changes to avoid doing unnecessary remounting work.
+	const hasStoppedTyping = useRef( false );
+
+	useEffect( () => {
+		if ( hasStoppedTyping.current ) {
+			return;
+		}
+
+		if ( ! hasStoppedTyping.current && ! isTyping ) {
+			hasStoppedTyping.current = true;
+		}
+	}, [ isTyping ] );
+
+	// The shortcut doing the work lives in the NavigableToolbar component.
+	// It doesn't exist until it's mounted, so we need to dispatch `stopTyping`
+	// when the shortcut is pressed to cause a rerender, which mounts the
+	// NavigableToolbar and sends focus to the toolbar.
+	const isToolbarForced = useRef( false );
+	useShortcut( 'core/block-editor/focus-toolbar', () => {
+		hasStoppedTyping.current = true;
+		isToolbarForced.current = true;
+		stopTyping();
+	} );
+
+	// Force the component to unmount when the clientID changes.
+	useEffect( () => {
+		hasStoppedTyping.current = false;
+		isToolbarForced.current = false;
+	}, [ clientId ] );
+
+	// isTyping will cause a rerender since it's a state change.
+	// After that, we can rely on hasStoppedTyping to keep the toolbar in the DOM until the clientID changes.
 	return (
-		<BlockPopover
-			clientId={ capturingClientId || clientId }
-			bottomClientId={ lastClientId }
-			className={ classnames( 'block-editor-block-list__block-popover', {
-				'is-insertion-point-visible': isInsertionPointVisible,
-				'is-hidden': isTyping, // Leave the toolbar in the DOM so it can be focused at the same roving tabindex it was previously at
-			} ) }
-			resize={ false }
-			{ ...popoverProps }
-		>
-			<BlockToolbar variant="toolbar" />
-		</BlockPopover>
+		( ! isTyping || hasStoppedTyping.current ) && (
+			<BlockPopover
+				clientId={ capturingClientId || clientId }
+				bottomClientId={ lastClientId }
+				className={ classnames(
+					'block-editor-block-list__block-popover',
+					{
+						'is-insertion-point-visible': isInsertionPointVisible,
+						'is-hidden': isTyping, // Leave the toolbar in the DOM so it can be focused at the same roving tabindex it was previously at
+					}
+				) }
+				resize={ false }
+				{ ...popoverProps }
+			>
+				<PrivateBlockToolbar
+					focusOnMount={ isToolbarForced.current }
+					variant="toolbar"
+				/>
+			</BlockPopover>
+		)
 	);
 }

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -9,7 +9,7 @@ import {
 	useEffect,
 	useCallback,
 } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { focus } from '@wordpress/dom';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
@@ -23,14 +23,6 @@ import { store as blockEditorStore } from '../../store';
 function hasOnlyToolbarItem( elements ) {
 	const dataProp = 'toolbarItem';
 	return ! elements.some( ( element ) => ! ( dataProp in element.dataset ) );
-}
-
-function getAllToolbarItemsIn( container ) {
-	return Array.from( container.querySelectorAll( '[data-toolbar-item]' ) );
-}
-
-function hasFocusWithin( container ) {
-	return container.contains( container.ownerDocument.activeElement );
 }
 
 function focusFirstTabbableIn( container ) {
@@ -108,6 +100,7 @@ function useToolbarFocus( {
 } ) {
 	// focusOnMount deprecated in 6.5.0
 	const [ initialFocusOnMount ] = useState( focusOnMount );
+	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const focusToolbar = useCallback( () => {
 		focusFirstTabbableIn( toolbarRef.current );
@@ -115,6 +108,7 @@ function useToolbarFocus( {
 
 	const focusToolbarViaShortcut = () => {
 		if ( shouldUseKeyboardFocusShortcut ) {
+			stopTyping( true ); // This matches the behavior of the Tab/Escape observe typing to stopTyping. Should we add this shortcut there?
 			focusToolbar();
 		}
 	};
@@ -128,23 +122,6 @@ function useToolbarFocus( {
 			focusToolbar();
 		}
 	}, [ isAccessibleToolbar, initialFocusOnMount, focusToolbar ] );
-
-	// Focus the first toolbar item when the toolbar is mounted and attempting to be focused (such as via alt+f10 shortcut).
-	useEffect( () => {
-		// We have to wait for the next browser paint because block controls aren't
-		// rendered right away when the toolbar gets mounted.
-		window.requestAnimationFrame( () => {
-			const items = getAllToolbarItemsIn( toolbarRef.current );
-			if ( items[ 0 ] && hasFocusWithin( toolbarRef.current ) ) {
-				items[ 0 ].focus( {
-					// When focusing newly mounted toolbars,
-					// the position of the popover is often not right on the first render
-					// This prevents the layout shifts when focusing the dialogs.
-					preventScroll: true,
-				} );
-			}
-		} );
-	}, [ toolbarRef ] );
 
 	const { lastFocus } = useSelect( ( select ) => {
 		const { getLastFocus } = select( blockEditorStore );

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -9,7 +9,7 @@ import {
 	useEffect,
 	useCallback,
 } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { focus } from '@wordpress/dom';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
@@ -111,6 +111,7 @@ function useToolbarFocus( {
 	// Make sure we don't use modified versions of this prop.
 	const [ initialFocusOnMount ] = useState( focusOnMount );
 	const [ initialIndex ] = useState( defaultIndex );
+	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const focusToolbar = useCallback( () => {
 		focusFirstTabbableIn( toolbarRef.current );
@@ -118,6 +119,7 @@ function useToolbarFocus( {
 
 	const focusToolbarViaShortcut = () => {
 		if ( shouldUseKeyboardFocusShortcut ) {
+			stopTyping( true ); // This matches the behavior of the Tab/Escape observe typing to stopTyping. Should we add this shortcut there?
 			focusToolbar();
 		}
 	};

--- a/test/e2e/specs/editor/various/is-typing.spec.js
+++ b/test/e2e/specs/editor/various/is-typing.spec.js
@@ -22,19 +22,19 @@ test.describe( 'isTyping', () => {
 		);
 
 		// Toolbar Popover should not be showing
-		await expect( blockToolbarPopover ).toBeHidden();
+		await expect( blockToolbarPopover ).toHaveCSS( 'opacity', '0' );
 
 		// Moving the mouse shows the toolbar.
 		await editor.showBlockToolbar();
 
 		// Toolbar Popover is visible.
-		await expect( blockToolbarPopover ).toBeVisible();
+		await expect( blockToolbarPopover ).toHaveCSS( 'opacity', '1' );
 
 		// Typing again hides the toolbar
 		await page.keyboard.type( ' and continue' );
 
 		// Toolbar Popover is hidden again
-		await expect( blockToolbarPopover ).toBeHidden();
+		await expect( blockToolbarPopover ).toHaveCSS( 'opacity', '0' );
 	} );
 
 	test( 'should not close the dropdown when typing in it', async ( {

--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -26,6 +26,7 @@ export interface WPRawPerformanceResults {
 	firstContentfulPaint: number[];
 	firstBlock: number[];
 	type: number[];
+	typeWithTopToolbar: number[];
 	typeWithoutInspector: number[];
 	typeContainer: number[];
 	focus: number[];
@@ -49,6 +50,7 @@ export interface WPPerformanceResults {
 	type?: number;
 	minType?: number;
 	maxType?: number;
+	typeWithTopToolbar: number;
 	typeWithoutInspector?: number;
 	typeContainer?: number;
 	minTypeContainer?: number;
@@ -94,6 +96,9 @@ export function curateResults(
 		type: average( results.type ),
 		minType: minimum( results.type ),
 		maxType: maximum( results.type ),
+		typeWithTopToolbar: average( results.typeWithTopToolbar ),
+		minWithTopToolbarType: minimum( results.typeWithTopToolbar ),
+		maxWithTopToolbarType: maximum( results.typeWithTopToolbar ),
 		typeWithoutInspector: average( results.typeWithoutInspector ),
 		typeContainer: average( results.typeContainer ),
 		minTypeContainer: minimum( results.typeContainer ),

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -22,6 +22,7 @@ const results = {
 	firstContentfulPaint: [],
 	firstBlock: [],
 	type: [],
+	typeWithTopToolbar: [],
 	typeWithoutInspector: [],
 	typeContainer: [],
 	focus: [],
@@ -146,6 +147,30 @@ test.describe( 'Post Editor Performance', () => {
 			} );
 
 			await type( paragraph, metrics, 'type' );
+		} );
+	} );
+
+	test.describe( 'Typing with Top Toolbar', () => {
+		let draftId = null;
+
+		test( 'Setup the test post', async ( { admin, perfUtils, editor } ) => {
+			await admin.createNewPost();
+			await editor.setIsFixedToolbar( true );
+			await perfUtils.loadBlocksForLargePost();
+			await editor.insertBlock( { name: 'core/paragraph' } );
+			draftId = await perfUtils.saveDraft();
+		} );
+
+		test( 'Run the test', async ( { admin, perfUtils, metrics } ) => {
+			await admin.editPost( draftId );
+			await perfUtils.disableAutosave();
+			const canvas = await perfUtils.getCanvas();
+
+			const paragraph = canvas.getByRole( 'document', {
+				name: /Empty block/i,
+			} );
+
+			await type( paragraph, metrics, 'typeWithTopToolbar' );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
POC at this point. If we can get the typing metric down for when the block toolbar is mounted, we could simplify the code further by removing the "don't mount it until typing stops" part.

## What?
<!-- In a few words, what is the PR actually doing? -->
Instead of unmounting/remounting the BlockToolbarPopover, once it is mounted, keep it mounted until the block id changes. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Simplifies the code related to returning focus to the toolbar in the same index it was previously at. 
- Allows alt+f10 shortcut to focus the previous roving tabindex. This doesn't work on trunk.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Instead of unmounting/remounting the popover when typing stops, show/hide it via CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
