### PR TITLE
Fix e2e test: update how we find the template title to match markup changes

### DIFF
--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -33,10 +33,7 @@ test.describe( 'Templates', () => {
 				name: 'Template',
 				includeHidden: true,
 			} )
-			.getByRole( 'heading', {
-				level: 3,
-				includeHidden: true,
-			} )
+			.getByRole( 'link', { includeHidden: true } )
 			.first();
 		await expect( firstTitle ).toHaveText( 'Tag Archives' );
 		// Ascending by title.
@@ -57,7 +54,7 @@ test.describe( 'Templates', () => {
 		await page.keyboard.type( 'tag' );
 		const titles = page
 			.getByRole( 'region', { name: 'Template' } )
-			.getByRole( 'heading', { level: 3 } );
+			.getByRole( 'link' );
 		await expect( titles ).toHaveCount( 1 );
 		await expect( titles.first() ).toHaveText( 'Tag Archives' );
 		await page.getByRole( 'button', { name: 'Reset filters' } ).click();


### PR DESCRIPTION
Fixes e2e tests that started failing after https://github.com/WordPress/gutenberg/pull/56955

56955 changed the markup of an element that was used by the e2e tests. This PR updates the tests accordingly.