### PR TITLE
Data views: Add hover style to table rows

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -97,6 +97,12 @@
 		&:last-child {
 			border-bottom: 0;
 		}
+
+		&:hover {
+			td {
+				background-color: #f8f8f8;
+			}
+		}
 	}
 	thead {
 		tr {


### PR DESCRIPTION
## What?
Add a hover style to rows in Table layout. 

## Why?
Highlighting the hovered row makes it much easier to ensure you're working with the correct item. This is particularly useful on wide screens where the right-most column can be a great distance from the identifier (title).

## How

Apply hover style to `.dataviews-table-view tr td:hover`. The background color matches the one used in List layout. Ideally this is made into a variable in the future. 

## To test

* Go to Manage pages or templates
* Select Table layout
* Mouse over a table row and observe a background color

## Screenshot

<img width="2000" alt="Screenshot 2023-12-14 at 11 01 50" src="https://github.com/WordPress/gutenberg/assets/846565/b0eeecf5-6428-4b41-94bf-149270a2d775">
