### PR TITLE
[Pattern Overrides] Use a single checkbox to turn on pattern overrides for all allowed attributes

### DIFF
--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -17,6 +17,18 @@ import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
 
 function PartialSyncingControls( { name, attributes, setAttributes } ) {
 	const syncedAttributes = PARTIAL_SYNCING_SUPPORTED_BLOCKS[ name ];
+	const attributeSources = Object.keys( syncedAttributes ).map(
+		( attributeName ) =>
+			attributes.connections?.attributes?.[ attributeName ]?.source
+	);
+	const isConnectedToOtherSources = attributeSources.every(
+		( source ) => source && source !== 'pattern_attributes'
+	);
+
+	// Render nothing if all supported attributes are connected to other sources.
+	if ( isConnectedToOtherSources ) {
+		return null;
+	}
 
 	function updateConnections( isChecked ) {
 		let updatedConnections = {
@@ -77,11 +89,8 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 				<CheckboxControl
 					__nextHasNoMarginBottom
 					label={ __( 'Allow instance overrides' ) }
-					checked={ Object.keys( syncedAttributes ).some(
-						( attributeName ) =>
-							attributes.connections?.attributes?.[
-								attributeName
-							]?.source === 'pattern_attributes'
+					checked={ attributeSources.some(
+						( source ) => source === 'pattern_attributes'
 					) }
 					onChange={ ( isChecked ) => {
 						updateConnections( isChecked );

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -18,22 +18,20 @@ import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
 function PartialSyncingControls( { name, attributes, setAttributes } ) {
 	const syncedAttributes = PARTIAL_SYNCING_SUPPORTED_BLOCKS[ name ];
 
-	function updateConnections( attributeName, isChecked ) {
+	function updateConnections( isChecked ) {
+		let updatedConnections = {
+			...attributes.connections,
+			attributes: { ...attributes.connections?.attributes },
+		};
+
 		if ( ! isChecked ) {
-			let updatedConnections = {
-				...attributes.connections,
-				attributes: {
-					...attributes.connections?.attributes,
-					[ attributeName ]: undefined,
-				},
-			};
-			if ( Object.keys( updatedConnections.attributes ).length === 1 ) {
-				updatedConnections.attributes = undefined;
+			for ( const attributeName of Object.keys( syncedAttributes ) ) {
+				delete updatedConnections.attributes[ attributeName ];
 			}
-			if (
-				Object.keys( updatedConnections ).length === 1 &&
-				updateConnections.attributes === undefined
-			) {
+			if ( ! Object.keys( updatedConnections.attributes ).length ) {
+				delete updatedConnections.attributes;
+			}
+			if ( ! Object.keys( updatedConnections ).length ) {
 				updatedConnections = undefined;
 			}
 			setAttributes( {
@@ -42,15 +40,11 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			return;
 		}
 
-		const updatedConnections = {
-			...attributes.connections,
-			attributes: {
-				...attributes.connections?.attributes,
-				[ attributeName ]: {
-					source: 'pattern_attributes',
-				},
-			},
-		};
+		for ( const attributeName of Object.keys( syncedAttributes ) ) {
+			updatedConnections.attributes[ attributeName ] = {
+				source: 'pattern_attributes',
+			};
+		}
 
 		if ( typeof attributes.metadata?.id === 'string' ) {
 			setAttributes( { connections: updatedConnections } );
@@ -71,25 +65,21 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 		<InspectorControls group="advanced">
 			<BaseControl __nextHasNoMarginBottom>
 				<BaseControl.VisualLabel>
-					{ __( 'Synced attributes' ) }
+					{ __( 'Pattern overrides' ) }
 				</BaseControl.VisualLabel>
-				{ Object.entries( syncedAttributes ).map(
-					( [ attributeName, label ] ) => (
-						<CheckboxControl
-							key={ attributeName }
-							__nextHasNoMarginBottom
-							label={ label }
-							checked={
-								attributes.connections?.attributes?.[
-									attributeName
-								]?.source === 'pattern_attributes'
-							}
-							onChange={ ( isChecked ) => {
-								updateConnections( attributeName, isChecked );
-							} }
-						/>
-					)
-				) }
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ __( 'Allow instance overrides' ) }
+					checked={ Object.keys( syncedAttributes ).some(
+						( attributeName ) =>
+							attributes.connections?.attributes?.[
+								attributeName
+							]?.source === 'pattern_attributes'
+					) }
+					onChange={ ( isChecked ) => {
+						updateConnections( isChecked );
+					} }
+				/>
 			</BaseControl>
 		</InspectorControls>
 	);

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -26,7 +26,12 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 
 		if ( ! isChecked ) {
 			for ( const attributeName of Object.keys( syncedAttributes ) ) {
-				delete updatedConnections.attributes[ attributeName ];
+				if (
+					updatedConnections.attributes[ attributeName ]?.source ===
+					'pattern_attributes'
+				) {
+					delete updatedConnections.attributes[ attributeName ];
+				}
 			}
 			if ( ! Object.keys( updatedConnections.attributes ).length ) {
 				delete updatedConnections.attributes;
@@ -41,9 +46,11 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 		}
 
 		for ( const attributeName of Object.keys( syncedAttributes ) ) {
-			updatedConnections.attributes[ attributeName ] = {
-				source: 'pattern_attributes',
-			};
+			if ( ! updatedConnections.attributes[ attributeName ] ) {
+				updatedConnections.attributes[ attributeName ] = {
+					source: 'pattern_attributes',
+				};
+			}
 		}
 
 		if ( typeof attributes.metadata?.id === 'string' ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As opposed to the current behavior of turning on syncing each attribute for a given block, use a single checkbox to turn on pattern overrides for all allowed attributes (a hardcoded allowed list).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
While per attribute override and locking is a compelling feature, it also surfaces the concept of `attributes` to the end users, which should remain an implementation detail. Until we can decide how the user flow would be for individual attribute override, maintaining an allowed list for the supported attributes and turn them all on at once seems like a better option at this stage.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Some tiny refactoring in the pattern syncing controls.

**The wording can be changed though!**

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the "Partial syncing patterns gutenberg experiment.
2. Go to Site Editor -> Patterns -> Create a synced pattern.
3. Add a paragraph and go to the block inspector sidebar -> Advanced -> Check the "Allow instance overrides" checkbox.
4. Save the pattern.
5. Go to edit a post.
6. Insert the pattern.
7. Make some changes to the enabled paragraph and save the post.
8. View it on the frontend that the paragraph is updated.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/b5c3b8e6-5799-4e0d-8e0d-11687937187b)
