### PR TITLE
Apply __next40pxDefaultSize to TextControl and Button component in renaming UIs

### DIFF
--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -88,6 +88,7 @@ export default function BlockRenameModal( {
 				<VStack spacing="3">
 					<TextControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						value={ editedBlockName }
 						label={ __( 'Block name' ) }
 						hideLabelFromVision={ true }

--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -97,11 +97,16 @@ export default function BlockRenameModal( {
 						onFocus={ autoSelectInputText }
 					/>
 					<HStack justify="right">
-						<Button variant="tertiary" onClick={ onClose }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onClose }
+						>
 							{ __( 'Cancel' ) }
 						</Button>
 
 						<Button
+							__next40pxDefaultSize
 							aria-disabled={ ! isNameValid }
 							variant="primary"
 							type="submit"

--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -50,6 +50,7 @@ function BlockRenameControlPure( { metadata, setAttributes } ) {
 		<InspectorControls group="advanced">
 			<TextControl
 				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 				label={ __( 'Block name' ) }
 				value={ metadata?.name || '' }
 				onChange={ ( newName ) => {

--- a/packages/edit-site/src/components/page-patterns/rename-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-menu-item.js
@@ -105,6 +105,7 @@ export default function RenameMenuItem( { item, onClose } ) {
 
 							<HStack justify="right">
 								<Button
+									__next40pxDefaultSize
 									variant="tertiary"
 									onClick={ () => {
 										setIsModalOpen( false );
@@ -114,7 +115,11 @@ export default function RenameMenuItem( { item, onClose } ) {
 									{ __( 'Cancel' ) }
 								</Button>
 
-								<Button variant="primary" type="submit">
+								<Button
+									__next40pxDefaultSize
+									variant="primary"
+									type="submit"
+								>
 									{ __( 'Save' ) }
 								</Button>
 							</HStack>

--- a/packages/edit-site/src/components/page-patterns/rename-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/rename-menu-item.js
@@ -96,6 +96,7 @@ export default function RenameMenuItem( { item, onClose } ) {
 						<VStack spacing="5">
 							<TextControl
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								label={ __( 'Name' ) }
 								value={ title }
 								onChange={ setTitle }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -33,11 +33,16 @@ export default function RenameModal( { menuTitle, onClose, onSave } ) {
 						onChange={ setEditedMenuTitle }
 					/>
 					<HStack justify="right">
-						<Button variant="tertiary" onClick={ onClose }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onClose }
+						>
 							{ __( 'Cancel' ) }
 						</Button>
 
 						<Button
+							__next40pxDefaultSize
 							disabled={ ! isEditedMenuTitleValid }
 							variant="primary"
 							type="submit"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/rename-modal.js
@@ -27,6 +27,7 @@ export default function RenameModal( { menuTitle, onClose, onSave } ) {
 				<VStack spacing="3">
 					<TextControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						value={ editedMenuTitle }
 						placeholder={ __( 'Navigation title' ) }
 						onChange={ setEditedMenuTitle }

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -116,6 +116,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 
 							<HStack justify="right">
 								<Button
+									__next40pxDefaultSize
 									variant="tertiary"
 									onClick={ () => {
 										setIsModalOpen( false );
@@ -124,7 +125,11 @@ export default function RenameMenuItem( { template, onClose } ) {
 									{ __( 'Cancel' ) }
 								</Button>
 
-								<Button variant="primary" type="submit">
+								<Button
+									__next40pxDefaultSize
+									variant="primary"
+									type="submit"
+								>
 									{ __( 'Save' ) }
 								</Button>
 							</HStack>

--- a/packages/edit-site/src/components/template-actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/template-actions/rename-menu-item.js
@@ -107,6 +107,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 						<VStack spacing="5">
 							<TextControl
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								label={ __( 'Name' ) }
 								value={ editedTitle }
 								onChange={ setEditedTitle }

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -138,6 +138,7 @@ export default function RenamePatternCategoryModal( {
 						<TextControl
 							ref={ textControlRef }
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							label={ __( 'Name' ) }
 							value={ name }
 							onChange={ onChange }

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -155,10 +155,15 @@ export default function RenamePatternCategoryModal( {
 						) }
 					</VStack>
 					<HStack justify="right">
-						<Button variant="tertiary" onClick={ onRequestClose }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onRequestClose }
+						>
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							__next40pxDefaultSize
 							variant="primary"
 							type="submit"
 							aria-disabled={

--- a/packages/patterns/src/components/rename-pattern-modal.js
+++ b/packages/patterns/src/components/rename-pattern-modal.js
@@ -101,11 +101,19 @@ export default function RenamePatternModal( {
 					/>
 
 					<HStack justify="right">
-						<Button variant="tertiary" onClick={ onRequestClose }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onRequestClose }
+						>
 							{ __( 'Cancel' ) }
 						</Button>
 
-						<Button variant="primary" type="submit">
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							type="submit"
+						>
 							{ __( 'Save' ) }
 						</Button>
 					</HStack>

--- a/packages/patterns/src/components/rename-pattern-modal.js
+++ b/packages/patterns/src/components/rename-pattern-modal.js
@@ -93,6 +93,7 @@ export default function RenamePatternModal( {
 				<VStack spacing="5">
 					<TextControl
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						label={ __( 'Name' ) }
 						value={ name }
 						onChange={ setName }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/46741

## What?
This PR adds a `__next40pxDefaultSize` to the text control component in actions related to renaming.

## How?
I made changes in 7 places related to renaming. As for renaming the block, it should have already been changed in #56022, but it looks like it was unintentionally deleted by #56386 ([Source 1](https://github.com/WordPress/gutenberg/pull/56386/files#diff-c2a9b15e4cf134ddbabc096ce758a34cd8df2896f845cc34a0a39d74b2cae94fR89-R97), [Source 2](https://github.com/WordPress/gutenberg/pull/56386/files#diff-2e47bdc590ad400db1d1457b03f35587452729b4f15a83f1586297763e9ce374R60-R72)).

## Testing Instructions

In the UI below, confirm that the height of the text control is 40px.

### Block Renaming Modal

Open the Post Editor > Insert a block > Open the Options dropdown > Rename

![Block Renaming Modal](https://github.com/WordPress/gutenberg/assets/54422211/4dce1851-8084-4be6-9e81-2f14923cd943)

### Block Advanced Panel

Open the Post Editor > Insert a block > Show block sidebar > Open Advanced panel > Block Name

![Block Advanced Panel](https://github.com/WordPress/gutenberg/assets/54422211/e61961d1-5c88-4899-877a-1385f61202bf)

### Navigation Renaming Modal

Open the  Site Editor > Navigation Page > Select a navigation > Open the Actions dropdown > Rename

![Navigation Renaming Modal](https://github.com/WordPress/gutenberg/assets/54422211/fc4e57ef-a524-4828-b23b-30d01ba4cf91)

### Template Renaming Modal

Open the Site Editor > Patterns page > Create a custom template > Select the template > Open the Actions dropdpwn > Rename

![Template Renaming Modal](https://github.com/WordPress/gutenberg/assets/54422211/4bbc1dc6-f253-472b-b2bc-98dccceec0d6)

### Pattern Renaming Modal and Pattern Renaming Modal via Command Palette

- Open the Site Editor > Patterns page > Create a pattern > Select the pattern > Open the Actions dropdpwn > Rename
- Open the Site Editor > Patterns page > Create a pattern > Open the pattern editor canvas > Open Command Palette > Select Rename pattern

![Pattern Renaming Modal](https://github.com/WordPress/gutenberg/assets/54422211/073e549b-69c0-4ff1-9240-5916442c7bac)

### Pattern Category Renaming Modal

Open the Site Editor > Patterns page > Create a pattern with categories > Select the category > Open the Actions dropdpwn > Rename

![Pattern Category Renaming Modal](https://github.com/WordPress/gutenberg/assets/54422211/520cae61-d6cb-4eb2-85c8-22541f31dc4c)

