### PR TITLE
Interactivity API: fix namespaces in nested interactive regions

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/render.php
@@ -68,4 +68,16 @@ gutenberg_enqueue_module( 'tovdom-islands-view' );
 			</div>
 		</div>
 	</div>
+
+
+
+	<div data-wp-interactive='{ "namespace": "tovdom-islands" }'>
+		<div data-wp-interactive='{ "namespace": "something-new" }'></div>
+		<div data-wp-show-mock="state.falseValue">
+			<span data-testid="directive after different namespace">
+				The directive above should keep the `tovdom-island` namespace,
+				so this message should not be visible.
+			</span>
+		</div>
+	</div>
 </div>

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix namespaces when there are nested interactive regions. ([#57029](https://github.com/WordPress/gutenberg/pull/57029))
+
 ## 3.1.0 (2023-12-13)
 
 ## 3.0.0 (2023-11-29)

--- a/packages/interactivity/src/vdom.js
+++ b/packages/interactivity/src/vdom.js
@@ -10,7 +10,8 @@ import { directivePrefix as p } from './constants';
 const ignoreAttr = `data-${ p }-ignore`;
 const islandAttr = `data-${ p }-interactive`;
 const fullPrefix = `data-${ p }-`;
-let namespace = null;
+const namespaces = [];
+const currentNamespace = () => namespaces[ namespaces.length - 1 ] ?? null;
 
 // Regular expression for directive parsing.
 const directiveParser = new RegExp(
@@ -79,7 +80,7 @@ export function toVdom( root ) {
 					} catch ( e ) {}
 					if ( n === islandAttr ) {
 						island = true;
-						namespace = value?.namespace ?? null;
+						namespaces.push( value?.namespace ?? null );
 					} else {
 						directives.push( [ n, ns, value ] );
 					}
@@ -107,7 +108,7 @@ export function toVdom( root ) {
 						directiveParser.exec( name );
 					if ( ! obj[ prefix ] ) obj[ prefix ] = [];
 					obj[ prefix ].push( {
-						namespace: ns ?? namespace,
+						namespace: ns ?? currentNamespace(),
 						value,
 						suffix,
 					} );
@@ -126,6 +127,9 @@ export function toVdom( root ) {
 			}
 			treeWalker.parentNode();
 		}
+
+		// Restore previous namespace.
+		if ( island ) namespaces.pop();
 
 		return [ h( node.localName, props, children ) ];
 	}

--- a/test/e2e/specs/interactivity/tovdom-islands.spec.ts
+++ b/test/e2e/specs/interactivity/tovdom-islands.spec.ts
@@ -55,4 +55,11 @@ test.describe( 'toVdom - islands', () => {
 		);
 		await expect( el ).toBeHidden();
 	} );
+
+	test( 'islands should recover their namespace if an inner island has changed it', async ( {
+		page,
+	} ) => {
+		const el = page.getByTestId( 'directive after different namespace' );
+		await expect( el ).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
## What?

Fixes a problem with namespaces not being restored when a nested interactive region changes it. E.g.:

```html
<div data-wp-interactive='{ "namespace": "A }'> 
  <!-- namespace is A -->
  <div data-wp-interactive='{ "namespace": "B" }'>
     <!-- namespace is B -->
  </div>
  <!-- namespace is still B!! ❌  -->
  <div data-wp-text="state.message"></div> 
</div>
```

## Why?

The case described above makes `state.message` not to be resolved correctly because it tries to read `message` from namespace B. It likely returns an error like the following:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'message')
```

We need to ensure the property is read from the right namespace.

## How?

A single variable to store the current namespace was used before. I replaced that with a namespace array that works as a stack.

## Testing Instructions

To reproduce the issue:
1. Checkout `trunk`. In the editor, go to the home blog template.
2. Disable 'force page reload' in the Query block settings.
3. Inside the Post Template block, add an Image block.
4. Enable 'expand on click' inside the Image block.
5. Save and visit the home blog.
6. Check the console in the developer tools. The error should be there.

To verify the fix:

7. Checkout this PR branch.
8. Check the console in the developer tools. No error should appear now.


