### PR TITLE
Components: Fix logic of `has-text` class addition in Button

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `TabPanel`: do not render hidden content ([#57046](https://github.com/WordPress/gutenberg/pull/57046)).
 
+### Bug Fix
+
+-   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
+
 ## 25.14.0 (2023-12-13)
 
 ### Enhancements
@@ -25,7 +29,6 @@
 -   `ToolsPanel`: fix a performance issue ([#56770](https://github.com/WordPress/gutenberg/pull/56770)).
 -   `BorderControl`: adjust `BorderControlDropdown` Button size to fix misaligned border ([#56730](https://github.com/WordPress/gutenberg/pull/56730)).
 -   `SlotFillProvider`: Restore contextual Slot/Fills within SlotFillProvider ([#56779](https://github.com/WordPress/gutenberg/pull/56779)).
--   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   `ToolsPanel`: fix a performance issue ([#56770](https://github.com/WordPress/gutenberg/pull/56770)).
 -   `BorderControl`: adjust `BorderControlDropdown` Button size to fix misaligned border ([#56730](https://github.com/WordPress/gutenberg/pull/56730)).
 -   `SlotFillProvider`: Restore contextual Slot/Fills within SlotFillProvider ([#56779](https://github.com/WordPress/gutenberg/pull/56779)).
+-   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
 
 ### Internal
 

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -156,7 +156,7 @@ export function UnforwardedButton(
 		'is-busy': isBusy,
 		'is-link': variant === 'link',
 		'is-destructive': isDestructive,
-		'has-text': !! icon && hasChildren,
+		'has-text': !! icon && ( hasChildren || text ),
 		'has-icon': !! icon,
 	} );
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -282,7 +282,6 @@
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
-			width: $button-size-small;
 			min-width: $button-size-small;
 		}
 	}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -270,7 +270,6 @@
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
-			width: $button-size-compact;
 			min-width: $button-size-compact;
 		}
 	}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -270,6 +270,7 @@
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
+			width: $button-size-compact;
 			min-width: $button-size-compact;
 		}
 	}
@@ -282,6 +283,7 @@
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
+			width: $button-size-small;
 			min-width: $button-size-small;
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/44043

I observed in DataViews experiment pages list that when we sort a field, the icon in Button that is used is either not shown or is shown really small. The button uses the `compact` size that seem to add a specific fixed width. After testing it seems the `small` size has the fixed width too.

This PR updates the condition where we add the `has-text` CSS class.

## Testing instructions
1. In storybook `Button` go to the `Icon` story([link here](https://wordpress.github.io/gutenberg/?path=/story/components-button--icon))
2. add some text and select the `compact` or `small` sizes
3. Observe that the Button is not displayed properly.


