### PR TITLE
Comments block: Try client-side form submission [new store API]

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -181,7 +181,7 @@ An advanced block that allows displaying post comments using different visual co
 -	**Name:** core/comments
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** legacy, tagName
+-	**Attributes:** enhancedSubmission, legacy, tagName
 
 ## Comments Pagination
 

--- a/packages/block-library/src/comment-reply-link/block.json
+++ b/packages/block-library/src/comment-reply-link/block.json
@@ -7,7 +7,7 @@
 	"ancestor": [ "core/comment-template" ],
 	"description": "Displays a link to reply to a comment.",
 	"textdomain": "default",
-	"usesContext": [ "commentId" ],
+	"usesContext": [ "commentId", "enhancedSubmission" ],
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/comment-reply-link/index.php
+++ b/packages/block-library/src/comment-reply-link/index.php
@@ -68,7 +68,7 @@ function render_block_core_comment_reply_link( $attributes, $content, $block ) {
 			'class_name' => 'comment-reply-link',
 		)
 	) ) {
-		$p->set_attribute( 'data-wp-on--click', 'actions.core.comments.changeReplyTo' );
+		$p->set_attribute( 'data-wp-on--click', 'actions.changeReplyTo' );
 	}
 	$comment_reply_link = $p->get_updated_html();
 

--- a/packages/block-library/src/comment-reply-link/index.php
+++ b/packages/block-library/src/comment-reply-link/index.php
@@ -61,6 +61,17 @@ function render_block_core_comment_reply_link( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
+	$p = new WP_HTML_Tag_Processor( $comment_reply_link );
+	if ( $p->next_tag(
+		array(
+			'tag_name'   => 'A',
+			'class_name' => 'comment-reply-link',
+		)
+	) ) {
+		$p->set_attribute( 'data-wp-on--click', 'actions.core.comments.changeReplyTo' );
+	}
+	$comment_reply_link = $p->get_updated_html();
+
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -7,7 +7,7 @@
 	"parent": [ "core/comments" ],
 	"description": "Contains the block elements used to display a comment, like the title, date, author, avatar and more.",
 	"textdomain": "default",
-	"usesContext": [ "postId" ],
+	"usesContext": [ "postId", "enhancedSubmission" ],
 	"supports": {
 		"align": true,
 		"html": false,

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -20,6 +20,7 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 	global $comment_depth;
 	$thread_comments       = get_option( 'thread_comments' );
 	$thread_comments_depth = get_option( 'thread_comments_depth' );
+	$enhanced_submission   = isset( $block->context['enhancedSubmission'] ) && $block->context['enhancedSubmission'];
 
 	if ( empty( $comment_depth ) ) {
 		$comment_depth = 1;
@@ -83,7 +84,15 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			}
 		}
 
-		$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );
+		$comment_directives = $enhanced_submission ? ' data-wp-key="comment-' . $comment->comment_ID . '" data-wp-slot=\'{"name":"comment-' . $comment->comment_ID . '","position":"after"}\'' : '';
+
+		$content .= sprintf(
+			'<li id="comment-%1$s" %2$s%3$s>%4$s</li>',
+			$comment->comment_ID,
+			$comment_classes,
+			$comment_directives,
+			$block_content
+		);
 	}
 
 	return $content;

--- a/packages/block-library/src/comments/block.json
+++ b/packages/block-library/src/comments/block.json
@@ -14,6 +14,10 @@
 		"legacy": {
 			"type": "boolean",
 			"default": false
+		},
+		"enhancedSubmission": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {
@@ -48,5 +52,8 @@
 		}
 	},
 	"editorStyle": "wp-block-comments-editor",
-	"usesContext": [ "postId", "postType" ]
+	"usesContext": [ "postId", "postType" ],
+	"providesContext": {
+		"enhancedSubmission": "enhancedSubmission"
+	}
 }

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -43,19 +43,15 @@ function render_block_core_comments( $attributes, $content, $block ) {
 			$p = new WP_HTML_Tag_Processor( $output );
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-comments' ) ) ) {
 				// Add the necessary directives.
-				$p->set_attribute( 'data-wp-interactive', true );
+				$p->set_attribute( 'data-wp-interactive', 'core/comments' );
 				$p->set_attribute( 'data-wp-navigation-id', 'comments-' . ++$id );
 				$p->set_attribute( 'data-wp-slot-provider', true );
 				$p->set_attribute(
 					'data-wp-context',
 					wp_json_encode(
 						array(
-							'core' => array(
-								'comments' => (object) array(
-									'fields' => (object) array(
-										'comment_parent' => 0,
-									),
-								),
+							'fields' => (object) array(
+								'comment_parent' => 0,
 							),
 						)
 					)

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -117,6 +117,15 @@ function register_block_core_comments() {
 			'skip_inner_blocks' => true,
 		)
 	);
+
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		gutenberg_register_module(
+			'@wordpress/block-library/comments',
+			gutenberg_url( '/build/interactivity/comments.min.js' ),
+			array( '@wordpress/interactivity' ),
+			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+		);
+	}
 }
 add_action( 'init', 'register_block_core_comments' );
 
