### PR TITLE
DataViews: display column header when the field is only filterable

### DIFF
--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -45,9 +45,6 @@ const sortIcons = { asc: chevronUp, desc: chevronDown };
 function HeaderMenu( { field, view, onChangeView } ) {
 	const isSortable = field.enableSorting !== false;
 	const isHidable = field.enableHiding !== false;
-	if ( ! isSortable && ! isHidable ) {
-		return field.header;
-	}
 	const isSorted = view.sort?.field === field.id;
 	let filter, filterInView;
 	const otherFilters = [];
@@ -73,6 +70,10 @@ function HeaderMenu( { field, view, onChangeView } ) {
 		}
 	}
 	const isFilterable = !! filter;
+
+	if ( ! isSortable && ! isHidable && ! isFilterable ) {
+		return field.header;
+	}
 
 	if ( isFilterable ) {
 		const columnFilters = view.filters;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Make the column header displayable when a field is only filterable (but not sortable and hidable).

## Testing Instructions

- Edit the file `packages/edit-site/src/components/page-pages/index.js` and disable the `status` filter from being hidden.

```diff
diff --git a/packages/edit-site/src/components/page-pages/index.js b/packages/edit-site/src/components/page-pages/index.js
index 55eb450f7a..ce03ab282e 100644
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -263,6 +263,7 @@ export default function PagePages() {
                                type: ENUMERATION_TYPE,
                                elements: STATUSES,
                                enableSorting: false,
+                               enableHiding: false,
                                filterBy: {
                                        operators: [ OPERATOR_IN ],
                                },
```
- Enable the "admin views" experiment and visit "Manage all pages" page.
- Interact with the "status" column header and verify that a menu opens on clicking and shows the existing filter (it didn't work before):

https://github.com/WordPress/gutenberg/assets/583546/b9843dfb-2276-4c4b-92d2-4aa98072af2f

