### PR TITLE
Fix flaky Navigation focus mode test

### DIFF
--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -66,6 +66,10 @@ test.describe( 'Editing Navigation Menus', () => {
 				} )
 			).toBeVisible();
 
+			await expect( page ).toHaveURL(
+				`wp-admin/site-editor.php?path=%2Fnavigation`
+			);
+
 			await editorSidebar
 				.getByRole( 'button', {
 					name: 'Primary Menu',

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -20,20 +20,6 @@ test.describe( 'Editing Navigation Menus', () => {
 		editor,
 	} ) => {
 		await test.step( 'Manually browse to focus mode for a Navigation Menu', async () => {
-			// We could Navigate directly to editing the Navigation Menu but we intentionally do not do this.
-			//
-			// Why? To provide coverage for a bug that caused the Navigation Editor behaviours to fail
-			// only when navigating through the editor screens (rather than going directly to the editor by URL).
-			// See: https://github.com/WordPress/gutenberg/pull/56856.
-			//
-			// Example (what we could do):
-			// await admin.visitSiteEditor( {
-			// 	postId: createdMenu?.id,
-			// 	postType: 'wp_navigation',
-			// } );
-			//
-			await admin.visitSiteEditor();
-
 			// create a Navigation Menu called "Test Menu" using the REST API helpers
 			const createdMenu = await requestUtils.createNavigationMenu( {
 				title: 'Primary Menu',
@@ -47,6 +33,20 @@ test.describe( 'Editing Navigation Menus', () => {
 				content:
 					'<!-- wp:navigation-link {"label":"Another Item","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
 			} );
+
+			// We could Navigate directly to editing the Navigation Menu but we intentionally do not do this.
+			//
+			// Why? To provide coverage for a bug that caused the Navigation Editor behaviours to fail
+			// only when navigating through the editor screens (rather than going directly to the editor by URL).
+			// See: https://github.com/WordPress/gutenberg/pull/56856.
+			//
+			// Example (what we could do):
+			// await admin.visitSiteEditor( {
+			// 	postId: createdMenu?.id,
+			// 	postType: 'wp_navigation',
+			// } );
+			//
+			await admin.visitSiteEditor();
 
 			const editorSidebar = page.getByRole( 'region', {
 				name: 'Navigation',

--- a/test/e2e/specs/site-editor/navigation-editor.spec.js
+++ b/test/e2e/specs/site-editor/navigation-editor.spec.js
@@ -77,10 +77,12 @@ test.describe( 'Editing Navigation Menus', () => {
 			);
 
 			// Wait for list of Navigations to appear.
-			editorSidebar.getByRole( 'heading', {
-				name: 'Primary Menu',
-				level: 1,
-			} );
+			await expect(
+				editorSidebar.getByRole( 'heading', {
+					name: 'Primary Menu',
+					level: 1,
+				} )
+			).toBeVisible();
 
 			// Switch to editing the Navigation Menu
 			await editorSidebar


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to https://github.com/WordPress/gutenberg/pull/56871 to try and fix [the flaky test](https://github.com/WordPress/gutenberg/pull/56871/files#r1425183730).

Closes https://github.com/WordPress/gutenberg/issues/57017

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Flaky tests are annoying.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Find fix.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

```
npm run test:e2e:playwright -- -g "Editing Navigation Menus" --repeat-each 2
```



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
