### PR TITLE
DataViews: make filters footprint more condensed

### DIFF
--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -68,7 +68,20 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 						key={ filter.field }
 						trigger={
 							<DropdownSubMenuTrigger
-								suffix={ <Icon icon={ chevronRightSmall } /> }
+								suffix={
+									<>
+										{ activeElement &&
+											activeOperator === OPERATOR_IN &&
+											__( 'Is' ) }
+										{ activeElement &&
+											activeOperator ===
+												OPERATOR_NOT_IN &&
+											__( 'Is not' ) }
+										{ activeElement && ' ' }
+										{ activeElement?.label }
+										<Icon icon={ chevronRightSmall } />
+									</>
+								}
 							>
 								{ filter.name }
 							</DropdownSubMenuTrigger>

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -13,7 +13,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
-import { OPERATOR_IN } from './constants';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -81,8 +80,14 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 											),
 											{
 												field: filter.field,
-												operator: OPERATOR_IN,
-												value: element.value,
+												operator:
+													filterInView?.operator ||
+													filter.operators[ 0 ],
+												value:
+													activeElement?.value ===
+													element.value
+														? undefined
+														: element.value,
 											},
 										],
 									} ) );

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
-import { ENUMERATION_TYPE, OPERATOR_IN } from './constants';
+import { OPERATOR_IN } from './constants';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -22,23 +22,7 @@ const {
 	DropdownMenuItemV2: DropdownMenuItem,
 } = unlock( componentsPrivateApis );
 
