### PR TITLE
[RNMobile] Avoid keyboard dismiss when interacting text blocks

### DIFF
--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -823,12 +823,6 @@ export class RichText extends Component {
 		}
 	}
 
-	componentWillUnmount() {
-		if ( this._editor.isFocused() ) {
-			this._editor.blur();
-		}
-	}
-
 	componentDidUpdate( prevProps ) {
 		const { style, tagName } = this.props;
 		const { currentFontSize } = this.state;

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -19,7 +19,10 @@ import SafeArea from 'react-native-safe-area';
 /**
  * WordPress dependencies
  */
-import { subscribeAndroidModalClosed } from '@wordpress/react-native-bridge';
+import {
+	subscribeAndroidModalClosed,
+	showAndroidSoftKeyboard,
+} from '@wordpress/react-native-bridge';
 import { Component } from '@wordpress/element';
 import { withPreferredColorScheme } from '@wordpress/compose';
 
@@ -215,6 +218,11 @@ class BottomSheet extends Component {
 		if ( this.androidModalClosedSubscription ) {
 			this.androidModalClosedSubscription.remove();
 		}
+
+		if ( this.props.isVisible ) {
+			showAndroidSoftKeyboard();
+		}
+
 		if ( this.safeAreaEventSubscription === null ) {
 			return;
 		}
@@ -315,6 +323,9 @@ class BottomSheet extends Component {
 	onDismiss() {
 		const { onDismiss } = this.props;
 
+		// Restore Keyboard Visibility
+		showAndroidSoftKeyboard();
+
 		if ( onDismiss ) {
 			onDismiss();
 		}
@@ -368,6 +379,7 @@ class BottomSheet extends Component {
 	onHardwareButtonPress() {
 		const { onClose } = this.props;
 		const { handleHardwareButtonPress } = this.state;
+
 		if ( handleHardwareButtonPress && handleHardwareButtonPress() ) {
 			return;
 		}
@@ -528,6 +540,8 @@ class BottomSheet extends Component {
 				}
 				onAccessibilityEscape={ this.onCloseBottomSheet }
 				testID="bottom-sheet"
+				hardwareAccelerated={ true }
+				useNativeDriverForBackdrop={ true }
 				{ ...rest }
 			>
 				<KeyboardAvoidingView

--- a/packages/format-library/src/link/test/__snapshots__/modal.native.js.snap
+++ b/packages/format-library/src/link/test/__snapshots__/modal.native.js.snap
@@ -7,6 +7,7 @@ exports[`LinksUI LinksUI renders 1`] = `
   backdropOpacity={0.2}
   backdropTransitionInTiming={50}
   backdropTransitionOutTiming={50}
+  hardwareAccelerated={true}
   isVisible={true}
   onAccessibilityEscape={[Function]}
   onBackButtonPress={[Function]}
@@ -18,6 +19,7 @@ exports[`LinksUI LinksUI renders 1`] = `
   preferredColorScheme="light"
   swipeDirection="down"
   testID="link-settings-modal"
+  useNativeDriverForBackdrop={true}
 >
   <View
     behavior={false}

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.swift
@@ -34,6 +34,17 @@ public class RCTAztecViewManager: RCTViewManager {
         return view
     }
 
+    /// This method is similar to `executeBlock` but prepends the block to execute it before other pending blocks.
+    func executeBlockBeforeOthers(viewTag: NSNumber, block: @escaping (RCTAztecView) -> Void) {
+        self.bridge.uiManager.prependUIBlock { (uiManager, viewRegistry) in
+            let view = viewRegistry?[viewTag]
+            guard let aztecView = view as? RCTAztecView else {
+                return
+            }
+            block(aztecView)
+        }
+    }
+    
     func executeBlock(viewTag: NSNumber, block: @escaping (RCTAztecView) -> Void) {
         self.bridge.uiManager.addUIBlock { (uiManager, viewRegistry) in
             let view = viewRegistry?[viewTag]
@@ -69,7 +80,7 @@ public class RCTAztecViewManager: RCTViewManager {
     
     @objc
     func focus(_ viewTag: NSNumber) -> Void {
-        self.executeBlock(viewTag: viewTag) { (aztecView) in
+        self.executeBlockBeforeOthers(viewTag: viewTag) { (aztecView) in
             aztecView.reactFocus()
         }
     }

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -3,6 +3,11 @@
  */
 import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
 
+/**
+ * WordPress dependencies
+ */
+import { debounce } from '@wordpress/compose';
+
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
 const focusChangeListeners = [];
@@ -131,20 +136,25 @@ export const focusInput = ( element ) => {
  * @param {RefObject} element Element to be focused.
  */
 export const focus = ( element ) => {
+	// If other blur events happen at the same time that focus is triggered, the focus event
+	// will take precedence and cancels pending blur events.
+	blur.cancel();
 	TextInputState.focusTextInput( element );
 	notifyInputChange();
 };
 
 /**
  * Unfocuses the specified element.
+ * This function uses debounce to avoid conflicts with the focus event when both are
+ * triggered at the same time. Focus events will take precedence.
  *
  * @param {RefObject} element Element to be unfocused.
  */
-export const blur = ( element ) => {
+export const blur = debounce( ( element ) => {
 	TextInputState.blurTextInput( element );
 	setCurrentCaretData( null );
 	notifyInputChange();
-};
+}, 0 );
 
 /**
  * Unfocuses the current focused element.

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { Platform } from 'react-native';
 import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
 
 /**
  * WordPress dependencies
  */
 import { debounce } from '@wordpress/compose';
+import { hideAndroidSoftKeyboard } from '@wordpress/react-native-bridge';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
@@ -139,6 +141,9 @@ export const focus = ( element ) => {
 	// If other blur events happen at the same time that focus is triggered, the focus event
 	// will take precedence and cancels pending blur events.
 	blur.cancel();
+	// Similar to blur events, we also need to cancel potential keyboard dismiss.
+	dismissKeyboardDebounce.cancel();
+
 	TextInputState.focusTextInput( element );
 	notifyInputChange();
 };
@@ -155,6 +160,34 @@ export const blur = debounce( ( element ) => {
 	setCurrentCaretData( null );
 	notifyInputChange();
 }, 0 );
+
+/**
+ * Unfocuses the specified element in case it's about to be unmounted.
+ *
+ * On iOS text inputs are automatically unfocused and keyboard dimissed when they
+ * are removed. However, this is not the case on Android, where text inputs are
+ * unfocused but the keyboard remains open.
+ *
+ * For dismissing the keyboard we use debounce to avoid conflicts with the focus
+ * event when both are triggered at the same time.
+ *
+ * Note that we can't trigger the blur event as it's likely that the Aztec view is no
+ * longer available when the event is executed and will produce an exception.
+ *
+ * @param {RefObject} element Element to be unfocused.
+ */
+export const blurOnUnmount = ( element ) => {
+	if ( getCurrentFocusedElement() === element ) {
+		// If a blur event was triggered before unmount, we need to cancel them to avoid
+		// exceptions.
+		blur.cancel();
+		if ( Platform.OS === 'android' ) {
+			dismissKeyboardDebounce();
+		}
+	}
+};
+
+const dismissKeyboardDebounce = debounce( () => hideAndroidSoftKeyboard(), 0 );
 
 /**
  * Unfocuses the current focused element.

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -164,14 +164,14 @@ export const blur = debounce( ( element ) => {
 /**
  * Unfocuses the specified element in case it's about to be unmounted.
  *
- * On iOS text inputs are automatically unfocused and keyboard dimissed when they
+ * On iOS text inputs are automatically unfocused and keyboard dismissed when they
  * are removed. However, this is not the case on Android, where text inputs are
  * unfocused but the keyboard remains open.
  *
- * For dismissing the keyboard we use debounce to avoid conflicts with the focus
+ * For dismissing the keyboard, we use debounce to avoid conflicts with the focus
  * event when both are triggered at the same time.
  *
- * Note that we can't trigger the blur event as it's likely that the Aztec view is no
+ * Note that we can't trigger the blur event, as it's likely that the Aztec view is no
  * longer available when the event is executed and will produce an exception.
  *
  * @param {RefObject} element Element to be unfocused.

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -66,6 +66,10 @@ class AztecView extends Component {
 		this.focus = this.focus.bind( this );
 	}
 
+	componentWillUnmount() {
+		AztecInputState.blurOnUnmount( this.aztecViewRef.current );
+	}
+
 	dispatch( command, params ) {
 		params = params || [];
 		UIManager.dispatchViewManagerCommand(

--- a/packages/react-native-aztec/src/test/AztecInputState.test.js
+++ b/packages/react-native-aztec/src/test/AztecInputState.test.js
@@ -32,6 +32,8 @@ const updateCurrentFocusedInput = ( value ) => {
 	notifyInputChange();
 };
 
+jest.useFakeTimers();
+
 describe( 'Aztec Input State', () => {
 	it( 'listens to focus change event', () => {
 		const listener = jest.fn();
@@ -96,6 +98,7 @@ describe( 'Aztec Input State', () => {
 
 	it( 'unfocuses an element', () => {
 		blur( ref );
+		jest.runAllTimers();
 		expect( TextInputState.blurTextInput ).toHaveBeenCalledWith( ref );
 	} );
 } );

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -8,6 +8,7 @@ import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.Settings;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.Nullable;
@@ -44,6 +45,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         DeferredEventEmitter.JSEventEmitter {
     private final ReactApplicationContext mReactContext;
     private final GutenbergBridgeJS2Parent mGutenbergBridgeJS2Parent;
+    private Runnable mKeyboardRunnable;
 
     private static final String EVENT_NAME_REQUEST_GET_HTML = "requestGetHtml";
     private static final String EVENT_NAME_UPDATE_HTML = "updateHtml";
@@ -555,13 +557,68 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     }
 
     @ReactMethod
+    public void showAndroidSoftKeyboard() {
+        Activity currentActivity = mReactContext.getCurrentActivity();
+        if (isAnyViewFocused()) {
+            // Cancel any previously scheduled Runnable
+            if (mKeyboardRunnable != null) {
+                currentActivity.getWindow().getDecorView().removeCallbacks(mKeyboardRunnable);
+            }
+
+            View currentFocusedView = getCurrentFocusedView();
+            currentFocusedView.getViewTreeObserver().addOnWindowFocusChangeListener(new ViewTreeObserver.OnWindowFocusChangeListener() {
+                @Override
+                public void onWindowFocusChanged(boolean hasFocus) {
+                    if (hasFocus) {
+                        mKeyboardRunnable = createShowKeyboardRunnable();
+                        currentActivity.getWindow().getDecorView().post(mKeyboardRunnable);
+                        currentFocusedView.getViewTreeObserver().removeOnWindowFocusChangeListener(this);
+                    }
+                }
+            });
+        }
+    }
+
+    private Runnable createShowKeyboardRunnable() {
+        return new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Activity activity = mReactContext.getCurrentActivity();
+                    View activeFocusedView = getCurrentFocusedView();
+                    if (activeFocusedView != null && activity.getWindow().getDecorView().isShown()) {
+                        InputMethodManager imm =
+                            (InputMethodManager) mReactContext.getSystemService(Context.INPUT_METHOD_SERVICE);
+                        imm.showSoftInput(activeFocusedView, InputMethodManager.SHOW_IMPLICIT);
+                    }
+                } catch (Exception e) {
+                    // Noop
+                }
+            }
+        };
+    }
+
+    private View getCurrentFocusedView() {
+        Activity activity = mReactContext.getCurrentActivity();
+        if (activity == null) {
+            return null;
+        }
+        return activity.getCurrentFocus();
+    }
+
+    private boolean isAnyViewFocused() {
+        View getCurrentFocusedView = getCurrentFocusedView();
+        return getCurrentFocusedView != null;
+    }
+
+    @ReactMethod
     public void hideAndroidSoftKeyboard() {
         Activity currentActivity = mReactContext.getCurrentActivity();
         if (currentActivity != null) {
             View currentFocusedView = currentActivity.getCurrentFocus();
             if (currentFocusedView != null) {
                 InputMethodManager imm =
-                        (InputMethodManager) mReactContext.getSystemService(Context.INPUT_METHOD_SERVICE);
+                    (InputMethodManager) mReactContext.getSystemService(Context.INPUT_METHOD_SERVICE);
                 imm.hideSoftInputFromWindow(currentFocusedView.getWindowToken(), 0);
             }
         }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -1,11 +1,14 @@
 package org.wordpress.mobile.ReactNativeGutenbergBridge;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.Settings;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.Nullable;
 
@@ -549,5 +552,18 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
                 jsCallback.invoke(isConnected);
             }
         };
+    }
+
+    @ReactMethod
+    public void hideAndroidSoftKeyboard() {
+        Activity currentActivity = mReactContext.getCurrentActivity();
+        if (currentActivity != null) {
+            View currentFocusedView = currentActivity.getCurrentFocus();
+            if (currentFocusedView != null) {
+                InputMethodManager imm =
+                        (InputMethodManager) mReactContext.getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.hideSoftInputFromWindow(currentFocusedView.getWindowToken(), 0);
+            }
+        }
     }
 }

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -516,6 +516,20 @@ export function sendEventToHost( eventName, properties ) {
 }
 
 /**
+ * Shows Android's soft keyboard if there's a TextInput focused and
+ * the keyboard is hidden.
+ *
+ * @return {void}
+ */
+export function showAndroidSoftKeyboard() {
+	if ( isIOS ) {
+		return;
+	}
+
+	RNReactNativeGutenbergBridge.showAndroidSoftKeyboard();
+}
+
+/**
  * Hides Android's soft keyboard.
  *
  * @return {void}

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -516,6 +516,21 @@ export function sendEventToHost( eventName, properties ) {
 }
 
 /**
+ * Hides Android's soft keyboard.
+ *
+ * @return {void}
+ */
+export function hideAndroidSoftKeyboard() {
+	if ( isIOS ) {
+		/* eslint-disable-next-line no-console */
+		console.warn( 'hideAndroidSoftKeyboard is not supported on iOS' );
+		return;
+	}
+
+	RNReactNativeGutenbergBridge.hideAndroidSoftKeyboard();
+}
+
+/**
  * Generate haptic feedback.
  */
 export function generateHapticFeedback() {

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -522,8 +522,6 @@ export function sendEventToHost( eventName, properties ) {
  */
 export function hideAndroidSoftKeyboard() {
 	if ( isIOS ) {
-		/* eslint-disable-next-line no-console */
-		console.warn( 'hideAndroidSoftKeyboard is not supported on iOS' );
 		return;
 	}
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -16,6 +16,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] Guard against an Image block styles crash due to null block values [#56903]
 -   [**] Fix crash when sharing unsupported media types on Android [#56791]
 -   [**] Fix regressions with wrapper props and font size customization [#56985]
+-   [***] Avoid keyboard dismiss when interacting with text blocks [#57070]
 
 ## 1.109.2
 -   [**] Fix issue related to text color format and receiving in rare cases an undefined ref from `RichText` component [#56686]

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -109,6 +109,7 @@ jest.mock( '@wordpress/react-native-bridge', () => {
 		subscribeOnRedoPressed: jest.fn(),
 		useIsConnected: jest.fn( () => ( { isConnected: true } ) ),
 		editorDidMount: jest.fn(),
+		hideAndroidSoftKeyboard: jest.fn(),
 		editorDidAutosave: jest.fn(),
 		subscribeMediaUpload: jest.fn(),
 		subscribeMediaSave: jest.fn(),

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -109,6 +109,7 @@ jest.mock( '@wordpress/react-native-bridge', () => {
 		subscribeOnRedoPressed: jest.fn(),
 		useIsConnected: jest.fn( () => ( { isConnected: true } ) ),
 		editorDidMount: jest.fn(),
+		showAndroidSoftKeyboard: jest.fn(),
 		hideAndroidSoftKeyboard: jest.fn(),
 		editorDidAutosave: jest.fn(),
 		subscribeMediaUpload: jest.fn(),


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6467
- _**[For testing]**_  https://github.com/wordpress-mobile/WordPress-iOS/pull/22235
- _**[For testing]**_ https://github.com/wordpress-mobile/WordPress-Android/pull/19795

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR solves the following cases that are affected by the keyboard’s disruptive hide-and-show behavior:
- Insert a new block by pressing the `enter` key in a text-based block.
- Merge blocks by pressing the `backspace` key in a text-based block.

However, there's a remaining case that this PR won't cover:
- Replace blocks when interacting with the List block.

We haven't found a solution to this yet, as a next step, we'd need to explore further the actions performed during block creation and merging in the List block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR will greatly improve the usability when writing content, as the hide-and-show behavior impacts negatively the editing experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Solve `blur`/`focus` event conflicts

Each `RichtText` component instance triggers `blur`/`focus` events based on its state (e.g. will be unmounted, gains/loses selection) without considering other instances states. This leads to conflicts between `blur` and `focus` events in different cases like pressing `enter` on a Paragraph block to insert a new paragraph.

Here is an example of the sequence of events generated when pressing `enter`:

- Paragraph 1 triggers `blur` event. This comes from the `componentDidUpdate` function due to changing its selection state from selected to unselected.
  - **This `blur` is the culprit of the keyboard being dismissed, as it executed first.**
- Paragraph 2 triggers `focus` event when it's mounted (i.e. from the `componentDidMount` function).
- **This `focus` event makes the keyboard to open.** 
- Paragraph 2 triggers `focus` a second time. However, this event is innocuous. This comes from the `componentDidUpdate` function due to changing its selection state from unselected to selected.
- Paragraph 1 triggers `blur` event. This comes from the  `_onBlur` callback triggered by Aztec because the text input lost focus. This event is innocuous.

To solve this conflict, this PR introduces the usage of `debounce` in the `blur` event (https://github.com/WordPress/gutenberg/pull/57070/commits/b6f237f1ad2bee2a4ab91182ac7920b8238abd2f). It will ensure that `focus` events take precedence when `blur` events have been triggered at the same time, as well as cancel them to avoid the keyboard to be dismissed.

### iOS - Keyboard dismisses automatically when text input is removed 

Another case to solve is when two blocks are merged. The editor internally replaces the blocks which implies removing one of them. On iOS, this presents a problem because the keyboard will be automatically dismissed. No `blur` events are generated so a different approach was taken.

The solution (https://github.com/WordPress/gutenberg/pull/57070/commits/a71b1c5df9e3cc9f3f9067cbb7e2d978f69b8919) implied tweaking the order of native commands invoked for `blur` and `focus` events ([reference](https://github.com/WordPress/gutenberg/blob/125c130818ebb83c50618722858e8315d90e76b8/packages/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.swift#L70-L82)). The `focus` event triggered by the new block created (i.e. the one that contains the merged content) happens at the same time the other block is removed. So, the workaround for this case is to ensure that `focus` events are prepended in the pending UI blocks list of the `UIManager` ([reference 1 ](https://github.com/facebook/react-native/blob/7ea7d946c643f076c29bcf11b927f7569e3c516f/React/Modules/RCTUIManager.m#L67), [reference 2](https://github.com/facebook/react-native/blob/7ea7d946c643f076c29bcf11b927f7569e3c516f/React/Modules/RCTUIManager.m#L508C16-L517)).

### Android - Avoid triggering `blur` events on unmounted instances

As mentioned below, when `RichText`/`AztecView` is unmounted a `blur` event is triggered. On Android, this behavior in combination with using `debounce` leads to an exception because we try to `blur` a text input that no longer exists. To address this, a new function has been introduced in the Aztec input state (`blurOnUnmount`) that is only called for the component unmounting case (https://github.com/WordPress/gutenberg/pull/57070/commits/634867f072bda9b6419c6c85162d5d2afdef386c). This function has two purposes:
1. Cancel potential previous `blur` calls to avoid exceptions.
2. Hide the keyboard, as it would happen in a regular `blur` event. Note that the call to hide the keyboard uses `debounce`. This is needed to avoid dismissing the keyboard if a `focus` event happens at the same time.

### Other changes

As a side note, the `blur` event triggered when unmounting the `RichText` component has been moved to the `AztecView` component as seems a better fit for this logic (https://github.com/WordPress/gutenberg/pull/57070/commits/d3fb48686426302c434d329676a1a1607e1fa528).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

> [!NOTE]
> It's recommended to use the installable builds for testing:
> * [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/19795#issuecomment-1857562794)
> * [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/22235#issuecomment-1857565204)

### 1 - Post title

1. Open the app.
3. Create an empty post.
4. Observe that the title is focused.
5. Type some words and press enter.
6. Observe the following:
   1. The Paragraph block is focused.
   2. The keyboard remained open when transitioning.
7. Press backspace.
8. Observe the following depending on the platform:
   1. Android
      1. The Paragraph block remains focused.
      2. The keyboard remains open.
   2. iOS
      1. The Paragraph block remains focused.
      2. The keyboard reopens (this should be tackled in the future)

### 2 - Insert a new block by pressing the `enter` key in a text-based block

1. Open the app.
2. Create an empty post.
3. Select the first Paragraph block.
4. Type some words and press enter.
5.  Observe the following:
   1. A new Paragraph block is created and focused.
   2. The keyboard remained open when transitioning.

### 3 - Merge blocks by pressing the `backspace` key in a text-based block (iOS only)

1. Open the app.
2. Create an empty post.
3. Select the first Paragraph block.
4. Type some words and press enter.
6.  Press backspace.
7.  Observe the following:
    1.  The second Paragraph block is removed.
    2.  The first Paragraph block is focused and the text caret is at the end of the content.
    3.  The keyboard remained open when transitioning.
9.  Place the text caret between two words.
10.  Press enter.
11. Observe the following:
    1.  The paragraph is split into a new Paragraph block and it's focused.
    2.  The keyboard remained open when transitioning.
12. Press backspace.
13. Observe the following:
    1.  The paragraph is merged with the first one and it's focused.
    2.  The keyboard remained open when transitioning.

### 4 - Automatically dismiss the keyboard when selecting non-text-based-blocks

1. Open the app.
2. Create an empty post.
3.  Add an Image block and set an image.
4.  Tap on the caption field.
5.  Observe the following:
    1.  The caption field is focused.
    2.  The keyboard opens.
6.  Type some words and press enter.
7.  Observe the following:
    1.  A new Paragraph block is created and focused.
    2.  The keyboard remained open when transitioning.
8.  Press backspace.
    1.  The Image block is selected.
    2.  The keyboard closes.
9. Insert a Paragraph block and type some words.
10. Observe that the Paragraph block is focused.
11. Tap on the Image block.
12. Observe the following:
    1.  The Paragraph block is no longer focused.
    2.  The keyboard closes.

### 5 - Manually dismiss the keyboard

1. Open the app.
2. Create an empty post.
3.  Select the first Paragraph block.
4.  Observe the following:
    1.  The Paragraph block is focused.
    2.  The keyboard opens.
5.  Tap on the keyboard icon located in the toolbar.
6.  Observe the following:
    1.  The Paragraph block is no longer focused.
    2.  The keyboard closes.

### 6 - The keyboard is dismissed and restored when opening modals

**NOTE:** On Android, this case will be covered by https://github.com/WordPress/gutenberg/pull/57069.

1. Open the app.
2. Create an empty post.
3.  Select the first Paragraph block.
4.  Open the block settings.
5.  Observe the following:
    1.  The Paragraph block is no longer focused.
    2.  The block settings bottom sheet opens.
    3.  The keyboard closes.
6.  Dismiss the bottom sheet.
7.  Observe the following:
    1.  The Paragraph block is focused again.
    2.  The keyboard opens.
8.  Navigate to the bottom of the post.
9.  Tap on the empty area below the content.
10. Observe the following:
    1.  A new Paragraph block is created and focused.
    2.  The keyboard remained open when transitioning.

### 6 - Writing flow

It's recommended to cover the [writing flow test suite](https://github.com/wordpress-mobile/test-cases/tree/trunk/test-cases/gutenberg/writing-flow) by manually testing.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

| Header | Header |
|--------|--------|
| <video src=https://github.com/WordPress/gutenberg/assets/14905380/7549afd9-a880-4436-b6cd-5380d8f7c010> | <video src=https://github.com/WordPress/gutenberg/assets/14905380/9afa6d86-b239-42a9-a526-f34f8b89db7c> | 