### PR TITLE
Fix content lock UI regression

### DIFF
--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -23,7 +23,7 @@ import border from './border';
 import position from './position';
 import layout from './layout';
 import childLayout from './layout-child';
-import './content-lock-ui';
+import contentLockUI from './content-lock-ui';
 import './metadata';
 import customFields from './custom-fields';
 import blockHooks from './block-hooks';
@@ -38,6 +38,7 @@ createBlockEditFilter(
 		duotone,
 		position,
 		layout,
+		contentLockUI,
 		window.__experimentalConnections ? customFields : null,
 		blockHooks,
 		blockRenaming,

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -418,12 +418,14 @@ export function createBlockEditFilter( features ) {
 							neededProps[ key ] = props.attributes[ key ];
 						}
 					}
+
 					return (
 						<Edit
 							// We can use the index because the array length
 							// is fixed per page load right now.
 							key={ i }
 							name={ props.name }
+							isSelected={ props.isSelected }
 							clientId={ props.clientId }
 							setAttributes={ props.setAttributes }
 							__unstableParentLayout={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ok this is a bit embarrassing, but I noticed yesterday that I forgot to use the exports from #56957 and pass the isSelected prop. I asked @jorgefilipecosta how to test it and it is indeed broken.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
