### PR TITLE
PaletteEdit: refactor custom color/gradient name assignment

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Bug Fix
-
+-   `PaletteEdit`: ensure number changes to custom names are classes as non-default ([#56932](https://github.com/WordPress/gutenberg/pull/56932)).
 -   `FontSizePicker`: Use Button API for keeping focus on reset ([#57221](https://github.com/WordPress/gutenberg/pull/57221)).
 -   `FontSizePicker`: Fix Reset button focus loss ([#57196](https://github.com/WordPress/gutenberg/pull/57196)).
 -   `PaletteEdit`: Consider digits when generating kebab-cased slug ([#56713](https://github.com/WordPress/gutenberg/pull/56713)).

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -264,15 +264,17 @@ function Option< T extends Color | Gradient >( {
 /**
  * Checks if a color or gradient is a temporary element by testing against default values.
  */
-export function isTemporaryElement(
+export function isDefaultElement(
 	slugPrefix: string,
-	{ slug, color, gradient }: Color | Gradient
+	{ slug, color, gradient }: Color | Gradient,
+	index: number = -1
 ): Boolean {
 	const regex = new RegExp( `^${ slugPrefix }color-([\\d]+)$` );
-
+	const [ , slugIndex ] = slug.match( regex ) || [];
+	const hasSameIndex = index === ( slugIndex ? Number( slugIndex ) : null );
 	// If the slug matches the temporary name regex,
 	// check if the color or gradient matches the default value.
-	if ( regex.test( slug ) ) {
+	if ( hasSameIndex && regex.test( slug ) ) {
 		// The order is important as gradient elements
 		// contain a color property.
 		if ( !! gradient ) {
@@ -305,12 +307,13 @@ function PaletteEditListView< T extends Color | Gradient >( {
 	useEffect( () => {
 		return () => {
 			if (
-				elementsReference.current?.some( ( element ) =>
-					isTemporaryElement( slugPrefix, element )
+				elementsReference.current?.some( ( element, index ) =>
+					isDefaultElement( slugPrefix, element, index + 1 )
 				)
 			) {
 				const newElements = elementsReference.current.filter(
-					( element ) => ! isTemporaryElement( slugPrefix, element )
+					( element, index ) =>
+						! isDefaultElement( slugPrefix, element, index + 1 )
 				);
 				onChange( newElements.length ? newElements : undefined );
 			}

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -326,11 +326,17 @@ function PaletteEditListView< T extends Color | Gradient >( {
 					.map( ( element, index, arr ) => {
 						element.name =
 							element?.name ||
-							sprintf(
-								/* translators: %s: is a temporary id for a custom color */
-								__( 'Color %s' ),
-								index + 1
-							);
+							( !! element.gradient
+								? sprintf(
+										/* translators: %s: is a temporary id for a custom gradient */
+										__( 'Gradient %s' ),
+										index + 1
+								  )
+								: sprintf(
+										/* translators: %s: is a temporary id for a custom color */
+										__( 'Color %s' ),
+										index + 1
+								  ) );
 						return element;
 					} );
 				onChange( newElements.length ? newElements : undefined );

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -58,11 +58,10 @@ import type {
 	PaletteEditListViewProps,
 	PaletteEditProps,
 	PaletteElement,
-	OnChangeDebouncedFunction,
 } from './types';
 
 export const DEFAULT_COLOR = '#000';
-const EMPTY_ARRAY = [];
+const EMPTY_ARRAY: Color[] = [];
 
 function NameInput( { value, onChange, label }: NameInputProps ) {
 	return (
@@ -323,7 +322,7 @@ function PaletteEditListView< T extends Color | Gradient >( {
 					.filter(
 						( element ) => ! isDefaultElement( slugPrefix, element )
 					)
-					.map( ( element, index, arr ) => {
+					.map( ( element, index ) => {
 						element.name =
 							element?.name ||
 							( !! element.gradient
@@ -346,10 +345,8 @@ function PaletteEditListView< T extends Color | Gradient >( {
 		// a heavier refactor to avoid. See https://github.com/WordPress/gutenberg/pull/43911
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
-	const debounceOnChange: OnChangeDebouncedFunction = useDebounce(
-		onChange,
-		100
-	);
+
+	const debounceOnChange = useDebounce( onChange, 100 );
 
 	return (
 		<VStack spacing={ 3 }>
@@ -499,7 +496,7 @@ export function PaletteEdit( {
 							}
 							onClick={ () => {
 								const tempOptionId = getIdForPosition(
-									elements || EMPTY_ARRAY,
+									elements || [],
 									slugPrefix
 								);
 

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -262,7 +262,7 @@ function Option< T extends Color | Gradient >( {
 }
 
 /**
- * Checks if a color or gradient is a temporary element by testing against default values.
+ * Checks if a color or gradient is a default element by testing against default values.
  */
 export function isDefaultElement(
 	slugPrefix: string,
@@ -272,6 +272,7 @@ export function isDefaultElement(
 	const regex = new RegExp( `^${ slugPrefix }color-([\\d]+)$` );
 	const [ , slugIndex ] = slug.match( regex ) || [];
 	const hasSameIndex = index === ( slugIndex ? Number( slugIndex ) : null );
+
 	// If the slug matches the temporary name regex,
 	// check if the color or gradient matches the default value.
 	if ( hasSameIndex && regex.test( slug ) ) {

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -7,3 +7,6 @@
 		width: 100%;
 	}
 }
+.components-palette-edit__item-column {
+	min-height: $grid-unit-20;
+}

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -8,5 +8,6 @@
 	}
 }
 .components-palette-edit__item-column {
-	min-height: $grid-unit-20;
+	// Height of PaletteItem component input + padding.
+	min-height: $grid-unit-30 + 6;
 }

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -7,7 +7,7 @@ import { render, fireEvent, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import PaletteEdit, {
-	getNameForPosition,
+	getIdForPosition,
 	isDefaultElement,
 	DEFAULT_COLOR,
 } from '..';
@@ -19,8 +19,8 @@ describe( 'getNameForPosition', () => {
 		const slugPrefix = 'test-';
 		const elements: PaletteElement[] = [];
 
-		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
-			'Color 1'
+		expect( getIdForPosition( elements, slugPrefix ) ).toEqual(
+			'test-color-1'
 		);
 	} );
 
@@ -34,8 +34,8 @@ describe( 'getNameForPosition', () => {
 			},
 		];
 
-		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
-			'Color 2'
+		expect( getIdForPosition( elements, slugPrefix ) ).toEqual(
+			'test-color-2'
 		);
 	} );
 
@@ -49,8 +49,8 @@ describe( 'getNameForPosition', () => {
 			},
 		];
 
-		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
-			'Color 1'
+		expect( getIdForPosition( elements, slugPrefix ) ).toEqual(
+			'test-color-1'
 		);
 	} );
 
@@ -79,8 +79,8 @@ describe( 'getNameForPosition', () => {
 			},
 		];
 
-		expect( getNameForPosition( elements, slugPrefix ) ).toEqual(
-			'Color 151'
+		expect( getIdForPosition( elements, slugPrefix ) ).toEqual(
+			'test-color-151'
 		);
 	} );
 } );
@@ -90,7 +90,6 @@ describe( 'isDefaultElement', () => {
 		{
 			message: 'identify temporary color',
 			slug: 'test-',
-			index: 1,
 			obj: {
 				name: '',
 				slug: 'test-color-1',
@@ -101,34 +100,12 @@ describe( 'isDefaultElement', () => {
 		{
 			message: 'identify default gradient',
 			slug: 'test-',
-			index: 1,
 			obj: {
 				name: '',
 				slug: 'test-color-1',
 				gradient: DEFAULT_GRADIENT,
 			},
 			expected: true,
-		},
-		{
-			message: 'not match default color with missing index arg',
-			slug: 'test-',
-			obj: {
-				name: '',
-				slug: 'test-color-1',
-				color: DEFAULT_COLOR,
-			},
-			expected: false,
-		},
-		{
-			message: 'identify custom color with mismatching index in name',
-			slug: 'test-',
-			index: 1,
-			obj: {
-				name: '',
-				slug: 'test-color-11',
-				color: DEFAULT_COLOR,
-			},
-			expected: false,
 		},
 		{
 			message: 'identify custom color slug',
@@ -170,9 +147,9 @@ describe( 'isDefaultElement', () => {
 			},
 			expected: false,
 		},
-	].forEach( ( { message, slug, index, obj, expected } ) => {
+	].forEach( ( { message, slug, obj, expected } ) => {
 		it( `should ${ message }`, () => {
-			expect( isDefaultElement( slug, obj, index ) ).toBe( expected );
+			expect( isDefaultElement( slug, obj ) ).toBe( expected );
 		} );
 	} );
 } );

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -8,7 +8,7 @@ import { render, fireEvent, screen } from '@testing-library/react';
  */
 import PaletteEdit, {
 	getNameForPosition,
-	isTemporaryElement,
+	isDefaultElement,
 	DEFAULT_COLOR,
 } from '..';
 import type { PaletteElement } from '../types';
@@ -85,11 +85,12 @@ describe( 'getNameForPosition', () => {
 	} );
 } );
 
-describe( 'isTemporaryElement', () => {
+describe( 'isDefaultElement', () => {
 	[
 		{
-			message: 'identifies temporary color',
+			message: 'identify temporary color',
 			slug: 'test-',
+			index: 1,
 			obj: {
 				name: '',
 				slug: 'test-color-1',
@@ -98,8 +99,9 @@ describe( 'isTemporaryElement', () => {
 			expected: true,
 		},
 		{
-			message: 'identifies temporary gradient',
+			message: 'identify default gradient',
 			slug: 'test-',
+			index: 1,
 			obj: {
 				name: '',
 				slug: 'test-color-1',
@@ -108,7 +110,28 @@ describe( 'isTemporaryElement', () => {
 			expected: true,
 		},
 		{
-			message: 'identifies custom color slug',
+			message: 'not match default color with missing index arg',
+			slug: 'test-',
+			obj: {
+				name: '',
+				slug: 'test-color-1',
+				color: DEFAULT_COLOR,
+			},
+			expected: false,
+		},
+		{
+			message: 'identify custom color with mismatching index in name',
+			slug: 'test-',
+			index: 1,
+			obj: {
+				name: '',
+				slug: 'test-color-11',
+				color: DEFAULT_COLOR,
+			},
+			expected: false,
+		},
+		{
+			message: 'identify custom color slug',
 			slug: 'test-',
 			obj: {
 				name: '',
@@ -118,7 +141,7 @@ describe( 'isTemporaryElement', () => {
 			expected: false,
 		},
 		{
-			message: 'identifies custom color value',
+			message: 'identify custom color value',
 			slug: 'test-',
 			obj: {
 				name: '',
@@ -128,7 +151,7 @@ describe( 'isTemporaryElement', () => {
 			expected: false,
 		},
 		{
-			message: 'identifies custom gradient slug',
+			message: 'identify custom gradient slug',
 			slug: 'test-',
 			obj: {
 				name: '',
@@ -138,7 +161,7 @@ describe( 'isTemporaryElement', () => {
 			expected: false,
 		},
 		{
-			message: 'identifies custom gradient value',
+			message: 'identify custom gradient value',
 			slug: 'test-',
 			obj: {
 				name: '',
@@ -147,9 +170,9 @@ describe( 'isTemporaryElement', () => {
 			},
 			expected: false,
 		},
-	].forEach( ( { message, slug, obj, expected } ) => {
+	].forEach( ( { message, slug, index, obj, expected } ) => {
 		it( `should ${ message }`, () => {
-			expect( isTemporaryElement( slug, obj ) ).toBe( expected );
+			expect( isDefaultElement( slug, obj, index ) ).toBe( expected );
 		} );
 	} );
 } );

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -127,7 +127,7 @@ export type OptionProps< T extends Color | Gradient > = {
 
 export type PaletteEditListViewProps< T extends Color | Gradient > = {
 	elements: T[];
-	onChange: ( newElements: T[] ) => void;
+	onChange: ( newElements: T[] | undefined ) => void;
 	isGradient: T extends Gradient ? true : false;
 	canOnlyChangeValues: PaletteEditProps[ 'canOnlyChangeValues' ];
 	editingElement?: EditingElement;
@@ -135,5 +135,3 @@ export type PaletteEditListViewProps< T extends Color | Gradient > = {
 	setEditingElement: ( newEditingElement?: EditingElement ) => void;
 	slugPrefix: string;
 };
-
-export type OnChangeDebouncedFunction = ( arr: PaletteElement[] ) => void;

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -127,7 +127,7 @@ export type OptionProps< T extends Color | Gradient > = {
 
 export type PaletteEditListViewProps< T extends Color | Gradient > = {
 	elements: T[];
-	onChange: ( newElements?: T[] ) => void;
+	onChange: ( newElements: T[] ) => void;
 	isGradient: T extends Gradient ? true : false;
 	canOnlyChangeValues: PaletteEditProps[ 'canOnlyChangeValues' ];
 	editingElement?: EditingElement;
@@ -135,3 +135,5 @@ export type PaletteEditListViewProps< T extends Color | Gradient > = {
 	setEditingElement: ( newEditingElement?: EditingElement ) => void;
 	slugPrefix: string;
 };
+
+export type OnChangeDebouncedFunction = ( arr: PaletteElement[] ) => void;


### PR DESCRIPTION
## What?
When a user edits a custom color/gradient name by adding digits to `Color n`, e.g., `Color n2` we class this color as custom and not "Default", and therefore unsaveable.

Context: https://github.com/WordPress/gutenberg/pull/56896#issuecomment-1849125622

## Why?
The user has edited the name. It's no a longer default.




## How?

Refactoring the UX:

- Allow empty color/gradient names
- If the color is NOT default and the name is empty, only then create a default name with "Done" is clicked.


## TODO

- [x] Merge https://github.com/WordPress/gutenberg/pull/56896
- [x] Add unit tests

## Testing Instructions
1. Head over to the site editor style panel and select "Colors > Palette"
2. Add some custom colors and gradients:
    i. a custom color/gradient without names, some with
    ii. some using the default  color/gradient with no name, and some with the default color/gradient with a name


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


### This PR in action



https://github.com/WordPress/gutenberg/assets/6458278/4597ba8b-9bfe-414f-a795-ac427d34a34f



