### PR TITLE
Improve pre-publish checks naming consistency.

### DIFF
--- a/packages/e2e-test-utils/src/disable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/disable-pre-publish-checks.js
@@ -10,7 +10,7 @@ import { toggleMoreMenu } from './toggle-more-menu';
 export async function disablePrePublishChecks() {
 	await togglePreferencesOption(
 		'General',
-		'Enable pre-publish flow',
+		'Enable pre-publish checks',
 		false
 	);
 	await toggleMoreMenu( 'close' );

--- a/packages/e2e-test-utils/src/enable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/enable-pre-publish-checks.js
@@ -8,6 +8,10 @@ import { toggleMoreMenu } from './toggle-more-menu';
  * Enables Pre-publish checks.
  */
 export async function enablePrePublishChecks() {
-	await togglePreferencesOption( 'General', 'Enable pre-publish flow', true );
+	await togglePreferencesOption(
+		'General',
+		'Enable pre-publish checks',
+		true
+	);
 	await toggleMoreMenu( 'close' );
 }

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -95,7 +95,7 @@ export default function EditPostPreferencesModal() {
 									help={ __(
 										'Review settings, such as visibility and tags.'
 									) }
-									label={ __( 'Enable pre-publish flow' ) }
+									label={ __( 'Enable pre-publish checks' ) }
 								/>
 							</PreferencesModalSection>
 						) }

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -200,8 +200,8 @@ export default function useCommonCommands() {
 			toggle( 'core/edit-post', 'isPublishSidebarEnabled' );
 			createInfoNotice(
 				isPublishSidebarEnabled
-					? __( 'Pre-publish checks off.' )
-					: __( 'Pre-publish checks on.' ),
+					? __( 'Pre-publish checks disabled.' )
+					: __( 'Pre-publish checks enabled.' ),
 				{
 					id: 'core/edit-post/publish-sidebar/notice',
 					type: 'snackbar',

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -192,16 +192,16 @@ export default function useCommonCommands() {
 	useCommand( {
 		name: 'core/toggle-publish-sidebar',
 		label: isPublishSidebarEnabled
-			? __( 'Disable pre-publish checklist' )
-			: __( 'Enable pre-publish checklist' ),
+			? __( 'Disable pre-publish checks' )
+			: __( 'Enable pre-publish checks' ),
 		icon: formatListBullets,
 		callback: ( { close } ) => {
 			close();
 			toggle( 'core/edit-post', 'isPublishSidebarEnabled' );
 			createInfoNotice(
 				isPublishSidebarEnabled
-					? __( 'Pre-publish checklist off.' )
-					: __( 'Pre-publish checklist on.' ),
+					? __( 'Pre-publish checks off.' )
+					: __( 'Pre-publish checks on.' ),
 				{
 					id: 'core/edit-post/publish-sidebar/notice',
 					type: 'snackbar',

--- a/packages/interface/src/components/preferences-modal/README.md
+++ b/packages/interface/src/components/preferences-modal/README.md
@@ -28,7 +28,7 @@ function MyEditorPreferencesModal() {
 									'Review settings, such as visibility and tags.'
 								) }
 								label={ __(
-									'Enable pre-publish flow'
+									'Enable pre-publish checks'
 								) }
 							/>
 						</PreferencesModalSection>

--- a/test/e2e/specs/editor/various/pref-modal.spec.js
+++ b/test/e2e/specs/editor/various/pref-modal.spec.js
@@ -9,7 +9,7 @@ test.describe( 'Preferences modal', () => {
 	} );
 
 	test.describe( 'Preferences modal adaps to viewport', () => {
-		test( 'Enable pre-publish flow is visible on desktop ', async ( {
+		test( 'Enable pre-publish checks is visible on desktop ', async ( {
 			page,
 		} ) => {
 			await page.click(
@@ -18,14 +18,14 @@ test.describe( 'Preferences modal', () => {
 			await page.click( 'role=menuitem[name="Preferences"i]' );
 
 			const prePublishToggle = page.locator(
-				'role=checkbox[name="Enable pre-publish flow"i]'
+				'role=checkbox[name="Enable pre-publish checks"i]'
 			);
 
 			await expect( prePublishToggle ).toBeVisible();
 		} );
 	} );
 	test.describe( 'Preferences modal adaps to viewport', () => {
-		test( 'Enable pre-publish flow is not visible on mobile ', async ( {
+		test( 'Enable pre-publish checks is not visible on mobile ', async ( {
 			page,
 		} ) => {
 			await page.setViewportSize( { width: 500, height: 800 } );
@@ -44,7 +44,7 @@ test.describe( 'Preferences modal', () => {
 			);
 
 			const prePublishToggle = page.locator(
-				'role=checkbox[name="Enable pre-publish flow"i]'
+				'role=checkbox[name="Enable pre-publish checks"i]'
 			);
 
 			await expect( generalButton ).toBeVisible();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/56977

## What?
<!-- In a few words, what is the PR actually doing? -->
Naming of the 'pre-publish' checks is greatly inconsistent across the UI: checks, checklist, flow.
Also, as a user I'm not supposed to know and understand what a `flow` is. That is more technical / UX design jargon that should not be used in a user interface.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Naming consistency is key for a good user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Standardizes the naming to `checks` as that the simplest naming. Also, it's more easy to translate to other languages, while `flow` is not well translatable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the reproduction instructions from the issue https://github.com/WordPress/gutenberg/issues/56977
- Observe the term used is now `checks`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
