### PR TITLE
Block editor: rewrite moving animation for better load performance

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -40,12 +40,6 @@ import { PrivateBlockContext } from './private-block-context';
 import { unlock } from '../../lock-unlock';
 
 /**
- * If the block count exceeds the threshold, we disable the reordering animation
- * to avoid laginess.
- */
-const BLOCK_ANIMATION_THRESHOLD = 200;
-
-/**
  * Merges wrapper props with special handling for classNames and styles.
  *
  * @param {Object} propsA
@@ -516,9 +510,7 @@ function BlockListBlockProvider( props ) {
 
 				getBlockIndex,
 				isTyping,
-				getGlobalBlockCount,
 				isBlockMultiSelected,
-				isAncestorMultiSelected,
 				isBlockSubtreeDisabled,
 				isBlockHighlighted,
 				__unstableIsFullySelected,
@@ -550,9 +542,6 @@ function BlockListBlockProvider( props ) {
 			const canRemove = canRemoveBlock( clientId, rootClientId );
 			const canMove = canMoveBlock( clientId, rootClientId );
 			const { name: blockName, attributes, isValid } = block;
-			const isPartOfMultiSelection =
-				isBlockMultiSelected( clientId ) ||
-				isAncestorMultiSelected( clientId );
 			const blockType = getBlockType( blockName );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const { outlineMode, supportsLayout } = getSettings();
@@ -600,12 +589,6 @@ function BlockListBlockProvider( props ) {
 				index: getBlockIndex( clientId ),
 				blockApiVersion: blockType?.apiVersion || 1,
 				blockTitle: match?.title || blockType?.title,
-				isPartOfSelection: _isSelected || isPartOfMultiSelection,
-				adjustScrolling:
-					_isSelected || isFirstMultiSelectedBlock( clientId ),
-				enableAnimation:
-					! typing &&
-					getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
 				isSubtreeDisabled: isBlockSubtreeDisabled( clientId ),
 				isOutlineEnabled: outlineMode,
 				hasOverlay: __unstableHasActiveBlockOverlayActive( clientId ),
@@ -662,9 +645,6 @@ function BlockListBlockProvider( props ) {
 		index,
 		blockApiVersion,
 		blockTitle,
-		isPartOfSelection,
-		adjustScrolling,
-		enableAnimation,
 		isSubtreeDisabled,
 		isOutlineEnabled,
 		hasOverlay,
@@ -699,9 +679,6 @@ function BlockListBlockProvider( props ) {
 		blockApiVersion,
 		blockTitle,
 		isSelected,
-		isPartOfSelection,
-		adjustScrolling,
-		enableAnimation,
 		isSubtreeDisabled,
 		isOutlineEnabled,
 		hasOverlay,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -80,9 +80,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		blockApiVersion,
 		blockTitle,
 		isSelected,
-		isPartOfSelection,
-		adjustScrolling,
-		enableAnimation,
 		isSubtreeDisabled,
 		isOutlineEnabled,
 		hasOverlay,
@@ -114,12 +111,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		useNavModeExit( clientId ),
 		useIsHovered( { isEnabled: isOutlineEnabled } ),
 		useIntersectionObserver(),
-		useMovingAnimation( {
-			isSelected: isPartOfSelection,
-			adjustScrolling,
-			enableAnimation,
-			triggerAnimationOnChange: index,
-		} ),
+		useMovingAnimation( { triggerAnimationOnChange: index, clientId } ),
 		useDisabled( { isDisabled: ! hasOverlay } ),
 	] );
 

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -86,11 +86,18 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 			}
 		}
 
-		if (
+		// We disable the animation if the user has a preference for reduced
+		// motion, if the user is typing (insertion by Enter), or if the block
+		// count exceeds the threshold (insertion caused all the blocks that
+		// follow to animate).
+		// To do: consider enableing the _moving_ animation even for large
+		// posts, while only disabling the _insertion_ animation?
+		const disableAnimation =
 			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ||
 			isTyping() ||
-			getGlobalBlockCount() > BLOCK_ANIMATION_THRESHOLD
-		) {
+			getGlobalBlockCount() > BLOCK_ANIMATION_THRESHOLD;
+
+		if ( disableAnimation ) {
 			// If the animation is disabled and the scroll needs to be adjusted,
 			// just move directly to the final scroll position.
 			preserveScrollPosition();
@@ -101,6 +108,7 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 			isSelected ||
 			isBlockMultiSelected( clientId ) ||
 			isAncestorMultiSelected( clientId );
+		// Make sure the other blocks move under the selected block(s).
 		const zIndex = isPartOfSelection ? '1' : '';
 
 		const controller = new Controller( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In this PR, we use the lower level, imperative API from react-spring. This gives us better performance for load since we only create an animation controller at the time that it's needed.

I believe this also makes the code easier to understand. There's just a single layout effect instead of all the complex state, multiple effects, and an obscure declarative API. Sometimes imperative rules!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I made some additional optimisations: checking reduce motion through match media is expensive. Let's run a few times again:

First run: -6%
Second run: -8.5%

---

First run: load -4%
Second: -2.2%
Third: -3.2%
Fourth: 3.6%

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
