### PR TITLE
Fix unsaved pattern not reflecting on pattern overrides

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -140,7 +140,7 @@ export default function ReusableBlockEdit( {
 } ) {
 	const registry = useRegistry();
 	const hasAlreadyRendered = useHasRecursion( ref );
-	const { record, hasResolved } = useEntityRecord(
+	const { record, editedRecord, hasResolved } = useEntityRecord(
 		'postType',
 		'wp_block',
 		ref
@@ -156,9 +156,13 @@ export default function ReusableBlockEdit( {
 	const { getBlockEditingMode } = useSelect( blockEditorStore );
 
 	useEffect( () => {
-		if ( ! record?.content?.raw ) return;
-		const initialBlocks = parse( record.content.raw );
+		const initialBlocks =
+			editedRecord.blocks ??
+			( editedRecord.content && typeof editedRecord.content !== 'function'
+				? parse( editedRecord.content )
+				: [] );
 
+		defaultValuesRef.current = {};
 		const editingMode = getBlockEditingMode( patternClientId );
 		registry.batch( () => {
 			setBlockEditingMode( patternClientId, 'default' );
@@ -176,7 +180,7 @@ export default function ReusableBlockEdit( {
 	}, [
 		__unstableMarkNextChangeAsNotPersistent,
 		patternClientId,
-		record,
+		editedRecord,
 		replaceInnerBlocks,
 		registry,
 		getBlockEditingMode,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/pull/57036#discussion_r1427730711.

Fix updated but unsaved patterns not reflecting the changes on pattern overrides instances.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/pull/57036#discussion_r1427730711.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use `editedRecord` to resync the changes once the pattern is updated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the "Pattern Overrides" or the "Partial syncing patterns" gutenberg experiment.
2. Go to the site editor and create a synced pattern.
3. Make some changes and save the pattern.
4. Navigate to a template and insert the pattern.
5. Use the navigator (don't reload the page) to go back to edit the pattern.
6. Make some changes to the pattern but don't save it.
7. Go back to the template, expect the change to be reflected.
8. Everything else should continue to work.

## Screenshots or screencast <!-- if applicable -->