@@ -236,14 +245,5 @@ function register_legacy_post_comments_block() {
 	$metadata = apply_filters( 'block_type_metadata', $metadata );
 
 	register_block_type( 'core/post-comments', $metadata );
-
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		gutenberg_register_module(
-			'@wordpress/block-library/comments',
-			gutenberg_url( '/build/interactivity/comments.min.js' ),
-			array( '@wordpress/interactivity' ),
-			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-		);
-	}
 }
 add_action( 'init', 'register_legacy_post_comments_block', 21 );

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -43,7 +43,7 @@ function render_block_core_comments( $attributes, $content, $block ) {
 			$p = new WP_HTML_Tag_Processor( $output );
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-comments' ) ) ) {
 				// Add the necessary directives.
-				$p->set_attribute( 'data-wp-interactive', 'core/comments' );
+				$p->set_attribute( 'data-wp-interactive', '{ "namespace": "core/comments" }' );
 				$p->set_attribute( 'data-wp-navigation-id', 'comments-' . ++$id );
 				$p->set_attribute( 'data-wp-slot-provider', true );
 				$p->set_attribute(

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -236,5 +236,14 @@ function register_legacy_post_comments_block() {
 	$metadata = apply_filters( 'block_type_metadata', $metadata );
 
 	register_block_type( 'core/post-comments', $metadata );
+
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		gutenberg_register_module(
+			'@wordpress/block-library/comments',
+			gutenberg_url( '/build/interactivity/comments.min.js' ),
+			array( '@wordpress/interactivity' ),
+			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+		);
+	}
 }
 add_action( 'init', 'register_legacy_post_comments_block', 21 );

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -23,6 +23,7 @@
  */
 function render_block_core_comments( $attributes, $content, $block ) {
 	global $post;
+	static $id = 0;
 
 	$post_id = $block->context['postId'];
 	if ( ! isset( $post_id ) ) {
@@ -37,7 +38,35 @@ function render_block_core_comments( $attributes, $content, $block ) {
 	// If this isn't the legacy block, we need to render the static version of this block.
 	$is_legacy = 'core/post-comments' === $block->name || ! empty( $attributes['legacy'] );
 	if ( ! $is_legacy ) {
-		return $block->render( array( 'dynamic' => false ) );
+		$output = $block->render( array( 'dynamic' => false ) );
+		if ( $attributes['enhancedSubmission'] ) {
+			$p = new WP_HTML_Tag_Processor( $output );
+			if ( $p->next_tag( array( 'class_name' => 'wp-block-comments' ) ) ) {
+				// Add the necessary directives.
+				$p->set_attribute( 'data-wp-interactive', true );
+				$p->set_attribute( 'data-wp-navigation-id', 'comments-' . ++$id );
+				$p->set_attribute( 'data-wp-slot-provider', true );
+				$p->set_attribute(
+					'data-wp-context',
+					wp_json_encode(
+						array(
+							'core' => array(
+								'comments' => (object) array(
+									'fields' => (object) array(
+										'comment_parent' => 0,
+									),
+								),
+							),
+						)
+					)
+				);
+				$output = $p->get_updated_html();
+
+				// Mark the block as interactive.
+				$block->block_type->supports['interactivity'] = true;
+			}
+		}
+		return $output;
 	}
 
 	$post_before = $post;

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -11,7 +11,7 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "postId", "postType" ],
+	"usesContext": [ "postId", "postType", "enhancedSubmission" ],
 	"supports": {
 		"html": false,
 		"color": {
@@ -44,5 +44,6 @@
 		"wp-block-post-comments-form",
 		"wp-block-buttons",
 		"wp-block-button"
-	]
+	],
+	"viewScript": "file:./view.min.js"
 }

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -140,12 +140,8 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 			// announce the spoken notices.
 			wp_store(
 				array(
-					'state' => array(
-						'core' => array(
-							'comments' => array(
-								'submittedNotice' => __( 'Comment submitted.' ),
-							),
-						),
+					'core/comments' => array(
+						'submittedNotice' => __( 'Comment submitted.' ),
 					),
 				)
 			);

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -29,7 +29,13 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
 		$classes[] = 'has-link-color';
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class'          => implode( ' ', $classes ),
+			'data-wp-fill'   => 'context.core.comments.formSlot',
+			'data-wp-effect' => 'effects.core.comments.scrollOnReply',
+		)
+	);
 
 	add_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );
 
@@ -46,9 +52,163 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	// of the 'Reply' link that the user clicked by Core's `comment-reply.js` script.
 	$form = str_replace( 'class="comment-respond"', $wrapper_attributes, $form );
 
