### PR TITLE
Fix: Fatal php error if a template was created by an author that was deleted.

### DIFF
--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -91,7 +91,11 @@ function _gutenberg_get_wp_templates_author_text_field( $template_object ) {
 		case 'site':
 			return get_bloginfo( 'name' );
 		case 'user':
-			return get_user_by( 'id', $template_object['author'] )->get( 'display_name' );
+			$author = get_user_by( 'id', $template_object['author'] );
+			if ( ! $author ) {
+				return __( 'Unknown author', 'gutenberg' );
+			}
+			return $author->get( 'display_name' );
 	}
 }
 


### PR DESCRIPTION
Fixes a fatal php error if a template was created by an author that was deleted.
cc: @fullofcaffeine 

## Testing
I'm not being able to test this scenario in the UI as when we delete a user the UI forces content deletion, or attribution to another author. But I guess it may happen and it is good to have this safe guard.