### PR TITLE
Fix: Code editor title width in classic theme

### DIFF
--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -2,4 +2,5 @@
 .edit-post-text-editor__body .editor-post-title.is-raw-text {
 	margin-bottom: $grid-unit-30;
 	margin-top: 2px; // space for focus outline to appear.
+	max-width: none;
 }


### PR DESCRIPTION
Related to #54718

## What?

This PR fixes an issue where the width of the title area is restricted when switching to the code editor in the classic theme.

![classic-css](https://github.com/WordPress/gutenberg/assets/54422211/b00c1d27-d29c-4a51-a9f0-02467e343896)

## Why?

If a theme does not have a `theme.json` file, a CSS file that defines the default layout will be [loaded](https://github.com/WordPress/gutenberg/blob/1783a4e15a0d0806151ed3b88fec8cded2886d5a/lib/client-assets.php#L334-L337). This CSS file [defines the maximum width of the block](https://github.com/WordPress/gutenberg/blob/1783a4e15a0d0806151ed3b88fec8cded2886d5a/packages/edit-post/src/classic.scss#L24), and this style also affects the title in the code editor.

## How?

Use `max-width: none;` to remove the maximum title width restriction.

## Testing Instructions

- Activate Twenty Twenty-One theme.
- Open the Post Editor.
- Switch to the code editor and check the title width.
- Also check that the title area does not overflow when the browser width is narrowed.