-export default function AddFilter( { fields, view, onChangeView } ) {
-	const filters = [];
-	fields.forEach( ( field ) => {
-		if ( ! field.type ) {
-			return;
-		}
-
-		switch ( field.type ) {
-			case ENUMERATION_TYPE:
-				filters.push( {
-					field: field.id,
-					name: field.header,
-					elements: field.elements || [],
-				} );
-		}
-	} );
-
+export default function AddFilter( { filters, view, onChangeView } ) {
 	if ( filters.length === 0 ) {
 		return null;
 	}

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -6,7 +6,7 @@ import {
 	Button,
 	Icon,
 } from '@wordpress/components';
-import { chevronRightSmall, plus } from '@wordpress/icons';
+import { chevronRightSmall, funnel } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -48,7 +48,7 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 
 	return (
 		<DropdownMenu
-			label={ __( 'Add filter' ) }
+			label={ __( 'Filters' ) }
 			trigger={
 				<Button
 					disabled={ filters.length === view.filters?.length }
@@ -56,8 +56,7 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 					variant="tertiary"
 					size="compact"
 				>
-					<Icon icon={ plus } style={ { flexShrink: 0 } } />
-					{ __( 'Add filter' ) }
+					<Icon icon={ funnel } style={ { flexShrink: 0 } } />
 				</Button>
 			}
 		>

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -76,7 +76,10 @@ export default function AddFilter( { fields, onChangeView } ) {
 										...currentView,
 										page: 1,
 										filters: [
-											...currentView.filters,
+											...currentView.filters.filter(
+												( f ) =>
+													f.field !== filter.field
+											),
 											{
 												field: filter.field,
 												operator: OPERATOR_IN,

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -22,7 +22,7 @@ const {
 	DropdownMenuItemV2: DropdownMenuItem,
 } = unlock( componentsPrivateApis );
 
-export default function AddFilter( { fields, view, onChangeView } ) {
+export default function AddFilter( { fields, onChangeView } ) {
 	const filters = [];
 	fields.forEach( ( field ) => {
 		if ( ! field.type ) {
@@ -35,9 +35,6 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 					field: field.id,
 					name: field.header,
 					elements: field.elements || [],
-					isVisible: view.filters.some(
-						( f ) => f.field === field.id
-					),
 				} );
 		}
 	} );
@@ -51,7 +48,6 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 			label={ __( 'Filters' ) }
 			trigger={
 				<Button
-					disabled={ filters.length === view.filters?.length }
 					__experimentalIsFocusable
 					variant="tertiary"
 					size="compact"
@@ -61,10 +57,6 @@ export default function AddFilter( { fields, view, onChangeView } ) {
 			}
 		>
 			{ filters.map( ( filter ) => {
-				if ( filter.isVisible ) {
-					return null;
-				}
-
 				return (
 					<DropdownSubMenu
 						key={ filter.field }

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -8,18 +8,33 @@ import {
 } from '@wordpress/components';
 import { chevronRightSmall, funnel, check } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { Children, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
+import { OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
 
 const {
 	DropdownMenuV2: DropdownMenu,
+	DropdownMenuGroupV2: DropdownMenuGroup,
 	DropdownSubMenuV2: DropdownSubMenu,
 	DropdownSubMenuTriggerV2: DropdownSubMenuTrigger,
 	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
+
+function WithSeparators( { children } ) {
+	return Children.toArray( children )
+		.filter( Boolean )
+		.map( ( child, i ) => (
+			<Fragment key={ i }>
+				{ i > 0 && <DropdownMenuSeparator /> }
+				{ child }
+			</Fragment>
+		) );
+}
 
 export default function AddFilter( { filters, view, onChangeView } ) {
 	if ( filters.length === 0 ) {
@@ -46,6 +61,8 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 				const activeElement = filter.elements.find(
 					( element ) => element.value === filterInView?.value
 				);
+				const activeOperator =
+					filterInView?.operator || filter.operators[ 0 ];
 				return (
 					<DropdownSubMenu
 						key={ filter.field }
@@ -57,45 +74,143 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 							</DropdownSubMenuTrigger>
 						}
 					>
-						{ filter.elements.map( ( element ) => (
-							<DropdownMenuItem
-								key={ element.value }
-								role="menuitemradio"
-								aria-checked={
-									activeElement?.value === element.value
-								}
-								prefix={
-									activeElement?.value === element.value && (
-										<Icon icon={ check } />
-									)
-								}
-								onSelect={ () => {
-									onChangeView( ( currentView ) => ( {
-										...currentView,
-										page: 1,
-										filters: [
-											...currentView.filters.filter(
-												( f ) =>
-													f.field !== filter.field
-											),
-											{
-												field: filter.field,
-												operator:
-													filterInView?.operator ||
-													filter.operators[ 0 ],
-												value:
-													activeElement?.value ===
-													element.value
-														? undefined
-														: element.value,
-											},
-										],
-									} ) );
-								} }
-							>
-								{ element.label }
-							</DropdownMenuItem>
-						) ) }
+						<WithSeparators>
+							<DropdownMenuGroup>
+								{ filter.elements.map( ( element ) => (
+									<DropdownMenuItem
+										key={ element.value }
+										role="menuitemradio"
+										aria-checked={
+											activeElement?.value ===
+											element.value
+										}
+										prefix={
+											activeElement?.value ===
+												element.value && (
+												<Icon icon={ check } />
+											)
+										}
+										onSelect={ () => {
+											onChangeView( ( currentView ) => ( {
+												...currentView,
+												page: 1,
+												filters: [
+													...currentView.filters.filter(
+														( f ) =>
+															f.field !==
+															filter.field
+													),
+													{
+														field: filter.field,
+														operator:
+															activeOperator,
+														value:
+															activeElement?.value ===
+															element.value
+																? undefined
+																: element.value,
+													},
+												],
+											} ) );
+										} }
+									>
+										{ element.label }
+									</DropdownMenuItem>
+								) ) }
+							</DropdownMenuGroup>
+							{ filter.operators.length > 1 && (
+								<DropdownSubMenu
+									trigger={
+										<DropdownSubMenuTrigger
+											suffix={
+												<>
+													{ activeOperator ===
+														OPERATOR_IN &&
+														__( 'Is' ) }
+													{ activeOperator ===
+														OPERATOR_NOT_IN &&
+														__( 'Is not' ) }
+													<Icon
+														icon={
+															chevronRightSmall
+														}
+													/>{ ' ' }
+												</>
+											}
+										>
+											{ __( 'Conditions' ) }
+										</DropdownSubMenuTrigger>
+									}
+								>
+									<DropdownMenuItem
+										key="in-filter"
+										role="menuitemradio"
+										aria-checked={
+											activeOperator === OPERATOR_IN
+										}
+										prefix={
+											activeOperator === OPERATOR_IN && (
+												<Icon icon={ check } />
+											)
+										}
+										onSelect={ () =>
+											onChangeView( ( currentView ) => ( {
+												...currentView,
+												page: 1,
+												filters: [
+													...view.filters.filter(
+														( f ) =>
+															f.field !==
+															filter.field
+													),
+													{
+														field: filter.field,
+														operator: OPERATOR_IN,
+														value: filterInView?.value,
+													},
+												],
+											} ) )
+										}
+									>
+										{ __( 'Is' ) }
+									</DropdownMenuItem>
+									<DropdownMenuItem
+										key="not-in-filter"
+										role="menuitemradio"
+										aria-checked={
+											activeOperator === OPERATOR_NOT_IN
+										}
+										prefix={
+											activeOperator ===
+												OPERATOR_NOT_IN && (
+												<Icon icon={ check } />
+											)
+										}
+										onSelect={ () =>
+											onChangeView( ( currentView ) => ( {
+												...currentView,
+												page: 1,
+												filters: [
+													...view.filters.filter(
+														( f ) =>
+															f.field !==
+															filter.field
+													),
+													{
+														field: filter.field,
+														operator:
+															OPERATOR_NOT_IN,
+														value: filterInView?.value,
+													},
+												],
+											} ) )
+										}
+									>
+										{ __( 'Is not' ) }
+									</DropdownMenuItem>
+								</DropdownSubMenu>
+							) }
+						</WithSeparators>
 					</DropdownSubMenu>
 				);
 			} ) }

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -54,179 +54,210 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 				</Button>
 			}
 		>
-			{ filters.map( ( filter ) => {
-				const filterInView = view.filters.find(
-					( f ) => f.field === filter.field
-				);
-				const activeElement = filter.elements.find(
-					( element ) => element.value === filterInView?.value
-				);
-				const activeOperator =
-					filterInView?.operator || filter.operators[ 0 ];
-				return (
-					<DropdownSubMenu
-						key={ filter.field }
-						trigger={
-							<DropdownSubMenuTrigger
-								suffix={
-									<>
-										{ activeElement &&
-											activeOperator === OPERATOR_IN &&
-											__( 'Is' ) }
-										{ activeElement &&
-											activeOperator ===
-												OPERATOR_NOT_IN &&
-											__( 'Is not' ) }
-										{ activeElement && ' ' }
-										{ activeElement?.label }
-										<Icon icon={ chevronRightSmall } />
-									</>
+			<WithSeparators>
+				<DropdownMenuGroup>
+					{ filters.map( ( filter ) => {
+						const filterInView = view.filters.find(
+							( f ) => f.field === filter.field
+						);
+						const activeElement = filter.elements.find(
+							( element ) => element.value === filterInView?.value
+						);
+						const activeOperator =
+							filterInView?.operator || filter.operators[ 0 ];
+						return (
+							<DropdownSubMenu
+								key={ filter.field }
+								trigger={
+									<DropdownSubMenuTrigger
+										suffix={
+											<>
+												{ activeElement &&
+													activeOperator ===
+														OPERATOR_IN &&
+													__( 'Is' ) }
+												{ activeElement &&
+													activeOperator ===
+														OPERATOR_NOT_IN &&
+													__( 'Is not' ) }
+												{ activeElement && ' ' }
+												{ activeElement?.label }
+												<Icon
+													icon={ chevronRightSmall }
+												/>
+											</>
+										}
+									>
+										{ filter.name }
+									</DropdownSubMenuTrigger>
 								}
 							>
-								{ filter.name }
-							</DropdownSubMenuTrigger>
-						}
-					>
-						<WithSeparators>
-							<DropdownMenuGroup>
-								{ filter.elements.map( ( element ) => (
-									<DropdownMenuItem
-										key={ element.value }
-										role="menuitemradio"
-										aria-checked={
-											activeElement?.value ===
-											element.value
-										}
-										prefix={
-											activeElement?.value ===
-												element.value && (
-												<Icon icon={ check } />
-											)
-										}
-										onSelect={ () => {
-											onChangeView( ( currentView ) => ( {
-												...currentView,
-												page: 1,
-												filters: [
-													...currentView.filters.filter(
-														( f ) =>
-															f.field !==
-															filter.field
-													),
-													{
-														field: filter.field,
-														operator:
-															activeOperator,
-														value:
-															activeElement?.value ===
-															element.value
-																? undefined
-																: element.value,
-													},
-												],
-											} ) );
-										} }
-									>
-										{ element.label }
-									</DropdownMenuItem>
-								) ) }
-							</DropdownMenuGroup>
-							{ filter.operators.length > 1 && (
-								<DropdownSubMenu
-									trigger={
-										<DropdownSubMenuTrigger
-											suffix={
-												<>
-													{ activeOperator ===
-														OPERATOR_IN &&
-														__( 'Is' ) }
-													{ activeOperator ===
-														OPERATOR_NOT_IN &&
-														__( 'Is not' ) }
-													<Icon
-														icon={
-															chevronRightSmall
-														}
-													/>{ ' ' }
-												</>
+								<WithSeparators>
+									<DropdownMenuGroup>
+										{ filter.elements.map( ( element ) => (
+											<DropdownMenuItem
+												key={ element.value }
+												role="menuitemradio"
+												aria-checked={
+													activeElement?.value ===
+													element.value
+												}
+												prefix={
+													activeElement?.value ===
+														element.value && (
+														<Icon icon={ check } />
+													)
+												}
+												onSelect={ () => {
+													onChangeView(
+														( currentView ) => ( {
+															...currentView,
+															page: 1,
+															filters: [
+																...currentView.filters.filter(
+																	( f ) =>
+																		f.field !==
+																		filter.field
+																),
+																{
+																	field: filter.field,
+																	operator:
+																		activeOperator,
+																	value:
+																		activeElement?.value ===
+																		element.value
+																			? undefined
+																			: element.value,
+																},
+															],
+														} )
+													);
+												} }
+											>
+												{ element.label }
+											</DropdownMenuItem>
+										) ) }
+									</DropdownMenuGroup>
+									{ filter.operators.length > 1 && (
+										<DropdownSubMenu
+											trigger={
+												<DropdownSubMenuTrigger
+													suffix={
+														<>
+															{ activeOperator ===
+																OPERATOR_IN &&
+																__( 'Is' ) }
+															{ activeOperator ===
+																OPERATOR_NOT_IN &&
+																__( 'Is not' ) }
+															<Icon
+																icon={
+																	chevronRightSmall
+																}
+															/>{ ' ' }
+														</>
+													}
+												>
+													{ __( 'Conditions' ) }
+												</DropdownSubMenuTrigger>
 											}
 										>
-											{ __( 'Conditions' ) }
-										</DropdownSubMenuTrigger>
-									}
-								>
-									<DropdownMenuItem
-										key="in-filter"
-										role="menuitemradio"
-										aria-checked={
-											activeOperator === OPERATOR_IN
-										}
-										prefix={
-											activeOperator === OPERATOR_IN && (
-												<Icon icon={ check } />
-											)
-										}
-										onSelect={ () =>
-											onChangeView( ( currentView ) => ( {
-												...currentView,
-												page: 1,
-												filters: [
-													...view.filters.filter(
-														( f ) =>
-															f.field !==
-															filter.field
-													),
-													{
-														field: filter.field,
-														operator: OPERATOR_IN,
-														value: filterInView?.value,
-													},
-												],
-											} ) )
-										}
-									>
-										{ __( 'Is' ) }
-									</DropdownMenuItem>
-									<DropdownMenuItem
-										key="not-in-filter"
-										role="menuitemradio"
-										aria-checked={
-											activeOperator === OPERATOR_NOT_IN
-										}
-										prefix={
-											activeOperator ===
-												OPERATOR_NOT_IN && (
-												<Icon icon={ check } />
-											)
-										}
-										onSelect={ () =>
-											onChangeView( ( currentView ) => ( {
-												...currentView,
-												page: 1,
-												filters: [
-													...view.filters.filter(
-														( f ) =>
-															f.field !==
-															filter.field
-													),
-													{
-														field: filter.field,
-														operator:
-															OPERATOR_NOT_IN,
-														value: filterInView?.value,
-													},
-												],
-											} ) )
-										}
-									>
-										{ __( 'Is not' ) }
-									</DropdownMenuItem>
-								</DropdownSubMenu>
-							) }
-						</WithSeparators>
-					</DropdownSubMenu>
-				);
-			} ) }
+											<DropdownMenuItem
+												key="in-filter"
+												role="menuitemradio"
+												aria-checked={
+													activeOperator ===
+													OPERATOR_IN
+												}
+												prefix={
+													activeOperator ===
+														OPERATOR_IN && (
+														<Icon icon={ check } />
+													)
+												}
+												onSelect={ () =>
+													onChangeView(
+														( currentView ) => ( {
+															...currentView,
+															page: 1,
+															filters: [
+																...view.filters.filter(
+																	( f ) =>
+																		f.field !==
+																		filter.field
+																),
+																{
+																	field: filter.field,
+																	operator:
+																		OPERATOR_IN,
+																	value: filterInView?.value,
+																},
+															],
+														} )
+													)
+												}
+											>
+												{ __( 'Is' ) }
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												key="not-in-filter"
+												role="menuitemradio"
+												aria-checked={
+													activeOperator ===
+													OPERATOR_NOT_IN
+												}
+												prefix={
+													activeOperator ===
+														OPERATOR_NOT_IN && (
+														<Icon icon={ check } />
+													)
+												}
+												onSelect={ () =>
+													onChangeView(
+														( currentView ) => ( {
+															...currentView,
+															page: 1,
+															filters: [
+																...view.filters.filter(
+																	( f ) =>
+																		f.field !==
+																		filter.field
+																),
+																{
+																	field: filter.field,
+																	operator:
+																		OPERATOR_NOT_IN,
+																	value: filterInView?.value,
+																},
+															],
+														} )
+													)
+												}
+											>
+												{ __( 'Is not' ) }
+											</DropdownMenuItem>
+										</DropdownSubMenu>
+									) }
+								</WithSeparators>
+							</DropdownSubMenu>
+						);
+					} ) }
+				</DropdownMenuGroup>
+				<DropdownMenuItem
+					disabled={
+						view.search === '' && view.filters?.length === 0
+					}
+					onSelect={ () =>
+						onChangeView( ( currentView ) => ( {
+							...currentView,
+							page: 1,
+							filters: [],
+						} ) )
+					}
+				>
+					{ __( 'Reset filters' ) }
+				</DropdownMenuItem>
+			</WithSeparators>
 		</DropdownMenu>
 	);
 }

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -6,7 +6,7 @@ import {
 	Button,
 	Icon,
 } from '@wordpress/components';
-import { chevronRightSmall, funnel } from '@wordpress/icons';
+import { chevronRightSmall, funnel, check } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -22,7 +22,7 @@ const {
 	DropdownMenuItemV2: DropdownMenuItem,
 } = unlock( componentsPrivateApis );
 
-export default function AddFilter( { fields, onChangeView } ) {
+export default function AddFilter( { fields, view, onChangeView } ) {
 	const filters = [];
 	fields.forEach( ( field ) => {
 		if ( ! field.type ) {
@@ -57,6 +57,12 @@ export default function AddFilter( { fields, onChangeView } ) {
 			}
 		>
 			{ filters.map( ( filter ) => {
+				const filterInView = view.filters.find(
+					( f ) => f.field === filter.field
+				);
+				const activeElement = filter.elements.find(
+					( element ) => element.value === filterInView?.value
+				);
 				return (
 					<DropdownSubMenu
 						key={ filter.field }
@@ -71,6 +77,15 @@ export default function AddFilter( { fields, onChangeView } ) {
 						{ filter.elements.map( ( element ) => (
 							<DropdownMenuItem
 								key={ element.value }
+								role="menuitemradio"
+								aria-checked={
+									activeElement?.value === element.value
+								}
+								prefix={
+									activeElement?.value === element.value && (
+										<Icon icon={ check } />
+									)
+								}
 								onSelect={ () => {
 									onChangeView( ( currentView ) => ( {
 										...currentView,

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -14,7 +14,7 @@ import { Children, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
-import { OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
+import { LAYOUT_LIST, OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -51,7 +51,14 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					variant="tertiary"
 					size="compact"
 					icon={ funnel }
-				/>
+					className="dataviews-filters-button"
+				>
+					{ view.type === LAYOUT_LIST ? (
+						<span className="dataviews-filters-count">
+							{ view.filters.length }
+						</span>
+					) : null }
+				</Button>
 			}
 		>
 			<WithSeparators>

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -47,6 +47,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 			trigger={
 				<Button
 					__experimentalIsFocusable
+					label={ __( 'Filters' ) }
 					variant="tertiary"
 					size="compact"
 					icon={ funnel }

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -41,6 +41,13 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 		return null;
 	}
 
+	const filterCount = view.filters.reduce( ( acc, filter ) => {
+		if ( filter.value !== undefined ) {
+			return acc + 1;
+		}
+		return acc;
+	}, 0 );
+
 	return (
 		<DropdownMenu
 			label={ __( 'Filters' ) }
@@ -53,9 +60,9 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					icon={ funnel }
 					className="dataviews-filters-button"
 				>
-					{ view.type === LAYOUT_LIST && view.filters.length > 0 ? (
+					{ view.type === LAYOUT_LIST && filterCount > 0 ? (
 						<span className="dataviews-filters-count">
-							{ view.filters.length }
+							{ filterCount }
 						</span>
 					) : null }
 				</Button>

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -53,7 +53,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					icon={ funnel }
 					className="dataviews-filters-button"
 				>
-					{ view.type === LAYOUT_LIST ? (
+					{ view.type === LAYOUT_LIST && view.filters.length > 0 ? (
 						<span className="dataviews-filters-count">
 							{ view.filters.length }
 						</span>

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -107,7 +107,8 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 														<Icon icon={ check } />
 													)
 												}
-												onSelect={ () => {
+												onSelect={ ( event ) => {
+													event.preventDefault();
 													onChangeView(
 														( currentView ) => ( {
 															...currentView,
@@ -174,7 +175,8 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 														<Icon icon={ check } />
 													)
 												}
-												onSelect={ () =>
+												onSelect={ ( event ) => {
+													event.preventDefault();
 													onChangeView(
 														( currentView ) => ( {
 															...currentView,
@@ -193,8 +195,8 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 																},
 															],
 														} )
-													)
-												}
+													);
+												} }
 											>
 												{ __( 'Is' ) }
 											</DropdownMenuItem>
@@ -211,7 +213,8 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 														<Icon icon={ check } />
 													)
 												}
-												onSelect={ () =>
+												onSelect={ ( event ) => {
+													event.preventDefault();
 													onChangeView(
 														( currentView ) => ( {
 															...currentView,
@@ -230,8 +233,8 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 																},
 															],
 														} )
-													)
-												}
+													);
+												} }
 											>
 												{ __( 'Is not' ) }
 											</DropdownMenuItem>
@@ -246,13 +249,14 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					disabled={
 						view.search === '' && view.filters?.length === 0
 					}
-					onSelect={ () =>
+					onSelect={ ( event ) => {
+						event.preventDefault();
 						onChangeView( ( currentView ) => ( {
 							...currentView,
 							page: 1,
 							filters: [],
-						} ) )
-					}
+						} ) );
+					} }
 				>
 					{ __( 'Reset filters' ) }
 				</DropdownMenuItem>

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -49,9 +49,8 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					__experimentalIsFocusable
 					variant="tertiary"
 					size="compact"
-				>
-					<Icon icon={ funnel } style={ { flexShrink: 0 } } />
-				</Button>
+					icon={ funnel }
+				/>
 			}
 		>
 			<WithSeparators>

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -7,7 +7,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { chevronRightSmall, funnel, check } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Children, Fragment } from '@wordpress/element';
 
 /**
@@ -240,6 +240,29 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 											</DropdownMenuItem>
 										</DropdownSubMenu>
 									) }
+									<DropdownMenuItem
+										key={ 'reset-filter-' + filter.name }
+										disabled={ ! activeElement }
+										onSelect={ ( event ) => {
+											event.preventDefault();
+											onChangeView( ( currentView ) => ( {
+												...currentView,
+												page: 1,
+												filters:
+													currentView.filters.filter(
+														( f ) =>
+															f.field !==
+															filter.field
+													),
+											} ) );
+										} }
+									>
+										{ sprintf(
+											/* translators: 1: Filter name. e.g.: "Reset Author". */
+											__( 'Reset %1$s' ),
+											filter.name.toLowerCase()
+										) }
+									</DropdownMenuItem>
 								</WithSeparators>
 							</DropdownSubMenu>
 						);

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -13,7 +13,7 @@ import { Children, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
+import { OPERATOR_IN, OPERATOR_NOT_IN, LAYOUT_LIST } from './constants';
 import { unlock } from './lock-unlock';
 
 const {
@@ -73,6 +73,10 @@ function WithSeparators( { children } ) {
 }
 
 export default function FilterSummary( { filter, view, onChangeView } ) {
+	if ( view.type === LAYOUT_LIST ) {
+		return null;
+	}
+
 	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
 	const activeElement = filter.elements.find(
 		( element ) => element.value === filterInView?.value

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -49,7 +49,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 	const addFilter = (
 		<AddFilter
 			key="add-filter"
-			fields={ fields }
+			filters={ filters }
 			view={ view }
 			onChangeView={ onChangeView }
 		/>

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -46,22 +46,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 		}
 	} );
 
-	const filterComponents = filters.map( ( filter ) => {
-		if ( ! filter.isVisible ) {
-			return null;
-		}
-
-		return (
-			<FilterSummary
-				key={ filter.field + '.' + filter.operator }
-				filter={ filter }
-				view={ view }
-				onChangeView={ onChangeView }
-			/>
-		);
-	} );
-
-	filterComponents.push(
+	const addFilter = (
 		<AddFilter
 			key="add-filter"
 			fields={ fields }
@@ -69,6 +54,23 @@ export default function Filters( { fields, view, onChangeView } ) {
 			onChangeView={ onChangeView }
 		/>
 	);
+	const filterComponents = [
+		addFilter,
+		...filters.map( ( filter ) => {
+			if ( ! filter.isVisible ) {
+				return null;
+			}
+
+			return (
+				<FilterSummary
+					key={ filter.field + '.' + filter.operator }
+					filter={ filter }
+					view={ view }
+					onChangeView={ onChangeView }
+				/>
+			);
+		} ),
+	];
 
 	if ( filterComponents.length > 1 ) {
 		filterComponents.push(

--- a/packages/dataviews/src/reset-filters.js
+++ b/packages/dataviews/src/reset-filters.js
@@ -4,7 +4,16 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { LAYOUT_LIST } from './constants';
+
 export default ( { view, onChangeView } ) => {
+	if ( view.type === LAYOUT_LIST ) {
+		return null;
+	}
+
 	return (
 		<Button
 			disabled={ view.search === '' && view.filters?.length === 0 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -12,6 +12,10 @@
 
 .dataviews__filters-view-actions {
 	padding: $grid-unit-15 $grid-unit-40;
+	.components-search-control {
+		flex-grow: 1;
+		max-width: 240px;
+	}
 }
 
 .dataviews-filters-button {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -14,6 +14,21 @@
 	padding: $grid-unit-15 $grid-unit-40;
 }
 
+.dataviews-filters-button {
+	position: relative;
+}
+
+.dataviews-filters-count {
+	position: absolute;
+	top: -7px;
+	right: -7px;
+	color: $white;
+	background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+	border-radius: 50%;
+	padding: 2px 5px;
+	font-size: 12px;
+}
+
 .dataviews-pagination {
 	margin-top: auto;
 	position: sticky;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -20,13 +20,20 @@
 
 .dataviews-filters-count {
 	position: absolute;
-	top: -7px;
-	right: -7px;
-	color: $white;
+	top: 0;
+	right: 0;
+	height: $grid-unit-20;
+	color: var(--wp-components-color-accent-inverted, $white);
 	background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-	border-radius: 50%;
-	padding: 2px 5px;
-	font-size: 12px;
+	border-radius: $grid-unit-10;
+	min-width: $grid-unit-20;
+	padding: 0 $grid-unit-05;
+	transform: translateX(40%) translateY(-40%);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 11px;
+	font-weight: 300;
 }
 
 .dataviews-pagination {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -156,7 +156,8 @@
 	}
 }
 
-.edit-site-template-pages-list-view {
+.edit-site-template-pages-list-view,
+.edit-site-page-pages-list-view {
 	max-width: $nav-sidebar-width;
 }
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -320,7 +320,14 @@ export default function PagePages() {
 	// TODO: we need to handle properly `data={ data || EMPTY_ARRAY }` for when `isLoading`.
 	return (
 		<>
-			<Page title={ __( 'Pages' ) }>
+			<Page
+				className={
+					view.type === LAYOUT_LIST
+						? 'edit-site-page-pages-list-view'
+						: null
+				}
+				title={ __( 'Pages' ) }
+			>
 				<DataViews
 					paginationInfo={ paginationInfo }
 					fields={ fields }

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -54,16 +54,19 @@ test.describe( 'Templates', () => {
 		await page.keyboard.type( 'tag' );
 		const titles = page
 			.getByRole( 'region', { name: 'Template' } )
-			.getByRole( 'link' );
+			.getByRole( 'link', { includeHidden: true } );
 		await expect( titles ).toHaveCount( 1 );
 		await expect( titles.first() ).toHaveText( 'Tag Archives' );
 		await page.getByRole( 'button', { name: 'Reset filters' } ).click();
 		await expect( titles ).toHaveCount( 6 );
 
 		// Filter by author.
-		await page.getByRole( 'button', { name: 'Add filter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Filters', exact: true } )
+			.click();
 		await page.getByRole( 'menuitem', { name: 'Author' } ).hover();
-		await page.getByRole( 'menuitem', { name: 'admin' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'admin' } ).click();
+		await page.keyboard.press( 'Escape' ); // close the menu.
 		await expect( titles ).toHaveCount( 1 );
 		await expect( titles.first() ).toHaveText( 'Date Archives' );
 
@@ -72,9 +75,12 @@ test.describe( 'Templates', () => {
 		await page.getByRole( 'searchbox', { name: 'Filter list' } ).click();
 		await page.keyboard.type( 'archives' );
 		await expect( titles ).toHaveCount( 3 );
-		await page.getByRole( 'button', { name: 'Add filter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Filters', exact: true } )
+			.click();
 		await page.getByRole( 'menuitem', { name: 'Author' } ).hover();
-		await page.getByRole( 'menuitem', { name: 'Emptytheme' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Emptytheme' } ).click();
+		await page.keyboard.press( 'Escape' ); // close the menu.
 		await expect( titles ).toHaveCount( 2 );
 	} );
 	test( 'Field visibility', async ( { admin, page } ) => {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/55100

## What?

Implements a more condensed filter UI. It also updates its behavior to be able to do any filter operation (change value, change operator).

https://github.com/WordPress/gutenberg/assets/583546/02b3dbc2-e92a-40df-a8d2-d257776490d9


## Why?

Some layouts such as list have a narrower space for information, and we'd like to condense it.

This is the first step of implementing https://github.com/WordPress/gutenberg/issues/55100#issuecomment-1847417577

<img width="1640" alt="filters-small-spaces" src="https://github.com/WordPress/gutenberg/assets/846565/f5013a5c-4438-4281-ac0f-8823afca377b">

## How?

- Updates the `AddFilter` component UI and behavior.
- Reduces the frame for the list view to be the same size of the sidebar.

## Testing Instructions

- Enable the "admin view" experiment and visit "Manage all pages" or "Manage all templates".
- Verify the filters work as expected.
