### PR TITLE
Font Library: disable some of the default api endpoints

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-library-controller.php
@@ -26,7 +26,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 	 * @since 6.5.0
 	 */
 	public function __construct() {
-		$this->rest_base = 'fonts';
+		$this->rest_base = 'font-families';
 		$this->namespace = 'wp/v2';
 	}
 
@@ -70,7 +70,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/collections',
+			'/font-collections',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -82,7 +82,7 @@ class WP_REST_Font_Library_Controller extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/collections' . '/(?P<id>[\/\w-]+)',
+			'/font-collections' . '/(?P<id>[\/\w-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -26,6 +26,7 @@ function gutenberg_init_font_library_routes() {
 		'_builtin'     => true,  /* internal use only. don't use this when registering your own post type. */
 		'label'        => 'Font Library',
 		'show_in_rest' => true,
+		'rest_base'    => 'font-families',
 	);
 	register_post_type( 'wp_font_family', $args );
 
@@ -36,6 +37,30 @@ function gutenberg_init_font_library_routes() {
 
 add_action( 'rest_api_init', 'gutenberg_init_font_library_routes' );
 
+/**
+ * Removes some default endpoints for the Font Library added when registering the wp_font_family post type.
+ *
+ * @core-merge: This code needs to be removed after the Font Library API redesign.
+ *
+ * @param array $endpoints The default endpoints.
+ * @return array The modified endpoints.
+ */
+function remove_font_families_default_endpoints( $endpoints ) {
+	unset( $endpoints['/wp/v2/font-families/(?P<id>[\d]+)'] );
+	unset( $endpoints['/wp/v2/font-families/(?P<id>[\d]+)/autosaves'] );
+	unset( $endpoints['/wp/v2/font-families/(?P<parent>[\d]+)/autosaves/(?P<id>[\d]+)'] );
+
+	// Removes the default POST endpoint for the wp_font_family post type to use just the custom one.
+	foreach ( $endpoints['/wp/v2/font-families'] as $endpoint => $details ) {
+		if ( ! isset( $details['args']['font_families'] ) && isset( $details['methods'] ) && $details['methods'] === 'POST' ) {
+			unset( $endpoints['/wp/v2/font-families'][ $endpoint ] );
+		}
+	}
+
+	return $endpoints;
+}
+
+add_filter( 'rest_endpoints', 'remove_font_families_default_endpoints' );
 
 if ( ! function_exists( 'wp_register_font_collection' ) ) {
 	/**

--- a/packages/edit-site/src/components/global-styles/font-library-modal/resolvers.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/resolvers.js
@@ -9,7 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 export async function fetchInstallFonts( data ) {
 	const config = {
-		path: '/wp/v2/fonts',
+		path: '/wp/v2/font-families',
 		method: 'POST',
 		body: data,
 	};
@@ -21,7 +21,7 @@ export async function fetchUninstallFonts( fonts ) {
 		font_families: fonts,
 	};
 	const config = {
-		path: '/wp/v2/fonts',
+		path: '/wp/v2/font-families',
 		method: 'DELETE',
 		data,
 	};
@@ -30,7 +30,7 @@ export async function fetchUninstallFonts( fonts ) {
 
 export async function fetchFontCollections() {
 	const config = {
-		path: '/wp/v2/fonts/collections',
+		path: '/wp/v2/font-collections',
 		method: 'GET',
 	};
 	return apiFetch( config );
@@ -38,7 +38,7 @@ export async function fetchFontCollections() {
 
 export async function fetchFontCollection( id ) {
 	const config = {
-		path: `/wp/v2/fonts/collections/${ id }`,
+		path: `/wp/v2/font-collections/${ id }`,
 		method: 'GET',
 	};
 	return apiFetch( config );

--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/getFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/getFontCollection.php
@@ -90,7 +90,7 @@ class Tests_Fonts_WPRESTFontLibraryController_GetFontCollection extends WP_REST_
 	}
 
 	public function test_get_font_collection_from_file() {
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/fonts/collections/one-collection' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections/one-collection' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertSame( 200, $response->get_status(), 'The response status is not 200.' );
@@ -99,7 +99,7 @@ class Tests_Fonts_WPRESTFontLibraryController_GetFontCollection extends WP_REST_
 	}
 
 	public function test_get_font_collection_from_url() {
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/fonts/collections/collection-with-url' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections/collection-with-url' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertSame( 200, $response->get_status(), 'The response status is not 200.' );
@@ -107,19 +107,19 @@ class Tests_Fonts_WPRESTFontLibraryController_GetFontCollection extends WP_REST_
 	}
 
 	public function test_get_non_existing_collection_should_return_404() {
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/fonts/collections/non-existing-collection-id' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections/non-existing-collection-id' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 404, $response->get_status() );
 	}
 
 	public function test_get_non_existing_file_should_return_500() {
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/fonts/collections/collection-with-non-existing-file' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections/collection-with-non-existing-file' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 500, $response->get_status() );
 	}
 
 	public function test_get_non_existing_url_should_return_500() {
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/fonts/collections/collection-with-non-existing-url' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections/collection-with-non-existing-url' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 500, $response->get_status() );
 	}

--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/getFontCollections.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/getFontCollections.php
@@ -14,7 +14,7 @@
 class Tests_Fonts_WPRESTFontLibraryController_GetFontCollections extends WP_REST_Font_Library_Controller_UnitTestCase {
 
 	public function test_get_font_collections_with_no_collection_registered() {
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/fonts/collections' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( array(), $response->get_data() );
@@ -34,7 +34,7 @@ class Tests_Fonts_WPRESTFontLibraryController_GetFontCollections extends WP_REST
 		);
 		wp_register_font_collection( $config );
 
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/fonts/collections' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertSame( 200, $response->get_status(), 'The response status is not 200.' );

--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/installFonts.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/installFonts.php
@@ -22,7 +22,7 @@ class Tests_Fonts_WPRESTFontLibraryController_InstallFonts extends WP_REST_Font_
 	 * @param array $expected_response Expected response data.
 	 */
 	public function test_install_fonts( $font_families, $files, $expected_response ) {
-		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
+		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
 		$font_families_json = json_encode( $font_families );
 		$install_request->set_param( 'font_families', $font_families_json );
 		$install_request->set_file_params( $files );
@@ -307,7 +307,7 @@ class Tests_Fonts_WPRESTFontLibraryController_InstallFonts extends WP_REST_Font_
 	 * @param array $files         Font files to install.
 	 */
 	public function test_install_with_improper_inputs( $font_families, $files = array() ) {
-		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
+		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
 		$font_families_json = json_encode( $font_families );
 		$install_request->set_param( 'font_families', $font_families_json );
 		$install_request->set_file_params( $files );

--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/registerRoutes.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/registerRoutes.php
@@ -15,14 +15,14 @@ class Tests_Fonts_WPRESTFontLibraryController_RegisterRoutes extends WP_UnitTest
 
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( '/wp/v2/fonts', $routes, 'Rest server has not the fonts path intialized.' );
-		$this->assertCount( 2, $routes['/wp/v2/fonts'], 'Rest server has not the 2 fonts paths initialized.' );
-		$this->assertCount( 1, $routes['/wp/v2/fonts/collections'], 'Rest server has not the collections path initialized.' );
-		$this->assertCount( 1, $routes['/wp/v2/fonts/collections/(?P<id>[\/\w-]+)'], 'Rest server has not the collection path initialized.' );
+		$this->assertArrayHasKey( '/wp/v2/font-families', $routes, 'Rest server has not the fonts path intialized.' );
+		$this->assertCount( 2, $routes['/wp/v2/font-families'], 'Rest server has not the 2 fonts paths initialized.' );
+		$this->assertCount( 1, $routes['/wp/v2/font-collections'], 'Rest server has not the collections path initialized.' );
+		$this->assertCount( 1, $routes['/wp/v2/font-collections/(?P<id>[\/\w-]+)'], 'Rest server has not the collection path initialized.' );
 
-		$this->assertArrayHasKey( 'POST', $routes['/wp/v2/fonts'][0]['methods'], 'Rest server has not the POST method for fonts intialized.' );
-		$this->assertArrayHasKey( 'DELETE', $routes['/wp/v2/fonts'][1]['methods'], 'Rest server has not the DELETE method for fonts intialized.' );
-		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/fonts/collections'][0]['methods'], 'Rest server has not the GET method for collections intialized.' );
-		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/fonts/collections/(?P<id>[\/\w-]+)'][0]['methods'], 'Rest server has not the GET method for collection intialized.' );
+		$this->assertArrayHasKey( 'POST', $routes['/wp/v2/font-families'][0]['methods'], 'Rest server has not the POST method for fonts intialized.' );
+		$this->assertArrayHasKey( 'DELETE', $routes['/wp/v2/font-families'][1]['methods'], 'Rest server has not the DELETE method for fonts intialized.' );
+		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections'][0]['methods'], 'Rest server has not the GET method for collections intialized.' );
+		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections/(?P<id>[\/\w-]+)'][0]['methods'], 'Rest server has not the GET method for collection intialized.' );
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpRestFontLibraryController/uninstallFonts.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontLibraryController/uninstallFonts.php
@@ -51,7 +51,7 @@ class Tests_Fonts_WPRESTFontLibraryController_UninstallFonts extends WP_REST_Fon
 			),
 		);
 
-		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/fonts' );
+		$install_request    = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
 		$font_families_json = json_encode( $mock_families );
 		$install_request->set_param( 'font_families', $font_families_json );
 		rest_get_server()->dispatch( $install_request );
@@ -67,7 +67,7 @@ class Tests_Fonts_WPRESTFontLibraryController_UninstallFonts extends WP_REST_Fon
 			),
 		);
 
-		$uninstall_request = new WP_REST_Request( 'DELETE', '/wp/v2/fonts' );
+		$uninstall_request = new WP_REST_Request( 'DELETE', '/wp/v2/font-families' );
 		$uninstall_request->set_param( 'font_families', $font_families_to_uninstall );
 		$response = rest_get_server()->dispatch( $uninstall_request );
 		$this->assertSame( 200, $response->get_status(), 'The response status is not 200.' );
@@ -75,7 +75,7 @@ class Tests_Fonts_WPRESTFontLibraryController_UninstallFonts extends WP_REST_Fon
 
 
 	public function test_uninstall_non_existing_fonts() {
-		$uninstall_request = new WP_REST_Request( 'DELETE', '/wp/v2/fonts' );
+		$uninstall_request = new WP_REST_Request( 'DELETE', '/wp/v2/font-families' );
 
 		$non_existing_font_data = array(
 			array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR disables some of the default API endpoints created when registering the `wp_font_family` post type.
 
## Why?
To avoid exposing default endpoints with no sanitization process in place.


## How?
Filtering the endpoints and removing the unwanted ones.

## Testing Instructions
- Use the font library from the editor and verify all the functionality is working as expected.

