### PR TITLE
DataViews: improve preview

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -13,6 +13,7 @@ import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -40,7 +41,7 @@ import {
 import PostPreview from '../post-preview';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
-const { useLocation } = unlock( routerPrivateApis );
+const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
 const defaultConfigPerViewType = {
@@ -130,6 +131,7 @@ export default function PagePages() {
 	const postType = 'page';
 	const [ view, setView ] = useView( postType );
 	const [ pageId, setPageId ] = useState( null );
+	const history = useHistory();
 
 	const onSelectionChange = ( items ) =>
 		setPageId( items?.length === 1 ? items[ 0 ].id : null );
@@ -346,7 +348,28 @@ export default function PagePages() {
 			</Page>
 			{ view.type === LAYOUT_LIST && (
 				<Page>
-					<div className="edit-site-page-pages-preview">
+					<div
+						className="edit-site-page-pages-preview"
+						tabIndex={ 0 }
+						role="button"
+						onKeyDown={ ( event ) => {
+							const { keyCode } = event;
+							if ( keyCode === ENTER || keyCode === SPACE ) {
+								history.push( {
+									postId: pageId,
+									postType,
+									canvas: 'edit',
+								} );
+							}
+						} }
+						onClick={ () =>
+							history.push( {
+								postId: pageId,
+								postType,
+								canvas: 'edit',
+							} )
+						}
+					>
 						{ pageId !== null ? (
 							<PostPreview
 								postId={ pageId }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -368,12 +368,12 @@ export default function DataviewsTemplates() {
 				}
 				title={ __( 'Templates' ) }
 				actions={
-					                                       <AddNewTemplate
-					                                               templateType={ TEMPLATE_POST_TYPE }
-					                                               showIcon={ false }
-					                                               toggleProps={ { variant: 'primary' } }
-					                                       />
-					                               }
+					<AddNewTemplate
+						templateType={ TEMPLATE_POST_TYPE }
+						showIcon={ false }
+						toggleProps={ { variant: 'primary' } }
+					/>
+				}
 			>
 				<DataViews
 					paginationInfo={ paginationInfo }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -18,12 +18,14 @@ import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 import { parse } from '@wordpress/blocks';
 import {
 	BlockPreview,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { DataViews } from '@wordpress/dataviews';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
@@ -53,6 +55,7 @@ import PostPreview from '../post-preview';
 const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis
 );
+const { useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
 
@@ -164,6 +167,7 @@ export default function DataviewsTemplates() {
 		useEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
 			per_page: -1,
 		} );
+	const history = useHistory();
 
 	const onSelectionChange = ( items ) =>
 		setTemplateId( items?.length === 1 ? items[ 0 ].id : null );
@@ -364,12 +368,12 @@ export default function DataviewsTemplates() {
 				}
 				title={ __( 'Templates' ) }
 				actions={
-					<AddNewTemplate
-						templateType={ TEMPLATE_POST_TYPE }
-						showIcon={ false }
-						toggleProps={ { variant: 'primary' } }
-					/>
-				}
+					                                       <AddNewTemplate
+					                                               templateType={ TEMPLATE_POST_TYPE }
+					                                               showIcon={ false }
+					                                               toggleProps={ { variant: 'primary' } }
+					                                       />
+					                               }
 			>
 				<DataViews
 					paginationInfo={ paginationInfo }
@@ -388,7 +392,28 @@ export default function DataviewsTemplates() {
 			</Page>
 			{ view.type === LAYOUT_LIST && (
 				<Page>
-					<div className="edit-site-template-pages-preview">
+					<div
+						className="edit-site-template-pages-preview"
+						tabIndex={ 0 }
+						role="button"
+						onKeyDown={ ( event ) => {
+							const { keyCode } = event;
+							if ( keyCode === ENTER || keyCode === SPACE ) {
+								history.push( {
+									postId: templateId,
+									postType: TEMPLATE_POST_TYPE,
+									canvas: 'edit',
+								} );
+							}
+						} }
+						onClick={ () =>
+							history.push( {
+								postId: templateId,
+								postType: TEMPLATE_POST_TYPE,
+								canvas: 'edit',
+							} )
+						}
+					>
 						{ templateId !== null ? (
 							<PostPreview
 								postId={ templateId }

--- a/packages/edit-site/src/components/post-preview/index.js
+++ b/packages/edit-site/src/components/post-preview/index.js
@@ -3,12 +3,14 @@
  */
 import Editor from '../editor';
 import { useInitEditedEntity } from '../sync-state-with-url/use-init-edited-entity-from-url';
+import { useIsSiteEditorLoading } from '../layout/hooks';
 
 export default function PostPreview( { postType, postId } ) {
 	useInitEditedEntity( {
 		postId,
 		postType,
 	} );
+	const isEditorLoading = useIsSiteEditorLoading();
 
-	return <Editor />;
+	return <Editor isLoading={ isEditorLoading } />;
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Improve the preview to open the site editor on click.

https://github.com/WordPress/gutenberg/assets/583546/024eb944-65f0-4051-b21b-4a821e0fdbd0

## Testing Instructions

- Enable the "new admin views" experiment and visit "Manage all templates" or "Manage all pages".
- Go to the list layout, click a template, then click on the editor canvas (rightmost panel with the content preview).

The expected result is that the editor is opened with the given entity being edited.
