### PR TITLE
Snackbar: Fix `__unstableHTML` support

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,14 +5,13 @@
 ### Bug Fix
 
 -   `PaletteEdit`: Consider digits when generating kebab-cased slug ([#56713](https://github.com/WordPress/gutenberg/pull/56713)).
+-   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
+-   `Snackbar`: Fix `__unstableHTML` support ([#57067](https://github.com/WordPress/gutenberg/pull/57067)).
+
 
 ### Experimental
 
 -   `TabPanel`: do not render hidden content ([#57046](https://github.com/WordPress/gutenberg/pull/57046)).
-
-### Bug Fix
-
--   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
 
 ## 25.14.0 (2023-12-13)
 

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -8,7 +8,12 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { speak } from '@wordpress/a11y';
-import { useEffect, forwardRef, renderToString } from '@wordpress/element';
+import {
+	useEffect,
+	forwardRef,
+	renderToString,
+	RawHTML,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import warning from '@wordpress/warning';
 
@@ -53,6 +58,7 @@ function UnforwardedSnackbar(
 		onRemove,
 		icon = null,
 		explicitDismiss = false,
+		__unstableHTML,
 		// onDismiss is a callback executed when the snackbar is dismissed.
 		// It is distinct from onRemove, which _looks_ like a callback but is
 		// actually the function to call to remove the snackbar from the UI.
@@ -118,6 +124,10 @@ function UnforwardedSnackbar(
 			'components-snackbar__content-with-icon': !! icon,
 		}
 	);
+
+	if ( __unstableHTML && typeof children === 'string' ) {
+		children = <RawHTML>{ children }</RawHTML>;
+	}
 
 	return (
 		<div


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/56767

I added the exact same handling we have from `Notice` compoenent.



## Testing Instructions
In dev tools run:
```
wp.data
	.dispatch( 'core/notices' )
	.createNotice(
		'warning',
		'<strong>Some</strong> message',
		{
			type: 'snackbar',
			isDismissible: true,
			__unstableHTML: true,
		}
	);
```


