### PR TITLE
Block editor: hooks: manage save props in one place

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -155,6 +155,7 @@ export default {
 	shareWithChildBlocks: true,
 	edit: BlockEditAlignmentToolbarControlsPure,
 	useBlockProps,
+	addSaveProps: addAssignedAlign,
 	attributeKeys: [ 'align' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, 'align', false );
@@ -208,9 +209,4 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/editor/align/addAttribute',
 	addAttribute
-);
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/editor/align/addAssignedAlign',
-	addAssignedAlign
 );

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -120,6 +120,7 @@ function BlockEditAnchorControlPure( {
 }
 
 export default {
+	addSaveProps,
 	edit: BlockEditAnchorControlPure,
 	attributeKeys: [ 'anchor' ],
 	hasSupport( name ) {
@@ -147,8 +148,3 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 }
 
 addFilter( 'blocks.registerBlockType', 'core/anchor/attribute', addAttribute );
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/editor/anchor/save-props',
-	addSaveProps
-);

--- a/packages/block-editor/src/hooks/aria-label.js
+++ b/packages/block-editor/src/hooks/aria-label.js
@@ -55,13 +55,13 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 	return extraProps;
 }
 
+export default {
+	addSaveProps,
+	attributeKeys: [ 'ariaLabel' ],
+};
+
 addFilter(
 	'blocks.registerBlockType',
 	'core/ariaLabel/attribute',
 	addAttribute
-);
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/ariaLabel/save-props',
-	addSaveProps
 );

