### PR TITLE
`CustomSelect`: Add `WordPressComponentsProps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Experimental
 
 -   `Tabs`: implement new `tabId` prop ([#56883](https://github.com/WordPress/gutenberg/pull/56883)).
+-   `CustomSelect`: add `WordPressComponentsProps` for more flexibility ([#56998](https://github.com/WordPress/gutenberg/pull/56998))
 
 ### Experimental
 

--- a/packages/components/src/custom-select-control-v2/index.tsx
+++ b/packages/components/src/custom-select-control-v2/index.tsx
@@ -42,17 +42,16 @@ function defaultRenderSelectedValue( value: CustomSelectProps[ 'value' ] ) {
 	return value;
 }
 
-export function CustomSelect( props: CustomSelectProps ) {
-	const {
-		children,
-		defaultValue,
-		label,
-		onChange,
-		size = 'default',
-		value,
-		renderSelectedValue = defaultRenderSelectedValue,
-	} = props;
-
+export function CustomSelect( {
+	children,
+	defaultValue,
+	label,
+	onChange,
+	size = 'default',
+	value,
+	renderSelectedValue = defaultRenderSelectedValue,
+	...props
+}: WordPressComponentProps< CustomSelectProps, 'button', false > ) {
 	const store = Ariakit.useSelectStore( {
 		setValue: ( nextValue ) => onChange?.( nextValue ),
 		defaultValue,
@@ -67,6 +66,7 @@ export function CustomSelect( props: CustomSelectProps ) {
 				{ label }
 			</Styled.CustomSelectLabel>
 			<Styled.CustomSelectButton
+				{ ...props }
 				size={ size }
 				hasCustomRenderProp={ !! renderSelectedValue }
 				store={ store }

--- a/packages/components/src/custom-select-control-v2/index.tsx
+++ b/packages/components/src/custom-select-control-v2/index.tsx
@@ -18,6 +18,7 @@ import type {
 	CustomSelectItemProps,
 	CustomSelectContext as CustomSelectContextType,
 } from './types';
+import type { WordPressComponentProps } from '../context';
 
 export const CustomSelectContext =
 	createContext< CustomSelectContextType >( undefined );
@@ -85,7 +86,7 @@ export function CustomSelect( props: CustomSelectProps ) {
 export function CustomSelectItem( {
 	children,
 	...props
-}: CustomSelectItemProps ) {
+}: WordPressComponentProps< CustomSelectItemProps, 'div', false > ) {
 	const customSelectContext = useContext( CustomSelectContext );
 	return (
 		<Styled.CustomSelectItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #55023 

Adding `WordPressComponentProps` for more flexibility in adding props. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To be able to add HTML attributes to CustomSelect and CustomSelectItem, the child items of CustomSelect. This will also be useful when adapting this to the legacy version. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding `WordPressComponentProps` to inherit html attributes from a `div` element

## Testing Instructions

1. Add a valid html attribute for a `button` to `CustomSelect` i.e. `onBlur`
2. Add a valid html attribute for a div to a `CustomSelectItem` i.e. `className`
3. Check there are no type errors and that it renders as expected 