### PR TITLE
InnerBlocks: combine store subscriptions

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -121,8 +121,6 @@ function UncontrolledInnerBlocks( props ) {
 		[ defaultLayout, usedLayout, allowSizingOnChildren ]
 	);
 
-	// This component needs to always be synchronous as it's the one changing
-	// the async mode depending on the block selection.
 	const items = (
 		<BlockListItems
 			rootClientId={ clientId }

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -105,8 +105,26 @@ function UncontrolledInnerBlocks( props ) {
 
 	const context = useBlockContext( clientId );
 
+	const { nestingLevel, innerBlocks, parentLock } = useSelect(
+		( select ) => {
+			const {
+				getBlockParents,
+				getBlocks,
+				getTemplateLock,
+				getBlockRootClientId,
+			} = select( blockEditorStore );
+			return {
+				nestingLevel: getBlockParents( clientId )?.length,
+				innerBlocks: getBlocks( clientId ),
+				parentLock: getTemplateLock( getBlockRootClientId( clientId ) ),
+			};
+		},
+		[ clientId ]
+	);
+
 	useNestedSettingsUpdate(
 		clientId,
+		parentLock,
 		allowedBlocks,
 		prioritizedInserterBlocks,
 		defaultBlock,
@@ -121,18 +139,12 @@ function UncontrolledInnerBlocks( props ) {
 
 	useInnerBlockTemplateSync(
 		clientId,
+		innerBlocks,
 		template,
 		templateLock,
 		templateInsertUpdatesSelection
 	);
 
-	const nestingLevel = useSelect(
-		( select ) => {
-			return select( blockEditorStore ).getBlockParents( clientId )
-				?.length;
-		},
-		[ clientId ]
-	);
 	if ( nestingLevel >= MAX_NESTING_DEPTH ) {
 		return <WarningMaxDepthExceeded clientId={ clientId } />;
 	}

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -23,6 +23,7 @@ import { store as blockEditorStore } from '../../store';
  * then we replace the inner blocks with the correct value after synchronizing it with the template.
  *
  * @param {string}  clientId                       The block client ID.
+ * @param {Array}   innerBlocks
  * @param {Object}  template                       The template to match.
  * @param {string}  templateLock                   The template lock state for the inner blocks. For
  *                                                 example, if the template lock is set to "all",
@@ -36,10 +37,14 @@ import { store as blockEditorStore } from '../../store';
  */
 export default function useInnerBlockTemplateSync(
 	clientId,
+	innerBlocks,
 	template,
 	templateLock,
 	templateInsertUpdatesSelection
 ) {
+	// Instead of adding a useSelect mapping here, please add to the useSelect
+	// mapping in InnerBlocks! Every subscription impacts performance.
+
 	const {
 		getBlocks,
 		getSelectedBlocksInitialCaretPosition,
@@ -47,13 +52,6 @@ export default function useInnerBlockTemplateSync(
 	} = useSelect( blockEditorStore );
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
-
-	const { innerBlocks } = useSelect(
-		( select ) => ( {
-			innerBlocks: select( blockEditorStore ).getBlocks( clientId ),
-		} ),
-		[ clientId ]
-	);
 
 	// Maintain a reference to the previous value so we can do a deep equality check.
 	const existingTemplate = useRef( null );

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
-import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { useDispatch, useRegistry } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
@@ -32,6 +32,7 @@ function useShallowMemo( value ) {
  * came from props.
  *
  * @param {string}               clientId                   The client ID of the block to update.
+ * @param {string}               parentLock
  * @param {string[]}             allowedBlocks              An array of block names which are permitted
  *                                                          in inner blocks.
  * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritized in the inserter, in the format {blockName}/{variationName}.
@@ -53,6 +54,7 @@ function useShallowMemo( value ) {
  */
 export default function useNestedSettingsUpdate(
 	clientId,
+	parentLock,
 	allowedBlocks,
 	prioritizedInserterBlocks,
 	defaultBlock,
@@ -64,20 +66,11 @@ export default function useNestedSettingsUpdate(
 	orientation,
 	layout
 ) {
+	// Instead of adding a useSelect mapping here, please add to the useSelect
+	// mapping in InnerBlocks! Every subscription impacts performance.
+
 	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 	const registry = useRegistry();
-
-	const { parentLock } = useSelect(
-		( select ) => {
-			const rootClientId =
-				select( blockEditorStore ).getBlockRootClientId( clientId );
-			return {
-				parentLock:
-					select( blockEditorStore ).getTemplateLock( rootClientId ),
-			};
-		},
-		[ clientId ]
-	);
 
 	// Implementors often pass a new array on every render,
 	// and the contents of the arrays are just strings, so the entire array

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -209,37 +209,14 @@ export default function useBlockDropZone( {
 	// values returned by the `getRootBlockClientId` selector, which also uses
 	// an empty string to represent top-level blocks.
 	rootClientId: targetRootClientId = '',
+	parentClientId: parentBlockClientId = '',
+	isDisabled = false,
 } = {} ) {
 	const registry = useRegistry();
 	const [ dropTarget, setDropTarget ] = useState( {
 		index: null,
 		operation: 'insert',
 	} );
-
-	const { isDisabled, parentBlockClientId, rootBlockIndex } = useSelect(
-		( select ) => {
-			const {
-				__unstableIsWithinBlockOverlay,
-				__unstableHasActiveBlockOverlayActive,
-				getBlockIndex,
-				getBlockParents,
-				getBlockEditingMode,
-			} = select( blockEditorStore );
-			const blockEditingMode = getBlockEditingMode( targetRootClientId );
-			return {
-				parentBlockClientId:
-					getBlockParents( targetRootClientId, true )[ 0 ] || '',
-				rootBlockIndex: getBlockIndex( targetRootClientId ),
-				isDisabled:
-					blockEditingMode !== 'default' ||
-					__unstableHasActiveBlockOverlayActive(
-						targetRootClientId
-					) ||
-					__unstableIsWithinBlockOverlay( targetRootClientId ),
-			};
-		},
-		[ targetRootClientId ]
-	);
 
 	const { getBlockListSettings, getBlocks, getBlockIndex } =
 		useSelect( blockEditorStore );
@@ -299,7 +276,7 @@ export default function useBlockDropZone( {
 							? getBlockListSettings( parentBlockClientId )
 									?.orientation
 							: undefined,
-						rootBlockIndex,
+						rootBlockIndex: getBlockIndex( targetRootClientId ),
 					}
 				);
 
@@ -330,7 +307,6 @@ export default function useBlockDropZone( {
 				showInsertionPoint,
 				getBlockIndex,
 				parentBlockClientId,
-				rootBlockIndex,
 			]
 		),
 		200

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -134,7 +134,7 @@ export function onBlockDrop(
  *
  * @param {string}   targetRootClientId    The root client id where the block(s) will be inserted.
  * @param {number}   targetBlockIndex      The index where the block(s) will be inserted.
- * @param {boolean}  hasUploadPermissions  Whether the user has upload permissions.
+ * @param {Function} getSettings           A function that gets the block editor settings.
  * @param {Function} updateBlockAttributes A function that updates a block's attributes.
  * @param {Function} canInsertBlockType    A function that returns checks whether a block type can be inserted.
  * @param {Function} insertOrReplaceBlocks A function that inserts or replaces blocks.
@@ -144,13 +144,13 @@ export function onBlockDrop(
 export function onFilesDrop(
 	targetRootClientId,
 	targetBlockIndex,
-	hasUploadPermissions,
+	getSettings,
 	updateBlockAttributes,
 	canInsertBlockType,
 	insertOrReplaceBlocks
 ) {
 	return ( files ) => {
-		if ( ! hasUploadPermissions ) {
+		if ( ! getSettings().mediaUpload ) {
 			return;
 		}
 
@@ -211,16 +211,13 @@ export default function useOnBlockDrop(
 	options = {}
 ) {
 	const { operation = 'insert' } = options;
-	const hasUploadPermissions = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
-		[]
-	);
 	const {
 		canInsertBlockType,
 		getBlockIndex,
 		getClientIdsOfDescendants,
 		getBlockOrder,
 		getBlocksByClientId,
+		getSettings,
 	} = useSelect( blockEditorStore );
 	const {
 		insertBlocks,
@@ -313,7 +310,7 @@ export default function useOnBlockDrop(
 	const _onFilesDrop = onFilesDrop(
 		targetRootClientId,
 		targetBlockIndex,
-		hasUploadPermissions,
+		getSettings,
 		updateBlockAttributes,
 		canInsertBlockType,
 		insertOrReplaceBlocks

--- a/packages/block-editor/src/components/use-on-block-drop/test/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/test/index.js
@@ -307,12 +307,12 @@ describe( 'onFilesDrop', () => {
 		const insertOrReplaceBlocks = jest.fn();
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
-		const uploadPermissions = false;
+		const getSettings = jest.fn( () => ( {} ) );
 
 		const onFileDropHandler = onFilesDrop(
 			targetRootClientId,
 			targetBlockIndex,
-			uploadPermissions,
+			getSettings,
 			updateBlockAttributes,
 			canInsertBlockType,
 			insertOrReplaceBlocks
@@ -332,12 +332,14 @@ describe( 'onFilesDrop', () => {
 		const canInsertBlockType = noop;
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
-		const uploadPermissions = true;
+		const getSettings = jest.fn( () => ( {
+			mediaUpload: true,
+		} ) );
 
 		const onFileDropHandler = onFilesDrop(
 			targetRootClientId,
 			targetBlockIndex,
-			uploadPermissions,
+			getSettings,
 			updateBlockAttributes,
 			canInsertBlockType,
 			insertOrReplaceBlocks
@@ -360,12 +362,14 @@ describe( 'onFilesDrop', () => {
 		const insertOrReplaceBlocks = jest.fn();
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
-		const uploadPermissions = true;
+		const getSettings = jest.fn( () => ( {
+			mediaUpload: true,
+		} ) );
 
 		const onFileDropHandler = onFilesDrop(
 			targetRootClientId,
 			targetBlockIndex,
-			uploadPermissions,
+			getSettings,
 			updateBlockAttributes,
 			canInsertBlockType,
 			insertOrReplaceBlocks


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR combines all the store subscriptions within InnerBlock into a single one. Note that the sub hooks are not public APIs but rather utility hooks of for InnerBlocks, so adjusting these is fine.

It also only runs the block context selector when needed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

First run: -21.5% type
Second run: -20.7% type

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
