### PR TITLE
Interactivity: Use domReady package over DOMContentLoaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55719,6 +55719,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.1.3",
+				"@wordpress/dom-ready": "file:../dom-ready",
 				"deepsignal": "^1.3.6",
 				"preact": "^10.13.2"
 			},
@@ -70867,6 +70868,7 @@
 			"version": "file:packages/interactivity",
 			"requires": {
 				"@preact/signals": "^1.1.3",
+				"@wordpress/dom-ready": "file:../dom-ready",
 				"deepsignal": "^1.3.6",
 				"preact": "^10.13.2"
 			}

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -27,6 +27,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@preact/signals": "^1.1.3",
+		"@wordpress/dom-ready": "file:../dom-ready",
 		"deepsignal": "^1.3.6",
 		"preact": "^10.13.2"
 	},

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -4,6 +4,11 @@
 import registerDirectives from './directives';
 import { init } from './router';
 
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
 export { store } from './store';
 export { directive, getContext, getElement } from './hooks';
 export { navigate, prefetch } from './router';
@@ -11,7 +16,7 @@ export { h as createElement } from 'preact';
 export { useEffect, useContext, useMemo } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';
 
-document.addEventListener( 'DOMContentLoaded', async () => {
+domReady( async () => {
 	registerDirectives();
 	await init();
 } );

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -16,7 +16,9 @@ export { h as createElement } from 'preact';
 export { useEffect, useContext, useMemo } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';
 
-domReady( async () => {
+domReady( () => {
 	registerDirectives();
-	await init();
+	init().catch( ( err ) => {
+		throw err;
+	} );
 } );

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -18,7 +18,5 @@ export { deepSignal } from 'deepsignal';
 
 domReady( () => {
 	registerDirectives();
-	init().catch( ( err ) => {
-		throw err;
-	} );
+	return init();
 } );

--- a/packages/interactivity/tsconfig.json
+++ b/packages/interactivity/tsconfig.json
@@ -6,5 +6,6 @@
 		"checkJs": false,
 		"strict": false
 	},
-	"include": [ "src/**/*" ]
+	"include": [ "src/**/*" ],
+	"references": [ { "path": "../dom-ready" } ]
 }


### PR DESCRIPTION
## What?

Use the `dom-ready` package for Interactivity API initialization.

## Why?

If the interactivity script is loaded after `DOMContentLoaded` (this is easy to trigger as an async import inside another `<script type=module>` tag), the interactivity API is never initialized.


## How?
By using the `dom-ready` package, we ensure that initialization happens regardless of when the script is loaded.

## Testing Instructions