-	// Enqueue the comment-reply script.
-	wp_enqueue_script( 'comment-reply' );
+	$enhanced_submission = $block->context['enhancedSubmission'];
+	$enhanced_form       = false;
 
+	if ( $enhanced_submission ) {
+		$p = new WP_HTML_Tag_Processor( $form );
+
+		// Move to the first tag and add a bookmark. This is supposed to be OK considering
+		// that the first element is not the form element.
+		$p->next_tag();
+		$p->set_bookmark( 'first-tag' );
+
+		// Try to find the form element. This is not optional; if it fails, we don't
+		// enhance the submission.
+		if ( $p->next_tag(
+			array(
+				'tag_name' => 'FORM',
+				'id'       => 'commentform',
+			)
+		) ) {
+			// Add the necessary directives.
+			$p->set_attribute( 'data-wp-on--submit', 'actions.core.comments.submit' );
+
+			while ( $p->next_tag() ) {
+				$tag  = $p->get_tag();
+				$name = $p->get_attribute( 'name' );
+				$type = $p->get_attribute( 'type' );
+
+				// Try to find the different input fields and save their values on the
+				// context so it can be restored when the form is moved around. This is
+				// optional.
+				if ( 'TEXTAREA' === $tag && 'comment' === $name ) {
+					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
+					$p->set_attribute( 'data-wp-on--change', 'actions.core.comments.updateField' );
+				}
+
+				if (
+					'INPUT' === $tag &&
+					in_array( $name, array( 'author', 'email', 'url' ), true )
+				) {
+					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
+					$p->set_attribute( 'data-wp-on--input', 'actions.core.comments.updateField' );
+				}
+
+				if ( 'INPUT' === $tag && 'comment_parent' === $name ) {
+					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
+				}
+
+				// Try to find the submit button and add directives to change its value
+				// on submission. This is optional.
+				if ( 'INPUT' === $tag && 'submit' === $type ) {
+					// Add the necessary directives.
+					$p->set_attribute( 'data-wp-bind--value', 'selectors.core.comments.submitText' );
+					$p->set_attribute( 'data-wp-bind--disabled', 'context.core.comments.isSubmitting' );
+
+					// Add translated strings to the state.
+					$submit_text = $p->get_attribute( 'value' );
+					wp_store(
+						array(
+							'state'     => array(
+								'core' => array(
+									'comments' => array(
+										'submitText'  => $submit_text,
+										'loadingText' => __( 'Submitting…' ),
+									),
+								),
+							),
+							'selectors' => array(
+								'core' => array(
+									'comments' => array(
+										'submitText' => $submit_text,
+									),
+								),
+							),
+						)
+					);
+				}
+			}
+
+			// Start again to add directives to the reply title elements.
+			$p->seek( 'first-tag' );
+			if ( $p->next_tag( array( 'class_name' => 'comment-reply-title' ) ) ) {
+				$p->set_attribute( 'data-wp-effect', 'actions.core.comments.updateReplyTitle' );
+			}
+
+			while ( $p->next_tag( array( 'tag_name' => 'a' ) ) ) {
+				if ( 'cancel-comment-reply-link' === $p->get_attribute( 'id' ) ) {
+					$p->set_attribute( 'data-wp-style--display', 'selectors.core.comments.displayCancelReply' );
+					$p->set_attribute( 'data-wp-on--click', 'actions.core.comments.cancelReply' );
+					break;
+				}
+			}
+
+			// Mark the block as interactive.
+			$block->block_type->supports['interactivity'] = true;
+
+			// Add a div to show error messages below the form and another div to
+			// announce the spoken notices.
+			wp_store(
+				array(
+					'state' => array(
+						'core' => array(
+							'comments' => array(
+								'submittedNotice' => __( 'Comment submitted.' ),
+							),
+						),
+					),
+				)
+			);
+			$enhanced_form     = $p->get_updated_html();
+			$last_div_position = strripos( $enhanced_form, '</form>' );
+			$enhanced_form     = substr_replace(
+				$enhanced_form,
+				'<div
+					class="wp-block-post-comments-form__error"
+					data-wp-style--display="selectors.core.comments.showError"
+					data-wp-effect="effects.core.comments.scrollToError"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+						<path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path>
+					</svg>
+					<span
+						data-wp-text="state.core.comments.error"
+						aria-live="polite"
+					></span>
+				</div>
+				<div
+					style="position:absolute;clip:rect(0,0,0,0);width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;border:0;"
+					aria-live="polite"
+					data-wp-text="context.core.comments.notice"
+				></div>
+				</form>',
+				$last_div_position,
+				0
+			);
+		}
+	}
+
+	$view_asset = 'wp-block-post-comments-form-view';
+	if ( ! wp_script_is( $view_asset ) ) {
+		$script_handles = $block->block_type->view_script_handles;
+		// If the script is not needed, and it is still in the `view_script_handles`, remove it.
+		if ( ! $enhanced_submission && in_array( $view_asset, $script_handles, true ) ) {
+			$block->block_type->view_script_handles = array_diff( $script_handles, array( $view_asset ) );
+		}
+		// If the script is needed, but it was previously removed, add it again.
+		if ( $enhanced_submission && ! in_array( $view_asset, $script_handles, true ) ) {
+			$block->block_type->view_script_handles = array_merge( $script_handles, array( $view_asset ) );
+		}
+	}
+
+	if ( $enhanced_form ) {
+		return $enhanced_form;
+	}
+
+	// If something failed or there is no enhanced submission, enqueue the regular
+	// comment-reply script and return the HTML without the directives.
+	wp_enqueue_script( 'comment-reply' );
 	return $form;
 }
 

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -103,7 +103,7 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 				// on submission. This is optional.
 				if ( 'INPUT' === $tag && 'submit' === $type ) {
 					// Add the necessary directives.
-					$p->set_attribute( 'data-wp-bind--value', 'state.submitText' );
+					$p->set_attribute( 'data-wp-bind--value', 'state.submitButtonText' );
 					$p->set_attribute( 'data-wp-bind--disabled', 'context.isSubmitting' );
 
 					// Add translated strings to the state.

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -31,9 +31,9 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	}
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class'          => implode( ' ', $classes ),
-			'data-wp-fill'   => 'context.core.comments.formSlot',
-			'data-wp-effect' => 'effects.core.comments.scrollOnReply',
+			'class'         => implode( ' ', $classes ),
+			'data-wp-fill'  => 'context.formSlot',
+			'data-wp-watch' => 'callbacks.scrollOnReply',
 		)
 	);
 
