### PR TITLE
Create-block-interactive-template: Add all files to the generated plugin zip

### DIFF
--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Add all files to the generated plugin zip. [#56943](https://github.com/WordPress/gutenberg/pull/56943)
+
 ## 1.10.1 (2023-12-07)
 
 -   Update template to use modules instead of scripts. [#56694](https://github.com/WordPress/gutenberg/pull/56694)

--- a/packages/create-block-interactive-template/index.js
+++ b/packages/create-block-interactive-template/index.js
@@ -10,6 +10,7 @@ module.exports = {
 		description: 'An interactive block with the Interactivity API',
 		dashicon: 'media-interactive',
 		npmDependencies: [ '@wordpress/interactivity' ],
+		customPackageJSON: { files: [ '[^.]*' ] },
 		supports: {
 			interactivity: true,
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It adds all the files to the generated plugin zip, including the `src` folder.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the Interactivity API is shipped as a module now and the view file is not processed by `wp-script` yet, so it never ends up in the `build` folder and we have to enqueue it from the `src` folder.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the `customPackageJSON` property to add a `files` field to the `package.json` that adds all the files that don't start with a dot (`.`).

Kudos to @jonathanbossenger for discovering and documenting the fix in https://github.com/WordPress/gutenberg/pull/56674.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Scaffold a project using the [Getting started guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/docs/1-getting-started.md).
- Run the `npm run plugin-zip` command.
- Inspect the zip to make sure that the `src` folder is included.
- Install the plugin using that zip in a WordPress site and check that the new interactive block works fine.
