### PR TITLE
Add `commit message` to code health

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -97,7 +97,8 @@ jobs:
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
               run: |
                   COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
-                  ./bin/log-performance-results.js $CODEHEALTH_PROJECT_TOKEN trunk $GITHUB_SHA b61dde2e5ec29d98801e623de968bfb286c5be3f $COMMITTED_AT
+                  COMMIT_MESSAGE=$(git show -s $GITHUB_SHA --format="%B")
+                  ./bin/log-performance-results.js $CODEHEALTH_PROJECT_TOKEN trunk $GITHUB_SHA b61dde2e5ec29d98801e623de968bfb286c5be3f $COMMIT_MESSAGE $COMMITTED_AT
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)
               uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/bin/log-performance-results.js
+++ b/bin/log-performance-results.js
@@ -6,7 +6,8 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const https = require( 'https' );
-const [ token, branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
+const [ token, branch, hash, baseHash, commitMessage, timestamp ] =
+	process.argv.slice( 2 );
 
 const resultsFiles = [
 	{
@@ -41,6 +42,7 @@ const data = new TextEncoder().encode(
 		branch,
 		hash,
 		baseHash,
+		commitMessage,
 		timestamp,
 		metrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
 			return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds the commit message to the data we send in the code health project in order to display more useful information per PR, instead of only showing the commit hash.