@@ -72,7 +72,7 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 			)
 		) ) {
 			// Add the necessary directives.
-			$p->set_attribute( 'data-wp-on--submit', 'actions.core.comments.submit' );
+			$p->set_attribute( 'data-wp-on--submit', 'actions.submit' );
 
 			while ( $p->next_tag() ) {
 				$tag  = $p->get_tag();
@@ -83,47 +83,36 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 				// context so it can be restored when the form is moved around. This is
 				// optional.
 				if ( 'TEXTAREA' === $tag && 'comment' === $name ) {
-					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
-					$p->set_attribute( 'data-wp-on--change', 'actions.core.comments.updateField' );
+					$p->set_attribute( 'data-wp-bind--value', 'context.fields.' . $name );
+					$p->set_attribute( 'data-wp-on--change', 'actions.updateField' );
 				}
 
 				if (
 					'INPUT' === $tag &&
 					in_array( $name, array( 'author', 'email', 'url' ), true )
 				) {
-					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
-					$p->set_attribute( 'data-wp-on--input', 'actions.core.comments.updateField' );
+					$p->set_attribute( 'data-wp-bind--value', 'context.fields.' . $name );
+					$p->set_attribute( 'data-wp-on--input', 'actions.updateField' );
 				}
 
 				if ( 'INPUT' === $tag && 'comment_parent' === $name ) {
-					$p->set_attribute( 'data-wp-bind--value', 'context.core.comments.fields.' . $name );
+					$p->set_attribute( 'data-wp-bind--value', 'context.fields.' . $name );
 				}
 
 				// Try to find the submit button and add directives to change its value
 				// on submission. This is optional.
 				if ( 'INPUT' === $tag && 'submit' === $type ) {
 					// Add the necessary directives.
-					$p->set_attribute( 'data-wp-bind--value', 'selectors.core.comments.submitText' );
-					$p->set_attribute( 'data-wp-bind--disabled', 'context.core.comments.isSubmitting' );
+					$p->set_attribute( 'data-wp-bind--value', 'state.submitText' );
+					$p->set_attribute( 'data-wp-bind--disabled', 'context.isSubmitting' );
 
 					// Add translated strings to the state.
 					$submit_text = $p->get_attribute( 'value' );
 					wp_store(
 						array(
-							'state'     => array(
-								'core' => array(
-									'comments' => array(
-										'submitText'  => $submit_text,
-										'loadingText' => __( 'Submitting…' ),
-									),
-								),
-							),
-							'selectors' => array(
-								'core' => array(
-									'comments' => array(
-										'submitText' => $submit_text,
-									),
-								),
+							'core/comments' => array(
+								'submitText'  => $submit_text,
+								'loadingText' => __( 'Submitting…' ),
 							),
 						)
 					);
@@ -133,13 +122,13 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 			// Start again to add directives to the reply title elements.
 			$p->seek( 'first-tag' );
 			if ( $p->next_tag( array( 'class_name' => 'comment-reply-title' ) ) ) {
-				$p->set_attribute( 'data-wp-effect', 'actions.core.comments.updateReplyTitle' );
+				$p->set_attribute( 'data-wp-watch', 'actions.updateReplyTitle' );
 			}
 
 			while ( $p->next_tag( array( 'tag_name' => 'a' ) ) ) {
 				if ( 'cancel-comment-reply-link' === $p->get_attribute( 'id' ) ) {
-					$p->set_attribute( 'data-wp-style--display', 'selectors.core.comments.displayCancelReply' );
-					$p->set_attribute( 'data-wp-on--click', 'actions.core.comments.cancelReply' );
+					$p->set_attribute( 'data-wp-style--display', 'state.displayCancelReply' );
+					$p->set_attribute( 'data-wp-on--click', 'actions.cancelReply' );
 					break;
 				}
 			}
@@ -166,21 +155,21 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 				$enhanced_form,
 				'<div
 					class="wp-block-post-comments-form__error"
-					data-wp-style--display="selectors.core.comments.showError"
-					data-wp-effect="effects.core.comments.scrollToError"
+					data-wp-style--display="state.showError"
+					data-wp-watch="callbacks.scrollToError"
 				>
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
 						<path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"></path>
 					</svg>
 					<span
-						data-wp-text="state.core.comments.error"
+						data-wp-text="state.error"
 						aria-live="polite"
 					></span>
 				</div>
 				<div
 					style="position:absolute;clip:rect(0,0,0,0);width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;border:0;"
 					aria-live="polite"
-					data-wp-text="context.core.comments.notice"
+					data-wp-text="context.notice"
 				></div>
 				</form>',
 				$last_div_position,

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -79,4 +79,25 @@
 			margin-left: 0.5em;
 		}
 	}
+
+	.wp-block-post-comments-form__error {
+		display: none;
+		gap: 12px;
+		align-items: stretch;
+		border: 1px solid #cc1818;
+		border-radius: 4px;
+		color: #2f2f2f;
+		padding: 16px;
+		margin-bottom: 20px;
+		background-color: #fff0f0;
+		& > svg {
+			background-color: #cc1818;
+			transform: rotate(180deg);
+			fill: #fff;
+			border-radius: 50%;
+			padding: 2px;
+			flex-shrink: 0;
+			flex-grow: 0;
+		}
+	}
 }

--- a/packages/block-library/src/post-comments-form/view.js
+++ b/packages/block-library/src/post-comments-form/view.js
@@ -1,0 +1,189 @@
+/**
+ * WordPress dependencies
+ */
+import { store, navigate } from '@wordpress/interactivity';
+
+const focusableSelectors = [
+	'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
+	'select:not([disabled]):not([aria-hidden])',
+	'textarea:not([disabled]):not([aria-hidden])',
+	'[contenteditable]',
+	'[tabindex]:not([tabindex^="-"])',
+];
+
+store( {
+	state: {
+		core: {
+			comments: {
+				error: '',
+			},
+		},
+	},
+	selectors: {
+		core: {
+			comments: {
+				showError: ( { state } ) =>
+					state.core.comments.error ? 'flex' : 'none',
+				submitText: ( { context, state } ) =>
+					context.core.comments.isSubmitting
+						? state.core.comments.loadingText
+						: state.core.comments.submitText,
+				displayCancelReply: ( { context } ) => {
+					return context.core.comments.formSlot ? undefined : 'none';
+				},
+			},
+		},
+	},
+	actions: {
+		core: {
+			comments: {
+				submit: async ( { event, context, state, ref } ) => {
+					let response;
+					const existingComments = new Set();
+					const comments = ref.closest( '.wp-block-comments' );
+					comments
+						.querySelectorAll( 'li[id^="comment-"]' )
+						.forEach( ( comment ) =>
+							existingComments.add( comment.id )
+						);
+
+					try {
+						event.preventDefault();
+
+						state.core.comments.error = '';
+						context.core.comments.isSubmitting = true;
+
+						response = await window.fetch( ref.action, {
+							method: 'POST',
+							body: new window.FormData( ref ),
+						} );
+					} catch ( e ) {
+						// If something fails at this point, the form hasn't been submitted
+						// and we can submit it again manually to the server. This is using
+						// the prototype because ref.submit() could be overwritten by an
+						// `<input name="submit"> element.
+						window.HTMLFormElement.prototype.submit.bind( ref )();
+					}
+
+					try {
+						const html = await response.text();
+						const dom = new window.DOMParser().parseFromString(
+							html,
+							'text/html'
+						);
+
+						if (
+							response.status !== 200 ||
+							dom.body.id === 'error-page'
+						) {
+							state.core.comments.error =
+								dom.querySelector(
+									'.wp-die-message'
+								).innerText;
+						} else {
+							await navigate( response.url, {
+								html,
+								replace: true,
+								force: true,
+							} );
+
+							let newComment;
+							comments
+								.querySelectorAll( 'li[id^="comment-"]' )
+								.forEach( ( comment ) => {
+									if ( ! existingComments.has( comment.id ) )
+										newComment = comment;
+								} );
+
+							// Scroll the new comment into view.
+							newComment.querySelector( 'a[href]' ).focus();
+
+							// Announce that the comment has been submitted. If the notice is
+							// the same, we use a no-break space similar to the trick used by
+							// the @wordpress/a11y package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
+							context.core.comments.notice =
+								state.core.comments.submittedNotice +
+								( context.core.comments.notice ===
+								state.core.comments.submittedNotice
+									? '\u00A0'
+									: '' );
+
+							// Add hash to the URL.
+							window.history.replaceState(
+								{},
+								'',
+								window.location.pathname +
+									window.location.search +
+									`#${ newComment.id }`
+							);
+
+							// Reset form fields and position.
+							context.core.comments.formSlot = undefined;
+							const { fields } = context.core.comments;
+							for ( const key in fields ) {
+								fields[ key ] =
+									key !== 'comment_parent' ? '' : 0;
+							}
+						}
+
+						context.core.comments.isSubmitting = false;
+					} catch ( e ) {
+						// If something happens at this point, the form has been submitted
+						// but we were not able to show it in the screen, so we can just
+						// refresh the page.
+						window.location.assign(
+							response.url || window.location
+						);
+					}
+				},
+				changeReplyTo: ( { context, ref, event } ) => {
+					event.preventDefault();
+					const { commentid, replyto } = ref.dataset;
+					context.core.comments.replyTitle = replyto;
+					context.core.comments.formSlot = `comment-${ commentid }`;
+					context.core.comments.fields.comment_parent = commentid;
+				},
+				cancelReply: ( { context, event } ) => {
+					event.preventDefault();
+					context.core.comments.formSlot = undefined;
+					context.core.comments.fields.comment_parent = 0;
+				},
+				updateField: ( { context, event } ) => {
+					const { name, value } = event.target;
+					context.core.comments.fields[ name ] = value;
+				},
+				updateReplyTitle: ( { context, ref } ) => {
+					if ( context.core.comments.fields.comment_parent !== 0 ) {
+						ref.firstChild.replaceWith(
+							context.core.comments.replyTitle
+						);
+					}
+				},
+			},
+		},
+	},
+	effects: {
+		core: {
+			comments: {
+				scrollToError: ( st ) => {
+					// Scroll to the error when it's shown.
+					if ( st.state.core.comments.error ) {
+						st.ref.scrollIntoView( {
+							behavior: 'smooth',
+							block: 'end',
+						} );
+					}
+				},
+				scrollOnReply: ( { context, ref } ) => {
+					const { formSlot } = context.core.comments;
+
+					// Focus on the first field in the comment form.
+					if ( formSlot )
+						ref.querySelector( 'form' )
+							.querySelector( focusableSelectors )
+							.focus();
+				},
+			},
+		},
+	},
+} );

--- a/packages/block-library/src/post-comments-form/view.js
+++ b/packages/block-library/src/post-comments-form/view.js
@@ -22,8 +22,9 @@ const { state } = store( 'core/comments', {
 		get showError() {
 			return state.error ? 'flex' : 'none';
 		},
-		get submitText() {
-			const { isSubmitting, loadingText, submitText } = getContext();
+		get submitButtonText() {
+			const { isSubmitting } = getContext();
+			const { loadingText, submitText } = state;
 			return isSubmitting ? loadingText : submitText;
 		},
 		get displayCancelReply() {

--- a/packages/block-library/src/post-comments-form/view.js
+++ b/packages/block-library/src/post-comments-form/view.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { store, navigate } from '@wordpress/interactivity';
+import {
+	getContext,
+	getElement,
+	store,
+	navigate,
+} from '@wordpress/interactivity';
 
 const focusableSelectors = [
 	'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
@@ -11,179 +16,160 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
-store( {
+const { state } = store( 'core/comments', {
 	state: {
-		core: {
-			comments: {
-				error: '',
-			},
+		error: '',
+		get showError() {
+			return state.error ? 'flex' : 'none';
 		},
-	},
-	selectors: {
-		core: {
-			comments: {
-				showError: ( { state } ) =>
-					state.core.comments.error ? 'flex' : 'none',
-				submitText: ( { context, state } ) =>
-					context.core.comments.isSubmitting
-						? state.core.comments.loadingText
-						: state.core.comments.submitText,
-				displayCancelReply: ( { context } ) => {
-					return context.core.comments.formSlot ? undefined : 'none';
-				},
-			},
+		get submitText() {
+			const { isSubmitting, loadingText, submitText } = getContext();
+			return isSubmitting ? loadingText : submitText;
+		},
+		get displayCancelReply() {
+			const { formSlot } = getContext();
+			return formSlot ? undefined : 'none';
 		},
 	},
 	actions: {
-		core: {
-			comments: {
-				submit: async ( { event, context, state, ref } ) => {
-					let response;
-					const existingComments = new Set();
-					const comments = ref.closest( '.wp-block-comments' );
+		submit: async ( event ) => {
+			let response;
+			const context = getContext();
+			const { ref } = getElement();
+			const existingComments = new Set();
+			const comments = ref.closest( '.wp-block-comments' );
+			comments
+				.querySelectorAll( 'li[id^="comment-"]' )
+				.forEach( ( comment ) => existingComments.add( comment.id ) );
+
+			try {
+				event.preventDefault();
+
+				state.error = '';
+				context.isSubmitting = true;
+
+				response = await window.fetch( ref.action, {
+					method: 'POST',
+					body: new window.FormData( ref ),
+				} );
+			} catch ( e ) {
+				// If something fails at this point, the form hasn't been submitted
+				// and we can submit it again manually to the server. This is using
+				// the prototype because ref.submit() could be overwritten by an
+				// `<input name="submit"> element.
+				window.HTMLFormElement.prototype.submit.bind( ref )();
+			}
+
+			try {
+				const html = await response.text();
+				const dom = new window.DOMParser().parseFromString(
+					html,
+					'text/html'
+				);
+
+				if ( response.status !== 200 || dom.body.id === 'error-page' ) {
+					state.error =
+						dom.querySelector( '.wp-die-message' ).innerText;
+				} else {
+					await navigate( response.url, {
+						html,
+						replace: true,
+						force: true,
+					} );
+
+					let newComment;
 					comments
 						.querySelectorAll( 'li[id^="comment-"]' )
-						.forEach( ( comment ) =>
-							existingComments.add( comment.id )
-						);
-
-					try {
-						event.preventDefault();
-
-						state.core.comments.error = '';
-						context.core.comments.isSubmitting = true;
-
-						response = await window.fetch( ref.action, {
-							method: 'POST',
-							body: new window.FormData( ref ),
+						.forEach( ( comment ) => {
+							if ( ! existingComments.has( comment.id ) )
+								newComment = comment;
 						} );
-					} catch ( e ) {
-						// If something fails at this point, the form hasn't been submitted
-						// and we can submit it again manually to the server. This is using
-						// the prototype because ref.submit() could be overwritten by an
-						// `<input name="submit"> element.
-						window.HTMLFormElement.prototype.submit.bind( ref )();
+
+					// Scroll the new comment into view.
+					newComment.querySelector( 'a[href]' ).focus();
+
+					// Announce that the comment has been submitted. If the notice is
+					// the same, we use a no-break space similar to the trick used by
+					// the @wordpress/a11y package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
+					context.notice =
+						state.submittedNotice +
+						( context.notice === state.submittedNotice
+							? '\u00A0'
+							: '' );
+
+					// Add hash to the URL.
+					window.history.replaceState(
+						{},
+						'',
+						window.location.pathname +
+							window.location.search +
+							`#${ newComment.id }`
+					);
+
+					// Reset form fields and position.
+					context.formSlot = undefined;
+					const { fields } = context;
+					for ( const key in fields ) {
+						fields[ key ] = key !== 'comment_parent' ? '' : 0;
 					}
+				}
 
-					try {
-						const html = await response.text();
-						const dom = new window.DOMParser().parseFromString(
-							html,
-							'text/html'
-						);
-
-						if (
-							response.status !== 200 ||
-							dom.body.id === 'error-page'
-						) {
-							state.core.comments.error =
-								dom.querySelector(
-									'.wp-die-message'
-								).innerText;
-						} else {
-							await navigate( response.url, {
-								html,
-								replace: true,
-								force: true,
-							} );
-
-							let newComment;
-							comments
-								.querySelectorAll( 'li[id^="comment-"]' )
-								.forEach( ( comment ) => {
-									if ( ! existingComments.has( comment.id ) )
-										newComment = comment;
-								} );
-
-							// Scroll the new comment into view.
-							newComment.querySelector( 'a[href]' ).focus();
-
-							// Announce that the comment has been submitted. If the notice is
-							// the same, we use a no-break space similar to the trick used by
-							// the @wordpress/a11y package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
-							context.core.comments.notice =
-								state.core.comments.submittedNotice +
-								( context.core.comments.notice ===
-								state.core.comments.submittedNotice
-									? '\u00A0'
-									: '' );
-
-							// Add hash to the URL.
-							window.history.replaceState(
-								{},
-								'',
-								window.location.pathname +
-									window.location.search +
-									`#${ newComment.id }`
-							);
-
-							// Reset form fields and position.
-							context.core.comments.formSlot = undefined;
-							const { fields } = context.core.comments;
-							for ( const key in fields ) {
-								fields[ key ] =
-									key !== 'comment_parent' ? '' : 0;
-							}
-						}
-
-						context.core.comments.isSubmitting = false;
-					} catch ( e ) {
-						// If something happens at this point, the form has been submitted
-						// but we were not able to show it in the screen, so we can just
-						// refresh the page.
-						window.location.assign(
-							response.url || window.location
-						);
-					}
-				},
-				changeReplyTo: ( { context, ref, event } ) => {
-					event.preventDefault();
-					const { commentid, replyto } = ref.dataset;
-					context.core.comments.replyTitle = replyto;
-					context.core.comments.formSlot = `comment-${ commentid }`;
-					context.core.comments.fields.comment_parent = commentid;
-				},
-				cancelReply: ( { context, event } ) => {
-					event.preventDefault();
-					context.core.comments.formSlot = undefined;
-					context.core.comments.fields.comment_parent = 0;
-				},
-				updateField: ( { context, event } ) => {
-					const { name, value } = event.target;
-					context.core.comments.fields[ name ] = value;
-				},
-				updateReplyTitle: ( { context, ref } ) => {
-					if ( context.core.comments.fields.comment_parent !== 0 ) {
-						ref.firstChild.replaceWith(
-							context.core.comments.replyTitle
-						);
-					}
-				},
-			},
+				context.isSubmitting = false;
+			} catch ( e ) {
+				// If something happens at this point, the form has been submitted
+				// but we were not able to show it in the screen, so we can just
+				// refresh the page.
+				window.location.assign( response.url || window.location );
+			}
+		},
+		changeReplyTo: ( event ) => {
+			event.preventDefault();
+			const context = getContext();
+			const { ref } = getElement();
+			const { commentid, replyto } = ref.dataset;
+			context.replyTitle = replyto;
+			context.formSlot = `comment-${ commentid }`;
+			context.fields.comment_parent = commentid;
+		},
+		cancelReply: ( event ) => {
+			event.preventDefault();
+			const context = getContext();
+			context.formSlot = undefined;
+			context.fields.comment_parent = 0;
+		},
+		updateField: ( event ) => {
+			const { name, value } = event.target;
+			const context = getContext();
+			context.fields[ name ] = value;
+		},
+		updateReplyTitle: () => {
+			const context = getContext();
+			const { ref } = getElement();
+			if ( context.fields.comment_parent !== 0 ) {
+				ref.firstChild.replaceWith( context.replyTitle );
+			}
 		},
 	},
-	effects: {
-		core: {
-			comments: {
-				scrollToError: ( st ) => {
-					// Scroll to the error when it's shown.
-					if ( st.state.core.comments.error ) {
-						st.ref.scrollIntoView( {
-							behavior: 'smooth',
-							block: 'end',
-						} );
-					}
-				},
-				scrollOnReply: ( { context, ref } ) => {
-					const { formSlot } = context.core.comments;
+	callbacks: {
+		scrollToError: () => {
+			// Scroll to the error when it's shown.
+			if ( state.error ) {
+				const { ref } = getElement();
+				ref.scrollIntoView( {
+					behavior: 'smooth',
+					block: 'end',
+				} );
+			}
+		},
+		scrollOnReply: () => {
+			const { formSlot } = getContext();
+			const { ref } = getElement();
 
-					// Focus on the first field in the comment form.
-					if ( formSlot )
-						ref.querySelector( 'form' )
-							.querySelector( focusableSelectors )
-							.focus();
-				},
-			},
+			// Focus on the first field in the comment form.
+			if ( formSlot )
+				ref.querySelector( 'form' )
+					.querySelector( focusableSelectors )
+					.focus();
 		},
 	},
 } );

--- a/test/integration/fixtures/blocks/core__comments.json
+++ b/test/integration/fixtures/blocks/core__comments.json
@@ -5,6 +5,7 @@
 		"attributes": {
 			"tagName": "div",
 			"legacy": false,
+			"enhancedSubmission": false,
 			"className": "comments-post-extra"
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__post-comments.json
+++ b/test/integration/fixtures/blocks/core__post-comments.json
@@ -4,7 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
-			"legacy": true
+			"legacy": true,
+			"enhancedSubmission": false
 		},
 		"innerBlocks": []
 	}

--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -19,6 +19,7 @@ module.exports = {
 		image: './packages/block-library/src/image/view.js',
 		file: './packages/block-library/src/file/view.js',
 		search: './packages/block-library/src/search/view.js',
+		comments: './packages/block-library/src/post-comments-form/view.js',
 	},
 	experiments: {
 		outputModule: true,


### PR DESCRIPTION
## What?
Attempt updating #53737 to use the new Store API.

## Why?
As a preparatory step to working on fetching required block styles and scripts upon comment submission.

## How?
By looking at [this diff](https://github.com/WordPress/gutenberg/pull/56764/files) and [this](https://github.com/WordPress/gutenberg/pull/56143/files).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
