### PR TITLE
DataViews: Hide pagination if we have only one page

### DIFF
--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -36,7 +36,7 @@ function Pagination( {
 					)
 				}
 			</Text>
-			{ !! totalItems && (
+			{ !! totalItems && totalPages !== 1 && (
 				<HStack expanded={ false } spacing={ 3 }>
 					<HStack
 						justify="flex-start"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Super small PR that hides the pagination controls if we have only one page of results.