### PR TITLE
DataViews: fix bug on operators count for table layout

### DIFF
--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -59,7 +59,7 @@ function HeaderMenu( { field, view, onChangeView } ) {
 		const operators = columnOperators.filter( ( operator ) =>
 			[ OPERATOR_IN, OPERATOR_NOT_IN ].includes( operator )
 		);
-		if ( operators.length >= 0 ) {
+		if ( operators.length > 0 ) {
 			filter = {
 				field: field.id,
 				operators,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related to https://github.com/WordPress/gutenberg/issues/55100
See https://github.com/WordPress/gutenberg/pull/56479#discussion_r1424326564

## What?

Fixes a bug by which the filters for a field couldn't be disabled in the `table` layout.

## Testing Instructions

- Open the file `packages/edit-site/src/components/page-pages/index.js` and, in the line 267, remove all the operators present:

```diff
diff --git a/packages/edit-site/src/components/page-pages/index.js b/packages/edit-site/src/components/page-pages/index.js
index 55eb450f7a..7fe1c5dcf2 100644
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -264,7 +264,7 @@ export default function PagePages() {
                                elements: STATUSES,
                                enableSorting: false,
                                filterBy: {
-                                       operators: [ OPERATOR_IN ],
+                                       operators: [],
                                },
                        },
                        {
```

- Enable the "admin views" experiment and visit the "Manage all pages" page.
- Using the `table` layout, click on the status column header and verify there is no filter. Check that there is no status filter in the filters menu (top-level row).

https://github.com/WordPress/gutenberg/assets/583546/7bbbf1e2-25b0-4d0b-acd5-b28b4b76d535
