### PR TITLE
DataViews: centralize control of filter visibility in the `Filters` component

### DIFF
--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -13,7 +13,7 @@ import { Children, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { OPERATOR_IN, OPERATOR_NOT_IN, LAYOUT_LIST } from './constants';
+import { OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
 import { unlock } from './lock-unlock';
 
 const {
@@ -73,10 +73,6 @@ function WithSeparators( { children } ) {
 }
 
 export default function FilterSummary( { filter, view, onChangeView } ) {
-	if ( view.type === LAYOUT_LIST ) {
-		return null;
-	}
-
 	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
 	const activeElement = filter.elements.find(
 		( element ) => element.value === filterInView?.value

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -4,7 +4,12 @@
 import FilterSummary from './filter-summary';
 import AddFilter from './add-filter';
 import ResetFilters from './reset-filters';
-import { ENUMERATION_TYPE, OPERATOR_IN, OPERATOR_NOT_IN } from './constants';
+import {
+	ENUMERATION_TYPE,
+	OPERATOR_IN,
+	OPERATOR_NOT_IN,
+	LAYOUT_LIST,
+} from './constants';
 
 const sanitizeOperators = ( field ) => {
 	let operators = field.filterBy?.operators;
@@ -57,7 +62,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 	const filterComponents = [
 		addFilter,
 		...filters.map( ( filter ) => {
-			if ( ! filter.isVisible ) {
+			if ( ! filter.isVisible || view.type === LAYOUT_LIST ) {
 				return null;
 			}
 
@@ -72,7 +77,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 		} ),
 	];
 
-	if ( filterComponents.length > 1 ) {
+	if ( filterComponents.length > 1 && view.type !== LAYOUT_LIST ) {
 		filterComponents.push(
 			<ResetFilters
 				key="reset-filters"

--- a/packages/dataviews/src/reset-filters.js
+++ b/packages/dataviews/src/reset-filters.js
@@ -4,16 +4,7 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { LAYOUT_LIST } from './constants';
-
 export default ( { view, onChangeView } ) => {
-	if ( view.type === LAYOUT_LIST ) {
-		return null;
-	}
-
 	return (
 		<Button
 			disabled={ view.search === '' && view.filters?.length === 0 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
See https://github.com/WordPress/gutenberg/pull/56983#discussion_r1426283427

## What?

This is a code quality change: it centralizes the visibility conditions of the filters subcomponents (add filter, reset filter) in the `<Filters>` component.

## Testing Instructions

- Enable the "view admin" experiment and visit "Manage all pages".
- Verify the filter visibility works as expected:
  - Switch to list layout: the reset filters shouldn't be present, but the add filter button should.
  - Disable all filters and verify the top-level row doesn't show the add filter and reset filter buttons:

```diff
diff --git a/packages/edit-site/src/components/page-pages/index.js b/packages/edit-site/src/components/page-pages/index.js
index 55eb450f7a..8562242451 100644
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -248,6 +248,9 @@ export default function PagePages() {
                                id: 'author',
                                getValue: ( { item } ) => item._embedded?.author[ 0 ]?.name,
                                type: ENUMERATION_TYPE,
+                               filterBy: {
+                                       operators: [],
+                               },
                                elements:
                                        authors?.map( ( { id, name } ) => ( {
                                                value: id,
@@ -264,7 +267,7 @@ export default function PagePages() {
                                elements: STATUSES,
                                enableSorting: false,
                                filterBy: {
-                                       operators: [ OPERATOR_IN ],
+                                       operators: [],
                                },
                        },
                        {
```