### PR TITLE
DataViews: remove reference to edit site class

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -242,13 +242,9 @@
 		}
 	}
 
-	.edit-site-page-pages__featured-image,
 	.dataviews-list-view__media-placeholder {
 		min-width: $grid-unit-40;
 		height: $grid-unit-40;
-	}
-
-	.dataviews-list-view__media-placeholder {
 		background-color: $gray-200;
 	}
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Removes the class `edit-site-page-pages__featured-image` from the dataviews' package.

## Why?

That class does not belong in dataviews. It's already being set in [edit-site anyway](https://github.com/WordPress/gutenberg/blob/fix/remove-edit-site-from-dataviews/packages/edit-site/src/components/page-pages/style.scss#L1).

## Testing Instructions

- Enable the "admin views" experiment and visit "Manage all pages".
- Verify the feature media field still works as expected.
