### PR TITLE
Site editor: fix image upload bug

### DIFF
--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -35,13 +35,13 @@ export default function mediaUpload( {
 	const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes;
 	maxUploadFileSize =
 		maxUploadFileSize || getEditorSettings().maxUploadFileSize;
-
+	const currentPostId = getCurrentPostId();
 	uploadMedia( {
 		allowedTypes,
 		filesList,
 		onFileChange,
 		additionalData: {
-			post: getCurrentPostId(),
+			...( ! isNaN( currentPostId ) ? { post: currentPostId } : {} ),
 			...additionalData,
 		},
 		maxUploadFileSize,


### PR DESCRIPTION
## What?
Fixes a bug with images not uploading in the site editor.
Fixes: https://github.com/WordPress/gutenberg/issues/57037

## Why?
In https://github.com/WordPress/gutenberg/pull/55970 the settings were shared between site editor and post editor, but the site editor image upload did not previously include a post id as the post id in site editor is a template string slug. This string slug is now being passed as a post id to the image upload endpoint which causes a bad request error.

## How?
Checks for a numeric post id before appending to upload media data.

## Testing Instructions

- Go to site editor and add edit a template and add an image block
- Selection the `Upload` option and make sure it succeeds
- Do the same in the post editor and make sure that the call to the media endpoint still includes a post id

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/ced80914-11e6-44ee-aab4-ab32236c1872

After:

https://github.com/WordPress/gutenberg/assets/3629020/e51c70c1-cd58-4410-ba5c-621cf0827f00



