### PR TITLE
Optimise getValueFromObjectPath

### DIFF
--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -41,11 +41,20 @@ export function setImmutably( object, path, value ) {
  * @param {*}            defaultValue Default value if the value at the specified path is nullish.
  * @return {*} Value of the object property at the specified path.
  */
-export const getValueFromObjectPath = ( object, path, defaultValue ) => {
-	const arrayPath = Array.isArray( path ) ? path : path.split( '.' );
+export function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! Array.isArray( path ) ) {
+		if ( path.indexOf( '.' ) === -1 ) {
+			return object[ path ] ?? defaultValue;
+		}
+
+		path = path.split( '.' );
+	}
+
 	let value = object;
-	arrayPath.forEach( ( fieldName ) => {
-		value = value?.[ fieldName ];
-	} );
+
+	for ( const key of path ) {
+		value = value?.[ key ];
+	}
+
 	return value ?? defaultValue;
-};
+}

--- a/packages/block-editor/src/utils/object.js
+++ b/packages/block-editor/src/utils/object.js
@@ -42,6 +42,10 @@ export function setImmutably( object, path, value ) {
  * @return {*} Value of the object property at the specified path.
  */
 export function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! object ) {
+		return defaultValue;
+	}
+
 	if ( ! Array.isArray( path ) ) {
 		if ( path.indexOf( '.' ) === -1 ) {
 			return object[ path ] ?? defaultValue;

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -57,18 +57,28 @@ export const getEntitiesInfo = ( entities ) => {
  * Path is specified as a string of properties, separated by dots,
  * for example: "parent.child".
  *
- * @param {Object} object Input object.
- * @param {string} path   Path to the object property.
+ * @param {Object} object       Input object.
+ * @param {string} path         Path to the object property.
+ * @param {*}      defaultValue Default value if the value at the specified path is nullish.
  * @return {*} Value of the object property at the specified path.
  */
-export const getValueFromObjectPath = ( object, path ) => {
-	const normalizedPath = path.split( '.' );
+export function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! Array.isArray( path ) ) {
+		if ( path.indexOf( '.' ) === -1 ) {
+			return object[ path ] ?? defaultValue;
+		}
+
+		path = path.split( '.' );
+	}
+
 	let value = object;
-	normalizedPath.forEach( ( fieldName ) => {
-		value = value?.[ fieldName ];
-	} );
-	return value;
-};
+
+	for ( const key of path ) {
+		value = value?.[ key ];
+	}
+
+	return value ?? defaultValue;
+}
 
 /**
  * Helper util to map records to add a `name` prop from a

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -63,6 +63,10 @@ export const getEntitiesInfo = ( entities ) => {
  * @return {*} Value of the object property at the specified path.
  */
 export function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! object ) {
+		return defaultValue;
+	}
+
 	if ( ! Array.isArray( path ) ) {
 		if ( path.indexOf( '.' ) === -1 ) {
 			return object[ path ] ?? defaultValue;

--- a/packages/blocks/src/store/utils.js
+++ b/packages/blocks/src/store/utils.js
@@ -11,6 +11,10 @@
  * @return {*} Value of the object property at the specified path.
  */
 export function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! object ) {
+		return defaultValue;
+	}
+
 	if ( ! Array.isArray( path ) ) {
 		if ( path.indexOf( '.' ) === -1 ) {
 			return object[ path ] ?? defaultValue;

--- a/packages/blocks/src/store/utils.js
+++ b/packages/blocks/src/store/utils.js
@@ -10,11 +10,20 @@
  * @param {*}            defaultValue Default value if the value at the specified path is nullish.
  * @return {*} Value of the object property at the specified path.
  */
-export const getValueFromObjectPath = ( object, path, defaultValue ) => {
-	const normalizedPath = Array.isArray( path ) ? path : path.split( '.' );
+export function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! Array.isArray( path ) ) {
+		if ( path.indexOf( '.' ) === -1 ) {
+			return object[ path ] ?? defaultValue;
+		}
+
+		path = path.split( '.' );
+	}
+
 	let value = object;
-	normalizedPath.forEach( ( fieldName ) => {
-		value = value?.[ fieldName ];
-	} );
+
+	for ( const key of path ) {
+		value = value?.[ key ];
+	}
+
 	return value ?? defaultValue;
-};
+}

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -208,6 +208,10 @@ export function getBlockTypography(
  * @return {*} Value of the object property at the specified path.
  */
 function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! object ) {
+		return defaultValue;
+	}
+
 	if ( ! Array.isArray( path ) ) {
 		if ( path.indexOf( '.' ) === -1 ) {
 			return object[ path ] ?? defaultValue;

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -202,17 +202,28 @@ export function getBlockTypography(
  * Return a value from a certain path of the object.
  * Path is specified as an array of properties, like: [ 'parent', 'child' ].
  *
- * @param {Object} object Input object.
- * @param {Array}  path   Path to the object property.
+ * @param {Object} object       Input object.
+ * @param {Array}  path         Path to the object property.
+ * @param {*}      defaultValue Default value if the value at the specified path is nullish.
  * @return {*} Value of the object property at the specified path.
  */
-const getValueFromObjectPath = ( object, path ) => {
+function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! Array.isArray( path ) ) {
+		if ( path.indexOf( '.' ) === -1 ) {
+			return object[ path ] ?? defaultValue;
+		}
+
+		path = path.split( '.' );
+	}
+
 	let value = object;
-	path.forEach( ( fieldName ) => {
-		value = value?.[ fieldName ];
-	} );
-	return value;
-};
+
+	for ( const key of path ) {
+		value = value?.[ key ];
+	}
+
+	return value ?? defaultValue;
+}
 
 export function parseStylesVariables( styles, mappedValues, customValues ) {
 	let stylesBase = styles;

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -15,18 +15,34 @@ import { blockMeta, post, archive } from '@wordpress/icons';
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 
 /**
+ * Helper util to return a value from a certain path of the object.
+ * Path is specified as a string of properties, separated by dots,
+ * for example: "parent.child".
+ *
  * @typedef IHasNameAndId
- * @property {string|number} id   The entity's id.
- * @property {string}        name The entity's name.
+ *
+ * @param {Object} object       Input object.
+ * @param {string} path         Path to the object property.
+ * @param {*}      defaultValue Default value if the value at the specified path is nullish.
+ * @return {*} Value of the object property at the specified path.
  */
+function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! Array.isArray( path ) ) {
+		if ( path.indexOf( '.' ) === -1 ) {
+			return object[ path ] ?? defaultValue;
+		}
 
-const getValueFromObjectPath = ( object, path ) => {
+		path = path.split( '.' );
+	}
+
 	let value = object;
-	path.split( '.' ).forEach( ( fieldName ) => {
-		value = value?.[ fieldName ];
-	} );
-	return value;
-};
+
+	for ( const key of path ) {
+		value = value?.[ key ];
+	}
+
+	return value ?? defaultValue;
+}
 
 /**
  * Helper util to map records to add a `name` prop from a

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -27,6 +27,10 @@ import { TEMPLATE_POST_TYPE } from '../../utils/constants';
  * @return {*} Value of the object property at the specified path.
  */
 function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! object ) {
+		return defaultValue;
+	}
+
 	if ( ! Array.isArray( path ) ) {
 		if ( path.indexOf( '.' ) === -1 ) {
 			return object[ path ] ?? defaultValue;

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -104,13 +104,33 @@ const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
 
 const SUPPORTED_STYLES = [ 'border', 'color', 'spacing', 'typography' ];
 
-const getValueFromObjectPath = ( object, path ) => {
+/**
+ * Helper util to return a value from a certain path of the object.
+ * Path is specified as a string of properties, separated by dots,
+ * for example: "parent.child".
+ *
+ * @param {Object} object       Input object.
+ * @param {string} path         Path to the object property.
+ * @param {*}      defaultValue Default value if the value at the specified path is nullish.
+ * @return {*} Value of the object property at the specified path.
+ */
+function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! Array.isArray( path ) ) {
+		if ( path.indexOf( '.' ) === -1 ) {
+			return object[ path ] ?? defaultValue;
+		}
+
+		path = path.split( '.' );
+	}
+
 	let value = object;
-	path.forEach( ( fieldName ) => {
-		value = value?.[ fieldName ];
-	} );
-	return value;
-};
+
+	for ( const key of path ) {
+		value = value?.[ key ];
+	}
+
+	return value ?? defaultValue;
+}
 
 const flatBorderProperties = [ 'borderColor', 'borderWidth', 'borderStyle' ];
 const sides = [ 'top', 'right', 'bottom', 'left' ];

--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -115,6 +115,10 @@ const SUPPORTED_STYLES = [ 'border', 'color', 'spacing', 'typography' ];
  * @return {*} Value of the object property at the specified path.
  */
 function getValueFromObjectPath( object, path, defaultValue ) {
+	if ( ! object ) {
+		return defaultValue;
+	}
+
 	if ( ! Array.isArray( path ) ) {
 		if ( path.indexOf( '.' ) === -1 ) {
 			return object[ path ] ?? defaultValue;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is called thousands and thousands of times, so it seems worth optimising. If the path is a string without a dot, bypass `split` and `foreach`.

I do wish we never supported the dot notation and forced using arrays instead. For block supports keys, there's only one use case.

@tyxla It would be great to not duplicate this function over and over. Any idea where we can move it to so it's shared?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
