### PR TITLE
Block Editor: several little refactors

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -84,7 +84,7 @@ export function PatternCategoryPreviews( {
 
 				// The uncategorized category should show all the patterns without any category
 				// or with no available category.
-				if ( pattern.categories ) {
+				if ( ! pattern.categories ) {
 					return true;
 				}
 

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -78,19 +78,19 @@ export function PatternCategoryPreviews( {
 					return true;
 				}
 
-				if ( category.name !== 'uncategorized' ) {
-					return pattern.categories?.includes( category.name );
+				if ( category.name === 'uncategorized' ) {
+					// The uncategorized category should show all the patterns without any category...
+					if ( ! pattern.categories ) {
+						return true;
+					}
+
+					// ...or with no available category.
+					return ! pattern.categories.some( ( catName ) =>
+						availableCategories.some( ( c ) => c.name === catName )
+					);
 				}
 
-				// The uncategorized category should show all the patterns without any category
-				// or with no available category.
-				if ( ! pattern.categories ) {
-					return true;
-				}
-
-				return ! pattern.categories.some( ( catName ) =>
-					availableCategories.some( ( cat ) => cat.name === catName )
-				);
+				return pattern.categories?.includes( category.name );
 			} ),
 		[
 			allPatterns,

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -70,27 +70,27 @@ export function PatternCategoryPreviews( {
 				if ( category.name === allPatternsCategory.name ) {
 					return true;
 				}
+
 				if (
 					category.name === myPatternsCategory.name &&
 					pattern.type === PATTERN_TYPES.user
 				) {
 					return true;
 				}
+
 				if ( category.name !== 'uncategorized' ) {
 					return pattern.categories?.includes( category.name );
 				}
 
 				// The uncategorized category should show all the patterns without any category
 				// or with no available category.
-				const availablePatternCategories =
-					pattern.categories?.filter( ( cat ) =>
-						availableCategories.find(
-							( availableCategory ) =>
-								availableCategory.name === cat
-						)
-					) ?? [];
+				if ( pattern.categories ) {
+					return true;
+				}
 
-				return availablePatternCategories.length === 0;
+				return ! pattern.categories.some( ( catName ) =>
+					availableCategories.some( ( cat ) => cat.name === catName )
+				);
 			} ),
 		[
 			allPatterns,

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { _x, _n, sprintf } from '@wordpress/i18n';
 
 import { speak } from '@wordpress/a11y';
@@ -16,6 +16,16 @@ import {
 	myPatternsCategory,
 	PATTERN_TYPES,
 } from './utils';
+
+function hasRegisteredCategory( pattern, allCategories ) {
+	if ( ! pattern.categories || ! pattern.categories.length ) {
+		return false;
+	}
+
+	return pattern.categories.some( ( cat ) =>
+		allCategories.some( ( category ) => category.name === cat )
+	);
+}
 
 export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 	const [ patterns, allCategories ] = usePatternsState(
@@ -34,19 +44,6 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 		[ sourceFilter, patterns ]
 	);
 
-	const hasRegisteredCategory = useCallback(
-		( pattern ) => {
-			if ( ! pattern.categories || ! pattern.categories.length ) {
-				return false;
-			}
-
-			return pattern.categories.some( ( cat ) =>
-				allCategories.some( ( category ) => category.name === cat )
-			);
-		},
-		[ allCategories ]
-	);
-
 	// Remove any empty categories.
 	const populatedCategories = useMemo( () => {
 		const categories = allCategories
@@ -59,7 +56,7 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 
 		if (
 			filteredPatterns.some(
-				( pattern ) => ! hasRegisteredCategory( pattern )
+				( pattern ) => ! hasRegisteredCategory( pattern, allCategories )
 			) &&
 			! categories.find(
 				( category ) => category.name === 'uncategorized'
@@ -95,7 +92,7 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 			)
 		);
 		return categories;
-	}, [ allCategories, filteredPatterns, hasRegisteredCategory ] );
+	}, [ allCategories, filteredPatterns ] );
 
 	return populatedCategories;
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -67,26 +67,23 @@ function InserterMenu(
 			insertionIndex: __experimentalInsertionIndex,
 			shouldFocusBlock,
 		} );
-	const { showPatterns, inserterItems } = useSelect(
+	const { showPatterns, hasReusableBlocks } = useSelect(
 		( select ) => {
 			const { hasAllowedPatterns, getInserterItems } = unlock(
 				select( blockEditorStore )
 			);
 			return {
 				showPatterns: hasAllowedPatterns( destinationRootClientId ),
-				inserterItems: getInserterItems( destinationRootClientId ),
+				hasReusableBlocks: getInserterItems(
+					destinationRootClientId
+				).some( ( item ) => item.category === 'reusable' ),
 			};
 		},
 		[ destinationRootClientId ]
 	);
-	const hasReusableBlocks = useMemo( () => {
-		return inserterItems.some(
-			( { category } ) => category === 'reusable'
-		);
-	}, [ inserterItems ] );
 
 	const mediaCategories = useMediaCategories( destinationRootClientId );
-	const showMedia = !! mediaCategories.length;
+	const showMedia = mediaCategories.length > 0;
 
 	const onInsert = useCallback(
 		( blocks, meta, shouldForceFocusBlock ) => {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -67,16 +67,11 @@ function InserterMenu(
 			insertionIndex: __experimentalInsertionIndex,
 			shouldFocusBlock,
 		} );
-	const { showPatterns, hasReusableBlocks } = useSelect(
+	const { showPatterns } = useSelect(
 		( select ) => {
-			const { hasAllowedPatterns, getInserterItems } = unlock(
-				select( blockEditorStore )
-			);
+			const { hasAllowedPatterns } = unlock( select( blockEditorStore ) );
 			return {
 				showPatterns: hasAllowedPatterns( destinationRootClientId ),
-				hasReusableBlocks: getInserterItems(
-					destinationRootClientId
-				).some( ( item ) => item.category === 'reusable' ),
 			};
 		},
 		[ destinationRootClientId ]
@@ -208,9 +203,7 @@ function InserterMenu(
 		selectedTab === 'patterns' &&
 		! delayedFilterValue &&
 		selectedPatternCategory;
-	const showAsTabs =
-		! delayedFilterValue &&
-		( showPatterns || hasReusableBlocks || showMedia );
+	const showAsTabs = ! delayedFilterValue && ( showPatterns || showMedia );
 	const showMediaPanel =
 		selectedTab === 'media' &&
 		! delayedFilterValue &&
@@ -264,7 +257,6 @@ function InserterMenu(
 				{ showAsTabs && (
 					<InserterTabs
 						showPatterns={ showPatterns }
-						showReusableBlocks={ hasReusableBlocks }
 						showMedia={ showMedia }
 						prioritizePatterns={ prioritizePatterns }
 						onSelect={ handleSetSelectedTab }

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -33,23 +32,15 @@ function InserterTabs( {
 	showPatterns = false,
 	showMedia = false,
 	onSelect,
-	prioritizePatterns,
+	prioritizePatterns = false,
 	tabsContents,
 } ) {
-	const tabs = useMemo( () => {
-		const tempTabs = [];
-		if ( prioritizePatterns && showPatterns ) {
-			tempTabs.push( patternsTab );
-		}
-		tempTabs.push( blocksTab );
-		if ( ! prioritizePatterns && showPatterns ) {
-			tempTabs.push( patternsTab );
-		}
-		if ( showMedia ) {
-			tempTabs.push( mediaTab );
-		}
-		return tempTabs;
-	}, [ prioritizePatterns, showPatterns, showMedia ] );
+	const tabs = [
+		prioritizePatterns && showPatterns && patternsTab,
+		blocksTab,
+		! prioritizePatterns && showPatterns && patternsTab,
+		showMedia && mediaTab,
+	].filter( Boolean );
 
 	return (
 		<div className="block-editor-inserter__tabs">


### PR DESCRIPTION
This PR contains several little refactors in the `block-editor` package that are a spinoff from block lazy loading in #51778. They are not related to each other, but each of them is quite simple.

`PatternCategoryPreviews`: rewrite the condition for `uncategorized` category to use `.some` instead of `.filter` and `.find`. We are interested only in yes/no boolean results.

`usePatternCategories`: avoid `useCallback` by extracting `hasRegisteredCategory` as a standalone top-level function. The `allCategories` parameter is already a dependency of the `useEffect` hook that calls the function.

`InserterMenu`: calculate the `hasReusableBlocks` boolean value directly in `useSelect` hook, instead of returning an `inserterItems` array. Should lead to fewer rerenders, and avoids an extra `useMemo` hook.

`InserterTabs`: calculate the `tabs` array without `.push`, and remove the `useMemo`. After refactoring in #56918, the `tabs` value is not used as a prop and doesn't need to be memoized.