### PR TITLE
Fix: Use span on template list titles.

### DIFF
--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -83,7 +83,7 @@ function TemplateTitle( { item } ) {
 	const { isCustomized } = useAddedBy( item.type, item.id );
 	return (
 		<VStack spacing={ 1 }>
-			<View as="h3">
+			<View as="span" className="edit-site-list-title__customized-info">
 				<Link
 					params={ {
 						postId: item.id,


### PR DESCRIPTION
Fixes a mistake on https://github.com/WordPress/gutenberg/pull/56785/.

I committed an in-progress version by mistake. This PR fixes the issue by adding the missing line change.