### PR TITLE
Components: replace `TabPanel` with `Tabs` in the editor Global Styles color palette

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-color-palette.js
+++ b/packages/edit-site/src/components/global-styles/screen-color-palette.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { TabPanel } from '@wordpress/components';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -10,6 +10,9 @@ import { TabPanel } from '@wordpress/components';
 import ColorPalettePanel from './color-palette-panel';
 import GradientPalettePanel from './gradients-palette-panel';
 import ScreenHeader from './header';
+import { unlock } from '../../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 function ScreenColorPalette( { name } ) {
 	return (
@@ -20,31 +23,18 @@ function ScreenColorPalette( { name } ) {
 					'Palettes are used to provide default color options for blocks and various design tools. Here you can edit the colors with their labels.'
 				) }
 			/>
-			<TabPanel
-				tabs={ [
-					{
-						name: 'solid',
-						title: 'Solid',
-						value: 'solid',
-					},
-					{
-						name: 'gradient',
-						title: 'Gradient',
-						value: 'gradient',
-					},
-				] }
-			>
-				{ ( tab ) => (
-					<>
-						{ tab.value === 'solid' && (
-							<ColorPalettePanel name={ name } />
-						) }
-						{ tab.value === 'gradient' && (
-							<GradientPalettePanel name={ name } />
-						) }
-					</>
-				) }
-			</TabPanel>
+			<Tabs>
+				<Tabs.TabList>
+					<Tabs.Tab tabId="solid">Solid</Tabs.Tab>
+					<Tabs.Tab tabId="gradient">Gradient</Tabs.Tab>
+				</Tabs.TabList>
+				<Tabs.TabPanel tabId="solid" focusable={ false }>
+					<ColorPalettePanel name={ name } />
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId="gradient" focusable={ false }>
+					<GradientPalettePanel name={ name } />
+				</Tabs.TabPanel>
+			</Tabs>
 		</>
 	);
 }


### PR DESCRIPTION
## What?
Replaces the legacy TabPanel component with the new Tabs component.

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

## How?
`TabPanel` is replaced by `Tabs` and its sub-components. 

## Testing Instructions
1. Open the site editor and the Global Styles sidebar
2. Click on **Colors** and then **Palette**
3. Test the **Solid** and **Gradient** tabs, confirming they match the behavior and appearance of `trunk`, and each one shows the correct content when selected

### Testing Instructions for Keyboard
1. Open the site editor and select the Global Styles sidebar
2. Once open, press [Tab] twice and then [Space] to reach and select the **Color** option
3. [Tab] and [Space] again to focus and activate the **Palette** button
4. [Tab] once to focus the current tab.
5. Use arrow keys to navigate between tabs. Focusing a tab should automatically activate it
6. Press [Tab] and confirm focus moves to the first tabbable element in the `tabpanel` contents.