### PR TITLE
Tabs: render tabs as `Button` components by default

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -46,9 +46,6 @@
 
 -   `Tabs`: implement new `tabId` prop ([#56883](https://github.com/WordPress/gutenberg/pull/56883)).
 -   `CustomSelect`: add `WordPressComponentsProps` for more flexibility ([#56998](https://github.com/WordPress/gutenberg/pull/56998))
-
-### Experimental
-
 -   `Tabs`: improve focus handling in controlled mode ([#56658](https://github.com/WordPress/gutenberg/pull/56658)).
 
 ### Documentation

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Experimental
 
 -   `Tabs`: do not render hidden content ([#57046](https://github.com/WordPress/gutenberg/pull/57046)).
+-   `Tabs`: render a `Button` component by default for consistent styling([#57121](https://github.com/WordPress/gutenberg/pull/57121)).
 -   `Tabs`: make sure `Tab`s are associated to the right `TabPanel`s, regardless of the order they're rendered in ([#57033](https://github.com/WordPress/gutenberg/pull/57033)).
 
 ### Bug Fix

--- a/packages/components/src/tabs/tab.tsx
+++ b/packages/components/src/tabs/tab.tsx
@@ -12,6 +12,7 @@ import warning from '@wordpress/warning';
 import { useTabsContext } from './context';
 import { Tab as StyledTab } from './styles';
 import type { WordPressComponentProps } from '../context';
+import Button from '../button';
 
 export const Tab = forwardRef<
 	HTMLButtonElement,
@@ -30,7 +31,7 @@ export const Tab = forwardRef<
 			store={ store }
 			id={ instancedTabId }
 			disabled={ disabled }
-			render={ render }
+			render={ render ?? <Button /> }
 			{ ...otherProps }
 		>
 			{ children }


### PR DESCRIPTION
## What?
Modifies the `Tabs.Tab` subcomponent to render as a `Button` component instead of a plain `button` html element.

## Why?
In an [effort](https://github.com/WordPress/gutenberg/pull/53960#discussion_r1342645318) to avoid making the `Tabs` component overly opinionated, we opted for a `button` element and an optional `render` prop, so consumers could use a `Button` if they wanted one for things like icons and tooltips.

At the time everything with this approach seemed good, but I've since noticed that there are some style differences that I'd missed until now. Specifically:

1. Hover effect: `Button` adds an accent color to the text of tertiary buttons when hovered. The `button` element rendered by `Tabs` via `Ariakit` does not do this.
2. Text alignment: This one is only apparent in cases where the tabs width is expanded, as it is in the [List View implementation](https://github.com/WordPress/gutenberg/pull/57082). In cases like this, where the button is wider than the text it contains, the text becomes centered, rather than left aligned. This is because it lacks the `display: inline-flex` and subsequent `align-items: center` provided by the `Button` component's styles.

## How?
A performing a `nullish` check when passing the `render` prop down to `Ariakit`, we can render whatever the consumer wants (including a more detailed `Button` with an icon and tooltip), and fall back to a standard `Button` component if no `render` prop is provided. All of the props passed to `Tabs.Tab` will flow through the `render` prop to the default `Button` component.

## Testing Instructions

<details>
<summary>To begin, apply this diff. It increases the width of the tabs on the default story template</summary>

```diff
diff --git a/packages/components/src/tabs/stories/index.story.tsx b/packages/components/src/tabs/stories/index.story.tsx
index 0e7ab725e3..f344767668 100644
--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -40,9 +40,15 @@ const Template: StoryFn< typeof Tabs > = ( props ) => {
 	return (
 		<Tabs { ...props }>
 			<Tabs.TabList>
-				<Tabs.Tab tabId="tab1">Tab 1</Tabs.Tab>
-				<Tabs.Tab tabId="tab2">Tab 2</Tabs.Tab>
-				<Tabs.Tab tabId="tab3">Tab 3</Tabs.Tab>
+				<Tabs.Tab tabId="tab1" style={ { width: '33%' } }>
+					Tab 1
+				</Tabs.Tab>
+				<Tabs.Tab tabId="tab2" style={ { width: '33%' } }>
+					Tab 2
+				</Tabs.Tab>
+				<Tabs.Tab tabId="tab3" style={ { width: '33%' } }>
+					Tab 3
+				</Tabs.Tab>
 			</Tabs.TabList>
 			<Tabs.TabPanel tabId="tab1">
 				<p>Selected tab: Tab 1</p>

```

</details>

### Testing Instructions
1. Launch Storybook
2. Experiment with the `Tabs` stories. Confirm that the tabs are properly highlighted when hovered.
3. On the Default story, which has now has wider tabs, confirm that the text is left-aligned.
4. Compared to trunk, confirm there aren't any other visual changes in Storybook
5. Compared to trunk, confirm these styles are now present in the editor (ie. Editor Settings Sidebar, Block Inserter, and in the background color picker for blocks) but there aren't any other unexpected changes.