### PR TITLE
Performance: Improve opening inserter in post editor

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -846,19 +846,6 @@ _Returns_
 
 -   `string|false`: Block Template Lock
 
-### hasAllowedPatterns
-
-Returns whether there is at least one allowed pattern for inner blocks children. This is useful for deferring the parsing of all patterns until needed.
-
-_Parameters_
-
--   _state_ `Object`: Editor state.
--   _rootClientId_ `?string`: Optional target root client ID.
-
-_Returns_
-
--   `boolean`: If there is at least one allowed pattern.
-
 ### hasBlockMovingClientId
 
 Returns whether block moving mode is enabled.

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -846,6 +846,19 @@ _Returns_
 
 -   `string|false`: Block Template Lock
 
+### hasAllowedPatterns
+
+Returns whether there is at least one allowed pattern for inner blocks children. This is useful for deferring the parsing of all patterns until needed.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _rootClientId_ `?string`: Optional target root client ID.
+
+_Returns_
+
+-   `boolean`: If there is at least one allowed pattern.
+
 ### hasBlockMovingClientId
 
 Returns whether block moving mode is enabled.

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -68,12 +68,10 @@ function InserterMenu(
 		} );
 	const { showPatterns, inserterItems } = useSelect(
 		( select ) => {
-			const { __experimentalGetAllowedPatterns, getInserterItems } =
+			const { hasAllowedPatterns, getInserterItems } =
 				select( blockEditorStore );
 			return {
-				showPatterns: !! __experimentalGetAllowedPatterns(
-					destinationRootClientId
-				).length,
+				showPatterns: hasAllowedPatterns( destinationRootClientId ),
 				inserterItems: getInserterItems( destinationRootClientId ),
 			};
 		},

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -22,6 +22,7 @@ import { useDebouncedInput } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { unlock } from '../../lock-unlock';
 import Tips from './tips';
 import InserterPreviewPanel from './preview-panel';
 import BlockTypesTab from './block-types-tab';
@@ -68,8 +69,9 @@ function InserterMenu(
 		} );
 	const { showPatterns, inserterItems } = useSelect(
 		( select ) => {
-			const { hasAllowedPatterns, getInserterItems } =
-				select( blockEditorStore );
+			const { hasAllowedPatterns, getInserterItems } = unlock(
+				select( blockEditorStore )
+			);
 			return {
 				showPatterns: hasAllowedPatterns( destinationRootClientId ),
 				inserterItems: getInserterItems( destinationRootClientId ),

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -1,0 +1,74 @@
+/**
+ * Internal dependencies
+ */
+import { PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
+
+const EMPTY_ARRAY = [];
+
+export function getUserPatterns( state ) {
+	const userPatterns =
+		state?.settings?.__experimentalReusableBlocks ?? EMPTY_ARRAY;
+	const userPatternCategories =
+		state?.settings?.__experimentalUserPatternCategories ?? [];
+	const categories = new Map();
+	userPatternCategories.forEach( ( userCategory ) =>
+		categories.set( userCategory.id, userCategory )
+	);
+	return userPatterns.map( ( userPattern ) => {
+		return {
+			name: `core/block/${ userPattern.id }`,
+			id: userPattern.id,
+			type: PATTERN_TYPES.user,
+			title: userPattern.title.raw,
+			categories: userPattern.wp_pattern_category.map( ( catId ) =>
+				categories && categories.get( catId )
+					? categories.get( catId ).slug
+					: catId
+			),
+			content: userPattern.content.raw,
+			syncStatus: userPattern.wp_pattern_sync_status,
+		};
+	} );
+}
+
+export const checkAllowList = ( list, item, defaultResult = null ) => {
+	if ( typeof list === 'boolean' ) {
+		return list;
+	}
+	if ( Array.isArray( list ) ) {
+		// TODO: when there is a canonical way to detect that we are editing a post
+		// the following check should be changed to something like:
+		// if ( list.includes( 'core/post-content' ) && getEditorMode() === 'post-content' && item === null )
+		if ( list.includes( 'core/post-content' ) && item === null ) {
+			return true;
+		}
+		return list.includes( item );
+	}
+	return defaultResult;
+};
+
+export const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {
+	if ( typeof allowedBlockTypes === 'boolean' ) {
+		return allowedBlockTypes;
+	}
+
+	const blocksQueue = [ ...blocks ];
+	while ( blocksQueue.length > 0 ) {
+		const block = blocksQueue.shift();
+
+		const isAllowed = checkAllowList(
+			allowedBlockTypes,
+			block.name || block.blockName,
+			true
+		);
+		if ( ! isAllowed ) {
+			return false;
+		}
+
+		block.innerBlocks?.forEach( ( innerBlock ) => {
+			blocksQueue.push( innerBlock );
+		} );
+	}
+
+	return true;
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR improves the performance when opening the main inserter in post editor by introducing a new selector to check if we have at least one available allowed pattern. The new selector does exactly what the `__experimentalGetAllowedPatterns` does, but doesn't need to parse all patterns and of course returns a boolean value.

In my profiling the tasks from `~116ms` is down to `~6ms`.

## Notes for follow ups
1. This doesn't apply in site editor yet, since there are more optimizations to happen there. For example the template parts' edit function call the selectors to parse all patterns
2. Investigate in what other places we can use this new selector.

## Testing Instructions
1. I guess we'll see it in the performance results in CI
3. You can profile in the browser in trunk and in this branch the action of opening the inserter

