### PR TITLE
DataViews: close actions menu upon switching layouts

### DIFF
--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -60,9 +60,7 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 								<Icon icon={ check } />
 							)
 						}
-						onSelect={ ( event ) => {
-							// We need to handle this on DropDown component probably..
-							event.preventDefault();
+						onSelect={ () => {
 							onChangeView( {
 								...view,
 								type: availableView.type,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
See https://github.com/WordPress/gutenberg/pull/57014#issuecomment-1853675035

## What?

Upon switching layouts, closes the view actions menu.

https://github.com/WordPress/gutenberg/assets/583546/4d5f59f1-b2df-4b5b-a4d8-fffec8de4bc9

## Why?

Switching layouts can modify the width of the dataviews' frame (for example, by switching from `table` to `list`), leaving the dropdown in a weird position.

## How?

Do not prevent the default behavior upon switching layouts.

## Testing Instructions

- Enable the "admin views" experiments and visit "Manage all pages".
- Interact with the view actions menu.
