### PR TITLE
Editor: Fix display of edit template blocks notification

### DIFF
--- a/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
@@ -42,7 +42,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 
 	useEffect( () => {
 		const handleClick = async ( event ) => {
-			if ( renderingMode === 'template-only' ) {
+			if ( renderingMode !== 'template-locked' ) {
 				return;
 			}
 			if ( ! event.target.classList.contains( 'is-root-container' ) ) {
@@ -71,7 +71,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 		};
 
 		const handleDblClick = ( event ) => {
-			if ( renderingMode === 'template-only' ) {
+			if ( renderingMode !== 'template-locked' ) {
 				return;
 			}
 			if ( ! event.target.classList.contains( 'is-root-container' ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/56979

I noticed that when we drag the cursor to have a multi selection in post editor the notification to edit the template is shown. This is because in post editor when we perform the above action, the event target is the post content block which contains the `is-root-container` css class.

I believe this notification makes sense only in `template-locked` mode and this PR updates the check to do that.

https://github.com/WordPress/gutenberg/assets/16275880/b4f2ec5e-3a77-4c08-a523-a25c3a9d38f9


## Testing Instructions
1. Everything works as before except the bug
2. Observe the above use case shared also in video is fixed


