### PR TITLE
Interactivity API: Fix `navigate()` issues related to initial state merges

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -69,6 +69,7 @@ HTML;
 		}
 		?>
 	</nav>
+	<div data-testid="getterProp" data-wp-text="state.data.getterProp"></div>
 	<div data-testid="prop1" data-wp-text="state.data.prop1"></div>
 	<div data-testid="prop2" data-wp-text="state.data.prop2"></div>
 	<div data-testid="prop3" data-wp-text="state.data.prop3"></div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -15,6 +15,10 @@ if ( $attributes['disableNavigation'] ) {
 		array( 'clientNavigationDisabled' => true )
 	);
 }
+
+if ( isset( $attributes['data'] ) ) {
+	$initial_state = array( 'router' => array( 'data' => $attributes['data'] ) );
+}
 ?>
 
 <div
@@ -65,5 +69,5 @@ HTML;
 </div>
 
 <script type="application/json" id="wp-interactivity-initial-state">
-	{ "router": { "data": <?php echo json_encode( $attributes['state'] ); ?> } }
+	<?php echo isset( $initial_state ) ? json_encode( $initial_state ) : '{}'; ?>
 </script>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -47,26 +47,28 @@ if ( isset( $attributes['data'] ) ) {
 		Timeout <span data-wp-text="state.timeout">NaN</span>
 	</button>
 
-	<?php
-	if ( isset( $attributes['links'] ) ) {
-		foreach ( $attributes['links'] as $key => $link ) {
-			$i = $key += 1;
-			echo <<<HTML
-			<a
-				data-testid="link $i"
-				data-wp-on--click="actions.navigate"
-				href="$link"
-			>link $i</a>
-			<a
-				data-testid="link $i with hash"
-				data-wp-on--click="actions.navigate"
-				data-force-navigation="true"
-				href="$link#link-$i-with-hash"
-			>link $i with hash</a>
+	<nav>
+		<?php
+		if ( isset( $attributes['links'] ) ) {
+			foreach ( $attributes['links'] as $key => $link ) {
+				$i = $key += 1;
+				echo <<<HTML
+				<a
+					data-testid="link $i"
+					data-wp-on--click="actions.navigate"
+					href="$link"
+				>link $i</a>
+				<a
+					data-testid="link $i with hash"
+					data-wp-on--click="actions.navigate"
+					data-force-navigation="true"
+					href="$link#link-$i-with-hash"
+				>link $i with hash</a>
 HTML;
+			}
 		}
-	}
-	?>
+		?>
+	</nav>
 	<div data-testid="prop1" data-wp-text="state.data.prop1"></div>
 	<div data-testid="prop2" data-wp-text="state.data.prop2"></div>
 	<div data-testid="prop3" data-wp-text="state.data.prop3"></div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -17,7 +17,11 @@ if ( $attributes['disableNavigation'] ) {
 }
 
 if ( isset( $attributes['data'] ) ) {
-	$initial_state = array( 'router' => array( 'data' => $attributes['data'] ) );
+	$initial_state = array(
+		'state' => array(
+			'router' => array( 'data' => $attributes['data'] ),
+		),
+	);
 }
 ?>
 
@@ -68,6 +72,6 @@ HTML;
 	<div data-testid="prop3" data-wp-text="state.data.prop3"></div>
 </div>
 
-<script type="application/json" id="wp-interactivity-initial-state">
+<script type="application/json" id="wp-interactivity-data">
 	<?php echo isset( $initial_state ) ? json_encode( $initial_state ) : '{}'; ?>
 </script>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -17,10 +17,9 @@ if ( $attributes['disableNavigation'] ) {
 }
 
 if ( isset( $attributes['data'] ) ) {
-	$initial_state = array(
-		'state' => array(
-			'router' => array( 'data' => $attributes['data'] ),
-		),
+	wp_interactivity_state(
+		'router',
+		array( 'data' => $attributes['data'] )
 	);
 }
 ?>
@@ -32,8 +31,12 @@ if ( isset( $attributes['data'] ) ) {
 	<h2 data-testid="title"><?php echo $attributes['title']; ?></h2>
 
 	<output
-		data-testid="router navigations"
-		data-wp-text="state.navigations"
+		data-testid="router navigations pending"
+		data-wp-text="state.navigations.pending"
+	>NaN</output>
+	<output
+		data-testid="router navigations count"
+		data-wp-text="state.navigations.count"
 	>NaN</output>
 	<output
 		data-testid="router status"
@@ -74,7 +77,3 @@ HTML;
 	<div data-testid="prop2" data-wp-text="state.data.prop2"></div>
 	<div data-testid="prop3" data-wp-text="state.data.prop3"></div>
 </div>
-
-<script type="application/json" id="wp-interactivity-data">
-	<?php echo isset( $initial_state ) ? json_encode( $initial_state ) : '{}'; ?>
-</script>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/render.php
@@ -59,4 +59,11 @@ HTML;
 		}
 	}
 	?>
+	<div data-testid="prop1" data-wp-text="state.data.prop1"></div>
+	<div data-testid="prop2" data-wp-text="state.data.prop2"></div>
+	<div data-testid="prop3" data-wp-text="state.data.prop3"></div>
 </div>
+
+<script type="application/json" id="wp-interactivity-initial-state">
+	{ "router": { "data": <?php echo json_encode( $attributes['state'] ); ?> } }
+</script>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
@@ -8,6 +8,11 @@ const { state } = store( 'router', {
 		status: 'idle',
 		navigations: 0,
 		timeout: 10000,
+		data: {
+			get getterProp() {
+				return `value from getter (${ state.data.prop1 })`;
+			}
+		}
 	},
 	actions: {
 		*navigate( e ) {

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/view.js
@@ -6,7 +6,10 @@ import { store } from '@wordpress/interactivity';
 const { state } = store( 'router', {
 	state: {
 		status: 'idle',
-		navigations: 0,
+		navigations: {
+			pending: 0,
+			count: 0,
+		},
 		timeout: 10000,
 		data: {
 			get getterProp() {
@@ -18,7 +21,8 @@ const { state } = store( 'router', {
 		*navigate( e ) {
 			e.preventDefault();
 
-			state.navigations += 1;
+			state.navigations.count += 1;
+			state.navigations.pending += 1;
 			state.status = 'busy';
 
 			const force = e.target.dataset.forceNavigation === 'true';
@@ -29,9 +33,9 @@ const { state } = store( 'router', {
 			);
 			yield actions.navigate( e.target.href, { force, timeout } );
 
-			state.navigations -= 1;
+			state.navigations.pending -= 1;
 
-			if ( state.navigations === 0 ) {
+			if ( state.navigations.pending === 0 ) {
 				state.status = 'idle';
 			}
 		},

--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix navigate() issues related to initial state merges. ([#57134](https://github.com/WordPress/gutenberg/pull/57134))
+
 ## 1.2.0 (2024-02-21)
 
 ## 1.1.0 (2024-02-09)

--- a/packages/interactivity-router/src/index.js
+++ b/packages/interactivity-router/src/index.js
@@ -3,10 +3,18 @@
  */
 import { store, privateApis, getConfig } from '@wordpress/interactivity';
 
-const { directivePrefix, getRegionRootFragment, initialVdom, toVdom, render } =
-	privateApis(
-		'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
-	);
+const {
+	directivePrefix,
+	getRegionRootFragment,
+	initialVdom,
+	toVdom,
+	render,
+	parseInitialData,
+	populateInitialData,
+	batch,
+} = privateApis(
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
+);
 
 // The cache of visited and prefetched pages.
 const pages = new Map();
@@ -45,21 +53,24 @@ const regionsToVdom = ( dom, { vdom } = {} ) => {
 			: toVdom( region );
 	} );
 	const title = dom.querySelector( 'title' )?.innerText;
-	return { regions, title };
+	const initialData = parseInitialData( dom );
+	return { regions, title, initialData };
 };
 
 // Render all interactive regions contained in the given page.
-const renderRegions = ( page ) => {
-	const attrName = `data-${ directivePrefix }-router-region`;
-	document.querySelectorAll( `[${ attrName }]` ).forEach( ( region ) => {
-		const id = region.getAttribute( attrName );
-		const fragment = getRegionRootFragment( region );
-		render( page.regions[ id ], fragment );
+const renderRegions = ( page ) =>
+	batch( () => {
+		populateInitialData( page.initialData );
+		const attrName = `data-${ directivePrefix }-router-region`;
+		document.querySelectorAll( `[${ attrName }]` ).forEach( ( region ) => {
+			const id = region.getAttribute( attrName );
+			const fragment = getRegionRootFragment( region );
+			render( page.regions[ id ], fragment );
+		} );
+		if ( page.title ) {
+			document.title = page.title;
+		}
 	} );
-	if ( page.title ) {
-		document.title = page.title;
-	}
-};
 
 /**
  * Load the given page forcing a full page reload.

--- a/packages/interactivity-router/src/index.js
+++ b/packages/interactivity-router/src/index.js
@@ -188,7 +188,11 @@ export const { state, actions } = store( 'core/router', {
 			// out, and let the newer execution to update the HTML.
 			if ( navigatingTo !== href ) return;
 
-			if ( page ) {
+			if (
+				page &&
+				! page.initialData?.config?.[ 'core/router' ]
+					?.clientNavigationDisabled
+			) {
 				renderRegions( page );
 				window.history[
 					options.replace ? 'replaceState' : 'pushState'

--- a/packages/interactivity-router/src/index.js
+++ b/packages/interactivity-router/src/index.js
@@ -58,7 +58,7 @@ const regionsToVdom = ( dom, { vdom } = {} ) => {
 };
 
 // Render all interactive regions contained in the given page.
-const renderRegions = ( page ) =>
+const renderRegions = ( page ) => {
 	batch( () => {
 		populateInitialData( page.initialData );
 		const attrName = `data-${ directivePrefix }-router-region`;
@@ -71,6 +71,7 @@ const renderRegions = ( page ) =>
 			document.title = page.title;
 		}
 	} );
+};
 
 /**
  * Load the given page forcing a full page reload.

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Prevent passing state proxies as receivers to deepSignal proxy handlers. ([#57134](https://github.com/WordPress/gutenberg/pull/57134))
+
 ## 5.1.0 (2024-02-21)
 
 ### Bug Fixes

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { h, cloneElement, render } from 'preact';
+import { batch } from '@preact/signals';
 import { deepSignal } from 'deepsignal';
 
 /**
@@ -12,6 +13,7 @@ import { init, getRegionRootFragment, initialVdom } from './init';
 import { directivePrefix } from './constants';
 import { toVdom } from './vdom';
 import { directive, getNamespace } from './hooks';
+import { parseInitialData, populateInitialData } from './store';
 
 export { store, getConfig } from './store';
 export { getContext, getElement } from './hooks';
@@ -43,6 +45,9 @@ export const privateApis = ( lock ): any => {
 			cloneElement,
 			render,
 			deepSignal,
+			parseInitialData,
+			populateInitialData,
+			batch,
 		};
 	}
 

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -86,13 +86,13 @@ const handlers = {
 			}
 		}
 
-		const result = Reflect.get( target, key, receiver );
+		const result = Reflect.get( target, key );
 
 		// Check if the proxy is the store root and no key with that name exist. In
 		// that case, return an empty object for the requested key.
 		if ( typeof result === 'undefined' && receiver === stores.get( ns ) ) {
 			const obj = {};
-			Reflect.set( target, key, obj, receiver );
+			Reflect.set( target, key, obj );
 			return proxify( obj, ns );
 		}
 
@@ -148,6 +148,9 @@ const handlers = {
 		if ( isObject( result ) ) return proxify( result, ns );
 
 		return result;
+	},
+	set( target: any, key: string, value: any ) {
+		return Reflect.set( target, key, value );
 	},
 };
 

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -26,10 +26,10 @@ const deepMerge = ( target: any, source: any ) => {
 			if ( typeof getter === 'function' ) {
 				Object.defineProperty( target, key, { get: getter } );
 			} else if ( isObject( source[ key ] ) ) {
-				if ( ! target[ key ] ) Object.assign( target, { [ key ]: {} } );
+				if ( ! target[ key ] ) target[ key ] = {};
 				deepMerge( target[ key ], source[ key ] );
 			} else {
-				Object.assign( target, { [ key ]: source[ key ] } );
+				target[ key ] = source[ key ];
 			}
 		}
 	}

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -35,7 +35,7 @@ const deepMerge = ( target: any, source: any ) => {
 	}
 };
 
-const parseInitialData = () => {
+export const parseInitialData = () => {
 	const storeTag = document.querySelector(
 		`script[type="application/json"]#wp-interactivity-data`
 	);
@@ -310,15 +310,22 @@ export function store(
 	return stores.get( namespace );
 }
 
+export const populateInitialData = ( data?: {
+	state?: Record< string, unknown >;
+	config?: Record< string, unknown >;
+} ) => {
+	if ( isObject( data?.state ) ) {
+		Object.entries( data.state ).forEach( ( [ namespace, state ] ) => {
+			store( namespace, { state }, { lock: universalUnlock } );
+		} );
+	}
+	if ( isObject( data?.config ) ) {
+		Object.entries( data.config ).forEach( ( [ namespace, config ] ) => {
+			storeConfigs.set( namespace, config );
+		} );
+	}
+};
+
 // Parse and populate the initial state and config.
 const data = parseInitialData();
-if ( isObject( data?.state ) ) {
-	Object.entries( data.state ).forEach( ( [ namespace, state ] ) => {
-		store( namespace, { state }, { lock: universalUnlock } );
-	} );
-}
-if ( isObject( data?.config ) ) {
-	Object.entries( data.config ).forEach( ( [ namespace, config ] ) => {
-		storeConfigs.set( namespace, config );
-	} );
-}
+populateInitialData( data );

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -149,6 +149,7 @@ const handlers = {
 
 		return result;
 	},
+	// Prevents passing the current proxy as the receiver to the deepSignal.
 	set( target: any, key: string, value: any ) {
 		return Reflect.set( target, key, value );
 	},

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -35,20 +35,6 @@ const deepMerge = ( target: any, source: any ) => {
 	}
 };
 
-export const parseInitialData = () => {
-	const storeTag = document.querySelector(
-		`script[type="application/json"]#wp-interactivity-data`
-	);
-	if ( storeTag?.textContent ) {
-		try {
-			return JSON.parse( storeTag.textContent );
-		} catch ( e ) {
-			// Do nothing.
-		}
-	}
-	return {};
-};
-
 export const stores = new Map();
 const rawStores = new Map();
 const storeLocks = new Map();
@@ -309,6 +295,20 @@ export function store(
 
 	return stores.get( namespace );
 }
+
+export const parseInitialData = ( dom = document ) => {
+	const storeTag = dom.querySelector(
+		`script[type="application/json"]#wp-interactivity-data`
+	);
+	if ( storeTag?.textContent ) {
+		try {
+			return JSON.parse( storeTag.textContent );
+		} catch ( e ) {
+			// Do nothing.
+		}
+	}
+	return {};
+};
 
 export const populateInitialData = ( data?: {
 	state?: Record< string, unknown >;

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -29,7 +29,12 @@ const deepMerge = ( target: any, source: any ) => {
 				if ( ! target[ key ] ) target[ key ] = {};
 				deepMerge( target[ key ], source[ key ] );
 			} else {
-				target[ key ] = source[ key ];
+				try {
+					target[ key ] = source[ key ];
+				} catch ( e ) {
+					// Assignemnts fail for properties that are only getters.
+					// When that's the case, the assignment is simply ignored.
+				}
 			}
 		}
 	}

--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -14,7 +14,11 @@ test.describe( 'Router navigate', () => {
 			alias: 'router navigate - link 1',
 			attributes: {
 				title: 'Link 1',
-				data: { prop1: 'link 1', prop3: 'link 1' },
+				data: {
+					getterProp: 'value from link1',
+					prop1: 'link 1',
+					prop3: 'link 1',
+				},
 			},
 		} );
 		await utils.addPostWithBlock( 'test/router-navigate', {
@@ -22,7 +26,11 @@ test.describe( 'Router navigate', () => {
 			attributes: {
 				title: 'Main',
 				links: [ link1, link2 ],
-				data: { prop1: 'main', prop2: 'main' },
+				data: {
+					getterProp: 'value from main',
+					prop1: 'main',
+					prop2: 'main',
+				},
 			},
 		} );
 		await utils.addPostWithBlock( 'test/router-navigate', {
@@ -225,5 +233,33 @@ test.describe( 'Router navigate', () => {
 		await expect( prop1 ).toHaveText( 'main' );
 		await expect( prop2 ).toHaveText( 'main' );
 		await expect( prop3 ).toHaveText( 'link 1' );
+	} );
+
+	test( 'should not try to overwrite getters with values from the initial data', async ( {
+		page,
+	} ) => {
+		const title = page.getByTestId( 'title' );
+		const getter = page.getByTestId( 'getterProp' );
+
+		// Title should start in 'Main' and the getter prop should be the one
+		// returned once hydrated.
+		await expect( title ).toHaveText( 'Main' );
+		await expect( getter ).toHaveText( 'value from getter (main)' );
+
+		await page.getByTestId( 'link 1' ).click();
+
+		// Title should have changed. If not, that means there was an error
+		// during render. The getter should return the correct value.
+		await expect( title ).toHaveText( 'Link 1' );
+		await expect( getter ).toHaveText( 'value from getter (link 1)' );
+
+		// Same behavior navigating back and forward.
+		await page.goBack();
+		await expect( title ).toHaveText( 'Main' );
+		await expect( getter ).toHaveText( 'value from getter (main)' );
+
+		await page.goForward();
+		await expect( title ).toHaveText( 'Link 1' );
+		await expect( getter ).toHaveText( 'value from getter (link 1)' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -21,24 +21,28 @@ test.describe( 'Router navigate', () => {
 				},
 			},
 		} );
-		await utils.addPostWithBlock( 'test/router-navigate', {
-			alias: 'router navigate - main',
-			attributes: {
-				title: 'Main',
-				links: [ link1, link2 ],
-				data: {
-					getterProp: 'value from main',
-					prop1: 'main',
-					prop2: 'main',
-				},
-			},
-		} );
-		await utils.addPostWithBlock( 'test/router-navigate', {
+		const link3 = await utils.addPostWithBlock( 'test/router-navigate', {
 			alias: 'router navigate - disabled',
 			attributes: {
 				title: 'Main (navigation disabled)',
 				links: [ link1, link2 ],
 				disableNavigation: true,
+				data: {
+					getterProp: 'value from main (navigation disabled)',
+					prop1: 'main (navigation disabled)',
+				},
+			},
+		} );
+		await utils.addPostWithBlock( 'test/router-navigate', {
+			alias: 'router navigate - main',
+			attributes: {
+				title: 'Main',
+				links: [ link1, link2, link3 ],
+				data: {
+					getterProp: 'value from main',
+					prop1: 'main',
+					prop2: 'main',
+				},
 			},
 		} );
 	} );
@@ -59,7 +63,7 @@ test.describe( 'Router navigate', () => {
 		const link1 = utils.getLink( 'router navigate - link 1' );
 		const link2 = utils.getLink( 'router navigate - link 2' );
 
-		const navigations = page.getByTestId( 'router navigations' );
+		const navigations = page.getByTestId( 'router navigations pending' );
 		const status = page.getByTestId( 'router status' );
 		const title = page.getByTestId( 'title' );
 
@@ -104,7 +108,7 @@ test.describe( 'Router navigate', () => {
 	} ) => {
 		const link1 = utils.getLink( 'router navigate - link 1' );
 
-		const navigations = page.getByTestId( 'router navigations' );
+		const navigations = page.getByTestId( 'router navigations pending' );
 		const status = page.getByTestId( 'router status' );
 		const title = page.getByTestId( 'title' );
 
@@ -190,12 +194,12 @@ test.describe( 'Router navigate', () => {
 	} ) => {
 		await page.goto( utils.getLink( 'router navigate - disabled' ) );
 
-		const navigations = page.getByTestId( 'router navigations' );
+		const count = page.getByTestId( 'router navigations count' );
 		const status = page.getByTestId( 'router status' );
 		const title = page.getByTestId( 'title' );
 
 		// Check some elements to ensure the page has hydrated.
-		await expect( navigations ).toHaveText( '0' );
+		await expect( count ).toHaveText( '0' );
 		await expect( status ).toHaveText( 'idle' );
 
 		await page.getByTestId( 'link 1' ).click();
@@ -204,7 +208,7 @@ test.describe( 'Router navigate', () => {
 		await expect( title ).toHaveText( 'Link 1' );
 
 		// Check that client-navigations count has not increased.
-		await expect( navigations ).toHaveText( '0' );
+		await expect( count ).toHaveText( '0' );
 	} );
 
 	test( 'should overwrite the state with the one serialized in the new page', async ( {

--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -12,11 +12,18 @@ test.describe( 'Router navigate', () => {
 		} );
 		const link1 = await utils.addPostWithBlock( 'test/router-navigate', {
 			alias: 'router navigate - link 1',
-			attributes: { title: 'Link 1' },
+			attributes: {
+				title: 'Link 1',
+				state: { prop1: 'link 1', prop3: 'link 1' },
+			},
 		} );
 		await utils.addPostWithBlock( 'test/router-navigate', {
 			alias: 'router navigate - main',
-			attributes: { title: 'Main', links: [ link1, link2 ] },
+			attributes: {
+				title: 'Main',
+				links: [ link1, link2 ],
+				state: { prop1: 'main', prop2: 'main' },
+			},
 		} );
 		await utils.addPostWithBlock( 'test/router-navigate', {
 			alias: 'router navigate - disabled',
@@ -190,5 +197,33 @@ test.describe( 'Router navigate', () => {
 
 		// Check that client-navigations count has not increased.
 		await expect( navigations ).toHaveText( '0' );
+	} );
+
+	test( 'should overwrite the state with the one serialized in the new page', async ( {
+		page,
+	} ) => {
+		const prop1 = page.getByTestId( 'prop1' );
+		const prop2 = page.getByTestId( 'prop2' );
+		const prop3 = page.getByTestId( 'prop3' );
+
+		await expect( prop1 ).toHaveText( 'main' );
+		await expect( prop2 ).toHaveText( 'main' );
+		await expect( prop3 ).toBeEmpty();
+
+		await page.getByTestId( 'link 1' ).click();
+
+		// New values for existing properties should change.
+		// Old values not overwritten should remain the same.
+		// New properties should appear.
+		await expect( prop1 ).toHaveText( 'link 1' );
+		await expect( prop2 ).toHaveText( 'main' );
+		await expect( prop3 ).toHaveText( 'link 1' );
+
+		await page.goBack();
+
+		// New added properties are preserved.
+		await expect( prop1 ).toHaveText( 'main' );
+		await expect( prop2 ).toHaveText( 'main' );
+		await expect( prop3 ).toHaveText( 'link 1' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -266,4 +266,32 @@ test.describe( 'Router navigate', () => {
 		await expect( title ).toHaveText( 'Link 1' );
 		await expect( getter ).toHaveText( 'value from getter (link 1)' );
 	} );
+
+	test( 'should force a page reload when navigating to a page with `clientNavigationDisabled`', async ( {
+		page,
+	} ) => {
+		const count = page.getByTestId( 'router navigations count' );
+		const title = page.getByTestId( 'title' );
+
+		// Check the cound to ensure the page has hydrated.
+		await expect( count ).toHaveText( '0' );
+
+		// Navigate to a page without clientNavigationDisabled.
+		await page.getByTestId( 'link 1' ).click();
+
+		// Check the page has updated and the navigation count has increased.
+		await expect( title ).toHaveText( 'Link 1' );
+		await expect( count ).toHaveText( '1' );
+
+		await page.goBack();
+		await expect( title ).toHaveText( 'Main' );
+		await expect( count ).toHaveText( '1' );
+
+		// Navigate to a page with clientNavigationDisabled.
+		await page.getByTestId( 'link 3' ).click();
+
+		// Check the page has updated and the navigation count is zero.
+		await expect( title ).toHaveText( 'Main (navigation disabled)' );
+		await expect( count ).toHaveText( '0' );
+	} );
 } );

--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -14,7 +14,7 @@ test.describe( 'Router navigate', () => {
 			alias: 'router navigate - link 1',
 			attributes: {
 				title: 'Link 1',
-				state: { prop1: 'link 1', prop3: 'link 1' },
+				data: { prop1: 'link 1', prop3: 'link 1' },
 			},
 		} );
 		await utils.addPostWithBlock( 'test/router-navigate', {
@@ -22,7 +22,7 @@ test.describe( 'Router navigate', () => {
 			attributes: {
 				title: 'Main',
 				links: [ link1, link2 ],
-				state: { prop1: 'main', prop2: 'main' },
+				data: { prop1: 'main', prop2: 'main' },
 			},
 		} );
 		await utils.addPostWithBlock( 'test/router-navigate', {


### PR DESCRIPTION
## What?

Epic: https://github.com/WordPress/gutenberg/issues/56803
Related discussion: https://github.com/WordPress/gutenberg/discussions/53056

Fixes the initial state not being merged with the current state during `navigate()` calls and the page not being reloaded when `clientNavigationDisabled` is true for the target page.

Also, fixes a hidden bug related to state proxies being passed as the `receiver` to deepSignal proxy handlers.

## How?

The `@wordpress/interactivity` module now exposes three more private functions:

- `parseInitialData`: deserializes and returns the content of the initial data tag.
- `populateInitialData`: merges the passed data onto the current state/config. Property values are overwritten, except for getters.
- `batch`: the Preact signals' [`batch` function](https://preactjs.com/guide/v10/signals/#batchfn).

Those functions are used by the `@wordpress/interactivity-router` module to preserve a cached copy of the initial state and update the global state during navigation. That update occurs inside a `batch` call to prevent directives from updating before the new page rendering has finished.

