### PR TITLE
DataViews: align filter implementations

### DIFF
--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -73,6 +73,9 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 						const filterInView = view.filters.find(
 							( f ) => f.field === filter.field
 						);
+						const otherFilters = view.filters.filter(
+							( f ) => f.field !== filter.field
+						);
 						const activeElement = filter.elements.find(
 							( element ) => element.value === filterInView?.value
 						);
@@ -107,50 +110,45 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 							>
 								<WithSeparators>
 									<DropdownMenuGroup>
-										{ filter.elements.map( ( element ) => (
-											<DropdownMenuItem
-												key={ element.value }
-												role="menuitemradio"
-												aria-checked={
-													activeElement?.value ===
-													element.value
-												}
-												prefix={
-													activeElement?.value ===
-														element.value && (
-														<Icon icon={ check } />
-													)
-												}
-												onSelect={ ( event ) => {
-													event.preventDefault();
-													onChangeView(
-														( currentView ) => ( {
-															...currentView,
+										{ filter.elements.map( ( element ) => {
+											const isActive =
+												activeElement?.value ===
+												element.value;
+											return (
+												<DropdownMenuItem
+													key={ element.value }
+													role="menuitemradio"
+													aria-checked={ isActive }
+													prefix={
+														isActive && (
+															<Icon
+																icon={ check }
+															/>
+														)
+													}
+													onSelect={ ( event ) => {
+														event.preventDefault();
+														onChangeView( {
+															...view,
 															page: 1,
 															filters: [
-																...currentView.filters.filter(
-																	( f ) =>
-																		f.field !==
-																		filter.field
-																),
+																...otherFilters,
 																{
 																	field: filter.field,
 																	operator:
 																		activeOperator,
-																	value:
-																		activeElement?.value ===
-																		element.value
-																			? undefined
-																			: element.value,
+																	value: isActive
+																		? undefined
+																		: element.value,
 																},
 															],
-														} )
-													);
-												} }
-											>
-												{ element.label }
-											</DropdownMenuItem>
-										) ) }
+														} );
+													} }
+												>
+													{ element.label }
+												</DropdownMenuItem>
+											);
+										} ) }
 									</DropdownMenuGroup>
 									{ filter.operators.length > 1 && (
 										<DropdownSubMenu
@@ -191,25 +189,19 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 												}
 												onSelect={ ( event ) => {
 													event.preventDefault();
-													onChangeView(
-														( currentView ) => ( {
-															...currentView,
-															page: 1,
-															filters: [
-																...view.filters.filter(
-																	( f ) =>
-																		f.field !==
-																		filter.field
-																),
-																{
-																	field: filter.field,
-																	operator:
-																		OPERATOR_IN,
-																	value: filterInView?.value,
-																},
-															],
-														} )
-													);
+													onChangeView( {
+														...view,
+														page: 1,
+														filters: [
+															...otherFilters,
+															{
+																field: filter.field,
+																operator:
+																	OPERATOR_IN,
+																value: filterInView?.value,
+															},
+														],
+													} );
 												} }
 											>
 												{ __( 'Is' ) }
@@ -229,25 +221,19 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 												}
 												onSelect={ ( event ) => {
 													event.preventDefault();
-													onChangeView(
-														( currentView ) => ( {
-															...currentView,
-															page: 1,
-															filters: [
-																...view.filters.filter(
-																	( f ) =>
-																		f.field !==
-																		filter.field
-																),
-																{
-																	field: filter.field,
-																	operator:
-																		OPERATOR_NOT_IN,
-																	value: filterInView?.value,
-																},
-															],
-														} )
-													);
+													onChangeView( {
+														...view,
+														page: 1,
+														filters: [
+															...otherFilters,
+															{
+																field: filter.field,
+																operator:
+																	OPERATOR_NOT_IN,
+																value: filterInView?.value,
+															},
+														],
+													} );
 												} }
 											>
 												{ __( 'Is not' ) }

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -74,9 +74,13 @@ function WithSeparators( { children } ) {
 
 export default function FilterSummary( { filter, view, onChangeView } ) {
 	const filterInView = view.filters.find( ( f ) => f.field === filter.field );
+	const otherFilters = view.filters.filter(
+		( f ) => f.field !== filter.field
+	);
 	const activeElement = filter.elements.find(
 		( element ) => element.value === filterInView?.value
 	);
+	const activeOperator = filterInView?.operator || filter.operators[ 0 ];
 
 	return (
 		<DropdownMenu
@@ -95,40 +99,28 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 			<WithSeparators>
 				<DropdownMenuGroup>
 					{ filter.elements.map( ( element ) => {
+						const isActive = activeElement?.value === element.value;
 						return (
 							<DropdownMenuItem
 								key={ element.value }
 								role="menuitemradio"
-								aria-checked={
-									activeElement?.value === element.value
-								}
-								prefix={
-									activeElement?.value === element.value && (
-										<Icon icon={ check } />
-									)
-								}
+								aria-checked={ isActive }
+								prefix={ isActive && <Icon icon={ check } /> }
 								onSelect={ () =>
-									onChangeView( ( currentView ) => ( {
-										...currentView,
+									onChangeView( {
+										...view,
 										page: 1,
 										filters: [
-											...view.filters.filter(
-												( f ) =>
-													f.field !== filter.field
-											),
+											...otherFilters,
 											{
 												field: filter.field,
-												operator:
-													filterInView?.operator ||
-													filter.operators[ 0 ],
-												value:
-													activeElement?.value ===
-													element.value
-														? undefined
-														: element.value,
+												operator: activeOperator,
+												value: isActive
+													? undefined
+													: element.value,
 											},
 										],
-									} ) )
+									} )
 								}
 							>
 								{ element.label }
@@ -142,9 +134,10 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 							<DropdownSubMenuTrigger
 								suffix={
 									<>
-										{ filterInView.operator === OPERATOR_IN
-											? __( 'Is' )
-											: __( 'Is not' ) }
+										{ activeOperator === OPERATOR_IN &&
+											__( 'Is' ) }
+										{ activeOperator === OPERATOR_NOT_IN &&
+											__( 'Is not' ) }
 										<Icon icon={ chevronRightSmall } />{ ' ' }
 									</>
 								}
@@ -156,29 +149,25 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 						<DropdownMenuItem
 							key="in-filter"
 							role="menuitemradio"
-							aria-checked={
-								filterInView?.operator === OPERATOR_IN
-							}
+							aria-checked={ activeOperator === OPERATOR_IN }
 							prefix={
-								filterInView?.operator === OPERATOR_IN && (
+								activeOperator === OPERATOR_IN && (
 									<Icon icon={ check } />
 								)
 							}
 							onSelect={ () =>
-								onChangeView( ( currentView ) => ( {
-									...currentView,
+								onChangeView( {
+									...view,
 									page: 1,
 									filters: [
-										...view.filters.filter(
-											( f ) => f.field !== filter.field
-										),
+										...otherFilters,
 										{
 											field: filter.field,
 											operator: OPERATOR_IN,
 											value: filterInView?.value,
 										},
 									],
-								} ) )
+								} )
 							}
 						>
 							{ __( 'Is' ) }
@@ -186,29 +175,25 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 						<DropdownMenuItem
 							key="not-in-filter"
 							role="menuitemradio"
-							aria-checked={
-								filterInView?.operator === OPERATOR_NOT_IN
-							}
+							aria-checked={ activeOperator === OPERATOR_NOT_IN }
 							prefix={
-								filterInView?.operator === OPERATOR_NOT_IN && (
+								activeOperator === OPERATOR_NOT_IN && (
 									<Icon icon={ check } />
 								)
 							}
 							onSelect={ () =>
-								onChangeView( ( currentView ) => ( {
-									...currentView,
+								onChangeView( {
+									...view,
 									page: 1,
 									filters: [
-										...view.filters.filter(
-											( f ) => f.field !== filter.field
-										),
+										...otherFilters,
 										{
 											field: filter.field,
 											operator: OPERATOR_NOT_IN,
 											value: filterInView?.value,
 										},
 									],
-								} ) )
+								} )
 							}
 						>
 							{ __( 'Is not' ) }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -42,32 +42,36 @@ const sortingItemsInfo = {
 };
 const sortIcons = { asc: chevronUp, desc: chevronDown };
 
+const sanitizeOperators = ( field ) => {
+	let operators = field.filterBy?.operators;
+	if ( ! operators || ! Array.isArray( operators ) ) {
+		operators = [ OPERATOR_IN, OPERATOR_NOT_IN ];
+	}
+	return operators.filter( ( operator ) =>
+		[ OPERATOR_IN, OPERATOR_NOT_IN ].includes( operator )
+	);
+};
+
 function HeaderMenu( { field, view, onChangeView } ) {
-	const isSortable = field.enableSorting !== false;
 	const isHidable = field.enableHiding !== false;
+
+	const isSortable = field.enableSorting !== false;
 	const isSorted = view.sort?.field === field.id;
-	let filter, filterInView;
-	const otherFilters = [];
-	if ( field.type === ENUMERATION_TYPE ) {
-		let columnOperators = field.filterBy?.operators;
-		if ( ! columnOperators || ! Array.isArray( columnOperators ) ) {
-			columnOperators = [ OPERATOR_IN, OPERATOR_NOT_IN ];
-		}
-		const operators = columnOperators.filter( ( operator ) =>
-			[ OPERATOR_IN, OPERATOR_NOT_IN ].includes( operator )
+
+	let filter, filterInView, activeElement, activeOperator, otherFilters;
+	const operators = sanitizeOperators( field );
+	if ( field.type === ENUMERATION_TYPE && operators.length > 0 ) {
+		filter = {
+			field: field.id,
+			operators,
+			elements: field.elements || [],
+		};
+		filterInView = view.filters.find( ( f ) => f.field === filter.field );
+		otherFilters = view.filters.filter( ( f ) => f.field !== filter.field );
+		activeElement = filter.elements.find(
+			( element ) => element.value === filterInView?.value
 		);
-		if ( operators.length > 0 ) {
-			filter = {
-				field: field.id,
-				operators,
-				elements: field.elements || [],
-			};
-			filterInView = {
-				field: filter.field,
-				operator: filter.operators[ 0 ],
-				value: undefined,
-			};
-		}
+		activeOperator = filterInView?.operator || filter.operators[ 0 ];
 	}
 	const isFilterable = !! filter;
 
@@ -75,18 +79,6 @@ function HeaderMenu( { field, view, onChangeView } ) {
 		return field.header;
 	}
 
-	if ( isFilterable ) {
-		const columnFilters = view.filters;
-		columnFilters.forEach( ( columnFilter ) => {
-			if ( columnFilter.field === filter.field ) {
-				filterInView = {
-					...columnFilter,
-				};
-			} else {
-				otherFilters.push( columnFilter );
-			}
-		} );
-	}
 	return (
 		<DropdownMenu
 			align="start"
@@ -161,7 +153,19 @@ function HeaderMenu( { field, view, onChangeView } ) {
 								<DropdownSubMenuTrigger
 									prefix={ <Icon icon={ funnel } /> }
 									suffix={
-										<Icon icon={ chevronRightSmall } />
+										<>
+											{ activeElement &&
+												activeOperator ===
+													OPERATOR_IN &&
+												__( 'Is' ) }
+											{ activeElement &&
+												activeOperator ===
+													OPERATOR_NOT_IN &&
+												__( 'Is not' ) }
+											{ activeElement && ' ' }
+											{ activeElement?.label }
+											<Icon icon={ chevronRightSmall } />
+										</>
 									}
 								>
 									{ __( 'Filter by' ) }
@@ -171,17 +175,9 @@ function HeaderMenu( { field, view, onChangeView } ) {
 							<WithSeparators>
 								<DropdownMenuGroup>
 									{ filter.elements.map( ( element ) => {
-										let isActive = false;
-										if ( filterInView ) {
-											// Intentionally use loose comparison, so it does type conversion.
-											// This covers the case where a top-level filter for the same field converts a number into a string.
-											/* eslint-disable eqeqeq */
-											isActive =
-												element.value ==
-												filterInView.value;
-											/* eslint-enable eqeqeq */
-										}
-
+										const isActive =
+											activeElement?.value ===
+											element.value;
 										return (
 											<DropdownMenuItem
 												key={ element.value }
@@ -195,12 +191,13 @@ function HeaderMenu( { field, view, onChangeView } ) {
 												onSelect={ () => {
 													onChangeView( {
 														...view,
+														page: 1,
 														filters: [
 															...otherFilters,
 															{
 																field: filter.field,
 																operator:
-																	filterInView?.operator,
+																	activeOperator,
 																value: isActive
 																	? undefined
 																	: element.value,
@@ -220,10 +217,12 @@ function HeaderMenu( { field, view, onChangeView } ) {
 											<DropdownSubMenuTrigger
 												suffix={
 													<>
-														{ filterInView.operator ===
-														OPERATOR_IN
-															? __( 'Is' )
-															: __( 'Is not' ) }
+														{ activeOperator ===
+															OPERATOR_IN &&
+															__( 'Is' ) }
+														{ activeOperator ===
+															OPERATOR_NOT_IN &&
+															__( 'Is not' ) }
 														<Icon
 															icon={
 																chevronRightSmall
@@ -240,11 +239,10 @@ function HeaderMenu( { field, view, onChangeView } ) {
 											key="in-filter"
 											role="menuitemradio"
 											aria-checked={
-												filterInView?.operator ===
-												OPERATOR_IN
+												activeOperator === OPERATOR_IN
 											}
 											prefix={
-												filterInView?.operator ===
+												activeOperator ===
 													OPERATOR_IN && (
 													<Icon icon={ check } />
 												)
@@ -252,6 +250,7 @@ function HeaderMenu( { field, view, onChangeView } ) {
 											onSelect={ () =>
 												onChangeView( {
 													...view,
+													page: 1,
 													filters: [
 														...otherFilters,
 														{
@@ -270,11 +269,11 @@ function HeaderMenu( { field, view, onChangeView } ) {
 											key="not-in-filter"
 											role="menuitemradio"
 											aria-checked={
-												filterInView?.operator ===
+												activeOperator ===
 												OPERATOR_NOT_IN
 											}
 											prefix={
-												filterInView?.operator ===
+												activeOperator ===
 													OPERATOR_NOT_IN && (
 													<Icon icon={ check } />
 												)
@@ -282,6 +281,7 @@ function HeaderMenu( { field, view, onChangeView } ) {
 											onSelect={ () =>
 												onChangeView( {
 													...view,
+													page: 1,
 													filters: [
 														...otherFilters,
 														{


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/pull/56514 and https://github.com/WordPress/gutenberg/pull/56479#discussion_r1424326564

## What?

This PR:

- Aligns the filter implementation across the different components (column filters, filter summary, and add filter).
- Fixes a bug in the column filters by which the pagination wasn't reset.
- Adds a summary of the current filter to the columns filter, following what we do in the other parts of the UI.

<img width="226" alt="Captura de ecrã 2023-12-14, às 13 07 05" src="https://github.com/WordPress/gutenberg/assets/583546/0af5f107-f837-4f8f-a906-4b8614359a7d">

## Why?

Fixes bugs.

In the past, I tried extracting a common UI component at https://github.com/WordPress/gutenberg/pull/56514 though it wasn't merged. At this point, the three implementations share the same logical model but vary in UI/interactions slightly (what's the trigger for the filter, whether it should stay open or close on clicking, copy, etc.).

## Testing Instructions

- Have a site with more than 10 pages or templates.
- Enable the "admin views" experiment and visit "Manage all pages" or "Manage all templates".
- Set pagination to 10.
- Verify that filters work as expected (filter resets pagination, it works, etc.).
