### PR TITLE
Create-block-interactive-template: Prevent crash when Gutenberg plugin is not installed

### DIFF
--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Prevent crash when Gutenberg plugin is not installed. [#56941](https://github.com/WordPress/gutenberg/pull/56941)
+
 ## 1.10.1 (2023-12-07)
 
 -   Update template to use modules instead of scripts. [#56694](https://github.com/WordPress/gutenberg/pull/56694)

--- a/packages/create-block-interactive-template/block-templates/render.php.mustache
+++ b/packages/create-block-interactive-template/block-templates/render.php.mustache
@@ -15,7 +15,9 @@
 $unique_id = wp_unique_id( 'p-' );
 
 // Enqueue the view file.
-gutenberg_enqueue_module( '{{namespace}}-view' );
+if (function_exists('gutenberg_enqueue_module')) {
+	gutenberg_enqueue_module( '{{namespace}}-view' );
+}
 ?>
 
 <div

--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -44,11 +44,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 	register_block_type( __DIR__ . '/build' );
 
-	gutenberg_register_module(
-		'{{namespace}}-view',
-		plugin_dir_url( __FILE__ ) . 'src/view.js',
-		array( '@wordpress/interactivity' ),
-		'{{version}}'
-	);
+	if (function_exists('gutenberg_register_module')) {
+		gutenberg_register_module(
+			'{{namespace}}-view',
+			plugin_dir_url( __FILE__ ) . 'src/view.js',
+			array( '@wordpress/interactivity' ),
+			'{{version}}'
+		);
+	}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This prevents a crash when you scaffold a project using the `@wordpress/create-block-interactive-template` and Gutenberg is not installed yet.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because when Gutenberg is not installed, the `gutenberg_*_module` functions don't exist yet and it crashes WordPress.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By wrapping those functions in a `function_exists` clause.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Scaffold a project using the [Getting started guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/docs/1-getting-started.md).
- Run WordPress using `wp-now start`.
- Open the site.
- It should not crash and you should be able to install Gutenberg.
