### PR TITLE
Fix form token field suggestion list reopening after blurring the input

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -35,6 +35,7 @@
 -   `ToolsPanel`: fix a performance issue ([#56770](https://github.com/WordPress/gutenberg/pull/56770)).
 -   `BorderControl`: adjust `BorderControlDropdown` Button size to fix misaligned border ([#56730](https://github.com/WordPress/gutenberg/pull/56730)).
 -   `SlotFillProvider`: Restore contextual Slot/Fills within SlotFillProvider ([#56779](https://github.com/WordPress/gutenberg/pull/56779)).
+-   `FormTokenField`: Fix a regression where the suggestion list would re-open after clicking away from the input ([#57002](https://github.com/WordPress/gutenberg/pull/57002)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fix
 
 -   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
+-   `FormTokenField`: Fix a regression where the suggestion list would re-open after clicking away from the input ([#57002](https://github.com/WordPress/gutenberg/pull/57002)).
 
 ## 25.14.0 (2023-12-13)
 
@@ -35,7 +36,6 @@
 -   `ToolsPanel`: fix a performance issue ([#56770](https://github.com/WordPress/gutenberg/pull/56770)).
 -   `BorderControl`: adjust `BorderControlDropdown` Button size to fix misaligned border ([#56730](https://github.com/WordPress/gutenberg/pull/56730)).
 -   `SlotFillProvider`: Restore contextual Slot/Fills within SlotFillProvider ([#56779](https://github.com/WordPress/gutenberg/pull/56779)).
--   `FormTokenField`: Fix a regression where the suggestion list would re-open after clicking away from the input ([#57002](https://github.com/WordPress/gutenberg/pull/57002)).
 
 ### Internal
 

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -177,13 +177,13 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			setInputOffsetFromEnd( 0 );
 			setIsActive( false );
 
-			// If `__experimentalExpandOnFocus` is true, don't close the suggestions list when
-			// the user clicks on it (`tokensAndInput` will be the element that caused the blur).
-			const shouldKeepSuggestionsExpanded =
-				! __experimentalExpandOnFocus ||
-				( __experimentalExpandOnFocus &&
-					event.relatedTarget === tokensAndInput.current );
-			setIsExpanded( shouldKeepSuggestionsExpanded );
+			if ( __experimentalExpandOnFocus ) {
+				// If `__experimentalExpandOnFocus` is true, don't close the suggestions list when
+				// the user clicks on it (`tokensAndInput` will be the element that caused the blur).
+				setIsExpanded( event.relatedTarget === tokensAndInput.current );
+			} else {
+				setIsExpanded( false );
+			}
 
 			setSelectedSuggestionIndex( -1 );
 			setSelectedSuggestionScroll( false );

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -180,8 +180,12 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			if ( __experimentalExpandOnFocus ) {
 				// If `__experimentalExpandOnFocus` is true, don't close the suggestions list when
 				// the user clicks on it (`tokensAndInput` will be the element that caused the blur).
-				setIsExpanded( event.relatedTarget === tokensAndInput.current );
+				const hasFocusWithin =
+					event.relatedTarget === tokensAndInput.current;
+				setIsExpanded( hasFocusWithin );
 			} else {
+				// Else collapse the suggestion list. This will result in the suggestion list closing
+				// after a suggestion has been submitted since that causes a blur.
 				setIsExpanded( false );
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a regression caused by #56426. Fixes #57085.

That PR accidentally changed the behavior of `FormTokenField` when `__experimentalExpandOnFocus` isn't defined, and it should have retained the existing behavior.

It results in the suggestion list unexpectedly reopening after selecting a suggestion and then blurring the input. 

## How?
I've adjusted the boolean logic that was previously in place to instead use an if statement that should make the code much more readable.

## Testing Instructions
Prerequisite: Ensure you already have some post tags defined
1. Create a new Post
2. Open the Post sidebar
3. Start typing the name of one of the tags
4. Click the suggestion that appears
5. Now click outside of the field to trigger a blur

In Trunk: The suggestion list closes and then reopens
In this PR: The suggestion list remains closed

## Screenshots or screencast <!-- if applicable -->
### Before
https://github.com/WordPress/gutenberg/assets/677833/aff86a0e-4661-4c46-bd01-a5237319a1c9

### After
https://github.com/WordPress/gutenberg/assets/677833/6e2b281a-7b0e-4de2-8c52-67298c33faf5
