### PR TITLE
Reduce clearance around frame in focus mode

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -46,7 +46,7 @@
 
 	&.is-focus-mode {
 		.edit-site-layout.is-full-canvas & {
-			padding: $grid-unit-60;
+			padding: $grid-unit-30;
 		}
 
 		.edit-site-visual-editor__editor-canvas {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
We don't need this clearance to be quite so large—just thick enough to provide context that this is a focused view for editing this site component (patterns, template part, etc). 

Reducing this also helps with the transitions that occur when you navigate through to a pattern/template part; as there is less "jump" between clearances. 

Related in part to #57023. 

## How?
Small CSS change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open one of your patterns from the site editor > patterns view.
2. See change.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-12-15 at 16 53 04](https://github.com/WordPress/gutenberg/assets/1813435/248587b3-f6fa-4135-995a-2cf288513012)|![CleanShot 2023-12-15 at 16 55 23](https://github.com/WordPress/gutenberg/assets/1813435/f1159817-238f-4224-977c-efe95dfcc468)|


