### PR TITLE
[Mobile] - Android - Bring the Keyboard back when closing modals

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -19,7 +19,10 @@ import SafeArea from 'react-native-safe-area';
 /**
  * WordPress dependencies
  */
-import { subscribeAndroidModalClosed } from '@wordpress/react-native-bridge';
+import {
+	subscribeAndroidModalClosed,
+	showAndroidSoftKeyboard,
+} from '@wordpress/react-native-bridge';
 import { Component } from '@wordpress/element';
 import { withPreferredColorScheme } from '@wordpress/compose';
 
@@ -209,6 +212,9 @@ class BottomSheet extends Component {
 	}
 
 	componentWillUnmount() {
+		// Restore Keyboard Visibility
+		showAndroidSoftKeyboard();
+
 		this.dimensionsChangeSubscription.remove();
 		this.keyboardShowListener.remove();
 		this.keyboardHideListener.remove();
@@ -353,6 +359,9 @@ class BottomSheet extends Component {
 			onClose();
 		}
 		this.onShouldSetBottomSheetMaxHeight( true );
+
+		// Restore Keyboard Visibility
+		showAndroidSoftKeyboard();
 	}
 
 	setIsFullScreen( isFullScreen ) {
@@ -368,6 +377,10 @@ class BottomSheet extends Component {
 	onHardwareButtonPress() {
 		const { onClose } = this.props;
 		const { handleHardwareButtonPress } = this.state;
+
+		// Restore Keyboard Visibility
+		showAndroidSoftKeyboard();
+
 		if ( handleHardwareButtonPress && handleHardwareButtonPress() ) {
 			return;
 		}

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -544,6 +544,8 @@ class BottomSheet extends Component {
 				}
 				onAccessibilityEscape={ this.onCloseBottomSheet }
 				testID="bottom-sheet"
+				hardwareAccelerated={ true }
+				useNativeDriverForBackdrop={ true }
 				{ ...rest }
 			>
 				<KeyboardAvoidingView

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -212,8 +212,7 @@ class BottomSheet extends Component {
 	}
 
 	componentWillUnmount() {
-		// Restore Keyboard Visibility
-		showAndroidSoftKeyboard();
+		const { isFullScreen } = this.props;
 
 		this.dimensionsChangeSubscription.remove();
 		this.keyboardShowListener.remove();
@@ -221,6 +220,13 @@ class BottomSheet extends Component {
 		if ( this.androidModalClosedSubscription ) {
 			this.androidModalClosedSubscription.remove();
 		}
+
+		if ( this.props.isVisible ) {
+			// For full screen modals we add a delay for the keyboard
+			const keyboardDelay = isFullScreen ? 500 : 0;
+			showAndroidSoftKeyboard( { delay: keyboardDelay } );
+		}
+
 		if ( this.safeAreaEventSubscription === null ) {
 			return;
 		}
@@ -321,6 +327,9 @@ class BottomSheet extends Component {
 	onDismiss() {
 		const { onDismiss } = this.props;
 
+		// Restore Keyboard Visibility
+		showAndroidSoftKeyboard();
+
 		if ( onDismiss ) {
 			onDismiss();
 		}
@@ -359,9 +368,6 @@ class BottomSheet extends Component {
 			onClose();
 		}
 		this.onShouldSetBottomSheetMaxHeight( true );
-
-		// Restore Keyboard Visibility
-		showAndroidSoftKeyboard();
 	}
 
 	setIsFullScreen( isFullScreen ) {
@@ -377,9 +383,6 @@ class BottomSheet extends Component {
 	onHardwareButtonPress() {
 		const { onClose } = this.props;
 		const { handleHardwareButtonPress } = this.state;
-
-		// Restore Keyboard Visibility
-		showAndroidSoftKeyboard();
 
 		if ( handleHardwareButtonPress && handleHardwareButtonPress() ) {
 			return;

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -212,8 +212,6 @@ class BottomSheet extends Component {
 	}
 
 	componentWillUnmount() {
-		const { isFullScreen } = this.props;
-
 		this.dimensionsChangeSubscription.remove();
 		this.keyboardShowListener.remove();
 		this.keyboardHideListener.remove();
@@ -222,9 +220,7 @@ class BottomSheet extends Component {
 		}
 
 		if ( this.props.isVisible ) {
-			// For full screen modals we add a delay for the keyboard
-			const keyboardDelay = isFullScreen ? 500 : 0;
-			showAndroidSoftKeyboard( { delay: keyboardDelay } );
+			showAndroidSoftKeyboard();
 		}
 
 		if ( this.safeAreaEventSubscription === null ) {

--- a/packages/format-library/src/link/test/__snapshots__/modal.native.js.snap
+++ b/packages/format-library/src/link/test/__snapshots__/modal.native.js.snap
@@ -7,6 +7,7 @@ exports[`LinksUI LinksUI renders 1`] = `
   backdropOpacity={0.2}
   backdropTransitionInTiming={50}
   backdropTransitionOutTiming={50}
+  hardwareAccelerated={true}
   isVisible={true}
   onAccessibilityEscape={[Function]}
   onBackButtonPress={[Function]}
@@ -18,6 +19,7 @@ exports[`LinksUI LinksUI renders 1`] = `
   preferredColorScheme="light"
   swipeDirection="down"
   testID="link-settings-modal"
+  useNativeDriverForBackdrop={true}
 >
   <View
     behavior={false}

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -584,19 +584,15 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
                 };
 
                 // Schedule the keyboard showing with a delay
-                if (currentFocusedView.hasWindowFocus()) {
-                    currentActivity.getWindow().getDecorView().postDelayed(showTheKeyboardNow, delayMillis);
-                } else {
-                    currentFocusedView.getViewTreeObserver().addOnWindowFocusChangeListener(new ViewTreeObserver.OnWindowFocusChangeListener() {
-                        @Override
-                        public void onWindowFocusChanged(boolean hasFocus) {
-                            if (hasFocus) {
-                                currentActivity.getWindow().getDecorView().postDelayed(showTheKeyboardNow, delayMillis);
-                                currentFocusedView.getViewTreeObserver().removeOnWindowFocusChangeListener(this);
-                            }
+                currentFocusedView.getViewTreeObserver().addOnWindowFocusChangeListener(new ViewTreeObserver.OnWindowFocusChangeListener() {
+                    @Override
+                    public void onWindowFocusChanged(boolean hasFocus) {
+                        if (hasFocus) {
+                            currentActivity.getWindow().getDecorView().postDelayed(showTheKeyboardNow, delayMillis);
+                            currentFocusedView.getViewTreeObserver().removeOnWindowFocusChangeListener(this);
                         }
-                    });
-                }
+                    }
+                });
             }
         }
     }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -566,18 +566,16 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
             }
 
             View currentFocusedView = getCurrentFocusedView();
-            if (currentFocusedView != null) {
-                currentFocusedView.getViewTreeObserver().addOnWindowFocusChangeListener(new ViewTreeObserver.OnWindowFocusChangeListener() {
-                    @Override
-                    public void onWindowFocusChanged(boolean hasFocus) {
-                        if (hasFocus) {
-                            mKeyboardRunnable = createShowKeyboardRunnable();
-                            currentActivity.getWindow().getDecorView().post(mKeyboardRunnable);
-                            currentFocusedView.getViewTreeObserver().removeOnWindowFocusChangeListener(this);
-                        }
+            currentFocusedView.getViewTreeObserver().addOnWindowFocusChangeListener(new ViewTreeObserver.OnWindowFocusChangeListener() {
+                @Override
+                public void onWindowFocusChanged(boolean hasFocus) {
+                    if (hasFocus) {
+                        mKeyboardRunnable = createShowKeyboardRunnable();
+                        currentActivity.getWindow().getDecorView().post(mKeyboardRunnable);
+                        currentFocusedView.getViewTreeObserver().removeOnWindowFocusChangeListener(this);
                     }
-                });
-            }
+                }
+            });
         }
     }
 

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -571,7 +571,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
                     @Override
                     public void onWindowFocusChanged(boolean hasFocus) {
                         if (hasFocus) {
-                            mKeyboardRunnable = createShowKeyboardRunnable(currentActivity);
+                            mKeyboardRunnable = createShowKeyboardRunnable();
                             currentActivity.getWindow().getDecorView().post(mKeyboardRunnable);
                             currentFocusedView.getViewTreeObserver().removeOnWindowFocusChangeListener(this);
                         }
@@ -581,13 +581,14 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         }
     }
 
-    private Runnable createShowKeyboardRunnable(final Activity currentActivity) {
+    private Runnable createShowKeyboardRunnable() {
         return new Runnable() {
             @Override
             public void run() {
                 try {
+                    Activity activity = mReactContext.getCurrentActivity();
                     View activeFocusedView = getCurrentFocusedView();
-                    if (activeFocusedView != null && currentActivity.getWindow().getDecorView().isShown()) {
+                    if (activeFocusedView != null && activity.getWindow().getDecorView().isShown()) {
                         InputMethodManager imm =
                             (InputMethodManager) mReactContext.getSystemService(Context.INPUT_METHOD_SERVICE);
                         imm.showSoftInput(activeFocusedView, InputMethodManager.SHOW_IMPLICIT);

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -592,7 +592,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
             View currentFocusedView = currentActivity.getCurrentFocus();
             if (currentFocusedView != null) {
                 InputMethodManager imm =
-                        (InputMethodManager) mReactContext.getSystemService(Context.INPUT_METHOD_SERVICE);
+                    (InputMethodManager) mReactContext.getSystemService(Context.INPUT_METHOD_SERVICE);
                 imm.hideSoftInputFromWindow(currentFocusedView.getWindowToken(), 0);
             }
         }

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -516,6 +516,22 @@ export function sendEventToHost( eventName, properties ) {
 }
 
 /**
+ * Shows Android's soft keyboard if there's a TextInput focused and
+ * the keyboard is hidden.
+ *
+ * @return {void}
+ */
+export function showAndroidSoftKeyboard() {
+	if ( isIOS ) {
+		/* eslint-disable-next-line no-console */
+		console.warn( 'showAndroidSoftKeyboard is not supported on iOS' );
+		return;
+	}
+
+	RNReactNativeGutenbergBridge.showAndroidSoftKeyboard();
+}
+
+/**
  * Hides Android's soft keyboard.
  *
  * @return {void}

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -538,6 +538,8 @@ export function showAndroidSoftKeyboard() {
  */
 export function hideAndroidSoftKeyboard() {
 	if ( isIOS ) {
+		/* eslint-disable-next-line no-console */
+		console.warn( 'hideAndroidSoftKeyboard is not supported on iOS' );
 		return;
 	}
 

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -519,16 +519,14 @@ export function sendEventToHost( eventName, properties ) {
  * Shows Android's soft keyboard if there's a TextInput focused and
  * the keyboard is hidden.
  *
- * @param {Object} options
  * @return {void}
  */
-export function showAndroidSoftKeyboard( options ) {
+export function showAndroidSoftKeyboard() {
 	if ( isIOS ) {
 		return;
 	}
 
-	const { delay = 0 } = options || {};
-	RNReactNativeGutenbergBridge.showAndroidSoftKeyboard( delay );
+	RNReactNativeGutenbergBridge.showAndroidSoftKeyboard();
 }
 
 /**

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -523,8 +523,6 @@ export function sendEventToHost( eventName, properties ) {
  */
 export function showAndroidSoftKeyboard() {
 	if ( isIOS ) {
-		/* eslint-disable-next-line no-console */
-		console.warn( 'showAndroidSoftKeyboard is not supported on iOS' );
 		return;
 	}
 
@@ -538,8 +536,6 @@ export function showAndroidSoftKeyboard() {
  */
 export function hideAndroidSoftKeyboard() {
 	if ( isIOS ) {
-		/* eslint-disable-next-line no-console */
-		console.warn( 'hideAndroidSoftKeyboard is not supported on iOS' );
 		return;
 	}
 

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -519,14 +519,16 @@ export function sendEventToHost( eventName, properties ) {
  * Shows Android's soft keyboard if there's a TextInput focused and
  * the keyboard is hidden.
  *
+ * @param {Object} options
  * @return {void}
  */
-export function showAndroidSoftKeyboard() {
+export function showAndroidSoftKeyboard( options ) {
 	if ( isIOS ) {
 		return;
 	}
 
-	RNReactNativeGutenbergBridge.showAndroidSoftKeyboard();
+	const { delay = 0 } = options || {};
+	RNReactNativeGutenbergBridge.showAndroidSoftKeyboard( delay );
 }
 
 /**

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -109,6 +109,7 @@ jest.mock( '@wordpress/react-native-bridge', () => {
 		subscribeOnRedoPressed: jest.fn(),
 		useIsConnected: jest.fn( () => ( { isConnected: true } ) ),
 		editorDidMount: jest.fn(),
+		showAndroidSoftKeyboard: jest.fn(),
 		hideAndroidSoftKeyboard: jest.fn(),
 		editorDidAutosave: jest.fn(),
 		subscribeMediaUpload: jest.fn(),


### PR DESCRIPTION
This PR is part of https://github.com/WordPress/gutenberg/pull/57070

## What?
It adds new implementations in the bridge for Android, so we can control hiding and showing the keyboard in some cases.

## Why?
To improve the writing flow experience, we'll handle the keyboard manually in some cases.

## How?
It adds two methods `showAndroidSoftKeyboard` and `hideAndroidSoftKeyboard` in the React Native Bridge package, this functionality will be shared for both the demo app and the host apps as the functionality is kept entirely in `RNReactNativeGutenbergBridgeModule`.

The `showAndroidSoftKeyboard` method is introduced in the `BottomSheet` component, to prevent not displaying the Keyboard when these modals are dismissed and a TextInput was focused prior to opening the Modal.

This is only needed in Android since iOS handles this internally.

It's used in three parts of the code:

- `componentWillUnmount` some Modals get removed completely when they're hidden, which prevents other callbacks to be triggered like `onModalHide`.
- `onHardwareButtonPress` when a user dismisses the modal by using the hardware back button on Android.
- `onCloseBottomSheet` triggered when the modal is hidden either by swiping down, or tapping on the Modal backdrop.

## Testing Instructions

### Case 1 - Opening the block settings of a Paragraph block
- Open the host app with metro running (It requires a local build of Gutenberg Mobile due to the bridge changes)
- Create a new post
- Add a Paragraph block
- Type some text
- Open the block settings
- Close the modal either by using the hardware back button or tapping on the backdrop
- **Expect** the Keyboard to be shown when the modal is closed

### Case 2 - Changing the text color of a Paragraph block
- Open the host app with metro running (It requires a local build of Gutenberg Mobile due to the bridge changes)
- Create a new post
- Add a Paragraph block
- Type some text
- Open the block settings
- Tap on the Text color option
- Tap on a color
- Close the modal either by using the hardware back button or tapping on the backdrop
- **Expect** the Keyboard to be shown when the modal is closed and the text color changed

### Case 3 -  Changing the text alignment
- Open the host app with metro running (It requires a local build of Gutenberg Mobile due to the bridge changes)
- Create a new post
- Add a Paragraph block
- Type some text
- Open the text alignment options
- Tap on any option
- **Expect** the Keyboard to be shown when the modal is closed and the text aligned to the previously selected option

### Case 4 - Opening the block inserter when focused on a Paragraph block
- Open the host app with metro running (It requires a local build of Gutenberg Mobile due to the bridge changes)
- Create a new post
- Add a Paragraph block
- Type some text
- Open the block insterter
- Close the modal by using the hardware back button or swiping down
- **Expect** the Keyboard to be shown when the modal is closed

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->

Case 1|Case 2
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/a5682829-a993-4757-87ab-0a0b36af3410" width="200" />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/212cd4b1-bb7f-4bba-8ada-253cd4c9ea24" width="200" />

Case 3|Case 4
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/600b2739-4f1e-422e-8e02-1cdfbedf79c7" width="200" />|<video src="https://github.com/WordPress/gutenberg/assets/4885740/4253364e-a2fa-4b88-be25-893897c9aabf" width="200" />




