### PR TITLE
Components: replace `TabPanel` with `Tabs` in the Block Inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -191,17 +191,13 @@ function InserterMenu(
 		]
 	);
 
-	const getCurrentTab = useCallback(
-		( tab ) => {
-			if ( tab.name === 'blocks' ) {
-				return blocksTab;
-			} else if ( tab.name === 'patterns' ) {
-				return patternsTab;
-			} else if ( tab.name === 'media' ) {
-				return mediaTab;
-			}
-		},
-		[ blocksTab, patternsTab, mediaTab ]
+	const inserterTabsContents = useMemo(
+		() => ( {
+			blocks: blocksTab,
+			patterns: patternsTab,
+			media: mediaTab,
+		} ),
+		[ blocksTab, mediaTab, patternsTab ]
 	);
 
 	const searchRef = useRef();
@@ -276,7 +272,7 @@ function InserterMenu(
 						prioritizePatterns={ prioritizePatterns }
 						onSelect={ handleSetSelectedTab }
 					>
-						{ getCurrentTab }
+						{ inserterTabsContents }
 					</InserterTabs>
 				) }
 				{ ! delayedFilterValue && ! showAsTabs && (

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -271,9 +271,8 @@ function InserterMenu(
 						showMedia={ showMedia }
 						prioritizePatterns={ prioritizePatterns }
 						onSelect={ handleSetSelectedTab }
-					>
-						{ inserterTabsContents }
-					</InserterTabs>
+						tabsContents={ inserterTabsContents }
+					/>
 				) }
 				{ ! delayedFilterValue && ! showAsTabs && (
 					<div className="block-editor-inserter__no-tab-container">

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -61,7 +61,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__popover .block-editor-inserter__menu {
 	margin: -$grid-unit-15;
 
-	.block-editor-inserter__tabs .components-tab-panel__tabs {
+	.block-editor-inserter__tabs div[role="tablist"] {
 		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60 - $grid-unit-15;
 	}
 
@@ -118,10 +118,10 @@ $block-inserter-tabs-height: 44px;
 	flex-direction: column;
 	overflow: hidden;
 
-	.components-tab-panel__tabs {
+	div[role="tablist"] {
 		border-bottom: $border-width solid $gray-300;
 
-		.components-tab-panel__tabs-item {
+		button[role="tab"] {
 			flex-grow: 1;
 			margin-bottom: -$border-width;
 			&[id$="reusable"] {
@@ -133,7 +133,7 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 
-	.components-tab-panel__tab-content {
+	div[role="tabpanel"] {
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -67,7 +67,7 @@ function InserterTabs( {
 						tabId={ tab.name }
 						focusable={ false }
 					>
-						{ children( tab ) }
+						{ children[ tab.name ] }
 					</Tabs.TabPanel>
 				) ) }
 			</Tabs>

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -2,8 +2,15 @@
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
-import { TabPanel } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 const blocksTab = {
 	name: 'blocks',
@@ -45,13 +52,22 @@ function InserterTabs( {
 	}, [ prioritizePatterns, showPatterns, showMedia ] );
 
 	return (
-		<TabPanel
-			className="block-editor-inserter__tabs"
-			tabs={ tabs }
-			onSelect={ onSelect }
-		>
-			{ children }
-		</TabPanel>
+		<div className="block-editor-inserter__tabs">
+			<Tabs onSelect={ onSelect }>
+				<Tabs.TabList>
+					{ tabs.map( ( tab ) => (
+						<Tabs.Tab key={ tab.name } tabId={ tab.name }>
+							{ tab.title }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.TabList>
+				{ tabs.map( ( tab ) => (
+					<Tabs.TabPanel key={ tab.name } tabId={ tab.name }>
+						{ children( tab ) }
+					</Tabs.TabPanel>
+				) ) }
+			</Tabs>
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -62,7 +62,11 @@ function InserterTabs( {
 					) ) }
 				</Tabs.TabList>
 				{ tabs.map( ( tab ) => (
-					<Tabs.TabPanel key={ tab.name } tabId={ tab.name }>
+					<Tabs.TabPanel
+						key={ tab.name }
+						tabId={ tab.name }
+						focusable={ false }
+					>
 						{ children( tab ) }
 					</Tabs.TabPanel>
 				) ) }

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -30,11 +30,11 @@ const mediaTab = {
 };
 
 function InserterTabs( {
-	children,
 	showPatterns = false,
 	showMedia = false,
 	onSelect,
 	prioritizePatterns,
+	tabsContents,
 } ) {
 	const tabs = useMemo( () => {
 		const tempTabs = [];
@@ -67,7 +67,7 @@ function InserterTabs( {
 						tabId={ tab.name }
 						focusable={ false }
 					>
-						{ children[ tab.name ] }
+						{ tabsContents[ tab.name ] }
 					</Tabs.TabPanel>
 				) ) }
 			</Tabs>

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -86,7 +86,10 @@ export async function selectGlobalInserterTab( label ) {
 	}
 
 	const activeTab = await page.waitForSelector(
-		'.block-editor-inserter__tabs button.is-active'
+		// Targeting a class name is necessary here, because there are likely
+		// two implementations of the `Tabs` component visible to this test, and
+		// we want to confirm that it's waiting for the correct one.
+		'.block-editor-inserter__tabs [role="tab"][aria-selected="true"]'
 	);
 
 	const activeTabLabel = await page.evaluate(


### PR DESCRIPTION
## What?
Replaces the legacy TabPanel component with the new Tabs component.

Because the items in the tabpanels are focusable, I've applied `focusable=false` so focus can skip the panel itself.

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

## How?
`TabPanel` is replaced by `Tabs` and its sub-components.

The data to render the contents of the individual `tabpanel`s was previously delivered via a render function, because that's how `TabPanel` operates. Because a function is no longer required, I've converted that data into a simple object, which I hope will be easier to parse for anyone updating this code in the future.

## Testing Instructions
1. Launch the editor
2. Open the block inserter using the button on the left hand side of the top toolbar
3. Confirm that all three tabs (Blocks, Patterns, and Media) are present
4. Confirm that all three tabs render the correct content
5. Behavior and appearance should match trunk

### Testing Instructions for Keyboard
1. Create a new post
2. Press `` ctrl + ` `` until you're focused on the top toolbar
3. Press [Tab] to focus the block inserter toggle, and [Enter/Return] to open the sidebar
4. Press [Tab] again to focus the current tab
5. Press [Tab] once more to focus on the first actionable item in the tabpanel. Confirm that focus skips over the tabpanel and goes straight to the first button
