### PR TITLE
Fix BlockSwitcher checks for showing a Dropdown menu or not

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -138,11 +138,14 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;
-	if (
-		! hasBlockStyles &&
-		! hasPossibleBlockTransformations &&
-		! hasPossibleBlockVariationTransformations
-	) {
+	const hasBlockOrBlockVariationTransforms =
+		hasPossibleBlockTransformations ||
+		hasPossibleBlockVariationTransformations;
+	const showDropdown =
+		hasBlockStyles ||
+		hasBlockOrBlockVariationTransforms ||
+		hasPatternTransformation;
+	if ( ! showDropdown ) {
 		return (
 			<ToolbarGroup>
 				<ToolbarButton
@@ -180,13 +183,6 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 				blocks.length
 		  );
 
-	const hasBlockOrBlockVariationTransforms =
-		hasPossibleBlockTransformations ||
-		hasPossibleBlockVariationTransformations;
-	const showDropDown =
-		hasBlockStyles ||
-		hasBlockOrBlockVariationTransforms ||
-		hasPatternTransformation;
 	return (
 		<ToolbarGroup>
 			<ToolbarItem>
@@ -218,54 +214,48 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 						} }
 						menuProps={ { orientation: 'both' } }
 					>
-						{ ( { onClose } ) =>
-							showDropDown && (
-								<div className="block-editor-block-switcher__container">
-									{ hasPatternTransformation && (
-										<PatternTransformationsMenu
-											blocks={ blocks }
-											patterns={ patterns }
-											onSelect={ (
+						{ ( { onClose } ) => (
+							<div className="block-editor-block-switcher__container">
+								{ hasPatternTransformation && (
+									<PatternTransformationsMenu
+										blocks={ blocks }
+										patterns={ patterns }
+										onSelect={ ( transformedBlocks ) => {
+											onPatternTransform(
 												transformedBlocks
-											) => {
-												onPatternTransform(
-													transformedBlocks
-												);
-												onClose();
-											} }
-										/>
-									) }
-									{ hasBlockOrBlockVariationTransforms && (
-										<BlockTransformationsMenu
-											className="block-editor-block-switcher__transforms__menugroup"
-											possibleBlockTransformations={
-												possibleBlockTransformations
-											}
-											possibleBlockVariationTransformations={
-												blockVariationTransformations
-											}
-											blocks={ blocks }
-											onSelect={ ( name ) => {
-												onBlockTransform( name );
-												onClose();
-											} }
-											onSelectVariation={ ( name ) => {
-												onBlockVariationTransform(
-													name
-												);
-												onClose();
-											} }
-										/>
-									) }
-									{ hasBlockStyles && (
-										<BlockStylesMenu
-											hoveredBlock={ blocks[ 0 ] }
-											onSwitch={ onClose }
-										/>
-									) }
-								</div>
-							)
-						}
+											);
+											onClose();
+										} }
+									/>
+								) }
+								{ hasBlockOrBlockVariationTransforms && (
+									<BlockTransformationsMenu
+										className="block-editor-block-switcher__transforms__menugroup"
+										possibleBlockTransformations={
+											possibleBlockTransformations
+										}
+										possibleBlockVariationTransformations={
+											blockVariationTransformations
+										}
+										blocks={ blocks }
+										onSelect={ ( name ) => {
+											onBlockTransform( name );
+											onClose();
+										} }
+										onSelectVariation={ ( name ) => {
+											onBlockVariationTransform( name );
+											onClose();
+										} }
+									/>
+								) }
+								{ hasBlockStyles && (
+									<BlockStylesMenu
+										hoveredBlock={ blocks[ 0 ] }
+										onSwitch={ onClose }
+									/>
+								) }
+							</div>
+						) }
 					</DropdownMenu>
 				) }
 			</ToolbarItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes a bug I noticed while reviewing [this PR](https://github.com/WordPress/gutenberg/pull/57020). Right now if a block has no styles or block transformations, but has pattern transformations we don't render the Dropdown.

## Testing Instructions
1. Everything should work as before(except the fix :) )
2. To check the bug in trunk you should have a block that meets the above conditions and observe that the available pattern transforms cannot be seen.
