### PR TITLE
(edit-site)(use-init-edited-entity-from-url) Safely access `toString()` on `siteData`'s `page_on_front`

### DIFF
--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -55,7 +55,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				hasLoadedAllDependencies: !! base && !! siteData,
 				homepageId:
 					siteData?.show_on_front === 'page'
-						? siteData.page_on_front.toString()
+						? siteData.page_on_front?.toString()
 						: null,
 				url: base?.home,
 				frontPageTemplateId: _frontPateTemplateId,

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -55,7 +55,9 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				hasLoadedAllDependencies: !! base && !! siteData,
 				homepageId:
 					siteData?.show_on_front === 'page' &&
-					typeof siteData.page_on_front === 'string'
+					[ 'number', 'string' ].includes(
+						typeof siteData.page_on_front
+					)
 						? siteData.page_on_front.toString()
 						: null,
 				url: base?.home,

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -56,7 +56,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				homepageId:
 					siteData?.show_on_front === 'page' &&
 					[ 'number', 'string' ].includes(
-						typeof siteData.page_on_front
+						typeof siteData?.page_on_front
 					)
 						? siteData.page_on_front.toString()
 						: null,

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -56,7 +56,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				homepageId:
 					siteData?.show_on_front === 'page' &&
 					[ 'number', 'string' ].includes(
-						typeof siteData?.page_on_front
+						typeof siteData.page_on_front
 					)
 						? siteData.page_on_front.toString()
 						: null,

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -54,8 +54,9 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 			return {
 				hasLoadedAllDependencies: !! base && !! siteData,
 				homepageId:
-					siteData?.show_on_front === 'page'
-						? siteData.page_on_front?.toString()
+					siteData?.show_on_front === 'page' &&
+					typeof siteData.page_on_front === 'string'
+						? siteData.page_on_front.toString()
 						: null,
 				url: base?.home,
 				frontPageTemplateId: _frontPateTemplateId,


### PR DESCRIPTION
## What?

Safely access `toString()` on possibly `null` property.

## Why?

In some circunstances/edge cases, `siteData.page_on_front` might be `null`, causing a `TypeError` and completely BSODing the Site Editor.

@youknowriad clarified that it might be a `string` or `number`. 

## How?

See `What`.
