### PR TITLE
Site editor: remove `isResizing` variable from layout component as it is always false

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -126,7 +126,6 @@ export default function Layout() {
 		( isMobileViewport && isListPage ) || ( isEditorPage && isEditing );
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
 	const [ fullResizer ] = useResizeObserver();
-	const [ isResizing ] = useState( false );
 	const isEditorLoading = useIsSiteEditorLoading();
 	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
 		useState( false );
@@ -309,10 +308,7 @@ export default function Layout() {
 							{ isEditorPage && (
 								<div
 									className={ classnames(
-										'edit-site-layout__canvas-container',
-										{
-											'is-resizing': isResizing,
-										}
+										'edit-site-layout__canvas-container'
 									) }
 								>
 									{ canvasResizer }
@@ -325,8 +321,7 @@ export default function Layout() {
 															scale: 1.005,
 															transition: {
 																duration:
-																	disableMotion ||
-																	isResizing
+																	disableMotion
 																		? 0
 																		: 0.5,
 																ease: 'easeOut',
@@ -345,10 +340,9 @@ export default function Layout() {
 											) }
 											transition={ {
 												type: 'tween',
-												duration:
-													disableMotion || isResizing
-														? 0
-														: ANIMATION_DURATION,
+												duration: disableMotion
+													? 0
+													: ANIMATION_DURATION,
 												ease: 'easeOut',
 											} }
 										>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -306,11 +306,7 @@ export default function Layout() {
 						<>
 							{ isListPage && <PageMain /> }
 							{ isEditorPage && (
-								<div
-									className={ classnames(
-										'edit-site-layout__canvas-container'
-									) }
-								>
+								<div className="edit-site-layout__canvas-container">
 									{ canvasResizer }
 									{ !! canvasSize.width && (
 										<motion.div


### PR DESCRIPTION
## What?

Removes the `isResizing` variable, that is always set to false. 

## Why?

It's a leftover from https://github.com/WordPress/gutenberg/pull/49910/files#diff-89e57bfd1de96b1cee155f91aa9754cb37715e9ffa9e4cc2f21463a770f7ec55L121 that removed the `setIsResizing` method.

## Testing Instructions

Open the site editor and verify that resizing still works.
