### PR TITLE
Save Button: Fix the translation of the Activate button

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -68,7 +68,6 @@ export default function SaveButton( {
 			} else if ( disabled ) {
 				return __( 'Saved' );
 			} else if ( isDirty ) {
-				
 				return sprintf(
 					/* translators: %s: The name of theme to be activated. */
 					__( 'Activate %s & Save' ),

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -60,12 +60,16 @@ export default function SaveButton( {
 	const getLabel = () => {
 		if ( isPreviewingTheme() ) {
 			if ( isSaving ) {
+				/* translators: %s: The name of theme to be activated. */
 				return sprintf( 'Activating %s', previewingThemeName );
 			} else if ( disabled ) {
 				return __( 'Saved' );
 			} else if ( isDirty ) {
+				/* translators: %s: The name of theme to be activated. */
 				return sprintf( 'Activate %s & Save', previewingThemeName );
 			}
+
+			/* translators: %s: The name of theme to be activated. */
 			return sprintf( 'Activate %s', previewingThemeName );
 		}
 

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -60,17 +60,27 @@ export default function SaveButton( {
 	const getLabel = () => {
 		if ( isPreviewingTheme() ) {
 			if ( isSaving ) {
-				/* translators: %s: The name of theme to be activated. */
-				return sprintf( 'Activating %s', previewingThemeName );
+				return sprintf(
+					/* translators: %s: The name of theme to be activated. */
+					__( 'Activating %s' ),
+					previewingThemeName
+				);
 			} else if ( disabled ) {
 				return __( 'Saved' );
 			} else if ( isDirty ) {
-				/* translators: %s: The name of theme to be activated. */
-				return sprintf( 'Activate %s & Save', previewingThemeName );
+				
+				return sprintf(
+					/* translators: %s: The name of theme to be activated. */
+					__( 'Activate %s & Save' ),
+					previewingThemeName
+				);
 			}
 
-			/* translators: %s: The name of theme to be activated. */
-			return sprintf( 'Activate %s', previewingThemeName );
+			return sprintf(
+				/* translators: %s: The name of theme to be activated. */
+				__( 'Activate %s' ),
+				previewingThemeName
+			);
 		}
 
 		if ( isSaving ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add the comment of the translator to the interpolation string to make the string able to be translated

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Referring to https://github.com/WordPress/gutenberg/pull/55752#discussion_r1428062410, we have to fix the translation for the interpolation string.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Simply add the comment of the translator.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
