### PR TITLE
a11y: Apply focus style to revision items

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -13,8 +13,6 @@
 
 .edit-site-global-styles-screen-revisions__revision-item {
 	position: relative;
-	padding-left: $grid-unit-20;
-	overflow: hidden;
 	cursor: pointer;
 
 	&:hover {
@@ -40,9 +38,20 @@
 		left: $grid-unit-20 + 1; // So the circle is centered on the line.
 		transform: translate(-50%, -50%);
 		z-index: 1;
+
+		// This border serves as a background color in Windows High Contrast mode.
+		border: 4px solid transparent;
 	}
-	&.is-selected::before {
-		background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+	&.is-selected {
+		border-radius: $radius-block-ui;
+
+		// Only visible in Windows High Contrast mode.
+		outline: 3px solid transparent;
+		outline-offset: -2px;
+
+		&::before {
+			background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+		}
 	}
 
 	&::after {
@@ -66,12 +75,10 @@
 		width: 100%;
 		height: auto;
 		display: block;
-		padding: $grid-unit-15 $grid-unit-15 $grid-unit-10 $grid-unit-30;
-		&:focus,
-		&:active {
-			outline: 0;
-			box-shadow: none;
-		}
+		padding: $grid-unit-15 $grid-unit-15 $grid-unit-10 $grid-unit-50;
+		z-index: 1;
+		position: relative;
+		outline-offset: -2px;
 	}
 }
 


### PR DESCRIPTION
## What?

This PR applies a focus style to revision items in the Global Style Revisions panel.

## Why?

I've noticed that users using only the keyboard can't know which revision they're switching to because revision items don't have a focus style.

## How?

I removed the style that canceled out the focus style of the button element, and at the same time adjusted the padding so that the focus outline was displayed correctly.

I also added transparent outlines and borders to help users distinguish between revisions even in Windows' high contrast mode. This approach can be seen by searching the Gutenberg project for the keyword `Windows High Contrast mode.`.

## Testing Instructions for Mouse

- Open the Global Style Revisions panel.
- Press one of the revisions.
- A focus outline should appear.

### Testing Instructions for Keyboard

- Open the Global Style Revisions panel.
- Use only the `tab` key or `shift+tab` on your keyboard.
- Check that the focus outline is displayed correctly.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/0700c329-41ac-425d-b57e-d4579ff5e455

### Widows High Contrast Mode

You should be able to see the revision status just as you would if you were not in high contrast mode.

https://github.com/WordPress/gutenberg/assets/54422211/d925cc76-96db-4349-86f3-656675f23a9b