### PR TITLE
DataViews: rename `operatorsFromField` to `sanitizeOperators`

### DIFF
--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -6,7 +6,7 @@ import AddFilter from './add-filter';
 import ResetFilters from './reset-filters';
 import { ENUMERATION_TYPE, OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
 
-const operatorsFromField = ( field ) => {
+const sanitizeOperators = ( field ) => {
 	let operators = field.filterBy?.operators;
 	if ( ! operators || ! Array.isArray( operators ) ) {
 		operators = [ OPERATOR_IN, OPERATOR_NOT_IN ];
@@ -23,7 +23,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 			return;
 		}
 
-		const operators = operatorsFromField( field );
+		const operators = sanitizeOperators( field );
 		if ( operators.length === 0 ) {
 			return;
 		}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related to https://github.com/WordPress/gutenberg/issues/55100

## What?

Rename `operatorsFromField` to `sanitizeOperators` for clarity.

## Testing Instructions

- Enable the "admin views" experiment and visit "Manage all pages" or "Manage all templates".
- Verify the filters (top-level row) still work as expected.
