### PR TITLE
Update: Dataviews make template list actions consistent.

### DIFF
--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -23,7 +23,7 @@ const {
 	DropdownMenuItemLabelV2Ariakit: DropdownMenuItemLabel,
 } = unlock( componentsPrivateApis );
 
-function ButtonTrigger( { action, onClick } ) {
+function ButtonTrigger( { action, onClick, disabled } ) {
 	return (
 		<Button
 			label={ action.label }
@@ -31,6 +31,7 @@ function ButtonTrigger( { action, onClick } ) {
 			isDestructive={ action.isDestructive }
 			size="compact"
 			onClick={ onClick }
+			disabled={ disabled }
 		/>
 	);
 }
@@ -51,6 +52,7 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 	const actionTriggerProps = {
 		action,
 		onClick: () => setIsModalOpen( true ),
+		disabled: action.isEnabled && ! action.isEnabled( item ),
 	};
 	const { RenderModal, hideModalHeader } = action;
 	return (
@@ -79,6 +81,9 @@ function ActionsDropdownMenuGroup( { actions, item } ) {
 	return (
 		<DropdownMenuGroup>
 			{ actions.map( ( action ) => {
+				if ( action.isEnabled && ! action.isEnabled( item ) ) {
+					return null;
+				}
 				if ( !! action.RenderModal ) {
 					return (
 						<ActionWithModal
@@ -158,6 +163,9 @@ export default function ItemActions( { item, actions, isCompact } ) {
 							key={ action.id }
 							action={ action }
 							onClick={ () => action.callback( item ) }
+							disabled={
+								action.isEnabled && ! action.isEnabled( item )
+							}
 						/>
 					);
 				} ) }

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -24,6 +24,10 @@ import isTemplateRevertable from '../../utils/is-template-revertable';
 import isTemplateRemovable from '../../utils/is-template-removable';
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
+function hasThemeFile( template ) {
+	return !! template?.has_theme_file;
+}
+
 export function useResetTemplateAction() {
 	const { revertTemplate } = useDispatch( editSiteStore );
 	const { saveEditedEntityRecord } = useDispatch( coreStore );
@@ -35,7 +39,8 @@ export function useResetTemplateAction() {
 			label: __( 'Reset template' ),
 			isPrimary: true,
 			icon: backup,
-			isEligible: isTemplateRevertable,
+			isEligible: hasThemeFile,
+			isEnabled: isTemplateRevertable,
 			async callback( template ) {
 				try {
 					await revertTemplate( template, { allowUndo: false } );


### PR DESCRIPTION
This PR expands the action api adding a new isEnabled mechanism. This mechanism makes it possible for an action to speificfy it may be eligible for a given item in the future but right now is disabled.
The API is optional if not passed the old behaviour is kept as is.

This new API is used to make actions on the template list consistent.

## Screenshot

<img width="1183" alt="Screenshot 2023-12-13 at 17 56 23" src="https://github.com/WordPress/gutenberg/assets/11271197/11563d78-c5c7-4f1e-a150-9590ff9ac316">

