### PR TITLE
[a11y] Fix: Use spans instead of headings on dataviews table view page title

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	__experimentalHeading as Heading,
+	__experimentalView as View,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -216,7 +216,10 @@ export default function PagePages() {
 				render: ( { item } ) => {
 					return (
 						<VStack spacing={ 1 }>
-							<Heading as="h3" level={ 5 } weight={ 500 }>
+							<View
+								as="span"
+								className="edit-site-page-pages__list-view-title-field"
+							>
 								{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
 									view.type
 								) ? (
@@ -236,7 +239,7 @@ export default function PagePages() {
 										item.title?.rendered || item.slug
 									) || __( '(no title)' )
 								) }
-							</Heading>
+							</View>
 						</VStack>
 					);
 				},

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -3,3 +3,9 @@
 	width: $grid-unit-40;
 	height: $grid-unit-40;
 }
+
+
+.edit-site-page-pages__list-view-title-field {
+	font-size: $default-font-size;
+	font-weight: 500;
+}


### PR DESCRIPTION
Fixes an issue referred by @afercia where the dataviews table view uses a h3 heading in the titles cells.
This PR fixes the issue for the pages view `/wp-admin/site-editor.php?path=%2Fpages`.


# Testing
Verify the pages UI looks the same as in the trunk.
Verify the page's title is now a span and not a heading.