### PR TITLE
Implement `Tabs` in site-editor settings

### DIFF
--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -154,6 +154,7 @@ export function SidebarComplementaryAreaFills() {
 				isEditorOpen && isEditorSidebarOpened ? sidebarName : null
 			}
 			onSelect={ onTabSelect }
+			selectOnMove={ false }
 		>
 			<FillContents
 				sidebarName={ sidebarName }

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -63,12 +63,14 @@ const FillContents = ( {
 				className="edit-site-sidebar__panel"
 			>
 				<Tabs.Context.Provider value={ tabsContextValue }>
-					<Tabs.TabPanel id={ SIDEBAR_BLOCK } focusable={ false }>
+					<Tabs.TabPanel
+						tabId={ SIDEBAR_TEMPLATE }
+						focusable={ false }
+					>
 						{ isEditingPage ? <PagePanels /> : <TemplatePanel /> }
 						<PluginTemplateSettingPanel.Slot />
 					</Tabs.TabPanel>
-
-					<Tabs.TabPanel id={ SIDEBAR_TEMPLATE } focusable={ false }>
+					<Tabs.TabPanel tabId={ SIDEBAR_BLOCK } focusable={ false }>
 						<InspectorSlot bubblesVirtually />
 					</Tabs.TabPanel>
 				</Tabs.Context.Provider>

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -85,13 +85,17 @@ export function SidebarComplementaryAreaFills() {
 		hasBlockSelection,
 		supportsGlobalStyles,
 		isEditingPage,
+		isEditorOpen,
 	} = useSelect( ( select ) => {
 		const _sidebar =
 			select( interfaceStore ).getActiveComplementaryArea( STORE_NAME );
+
 		const _isEditorSidebarOpened = [
 			SIDEBAR_BLOCK,
 			SIDEBAR_TEMPLATE,
 		].includes( _sidebar );
+		const { getCanvasMode } = unlock( select( editSiteStore ) );
+
 		return {
 			sidebar: _sidebar,
 			isEditorSidebarOpened: _isEditorSidebarOpened,
@@ -100,6 +104,7 @@ export function SidebarComplementaryAreaFills() {
 			supportsGlobalStyles:
 				select( coreStore ).getCurrentTheme()?.is_block_theme,
 			isEditingPage: select( editSiteStore ).isPage(),
+			isEditorOpen: getCanvasMode() === 'edit',
 		};
 	}, [] );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
@@ -143,7 +148,9 @@ export function SidebarComplementaryAreaFills() {
 			// tab can't be found. This causes the component to continuously reset
 			// the selection to `null` in an infinite loop. Proactively setting
 			// the selected tab to `null` avoids that.
-			selectedTabId={ isEditorSidebarOpened ? sidebarName : null }
+			selectedTabId={
+				isEditorOpen && isEditorSidebarOpened ? sidebarName : null
+			}
 			onSelect={ onTabSelect }
 		>
 			<FillContents

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -57,6 +57,10 @@ const FillContents = ( {
 					</Tabs.Context.Provider>
 				}
 				headerClassName="edit-site-sidebar-edit-mode__panel-tabs"
+				// This classname is added so we can apply a corrective negative
+				// margin to the panel.
+				// see https://github.com/WordPress/gutenberg/pull/55360#pullrequestreview-1737671049
+				className="edit-site-sidebar__panel"
 			>
 				<Tabs.Context.Provider value={ tabsContextValue }>
 					<Tabs.TabPanel id={ SIDEBAR_BLOCK } focusable={ false }>

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -48,6 +48,7 @@ const FillContents = ( {
 	// This effect addresses a race condition caused by tabbing from the last
 	// block in the editor into the settings sidebar. Without this effect, the
 	// selected tab and browser focus can become separated in an unexpected way.
+	// (e.g the "block" tab is focused, but the "post" tab is selected).
 	useEffect( () => {
 		const tabsElements = Array.from(
 			tabListRef.current?.querySelectorAll( '[role="tab"]' ) || []
@@ -163,9 +164,15 @@ export function SidebarComplementaryAreaFills() {
 		sidebarName = hasBlockSelection ? SIDEBAR_BLOCK : SIDEBAR_TEMPLATE;
 	}
 
+	// `newSelectedTabId` could technically be falsey if no tab is selected (i.e.
+	// the initial render) or when we don't want a tab displayed (i.e. the
+	// sidebar is closed). These cases should both be covered by the `!!` check
+	// below, so we shouldn't need any additional falsey handling.
 	const onTabSelect = useCallback(
 		( newSelectedTabId ) => {
-			enableComplementaryArea( STORE_NAME, newSelectedTabId );
+			if ( !! newSelectedTabId ) {
+				enableComplementaryArea( STORE_NAME, newSelectedTabId );
+			}
 		},
 		[ enableComplementaryArea ]
 	);

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
@@ -1,81 +1,30 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { store as interfaceStore } from '@wordpress/interface';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from '../../../store/constants';
 import { SIDEBAR_BLOCK, SIDEBAR_TEMPLATE } from '../constants';
+import { unlock } from '../../../lock-unlock';
 
-const SettingsHeader = ( { sidebarName } ) => {
+const { Tabs } = unlock( componentsPrivateApis );
+
+const SettingsHeader = () => {
 	const postTypeLabel = useSelect(
 		( select ) => select( editorStore ).getPostTypeLabel(),
 		[]
 	);
 
-	const { enableComplementaryArea } = useDispatch( interfaceStore );
-	const openTemplateSettings = () =>
-		enableComplementaryArea( STORE_NAME, SIDEBAR_TEMPLATE );
-	const openBlockSettings = () =>
-		enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
-
-	const documentAriaLabel =
-		sidebarName === SIDEBAR_TEMPLATE
-			? // translators: ARIA label for the Template sidebar tab, selected.
-			  sprintf( __( '%s (selected)' ), postTypeLabel )
-			: postTypeLabel;
-
-	/* Use a list so screen readers will announce how many tabs there are. */
 	return (
-		<ul>
-			<li>
-				<Button
-					onClick={ openTemplateSettings }
-					className={ classnames(
-						'edit-site-sidebar-edit-mode__panel-tab',
-						{
-							'is-active': sidebarName === SIDEBAR_TEMPLATE,
-						}
-					) }
-					aria-label={ documentAriaLabel }
-					data-label={ postTypeLabel }
-				>
-					{ postTypeLabel }
-				</Button>
-			</li>
-			<li>
-				<Button
-					onClick={ openBlockSettings }
-					className={ classnames(
-						'edit-site-sidebar-edit-mode__panel-tab',
-						{
-							'is-active': sidebarName === SIDEBAR_BLOCK,
-						}
-					) }
-					aria-label={
-						sidebarName === SIDEBAR_BLOCK
-							? // translators: ARIA label for the Block Settings Sidebar tab, selected.
-							  __( 'Block (selected)' )
-							: // translators: ARIA label for the Block Settings Sidebar tab, not selected.
-							  __( 'Block' )
-					}
-					data-label={ __( 'Block' ) }
-				>
-					{ __( 'Block' ) }
-				</Button>
-			</li>
-		</ul>
+		<Tabs.TabList>
+			<Tabs.Tab tabId={ SIDEBAR_TEMPLATE }>{ postTypeLabel }</Tabs.Tab>
+			<Tabs.Tab tabId={ SIDEBAR_BLOCK }>{ __( 'Block' ) }</Tabs.Tab>
+		</Tabs.TabList>
 	);
 };
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
@@ -5,6 +5,7 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,18 +15,30 @@ import { unlock } from '../../../lock-unlock';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
-const SettingsHeader = () => {
+const SettingsHeader = ( _, ref ) => {
 	const postTypeLabel = useSelect(
 		( select ) => select( editorStore ).getPostTypeLabel(),
 		[]
 	);
 
 	return (
-		<Tabs.TabList>
-			<Tabs.Tab tabId={ SIDEBAR_TEMPLATE }>{ postTypeLabel }</Tabs.Tab>
-			<Tabs.Tab tabId={ SIDEBAR_BLOCK }>{ __( 'Block' ) }</Tabs.Tab>
+		<Tabs.TabList ref={ ref }>
+			<Tabs.Tab
+				tabId={ SIDEBAR_TEMPLATE }
+				// Used for focus management in the SettingsSidebar component.
+				data-tab-id={ SIDEBAR_TEMPLATE }
+			>
+				{ postTypeLabel }
+			</Tabs.Tab>
+			<Tabs.Tab
+				tabId={ SIDEBAR_BLOCK }
+				// Used for focus management in the SettingsSidebar component.
+				data-tab-id={ SIDEBAR_BLOCK }
+			>
+				{ __( 'Block' ) }
+			</Tabs.Tab>
 		</Tabs.TabList>
 	);
 };
 
-export default SettingsHeader;
+export default forwardRef( SettingsHeader );

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/style.scss
@@ -1,20 +1,8 @@
 .components-panel__header.edit-site-sidebar-edit-mode__panel-tabs {
-	justify-content: flex-start;
 	padding-left: 0;
 	padding-right: $grid-unit-20;
-	border-top: 0;
-	margin-top: 0;
-
-	ul {
-		display: flex;
-	}
-	li {
-		margin: 0;
-	}
 
 	.components-button.has-icon {
-		display: none;
-		margin: 0 0 0 auto;
 		padding: 0;
 		min-width: $icon-size;
 		height: $icon-size;
@@ -22,80 +10,5 @@
 		@include break-medium() {
 			display: flex;
 		}
-	}
-}
-
-// This tab style CSS is duplicated verbatim in
-// /packages/components/src/tab-panel/style.scss
-.components-button.edit-site-sidebar-edit-mode__panel-tab {
-	position: relative;
-	border-radius: 0;
-	height: $grid-unit-60;
-	background: transparent;
-	border: none;
-	box-shadow: none;
-	cursor: pointer;
-	padding: 3px $grid-unit-20; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
-	margin-left: 0;
-	font-weight: 500;
-
-	&:focus:not(:disabled) {
-		position: relative;
-		box-shadow: none;
-		outline: none;
-	}
-
-	// Tab indicator
-	&::after {
-		content: "";
-		position: absolute;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		pointer-events: none;
-
-		// Draw the indicator.
-		background: var(--wp-admin-theme-color);
-		height: calc(0 * var(--wp-admin-border-width-focus));
-		border-radius: 0;
-
-		// Animation
-		transition: all 0.1s linear;
-		@include reduce-motion("transition");
-	}
-
-	// Active.
-	&.is-active::after {
-		height: calc(1 * var(--wp-admin-border-width-focus));
-
-		// Windows high contrast mode.
-		outline: 2px solid transparent;
-		outline-offset: -1px;
-	}
-
-	// Focus.
-	&::before {
-		content: "";
-		position: absolute;
-		top: $grid-unit-15;
-		right: $grid-unit-15;
-		bottom: $grid-unit-15;
-		left: $grid-unit-15;
-		pointer-events: none;
-
-		// Draw the indicator.
-		box-shadow: 0 0 0 0 transparent;
-		border-radius: $radius-block-ui;
-
-		// Animation
-		transition: all 0.1s linear;
-		@include reduce-motion("transition");
-	}
-
-	&:focus-visible::before {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-
-		// Windows high contrast mode.
-		outline: 2px solid transparent;
 	}
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/style.scss
@@ -99,3 +99,7 @@
 		}
 	}
 }
+
+.edit-site-sidebar__panel {
+	margin-top: -1px;
+}

--- a/test/e2e/specs/site-editor/settings-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/settings-sidebar.spec.js
@@ -38,8 +38,8 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'button', { name: 'Template (selected)' } )
-			).toHaveClass( /is-active/ );
+					.getByRole( 'tab', { selected: true } )
+			).toHaveText( 'Template' );
 		} );
 
 		test( `should show the currently selected template's title and description`, async ( {
@@ -90,8 +90,8 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'button', { name: 'Block (selected)' } )
-			).toHaveClass( /is-active/ );
+					.getByRole( 'tab', { selected: true } )
+			).toHaveText( 'Block' );
 		} );
 	} );
 
@@ -105,16 +105,17 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'button', { name: 'Template (selected)' } )
-			).toHaveClass( /is-active/ );
+					.getByRole( 'tab', { selected: true } )
+			).toHaveText( 'Template' );
 
 			// By inserting the block is also selected.
 			await editor.insertBlock( { name: 'core/heading' } );
