### PR TITLE
Platform Docs: Fix missing link

### DIFF
--- a/platform-docs/docs/basic-concepts/data.md
+++ b/platform-docs/docs/basic-concepts/data.md
@@ -100,7 +100,7 @@ After running this through the parser, we're left with a simple object we can ma
 
 This has dramatic implications for how simple and performant we can make our parser. These explicit boundaries also protect damage to a single block from bleeding into other blocks or tarnishing the entire document. It also allows the system to identify unrecognized blocks before rendering them.
 
-_N.B.:_ The defining aspects of blocks are their semantics and the isolation mechanism they provide: in other words, their identity. On the other hand, where their data is stored is a more liberal aspect. Blocks support more than just static local data (via JSON literals inside the HTML comment or within the block's HTML), and more mechanisms (_e.g._, global blocks or otherwise resorting to storage in complementary `WP_Post` objects) are expected. See [attributes](/docs/reference-guides/block-api/block-attributes.md) for details.
+_N.B.:_ The defining aspects of blocks are their semantics and the isolation mechanism they provide: in other words, their identity. On the other hand, where their data is stored is a more liberal aspect. Blocks support more than just static local data (via JSON literals inside the HTML comment or within the block's HTML), and more mechanisms (_e.g._, global blocks or otherwise resorting to storage in complementary `WP_Post` objects) are expected. See [attributes](https://github.com/WordPress/gutenberg/tree/HEAD/docs/reference-guides/block-api/block-attributes.md) for details.
 
 ### The Anatomy of a Serialized Block
 

--- a/platform-docs/docs/basic-concepts/data.md
+++ b/platform-docs/docs/basic-concepts/data.md
@@ -100,7 +100,7 @@ After running this through the parser, we're left with a simple object we can ma
 
 This has dramatic implications for how simple and performant we can make our parser. These explicit boundaries also protect damage to a single block from bleeding into other blocks or tarnishing the entire document. It also allows the system to identify unrecognized blocks before rendering them.
 
-_N.B.:_ The defining aspects of blocks are their semantics and the isolation mechanism they provide: in other words, their identity. On the other hand, where their data is stored is a more liberal aspect. Blocks support more than just static local data (via JSON literals inside the HTML comment or within the block's HTML), and more mechanisms (_e.g._, global blocks or otherwise resorting to storage in complementary `WP_Post` objects) are expected. See [attributes](https://github.com/WordPress/gutenberg/tree/HEAD/docs/reference-guides/block-api/block-attributes.md) for details.
+_N.B.:_ The defining aspects of blocks are their semantics and the isolation mechanism they provide: in other words, their identity. On the other hand, where their data is stored is a more liberal aspect. Blocks support more than just static local data (via JSON literals inside the HTML comment or within the block's HTML), and more mechanisms (_e.g._, global blocks or otherwise resorting to storage in complementary `WP_Post` objects) are expected.
 
 ### The Anatomy of a Serialized Block
 


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/53874

## What?
This PR fixes one link. This will also allow the `npm run build` command to work correctly.

```
[ERROR] Unable to build website for locale en.
[ERROR] Error: Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /docs/basic-concepts/data:
   -> linking to /docs/reference-guides/block-api/block-attributes.md
```

## Why?

The `/docs/` path link will work correctly in markdown on GitHub repository. However, if this document is published in the future, the docs directory will not exist and will not be linked correctly.

## Testing Instructions

- cd `./platform-docs`
- `npm install`
- `npm run build`
