### PR TITLE
Update block-registration.md

### DIFF
--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -292,7 +292,7 @@ The key is the name of the block (`string`) to hook into, and the value is the p
 ```js
 {
 	blockHooks: {
-		'core/verse': 'before'
+		'core/verse': 'before',
 		'core/spacer': 'after',
 		'core/column': 'firstChild',
 		'core/group': 'lastChild',


### PR DESCRIPTION
# Comma is missing after JSON property issue #1397

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Briefly describe what your PR is doing. -->

This pull request addresses the missing comma after a JSON property in relation to issue #1397.

## Why?
<!-- Explain why this PR is necessary and the problem it's solving. Reference any existing issues or PRs, and provide a short summary. -->

The missing comma in the JSON property causes an issue in [provide brief context here]. This PR adds the necessary commas to resolve the problem.

## How?
<!-- Describe the implementation details of your PR. How is it addressing the issue? -->

I have modified the affected code to include the missing commas in the JSON properties.

## Testing Instructions
<!-- Provide step-by-step instructions on how to test your changes. -->

1. Open a post or page.
2. Insert a heading block.
3. [Add any additional testing steps if necessary.]

### Testing Instructions for Keyboard
<!-- If your changes impact the UI, provide instructions for testing with a keyboard only for accessibility testing. -->

## Screenshots or Screencast
<!-- Include screenshots or a screencast if applicable to visually demonstrate your changes. -->

![image](https://github.com/WordPress/gutenberg/assets/109151905/6872bc2b-4d59-4e9c-a4d7-af782a7dd30e)

<!-- Thank you for your contribution! -->
