### PR TITLE
Fix: Template list title font styles.

### DIFF
--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -188,6 +188,6 @@
 }
 
 .edit-site-list-title__customized-info {
-	font-size: 1.3em;
-	font-weight: 600;
+	font-size: $default-font-size;
+	font-weight: 500;
 }


### PR DESCRIPTION
This pull request resolves the issue with title font styles on the new templates list implemented using dataviews.

## Screenshot

<img width="1163" alt="Screenshot 2023-12-13 at 16 43 10" src="https://github.com/WordPress/gutenberg/assets/11271197/872e0e6b-6822-4515-b7f9-d63d7e90061d">
