### PR TITLE
Blocks: simplify/optimise isUnmodifiedBlock

### DIFF
--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -18,7 +18,6 @@ import { RichTextData } from '@wordpress/rich-text';
  */
 import { BLOCK_ICON_DEFAULT } from './constants';
 import { getBlockType, getDefaultBlockName } from './registration';
-import { createBlock } from './factory';
 
 extend( [ namesPlugin, a11yPlugin ] );
 
@@ -39,21 +38,16 @@ const ICON_COLORS = [ '#191e23', '#f8f9f9' ];
  * @return {boolean} Whether the block is an unmodified block.
  */
 export function isUnmodifiedBlock( block ) {
-	// Cache a created default block if no cache exists or the default block
-	// name changed.
-	if ( ! isUnmodifiedBlock[ block.name ] ) {
-		isUnmodifiedBlock[ block.name ] = createBlock( block.name );
-	}
+	return Object.entries( getBlockType( block.name )?.attributes ?? {} ).every(
+		( [ key, definition ] ) => {
+			// Every attribute that has a default must match the default.
+			if ( definition.hasOwnProperty( 'default' ) ) {
+				return block.attributes[ key ] === definition.default;
+			}
 
-	const newBlock = isUnmodifiedBlock[ block.name ];
-	const blockType = getBlockType( block.name );
-
-	function isEqual( a, b ) {
-		return ( a?.valueOf() ?? a ) === ( b?.valueOf() ?? b );
-	}
-
-	return Object.keys( blockType?.attributes ?? {} ).every( ( key ) =>
-		isEqual( newBlock.attributes[ key ], block.attributes[ key ] )
+			// Every attribute that does not have a default must be empty.
+			return ! block.attributes[ key ]?.length;
+		}
 	);
 }
 

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -40,13 +40,22 @@ const ICON_COLORS = [ '#191e23', '#f8f9f9' ];
 export function isUnmodifiedBlock( block ) {
 	return Object.entries( getBlockType( block.name )?.attributes ?? {} ).every(
 		( [ key, definition ] ) => {
+			const value = block.attributes[ key ];
+
 			// Every attribute that has a default must match the default.
 			if ( definition.hasOwnProperty( 'default' ) ) {
-				return block.attributes[ key ] === definition.default;
+				return value === definition.default;
 			}
 
-			// Every attribute that does not have a default must be empty.
-			return ! block.attributes[ key ]?.length;
+			// The rich text type is a bit different from the rest because it
+			// has an implicit default value of an empty RichTextData instance,
+			// so check the length of the value.
+			if ( definition.type === 'rich-text' ) {
+				return ! value?.length;
+			}
+
+			// Every attribute that doesn't have a default should be undefined.
+			return value === undefined;
 		}
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is one of the functions I see pop up a lot in the performance graph for the `input` event, due to the rich text value to store PR (#43204). Because we're now comparing `.valueOf()`, these attributes are now serialised to check strict equality.

This PR changes to function to look at the defaults in the attribute definition. If the attributes don't match the defaults, or are not empty, it means the block was modified.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This function runs on typing so it's important to change. It's also simpler.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Described above

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

No tests should fail.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
