### PR TITLE
Block: optimise and clean up selector

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -8,7 +8,10 @@ import classnames from 'classnames';
  */
 import { useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
+import {
+	__unstableGetBlockProps as getBlockProps,
+	getBlockDefaultClassName,
+} from '@wordpress/blocks';
 import { useMergeRefs, useDisabled } from '@wordpress/compose';
 import warning from '@wordpress/warning';
 
@@ -99,7 +102,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		canInsertMovingBlock,
 		isEditingDisabled,
 		isTemporarilyEditingAsBlocks,
-		defaultClassName,
 	} = useContext( PrivateBlockContext );
 
 	// translators: %s: Type of block (i.e. Text, Image etc)
@@ -166,7 +168,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			className,
 			props.className,
 			wrapperProps.className,
-			defaultClassName
+			getBlockDefaultClassName( name )
 		),
 		style: { ...wrapperProps.style, ...props.style },
 	};

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -735,11 +735,11 @@ export function getSelectedBlocksInitialCaretPosition( state ) {
  */
 export const getSelectedBlockClientIds = createSelector(
 	( state ) => {
-		const { selectionStart, selectionEnd } = state.selection;
-
-		if ( ! selectionStart.clientId || ! selectionEnd.clientId ) {
+		if ( ! hasSelection( state ) ) {
 			return EMPTY_ARRAY;
 		}
+
+		const { selectionStart, selectionEnd } = state.selection;
 
 		if ( selectionStart.clientId === selectionEnd.clientId ) {
 			return [ selectionStart.clientId ];
@@ -1208,6 +1208,9 @@ export function isBlockSelected( state, clientId ) {
  * @return {boolean} Whether the block has an inner block selected
  */
 export function hasSelectedInnerBlock( state, clientId, deep = false ) {
+	if ( ! hasSelection( state ) ) {
+		return false;
+	}
 	return getBlockOrder( state, clientId ).some(
 		( innerClientId ) =>
 			isBlockSelected( state, innerClientId ) ||
@@ -1253,6 +1256,13 @@ export function isBlockWithinSelection( state, clientId ) {
 	const clientIds = getMultiSelectedBlockClientIds( state );
 	const index = clientIds.indexOf( clientId );
 	return index > -1 && index < clientIds.length - 1;
+}
+
+function hasSelection( state ) {
+	return (
+		state.selection.selectionStart.clientId &&
+		state.selection.selectionEnd.clientId
+	);
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Moves `canRemove` and `isLocked` into the callbacks instead of passing undefined callbacks.

* This removes the need for us to check preemptively if an action is possible. We should simply check when the callback is run. If necessary, we should check before running the callback in the implementation.
* Currently these callbacks may be undefined which may be unexpected if you're not used to blocks being locked.
* Generally these kind of checks should always be moved to callbacks. It's very wasteful to check if a block can be removed etc. when that block might never be touched!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
