### PR TITLE
Fix/dataviews tooltip overlap

### DIFF
--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -109,6 +109,8 @@ export function UnforwardedButton(
 		variant,
 		__experimentalIsFocusable: isFocusable,
 		describedBy,
+		tooltipPortal,
+		tooltipPortalElement,
 		...buttonOrAnchorProps
 	} = useDeprecatedProps( props );
 
@@ -280,6 +282,8 @@ export function UnforwardedButton(
 				}
 				shortcut={ shortcut }
 				placement={ computedPlacement }
+				portal={ tooltipPortal }
+				portalElement={ tooltipPortalElement }
 			>
 				{ element }
 			</Tooltip>

--- a/packages/components/src/button/types.ts
+++ b/packages/components/src/button/types.ts
@@ -118,6 +118,12 @@ type BaseButtonProps = {
 	 * Whether this is focusable.
 	 */
 	__experimentalIsFocusable?: boolean;
+
+	tooltipPortal?: boolean;
+	tooltipPortalElement?:
+		| HTMLElement
+		| ( ( element: HTMLElement ) => HTMLElement | null )
+		| null;
 };
 
 type _ButtonProps = {

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -29,9 +29,13 @@ function Tooltip( props: TooltipProps ) {
 		delay = TOOLTIP_DELAY,
 		hideOnClick = true,
 		placement,
-		position,
 		shortcut,
 		text,
+		portal = true,
+		portalElement,
+
+		// Deprecated props
+		position,
 	} = props;
 
 	const baseId = useInstanceId( Tooltip, 'tooltip' );
@@ -86,6 +90,8 @@ function Tooltip( props: TooltipProps ) {
 					id={ describedById }
 					overflowPadding={ 0.5 }
 					store={ tooltipStore }
+					portal={ portal }
+					portalElement={ portalElement }
 				>
 					{ text }
 					{ shortcut && (

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -58,4 +58,9 @@ export type TooltipProps = {
 	 * The text shown in the tooltip when anchor element is focused or hovered.
 	 */
 	text?: string;
+	portal?: boolean;
+	portalElement?:
+		| HTMLElement
+		| ( ( element: HTMLElement ) => HTMLElement | null )
+		| null;
 };

--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -31,6 +31,7 @@ function ButtonTrigger( { action, onClick } ) {
 			isDestructive={ action.isDestructive }
 			size="compact"
 			onClick={ onClick }
+			tooltipPortal={ false }
 		/>
 	);
 }
@@ -168,6 +169,7 @@ export default function ItemActions( { item, actions, isCompact } ) {
 							size="compact"
 							icon={ moreVertical }
 							label={ __( 'Actions' ) }
+							tooltipPortal={ false }
 						/>
 					}
 					placement="bottom-end"
@@ -190,6 +192,7 @@ function CompactItemActions( { item, primaryActions, secondaryActions } ) {
 					size="compact"
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
+					tooltipPortal={ false }
 				/>
 			}
 			placement="bottom-end"

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -73,12 +73,14 @@
 		}
 	}
 	thead {
+		position: sticky;
+		top: -1px;
+		z-index: z-index(".components-tooltip") + 1;
+
 		tr {
 			border: 0;
 		}
 		th {
-			position: sticky;
-			top: -1px;
 			background-color: lighten($gray-100, 4%);
 			box-shadow: inset 0 -#{$border-width} 0 $gray-100;
 			border-top: 1px solid $gray-100;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related to #56939

## What?
<!-- In a few words, what is the PR actually doing? -->

Experiment with fixing an issue with tooltip overlap

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
|  ![Screenshot 2023-12-13 at 17 51 16](https://github.com/WordPress/gutenberg/assets/1083581/472aa4d1-1d84-4aef-9736-bd755356d307) | ![Screenshot 2023-12-13 at 17 45 36](https://github.com/WordPress/gutenberg/assets/1083581/df4a73ef-8fd2-44df-8c59-94e5c2a515ab) |