### PR TITLE
Implement proposal to remove the WordPress-Docs ruleset

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,6 @@
 	</rule>
 
 	<rule ref="WordPress-Core"/>
-	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
@@ -58,45 +57,6 @@
 	<!-- Exclude third party libraries -->
 	<exclude-pattern>./vendor/*</exclude-pattern>
 	<exclude-pattern>./test/php/gutenberg-coding-standards/*</exclude-pattern>
-
-	<!-- Exclude files maintained in WordPress Core and backported to Gutenberg -->
-	<exclude-pattern>./lib/compat/wordpress-*/html-api/*.php</exclude-pattern>
-
-	<!-- These special comments are markers for the build process -->
-	<rule ref="Squiz.Commenting.InlineComment.WrongStyle">
-		<exclude-pattern>gutenberg.php</exclude-pattern>
-	</rule>
-
-	<!-- Do not require docblocks for unit tests -->
-	<rule ref="Squiz.Commenting.FunctionComment.Missing">
-		<exclude-pattern>phpunit/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<exclude-pattern>phpunit/*</exclude-pattern>
-		<exclude-pattern>test/gutenberg-test-themes/*</exclude-pattern>
-		<exclude-pattern>**/*.min.asset.php</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.ClassComment.Missing">
-		<exclude-pattern>phpunit/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.ClassComment.SpacingAfter">
-		<exclude-pattern>phpunit/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
-		<exclude-pattern>phpunit/*</exclude-pattern>
-	</rule>
-	<rule ref="Generic.Commenting.DocComment.Empty">
-    	<exclude-pattern>phpunit/*</exclude-pattern>
-    </rule>
-	<rule ref="Generic.Commenting.DocComment.MissingShort">
-		<exclude-pattern>phpunit/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.VariableComment.Missing">
-		<exclude-pattern>phpunit/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
-		<exclude-pattern>phpunit/*</exclude-pattern>
-	</rule>
 
 	<!-- Ignore filename error since it requires WP core build process change -->
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines: https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This pull request removes the `WordPress-Docs` ruleset from Gutenberg with the goal of simplifying the backporting process.

Fixes https://github.com/WordPress/gutenberg/issues/56487.

## Why?

1. Simplifies the backporting process from Core to Gutenberg.
2. Reduces contributor workload.

Also, please read the [proposal](https://github.com/WordPress/gutenberg/issues/56487) as it explains this in more detail.

## How?

1. Removes the `WordPress-Docs` ruleset from the `phpcs.xml.dist` file.
2. Removes `Squiz.Commenting*` and `Generic.Commenting.DocComment*` rules as they are added by the `WordPress-Docs` ruleset and are no longer needed.
3. Reverts changes made in commit e1a88b33ef10d88da4be6094f2ae8757893e1272 in the part that concerns the `phpcs.xml.dist` file (those changes are no longer needed).

## Testing Instructions

Review the changes and make sure that the Github CI jobs pass.

### Testing Instructions for Keyboard

<!-- How can you test the changes using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or Screencast <!-- if applicable -->
