### PR TITLE
Global styles revisions e2e: tidy up selectors to open revisions panel

### DIFF
--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -148,9 +148,6 @@ class UserGlobalStylesRevisions {
 	}
 
 	async openRevisions() {
-		await this.page
-			.getByRole( 'menubar', { name: 'Styles actions' } )
-			.click();
 		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
 	}
 

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -49,7 +49,7 @@ test.describe( 'Global styles revisions', () => {
 		await editor.saveSiteEditorEntities();
 
 		// Now there should be enough revisions to show the revisions UI.
-		await userGlobalStylesRevisions.openRevisions();
+		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
 
 		const revisionButtons = page.getByRole( 'button', {
 			name: /^Changes saved by /,
@@ -81,7 +81,7 @@ test.describe( 'Global styles revisions', () => {
 			.getByRole( 'option', { name: 'Color: Luminous vivid amber' } )
 			.click( { force: true } );
 
-		await userGlobalStylesRevisions.openRevisions();
+		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
 
 		const unSavedButton = page.getByRole( 'button', {
 			name: /^Unsaved changes/,
@@ -117,7 +117,7 @@ test.describe( 'Global styles revisions', () => {
 	} ) => {
 		await editor.canvas.locator( 'body' ).click();
 		await userGlobalStylesRevisions.openStylesPanel();
-		await userGlobalStylesRevisions.openRevisions();
+		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
 		const lastRevisionButton = page
 			.getByLabel( 'Global styles revisions' )
 			.getByRole( 'button' )
@@ -145,10 +145,6 @@ class UserGlobalStylesRevisions {
 			);
 		}
 		return [];
-	}
-
-	async openRevisions() {
-		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
 	}
 
 	async openStylesPanel() {

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -49,7 +49,7 @@ test.describe( 'Global styles revisions', () => {
 		await editor.saveSiteEditorEntities();
 
 		// Now there should be enough revisions to show the revisions UI.
-		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
+		await page.getByRole( 'button', { name: 'Revisions' } ).click();
 
 		const revisionButtons = page.getByRole( 'button', {
 			name: /^Changes saved by /,
@@ -81,7 +81,7 @@ test.describe( 'Global styles revisions', () => {
 			.getByRole( 'option', { name: 'Color: Luminous vivid amber' } )
 			.click( { force: true } );
 
-		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
+		await page.getByRole( 'button', { name: 'Revisions' } ).click();
 
 		const unSavedButton = page.getByRole( 'button', {
 			name: /^Unsaved changes/,
@@ -117,7 +117,7 @@ test.describe( 'Global styles revisions', () => {
 	} ) => {
 		await editor.canvas.locator( 'body' ).click();
 		await userGlobalStylesRevisions.openStylesPanel();
-		await this.page.getByRole( 'button', { name: 'Revisions' } ).click();
+		await page.getByRole( 'button', { name: 'Revisions' } ).click();
 		const lastRevisionButton = page
 			.getByLabel( 'Global styles revisions' )
 			.getByRole( 'button' )


### PR DESCRIPTION

## What?
Removing playwright locator and action on the global styles ellipsis menu in `openRevisions`, which is meant to open the revisions panel.

## Why?

Since https://github.com/WordPress/gutenberg/pull/56454 the revisions button is no longer in the drop down actions list so we don't need to click it.

## How?
DELETE!

## Testing Instructions

The tests in test/e2e/specs/site-editor/user-global-styles-revisions.spec.js should pass.