### PR TITLE
DataViews: add list layout to templates

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -196,6 +196,7 @@
 		border-radius: $grid-unit-05;
 		overflow: hidden;
 		position: relative;
+		margin-top: $grid-unit-05;
 
 		&::after {
 			content: "";

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -64,7 +64,7 @@ export default function ViewList( {
 							) }
 							onClick={ () => onSelectionChange( [ item ] ) }
 						>
-							<HStack spacing={ 3 }>
+							<HStack spacing={ 3 } alignment="flex-start">
 								<div className="dataviews-list-view__media-wrapper">
 									{ mediaField?.render( { item } ) || (
 										<div className="dataviews-list-view__media-placeholder"></div>

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -158,12 +158,14 @@
 
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative
 .edit-site-layout__canvas .interface-interface-skeleton,
-.edit-site-page-pages-preview .interface-interface-skeleton {
+.edit-site-page-pages-preview .interface-interface-skeleton,
+.edit-site-template-pages-preview .interface-interface-skeleton {
 	position: relative !important;
 	min-height: 100% !important;
 }
 
-.edit-site-page-pages-preview {
+.edit-site-page-pages-preview,
+.edit-site-template-pages-preview {
 	height: 100%;
 }
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -156,6 +156,10 @@
 	}
 }
 
+.edit-site-template-pages-list-view {
+	max-width: $nav-sidebar-width;
+}
+
 // This shouldn't be necessary (we should have a way to say that a skeletton is relative
 .edit-site-layout__canvas .interface-interface-skeleton,
 .edit-site-page-pages-preview .interface-interface-skeleton,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -37,7 +37,7 @@ import {
 	viewPostAction,
 	useEditPostAction,
 } from '../actions';
-import SideEditor from './side-editor';
+import PostPreview from '../post-preview';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
 const { useLocation } = unlock( routerPrivateApis );
@@ -338,7 +338,7 @@ export default function PagePages() {
 				<Page>
 					<div className="edit-site-page-pages-preview">
 						{ pageId !== null ? (
-							<SideEditor
+							<PostPreview
 								postId={ pageId }
 								postType={ postType }
 							/>

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -47,6 +47,7 @@ import {
 } from './template-actions';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
+import SideEditor from '../page-pages/side-editor';
 
 const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis
@@ -173,11 +174,15 @@ function TemplatePreview( { content, viewType } ) {
 }
 
 export default function DataviewsTemplates() {
+	const [ templateId, setTemplateId ] = useState( null );
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const { records: allTemplates, isResolving: isLoadingData } =
 		useEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
 			per_page: -1,
 		} );
+
+	const onSelectionChange = ( items ) =>
+		setTemplateId( items?.length === 1 ? items[ 0 ].id : null );
 
 	const authors = useMemo( () => {
 		if ( ! allTemplates ) {
@@ -366,18 +371,47 @@ export default function DataviewsTemplates() {
 		[ view, setView ]
 	);
 	return (
-		<Page title={ __( 'Templates' ) }>
-			<DataViews
-				paginationInfo={ paginationInfo }
-				fields={ fields }
-				actions={ actions }
-				data={ shownTemplates }
-				getItemId={ ( item ) => item.id }
-				isLoading={ isLoadingData }
-				view={ view }
-				onChangeView={ onChangeView }
-				deferredRendering={ ! view.hiddenFields?.includes( 'preview' ) }
-			/>
-		</Page>
+		<>
+			<Page title={ __( 'Templates' ) }>
+				<DataViews
+					paginationInfo={ paginationInfo }
+					fields={ fields }
+					actions={ actions }
+					data={ shownTemplates }
+					getItemId={ ( item ) => item.id }
+					isLoading={ isLoadingData }
+					view={ view }
+					onChangeView={ onChangeView }
+					onSelectionChange={ onSelectionChange }
+					deferredRendering={
+						! view.hiddenFields?.includes( 'preview' )
+					}
+				/>
+			</Page>
+			{ view.type === LAYOUT_LIST && (
+				<Page>
+					<div className="edit-site-template-pages-preview">
+						{ templateId !== null ? (
+							<SideEditor
+								postId={ templateId }
+								postType={ TEMPLATE_POST_TYPE }
+							/>
+						) : (
+							<div
+								style={ {
+									display: 'flex',
+									flexDirection: 'column',
+									justifyContent: 'center',
+									textAlign: 'center',
+									height: '100%',
+								} }
+							>
+								<p>{ __( 'Select a template to preview' ) }</p>
+							</div>
+						) }
+					</div>
+				</Page>
+			) }
+		</>
 	);
 }

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -38,6 +38,7 @@ import {
 	OPERATOR_NOT_IN,
 	LAYOUT_GRID,
 	LAYOUT_TABLE,
+	LAYOUT_LIST,
 } from '../../utils/constants';
 import {
 	useResetTemplateAction,
@@ -57,6 +58,9 @@ const defaultConfigPerViewType = {
 	[ LAYOUT_TABLE ]: {},
 	[ LAYOUT_GRID ]: {
 		mediaField: 'preview',
+		primaryField: 'title',
+	},
+	[ LAYOUT_LIST ]: {
 		primaryField: 'title',
 	},
 };
@@ -79,8 +83,32 @@ function normalizeSearchInput( input = '' ) {
 
 // TODO: these are going to be reused in the template part list.
 // That's the reason for leaving the template parts code for now.
-function TemplateTitle( { item } ) {
+const Customized = ( { item, isCustomized } ) => {
+	if ( ! isCustomized ) {
+		return null;
+	}
+	return (
+		<span className="edit-site-list-added-by__customized-info">
+			{ item.type === TEMPLATE_POST_TYPE
+				? _x( 'Customized', 'template' )
+				: _x( 'Customized', 'template part' ) }
+		</span>
+	);
+};
+
+function TemplateTitle( { item, view } ) {
 	const { isCustomized } = useAddedBy( item.type, item.id );
+
+	if ( view.type === LAYOUT_LIST ) {
+		return (
+			<>
+				{ decodeEntities( item.title?.rendered || item.slug ) ||
+					__( '(no title)' ) }
+				<Customized item={ item } isCustomized={ isCustomized } />
+			</>
+		);
+	}
+
 	return (
 		<VStack spacing={ 1 }>
 			<View as="span" className="edit-site-list-title__customized-info">
@@ -95,13 +123,7 @@ function TemplateTitle( { item } ) {
 						__( '(no title)' ) }
 				</Link>
 			</View>
-			{ isCustomized && (
-				<span className="edit-site-list-added-by__customized-info">
-					{ item.type === TEMPLATE_POST_TYPE
-						? _x( 'Customized', 'template' )
-						: _x( 'Customized', 'template part' ) }
-				</span>
-			) }
+			<Customized item={ item } isCustomized={ isCustomized } />
 		</VStack>
 	);
 }
@@ -192,7 +214,9 @@ export default function DataviewsTemplates() {
 				header: __( 'Template' ),
 				id: 'title',
 				getValue: ( { item } ) => item.title?.rendered || item.slug,
-				render: ( { item } ) => <TemplateTitle item={ item } />,
+				render: ( { item } ) => (
+					<TemplateTitle item={ item } view={ view } />
+				),
 				maxWidth: 400,
 				enableHiding: false,
 			},
@@ -352,7 +376,6 @@ export default function DataviewsTemplates() {
 				isLoading={ isLoadingData }
 				view={ view }
 				onChangeView={ onChangeView }
-				supportedLayouts={ [ LAYOUT_TABLE, LAYOUT_GRID ] }
 				deferredRendering={ ! view.hiddenFields?.includes( 'preview' ) }
 			/>
 		</Page>

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -373,7 +373,14 @@ export default function DataviewsTemplates() {
 	);
 	return (
 		<>
-			<Page title={ __( 'Templates' ) }>
+			<Page
+				className={
+					view.type === LAYOUT_LIST
+						? 'edit-site-template-pages-list-view'
+						: null
+				}
+				title={ __( 'Templates' ) }
+			>
 				<DataViews
 					paginationInfo={ paginationInfo }
 					fields={ fields }

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -63,6 +63,7 @@ const defaultConfigPerViewType = {
 	},
 	[ LAYOUT_LIST ]: {
 		primaryField: 'title',
+		mediaField: 'preview',
 	},
 };
 

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -130,13 +130,14 @@ function TemplateTitle( { item, view } ) {
 	);
 }
 
-function AuthorField( { item } ) {
+function AuthorField( { item, view } ) {
 	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
+	const withIcon = view.type !== LAYOUT_LIST;
+
 	return (
 		<HStack alignment="left" spacing={ 1 }>
-			{ imageUrl ? (
-				<AvatarImage imageUrl={ imageUrl } />
-			) : (
+			{ withIcon && imageUrl && <AvatarImage imageUrl={ imageUrl } /> }
+			{ withIcon && ! imageUrl && (
 				<div className="edit-site-list-added-by__icon">
 					<Icon icon={ icon } />
 				</div>
@@ -252,7 +253,7 @@ export default function DataviewsTemplates() {
 				id: 'author',
 				getValue: ( { item } ) => item.author_text,
 				render: ( { item } ) => {
-					return <AuthorField item={ item } />;
+					return <AuthorField view={ view } item={ item } />;
 				},
 				enableHiding: false,
 				type: ENUMERATION_TYPE,

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -47,7 +47,7 @@ import {
 } from './template-actions';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
-import SideEditor from '../page-pages/side-editor';
+import PostPreview from '../post-preview';
 
 const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis
@@ -400,7 +400,7 @@ export default function DataviewsTemplates() {
 				<Page>
 					<div className="edit-site-template-pages-preview">
 						{ templateId !== null ? (
-							<SideEditor
+							<PostPreview
 								postId={ templateId }
 								postType={ TEMPLATE_POST_TYPE }
 							/>

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -14,7 +14,7 @@ import {
 	__experimentalVStack as VStack,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -83,24 +83,7 @@ function normalizeSearchInput( input = '' ) {
 	return removeAccents( input.trim().toLowerCase() );
 }
 
-// TODO: these are going to be reused in the template part list.
-// That's the reason for leaving the template parts code for now.
-const Customized = ( { item, isCustomized } ) => {
-	if ( ! isCustomized ) {
-		return null;
-	}
-	return (
-		<span className="edit-site-list-added-by__customized-info">
-			{ item.type === TEMPLATE_POST_TYPE
-				? _x( 'Customized', 'template' )
-				: _x( 'Customized', 'template part' ) }
-		</span>
-	);
-};
-
 function TemplateTitle( { item, view } ) {
-	const { isCustomized } = useAddedBy( item.type, item.id );
-
 	if ( view.type === LAYOUT_LIST ) {
 		return (
 			<>
@@ -124,7 +107,6 @@ function TemplateTitle( { item, view } ) {
 						__( '(no title)' ) }
 				</Link>
 			</View>
-			<Customized item={ item } isCustomized={ isCustomized } />
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/page-templates/dataviews-templates.js
+++ b/packages/edit-site/src/components/page-templates/dataviews-templates.js
@@ -106,7 +106,6 @@ function TemplateTitle( { item, view } ) {
 			<>
 				{ decodeEntities( item.title?.rendered || item.slug ) ||
 					__( '(no title)' ) }
-				<Customized item={ item } isCustomized={ isCustomized } />
 			</>
 		);
 	}

--- a/packages/edit-site/src/components/post-preview/index.js
+++ b/packages/edit-site/src/components/post-preview/index.js
@@ -4,7 +4,7 @@
 import Editor from '../editor';
 import { useInitEditedEntity } from '../sync-state-with-url/use-init-edited-entity-from-url';
 
-export default function SideEditor( { postType, postId } ) {
+export default function PostPreview( { postType, postId } ) {
 	useInitEditedEntity( {
 		postId,
 		postType,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Adds the list layout to the templates page.

There's https://github.com/WordPress/gutenberg/pull/56983 to make the filters UI footprint smaller. I'd think both can land independently, even if it means this PR lands first and the filters take too much space.

https://github.com/WordPress/gutenberg/assets/583546/64212816-d5f2-4f18-b557-1fee10fa7778

## Why?

We want the list layout to become the main navigation screen for templates.

## How?

Implements the list layout for templates:

- declare a `primaryField` and `mediaField`
- implement the preview

## Testing Instructions

- Enable the "new admin views" experiment and visit "Manage all templates".
- Interact with the list view.
