### PR TITLE
Background image support: Fix duplicate output of styling rules

### DIFF
--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -103,4 +103,7 @@ WP_Block_Supports::get_instance()->register(
 	)
 );
 
+if ( function_exists( 'wp_render_background_support' ) ) {
+	remove_filter( 'render_block', 'wp_render_background_support' );
+}
 add_filter( 'render_block', 'gutenberg_render_background_support', 10, 2 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/54336

Fix duplicate output of background image styling rules for the Group block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As of WP 6.4, the background image block support exists in core as well as in the Gutenberg plugin. Unlike the other block supports, in Gutenberg, we were missing the `remove_filter` line to switch off the core behaviour if present, to prioritise the Gutenberg behaviour and allow further development of the block support within the plugin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `remove_filter` line to disable core's callback for the background support if present

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Test with WP 6.4+

Prior to applying this PR, add a post or page with a Group block and set a background image for it. Save and view the site frontend, and inspect the generated markup — notice that the `background-image` and `background-size:cover` rules are duplicated.

With this PR applied, there should only be one `background-image` and `background-size:cover` rule in the generated markup.

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/WordPress/gutenberg/assets/14988353/3adb97f2-d943-47d5-b41a-411db6a3f326)

### After

![image](https://github.com/WordPress/gutenberg/assets/14988353/53392412-2279-49a2-9eaa-56a2a982b3b9)

