### PR TITLE
useSelect: only invalidate on subscribe if store changed

### DIFF
--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -53,8 +53,8 @@ describe( 'useQuerySelect', () => {
 		// 2 times expected
 		// - 1 for initial mount
 		// - 1 for after mount before subscription set.
-		expect( selectSpy ).toHaveBeenCalledTimes( 2 );
-		expect( TestComponent ).toHaveBeenCalledTimes( 2 );
+		expect( selectSpy ).toHaveBeenCalledTimes( 1 );
+		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
 		// ensure expected state was rendered
 		expect( screen.getByText( 'bar' ) ).toBeInTheDocument();
@@ -81,10 +81,9 @@ describe( 'useQuerySelect', () => {
 		);
 
 		// ensure the selectors were properly memoized
-		expect( selectors ).toHaveLength( 4 );
+		expect( selectors ).toHaveLength( 2 );
 		expect( selectors[ 0 ] ).toHaveProperty( 'testSelector' );
 		expect( selectors[ 0 ] ).toBe( selectors[ 1 ] );
-		expect( selectors[ 1 ] ).toBe( selectors[ 2 ] );
 
 		// Re-render
 		render(
@@ -94,9 +93,10 @@ describe( 'useQuerySelect', () => {
 		);
 
 		// ensure we still got the memoized results after re-rendering
-		expect( selectors ).toHaveLength( 8 );
-		expect( selectors[ 3 ] ).toHaveProperty( 'testSelector' );
-		expect( selectors[ 5 ] ).toBe( selectors[ 6 ] );
+		expect( selectors ).toHaveLength( 4 );
+		expect( selectors[ 2 ] ).toHaveProperty( 'testSelector' );
+		expect( selectors[ 1 ] ).toBe( selectors[ 2 ] );
+		expect( selectors[ 2 ] ).toBe( selectors[ 3 ] );
 	} );
 
 	it( 'returns the expected "response" details – no resolvers and arguments', () => {

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -50,9 +50,7 @@ describe( 'useQuerySelect', () => {
 				<TestComponent keyName="foo" />
 			</RegistryProvider>
 		);
-		// 2 times expected
-		// - 1 for initial mount
-		// - 1 for after mount before subscription set.
+
 		expect( selectSpy ).toHaveBeenCalledTimes( 1 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -187,8 +187,8 @@ function Store( registry, suspense ) {
 
 		lastIsAsync = isAsync;
 
-		// Check if the store changed between now the `updateValue` call above
-		// and the actual `subscribe` call.
+		// Check if the store changed between the `updateValue` call above and
+		// the actual `subscribe` call.
 		const cleanup = subscriber.subscribe( () => {
 			lastMapResultValid = false;
 		} );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -61,7 +61,13 @@ function Store( registry, suspense ) {
 			// in the interval between the `getValue` call during render and creating
 			// the subscription, which is slightly delayed. We need to ensure that this
 			// second `getValue` call will compute a fresh value.
-			lastMapResultValid = false;
+
+			// Why? React subscribes after the component has rendered, and the
+			// by that time we already have a value. Marking it invalid means
+			// all selectors mappings have to be run at render, and right after
+			// render. Let's see what tests are failing.
+
+			// lastMapResultValid = false;
 
 			const onStoreChange = () => {
 				// Invalidate the value on store update, so that a fresh value is computed.

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -187,8 +187,18 @@ function Store( registry, suspense ) {
 
 		lastIsAsync = isAsync;
 
+		// Check if the store changed between now the `updateValue` call above
+		// and the actual `subscribe` call.
+		const cleanup = subscriber.subscribe( () => {
+			lastMapResultValid = false;
+		} );
+		const subscribe = ( _listener ) => {
+			cleanup();
+			return subscriber.subscribe( _listener );
+		};
+
 		// Return a pair of functions that can be passed to `useSyncExternalStore`.
-		return { subscribe: subscriber.subscribe, getValue };
+		return { subscribe, getValue };
 	};
 }
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -46,6 +46,13 @@ function Store( registry, suspense ) {
 	let didWarnUnstableReference;
 	let storeStatesOnMount;
 
+	function getStoreState( name ) {
+		// If there's no store property (custom generic store), return an empty
+		// object. When comparing the state, the empty objects will cause the
+		// equality check to fail, setting `lastMapResultValid` to false.
+		return registry.stores[ name ]?.store?.getState?.() ?? {};
+	}
+
 	const createSubscriber = ( stores ) => {
 		// The set of stores the `subscribe` function is supposed to subscribe to. Here it is
 		// initialized, and then the `updateStores` function can add new stores to it.
@@ -57,20 +64,23 @@ function Store( registry, suspense ) {
 		const activeSubscriptions = new Set();
 
 		function subscribe( listener ) {
-			// Invalidate the value right after subscription was created. React will
-			// call `getValue` after subscribing, to detect store updates that happened
-			// in the interval between the `getValue` call during render and creating
-			// the subscription, which is slightly delayed. We need to ensure that this
-			// second `getValue` call will compute a fresh value.
-			lastMapResultValid =
-				activeStores.length === storeStatesOnMount.length &&
-				activeStores.every(
-					( storeName, index ) =>
-						storeStatesOnMount[ index ] ===
-						// To do: figure out why it's sometimes not available in
-						// unit tests.
-						registry.stores[ storeName ]?.store?.getState?.()
-				);
+			// Maybe invalidate the value right after subscription was created.
+			// React will call `getValue` after subscribing, to detect store
+			// updates that happened in the interval between the `getValue` call
+			// during render and creating the subscription, which is slightly
+			// delayed. We need to ensure that this second `getValue` call will
+			// compute a fresh value only if any of the store states have
+			// changed in the meantime.
+			if ( lastMapResultValid ) {
+				lastMapResultValid =
+					activeStores.length === storeStatesOnMount.length &&
+					activeStores.every(
+						( name, index ) =>
+							storeStatesOnMount[ index ] ===
+							getStoreState( name )
+					);
+			}
+
 			storeStatesOnMount = null;
 
 			const onStoreChange = () => {
@@ -159,9 +169,8 @@ function Store( registry, suspense ) {
 			}
 
 			if ( ! subscriber ) {
-				storeStatesOnMount = listeningStores.current.map( ( name ) =>
-					registry.stores[ name ]?.store?.getState?.()
-				);
+				storeStatesOnMount =
+					listeningStores.current.map( getStoreState );
 				subscriber = createSubscriber( listeningStores.current );
 			} else {
 				subscriber.updateStores( listeningStores.current );

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -64,7 +64,7 @@ describe( 'useSelect', () => {
 		// 2 selectSpy calls expected
 		// - 1 for initial mount
 		// - 1 for the subscription effect checking if value has changed
-		expect( selectSpy ).toHaveBeenCalledTimes( 2 );
+		expect( selectSpy ).toHaveBeenCalledTimes( 1 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
 		// Ensure expected state was rendered.
@@ -93,7 +93,7 @@ describe( 'useSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( selectSpyFoo ).toHaveBeenCalledTimes( 2 );
+		expect( selectSpyFoo ).toHaveBeenCalledTimes( 1 );
 		expect( selectSpyBar ).toHaveBeenCalledTimes( 0 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -107,7 +107,7 @@ describe( 'useSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( selectSpyFoo ).toHaveBeenCalledTimes( 2 );
+		expect( selectSpyFoo ).toHaveBeenCalledTimes( 1 );
 		expect( selectSpyBar ).toHaveBeenCalledTimes( 0 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 
@@ -121,7 +121,7 @@ describe( 'useSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( selectSpyFoo ).toHaveBeenCalledTimes( 2 );
+		expect( selectSpyFoo ).toHaveBeenCalledTimes( 1 );
 		expect( selectSpyBar ).toHaveBeenCalledTimes( 1 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 3 );
 
@@ -163,7 +163,7 @@ describe( 'useSelect', () => {
 
 		// Initial render renders only parent and subscribes the parent to store.
 		expect( screen.getByText( 'none' ) ).toBeInTheDocument();
-		expect( mapSelectParent ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectParent ).toHaveBeenCalledTimes( 1 );
 		expect( mapSelectChild ).toHaveBeenCalledTimes( 0 );
 		expect( Parent ).toHaveBeenCalledTimes( 1 );
 		expect( Child ).toHaveBeenCalledTimes( 0 );
@@ -174,8 +174,8 @@ describe( 'useSelect', () => {
 
 		// Child was rendered and subscribed to the store, as the _second_ subscription.
 		expect( screen.getByText( 'yes' ) ).toBeInTheDocument();
-		expect( mapSelectParent ).toHaveBeenCalledTimes( 3 );
-		expect( mapSelectChild ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectParent ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectChild ).toHaveBeenCalledTimes( 1 );
 		expect( Parent ).toHaveBeenCalledTimes( 2 );
 		expect( Child ).toHaveBeenCalledTimes( 1 );
 
@@ -187,8 +187,8 @@ describe( 'useSelect', () => {
 		// I.e., `mapSelectChild` was called again, and state update was scheduled, we cannot
 		// avoid that, but the state update is never executed and doesn't do a rerender.
 		expect( screen.getByText( 'none' ) ).toBeInTheDocument();
-		expect( mapSelectParent ).toHaveBeenCalledTimes( 4 );
-		expect( mapSelectChild ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelectParent ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelectChild ).toHaveBeenCalledTimes( 2 );
 		expect( Parent ).toHaveBeenCalledTimes( 3 );
 		expect( Child ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -217,7 +217,7 @@ describe( 'useSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( mapSelect ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelect ).toHaveBeenCalledTimes( 1 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0:0' );
 
@@ -226,7 +226,7 @@ describe( 'useSelect', () => {
 			registry.dispatch( 'store-even' ).inc();
 		} );
 
-		expect( mapSelect ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelect ).toHaveBeenCalledTimes( 2 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0:2' );
 
@@ -235,7 +235,7 @@ describe( 'useSelect', () => {
 			registry.dispatch( 'store-odd' ).inc();
 		} );
 
-		expect( mapSelect ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelect ).toHaveBeenCalledTimes( 2 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0:2' );
 
@@ -244,7 +244,7 @@ describe( 'useSelect', () => {
 			registry.dispatch( 'store-main' ).inc();
 		} );
 
-		expect( mapSelect ).toHaveBeenCalledTimes( 4 );
+		expect( mapSelect ).toHaveBeenCalledTimes( 3 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 3 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( '1:3' );
 
@@ -253,7 +253,7 @@ describe( 'useSelect', () => {
 			registry.dispatch( 'store-odd' ).inc();
 		} );
 
-		expect( mapSelect ).toHaveBeenCalledTimes( 5 );
+		expect( mapSelect ).toHaveBeenCalledTimes( 4 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 4 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( '1:5' );
 
@@ -263,7 +263,7 @@ describe( 'useSelect', () => {
 			registry.dispatch( 'store-even' ).inc();
 		} );
 
-		expect( mapSelect ).toHaveBeenCalledTimes( 6 );
+		expect( mapSelect ).toHaveBeenCalledTimes( 5 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 4 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( '1:5' );
 	} );
@@ -336,7 +336,7 @@ describe( 'useSelect', () => {
 				expect( screen.getByRole( 'status' ).dataset.d ).toBe(
 					JSON.stringify( valueB )
 				);
-				expect( mapSelectSpy ).toHaveBeenCalledTimes( 3 );
+				expect( mapSelectSpy ).toHaveBeenCalledTimes( 2 );
 			}
 		);
 	} );
@@ -368,8 +368,8 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
-			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
+			expect( selectCount1 ).toHaveBeenCalledTimes( 1 );
+			expect( selectCount2 ).toHaveBeenCalledTimes( 1 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0' );
 
@@ -377,8 +377,8 @@ describe( 'useSelect', () => {
 				registry.dispatch( 'store-2' ).inc();
 			} );
 
-			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
-			expect( selectCount2 ).toHaveBeenCalledTimes( 3 );
+			expect( selectCount1 ).toHaveBeenCalledTimes( 1 );
+			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0' );
 
@@ -386,8 +386,8 @@ describe( 'useSelect', () => {
 				registry.dispatch( 'store-1' ).inc();
 			} );
 
-			expect( selectCount1 ).toHaveBeenCalledTimes( 3 );
-			expect( selectCount2 ).toHaveBeenCalledTimes( 3 );
+			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
+			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 3 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '1' );
 
@@ -425,21 +425,21 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			expect( selectCount1And2 ).toHaveBeenCalledTimes( 2 );
+			expect( selectCount1And2 ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0,0' );
 
 			act( () => {
 				registry.dispatch( 'store-2' ).inc();
 			} );
 
-			expect( selectCount1And2 ).toHaveBeenCalledTimes( 3 );
+			expect( selectCount1And2 ).toHaveBeenCalledTimes( 2 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0,1' );
 
 			act( () => {
 				registry.dispatch( 'store-3' ).inc();
 			} );
 
-			expect( selectCount1And2 ).toHaveBeenCalledTimes( 3 );
+			expect( selectCount1And2 ).toHaveBeenCalledTimes( 2 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0,1' );
 		} );
 
@@ -475,7 +475,7 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 2 );
+			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 				'count:0,dep:0'
 			);
@@ -484,7 +484,7 @@ describe( 'useSelect', () => {
 				setDep( 1 );
 			} );
 
-			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 3 );
+			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 2 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 				'count:0,dep:1'
 			);
@@ -493,7 +493,7 @@ describe( 'useSelect', () => {
 				registry.dispatch( 'store-1' ).inc();
 			} );
 
-			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 4 );
+			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 3 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 				'count:1,dep:1'
 			);
@@ -636,7 +636,7 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			expect( selectCount1And2 ).toHaveBeenCalledTimes( 2 );
+			expect( selectCount1And2 ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 				'count1:0,count2:0'
 			);
@@ -645,7 +645,7 @@ describe( 'useSelect', () => {
 				registry.dispatch( 'store-2' ).inc();
 			} );
 
-			expect( selectCount1And2 ).toHaveBeenCalledTimes( 3 );
+			expect( selectCount1And2 ).toHaveBeenCalledTimes( 2 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 				'count1:0,count2:1'
 			);
@@ -691,7 +691,7 @@ describe( 'useSelect', () => {
 			);
 
 			expect( selectCount1 ).toHaveBeenCalledTimes( 0 );
-			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
+			expect( selectCount2 ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 				'count2:0'
 			);
@@ -699,7 +699,7 @@ describe( 'useSelect', () => {
 			act( () => screen.getByText( 'Toggle' ).click() );
 
 			expect( selectCount1 ).toHaveBeenCalledTimes( 1 );
-			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
+			expect( selectCount2 ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 				'count1:0'
 			);
@@ -710,7 +710,7 @@ describe( 'useSelect', () => {
 			} );
 
 			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
-			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
+			expect( selectCount2 ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 				'count1:1'
 			);
@@ -968,7 +968,7 @@ describe( 'useSelect', () => {
 			);
 
 			// initial render + missed update catcher in subscribing effect
-			expect( selectSpy ).toHaveBeenCalledTimes( 2 );
+			expect( selectSpy ).toHaveBeenCalledTimes( 1 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
 			// Ensure expected state was rendered.
@@ -979,12 +979,12 @@ describe( 'useSelect', () => {
 			} );
 
 			// still not called right after increment
-			expect( selectSpy ).toHaveBeenCalledTimes( 2 );
+			expect( selectSpy ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '0' );
 
 			expect( await screen.findByText( 1 ) ).toBeInTheDocument();
 
-			expect( selectSpy ).toHaveBeenCalledTimes( 3 );
+			expect( selectSpy ).toHaveBeenCalledTimes( 2 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		} );
 
@@ -1027,7 +1027,7 @@ describe( 'useSelect', () => {
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '1' );
 
 			// initial render + subscription check + rerender with isAsync=false
-			expect( selectSpy ).toHaveBeenCalledTimes( 3 );
+			expect( selectSpy ).toHaveBeenCalledTimes( 2 );
 			// initial render + rerender with isAsync=false
 			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		} );
@@ -1077,8 +1077,8 @@ describe( 'useSelect', () => {
 			// Give the async update time to run in case it wasn't cancelled
 			await new Promise( setImmediate );
 
-			expect( selectA ).toHaveBeenCalledTimes( 2 );
-			expect( selectB ).toHaveBeenCalledTimes( 2 );
+			expect( selectA ).toHaveBeenCalledTimes( 1 );
+			expect( selectB ).toHaveBeenCalledTimes( 1 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		} );
 
@@ -1120,7 +1120,7 @@ describe( 'useSelect', () => {
 			await new Promise( setImmediate );
 
 			// only the initial render, no state updates
-			expect( selectSpy ).toHaveBeenCalledTimes( 2 );
+			expect( selectSpy ).toHaveBeenCalledTimes( 1 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 		} );
 
@@ -1163,7 +1163,7 @@ describe( 'useSelect', () => {
 			await new Promise( setImmediate );
 
 			// initial render + registry change rerender, no state updates
-			expect( selectSpy ).toHaveBeenCalledTimes( 4 );
+			expect( selectSpy ).toHaveBeenCalledTimes( 2 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -1078,7 +1078,7 @@ describe( 'useSelect', () => {
 			await new Promise( setImmediate );
 
 			expect( selectA ).toHaveBeenCalledTimes( 1 );
-			expect( selectB ).toHaveBeenCalledTimes( 1 );
+			expect( selectB ).toHaveBeenCalledTimes( 2 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		} );
 

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -61,9 +61,6 @@ describe( 'useSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 selectSpy calls expected
-		// - 1 for initial mount
-		// - 1 for the subscription effect checking if value has changed
 		expect( selectSpy ).toHaveBeenCalledTimes( 1 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -525,8 +522,8 @@ describe( 'useSelect', () => {
 				</RegistryProvider>
 			);
 
-			// One select on initial render, and one in `checkIfSnapshotChanged` after subscribing.
-			// There's a third selector call on the second render, but that one returns a memoized value.
+			// One select on initial render.
+			// There's a second selector call on the second render, but that one returns a memoized value.
 			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
 
 			// Initial render and second render after counter increment (which is expected to be detected).
@@ -967,7 +964,7 @@ describe( 'useSelect', () => {
 				</AsyncModeProvider>
 			);
 
-			// initial render + missed update catcher in subscribing effect
+			// initial render
 			expect( selectSpy ).toHaveBeenCalledTimes( 1 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -1026,9 +1023,8 @@ describe( 'useSelect', () => {
 			// Ensure the async update was flushed during the rerender.
 			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '1' );
 
-			// initial render + subscription check + rerender with isAsync=false
-			expect( selectSpy ).toHaveBeenCalledTimes( 2 );
 			// initial render + rerender with isAsync=false
+			expect( selectSpy ).toHaveBeenCalledTimes( 2 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		} );
 

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -52,9 +52,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// Expected two times:
-		// - Once on initial render.
-		// - Once on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -107,9 +104,6 @@ describe( 'withSelect', () => {
 		);
 
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( mapDispatchToProps ).toHaveBeenCalledTimes( 1 );
 
@@ -119,13 +113,11 @@ describe( 'withSelect', () => {
 		await user.click( button );
 
 		expect( button ).toHaveTextContent( '1' );
-		// 2 times =
-		//  1. Initial mount
+		// 1. Initial mount
 		// 2. When click handler is called.
 		expect( mapDispatchToProps ).toHaveBeenCalledTimes( 2 );
-		// 4 times
+		// 3 times
 		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		// - 1 on click triggering subscription firing.
 		// - 1 on rerender.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
@@ -253,9 +245,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -296,9 +285,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -339,9 +325,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -373,9 +356,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -411,9 +391,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -451,9 +428,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -510,9 +484,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Unknown' );
@@ -574,9 +545,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
@@ -620,9 +588,6 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 2 times:
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -642,11 +607,9 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		// 4 times:
+		// 2 times:
 		// - 1 on initial render
-		// - 1 on effect before subscription set.
 		// - 1 on re-render
-		// - 1 on effect before new subscription set (because registry has changed)
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'second' );

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -55,7 +55,7 @@ describe( 'withSelect', () => {
 		// Expected two times:
 		// - Once on initial render.
 		// - Once on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		// Wrapper is the enhanced component.
@@ -110,7 +110,7 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( mapDispatchToProps ).toHaveBeenCalledTimes( 1 );
 
 		// Simulate a click on the button.
@@ -128,7 +128,7 @@ describe( 'withSelect', () => {
 		// - 1 on effect before subscription set.
 		// - 1 on click triggering subscription firing.
 		// - 1 on rerender.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 4 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		// Verifies component only renders twice.
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
@@ -256,7 +256,7 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		rerender(
@@ -266,7 +266,7 @@ describe( 'withSelect', () => {
 		);
 
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( '10' );
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
 
@@ -299,7 +299,7 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		rerender(
@@ -308,7 +308,7 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 	} );
 
@@ -342,12 +342,12 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		await act( async () => registry.dispatch( 'demo' ).update() );
 
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 	} );
 
@@ -376,7 +376,7 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		rerender(
@@ -385,7 +385,7 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
 
@@ -414,12 +414,12 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		await act( async () => store.dispatch( { type: 'dummy' } ) );
 
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 	} );
 
@@ -454,7 +454,7 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent(
@@ -470,7 +470,7 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 			JSON.stringify( {
@@ -513,7 +513,7 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Unknown' );
 
@@ -523,7 +523,7 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'OK' );
 
@@ -533,7 +533,7 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 4 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 3 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Unknown' );
 	} );
@@ -577,8 +577,8 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 2 );
-		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 1 );
 
@@ -588,8 +588,8 @@ describe( 'withSelect', () => {
 			registry.dispatch( 'childRender' ).toggleRender();
 		} );
 
-		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 2 );
-		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 4 );
+		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
@@ -623,7 +623,7 @@ describe( 'withSelect', () => {
 		// 2 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'first' );
@@ -647,7 +647,7 @@ describe( 'withSelect', () => {
 		// - 1 on effect before subscription set.
 		// - 1 on re-render
 		// - 1 on effect before new subscription set (because registry has changed)
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 4 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'second' );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently we invalidate the selector mapping result whenever React subscribes to the store. This is to make sure the value is fresh because it might have changed between the first time we update the value and when React subscribes.

Instead, temporarily listen for store changes and only invalidate the result if it changed (which shouldn't happen often).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This prevents all the `useSelect` result from being calculated twice on load/mount.

First run load first block -6.75% (after the rewrite)
Second run -6.6%

The block marked red is now gone:

<img width="790" alt="Screenshot 2023-12-15 at 15 47 41" src="https://github.com/WordPress/gutenberg/assets/4710635/b09d6603-e512-41b5-8aaa-0ad6d2c3925d">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
