### PR TITLE
Performance: Prevent layout re-rendering when changing selected block

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -197,7 +197,7 @@ function Layout() {
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
 			hasBlockSelected:
-				select( blockEditorStore ).getBlockSelectionStart(),
+				!! select( blockEditorStore ).getBlockSelectionStart(),
 		};
 	}, [] );
 


### PR DESCRIPTION
Just a tiny PR that prevents the "Layout" component from re-rendering when switching the selected block.
It's important to prevent this top level components from re-rendering as much as possible because all non pure components in the tree will re-render as a consequence.

This PR might or might not have an impact on "block selection" metric.