### PR TITLE
Disable resizing when viewport is small and wide-aligned

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -196,7 +196,8 @@ export default function Image( {
 	const isResizable =
 		allowResize &&
 		hasNonContentControls &&
-		! ( isWideAligned && isLargeViewport );
+		! isWideAligned &&
+		isLargeViewport;
 	const imageSizeOptions = imageSizes
 		.filter(
 			( { slug } ) => image?.media_details?.sizes?.[ slug ]?.source_url


### PR DESCRIPTION
Fixes: #57003

## What?

This PR fixes an issue where images can be resized unintentionally when the following conditions are met:

- If it's not a large viewport
- If the image is wide-aligned or full-width

| Before | After |
|--------|--------|
| ![before](https://github.com/WordPress/gutenberg/assets/54422211/f0080657-4356-4824-a337-8d2a04e4bb53) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/b88cee00-3f35-4d08-84cf-a10290c1a7c2) | 

## Why?

From what I've researched, this issue appears to be a regression that occurred when the gallery block was refactored to v2. More detailed information is provided in #57003.

## How?

I change part of the conditional statement that determines whether it is resizable as follows. I believe this is the expected condition.

- From: Not wide and not a large viewport
- To: Not wide and large viewport

## Testing Instructions

- Insert an Image block.
- Apply Wide width or Full width.
- Narrow the browser width.
- The image should NOT be able to be resized.
