### PR TITLE
feat: Automatically retry pending media uploads

### DIFF
--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -14,7 +14,11 @@ import {
 	FloatingToolbar,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { compose, withPreferredColorScheme } from '@wordpress/compose';
+import {
+	compose,
+	withPreferredColorScheme,
+	withNetworkConnectivity,
+} from '@wordpress/compose';
 import {
 	HTMLTextInput,
 	KeyboardAvoidingView,
@@ -23,7 +27,10 @@ import {
 	__unstableAutocompletionItemsSlot as AutocompletionItemsSlot,
 } from '@wordpress/components';
 import { AutosaveMonitor, store as editorStore } from '@wordpress/editor';
-import { sendNativeEditorDidLayout } from '@wordpress/react-native-bridge';
+import {
+	sendNativeEditorDidLayout,
+	requestMediaFilesFailedRetry,
+} from '@wordpress/react-native-bridge';
 
 /**
  * Internal dependencies
@@ -57,6 +64,15 @@ class Layout extends Component {
 			'safeAreaInsetsForRootViewDidChange',
 			this.onSafeAreaInsetsUpdate
 		);
+	}
+
+	componentDidUpdate( prevProps ) {
+		if (
+			this.props.isConnected &&
+			prevProps.isConnected !== this.props.isConnected
+		) {
+			requestMediaFilesFailedRetry();
+		}
 	}
 
 	componentWillUnmount() {
@@ -201,4 +217,5 @@ export default compose( [
 		};
 	} ),
 	withPreferredColorScheme,
+	withNetworkConnectivity,
 ] )( Layout );

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -379,6 +379,15 @@ export function requestMediaFilesFailedRetryDialog( mediaFiles ) {
 }
 
 /**
+ * Request the host app retry uploading all media for the post.
+ *
+ * @return {void}
+ */
+export function requestMediaFilesFailedRetry() {
+	RNReactNativeGutenbergBridge.requestMediaFilesFailedRetry();
+}
+
+/**
  * Request the host app to show a cancel dialog for mediaFiles arrays currently being uploaded
  *
  * For example, tapping on a block containing mediaFiles that are currently being uplaoded would trigger this request

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -213,7 +213,7 @@ public protocol GutenbergBridgeDelegate: AnyObject {
     /// - Parameter path: The path to perform the request.
     /// - Parameter completion: Completion handler to be called with the result or an error.
     func gutenbergDidGetRequestFetch(path: String, completion: @escaping (Swift.Result<Any, NSError>) -> Void)
-    
+
     /// Tells the delegate that the editor needs to perform a POST request.
     /// The paths given to perform the request are from the WP ORG REST API.
     /// https://developer.wordpress.org/rest-api/reference/
@@ -279,9 +279,9 @@ public protocol GutenbergBridgeDelegate: AnyObject {
 
     /// Tells the delegate the editor requested sending an event
     func gutenbergDidRequestSendEventToHost(_ eventName: String, properties: [AnyHashable: Any])
-    
+
     func gutenbergDidRequestToggleUndoButton(_ isDisabled: Bool)
-    
+
     func gutenbergDidRequestToggleRedoButton(_ isDisabled: Bool)
 
     func gutenbergDidRequestConnectionStatus() -> Bool

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -259,6 +259,8 @@ public protocol GutenbergBridgeDelegate: AnyObject {
 
     func gutenbergDidRequestMediaFilesFailedRetryDialog(_ mediaFiles: [[String: Any]])
 
+    func gutenbergDidRequestMediaFilesFailedRetry() -> Bool
+
     func gutenbergDidRequestMediaFilesUploadCancelDialog(_ mediaFiles: [[String: Any]])
 
     func gutenbergDidRequestMediaFilesSaveCancelDialog(_ mediaFiles: [[String: Any]])
@@ -300,6 +302,7 @@ public extension GutenbergBridgeDelegate {
     func gutenbergDidRequestMediaSaveSync() {}
     func gutenbergDidRequestMediaFilesEditorLoad(_ mediaFiles: [[String: Any]], blockId: String) { }
     func gutenbergDidRequestMediaFilesFailedRetryDialog(_ mediaFiles: [[String: Any]]) { }
+    func gutenbergDidRequestMediaFilesFailedRetry() { }
     func gutenbergDidRequestMediaFilesUploadCancelDialog(_ mediaFiles: [[String: Any]]) { }
     func gutenbergDidRequestMediaFilesSaveCancelDialog(_ mediaFiles: [[String: Any]]) { }
     func gutenbergDidRequestMediaFilesBlockReplaceSync(_ mediaFiles: [[String: Any]], clientId: String) {}

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -25,6 +25,7 @@ RCT_EXTERN_METHOD(showUserSuggestions:(RCTPromiseResolveBlock)resolve rejecter:(
 RCT_EXTERN_METHOD(showXpostSuggestions:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)rejecter)
 RCT_EXTERN_METHOD(requestMediaFilesEditorLoad:(NSArray<NSDictionary *> *)mediaFiles blockId:(NSString *)blockId)
 RCT_EXTERN_METHOD(requestMediaFilesFailedRetryDialog:(NSArray<NSDictionary *> *)mediaFiles)
+RCT_EXTERN_METHOD(requestMediaFilesFailedRetry)
 RCT_EXTERN_METHOD(requestMediaFilesUploadCancelDialog:(NSArray<NSDictionary *> *)mediaFiles)
 RCT_EXTERN_METHOD(requestMediaFilesSaveCancelDialog:(NSArray<NSDictionary *> *)mediaFiles)
 RCT_EXTERN_METHOD(onCancelUploadForMediaCollection:(NSArray<NSDictionary *> *)mediaFiles)

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -320,6 +320,13 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     }
 
     @objc
+    func requestMediaFilesFailedRetry() {
+        DispatchQueue.main.async {
+            self.delegate?.gutenbergDidRequestMediaFilesFailedRetry()
+        }
+    }
+
+    @objc
     func requestMediaFilesUploadCancelDialog(_ mediaFiles: [[String: Any]]) {
         DispatchQueue.main.async {
             self.delegate?.gutenbergDidRequestMediaFilesUploadCancelDialog(mediaFiles)

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -256,7 +256,7 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
             }
         })
     }
-    
+
     @objc
     func postRequest(_ path: String, data: [String: AnyObject]?, resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) {
         self.delegate?.gutenbergDidPostRequestFetch(path: path, data: data, completion: { (result) in
@@ -411,12 +411,12 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     func generateHapticFeedback() {
         UISelectionFeedbackGenerator().selectionChanged()
     }
-    
+
     @objc
     func toggleUndoButton(_ isDisabled: Bool) {
         self.delegate?.gutenbergDidRequestToggleUndoButton(isDisabled)
     }
-    
+
     @objc
     func toggleRedoButton(_ isDisabled: Bool) {
         self.delegate?.gutenbergDidRequestToggleRedoButton(isDisabled)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Automatically retry failed media uploads when network connectivity is
re-established.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6406. Improve the UX through 
assisting users with successful media uploads.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add `requestMediaFilesFailedRetry` bridge method that is invoked whenever the
editor regains network connectivity. The host app manages as queue of failed
media uploads for the post, which allows the editor to safely request a retry
regardless of the post content state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
### When network connectivity is available
1. Launch the editor.
1. Add several media blocks, attaching media to the blocks.
1. Disconnect your device network connection.
1. Note the failed state of media uploads.
1. Connect your device network connection.
1. Verify the media uploads automatically restart and succeed.

### When network connectivity is unavailable
1. Launch the editor.
1. Add several media blocks, attaching media to the blocks.
1. Note the failed state of media uploads.
1. Connect your device network connection.
1. Verify the media uploads automatically restart and succeed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
While using a screen reader, verify interacting with media blocks as not
changed.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes are proposed.
