### PR TITLE
[RNMobile] Adjust font sizes in `RichText` based on device settings

### DIFF
--- a/packages/block-editor/src/components/rich-text/native/get-screen-adjusted-font-size.native.js
+++ b/packages/block-editor/src/components/rich-text/native/get-screen-adjusted-font-size.native.js
@@ -25,7 +25,7 @@ const clamp = ( value, min, max ) => {
  */
 export function getScreenAdjustedFontSize(
 	currentFontSize,
-	minFontSize = 12,
+	minFontSize = 10,
 	maxFontSize = 100
 ) {
 	if ( typeof currentFontSize !== 'number' || isNaN( currentFontSize ) ) {

--- a/packages/block-editor/src/components/rich-text/native/get-screen-adjusted-font-size.native.js
+++ b/packages/block-editor/src/components/rich-text/native/get-screen-adjusted-font-size.native.js
@@ -28,6 +28,10 @@ export function getScreenAdjustedFontSize(
 	minFontSize = 12,
 	maxFontSize = 100
 ) {
+	if ( typeof currentFontSize !== 'number' || isNaN( currentFontSize ) ) {
+		return undefined;
+	}
+
 	const fontScale = PixelRatio.getFontScale() ?? 1;
 	const scaledFontSize = currentFontSize * fontScale;
 	const fontSize = clamp( scaledFontSize, minFontSize, maxFontSize );

--- a/packages/block-editor/src/components/rich-text/native/get-screen-adjusted-font-size.native.js
+++ b/packages/block-editor/src/components/rich-text/native/get-screen-adjusted-font-size.native.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { PixelRatio } from 'react-native';
+
+const clamp = ( value, min, max ) => {
+	return Math.min( Math.max( value, min ), max );
+};
+
+/**
+ * Function to adjust font size for screen display based on user's device settings.
+ *
+ * This function calculates an adjusted font size by scaling the provided `currentFontSize`
+ * according to the user's device font scale settings. This is particularly useful for
+ * respecting accessibility preferences such as larger text sizes set by the user.
+ *
+ * The calculated font size is then clamped within the specified range defined by
+ * `minFontSize` and `maxFontSize` to ensure it remains within a reasonable and
+ * manageable range for the app's UI.
+ *
+ * @param {number} currentFontSize - The base font size to be adjusted.
+ * @param {number} minFontSize     - The minimum font size limit for the adjustment.
+ * @param {number} maxFontSize     - The maximum font size limit for the adjustment.
+ * @return {number}                - The adjusted font size.
+ */
+export function getScreenAdjustedFontSize(
+	currentFontSize,
+	minFontSize = 12,
+	maxFontSize = 100
+) {
+	const fontScale = PixelRatio.getFontScale() ?? 1;
+	const scaledFontSize = currentFontSize * fontScale;
+	const fontSize = clamp( scaledFontSize, minFontSize, maxFontSize );
+	return fontSize;
+}

--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { View, Platform, Dimensions } from 'react-native';
+import { View, Platform, Dimensions, PixelRatio } from 'react-native';
 import memize from 'memize';
 import { colord } from 'colord';
 
@@ -1124,7 +1124,9 @@ export class RichText extends Component {
 		const editableProps = this.getEditableProps();
 		const blockUseDefaultFont = this.getBlockUseDefaultFont();
 
-		const fontSize = currentFontSize;
+		const fontScale = PixelRatio.getFontScale() || 1;
+		const scaledFontSize = currentFontSize * fontScale;
+		const fontSize = scaledFontSize;
 		const lineHeight = this.getLineHeight();
 
 		const {

--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -1124,6 +1124,7 @@ export class RichText extends Component {
 		const html = this.getHtmlToRender( record, tagName );
 		const editableProps = this.getEditableProps();
 		const blockUseDefaultFont = this.getBlockUseDefaultFont();
+
 		const fontSize = getScreenAdjustedFontSize( currentFontSize );
 		const lineHeight = this.getLineHeight();
 

--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -1125,7 +1125,9 @@ export class RichText extends Component {
 		const editableProps = this.getEditableProps();
 		const blockUseDefaultFont = this.getBlockUseDefaultFont();
 
-		const fontSize = getScreenAdjustedFontSize( currentFontSize );
+		const fontSize = this.isIOS
+			? getScreenAdjustedFontSize( currentFontSize )
+			: currentFontSize;
 		const lineHeight = this.getLineHeight();
 
 		const {

--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -48,7 +48,6 @@ import {
 import { useFormatTypes } from './use-format-types';
 import FormatEdit from './format-edit';
 import { getFormatColors } from './get-format-colors';
-import { getScreenAdjustedFontSize } from './get-screen-adjusted-font-size';
 import styles from './style.scss';
 import ToolbarButtonWithOptions from './toolbar-button-with-options';
 
@@ -1125,9 +1124,7 @@ export class RichText extends Component {
 		const editableProps = this.getEditableProps();
 		const blockUseDefaultFont = this.getBlockUseDefaultFont();
 
-		const fontSize = this.isIOS
-			? getScreenAdjustedFontSize( currentFontSize )
-			: currentFontSize;
+		const fontSize = currentFontSize;
 		const lineHeight = this.getLineHeight();
 
 		const {

--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { View, Platform, Dimensions, PixelRatio } from 'react-native';
+import { View, Platform, Dimensions } from 'react-native';
 import memize from 'memize';
 import { colord } from 'colord';
 
@@ -48,6 +48,7 @@ import {
 import { useFormatTypes } from './use-format-types';
 import FormatEdit from './format-edit';
 import { getFormatColors } from './get-format-colors';
+import { getScreenAdjustedFontSize } from './get-screen-adjusted-font-size';
 import styles from './style.scss';
 import ToolbarButtonWithOptions from './toolbar-button-with-options';
 
@@ -1123,10 +1124,7 @@ export class RichText extends Component {
 		const html = this.getHtmlToRender( record, tagName );
 		const editableProps = this.getEditableProps();
 		const blockUseDefaultFont = this.getBlockUseDefaultFont();
-
-		const fontScale = PixelRatio.getFontScale() || 1;
-		const scaledFontSize = currentFontSize * fontScale;
-		const fontSize = scaledFontSize;
+		const fontSize = getScreenAdjustedFontSize( currentFontSize );
 		const lineHeight = this.getLineHeight();
 
 		const {

--- a/packages/block-editor/src/components/rich-text/native/test/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/test/index.native.js
@@ -169,13 +169,13 @@ describe( '<RichText/>', () => {
 		it( `should display rich text at the font size computed from the LOCAL \`style.fontSize\` CSS with HIGHEST PRIORITY
 		when CSS is provided ambiguously from ALL possible sources.`, () => {
 			// Arrange.
-			const expectedFontSize = 1;
+			const expectedFontSize = 10;
 			mockGlobalSettings( { fontSize: '0' } );
 			// Act.
 			const { getByLabelText } = render(
 				<RichText
 					accessibilityLabel={ 'editor' }
-					style={ { fontSize: '1' } }
+					style={ { fontSize: '10' } }
 					fontSize={ '2' }
 					tagName="p"
 				/>
@@ -188,13 +188,13 @@ describe( '<RichText/>', () => {
 		it( `should display rich text at the font size computed from the LOCAL \`style.fontSize\` CSS with
 		NEXT PRIORITY when CSS is provided ambiguously from MULTIPLE possible sources EXCLUDING \`fontSize\`.`, () => {
 			// Arrange.
-			const expectedFontSize = 1;
+			const expectedFontSize = 10;
 			mockGlobalSettings( { fontSize: '0' } );
 			// Act.
 			const { getByLabelText } = render(
 				<RichText
 					accessibilityLabel={ 'editor' }
-					style={ { fontSize: '1' } }
+					style={ { fontSize: '10' } }
 					tagName="p"
 				/>
 			);
@@ -205,8 +205,8 @@ describe( '<RichText/>', () => {
 
 		it( 'should display rich text at the font size computed from CSS relative to the VIEWPORT WIDTH.', () => {
 			// Arrange.
-			const expectedFontSize = 3;
-			Dimensions.set( { window: { ...window, width: 300 } } );
+			const expectedFontSize = 10;
+			Dimensions.set( { window: { ...window, width: 1000 } } );
 			// Act.
 			const { getByLabelText } = render(
 				<RichText accessibilityLabel={ 'editor' } fontSize={ '1vw' } />
@@ -218,8 +218,8 @@ describe( '<RichText/>', () => {
 
 		it( 'should display rich text at the font size computed from CSS relative to the VIEWPORT HEIGHT.', () => {
 			// Arrange.
-			const expectedFontSize = 3;
-			Dimensions.set( { window: { ...window, height: 300 } } );
+			const expectedFontSize = 10;
+			Dimensions.set( { window: { ...window, height: 1000 } } );
 			// Act.
 			const { getByLabelText } = render(
 				<RichText accessibilityLabel={ 'editor' } fontSize={ '1vh' } />

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -3,7 +3,7 @@
  */
 import 'react-native-gesture-handler/jestSetup';
 import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
-import { Image, Linking } from 'react-native';
+import { Image, Linking, PixelRatio } from 'react-native';
 
 // React Native sets up a global navigator, but that is not executed in the
 // testing environment: https://github.com/facebook/react-native/blob/6c19dc3266b84f47a076b647a1c93b3c3b69d2c5/Libraries/Core/setUpNavigator.js#L17
@@ -280,3 +280,7 @@ jest.mock( '@wordpress/compose', () => {
 jest.spyOn( Image, 'getSize' ).mockImplementation( ( url, success ) =>
 	success( 0, 0 )
 );
+
+// Jest's environment returns pixel ratio, not font scale, when getFontScale() is called.
+// It's necessary to mock this method to return 1, the standard default for most devices.
+jest.spyOn( PixelRatio, 'getFontScale' ).mockImplementation( () => 1 );


### PR DESCRIPTION
Partial fix for: https://github.com/wordpress-mobile/gutenberg-mobile/issues/4097

## Related PRs

* Gutenberg Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6465/
* Aztec: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1381
* iOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/22242
* Android: https://github.com/wordpress-mobile/WordPress-Android/pull/19800/ 

## What?

`RichText` component. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

## Screenshots or screencast 

### Android

<details>
 <summary>Font size of 30px with largest available accessibility setting ⤵️</summary>

| Android  | iOS |
| ------------- | ------------- |
| <img src="https://github.com/WordPress/gutenberg/assets/2998162/67c73b3e-ca75-4283-8495-7c5e5fb5713a" width="100%"> | <img src="" width="100%"> |

</details>
