### PR TITLE
Don't render undefined classname in useBlockProps hook

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -191,7 +191,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 							getBlockName( movingClientId ),
 							getBlockRootClientId( clientId )
 						),
-					[ attributes.className ]: hasLightBlockWrapper,
+					[ attributes.className ]:
+						attributes.className && hasLightBlockWrapper,
 					[ getBlockDefaultClassName( blockName ) ]:
 						hasLightBlockWrapper,
 				} ),

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -172,30 +172,32 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 					_isSelected && __unstableGetEditorMode() === 'edit'
 						? getSelectedBlocksInitialCaretPosition()
 						: undefined,
-				classNames: classnames( {
-					'is-selected': _isSelected,
-					'is-highlighted': isBlockHighlighted( clientId ),
-					'is-multi-selected': isMultiSelected,
-					'is-partially-selected':
-						isMultiSelected &&
-						! __unstableIsFullySelected() &&
-						! __unstableSelectionHasUnmergeableBlock(),
-					'is-reusable': isReusableBlock( blockType ),
-					'is-dragging': isBlockBeingDragged( clientId ),
-					'has-child-selected': isAncestorOfSelectedBlock,
-					'remove-outline': _isSelected && outlineMode && typing,
-					'is-block-moving-mode': !! movingClientId,
-					'can-insert-moving-block':
-						movingClientId &&
-						canInsertBlockType(
-							getBlockName( movingClientId ),
-							getBlockRootClientId( clientId )
-						),
-					[ attributes.className ]:
-						attributes.className && hasLightBlockWrapper,
-					[ getBlockDefaultClassName( blockName ) ]:
-						hasLightBlockWrapper,
-				} ),
+				classNames: classnames(
+					{
+						'is-selected': _isSelected,
+						'is-highlighted': isBlockHighlighted( clientId ),
+						'is-multi-selected': isMultiSelected,
+						'is-partially-selected':
+							isMultiSelected &&
+							! __unstableIsFullySelected() &&
+							! __unstableSelectionHasUnmergeableBlock(),
+						'is-reusable': isReusableBlock( blockType ),
+						'is-dragging': isBlockBeingDragged( clientId ),
+						'has-child-selected': isAncestorOfSelectedBlock,
+						'remove-outline': _isSelected && outlineMode && typing,
+						'is-block-moving-mode': !! movingClientId,
+						'can-insert-moving-block':
+							movingClientId &&
+							canInsertBlockType(
+								getBlockName( movingClientId ),
+								getBlockRootClientId( clientId )
+							),
+					},
+					hasLightBlockWrapper ? attributes.className : undefined,
+					hasLightBlockWrapper
+						? getBlockDefaultClassName( blockName )
+						: undefined
+				),
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
Related to #56847

## What?

This PR removes `undefined` class that is rendered when a block has no additional CSS classes.

![undefined-class](https://github.com/WordPress/gutenberg/assets/54422211/174c22f3-0645-441d-bff8-e8c8bce8d93e)

## Why?

We need to check that `attributes.className` does not appear undefined. This [existed](https://github.com/WordPress/gutenberg/pull/56847/files#diff-240dee2be63bf0a921d62156d1e9f080ec307d11aa2dd6ff71e0a97d7c5cd2f3L29-L31) before #56847 refactored the useBlockProps hook.

## Testing Instructions

- Insert some block.
- The undefined class should not be output in the block wrapper.
- It should output correctly when you apply the additional CSS class.