### PR TITLE
Fix/remove empty space from inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/panel.js
+++ b/packages/block-editor/src/components/inserter/panel.js
@@ -1,12 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon, VisuallyHidden } from '@wordpress/components';
 
 function InserterPanel( { title, icon, children } ) {
+	const isVisuallyHidden = title.type && title.type === VisuallyHidden;
 	return (
 		<>
-			<div className="block-editor-inserter__panel-header">
+			<div
+				className={
+					isVisuallyHidden === true
+						? 'block-editor-inserter__hidden-panel-header'
+						: 'block-editor-inserter__panel-header'
+				}
+			>
 				<h2 className="block-editor-inserter__panel-title">
 					{ title }
 				</h2>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -152,6 +152,14 @@ $block-inserter-tabs-height: 44px;
 	padding: $grid-unit-20 $grid-unit-20 0;
 }
 
+.block-editor-inserter__hidden-panel-header {
+	&:first-of-type + .block-editor-inserter__panel-content {
+		// "Remove" top padding from the first element.
+		// Search term might only return patterns which have hover effect (box-shadow) which will become invisible on top side if padding is set to zero
+		padding-top: 2px;
+	}
+}
+
 .block-editor-inserter__panel-content {
 	padding: $grid-unit-20;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR is removing unnecessary empty space(s) in the Inserter panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Closes #56802

In the inserter panel the goal is to remove space between content area and search results

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The `InserterPanel` component takes a title property. After checking Gutenberg codebase revealed that property is either plain string or `VisuallyHidden` component. Added logic now checks whether title property is specifically `VisuallyHidden` component and use proper classes after that

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Open Inserter panel
3. Observe the labels before block listing
4. Search for "Social" and observe there is no empty space before the list(s).
5. Search for "Social with" this returns pattern list and again observe no empty space before the list and hover effect still works on the pattern list items

This one hard to describe. Please also check the linked issue there are some really good screenshots (one picture versus million words)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

