### PR TITLE
Fix code style in Gutenberg_HTML_Tag_Processor_6_5

### DIFF
--- a/lib/compat/wordpress-6.5/html-api/class-gutenberg-html-tag-processor-6-5.php
+++ b/lib/compat/wordpress-6.5/html-api/class-gutenberg-html-tag-processor-6-5.php
@@ -1651,7 +1651,7 @@ class Gutenberg_HTML_Tag_Processor_6_5 {
 		 * replacements adjust offsets in the input document.
 		 */
 		foreach ( $this->bookmarks as $bookmark_name => $bookmark ) {
-			$bookmark_end   = $bookmark->start + $bookmark->length;
+			$bookmark_end = $bookmark->start + $bookmark->length;
 
 			/*
 			 * Each lexical update which appears before the bookmark's endpoints


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes code style in the Gutenberg_HTML_Tag_Processor_6_5 class.

## Why?
The class contains excess space characters.

## How?
I've removed these excess space characeters.

## Testing Instructions
Make sure that CI jobs pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
