### PR TITLE
Doc: Added missing label property to FormTokenField

### DIFF
--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -28,7 +28,7 @@ The `value` property is handled in a manner similar to controlled form component
 	onMouseLeave: '(function) Function to call when onMouseLeave is triggered on token.'
 }
 ```
-
+-   `label` - If this property is added, a label will be generated using label property as the content.
 -   `displayTransform` - Function to call to transform tokens for display. (In
     the editor, this is needed to decode HTML entities embedded in tags -
     otherwise entities like `&` in tag names are double-encoded like `&amp;`,


### PR DESCRIPTION
## What?
This change adds the missing `label` property to the FormTokenField component's README.md.

## Why?
All component properties should be listed in the documentation. 

## How?
Simply updating the README.md file.

## Testing Instructions
1. Open the `FormTokenField` component's README.md file
2. You should see the new `label` property listed