### PR TITLE
[RNMobile] Add withIsConnected higher order component

### DIFF
--- a/packages/compose/src/higher-order/with-is-connected/README.md
+++ b/packages/compose/src/higher-order/with-is-connected/README.md
@@ -1,0 +1,19 @@
+# withIsConnected
+
+`withIsConnected` provides a true/false mobile connectivity status based on the [useIsConnected hook](https://github.com/WordPress/gutenberg/blob/aadf8c66ff345b176041ad82e3793191ade5d271/packages/react-native-bridge/index.js#L193-L212).
+
+## Usage
+```jsx
+/**
+ * WordPress dependencies
+ */
+import { withIsConnected } from '@wordpress/compose';
+
+export class MyComponent extends Component {
+	if ( this.props.isConnected !== true ) {
+		console.log( 'You are currently offline.' )
+	}
+}
+
+export default withIsConnected( MyComponent )
+```

--- a/packages/compose/src/higher-order/with-is-connected/README.md
+++ b/packages/compose/src/higher-order/with-is-connected/README.md
@@ -1,6 +1,6 @@
 # withIsConnected
 
-`withIsConnected` provides a true/false mobile connectivity status based on the [useIsConnected hook](https://github.com/WordPress/gutenberg/blob/aadf8c66ff345b176041ad82e3793191ade5d271/packages/react-native-bridge/index.js#L193-L212).
+`withIsConnected` provides a true/false mobile connectivity status based on the `useIsConnected` hook found in the [bridge](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-bridge/index.js).
 
 ## Usage
 ```jsx

--- a/packages/compose/src/higher-order/with-is-connected/index.native.js
+++ b/packages/compose/src/higher-order/with-is-connected/index.native.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { useIsConnected } from '@wordpress/react-native-bridge';
+
+const withIsConnected = createHigherOrderComponent( ( WrappedComponent ) => {
+	return ( props ) => {
+		const isConnected = useIsConnected();
+		return <WrappedComponent { ...props } isConnected={ isConnected } />;
+	};
+}, 'withIsConnected' );
+
+export default withIsConnected;

--- a/packages/compose/src/higher-order/with-is-connected/index.native.js
+++ b/packages/compose/src/higher-order/with-is-connected/index.native.js
@@ -1,11 +1,7 @@
 /**
- * WordPress dependencies
- */
-import { createHigherOrderComponent } from '@wordpress/compose';
-
-/**
  * Internal dependencies
  */
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 import { useIsConnected } from '@wordpress/react-native-bridge';
 
 const withIsConnected = createHigherOrderComponent( ( WrappedComponent ) => {

--- a/packages/compose/src/higher-order/with-is-connected/index.native.js
+++ b/packages/compose/src/higher-order/with-is-connected/index.native.js
@@ -10,7 +10,7 @@ import { useIsConnected } from '@wordpress/react-native-bridge';
 
 const withIsConnected = createHigherOrderComponent( ( WrappedComponent ) => {
 	return ( props ) => {
-		const isConnected = useIsConnected();
+		const { isConnected } = useIsConnected();
 		return <WrappedComponent { ...props } isConnected={ isConnected } />;
 	};
 }, 'withIsConnected' );

--- a/packages/compose/src/higher-order/with-is-connected/index.native.js
+++ b/packages/compose/src/higher-order/with-is-connected/index.native.js
@@ -1,8 +1,12 @@
 /**
+ * WordPress dependencies
+ */
+import { useIsConnected } from '@wordpress/react-native-bridge';
+
+/**
  * Internal dependencies
  */
 import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
-import { useIsConnected } from '@wordpress/react-native-bridge';
 
 const withIsConnected = createHigherOrderComponent( ( WrappedComponent ) => {
 	return ( props ) => {

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -17,6 +17,7 @@ export { default as withInstanceId } from './higher-order/with-instance-id';
 export { default as withSafeTimeout } from './higher-order/with-safe-timeout';
 export { default as withState } from './higher-order/with-state';
 export { default as withPreferredColorScheme } from './higher-order/with-preferred-color-scheme';
+export { default as withIsConnected } from './higher-order/with-is-connected';
 
 // Hooks.
 export { default as useConstrainedTabbing } from './hooks/use-constrained-tabbing';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a mobile connectivity status HOC.

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6457

## Why?
To be able to use the value returned from `useIsConnected` hook as a higher-order component.

## How?
Creates a higher-order component called `withIsConnected` that returns the value of `useIsConnected` to the WrappedComponent. 

## Testing Instructions
1. Apply the following patch:
    <details><summary>Test Diff</summary>

    ```diff
    diff --git a/packages/block-editor/src/components/media-upload-progress/index.native.js b/packages/block-editor/src/components/media-upload-progress/index.native.js
	index b64b08eec0..cf4b26f267 100644
	--- a/packages/block-editor/src/components/media-upload-progress/index.native.js
	+++ b/packages/block-editor/src/components/media-upload-progress/index.native.js
	@@ -10,6 +10,7 @@ import { Component } from '@wordpress/element';
	import { Spinner } from '@wordpress/components';
	import { __ } from '@wordpress/i18n';
	import { subscribeMediaUpload } from '@wordpress/react-native-bridge';
	+import { withIsConnected } from '@wordpress/compose';
	
	/**
	 * Internal dependencies
	@@ -32,6 +33,7 @@ export class MediaUploadProgress extends Component {
			};
	
			this.mediaUpload = this.mediaUpload.bind( this );
	+		this.getRetryMessage = this.getRetryMessage.bind( this );
		}
	
		componentDidMount() {
	@@ -115,19 +117,26 @@ export class MediaUploadProgress extends Component {
			}
		}
	
	+	getRetryMessage() {
	+		if ( this.props.isConnected === true ) {
	+			// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
	+			return __( 'Failed to insert media.\nTap for more info.' );
	+		}
	+		return __( 'You are currently offline.' );
	+	}
	+
		render() {
			const { renderContent = () => null } = this.props;
			const { isUploadInProgress, isUploadFailed } = this.state;
			const showSpinner = this.state.isUploadInProgress;
			const progress = this.state.progress * 100;
	-		// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
	-		const retryMessage = __(
	-			'Failed to insert media.\nTap for more info.'
	-		);
	+		const retryMessage = this.getRetryMessage();
	
			const progressBarStyle = [
				styles.progressBar,
	-			showSpinner || styles.progressBarHidden,
	+			showSpinner && this.props.isConnected
	+				? styles.progressBarHidden
	+				: null,
				this.props.progressBarStyle,
			];
	
	@@ -158,4 +167,4 @@ export class MediaUploadProgress extends Component {
		}
	}
	
	-export default MediaUploadProgress;
	+export default withIsConnected( MediaUploadProgress );
</details>

2. Run the host app with Gutenberg Mobile running locally
3. Enable airplane mode
4. Upload an image
5. Note that "You are currently offline." is displayed (instead of "Failed to insert media. Tap for more info.")

