### PR TITLE
Block editor: hooks: useBlockProps for layout

### DIFF
--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -52,6 +52,7 @@ createBlockListBlockFilter( [
 	fontSize,
 	border,
 	position,
+	layout,
 	childLayout,
 ] );
 createBlockSaveFilter( [

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -516,6 +516,14 @@ export function createBlockListBlockFilter( features ) {
 				<BlockListBlock
 					key="edit"
 					{ ...props }
+					__unstableLayoutClassNames={ allWrapperProps
+						.filter( Boolean )
+						.reduce( ( acc, wrapperProps ) =>
+							classnames(
+								acc,
+								wrapperProps.__unstableLayoutClassNames
+							)
+						) }
 					wrapperProps={ allWrapperProps
 						.filter( Boolean )
 						.reduce( ( acc, wrapperProps ) => {

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -518,11 +518,13 @@ export function createBlockListBlockFilter( features ) {
 					{ ...props }
 					__unstableLayoutClassNames={ allWrapperProps
 						.filter( Boolean )
-						.reduce( ( acc, wrapperProps ) =>
-							classnames(
-								acc,
-								wrapperProps.__unstableLayoutClassNames
-							)
+						.reduce(
+							( acc, wrapperProps ) =>
+								classnames(
+									acc,
+									wrapperProps.__unstableLayoutClassNames
+								),
+							undefined
 						) }
 					wrapperProps={ allWrapperProps
 						.filter( Boolean )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I skipped this one because it had some odd things: it passes `__unstableLayoutClassNames` to `BlockListBlock` instead of wrapper props. I wonder if we can refactor this in the future. It also relies on the style attribute... not sure why.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is the last `BlockListBlock` to be removed. Also removes a `useSelect` call per block, since it was unguarded.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I have no idea how to test this so would appreciate any help 😃

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
