### PR TITLE
Components: replace `TabPanel` with `Tabs` in the editor Document Overview sidebar

### DIFF
--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -156,7 +156,11 @@ export default function ListViewSidebar() {
 						<ListView dropZoneElement={ dropZoneElement } />
 					</div>
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId="outline" focusable={ false }>
+				<Tabs.TabPanel
+					className="editor-list-view-sidebar__list-view-container"
+					tabId="outline"
+					focusable={ false }
+				>
 					<ListViewOutline />
 				</Tabs.TabPanel>
 			</Tabs>

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -120,7 +120,10 @@ export default function ListViewSidebar() {
 			onKeyDown={ closeOnEscape }
 			ref={ sidebarRef }
 		>
-			<Tabs onSelect={ ( tabName ) => setTab( tabName ) }>
+			<Tabs
+				onSelect={ ( tabName ) => setTab( tabName ) }
+				selectOnMove={ false }
+			>
 				<div className="edit-post-editor__document-overview-panel__header">
 					<Button
 						className="edit-post-editor__document-overview-panel__close-button"

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -157,20 +157,24 @@ export default function ListViewSidebar() {
 
 				<Tabs.TabPanel
 					ref={ listViewContainerRef }
-					className="editor-list-view-sidebar__list-view-container editor-list-view-sidebar__tabs-tabpanel"
+					className="editor-list-view-sidebar__tabs-tabpanel"
 					tabId="list-view"
 					focusable={ false }
 				>
-					<div className="editor-list-view-sidebar__list-view-panel-content">
-						<ListView dropZoneElement={ dropZoneElement } />
+					<div className="editor-list-view-sidebar__list-view-container">
+						<div className="editor-list-view-sidebar__list-view-panel-content">
+							<ListView dropZoneElement={ dropZoneElement } />
+						</div>
 					</div>
 				</Tabs.TabPanel>
 				<Tabs.TabPanel
-					className="editor-list-view-sidebar__list-view-container"
+					className="editor-list-view-sidebar__tabs-tabpanel"
 					tabId="outline"
 					focusable={ false }
 				>
-					<ListViewOutline />
+					<div className="editor-list-view-sidebar__list-view-container">
+						<ListViewOutline />
+					</div>
 				</Tabs.TabPanel>
 			</Tabs>
 		</div>

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -123,6 +123,11 @@ export default function ListViewSidebar() {
 			<Tabs
 				onSelect={ ( tabName ) => setTab( tabName ) }
 				selectOnMove={ false }
+				// The initial tab value is set explicitly to avoid a an initial
+				// render where no tab is selected. This ensures that the
+				// tabpanel height is correct so the relevant scroll container
+				// can be rendered internally.
+				initialTabId="list-view"
 			>
 				<div className="edit-post-editor__document-overview-panel__header">
 					<Button

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -136,11 +136,20 @@ export default function ListViewSidebar() {
 						label={ __( 'Close' ) }
 						onClick={ closeListView }
 					/>
-					<Tabs.TabList ref={ tabsRef }>
-						<Tabs.Tab tabId="list-view">
+					<Tabs.TabList
+						className="editor-list-view-sidebar__tabs-tablist"
+						ref={ tabsRef }
+					>
+						<Tabs.Tab
+							className="editor-list-view-sidebar__tabs-tab"
+							tabId="list-view"
+						>
 							{ _x( 'List View', 'Post overview' ) }
 						</Tabs.Tab>
-						<Tabs.Tab tabId="outline">
+						<Tabs.Tab
+							className="editor-list-view-sidebar__tabs-tab"
+							tabId="outline"
+						>
 							{ _x( 'Outline', 'Post overview' ) }
 						</Tabs.Tab>
 					</Tabs.TabList>
@@ -148,7 +157,7 @@ export default function ListViewSidebar() {
 
 				<Tabs.TabPanel
 					ref={ listViewContainerRef }
-					className="editor-list-view-sidebar__list-view-container"
+					className="editor-list-view-sidebar__list-view-container editor-list-view-sidebar__tabs-tabpanel"
 					tabId="list-view"
 					focusable={ false }
 				>

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -120,10 +120,7 @@ export default function ListViewSidebar() {
 			onKeyDown={ closeOnEscape }
 			ref={ sidebarRef }
 		>
-			<Tabs
-				selectOnMove={ false }
-				onSelect={ ( tabName ) => setTab( tabName ) }
-			>
+			<Tabs onSelect={ ( tabName ) => setTab( tabName ) }>
 				<div className="edit-post-editor__document-overview-panel__header">
 					<Button
 						className="edit-post-editor__document-overview-panel__close-button"

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -123,7 +123,7 @@ export default function ListViewSidebar() {
 			<Tabs
 				onSelect={ ( tabName ) => setTab( tabName ) }
 				selectOnMove={ false }
-				// The initial tab value is set explicitly to avoid a an initial
+				// The initial tab value is set explicitly to avoid an initial
 				// render where no tab is selected. This ensures that the
 				// tabpanel height is correct so the relevant scroll container
 				// can be rendered internally.

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -128,21 +128,22 @@ export default function ListViewSidebar() {
 					selectOnMove={ false }
 					onSelect={ ( tabName ) => setTab( tabName ) }
 				>
-					<Tabs.TabList>
-						<Tabs.Tab tabId="list-view">
-							{ _x( 'List View', 'Post overview' ) }
-						</Tabs.Tab>
-						<Tabs.Tab tabId="outline">
-							{ _x( 'Outline', 'Post overview' ) }
-						</Tabs.Tab>
-					</Tabs.TabList>
-					<Button
-						className="editor-list-view-sidebar__close-button"
-						icon={ closeSmall }
-						label={ __( 'Close' ) }
-						onClick={ closeListView }
-					/>
-
+					<div className="edit-post-editor__document-overview-panel__header">
+						<Button
+							className="edit-post-editor__document-overview-panel__close-button"
+							icon={ closeSmall }
+							label={ __( 'Close' ) }
+							onClick={ closeListView }
+						/>
+						<Tabs.TabList>
+							<Tabs.Tab tabId="list-view">
+								{ _x( 'List View', 'Post overview' ) }
+							</Tabs.Tab>
+							<Tabs.Tab tabId="outline">
+								{ _x( 'Outline', 'Post overview' ) }
+							</Tabs.Tab>
+						</Tabs.TabList>
+					</div>
 					<div
 						className="editor-list-view-sidebar__list-view-container"
 						ref={ listViewContainerRef }

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -131,7 +131,7 @@ export default function ListViewSidebar() {
 			>
 				<div className="edit-post-editor__document-overview-panel__header">
 					<Button
-						className="edit-post-editor__document-overview-panel__close-button"
+						className="editor-list-view-sidebar__close-button"
 						icon={ closeSmall }
 						label={ __( 'Close' ) }
 						onClick={ closeListView }
@@ -148,19 +148,15 @@ export default function ListViewSidebar() {
 
 				<Tabs.TabPanel
 					ref={ listViewContainerRef }
-					className="edit-post-editor__list-view-container"
+					className="editor-list-view-sidebar__list-view-container"
 					tabId="list-view"
 					focusable={ false }
 				>
-					<div className="edit-post-editor__list-view-panel-content">
+					<div className="editor-list-view-sidebar__list-view-panel-content">
 						<ListView dropZoneElement={ dropZoneElement } />
 					</div>
 				</Tabs.TabPanel>
-				<Tabs.TabPanel
-					className="editor-list-view-sidebar__list-view-container"
-					tabId="outline"
-					focusable={ false }
-				>
+				<Tabs.TabPanel tabId="outline" focusable={ false }>
 					<ListViewOutline />
 				</Tabs.TabPanel>
 			</Tabs>

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -56,7 +56,7 @@ export default function ListViewSidebar() {
 	// This ref refers to the sidebar as a whole.
 	const sidebarRef = useRef();
 	// This ref refers to the tab panel.
-	const tabPanelRef = useRef();
+	const tabsRef = useRef();
 	// This ref refers to the list view application area.
 	const listViewRef = useRef();
 
@@ -76,7 +76,7 @@ export default function ListViewSidebar() {
 	 */
 	function handleSidebarFocus( currentTab ) {
 		// Tab panel focus.
-		const tabPanelFocus = focus.tabbable.find( tabPanelRef.current )[ 0 ];
+		const tabPanelFocus = focus.tabbable.find( tabsRef.current )[ 0 ];
 		// List view tab is selected.
 		if ( currentTab === 'list-view' ) {
 			// Either focus the list view or the tab panel. Must have a fallback because the list view does not render when there are no blocks.
@@ -120,45 +120,45 @@ export default function ListViewSidebar() {
 			onKeyDown={ closeOnEscape }
 			ref={ sidebarRef }
 		>
-			<div
-				className="editor-list-view-sidebar__tab-panel"
-				ref={ tabPanelRef }
+			<Tabs
+				selectOnMove={ false }
+				onSelect={ ( tabName ) => setTab( tabName ) }
 			>
-				<Tabs
-					selectOnMove={ false }
-					onSelect={ ( tabName ) => setTab( tabName ) }
+				<div className="edit-post-editor__document-overview-panel__header">
+					<Button
+						className="edit-post-editor__document-overview-panel__close-button"
+						icon={ closeSmall }
+						label={ __( 'Close' ) }
+						onClick={ closeListView }
+					/>
+					<Tabs.TabList ref={ tabsRef }>
+						<Tabs.Tab tabId="list-view">
+							{ _x( 'List View', 'Post overview' ) }
+						</Tabs.Tab>
+						<Tabs.Tab tabId="outline">
+							{ _x( 'Outline', 'Post overview' ) }
+						</Tabs.Tab>
+					</Tabs.TabList>
+				</div>
+
+				<Tabs.TabPanel
+					ref={ listViewContainerRef }
+					className="edit-post-editor__list-view-container"
+					tabId="list-view"
+					focusable={ false }
 				>
-					<div className="edit-post-editor__document-overview-panel__header">
-						<Button
-							className="edit-post-editor__document-overview-panel__close-button"
-							icon={ closeSmall }
-							label={ __( 'Close' ) }
-							onClick={ closeListView }
-						/>
-						<Tabs.TabList>
-							<Tabs.Tab tabId="list-view">
-								{ _x( 'List View', 'Post overview' ) }
-							</Tabs.Tab>
-							<Tabs.Tab tabId="outline">
-								{ _x( 'Outline', 'Post overview' ) }
-							</Tabs.Tab>
-						</Tabs.TabList>
+					<div className="edit-post-editor__list-view-panel-content">
+						<ListView dropZoneElement={ dropZoneElement } />
 					</div>
-					<div
-						className="editor-list-view-sidebar__list-view-container"
-						ref={ listViewContainerRef }
-					>
-						<Tabs.TabPanel tabId="list-view" focusable={ false }>
-							<div className="edit-post-editor__list-view-panel-content">
-								<ListView dropZoneElement={ dropZoneElement } />
-							</div>
-						</Tabs.TabPanel>
-						<Tabs.TabPanel tabId="outline" focusable={ false }>
-							<ListViewOutline />
-						</Tabs.TabPanel>
-					</div>
-				</Tabs>
-			</div>
+				</Tabs.TabPanel>
+				<Tabs.TabPanel
+					className="editor-list-view-sidebar__list-view-container"
+					tabId="outline"
+					focusable={ false }
+				>
+					<ListViewOutline />
+				</Tabs.TabPanel>
+			</Tabs>
 		</div>
 	);
 }

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { __experimentalListView as ListView } from '@wordpress/block-editor';
-import { Button, TabPanel } from '@wordpress/components';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
@@ -18,6 +21,8 @@ import { ESCAPE } from '@wordpress/keycodes';
 import ListViewOutline from './list-view-outline';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 export default function ListViewSidebar() {
 	const { setIsListViewOpened } = useDispatch( editorStore );
@@ -108,22 +113,6 @@ export default function ListViewSidebar() {
 	// It is the same shortcut to open but that is defined as a global shortcut and only fires when the sidebar is closed.
 	useShortcut( 'core/editor/toggle-list-view', handleToggleListViewShortcut );
 
-	/**
-	 * Render tab content for a given tab name.
-	 *
-	 * @param {string} tabName The name of the tab to render.
-	 */
-	function renderTabContent( tabName ) {
-		if ( tabName === 'list-view' ) {
-			return (
-				<div className="editor-list-view-sidebar__list-view-panel-content">
-					<ListView dropZoneElement={ dropZoneElement } />
-				</div>
-			);
-		}
-		return <ListViewOutline />;
-	}
-
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
@@ -131,39 +120,44 @@ export default function ListViewSidebar() {
 			onKeyDown={ closeOnEscape }
 			ref={ sidebarRef }
 		>
-			<Button
-				className="editor-list-view-sidebar__close-button"
-				icon={ closeSmall }
-				label={ __( 'Close' ) }
-				onClick={ closeListView }
-			/>
-			<TabPanel
+			<div
 				className="editor-list-view-sidebar__tab-panel"
 				ref={ tabPanelRef }
-				onSelect={ ( tabName ) => setTab( tabName ) }
-				selectOnMove={ false }
-				tabs={ [
-					{
-						name: 'list-view',
-						title: _x( 'List View', 'Post overview' ),
-						className: 'editor-list-view-sidebar__panel-tab',
-					},
-					{
-						name: 'outline',
-						title: _x( 'Outline', 'Post overview' ),
-						className: 'editor-list-view-sidebar__panel-tab',
-					},
-				] }
 			>
-				{ ( currentTab ) => (
+				<Tabs
+					selectOnMove={ false }
+					onSelect={ ( tabName ) => setTab( tabName ) }
+				>
+					<Tabs.TabList>
+						<Tabs.Tab tabId="list-view">
+							{ _x( 'List View', 'Post overview' ) }
+						</Tabs.Tab>
+						<Tabs.Tab tabId="outline">
+							{ _x( 'Outline', 'Post overview' ) }
+						</Tabs.Tab>
+					</Tabs.TabList>
+					<Button
+						className="editor-list-view-sidebar__close-button"
+						icon={ closeSmall }
+						label={ __( 'Close' ) }
+						onClick={ closeListView }
+					/>
+
 					<div
 						className="editor-list-view-sidebar__list-view-container"
 						ref={ listViewContainerRef }
 					>
-						{ renderTabContent( currentTab.name ) }
+						<Tabs.TabPanel tabId="list-view" focusable={ false }>
+							<div className="edit-post-editor__list-view-panel-content">
+								<ListView dropZoneElement={ dropZoneElement } />
+							</div>
+						</Tabs.TabPanel>
+						<Tabs.TabPanel tabId="outline" focusable={ false }>
+							<ListViewOutline />
+						</Tabs.TabPanel>
 					</div>
-				) }
-			</TabPanel>
+				</Tabs>
+			</div>
 		</div>
 	);
 }

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -17,21 +17,18 @@
 		background: $white;
 	}
 
-	// The TabPanel style overrides in the following blocks should be removed when the new TabPanel is available.
-	.components-tab-panel__tabs {
+	[role="tablist"] {
 		border-bottom: $border-width solid $gray-300;
-		box-sizing: border-box;
-		display: flex;
-		width: 100%;
 		padding-right: $grid-unit-70;
+		box-sizing: border-box;
 
-		.editor-list-view-sidebar__panel-tab {
+		[role="tab"] {
 			width: 50%;
 			margin-bottom: -$border-width;
 		}
 	}
 
-	.components-tab-panel__tab-content {
+	[role="tabpanel"] {
 		height: calc(100% - #{$grid-unit-60 - $border-width});
 	}
 }

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -18,20 +18,21 @@
 		align-self: center;
 		margin-right: $grid-unit-10;
 	}
+}
 
-	[role="tablist"] {
-		box-sizing: border-box;
-		flex-grow: 1;
+.editor-list-view-sidebar__tabs-tablist {
+	box-sizing: border-box;
+	flex-grow: 1;
 
-		[role="tab"] {
-			width: 50%;
-			margin-bottom: -$border-width;
-		}
-	}
+}
 
-	[role="tabpanel"] {
-		height: calc(100% - #{$grid-unit-60 - $border-width});
-	}
+.editor-list-view-sidebar__tabs-tab {
+	width: 50%;
+	margin-bottom: -$border-width;
+}
+
+.editor-list-view-sidebar__tabs-tabpanel {
+	height: calc(100% - #{$grid-unit-60 - $border-width});
 }
 
 .editor-list-view-sidebar__list-view-panel-content,

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -80,3 +80,9 @@
 		color: $gray-700;
 	}
 }
+
+.edit-post-editor__list-view-container {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -81,8 +81,3 @@
 	}
 }
 
-.edit-post-editor__list-view-container {
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-}

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -8,19 +8,20 @@
 		// @see packages/block-editor/src/components/inserter/style.scss
 		width: 350px;
 	}
-
+	.edit-post-editor__document-overview-panel__header {
+		display: flex;
+		border-bottom: $border-width solid $gray-300;
+	}
 	.editor-list-view-sidebar__close-button {
-		position: absolute;
-		right: $grid-unit-10;
-		top: math.div($grid-unit-60 - $button-size, 2); // ( tab height - button size ) / 2
-		z-index: 1;
 		background: $white;
+		order: 1;
+		align-self: center;
+		margin-right: $grid-unit-10;
 	}
 
 	[role="tablist"] {
-		border-bottom: $border-width solid $gray-300;
-		padding-right: $grid-unit-70;
 		box-sizing: border-box;
+		flex-grow: 1;
 
 		[role="tab"] {
 			width: 50%;


### PR DESCRIPTION
## What?
Replaces the legacy TabPanel component with the new Tabs component.

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

## How?
`TabPanel` is replaced by `Tabs` and its sub-components.

The biggest change in terms of actual behavior is the order of the tab stops. Previously, the close button had to be rendered outside of (specifically before) `TabPanel` and then placed next to the tabs via CSS. With `Tabs` we can actually compose the sidebar with the button right where we want it. This changes the flow of focus when tabbing into the sidebar:

<table>
<tr>
<th>Before</th>
<th>After</th>
<tr>
 <td>
  <ol>
   <li>Close Button</li>
   <li>Active Tab</li>
   <li>The currently displayed `tabpanel`</li>
   <li> First focusable element within the current `tabpanel`</li>
  </ol>
 </td>
 <td>
  <ol>
   <li>Active Tab</li>
   <li>Close Button</li>
   <li>The currently displayed `tabpanel`</li>
   <li> First focusable element within the current `tabpanel`</li>
  </ol>
 </td>
</table>

This matches what the Editor Settings sidebar on the other side of the screen does, but I wanted to confirm this is an acceptable change from an a11y point of view, for both sidebars. cc @andrewhayward @alexstine 

## Notes
1. There are some visual changes at the moment regarding hover effects and text alignment on the tabs. These are being discuss/addressed in #57121
2. There is currently one failing e2e test, which is a direct result of the change in tabstops mentioned above. Before this merges, I'll make sure we update either the test or the tab flow as necessary.

## Testing Instructions
1. Create a new post and open the Document Overview sidebar
2. Test the **Document Overview** and **Outline** tabs, confirming they work as expected and display the correct data
3. Open and close the sidebar to confirm there are no errors.
4. Test the shortcut keys (`alt+shift+o` on Windows, and `control+option+o` on Mac) to confirm it opens and closes the sidebar properly

This sidebar has some specific focus behavior built-in. The following tests are to double check we aren't breaking any of that.
tl;dr:
- When closed, the shortcut key should open the sidebar.
- When open, if the sidebar doesn't have focus the shortcut should apply focus to the correct element in the sidebar.
- When open, if the sidebar does have focus, the shortcut should close the sidebar
- When the shortcut closes the sidebar, focus should land on the Document Overview sidebar toggle button

**On a post with no blocks:**
1. Click to place focus on the canvas
2. Press the Document Overview shortcut keys
3. Document Overview should open, focus should remain on the editor canvas
4. Press the shortcut again, focus should move to the first tabbable item in the sidebar (ie, the List View tab)
5. Press the shortcut one more time, and the sidebar should close
6. Confirm that when the sidebar closes, the focus goes to the sidebar toggle button
7.  Open the Document Overview again (either by clicking or by shortcut, it doesn't matter which)
8. Click any element in the sidebar to focus it
9. Press the shortcut keys, and the sidebar should close
10. Open the sidebar, and then click the canvas to move focus outside the sidebar
11. Press the shortcut keys, and confirm focus moves to the first tabbale item (which should still be the List View tab)
12. Press the shortcut keys again, the sidebar should close

**On a post with blocks:**
1. Click to place focus on the canvas
2. Press the Document Overview shortcut keys
3. Document Overview should open, focus should go straight to the first block listed in the sidebar
4. Pressing the shortcut keys again should close the sidebar
5.  Confirm that when the sidebar closes, the focus goes to the sidebar toggle button
6. Open the sidebar, and then click the canvas to move focus outside the sidebar
7. Press the shortcut keys, and confirm focus moves to the first block in the list
8. Press the shortcut keys again, the sidebar should close

### Testing Instructions for Keyboard
1. Create a new post
2. Press `` ctrl+` `` four times to navigate to the top toolbar region
3. Press [Tab] to focus the first toolbar button
4. [ArrowRight] to the **Document Overview** button
5. Press [Enter/Return/Space] to action the button and open the sidebar
6. Press [Tab] until you've traversed the top toolbar
7. When focus lands on the **List View** tab, confirm that arrow keys can be used to navigate between tabs
8. Select a tab with [Enter/Return/Space]
9. Confirm that [Tab] moves focus to the **Close** button
10. Confirm that [Tab] again moves focus to the canvas, because there's nothing in the list view/outline
11. Close the sidebar by pressing the shortcut key twice
12. Add some text to the default paragraph block
13. Use `` ctrl+` `` to once again navigate to the top toolbar
14. [Tab] will now focus the **Document Overview** toggle
15. Open the sidebar, confirm that focus jumps to the first block in the list