### PR TITLE
Media upload component: lazy mount

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -316,7 +316,7 @@ class MediaUpload extends Component {
 	}
 
 	componentWillUnmount() {
-		this.frame.remove();
+		this.frame?.remove();
 	}
 
 	onUpdate( selections ) {

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -224,45 +224,13 @@ const getAttachmentsCollection = ( ids ) => {
 };
 
 class MediaUpload extends Component {
-	constructor( {
-		allowedTypes,
-		gallery = false,
-		unstableFeaturedImageFlow = false,
-		modalClass,
-		multiple = false,
-		title = __( 'Select or Upload Media' ),
-	} ) {
+	constructor() {
 		super( ...arguments );
 		this.openModal = this.openModal.bind( this );
 		this.onOpen = this.onOpen.bind( this );
 		this.onSelect = this.onSelect.bind( this );
 		this.onUpdate = this.onUpdate.bind( this );
 		this.onClose = this.onClose.bind( this );
-
-		const { wp } = window;
-
-		if ( gallery ) {
-			this.buildAndSetGalleryFrame();
-		} else {
-			const frameConfig = {
-				title,
-				multiple,
-			};
-			if ( !! allowedTypes ) {
-				frameConfig.library = { type: allowedTypes };
-			}
-
-			this.frame = wp.media( frameConfig );
-		}
-
-		if ( modalClass ) {
-			this.frame.$el.addClass( modalClass );
-		}
-
-		if ( unstableFeaturedImageFlow ) {
-			this.buildAndSetFeatureImageFrame();
-		}
-		this.initializeListeners();
 	}
 
 	initializeListeners() {
@@ -444,9 +412,38 @@ class MediaUpload extends Component {
 	}
 
 	openModal() {
-		if ( this.props.gallery ) {
+		const {
+			allowedTypes,
+			gallery = false,
+			unstableFeaturedImageFlow = false,
+			modalClass,
+			multiple = false,
+			title = __( 'Select or Upload Media' ),
+		} = this.props;
+		const { wp } = window;
+
+		if ( gallery ) {
 			this.buildAndSetGalleryFrame();
+		} else {
+			const frameConfig = {
+				title,
+				multiple,
+			};
+			if ( !! allowedTypes ) {
+				frameConfig.library = { type: allowedTypes };
+			}
+
+			this.frame = wp.media( frameConfig );
 		}
+
+		if ( modalClass ) {
+			this.frame.$el.addClass( modalClass );
+		}
+
+		if ( unstableFeaturedImageFlow ) {
+			this.buildAndSetFeatureImageFrame();
+		}
+		this.initializeListeners();
 		this.frame.open();
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This component initialised the media library on mount/load, while it's only needed when the user presses the button to open it. Let's delay initialising until then. A decent chuck of loading time is coming from this component.

(There's many more instances of the one below for the "large post", this one is larger because of a garbage collection.)

<img width="391" alt="Screenshot 2023-12-11 at 21 13 13" src="https://github.com/WordPress/gutenberg/assets/4710635/efa6b8d2-1023-46a3-b3d0-b3f980c29746">

First run: -1% load (first block)
Second run also -1%

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Why do work when it might not be needed?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
