### PR TITLE
Image Block: Fix deprecation when width/height attribute is number

### DIFF
--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -651,6 +651,14 @@ const v6 = {
 			},
 		},
 	},
+	migrate( attributes ) {
+		const { height, width } = attributes;
+		return {
+			...attributes,
+			width: typeof width === 'number' ? `${ width }px` : width,
+			height: typeof height === 'number' ? `${ height }px` : height,
+		};
+	},
 	save( { attributes } ) {
 		const {
 			url,

--- a/test/integration/fixtures/blocks/core__image__deprecated-v3-add-align-wrapper.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v3-add-align-wrapper.json
@@ -7,8 +7,8 @@
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": "",
-			"width": 100,
-			"height": 100
+			"width": "100px",
+			"height": "100px"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__image__deprecated-v3-add-align-wrapper.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v3-add-align-wrapper.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"width":100,"height":100,"align":"left"} -->
+<!-- wp:image {"width":"100px","height":"100px","align":"left"} -->
 <figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v6-add-style-width-height.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v6-add-style-width-height.json
@@ -7,8 +7,8 @@
 			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
 			"alt": "",
 			"caption": "",
-			"width": 164,
-			"height": 164,
+			"width": "164px",
+			"height": "164px",
 			"sizeSlug": "large",
 			"className": "is-style-rounded",
 			"style": {

--- a/test/integration/fixtures/blocks/core__image__deprecated-v6-add-style-width-height.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v6-add-style-width-height.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"width":164,"height":164,"sizeSlug":"large","align":"left","className":"is-style-rounded","style":{"border":{"radius":"100%"}}} -->
+<!-- wp:image {"width":"164px","height":"164px","sizeSlug":"large","align":"left","className":"is-style-rounded","style":{"border":{"radius":"100%"}}} -->
 <figure class="wp-block-image alignleft size-large is-resized has-custom-border is-style-rounded"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="border-radius:100%;width:164px;height:164px"/></figure>
 <!-- /wp:image -->


### PR DESCRIPTION
Fixes #56916

## What?

This PR fixes an issue where deprecation is not performed correctly and the block is broken when the image block's width/height attributes are _number_.

That is, it fixes the v6 deprecation that runs when updating from WordPress 6.2 to 6.3/6.4.

## Why?

In #52286, the width/height attributes (not block attributes) of the `img` element are now output as inline styles of the `figure` element. This change has been backported to WP6.3.

To that end, a v6 deprecation was added that outputs inline styles based on existing block attribute values. However, the block attribute value stored as a comment delimiter remains number, which causes the block validation to fail.

## How?

In v6 migration, numbers are now explicitly converted to pixel strings. In this migration, the width/height block attributes should always be numbers, but just to be sure, I check whether they are numbers or not, and then convert them to pixel strings.

## Testing Instructions

- Check out this branch.
- In the Post Editor, switch to the code editor and paste the HTML below. This is the markup for image blocks generated in WP6.2.3, the first one has width/height set, the second one does not.
  ```html
  <!-- wp:image {"id":13,"width":500,"height":300,"sizeSlug":"full","linkDestination":"none"} -->
  <figure class="wp-block-image size-full is-resized"><img src="http://localhost:8888/wp-content/uploads/2023/12/test.jpg" alt="" class="wp-image-13" width="500" height="300"/></figure>
  <!-- /wp:image -->

  <!-- wp:image {"id":13,"sizeSlug":"full","linkDestination":"none"} -->
  <figure class="wp-block-image size-full"><img src="http://localhost:8888/wp-content/uploads/2023/12/test.jpg" alt="" class="wp-image-13"/></figure>
  <!-- /wp:image -->
  ```
- Save the post and reload your browser.
- Add text to the content. Don't touch the two image blocks.
- Save the post and reload your browser.
- The block should not break.
- When you switch to the code editor, the values of the width/height block attributes of the first block should be updated to px strings as shown below.
  ```html
  <!-- wp:image {"id":13,"width":"500px","height":"300px","sizeSlug":"full","linkDestination":"none"} -->
  <figure class="wp-block-image size-full is-resized"><img src="http://localhost:8888/wp-content/uploads/2023/12/test.jpg" alt="" class="wp-image-13" style="width:500px;height:300px"/></figure>
  <!-- /wp:image -->

  <!-- wp:image {"id":13,"sizeSlug":"full","linkDestination":"none"} -->
  <figure class="wp-block-image size-full"><img src="http://localhost:8888/wp-content/uploads/2023/12/test.jpg" alt="" class="wp-image-13"/></figure>
  <!-- /wp:image -->
  ```