--- a/packages/block-editor/src/hooks/aria-label.js
+++ b/packages/block-editor/src/hooks/aria-label.js
@@ -58,6 +58,9 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 export default {
 	addSaveProps,
 	attributeKeys: [ 'ariaLabel' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'ariaLabel' );
+	},
 };
 
 addFilter(

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -348,6 +348,7 @@ function useBlockProps( { name, borderColor, style } ) {
 
 export default {
 	useBlockProps,
+	addSaveProps,
 	attributeKeys: [ 'borderColor', 'style' ],
 	hasSupport( name ) {
 		return hasBorderSupport( name, 'color' );
@@ -358,10 +359,4 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/border/addAttributes',
 	addAttributes
-);
-
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/border/addSaveProps',
-	addSaveProps
 );

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -399,6 +399,7 @@ function useBlockProps( {
 
 export default {
 	useBlockProps,
+	addSaveProps,
 	attributeKeys: [ 'backgroundColor', 'textColor', 'gradient', 'style' ],
 	hasSupport: hasColorSupport,
 };
@@ -435,12 +436,6 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/color/addAttribute',
 	addAttributes
-);
-
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/color/addSaveProps',
-	addSaveProps
 );
 
 addFilter(

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -65,6 +65,7 @@ function CustomClassNameControlsPure( { className, setAttributes } ) {
 
 export default {
 	edit: CustomClassNameControlsPure,
+	addSaveProps,
 	attributeKeys: [ 'className' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, 'customClassName', true );
@@ -139,11 +140,6 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/editor/custom-class-name/attribute',
 	addAttribute
-);
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/editor/custom-class-name/save-props',
-	addSaveProps
 );
 
 addFilter(

--- a/packages/block-editor/src/hooks/custom-class-name.native.js
+++ b/packages/block-editor/src/hooks/custom-class-name.native.js
@@ -60,8 +60,11 @@ addFilter(
 	'core/custom-class-name/attribute',
 	addAttribute
 );
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/custom-class-name/save-props',
-	addSaveProps
-);
+
+export default {
+	addSaveProps,
+	attributeKeys: [ 'className' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'customClassName', true );
+	},
+};

--- a/packages/block-editor/src/hooks/font-family.js
+++ b/packages/block-editor/src/hooks/font-family.js
@@ -82,6 +82,7 @@ function useBlockProps( { name, fontFamily } ) {
 
 export default {
 	useBlockProps,
+	addSaveProps,
 	attributeKeys: [ 'fontFamily' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, FONT_FAMILY_SUPPORT_KEY );
@@ -104,10 +105,4 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/fontFamily/addAttribute',
 	addAttributes
-);
-
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/fontFamily/addSaveProps',
-	addSaveProps
 );

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -211,6 +211,7 @@ function useBlockProps( { name, fontSize, style } ) {
 
 export default {
 	useBlockProps,
+	addSaveProps,
 	attributeKeys: [ 'fontSize', 'style' ],
 	hasSupport( name ) {
 		return hasBlockSupport( name, FONT_SIZE_SUPPORT_KEY );
@@ -243,12 +244,6 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/font/addAttribute',
 	addAttributes
-);
-
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/font/addSaveProps',
-	addSaveProps
 );
 
 addFilter(

--- a/packages/block-editor/src/hooks/generated-class-name.js
+++ b/packages/block-editor/src/hooks/generated-class-name.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport, getBlockDefaultClassName } from '@wordpress/blocks';
 
 /**
@@ -38,8 +37,10 @@ export function addGeneratedClassName( extraProps, blockType ) {
 	return extraProps;
 }
 
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/generated-class-name/save-props',
-	addGeneratedClassName
-);
+export default {
+	addSaveProps: addGeneratedClassName,
+	attributeKeys: [ 'className' ],
+	hasSupport( name ) {
+		return hasBlockSupport( name, 'className', true );
+	},
+};

--- a/packages/block-editor/src/hooks/generated-class-name.js
+++ b/packages/block-editor/src/hooks/generated-class-name.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport, getBlockDefaultClassName } from '@wordpress/blocks';
 
 /**
@@ -37,10 +38,8 @@ export function addGeneratedClassName( extraProps, blockType ) {
 	return extraProps;
 }
 
-export default {
-	addSaveProps: addGeneratedClassName,
-	attributeKeys: [ 'className' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, 'className', true );
-	},
-};
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'core/generated-class-name/save-props',
+	addGeneratedClassName
+);

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -12,7 +12,7 @@ import './lock';
 import anchor from './anchor';
 import ariaLabel from './aria-label';
 import customClassName from './custom-class-name';
-import generatedClassName from './generated-class-name';
+import './generated-class-name';
 import style from './style';
 import './settings';
 import color from './color';
@@ -63,7 +63,6 @@ createBlockSaveFilter( [
 	customClassName,
 	fontFamily,
 	fontSize,
-	generatedClassName,
 	style,
 ] );
 

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -59,11 +59,11 @@ createBlockSaveFilter( [
 	anchor,
 	ariaLabel,
 	customClassName,
-	style,
+	border,
 	color,
+	style,
 	fontFamily,
 	fontSize,
-	border,
 ] );
 
 export { useCustomSides } from './dimensions';

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -1,14 +1,18 @@
 /**
  * Internal dependencies
  */
-import { createBlockEditFilter, createBlockListBlockFilter } from './utils';
+import {
+	createBlockEditFilter,
+	createBlockListBlockFilter,
+	createBlockSaveFilter,
+} from './utils';
 import './compat';
 import align from './align';
 import './lock';
 import anchor from './anchor';
-import './aria-label';
+import ariaLabel from './aria-label';
 import customClassName from './custom-class-name';
-import './generated-class-name';
+import generatedClassName from './generated-class-name';
 import style from './style';
 import './settings';
 import color from './color';
@@ -49,6 +53,18 @@ createBlockListBlockFilter( [
 	border,
 	position,
 	childLayout,
+] );
+createBlockSaveFilter( [
+	align,
+	anchor,
+	ariaLabel,
+	border,
+	color,
+	customClassName,
+	fontFamily,
+	fontSize,
+	generatedClassName,
+	style,
 ] );
 
 export { useCustomSides } from './dimensions';

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -58,12 +58,12 @@ createBlockSaveFilter( [
 	align,
 	anchor,
 	ariaLabel,
-	border,
-	color,
 	customClassName,
+	style,
+	color,
 	fontFamily,
 	fontSize,
-	style,
+	border,
 ] );
 
 export { useCustomSides } from './dimensions';

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -9,7 +9,7 @@ import {
 import './compat';
 import align from './align';
 import anchor from './anchor';
-import './custom-class-name';
+import customClassName from './custom-class-name';
 import './generated-class-name';
 import style from './style';
 import color from './color';
@@ -18,7 +18,14 @@ import './layout';
 
 createBlockEditFilter( [ align, anchor, style ] );
 createBlockListBlockFilter( [ align, style, color, fontSize ] );
-createBlockSaveFilter( [ align, anchor, color, style, fontSize ] );
+createBlockSaveFilter( [
+	align,
+	anchor,
+	customClassName,
+	color,
+	style,
+	fontSize,
+] );
 
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { createBlockEditFilter, createBlockListBlockFilter } from './utils';
+import {
+	createBlockEditFilter,
+	createBlockListBlockFilter,
+	createBlockSaveFilter,
+} from './utils';
 import './compat';
 import align from './align';
 import anchor from './anchor';
@@ -14,6 +18,7 @@ import './layout';
 
 createBlockEditFilter( [ align, anchor, style ] );
 createBlockListBlockFilter( [ align, style, color, fontSize ] );
+createBlockSaveFilter( [ align, anchor, style, color, fontSize ] );
 
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -18,7 +18,7 @@ import './layout';
 
 createBlockEditFilter( [ align, anchor, style ] );
 createBlockListBlockFilter( [ align, style, color, fontSize ] );
-createBlockSaveFilter( [ align, anchor, style, color, fontSize ] );
+createBlockSaveFilter( [ align, anchor, color, style, fontSize ] );
 
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -343,6 +343,7 @@ function BlockStyleControls( {
 export default {
 	edit: BlockStyleControls,
 	hasSupport: hasStyleSupport,
+	addSaveProps,
 	attributeKeys: [ 'style' ],
 	useBlockProps,
 };
@@ -454,10 +455,4 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/style/addAttribute',
 	addAttribute
-);
-
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/style/addSaveProps',
-	addSaveProps
 );

--- a/packages/block-editor/src/hooks/test/anchor.js
+++ b/packages/block-editor/src/hooks/test/anchor.js
@@ -6,7 +6,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import '../anchor';
+import anchor from '../anchor';
 
 const noop = () => {};
 
@@ -62,14 +62,9 @@ describe( 'anchor', () => {
 	} );
 
 	describe( 'addSaveProps', () => {
-		const getSaveContentExtraProps = applyFilters.bind(
-			null,
-			'blocks.getSaveContent.extraProps'
-		);
-
 		it( 'should do nothing if the block settings do not define anchor support', () => {
 			const attributes = { anchor: 'foo' };
-			const extraProps = getSaveContentExtraProps(
+			const extraProps = anchor.addSaveProps(
 				{},
 				blockSettings,
 				attributes
@@ -80,7 +75,7 @@ describe( 'anchor', () => {
 
 		it( 'should inject anchor attribute ID', () => {
 			const attributes = { anchor: 'foo' };
-			const extraProps = getSaveContentExtraProps(
+			const extraProps = anchor.addSaveProps(
 				{},
 				{
 					...blockSettings,
@@ -96,7 +91,7 @@ describe( 'anchor', () => {
 
 		it( 'should remove an anchor attribute ID when field is cleared', () => {
 			const attributes = { anchor: '' };
-			const extraProps = getSaveContentExtraProps(
+			const extraProps = anchor.addSaveProps(
 				{},
 				{
 					...blockSettings,

--- a/packages/block-editor/src/hooks/test/custom-class-name.js
+++ b/packages/block-editor/src/hooks/test/custom-class-name.js
@@ -6,7 +6,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import '../custom-class-name';
+import customClassName from '../custom-class-name';
 
 describe( 'custom className', () => {
 	const blockSettings = {
@@ -40,14 +40,9 @@ describe( 'custom className', () => {
 	} );
 
 	describe( 'addSaveProps', () => {
-		const addSaveProps = applyFilters.bind(
-			null,
-			'blocks.getSaveContent.extraProps'
-		);
-
 		it( 'should do nothing if the block settings do not define custom className support', () => {
 			const attributes = { className: 'foo' };
-			const extraProps = addSaveProps(
+			const extraProps = customClassName.addSaveProps(
 				{},
 				{
 					...blockSettings,
@@ -63,7 +58,7 @@ describe( 'custom className', () => {
 
 		it( 'should inject the custom className', () => {
 			const attributes = { className: 'bar' };
-			const extraProps = addSaveProps(
+			const extraProps = customClassName.addSaveProps(
 				{ className: 'foo' },
 				blockSettings,
 				attributes

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -1,12 +1,7 @@
 /**
- * WordPress dependencies
- */
-import { applyFilters } from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
-import { getInlineStyles, omitStyle } from '../style';
+import _style, { getInlineStyles, omitStyle } from '../style';
 
 describe( 'getInlineStyles', () => {
 	it( 'should return an empty object when called with undefined', () => {
@@ -120,11 +115,6 @@ describe( 'getInlineStyles', () => {
 } );
 
 describe( 'addSaveProps', () => {
-	const addSaveProps = applyFilters.bind(
-		null,
-		'blocks.getSaveContent.extraProps'
-	);
-
 	const blockSettings = {
 		save: () => <div className="default" />,
 		category: 'text',
@@ -166,7 +156,7 @@ describe( 'addSaveProps', () => {
 	};
 
 	it( 'should serialize all styles by default', () => {
-		const extraProps = addSaveProps( {}, blockSettings, attributes );
+		const extraProps = _style.addSaveProps( {}, blockSettings, attributes );
 
 		expect( extraProps.style ).toEqual( {
 			background:
@@ -183,7 +173,7 @@ describe( 'addSaveProps', () => {
 		const settings = applySkipSerialization( {
 			typography: true,
 		} );
-		const extraProps = addSaveProps( {}, settings, attributes );
+		const extraProps = _style.addSaveProps( {}, settings, attributes );
 
 		expect( extraProps.style ).toEqual( {
 			background:
@@ -198,7 +188,7 @@ describe( 'addSaveProps', () => {
 			color: [ 'gradient' ],
 			typography: [ 'textDecoration', 'textTransform' ],
 		} );
-		const extraProps = addSaveProps( {}, settings, attributes );
+		const extraProps = _style.addSaveProps( {}, settings, attributes );
 
 		expect( extraProps.style ).toEqual( {
 			color: '#d92828',

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -546,26 +546,26 @@ export function createBlockListBlockFilter( features ) {
 
 export function createBlockSaveFilter( features ) {
 	function extraPropsFromHooks( props, name, attributes ) {
-		features.reduce( ( accu, feature ) => {
+		return features.reduce( ( accu, feature ) => {
 			const { hasSupport, attributeKeys = [], addSaveProps } = feature;
 
-			const neededProps = {};
+			const neededAttributes = {};
 			for ( const key of attributeKeys ) {
 				if ( attributes[ key ] ) {
-					neededProps[ key ] = attributes[ key ];
+					neededAttributes[ key ] = attributes[ key ];
 				}
 			}
 
 			if (
 				// Skip rendering if none of the needed attributes are
 				// set.
-				! Object.keys( neededProps ).length ||
+				! Object.keys( neededAttributes ).length ||
 				! hasSupport( name )
 			) {
 				return accu;
 			}
 
-			return addSaveProps( accu, name, neededProps );
+			return addSaveProps( accu, name, neededAttributes );
 		}, props );
 	}
 	addFilter(

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -545,14 +545,14 @@ export function createBlockListBlockFilter( features ) {
 }
 
 export function createBlockSaveFilter( features ) {
-	function extraPropsFromHooks( props ) {
+	function extraPropsFromHooks( props, name, attributes ) {
 		features.reduce( ( accu, feature ) => {
 			const { hasSupport, attributeKeys = [], addSaveProps } = feature;
 
 			const neededProps = {};
 			for ( const key of attributeKeys ) {
-				if ( props.attributes[ key ] ) {
-					neededProps[ key ] = props.attributes[ key ];
+				if ( attributes[ key ] ) {
+					neededProps[ key ] = attributes[ key ];
 				}
 			}
 
@@ -560,12 +560,12 @@ export function createBlockSaveFilter( features ) {
 				// Skip rendering if none of the needed attributes are
 				// set.
 				! Object.keys( neededProps ).length ||
-				! hasSupport( props.name )
+				! hasSupport( name )
 			) {
 				return accu;
 			}
 
-			return addSaveProps( accu, props.name, neededProps );
+			return addSaveProps( accu, name, neededProps );
 		}, props );
 	}
 	addFilter(

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -546,40 +546,33 @@ export function createBlockListBlockFilter( features ) {
 
 export function createBlockSaveFilter( features ) {
 	function extraPropsFromHooks( props, name, attributes ) {
-		return features.reduce(
-			( accu, feature ) => {
-				const {
-					hasSupport,
-					attributeKeys = [],
-					addSaveProps,
-				} = feature;
+		// Previously we had a filter deleting the className if it was an empty
+		// string. That filter is no longer running, so now we need to delete it
+		// here.
+		if ( props.hasOwnProperty( 'className' ) && ! props.className ) {
+			delete props.className;
+		}
+		return features.reduce( ( accu, feature ) => {
+			const { hasSupport, attributeKeys = [], addSaveProps } = feature;
 
-				const neededAttributes = {};
-				for ( const key of attributeKeys ) {
-					if ( attributes[ key ] ) {
-						neededAttributes[ key ] = attributes[ key ];
-					}
+			const neededAttributes = {};
+			for ( const key of attributeKeys ) {
+				if ( attributes[ key ] ) {
+					neededAttributes[ key ] = attributes[ key ];
 				}
-
-				if (
-					// Skip rendering if none of the needed attributes are
-					// set.
-					! Object.keys( neededAttributes ).length ||
-					! hasSupport( name )
-				) {
-					return accu;
-				}
-
-				return addSaveProps( accu, name, neededAttributes );
-			},
-			{
-				...props,
-				// Previously we had a filter setting the className to undefined
-				// while it was an empty string. This filter is no longer
-				// running, so now we need to set it to undefined here.
-				className: props.className ? props.className : undefined,
 			}
-		);
+
+			if (
+				// Skip rendering if none of the needed attributes are
+				// set.
+				! Object.keys( neededAttributes ).length ||
+				! hasSupport( name )
+			) {
+				return accu;
+			}
+
+			return addSaveProps( accu, name, neededAttributes );
+		}, props );
 	}
 	addFilter(
 		'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -546,12 +546,6 @@ export function createBlockListBlockFilter( features ) {
 
 export function createBlockSaveFilter( features ) {
 	function extraPropsFromHooks( props, name, attributes ) {
-		// Previously we had a filter deleting the className if it was an empty
-		// string. That filter is no longer running, so now we need to delete it
-		// here.
-		if ( props.hasOwnProperty( 'className' ) && ! props.className ) {
-			delete props.className;
-		}
 		return features.reduce( ( accu, feature ) => {
 			const { hasSupport, attributeKeys = [], addSaveProps } = feature;
 
@@ -579,5 +573,19 @@ export function createBlockSaveFilter( features ) {
 		'core/editor/hooks',
 		extraPropsFromHooks,
 		0
+	);
+	addFilter(
+		'blocks.getSaveContent.extraProps',
+		'core/editor/hooks',
+		( props ) => {
+			// Previously we had a filter deleting the className if it was an empty
+			// string. That filter is no longer running, so now we need to delete it
+			// here.
+			if ( props.hasOwnProperty( 'className' ) && ! props.className ) {
+				delete props.className;
+			}
+
+			return props;
+		}
 	);
 }

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -546,27 +546,40 @@ export function createBlockListBlockFilter( features ) {
 
 export function createBlockSaveFilter( features ) {
 	function extraPropsFromHooks( props, name, attributes ) {
-		return features.reduce( ( accu, feature ) => {
-			const { hasSupport, attributeKeys = [], addSaveProps } = feature;
+		return features.reduce(
+			( accu, feature ) => {
+				const {
+					hasSupport,
+					attributeKeys = [],
+					addSaveProps,
+				} = feature;
 
-			const neededAttributes = {};
-			for ( const key of attributeKeys ) {
-				if ( attributes[ key ] ) {
-					neededAttributes[ key ] = attributes[ key ];
+				const neededAttributes = {};
+				for ( const key of attributeKeys ) {
+					if ( attributes[ key ] ) {
+						neededAttributes[ key ] = attributes[ key ];
+					}
 				}
-			}
 
-			if (
-				// Skip rendering if none of the needed attributes are
-				// set.
-				! Object.keys( neededAttributes ).length ||
-				! hasSupport( name )
-			) {
-				return accu;
-			}
+				if (
+					// Skip rendering if none of the needed attributes are
+					// set.
+					! Object.keys( neededAttributes ).length ||
+					! hasSupport( name )
+				) {
+					return accu;
+				}
 
-			return addSaveProps( accu, name, neededAttributes );
-		}, props );
+				return addSaveProps( accu, name, neededAttributes );
+			},
+			{
+				...props,
+				// Previously we had a filter setting the className to undefined
+				// while it was an empty string. This filter is no longer
+				// running, so now we need to set it to undefined here.
+				className: props.className ? props.className : undefined,
+			}
+		);
 	}
 	addFilter(
 		'blocks.getSaveContent.extraProps',

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -584,6 +584,7 @@ export function createBlockSaveFilter( features ) {
 	addFilter(
 		'blocks.getSaveContent.extraProps',
 		'core/editor/hooks',
-		extraPropsFromHooks
+		extraPropsFromHooks,
+		0
 	);
 }

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -488,10 +488,10 @@ export function createBlockListBlockFilter( features ) {
 					}
 
 					if (
-						! hasSupport( props.name ) ||
 						// Skip rendering if none of the needed attributes are
 						// set.
-						! Object.keys( neededProps ).length
+						! Object.keys( neededProps ).length ||
+						! hasSupport( props.name )
 					) {
 						return null;
 					}
@@ -541,5 +541,36 @@ export function createBlockListBlockFilter( features ) {
 		'editor.BlockListBlock',
 		'core/editor/hooks',
 		withBlockListBlockHooks
+	);
+}
+
+export function createBlockSaveFilter( features ) {
+	function extraPropsFromHooks( props ) {
+		features.reduce( ( accu, feature ) => {
+			const { hasSupport, attributeKeys = [], addSaveProps } = feature;
+
+			const neededProps = {};
+			for ( const key of attributeKeys ) {
+				if ( props.attributes[ key ] ) {
+					neededProps[ key ] = props.attributes[ key ];
+				}
+			}
+
+			if (
+				// Skip rendering if none of the needed attributes are
+				// set.
+				! Object.keys( neededProps ).length ||
+				! hasSupport( props.name )
+			) {
+				return accu;
+			}
+
+			return addSaveProps( accu, props.name, neededProps );
+		}, props );
+	}
+	addFilter(
+		'blocks.getSaveContent.extraProps',
+		'core/editor/hooks',
+		extraPropsFromHooks
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There's now only a single filter for all the hooks, and we return early if the required attributes are not present.

First run: type -11%

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
