### PR TITLE
Tweak table block placeholder with __next40pxDefaultSize props

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -555,6 +555,7 @@ function TableEdit( {
 					>
 						<TextControl
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							type="number"
 							label={ __( 'Column count' ) }
 							value={ initialColumnCount }
@@ -564,6 +565,7 @@ function TableEdit( {
 						/>
 						<TextControl
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							type="number"
 							label={ __( 'Row count' ) }
 							value={ initialRowCount }
@@ -572,7 +574,7 @@ function TableEdit( {
 							className="blocks-table__placeholder-input"
 						/>
 						<Button
-							className="blocks-table__placeholder-button"
+							__next40pxDefaultSize
 							variant="primary"
 							type="submit"
 						>

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -58,27 +58,14 @@
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-
-	> * {
-		margin-bottom: $grid-unit-10;
-	}
+	gap: $grid-unit-10;
 
 	@include break-medium() {
 		flex-direction: row;
 		align-items: flex-end;
-
-		> * {
-			margin-bottom: 0;
-		}
 	}
 }
 
 .blocks-table__placeholder-input {
 	width: $grid-unit-10 * 14;
-	margin-right: $grid-unit-10;
-	margin-bottom: 0;
-
-	input {
-		height: $button-size;
-	}
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/46741

## What?
This PR introduces `__next40pxDefaultSize` prop to the placeholder input of the Table block to unify the layout.

## Why?

As part of an attempt to standardize the default size of components to 40px in the future.

## How?

Added `__next40pxDefaultSize` prop to TextControl and Button components. At the same time, I applied gaps to the flex layout and removed many placeholder styles that were no longer needed.

## Testing Instructions

- Insert a table block to see the placeholder layout.
- Enable custom fields from the preferences panel. The editor canvas is no longer iframed and WP-Admin's form styles will affect it, but the layout should remain the same.

## Screenshots or screencast <!-- if applicable -->

For better visual clarity, I have also included the standardized RSS block as part of #53819.

### Desktop view

#### Before

![before_desktop](https://github.com/WordPress/gutenberg/assets/54422211/fa996644-5ac1-4fa1-86bc-1461902a7a63)

#### After

![after_desktop](https://github.com/WordPress/gutenberg/assets/54422211/a867972d-5a12-4783-8ef7-b0ff2b244067)

### Mobile view

#### Before

![before_mobile](https://github.com/WordPress/gutenberg/assets/54422211/e2b78baa-2a8e-4d92-9aea-167e5f128aef)

#### After

![after_mobile](https://github.com/WordPress/gutenberg/assets/54422211/98eae892-6f78-44bd-8d18-f68ca4b94965)
