### PR TITLE
Components: replace `TabPanel` with `Tabs` in the Block Inspector

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { TabPanel } from '@wordpress/components';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,6 +14,9 @@ import SettingsTab from './settings-tab';
 import StylesTab from './styles-tab';
 import InspectorControls from '../inspector-controls';
 import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
+import { unlock } from '../../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 export default function InspectorControlsTabs( {
 	blockName,
@@ -26,34 +32,40 @@ export default function InspectorControlsTabs( {
 	const initialTabName = ! useIsListViewTabDisabled( blockName )
 		? TAB_LIST_VIEW.name
 		: undefined;
+
 	return (
-		<TabPanel
-			className="block-editor-block-inspector__tabs"
-			tabs={ tabs }
-			initialTabName={ initialTabName }
-			key={ clientId }
-		>
-			{ ( tab ) => {
-				if ( tab.name === TAB_SETTINGS.name ) {
-					return (
-						<SettingsTab showAdvancedControls={ !! blockName } />
-					);
-				}
-
-				if ( tab.name === TAB_STYLES.name ) {
-					return (
-						<StylesTab
-							blockName={ blockName }
-							clientId={ clientId }
-							hasBlockStyles={ hasBlockStyles }
+		<div className="block-editor-block-inspector__tabs">
+			<Tabs initialTabId={ initialTabName } key={ clientId }>
+				<Tabs.TabList>
+					{ tabs.map( ( tab ) => (
+						<Tabs.Tab
+							key={ tab.name }
+							tabId={ tab.name }
+							render={
+								<Button
+									icon={ tab.icon }
+									label={ tab.title }
+									className={ tab.className }
+									showTooltip
+								/>
+							}
 						/>
-					);
-				}
-
-				if ( tab.name === TAB_LIST_VIEW.name ) {
-					return <InspectorControls.Slot group="list" />;
-				}
-			} }
-		</TabPanel>
+					) ) }
+				</Tabs.TabList>
+				<Tabs.TabPanel tabId={ TAB_SETTINGS.name }>
+					<SettingsTab showAdvancedControls={ !! blockName } />
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId={ TAB_STYLES.name }>
+					<StylesTab
+						blockName={ blockName }
+						clientId={ clientId }
+						hasBlockStyles={ hasBlockStyles }
+					/>
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId={ TAB_LIST_VIEW.name }>
+					<InspectorControls.Slot group="list" />
+				</Tabs.TabPanel>
+			</Tabs>
+		</div>
 	);
 }

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -52,17 +52,17 @@ export default function InspectorControlsTabs( {
 						/>
 					) ) }
 				</Tabs.TabList>
-				<Tabs.TabPanel tabId={ TAB_SETTINGS.name }>
+				<Tabs.TabPanel tabId={ TAB_SETTINGS.name } focusable={ false }>
 					<SettingsTab showAdvancedControls={ !! blockName } />
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId={ TAB_STYLES.name }>
+				<Tabs.TabPanel tabId={ TAB_STYLES.name } focusable={ false }>
 					<StylesTab
 						blockName={ blockName }
 						clientId={ clientId }
 						hasBlockStyles={ hasBlockStyles }
 					/>
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId={ TAB_LIST_VIEW.name }>
+				<Tabs.TabPanel tabId={ TAB_LIST_VIEW.name } focusable={ false }>
 					<InspectorControls.Slot group="list" />
 				</Tabs.TabPanel>
 			</Tabs>

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -43,6 +43,7 @@ export default function InspectorControlsTabs( {
 							tabId={ tab.name }
 							render={
 								<Button
+									aria-label={ tab.title }
 									icon={ tab.icon }
 									label={ tab.title }
 									className={ tab.className }

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -43,11 +43,9 @@ export default function InspectorControlsTabs( {
 							tabId={ tab.name }
 							render={
 								<Button
-									aria-label={ tab.title }
 									icon={ tab.icon }
 									label={ tab.title }
 									className={ tab.className }
-									showTooltip
 								/>
 							}
 						/>

--- a/packages/block-editor/src/components/inspector-controls-tabs/style.scss
+++ b/packages/block-editor/src/components/inspector-controls-tabs/style.scss
@@ -1,5 +1,5 @@
 .show-icon-labels {
-	.block-editor-block-inspector__tabs .components-tab-panel__tabs {
+	.block-editor-block-inspector__tabs [role="tablist"] {
 		.components-button.has-icon {
 			// Hide the button icons when labels are set to display...
 			svg {


### PR DESCRIPTION
## What?
Replaces the legacy TabPanel component with the new Tabs component.

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

## How?
`TabPanel` is replaced by `Tabs` and its sub-components.

## Testing Instructions
1. Create a new post
2. Add a Cover Block
3. In the editor settings sidebar, test the **Settings** and **Styles** tabs, confirming that they both load the correct content.
4. Add another Cover Block
5. Select the **Styles** tab
6. Select the _other_ Cover Block
7. Confirm that when switching between blocks, even if they're of the same type, the first tab (in this case **Settings**) is always selected by default
8. Add a Navigation block
9. Confirm that the **List View** tab is selected by default whenever you select the Navigation block
10. Finally, use your browser inspector to add the `show-icon-labels` class to the page's `body` tag. Confirm that the tab icons are replaced with the appropriate labels.

### Testing Instructions for Keyboard
1. Create a new post with a Navigation Block in it
2. Starting with the focus on your Navigation Block, press [Tab] three times, and confirm that this places focus on the currently selected Block Inspector tab (in this case that should be **List View**
3. Confirm that arrow keys navigate through the different tabs
4. Press [Tab] a few more times. Confirm that focus goes to the next focusable element in the sidebar (the **Layout** panel title) and that it does _not_  focus the `tabpanel` itself