### PR TITLE
StylesPreview: Fix endless loop of ratio calculations when on the threshold of a scrollbar

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -89,8 +89,7 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 	const [ styles ] = useGlobalStylesOutput();
 	const disableMotion = useReducedMotion();
 	const [ isHovered, setIsHovered ] = useState( false );
-	const [ containerResizeListener, sizes ] = useResizeObserver();
-	const { width } = sizes || { width: 0, height: 0 };
+	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const [ throttledWidth, setThrottledWidthState ] = useState( width );
 	const [ ratioState, setRatioState ] = useState();
 

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -11,8 +11,12 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
-import { useState, useMemo } from '@wordpress/element';
+import {
+	useThrottle,
+	useReducedMotion,
+	useResizeObserver,
+} from '@wordpress/compose';
+import { useLayoutEffect, useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -60,6 +64,13 @@ const normalizedHeight = 152;
 
 const normalizedColorSwatchSize = 32;
 
+// Throttle options for useThrottle. Must be defined outside of the component,
+// so that the object reference is the same on each render.
+const THROTTLE_OPTIONS = {
+	leading: true,
+	trailing: true,
+};
+
 const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 	const [ fontWeight ] = useGlobalStyle( 'typography.fontWeight' );
 	const [ fontFamily = 'serif' ] = useGlobalStyle( 'typography.fontFamily' );
@@ -78,8 +89,49 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 	const [ styles ] = useGlobalStylesOutput();
 	const disableMotion = useReducedMotion();
 	const [ isHovered, setIsHovered ] = useState( false );
-	const [ containerResizeListener, { width } ] = useResizeObserver();
-	const ratio = width ? width / normalizedWidth : 1;
+	const [ containerResizeListener, sizes ] = useResizeObserver();
+	const { width } = sizes || { width: 0, height: 0 };
+	const [ throttledWidth, setThrottledWidthState ] = useState( width );
+	const [ ratioState, setRatioState ] = useState();
+
+	const setThrottledWidth = useThrottle(
+		setThrottledWidthState,
+		250,
+		THROTTLE_OPTIONS
+	);
+
+	// Must use useLayoutEffect to avoid a flash of the iframe at the wrong
+	// size before the width is set.
+	useLayoutEffect( () => {
+		if ( width ) {
+			setThrottledWidth( width );
+		}
+	}, [ width, setThrottledWidth ] );
+
+	// Must use useLayoutEffect to avoid a flash of the iframe at the wrong
+	// size before the width is set.
+	useLayoutEffect( () => {
+		const newRatio = throttledWidth ? throttledWidth / normalizedWidth : 1;
+		const ratioDiff = newRatio - ( ratioState || 0 );
+
+		// Only update the ratio state if the difference is big enough
+		// or if the ratio state is not yet set. This is to avoid an
+		// endless loop of updates at particular viewport heights when the
+		// presence of a scrollbar causes the width to change slightly.
+		const isRatioDiffBigEnough = Math.abs( ratioDiff ) > 0.1;
+
+		if ( isRatioDiffBigEnough || ! ratioState ) {
+			setRatioState( newRatio );
+		}
+	}, [ throttledWidth, ratioState ] );
+
+	// Set a fallbackRatio to use before the throttled ratio has been set.
+	const fallbackRatio = width ? width / normalizedWidth : 1;
+	// Use the throttled ratio if it has been calculated, otherwise
+	// use the fallback ratio. The throttled ratio is used to avoid
+	// an endless loop of updates at particular viewport heights.
+	// See: https://github.com/WordPress/gutenberg/issues/55112
+	const ratio = ratioState ? ratioState : fallbackRatio;
 
 	const { paletteColors, highlightedColors } = useStylesPreviewColors();
 
@@ -108,6 +160,7 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 				<Iframe
 					className="edit-site-global-styles-preview__iframe"
 					style={ {
+						width: '100%',
 						height: normalizedHeight * ratio,
 					} }
 					onMouseEnter={ () => setIsHovered( true ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Similar issue to #55112

Fix the `StylesPreview` component so that it doesn't endlessly "dance" when the viewport height means that the preview's container is right at the threshold of a scrollbar appearing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As described in https://github.com/WordPress/gutenberg/issues/55112#issuecomment-1752390866 the ratio calculations in the `StylesPreview` component can easily wind up in an endless loop when a scrollbar is shown or hidden. It goes something like this:

1. The sidebar is rendered without any previews
2. Enough previews are rendered to cause a scrollbar to appear
3. The presence of the scrollbar causes the sizes of the previews to be recalculated
4. The previews are re-rendered, and now that they're smaller, result in no scrollbar being present
5. As no scrollbar is present, the container is now wider, so the previews can be rendered larger again
6. The previews are rendered larger, which introduces the scrollbar (we are now back at step 2, so the rest is an infinite loop)

This issue will only be apparent at very particular viewport heights, and depending on the number of previews present. I could reproduce this issue reliably in Chrome on Mac at the following viewport heights:

* Styles variations picker in global styles, with TT4 theme active: `568px` viewport height
* Main global styles panel in the righthand sidebar: `663px` viewport height

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

TL;DR — don't recalculate ratio for these previews if the change in width is only quite small (and not worth the penalty of an infinite loop)

Long story:

The fix is a little convoluted, but required a few steps to avoid an infinite loop, and keep things performant (as far as I can tell):

* Use an initial ratio calculation as on trunk to ensure that the first renders of the previews are at the correct size.
* Then, use a throttled update to set state to store the calculated ratio. In this throttled logic, set it to update the state at both the leading and trailing edges of the throttle so that the state is updated as soon as possible since the first render, and is then throttled (at `250ms`).
* Once the ratio state has been updated by the throttled function, use this state for the ratio.
* Only update the ratio state again if the ratio has change by greater than `0.1` — this is a big enough threshold to account for the show/hiding of the scrollbar, without having a negative effect (subjectively) on the appearance of the previews

While I was at it, I've also fixed an issue with the preview iframes not filling their containers in mobile viewports.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. On `trunk` see if you can replicate the dancing previews issue by using the viewport heights from the "Why?" section above. The key screens to look at are the root of global styles in the right hand sidebar, and the style variations screen.
2. With this PR applied, there shouldn't be any dancing style previews at any viewport sizes.
3. Double-check that the previews still look good at mobile screen sizes.
4. Also, double-check that the Styles screen in the global styles browse mode (the dark background screen) work as expected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Global styles (before — trunk)

https://github.com/WordPress/gutenberg/assets/14988353/ca817c7a-f0b8-42a2-9037-ba955b53601f

### Style variations (before — trunk)

https://github.com/WordPress/gutenberg/assets/14988353/c7df1436-c0c8-479e-8634-770c1b605a59

### Global styles (with this PR applied)

https://github.com/WordPress/gutenberg/assets/14988353/ce1c8d49-e833-40e1-a724-f0f2421b7998

### Style variations (with this PR applied)

https://github.com/WordPress/gutenberg/assets/14988353/8ddd0378-9a14-4753-9433-c245b6a56e3e

| Mobile viewport sizing (before) | Mobile viewport sizing (after) |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/8431a02b-0ab4-4eaf-a101-cbe5871f5054) |  ![image](https://github.com/WordPress/gutenberg/assets/14988353/ef911853-ad6b-4b1d-909b-ba13d3343efb) |