### PR TITLE
Remove unnecessary TOCs from documentation

### DIFF
--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -10,37 +10,6 @@ Before you begin, there are some requirements that must be met in order to succe
 
 Similar requirements apply to releasing WordPress's [npm packages](https://developer.wordpress.org/block-editor/contributors/code/release/#packages-releases-to-npm-and-wordpress-core-updates).
 
-**Table of contents**
-
--   **[Gutenberg plugin releases](#gutenberg-plugin-releases)**
-    -   [Release schedule](#release-schedule)
-    -   [Release management](#release-management)
-    -   [Preparing a release](#preparing-a-release)
-        -   [Organizing and labeling milestone PRs](#organizing-and-labeling-milestone-prs)
-        -   [Running the release workflow](#running-the-release-workflow)
-        -   [Publishing the @wordpress packages to NPM](#publishing-the-wordpress-packages-to-npm)
-        -   [Viewing the release draft](#viewing-the-release-draft)
-        -   [Curating the release changelog](#curating-the-release-changelog)
-        -   [Creating release candidate patches (cherry-picking)](#creating-release-candidate-patches-cherry-picking)
-            -   [Automated cherry-picking](#automated-cherry-picking)
-            -   [Manual cherry-picking](#manual-cherry-picking)
-        -   [Publishing the release](#publishing-the-release)
-        -   [Troubleshooting the release](#troubleshooting-the-release)
-    -   [Documenting the release](#documenting-the-release)
-        -   [Selecting the release highlights](#selecting-the-release-highlights)
-        -   [Requesting release assets](#requesting-release-assets)
-        -   [Drafting the release post](#drafting-the-release-post)
-        -   [Publishing the release post](#publishing-the-release-post)
-    -   [Creating minor releases](#creating-minor-releases)
-        -   [Updating the release branch](#updating-the-release-branch)
-        -   [Running the minor release](#running-the-minor-release)
-        -   [Creating a minor release for previous stable releases](#creating-a-minor-release-for-previous-stable-releases)
-        -   [Troubleshooting](#troubleshooting)
--   [Packages releases to NPM and WordPress Core updates](#packages-releases-to-npm-and-wordpress-core-updates)
-    -   [Synchronizing the Gutenberg plugin](#synchronizing-the-gutenberg-plugin)
-    -   [WordPress releases](#wordpress-releases)
-    -   [Development releases](#development-releases)
-
 ## Gutenberg plugin releases
 
 The first step in releasing a stable version of the Gutenberg plugin is to [create an issue](https://github.com/WordPress/gutenberg/issues/new?assignees=&labels=&projects=&template=New_release.md) in the Gutenberg repository. The issue template is called "Gutenberg Release," and it contains a checklist for the complete release process, from release candidate to changelog curation to cherry-picking, stable release, and release post. The issue for [Gutenberg 15.7](https://github.com/WordPress/gutenberg/issues/50092) is a good example.

--- a/docs/how-to-guides/platform/custom-block-editor.md
+++ b/docs/how-to-guides/platform/custom-block-editor.md
@@ -10,21 +10,6 @@ This flexibility and interoperability makes blocks a powerful tool for building 
 
 This guide covers the basics of creating your first custom block editor.
 
-## Table of contents
-
--   [Introduction](#introduction)
-- 	[Code Syntax](#code-syntax)
--   [What you're going to be building](#what-youre-going-to-be-building)
--   [Plugin setup and organization](#plugin-setup-and-organization)
--   [The "Core" of the editor](#the-core-of-the-editor)
--   [Creating the custom "Block Editor" page](#creating-the-custom-block-editor-page)
--   [Registering and rendering the custom block editor](#registering-and-rendering-the-custom-block-editor)
--   [Reviewing the `<Editor>` component](#reviewing-the-editor-component)
--   [The custom `<BlockEditor>`](#the-custom-blockeditor)
--   [Reviewing the sidebar](#reviewing-the-sidebar)
--   [Block persistence](#block-persistence)
--   [Wrapping up](#wrapping-up)
-
 ## Introduction
 
 With its many packages and components, the Gutenberg codebase can be daunting at first. But at its core, it's all about managing and editing blocks. So if you want to work on the editor, it's essential to understand how block editing works at a fundamental level.

--- a/packages/block-editor/src/components/alignment-control/README.md
+++ b/packages/block-editor/src/components/alignment-control/README.md
@@ -6,11 +6,6 @@ This component is mostly used for blocks that display text, such as Heading, Par
 
 ![Post Title block alignment options](https://make.wordpress.org/core/files/2020/09/post-title-block-alignment-options.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-alignment-control/README.md
+++ b/packages/block-editor/src/components/block-alignment-control/README.md
@@ -4,11 +4,6 @@ The `BlockAlignmentToolbar` component is used to render block alignment options 
 
 ![Image block alignment options](https://make.wordpress.org/core/files/2020/09/image-block-alignment-options.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-alignment-matrix-control/README.md
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/README.md
@@ -4,16 +4,6 @@ The alignment matrix control allows users to quickly adjust inner block alignmen
 
 ![Button components](https://i.imgur.com/PxYkgL5.png)
 
-## Table of contents
-
--   [Alignment Matrix Control](#alignment-matrix-control)
-    -   [Table of contents](#table-of-contents)
-    -   [Design guidelines](#design-guidelines)
-        -   [Usage](#usage)
-    -   [Development guidelines](#development-guidelines)
-        -   [Usage](#usage-1)
-        -   [Props](#props)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-breadcrumb/README.md
+++ b/packages/block-editor/src/components/block-breadcrumb/README.md
@@ -6,11 +6,6 @@ The block breadcrumb trail displays the hierarchy of the current block selection
 
 ![Image in column block breadcrumb](https://make.wordpress.org/core/files/2020/08/gutenberg-image-in-column-block-breadcrumb.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 #### Props

--- a/packages/block-editor/src/components/block-caption/README.md
+++ b/packages/block-editor/src/components/block-caption/README.md
@@ -4,11 +4,6 @@ The `BlockCaption` component renders block-level UI for adding and editing capti
 
 `BlockCaption` is used in several native blocks, including `Video`, `Image`, `Audio`, etc.
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-card/README.md
+++ b/packages/block-editor/src/components/block-card/README.md
@@ -6,11 +6,6 @@ In the editor, this component is displayed in two different places: in the block
 
 ![Heading block card in the block inspector](https://make.wordpress.org/core/files/2020/09/screenshot-wordpress.org-2020.09.08-14_19_21.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-icon/README.md
+++ b/packages/block-editor/src/components/block-icon/README.md
@@ -6,11 +6,6 @@ The rendered an [Icon](https://github.com/WordPress/gutenberg/tree/HEAD/packages
 
 ![Image block icons in various places](https://make.wordpress.org/core/files/2020/08/image-block-icons-in-various-places.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-inspector/README.md
+++ b/packages/block-editor/src/components/block-inspector/README.md
@@ -4,11 +4,6 @@ The Block inspector is one of the panels that is displayed in the editor; it is 
 
 ![Paragraph block inspector](https://make.wordpress.org/core/files/2020/08/paragraph-block-inspector.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-mover/README.md
+++ b/packages/block-editor/src/components/block-mover/README.md
@@ -4,11 +4,6 @@ Block movers allow moving blocks inside the editor using up and down buttons.
 
 ![Block mover screenshot](https://make.wordpress.org/core/files/2020/08/block-mover-screenshot.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-parent-selector/README.md
+++ b/packages/block-editor/src/components/block-parent-selector/README.md
@@ -8,11 +8,6 @@ In practice the BlockParentSelector component renders a <ToolbarButton /> compon
 
 ![Block parent selector test](https://make.wordpress.org/core/files/2020/09/block-parent-selector-test.gif)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-patterns-list/README.md
+++ b/packages/block-editor/src/components/block-patterns-list/README.md
@@ -6,11 +6,6 @@ For more infos about blocks patterns, read [this](https://make.wordpress.org/cor
 
 ![Block patterns sidebar in WordPress 5.5](https://make.wordpress.org/core/files/2020/09/blocks-patterns-sidebar-in-wordpress-5-5.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-toolbar/README.md
+++ b/packages/block-editor/src/components/block-toolbar/README.md
@@ -6,11 +6,6 @@ The `BlockToolbar` component is used to render a toolbar that serves as a wrappe
 
 ![Image block toolbar](https://make.wordpress.org/core/files/2020/09/image-block-toolbar.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-types-list/README.md
+++ b/packages/block-editor/src/components/block-types-list/README.md
@@ -10,11 +10,6 @@ This component is present in the block insertion tab, the reusable blocks tab an
 
 ![Block types list in the quick inserter modal](https://make.wordpress.org/core/files/2020/09/block-types-list-emplacement-3.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-variation-picker/README.md
+++ b/packages/block-editor/src/components/block-variation-picker/README.md
@@ -10,11 +10,6 @@ This component is currently used by "Columns" and "Query Loop" blocks.
 
 ![Columns block variations](https://make.wordpress.org/core/files/2020/09/colums-block-variations.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/block-variation-transforms/README.md
+++ b/packages/block-editor/src/components/block-variation-transforms/README.md
@@ -4,11 +4,6 @@ This component allows to display the selected block's variations which have the 
 
 By selecting such a variation an update to the selected block's attributes happen, based on the variation's attributes.
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/caption/README.md
+++ b/packages/block-editor/src/components/caption/README.md
@@ -4,11 +4,6 @@ The `Caption` component renders the [caption part](https://wordpress.org/documen
 
 This component encapsulates the "caption" behaviour and styles over a `<RichText>` so it can be used in other components such as the `BlockCaption` component.
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/contrast-checker/README.md
+++ b/packages/block-editor/src/components/contrast-checker/README.md
@@ -6,10 +6,6 @@ ContrastChecker also accounts for font sizes.
 
 A notice will be rendered if the color combination of text and background colors are low.
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-
 ## Developer guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/copy-handler/README.md
+++ b/packages/block-editor/src/components/copy-handler/README.md
@@ -8,16 +8,6 @@ Concretely, it handles the display of success messages and takes care of copying
 
 ![Copy/cut behaviours](https://user-images.githubusercontent.com/150562/81698101-6e341d80-945d-11ea-9bfb-b20781f55033.gif)
 
-## Table of contents
-
-- [Copy Handler](#copy-handler)
-	- [Table of contents](#table-of-contents)
-	- [Development guidelines](#development-guidelines)
-		- [Usage](#usage)
-		- [Props](#props)
-		- [`children`](#children)
-	- [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/height-control/README.md
+++ b/packages/block-editor/src/components/height-control/README.md
@@ -4,11 +4,6 @@ The `HeightControl` component adds a linked unit control and slider component fo
 
 _Note:_ It is worth noting that the minimum height option is an opt-in feature. Themes need to declare support for it before it'll be available, and a convenient way to do that is via opting in to the [appearanceTools](/docs/how-to-guides/themes/theme-json/#opt-in-into-ui-controls) UI controls.
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/letter-spacing-control/README.md
+++ b/packages/block-editor/src/components/letter-spacing-control/README.md
@@ -5,11 +5,6 @@ The `LetterSpacingControl` component renders a [`UnitControl`](https://github.co
 This component is used for blocks that display text, commonly inside a 
 [`ToolsPanelItem`](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/tools-panel/tools-panel-item/README.md).
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/line-height-control/README.md
+++ b/packages/block-editor/src/components/line-height-control/README.md
@@ -6,11 +6,6 @@ The `LineHeightControl` component adds a lineHeight attribute to the core Paragr
 
 _Note:_ It is worth noting that the line height setting option is an opt-in feature. [Themes need to declare support for it](/docs/how-to-guides/themes/theme-support.md#supporting-custom-line-heights) before it'll be available.
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/list-view/README.md
+++ b/packages/block-editor/src/components/list-view/README.md
@@ -11,11 +11,6 @@ In addition to presenting the structure of the blocks in the editor, the ListVie
 ![List view](https://make.wordpress.org/core/files/2020/08/block-navigation.png)
 ![View of a group list view](https://make.wordpress.org/core/files/2020/08/view-of-group-block-navigation.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/multi-selection-inspector/README.md
+++ b/packages/block-editor/src/components/multi-selection-inspector/README.md
@@ -6,11 +6,6 @@ This card contains information on the number of blocks selected, and in the case
 
 ![Multi selection inspector card](https://make.wordpress.org/core/files/2020/09/multi-selection-inspector-card.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/text-transform-control/README.md
+++ b/packages/block-editor/src/components/text-transform-control/README.md
@@ -4,10 +4,6 @@ The `TextTransformControl` component is responsible for rendering a control elem
  
 ![TextTransformConrol Element in Inspector Control](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/assets/text-transform-component.png?raw=true)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/ungroup-button/README.md
+++ b/packages/block-editor/src/components/ungroup-button/README.md
@@ -6,11 +6,6 @@ This only happens in the mobile WordPress apps.
 
 ![Ungroup button icon](https://user-images.githubusercontent.com/21242757/65593577-11006000-df91-11e9-8460-1179e9ef46d2.png)
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/unit-control/README.md
+++ b/packages/block-editor/src/components/unit-control/README.md
@@ -15,10 +15,6 @@ UnitControl component allows the user to set a value as well as a unit (e.g. `px
 }
 ```
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-
 ## Developer guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/use-resize-canvas/README.md
+++ b/packages/block-editor/src/components/use-resize-canvas/README.md
@@ -6,10 +6,6 @@ On-page CSS media queries are also updated to match the width of the device.
 
 Note that this is currently experimental, and is available as `__experimentalUseResizeCanvas`.
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/block-editor/src/components/use-settings/README.md
+++ b/packages/block-editor/src/components/use-settings/README.md
@@ -9,10 +9,6 @@ It does the lookup of the settings in the following order:
 3. If that doesn't prove to be successful in getting a value, then it falls back to the settings from the block editor store.
 4. If none of the above steps prove to be successful, then it's likely to be a deprecated setting and the deprecated setting is used instead.
 
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-
 ## Development guidelines
 
 ### Usage

--- a/packages/components/src/button-group/README.md
+++ b/packages/components/src/button-group/README.md
@@ -4,12 +4,6 @@ ButtonGroup can be used to group any related buttons together. To emphasize rela
 
 ![ButtonGroup component](https://wordpress.org/gutenberg/files/2018/12/s_96EC471FE9C9D91A996770229947AAB54A03351BDE98F444FD3C1BF0CED365EA_1541792995815_ButtonGroup.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -4,12 +4,6 @@ Buttons let users take actions and make choices with a single click or tap.
 
 ![Button components](https://make.wordpress.org/design/files/2019/03/button.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/checkbox-control/README.md
+++ b/packages/components/src/checkbox-control/README.md
@@ -2,15 +2,7 @@
 
 Checkboxes allow the user to select one or more items from a set.
 
-![](https://make.wordpress.org/design/files/2019/02/CheckboxControl.png)
-
-Selected and unselected checkboxes
-
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
+![Selected and unselected checkboxes](https://make.wordpress.org/design/files/2019/02/CheckboxControl.png)
 
 ## Design guidelines
 

--- a/packages/components/src/combobox-control/README.md
+++ b/packages/components/src/combobox-control/README.md
@@ -2,12 +2,6 @@
 
 `ComboboxControl` is an enhanced version of a [`SelectControl`](/packages/components/src/select-control/README.md), with the addition of being able to search for options using a search input.
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 These are the same as [the ones for `SelectControl`s](/packages/components/src/select-control/README.md#design-guidelines), but this component is better suited for when there are too many items to scroll through or load at once so you need to filter them based on user input.

--- a/packages/components/src/custom-select-control/README.md
+++ b/packages/components/src/custom-select-control/README.md
@@ -2,12 +2,6 @@
 
 `CustomSelectControl` allows users to select an item from a single-option menu just like [`SelectControl`](/packages/components/src/select-control/readme.md), with the addition of being able to provide custom styles for each item in the menu. This means it does not use a native `<select>`, so should only be used if the custom styling is necessary.
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 These are the same as [the ones for `SelectControl`s](/packages/components/src/select-control/readme.md#design-guidelines).

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -4,11 +4,6 @@ The DropdownMenu displays a list of actions (each contained in a MenuItem, MenuI
 
 ![An expanded DropdownMenu, containing a list of MenuItems.](https://wordpress.org/gutenberg/files/2019/01/DropdownMenuExample.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-
 ## Anatomy
 
 ![Anatomy of a DropdownMenu.](https://wordpress.org/gutenberg/files/2019/01/DropdownMenuAnatomy.png)

--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -4,12 +4,6 @@ FormToggle switches a single setting on or off.
 
 ![On and off FormToggles. The top toggle is on, while the bottom toggle is off.](https://wordpress.org/gutenberg/files/2019/01/Toggle.jpg)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/menu-group/README.md
+++ b/packages/components/src/menu-group/README.md
@@ -4,14 +4,6 @@
 
 ![MenuGroup Example](https://wordpress.org/gutenberg/files/2019/03/MenuGroup.png)
 
-1. MenuGroup
-
-## Table of Contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/menu-items-choice/README.md
+++ b/packages/components/src/menu-items-choice/README.md
@@ -4,13 +4,6 @@
 
 ![MenuItemsChoice Example](https://wordpress.org/gutenberg/files/2019/03/MenuItemsChoice.png)
 
-1. MenuItemsChoice
-
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-
 ## Design guidelines
 
 A `MenuItemsChoice` should be housed within in its own distinct `MenuGroup`, so that the set of options are distinct from nearby `MenuItems`.

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -4,12 +4,6 @@ Modals give users information and choices related to a task they’re trying to 
 
 ![An alert modal for trashing a post](https://wordpress.org/gutenberg/files/2019/04/Modal.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -4,12 +4,6 @@ Use Notices to communicate prominent messages to the user.
 
 ![Notice component](https://make.wordpress.org/design/files/2019/03/Notice-Screenshot-alt.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 A Notice displays a succinct message. It can also offer the user options, like viewing a published post or updating a setting, and requires a user action to be dismissed.

--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -4,12 +4,6 @@ Panels expand and collapse multiple sections of content.
 
 ![](https://make.wordpress.org/design/files/2019/03/panel.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Anatomy

--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -5,12 +5,6 @@ Use radio buttons when you want users to select one option from a set, and you w
 ![](https://make.wordpress.org/design/files/2018/11/radio.png)
 Selected and unselected radio buttons
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/radio-group/README.md
+++ b/packages/components/src/radio-group/README.md
@@ -12,12 +12,6 @@ Use a RadioGroup component when you want users to select one option from a small
 
 ![RadioGroup component](https://wordpress.org/gutenberg/files/2018/12/s_96EC471FE9C9D91A996770229947AAB54A03351BDE98F444FD3C1BF0CED365EA_1541792995815_ButtonGroup.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -2,15 +2,7 @@
 
 RangeControls are used to make selections from a range of incremental values.
 
-![](https://make.wordpress.org/design/files/2018/12/rangecontrol.png)
-
-A RangeControl for volume
-
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
+![A RangeControl for volume](https://make.wordpress.org/design/files/2018/12/rangecontrol.png)
 
 ## Design guidelines
 

--- a/packages/components/src/search-control/README.md
+++ b/packages/components/src/search-control/README.md
@@ -2,12 +2,6 @@
 
 SearchControl components let users display a search control.
 
-
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
-
 Check out the [Storybook page](https://wordpress.github.io/gutenberg/?path=/docs/components-searchcontrol--docs) for a visual exploration of this component.
 
 ## Development guidelines

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -4,12 +4,6 @@ SelectControl allow users to select from a single or multiple option menu. It fu
 
 ![A “Link To” select with “none” selected.](https://wordpress.org/gutenberg/files/2018/12/select.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/snackbar/README.md
+++ b/packages/components/src/snackbar/README.md
@@ -2,12 +2,6 @@
 
 Use Snackbars to communicate low priority, non-interruptive messages to the user.
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 A Snackbar displays a succinct message that is cleared out after a small delay. It can also offer the user options, like viewing a published post but these options should also be available elsewhere in the UI.

--- a/packages/components/src/spacer/README.md
+++ b/packages/components/src/spacer/README.md
@@ -6,8 +6,6 @@ This feature is still experimental. “Experimental” means this is an early im
 
 `Spacer` is a primitive layout component that providers inner (`padding`) or outer (`margin`) space in-between components. It can also be used to adaptively provide space within an `HStack` or `VStack`.
 
-## Table of contents
-
 ## Usage
 
 `Spacer` comes with a bunch of shorthand props to adjust `margin` and `padding`. The values of these props work as a multiplier to the library's grid system (base of `4px`).

--- a/packages/components/src/tab-panel/README.md
+++ b/packages/components/src/tab-panel/README.md
@@ -6,11 +6,6 @@ TabPanels organize content across different screens, data sets, and interactions
 
 ![The “Document” tab selected in the sidebar TabPanel.](https://wordpress.org/gutenberg/files/2019/01/s_E36D9C9B8FFA15A1A8CE224E422535A12B016F88884089575F9998E52016A49F_1541785098230_TabPanel.png)
 
-## Table of contents
-
-1. Design guidelines
-2. Development guidelines
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/text-control/README.md
+++ b/packages/components/src/text-control/README.md
@@ -4,12 +4,6 @@ TextControl components let users enter and edit text.
 
 ![Unfilled and filled TextControl components](https://make.wordpress.org/design/files/2019/03/TextControl.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/textarea-control/README.md
+++ b/packages/components/src/textarea-control/README.md
@@ -4,12 +4,6 @@ TextareaControls are TextControls that allow for multiple lines of text, and wra
 
 ![An empty TextareaControl, and a focused TextareaControl with some content entered.](https://wordpress.org/gutenberg/files/2019/01/TextareaControl.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/toolbar/toolbar/README.md
+++ b/packages/components/src/toolbar/toolbar/README.md
@@ -4,12 +4,6 @@ Toolbar can be used to group related options. To emphasize groups of related ico
 
 ![Toolbar component above an image block](https://wordpress.org/gutenberg/files/2019/01/s_96EC471FE9C9D91A996770229947AAB54A03351BDE98F444FD3C1BF0CED365EA_1541782974545_ButtonGroup.png)
 
-## Table of contents
-
-1. [Design guidelines](#design-guidelines)
-2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
-
 ## Design guidelines
 
 ### Usage

--- a/packages/components/src/tree-grid/README.md
+++ b/packages/components/src/tree-grid/README.md
@@ -3,10 +3,6 @@
 <div class="callout callout-alert">
 This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 </div>
-## Table of contents
-
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
 
 ## Development guidelines
 

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -8,18 +8,6 @@ _It is largely inspired by [create-react-app](https://create-react-app.dev/docs/
 
 > _Learn more about the [Block API at the Gutenberg HandBook](https://developer.wordpress.org/block-editor/developers/block-api/block-registration/)._
 
-## Table of Contents
-
-- [Quick start](#quick-start)
-- [Usage](#usage)
-    - [Interactive Mode](#interactive-mode)
-    - [`slug`](#slug)
-    - [`options`](#options)
-- [Available Commands](#available-commands-in-the-scaffolded-project)
-- [External Project Templates](#external-project-templates)
-- [Contributing to this package](#contributing-to-this-package)
-
-
 ## Quick start
 
 ```bash


### PR DESCRIPTION
The Developer Resources section of WordPress.org was recently redesigned, which includes the [Block Editor Handbook](https://developer.wordpress.org/block-editor/). The new theme includes an autogenerated Table of Contents for all developer docs. Therefore, we can remove any hardcoded TOCs from within the docs themselves. 

This reduces the maintenance burden of keeping TOCs up-to-date and also removes duplicate content. 
