### PR TITLE
Data views: Use default variants for Filter and View buttons 

### DIFF
--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -55,7 +55,6 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 				<Button
 					__experimentalIsFocusable
 					label={ __( 'Filters' ) }
-					variant="tertiary"
 					size="compact"
 					icon={ funnel }
 					className="dataviews-filters-button"

--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -261,7 +261,6 @@ export default function ViewActions( {
 		<DropdownMenu
 			trigger={
 				<Button
-					variant="tertiary"
 					size="compact"
 					icon={
 						VIEW_LAYOUTS.find( ( v ) => v.type === view.type )


### PR DESCRIPTION
## What?
Use the default button variants for the Filter and View buttons.

## Why?
Consistency with other icon buttons like item actions and pagination.

## Before

<img width="1317" alt="Screenshot 2023-12-14 at 10 52 20" src="https://github.com/WordPress/gutenberg/assets/846565/fd2bb0db-bf1f-4704-b36e-3e43e05adbbe">

Note the blue filter / table icons above the table

## After

<img width="1317" alt="Screenshot 2023-12-14 at 10 51 58" src="https://github.com/WordPress/gutenberg/assets/846565/f4c0d522-bfd4-4acc-958e-be2c70e19365">
