### PR TITLE
Post Content block: Allow Block Hooks child insertion

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -61,15 +61,15 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	// - Changes to anchor block by get_hooked_block_markup() aren't respected.
 	// - No $context available.
 
-	$context              = null;
-	$anchor_block_type    = 'core/post-content';
-	$anchor_block         = array(
+	$context           = null;
+	$anchor_block_type = 'core/post-content';
+	$anchor_block      = array(
 		'blockName'  => $anchor_block_type,
-		'attributes' => $attributes
+		'attributes' => $attributes,
 	);
-	$hooked_blocks        = get_hooked_blocks();
+	$hooked_blocks     = get_hooked_blocks();
 
-	$first_child_markup = '';
+	$first_child_markup             = '';
 	$hooked_block_types_first_child = isset( $hooked_blocks[ $anchor_block_type ]['first_child'] )
 		? $hooked_blocks[ $anchor_block_type ]['first_child']
 		: array();
@@ -81,7 +81,7 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 	// TODO: Should run `get_the_content` and apply `the_content` filter here.
 
-	$last_child_markup = '';
+	$last_child_markup             = '';
 	$hooked_block_types_last_child = isset( $hooked_blocks[ $anchor_block_type ]['last_child'] )
 		? $hooked_blocks[ $anchor_block_type ]['last_child']
 		: array();


### PR DESCRIPTION
_Untested; this code probably doesn't work yet._

## What?
Try allowing `first_child` and `last_child` insertion into the Post Content block.

This is experimental; there's a pretty good chance that we'll never merge this code due to its limitations (see "Notes" section below).

## Why?
It was brought up that this would be beneficial e.g. for inserting a Like Button block as the Post Content block's `last_child` (rather than `after`) for consistency with the Classic Theme way of doing this (using the `the_content` filter).

## How?
By manually applying the `hooked_block_types` filter inside the Post Content block.

## Testing Instructions
Basically, follow Block Hooks instructions to insert a block as `core/post-content`'s `last_child`.

## Notes

Note that due to the fact that we're doing this manually, this approach has a number of significant shortcomings, among them:

- _Blocks hooked to these locations will not show up in the editor -- violating a core tenet of Block Hooks._
- Changes to anchor block by get_hooked_block_markup() aren't respected.
- No `$context` available.

## Alternatives considered

We could run our Block Hooks logic on the `$content` returned from `get_the_content()` (in the Post Content block's render method), or even generically on all post content (in any given context; e.g. when running `do_blocks`). 

However, that would present a pretty big departure from how it's worked up to now (which was pretty much limited to templates, parts, and patterns). It's something to consider for WP 6.5 (since it might be possible thanks to the [new mechanism](https://github.com/WordPress/wordpress-develop/pull/5712) we're using), but it'll require careful deliberation.