### PR TITLE
Revert "Doc: Spinner - add Storybook link"

### DIFF
--- a/packages/components/src/search-control/README.md
+++ b/packages/components/src/search-control/README.md
@@ -8,8 +8,6 @@ SearchControl components let users display a search control.
 1. [Development guidelines](#development-guidelines)
 2. [Related components](#related-components)
 
-   Check out the [Storybook page](https://wordpress.github.io/gutenberg/?path=/docs/components-spinner--docs) for a visual exploration of this component.
-
 ## Development guidelines
 
 ### Usage


### PR DESCRIPTION
Reverts WordPress/gutenberg#56818

This PR added the spinner link to the search control docs, not the spinner docs. Reverting and will update the correct control.