### PR TITLE
Font Library: update tab-panel component with tabs component

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -2,8 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Modal, TabPanel } from '@wordpress/components';
-import { useContext } from '@wordpress/element';
+import {
+	Modal,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { useState, useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,6 +15,9 @@ import InstalledFonts from './installed-fonts';
 import FontCollection from './font-collection';
 import UploadFonts from './upload-fonts';
 import { FontLibraryContext } from './context';
+import { unlock } from '../../../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 const DEFAULT_TABS = [
 	{
@@ -41,6 +47,7 @@ function FontLibraryModal( {
 	initialTabName = 'installed-fonts',
 } ) {
 	const { collections } = useContext( FontLibraryContext );
+	const [ selectedTab, setSelectedTab ] = useState( initialTabName );
 
 	const tabs = [
 		...DEFAULT_TABS,
@@ -54,22 +61,30 @@ function FontLibraryModal( {
 			isFullScreen
 			className="font-library-modal"
 		>
-			<TabPanel
-				className="font-library-modal__tab-panel"
-				initialTabName={ initialTabName }
-				tabs={ tabs }
-			>
-				{ ( tab ) => {
-					switch ( tab.name ) {
-						case 'upload-fonts':
-							return <UploadFonts />;
-						case 'installed-fonts':
-							return <InstalledFonts />;
-						default:
-							return <FontCollection id={ tab.name } />;
-					}
-				} }
-			</TabPanel>
+			<Tabs selectedTabId={ selectedTab } onSelect={ setSelectedTab }>
+				<Tabs.TabList className="font-library-modal__tab-list">
+					{ tabs.map( ( tab ) => (
+						<Tabs.Tab
+							key={ tab.name }
+							tabId={ tab.name }
+							className={ tab.className }
+						>
+							{ tab.title }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.TabList>
+				<Tabs.TabPanel tabId={ 'installed-fonts' }>
+					<InstalledFonts />
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId={ 'upload-fonts' }>
+					<UploadFonts />
+				</Tabs.TabPanel>
+				{ tabsFromCollections( collections || [] ).map( ( tab ) => (
+					<Tabs.TabPanel key={ tab.name } tabId={ tab.name }>
+						<FontCollection id={ tab.name } />
+					</Tabs.TabPanel>
+				) ) }
+			</Tabs>
 		</Modal>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -75,8 +75,8 @@
 	padding-bottom: 1rem;
 }
 
-.font-library-modal__tab-panel {
-	[role="tablist"] {
+.font-library-modal__tab-list {
+	&[role="tablist"] {
 		position: sticky;
 		top: 0;
 		width: calc(100% + 64px);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Replaces the legacy TabPanel component with the new Tabs component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To introduce composable behaviour, and to be able to switch tabs from code.
Code split from #55975

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Replaced `TabsPanel` with new `Tabs`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open font library modal from global styles.
2. Test the tabs and it should work without any issues.

<img width="993" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/6c4a86a2-0ed5-4f75-915b-9d3b35ff2fec">