+
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'button', { name: 'Block (selected)' } )
-			).toHaveClass( /is-active/ );
+					.getByRole( 'tab', { selected: true } )
+			).toHaveText( 'Block' );
 		} );
 
 		test( 'should switch to Template tab when a block was selected and we select the Template', async ( {
@@ -129,8 +130,8 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'button', { name: 'Block (selected)' } )
-			).toHaveClass( /is-active/ );
+					.getByRole( 'tab', { selected: true } )
+			).toHaveText( 'Block' );
 
 			await page.evaluate( () => {
 				window.wp.data
@@ -141,8 +142,8 @@ test.describe( 'Settings sidebar', () => {
 			await expect(
 				page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'button', { name: 'Template (selected)' } )
-			).toHaveClass( /is-active/ );
+					.getByRole( 'tab', { selected: true } )
+			).toHaveText( 'Template' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -294,12 +294,12 @@ class TemplateRevertUtils {
 		await this.editor.openDocumentSettingsSidebar();
 		const isTemplateTabVisible = await this.page
 			.locator(
-				'role=region[name="Editor settings"i] >> role=button[name="Template"i]'
+				'role=region[name="Editor settings"i] >> role=tab[name="Template"i]'
 			)
 			.isVisible();
 		if ( isTemplateTabVisible ) {
 			await this.page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Template"i]'
+				'role=region[name="Editor settings"i] >> role=tab[name="Template"i]'
 			);
 		}
 		await this.page.click(

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -65,9 +65,9 @@ test.describe( 'Site editor writing flow', () => {
 
 		// Tab to the inspector, tabbing three times to go past the two resize handles.
 		await pageUtils.pressKeys( 'Tab', { times: 3 } );
-		const inspectorTemplateTab = page.locator(
-			'role=region[name="Editor settings"i] >> role=button[name="Template part"i]'
+		const inspectorBlockTab = page.locator(
+			'role=region[name="Editor settings"i] >> role=tab[name="Block"i]'
 		);
-		await expect( inspectorTemplateTab ).toBeFocused();
+		await expect( inspectorBlockTab ).toBeFocused();
 	} );
 } );


### PR DESCRIPTION
## What?
Replace existing list-based tabs the new `Tabs` component in the site editor settings sidebar

## Why?
The current implementation was necessary because our legacy `TabPanel` component was not granular enough to be applied in this sidebar, due in large part to the internals of the the `ComplementaryArea` the sidebar uses.

## How?
Using the new, more granular sub-components of `Tabs`, we can render the appropriate parts of the UI via `ComplementaryArea`'s `slot`/`fill`, and pass the `Tabs` context to those components as needed.

This implementation is very similar to the one used previously in #55360. The biggest difference is that in this implementation, in addition to making sure the editor sidebar is active, we also need to confirm that that the canvas itself is in edit mode. When the editor canvas switches from `edit` to `view`, all of the tabs are removed from the DOM (much like when the sidebar itself gets closed). When this happens, the component can't find the currently selected tab (which is tracked in `interfaceStore`) which causes an infinite loop as the component and the store argue with each other. Checking the canvas state before setting the current tab makes sure that loop doesn't happen.

One important note on this specific `Tabs` implementation is that in the editor sidebars a race condition exists where if no tab is selected, and then the <kbd>Tab</kbd> key is used to cycle through all of the existing blocks, the next press of <kbd>Tab</kbd> will move focus to the settings sidebar.

When that happens, two events fire independently of each other in this order:
1. Focus moves from the final block to the currently active settings tab, which is **Block**
2. `interfaceStore` detects that focus is no longer on a block. The sidebar is automatically switched over the the **Post** tab.

The net result from a user perspective is that pressing <kbd>Tab</kbd> that last time focuses one tab wile selecting the other. This feels really confusing, so we're adding a check to prevent that from happening.

## Testing Instructions
1. Launch the site editor and edit a template.
2. In the sidebar test the document (i.e. Post/Template/etc.) and Block tabs.
3. Confirm that each tab shows the correct content
4. Select the Template tab
5. In the canvas, click on a block and confirm that the Block tab is auto-selected with the correct content displayed
6. Test opening and closing the sidebar, confirm there are no errors or crashes
7. Test "Open Navigation" button (WP logo, top left of site editor) and confirm the editor canvas closes without errors or crashes. Repeat this test with the editor sidebar open as well as collapsed to make sure both work.
8. Create a new, blank template. Don't use a pattern just start with a completely clean slate.
9. Add one or two Heading blocks with some random text in them
10. Click below your last block in the empty space on the canvas
11. Press <kbd>Tab</kbd> to cycle through the blocks, and then once more to focus the settings sidebar
12. Confirm that when focus leaves the last block, the **Template** tab is automatically selected, and it also receives browser focus (this confirms that we're addressing the race condition described above)

### Testing Instructions for Keyboard
1. Launch the site editor
2. Press [Tab] until focus is applied to the currently active tab in the sidebar
3. Confirm arrow keys move you focus between tabs, but do not automatically select the focused tab
4. Confirm the [Tab] key leaves the `tablist` and focuses the next element instead (the close button)
5. Confirm that hitting [Tab] once more takes you to the first focusable element in the sidebar contents (specifically, you're making sure it doesn't focus the sidebar panel itself)

