### PR TITLE
Background image: Add backgroundSize and repeat features

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -341,7 +341,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage), color (background, button, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, tagName, templateLock
 
 ## Heading

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -341,7 +341,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundRepeat, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, tagName, templateLock
 
 ## Heading

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -341,7 +341,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundRepeat, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, tagName, templateLock
 
 ## Heading

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -54,6 +54,7 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	$background_image_source = $block_attributes['style']['background']['backgroundImage']['source'] ?? null;
 	$background_image_url    = $block_attributes['style']['background']['backgroundImage']['url'] ?? null;
 	$background_size         = $block_attributes['style']['background']['backgroundSize'] ?? 'cover';
+	$background_repeat       = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
 
 	$background_block_styles = array();
 
@@ -64,8 +65,9 @@ function gutenberg_render_background_support( $block_content, $block ) {
 		// Set file based background URL.
 		// TODO: In a follow-up, similar logic could be added to inject a featured image url.
 		$background_block_styles['backgroundImage']['url'] = $background_image_url;
-		// Only output the background size when an image url is set.
-		$background_block_styles['backgroundSize'] = $background_size;
+		// Only output the background size and repeat when an image url is set.
+		$background_block_styles['backgroundSize']   = $background_size;
+		$background_block_styles['backgroundRepeat'] = $background_repeat;
 	}
 
 	$styles = gutenberg_style_engine_get_styles( array( 'background' => $background_block_styles ) );

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -54,6 +54,7 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	$background_image_source = $block_attributes['style']['background']['backgroundImage']['source'] ?? null;
 	$background_image_url    = $block_attributes['style']['background']['backgroundImage']['url'] ?? null;
 	$background_size         = $block_attributes['style']['background']['backgroundSize'] ?? 'cover';
+	$background_position     = $block_attributes['style']['background']['backgroundPosition'] ?? null;
 	$background_repeat       = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
 
 	$background_block_styles = array();
@@ -66,8 +67,14 @@ function gutenberg_render_background_support( $block_content, $block ) {
 		// TODO: In a follow-up, similar logic could be added to inject a featured image url.
 		$background_block_styles['backgroundImage']['url'] = $background_image_url;
 		// Only output the background size and repeat when an image url is set.
-		$background_block_styles['backgroundSize']   = $background_size;
-		$background_block_styles['backgroundRepeat'] = $background_repeat;
+		$background_block_styles['backgroundSize']     = $background_size;
+		$background_block_styles['backgroundRepeat']   = $background_repeat;
+		$background_block_styles['backgroundPosition'] = $background_position;
+
+		// If the background size is set to `contain` and no position is set, set the position to `center`.
+		if ( 'contain' === $background_size && ! isset( $background_position ) ) {
+			$background_block_styles['backgroundPosition'] = 'center';
+		}
 	}
 
 	$styles = gutenberg_style_engine_get_styles( array( 'background' => $background_block_styles ) );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -354,6 +354,7 @@ class WP_Theme_JSON_Gutenberg {
 		'useRootPaddingAwareAlignments' => null,
 		'background'                    => array(
 			'backgroundImage' => null,
+			'backgroundSize'  => null,
 		),
 		'border'                        => array(
 			'color'  => null,
@@ -650,6 +651,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const APPEARANCE_TOOLS_OPT_INS = array(
 		array( 'background', 'backgroundImage' ),
+		array( 'background', 'backgroundSize' ),
 		array( 'border', 'color' ),
 		array( 'border', 'radius' ),
 		array( 'border', 'style' ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -353,9 +353,8 @@ class WP_Theme_JSON_Gutenberg {
 		'appearanceTools'               => null,
 		'useRootPaddingAwareAlignments' => null,
 		'background'                    => array(
-			'backgroundImage'  => null,
-			'backgroundRepeat' => null,
-			'backgroundSize'   => null,
+			'backgroundImage' => null,
+			'backgroundSize'  => null,
 		),
 		'border'                        => array(
 			'color'  => null,
@@ -652,7 +651,6 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const APPEARANCE_TOOLS_OPT_INS = array(
 		array( 'background', 'backgroundImage' ),
-		array( 'background', 'backgroundRepeat' ),
 		array( 'background', 'backgroundSize' ),
 		array( 'border', 'color' ),
 		array( 'border', 'radius' ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -353,8 +353,9 @@ class WP_Theme_JSON_Gutenberg {
 		'appearanceTools'               => null,
 		'useRootPaddingAwareAlignments' => null,
 		'background'                    => array(
-			'backgroundImage' => null,
-			'backgroundSize'  => null,
+			'backgroundImage'  => null,
+			'backgroundRepeat' => null,
+			'backgroundSize'   => null,
 		),
 		'border'                        => array(
 			'color'  => null,
@@ -651,6 +652,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const APPEARANCE_TOOLS_OPT_INS = array(
 		array( 'background', 'backgroundImage' ),
+		array( 'background', 'backgroundRepeat' ),
 		array( 'background', 'backgroundSize' ),
 		array( 'border', 'color' ),
 		array( 'border', 'radius' ),

--- a/lib/compat/wordpress-6.5/kses.php
+++ b/lib/compat/wordpress-6.5/kses.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Temporary compatibility shims for block APIs present in Gutenberg.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Update allowed inline style attributes list.
+ *
+ * @param string[] $attrs Array of allowed CSS attributes.
+ * @return string[] CSS attributes.
+ */
+function gutenberg_safe_style_attrs_6_5( $attrs ) {
+	$attrs[] = 'background-repeat';
+	return $attrs;
+}
+add_filter( 'safe_style_css', 'gutenberg_safe_style_attrs_6_5' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -104,6 +104,7 @@ require __DIR__ . '/compat/wordpress-6.4/kses.php';
 // WordPress 6.5 compat.
 require __DIR__ . '/compat/wordpress-6.5/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.5/class-wp-navigation-block-renderer.php';
+require __DIR__ . '/compat/wordpress-6.5/kses.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -24,6 +24,8 @@ const EMPTY_CONFIG = { settings: {}, styles: {} };
 const VALID_SETTINGS = [
 	'appearanceTools',
 	'useRootPaddingAwareAlignments',
+	'background.backgroundImage',
+	'background.backgroundSize',
 	'border.color',
 	'border.radius',
 	'border.style',

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -25,6 +25,7 @@ const VALID_SETTINGS = [
 	'appearanceTools',
 	'useRootPaddingAwareAlignments',
 	'background.backgroundImage',
+	'background.backgroundRepeat',
 	'background.backgroundSize',
 	'border.color',
 	'border.radius',

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -397,9 +397,9 @@ function BackgroundSizePanelItem( { clientId, setAttributes } ) {
 					label={ __( 'Contain' ) }
 				/>
 				<ToggleGroupControlOption
-					key={ 'fixed' }
-					value={ 'fixed' }
-					label={ __( 'Fixed' ) }
+					key={ 'repeat' }
+					value={ 'auto' }
+					label={ __( 'Repeat' ) }
 				/>
 			</ToggleGroupControl>
 		</ToolsPanelItem>

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -13,6 +13,8 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalUnitControl as UnitControl,
+	__experimentalVStack as VStack,
 	DropZone,
 	FlexItem,
 	MenuItem,
@@ -334,6 +336,16 @@ function BackgroundImagePanelItem( { clientId, setAttributes } ) {
 	);
 }
 
+function backgroundSizeHelpText( value ) {
+	if ( value === 'cover' ) {
+		return __( 'Stretch image to cover the block.' );
+	}
+	if ( value === 'contain' ) {
+		return __( 'Image is contained within the block.' );
+	}
+	return __( 'Repeat the image, and set a fixed size.' );
+}
+
 function BackgroundSizePanelItem( { clientId, setAttributes } ) {
 	const style = useSelect(
 		( select ) =>
@@ -358,12 +370,34 @@ function BackgroundSizePanelItem( { clientId, setAttributes } ) {
 		};
 	}, [] );
 
+	const updateBackgroundSize = ( next ) => {
+		setAttributes( {
+			style: cleanEmptyObject( {
+				...style,
+				background: {
+					...style?.background,
+					backgroundSize: next,
+				},
+			} ),
+		} );
+	};
+
+	const currentValueForToggle =
+		value !== undefined &&
+		value !== 'cover' &&
+		value !== 'contain' &&
+		value !== ''
+			? 'auto'
+			: value || 'cover';
+
 	return (
-		<ToolsPanelItem
+		<VStack
+			as={ ToolsPanelItem }
+			spacing={ 2 }
 			className="single-column"
 			hasValue={ () => hasValue }
 			label={ __( 'Background size' ) }
-			onDeselect={ () => resetBackgroundImage( style, setAttributes ) }
+			onDeselect={ () => resetBackgroundSize( style, setAttributes ) }
 			isShownByDefault={ true }
 			resetAllFilter={ resetAllFilter }
 			panelId={ clientId }
@@ -372,19 +406,10 @@ function BackgroundSizePanelItem( { clientId, setAttributes } ) {
 				__nextHasNoMarginBottom
 				size={ '__unstable-large' }
 				label={ __( 'Background size' ) }
-				value={ value || 'cover' }
-				onChange={ ( next ) => {
-					setAttributes( {
-						style: cleanEmptyObject( {
-							...style,
-							background: {
-								...style?.background,
-								backgroundSize: next,
-							},
-						} ),
-					} );
-				} }
+				value={ currentValueForToggle }
+				onChange={ updateBackgroundSize }
 				isBlock={ true }
+				help={ backgroundSizeHelpText( value ) }
 			>
 				<ToggleGroupControlOption
 					key={ 'cover' }
@@ -402,7 +427,16 @@ function BackgroundSizePanelItem( { clientId, setAttributes } ) {
 					label={ __( 'Repeat' ) }
 				/>
 			</ToggleGroupControl>
-		</ToolsPanelItem>
+			{ value !== undefined &&
+			value !== 'cover' &&
+			value !== 'contain' ? (
+				<UnitControl
+					size={ '__unstable-large' }
+					onChange={ updateBackgroundSize }
+					value={ value }
+				/>
+			) : null }
+		</VStack>
 	);
 }
 

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -347,7 +347,7 @@ function backgroundSizeHelpText( value ) {
 	if ( value === 'contain' ) {
 		return __( 'Image is contained within the block.' );
 	}
-	return __( 'Repeat the image, and set a fixed size.' );
+	return __( 'Repeat the image, and set a fixed width.' );
 }
 
 function BackgroundSizePanelItem( {

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -517,9 +517,9 @@ function BackgroundSizePanelItem( {
 					label={ __( 'Contain' ) }
 				/>
 				<ToggleGroupControlOption
-					key={ 'size' }
+					key={ 'fixed' }
 					value={ 'auto' }
-					label={ __( 'Size' ) }
+					label={ __( 'Fixed' ) }
 				/>
 			</ToggleGroupControl>
 			{ value !== undefined &&

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -176,7 +176,11 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 	);
 }
 
-function BackgroundImagePanelItem( { clientId, setAttributes } ) {
+function BackgroundImagePanelItem( {
+	clientId,
+	isShownByDefault,
+	setAttributes,
+} ) {
 	const { style, mediaUpload } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } =
@@ -286,7 +290,7 @@ function BackgroundImagePanelItem( { clientId, setAttributes } ) {
 			hasValue={ () => hasValue }
 			label={ __( 'Background image' ) }
 			onDeselect={ () => resetBackgroundImage( style, setAttributes ) }
-			isShownByDefault={ true }
+			isShownByDefault={ isShownByDefault }
 			resetAllFilter={ resetAllFilter }
 			panelId={ clientId }
 		>
@@ -346,7 +350,11 @@ function backgroundSizeHelpText( value ) {
 	return __( 'Repeat the image, and set a fixed size.' );
 }
 
-function BackgroundSizePanelItem( { clientId, setAttributes } ) {
+function BackgroundSizePanelItem( {
+	clientId,
+	isShownByDefault,
+	setAttributes,
+} ) {
 	const style = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
@@ -398,7 +406,7 @@ function BackgroundSizePanelItem( { clientId, setAttributes } ) {
 			hasValue={ () => hasValue }
 			label={ __( 'Background size' ) }
 			onDeselect={ () => resetBackgroundSize( style, setAttributes ) }
-			isShownByDefault={ true }
+			isShownByDefault={ isShownByDefault }
 			resetAllFilter={ resetAllFilter }
 			panelId={ clientId }
 		>
@@ -457,10 +465,23 @@ export function BackgroundImagePanel( props ) {
 		backgroundSize && hasBackgroundSupport( props.name, 'backgroundSize' )
 	);
 
+	const defaultControls = getBlockSupport( props.name, [
+		BACKGROUND_SUPPORT_KEY,
+		'__experimentalDefaultControls',
+	] );
+
 	return (
 		<InspectorControls group="background">
-			<BackgroundImagePanelItem { ...props } />
-			{ showBackgroundSize && <BackgroundSizePanelItem { ...props } /> }
+			<BackgroundImagePanelItem
+				isShownByDefault={ defaultControls?.backgroundImage }
+				{ ...props }
+			/>
+			{ showBackgroundSize && (
+				<BackgroundSizePanelItem
+					isShownByDefault={ defaultControls?.backgroundSize }
+					{ ...props }
+				/>
+			) }
 		</InspectorControls>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -64,7 +64,7 @@ export function hasBackgroundImageValue( style ) {
  * @return {boolean}     Whether or not the block has a background size value set.
  */
 export function hasBackgroundSizeValue( style ) {
-	return !! style?.background?.backgroundSize;
+	return style?.background?.backgroundSize !== undefined;
 }
 
 /**
@@ -341,7 +341,7 @@ function BackgroundImagePanelItem( {
 }
 
 function backgroundSizeHelpText( value ) {
-	if ( value === 'cover' ) {
+	if ( value === 'cover' || value === undefined ) {
 		return __( 'Stretch image to cover the block.' );
 	}
 	if ( value === 'contain' ) {
@@ -390,11 +390,13 @@ function BackgroundSizePanelItem( {
 		} );
 	};
 
+	// An `undefined` value is treated as `cover` by the toggle group control.
+	// An empty string is treated as `auto` by the toggle group control. This
+	// allows a user to select "Size" and then enter a custom value, with an
+	// empty value being treated as `auto`.
 	const currentValueForToggle =
-		value !== undefined &&
-		value !== 'cover' &&
-		value !== 'contain' &&
-		value !== ''
+		( value !== undefined && value !== 'cover' && value !== 'contain' ) ||
+		value === ''
 			? 'auto'
 			: value || 'cover';
 
@@ -430,9 +432,9 @@ function BackgroundSizePanelItem( {
 					label={ __( 'Contain' ) }
 				/>
 				<ToggleGroupControlOption
-					key={ 'repeat' }
+					key={ 'size' }
 					value={ 'auto' }
-					label={ __( 'Repeat' ) }
+					label={ __( 'Size' ) }
 				/>
 			</ToggleGroupControl>
 			{ value !== undefined &&

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -409,7 +409,19 @@ function BackgroundSizePanelItem( {
 
 	const updateBackgroundSize = ( next ) => {
 		// When switching to 'contain' toggle the repeat off.
-		const nextRepeat = next === 'contain' ? 'no-repeat' : undefined;
+		let nextRepeat = repeatValue;
+
+		if ( next === 'contain' ) {
+			nextRepeat = 'no-repeat';
+		}
+
+		if (
+			( currentValueForToggle === 'cover' ||
+				currentValueForToggle === 'contain' ) &&
+			next === 'auto'
+		) {
+			nextRepeat = undefined;
+		}
 
 		setAttributes( {
 			style: cleanEmptyObject( {
@@ -482,12 +494,14 @@ function BackgroundSizePanelItem( {
 					value={ sizeValue }
 				/>
 			) : null }
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Repeat image' ) }
-				checked={ repeatCheckedValue }
-				onChange={ toggleIsRepeated }
-			/>
+			{ currentValueForToggle !== 'cover' && (
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Repeat image' ) }
+					checked={ repeatCheckedValue }
+					onChange={ toggleIsRepeated }
+				/>
+			) }
 		</VStack>
 	);
 }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -118,32 +118,13 @@ export function resetBackgroundImage( style = {}, setAttributes ) {
 }
 
 /**
- * Resets the background repeat block support attributes. This can be used when disabling
- * the background repeat controls for a block via a `ToolsPanel`.
- *
- * @param {Object}   style         Style attribute.
- * @param {Function} setAttributes Function to set block's attributes.
- */
-export function resetBackgroundRepeat( style = {}, setAttributes ) {
-	setAttributes( {
-		style: cleanEmptyObject( {
-			...style,
-			background: {
-				...style?.background,
-				backgroundRepeat: undefined,
-			},
-		} ),
-	} );
-}
-
-/**
  * Resets the background size block support attributes. This can be used when disabling
  * the background size controls for a block via a `ToolsPanel`.
  *
  * @param {Object}   style         Style attribute.
  * @param {Function} setAttributes Function to set block's attributes.
  */
-export function resetBackgroundSize( style = {}, setAttributes ) {
+function resetBackgroundSize( style = {}, setAttributes ) {
 	setAttributes( {
 		style: cleanEmptyObject( {
 			...style,

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -174,6 +174,8 @@ export function useStyleOverride( { id, css, assets, __unstableType } = {} ) {
  */
 export function useBlockSettings( name, parentLayout ) {
 	const [
+		backgroundImage,
+		backgroundSize,
 		fontFamilies,
 		fontSizes,
 		customFontSize,
@@ -217,6 +219,8 @@ export function useBlockSettings( name, parentLayout ) {
 		isHeadingEnabled,
 		isButtonEnabled,
 	] = useSettings(
+		'background.backgroundImage',
+		'background.backgroundSize',
 		'typography.fontFamilies',
 		'typography.fontSizes',
 		'typography.customFontSize',
@@ -263,6 +267,10 @@ export function useBlockSettings( name, parentLayout ) {
 
 	const rawSettings = useMemo( () => {
 		return {
+			background: {
+				backgroundImage,
+				backgroundSize,
+			},
 			color: {
 				palette: {
 					custom: customColors,
@@ -330,6 +338,8 @@ export function useBlockSettings( name, parentLayout ) {
 			parentLayout,
 		};
 	}, [
+		backgroundImage,
+		backgroundSize,
 		fontFamilies,
 		fontSizes,
 		customFontSize,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -29,7 +29,8 @@
 		"ariaLabel": true,
 		"html": false,
 		"background": {
-			"backgroundImage": true
+			"backgroundImage": true,
+			"backgroundSize": true
 		},
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -30,6 +30,7 @@
 		"html": false,
 		"background": {
 			"backgroundImage": true,
+			"backgroundRepeat": true,
 			"backgroundSize": true,
 			"__experimentalDefaultControls": {
 				"backgroundImage": true

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -30,7 +30,6 @@
 		"html": false,
 		"background": {
 			"backgroundImage": true,
-			"backgroundRepeat": true,
 			"backgroundSize": true,
 			"__experimentalDefaultControls": {
 				"backgroundImage": true

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -30,7 +30,10 @@
 		"html": false,
 		"background": {
 			"backgroundImage": true,
-			"backgroundSize": true
+			"backgroundSize": true,
+			"__experimentalDefaultControls": {
+				"backgroundImage": true
+			}
 		},
 		"color": {
 			"gradients": true,

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -31,6 +31,11 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		requiresOptOut: true,
 		useEngine: true,
 	},
+	backgroundSize: {
+		value: [ 'background', 'backgroundSize' ],
+		support: [ 'background', 'backgroundSize' ],
+		useEngine: true,
+	},
 	borderColor: {
 		value: [ 'border', 'color' ],
 		support: [ '__experimentalBorder', 'color' ],

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -31,6 +31,11 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		requiresOptOut: true,
 		useEngine: true,
 	},
+	backgroundRepeat: {
+		value: [ 'background', 'backgroundRepeat' ],
+		support: [ 'background', 'backgroundRepeat' ],
+		useEngine: true,
+	},
 	backgroundSize: {
 		value: [ 'background', 'backgroundSize' ],
 		support: [ 'background', 'backgroundSize' ],

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -51,6 +51,12 @@ final class WP_Style_Engine {
 				'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
 				'path'          => array( 'background', 'backgroundImage' ),
 			),
+			'backgroundRepeat'  => array(
+				'property_keys' => array(
+					'default' => 'background-repeat',
+				),
+				'path'          => array( 'background', 'backgroundRepeat' ),
+			),
 			'backgroundSize'  => array(
 				'property_keys' => array(
 					'default' => 'background-size',

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -44,26 +44,26 @@ final class WP_Style_Engine {
 	 */
 	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
 		'background' => array(
-			'backgroundImage' => array(
+			'backgroundImage'    => array(
 				'property_keys' => array(
 					'default' => 'background-image',
 				),
 				'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
 				'path'          => array( 'background', 'backgroundImage' ),
 			),
-			'backgroundPosition'  => array(
+			'backgroundPosition' => array(
 				'property_keys' => array(
 					'default' => 'background-position',
 				),
 				'path'          => array( 'background', 'backgroundPosition' ),
 			),
-			'backgroundRepeat'  => array(
+			'backgroundRepeat'   => array(
 				'property_keys' => array(
 					'default' => 'background-repeat',
 				),
 				'path'          => array( 'background', 'backgroundRepeat' ),
 			),
-			'backgroundSize'  => array(
+			'backgroundSize'     => array(
 				'property_keys' => array(
 					'default' => 'background-size',
 				),

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -51,6 +51,12 @@ final class WP_Style_Engine {
 				'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
 				'path'          => array( 'background', 'backgroundImage' ),
 			),
+			'backgroundPosition'  => array(
+				'property_keys' => array(
+					'default' => 'background-position',
+				),
+				'path'          => array( 'background', 'backgroundPosition' ),
+			),
 			'backgroundRepeat'  => array(
 				'property_keys' => array(
 					'default' => 'background-repeat',

--- a/packages/style-engine/src/styles/background/index.ts
+++ b/packages/style-engine/src/styles/background/index.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { GeneratedCSSRule, Style, StyleOptions } from '../../types';
-import { safeDecodeURI } from '../utils';
+import { generateRule, safeDecodeURI } from '../utils';
 
 const backgroundImage = {
 	name: 'backgroundImage',
@@ -40,4 +40,16 @@ const backgroundImage = {
 	},
 };
 
-export default [ backgroundImage ];
+const backgroundSize = {
+	name: 'backgroundSize',
+	generate: ( style: Style, options: StyleOptions ) => {
+		return generateRule(
+			style,
+			options,
+			[ 'background', 'backgroundSize' ],
+			'backgroundSize'
+		);
+	},
+};
+
+export default [ backgroundImage, backgroundSize ];

--- a/packages/style-engine/src/styles/background/index.ts
+++ b/packages/style-engine/src/styles/background/index.ts
@@ -55,12 +55,37 @@ const backgroundRepeat = {
 const backgroundSize = {
 	name: 'backgroundSize',
 	generate: ( style: Style, options: StyleOptions ) => {
-		return generateRule(
-			style,
-			options,
-			[ 'background', 'backgroundSize' ],
-			'backgroundSize'
+		const _backgroundSize = style?.background?.backgroundSize;
+		const _backgroundPosition = style?.background?.backgroundPosition;
+
+		const styleRules: GeneratedCSSRule[] = [];
+
+		if ( _backgroundSize === undefined ) {
+			return styleRules;
+		}
+
+		styleRules.push(
+			...generateRule(
+				style,
+				options,
+				[ 'background', 'backgroundSize' ],
+				'backgroundSize'
+			)
 		);
+
+		// If background size is set to contain, but no position is set, default to center.
+		if (
+			_backgroundSize === 'contain' &&
+			_backgroundPosition === undefined
+		) {
+			styleRules.push( {
+				selector: options.selector,
+				key: 'backgroundPosition',
+				value: 'center',
+			} );
+		}
+
+		return styleRules;
 	},
 };
 

--- a/packages/style-engine/src/styles/background/index.ts
+++ b/packages/style-engine/src/styles/background/index.ts
@@ -28,7 +28,7 @@ const backgroundImage = {
 		}
 
 		// If no background size is set, but an image is, default to cover.
-		if ( ! _backgroundSize ) {
+		if ( _backgroundSize === undefined ) {
 			styleRules.push( {
 				selector: options.selector,
 				key: 'backgroundSize',

--- a/packages/style-engine/src/styles/background/index.ts
+++ b/packages/style-engine/src/styles/background/index.ts
@@ -40,6 +40,18 @@ const backgroundImage = {
 	},
 };
 
+const backgroundRepeat = {
+	name: 'backgroundRepeat',
+	generate: ( style: Style, options: StyleOptions ) => {
+		return generateRule(
+			style,
+			options,
+			[ 'background', 'backgroundRepeat' ],
+			'backgroundRepeat'
+		);
+	},
+};
+
 const backgroundSize = {
 	name: 'backgroundSize',
 	generate: ( style: Style, options: StyleOptions ) => {
@@ -52,4 +64,4 @@ const backgroundSize = {
 	},
 };
 
-export default [ backgroundImage, backgroundSize ];
+export default [ backgroundImage, backgroundRepeat, backgroundSize ];

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -26,6 +26,8 @@ export interface Style {
 			url?: CSSProperties[ 'backgroundImage' ];
 			source?: string;
 		};
+		backgroundPosition?: CSSProperties[ 'backgroundPosition' ];
+		backgroundRepeat?: CSSProperties[ 'backgroundRepeat' ];
 		backgroundSize?: CSSProperties[ 'backgroundSize' ];
 	};
 	border?: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/54336

Explore adding a `backgroundSize` and `backgroundRepeat` set of controls for use with the background image block support. For the Group block, this allows users to set the background image to "Cover" (default), "Contain", or a custom size, which exposes repeating backgrounds automatically.

After some exploration, background repeat is included alongside backgroundSize as users will nearly always need to interact with background size when adjusting background repeat, so it's simpler and easier to keep them combined rather than separate.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

* Allow users to have repeating backgrounds, with control of the background image's size for repeating.
* Allow users to have contained background images, that fills one dimension and repeat along the other.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `backgroundSize` property and set of controls to the background block support
* Within these controls include a toggle for toggling repeating backgrounds on and off
* Opt the Group block in to this property (but have it hidden by default)
* Treat no value (undefined) as `cover`, with options for `contain` and custom sizes
* An empty string (switching to "Fixed") will default the output to the equivalent of `auto`, allowing repeating backgrounds
* Add a toggle for toggling repeat on and off. For the `contain` option, default to centering the background position. Note: background position controls will be explored in a separate PR.
* Note: global styles support is _not_ included in this PR, as the background image support will need separate work for global styles.

## To-do

* [x] Rename Fixed to Repeat, make clicking the toggle set the size to auto
* [x] Add controls to adjust the background size (so you can make it smaller or larger)
* [x] Ensure the controls are hidden when they should be
* [x] Hide these controls by default?
* [x] Add background repeat toggle
* [x] Rename Size to Fixed as the toggle option
* [x] Add centre positioning by default for the contained option
* [x] In the label and dropdown, rename to Size

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With TT4 theme active, add a Group block to a post, page, or template
2. Give the Group block a background image in the inspector controls
3. Click the ellipsis button to expose the background size controls
4. Have a play with the different options and try out setting a custom size value, and resetting values
5. How does it feel to use?

## Screenshots or screencast <!-- if applicable -->

### Screenshot

<img width="1266" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/ae7fd7d8-bb76-47d6-bdbd-e118f016d4b0">

### Screengrab

https://github.com/WordPress/gutenberg/assets/14988353/9337346e-7acc-444b-8e9f-2c095321f8a3

<!--
https://github.com/WordPress/gutenberg/assets/14988353/75ae8a61-e01f-47aa-807c-29f8224c0a80
-->
<!--

https://github.com/WordPress/gutenberg/assets/14988353/b0ef8b30-e32b-4909-9fa5-c90e99ede290

-->
<!--
<img width="1275" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/1e489788-3f4f-41a3-a66f-7f849ca67d0a">
-->