### PR TITLE
e2e: Try to fix flaky font-library test

### DIFF
--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -10,10 +10,7 @@ test.describe( 'Font Library', () => {
 		} );
 
 		test.beforeEach( async ( { admin, editor } ) => {
-			await admin.visitSiteEditor( {
-				postId: 'emptytheme//index',
-				postType: 'wp_template',
-			} );
+			await admin.visitSiteEditor();
 			await editor.canvas.locator( 'body' ).click();
 		} );
 
@@ -35,10 +32,7 @@ test.describe( 'Font Library', () => {
 		} );
 
 		test.beforeEach( async ( { admin, editor } ) => {
-			await admin.visitSiteEditor( {
-				postId: 'twentytwentythree//index',
-				postType: 'wp_template',
-			} );
+			await admin.visitSiteEditor();
 			await editor.canvas.locator( 'body' ).click();
 		} );
 


### PR DESCRIPTION
## What?

Attempt to fix Flaky test reported in #56776

## Why?

This e2e test seems to be unstable. I checked Artifacts and it seems that neither the sidebar nor the canvas is loading correctly.

![test-failed-1](https://github.com/WordPress/gutenberg/assets/54422211/19de9fa6-be72-4639-b1f1-3e101d3e8b70)

## How?

This test concerns the global style panel, so it doesn't matter which template is opened. Therefore, I am trying to remove the `visitSiteEditor()` argument and see if the test becomes stable.

## Testing Instructions

Try running the e2e test multiple times.