### PR TITLE
Swap Template: Show the right templates for the right post type

### DIFF
--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -41,21 +41,21 @@ export function useAllowSwitchingTemplates() {
 	);
 }
 
-function useTemplates() {
+function useTemplates( postType ) {
 	return useSelect(
 		( select ) =>
 			select( coreStore ).getEntityRecords( 'postType', 'wp_template', {
 				per_page: -1,
-				post_type: 'page',
+				post_type: postType,
 			} ),
 		[]
 	);
 }
 
-export function useAvailableTemplates() {
+export function useAvailableTemplates( postType ) {
 	const currentTemplateSlug = useCurrentTemplateSlug();
 	const allowSwitchingTemplate = useAllowSwitchingTemplates();
-	const templates = useTemplates();
+	const templates = useTemplates( postType );
 	return useMemo(
 		() =>
 			allowSwitchingTemplate &&
@@ -71,7 +71,7 @@ export function useAvailableTemplates() {
 
 export function useCurrentTemplateSlug() {
 	const { postType, postId } = useEditedPostContext();
-	const templates = useTemplates();
+	const templates = useTemplates( postType );
 	const entityTemplate = useSelect(
 		( select ) => {
 			const post = select( coreStore ).getEditedEntityRecord(

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -48,7 +48,7 @@ function useTemplates( postType ) {
 				per_page: -1,
 				post_type: postType,
 			} ),
-		[]
+		[ postType ]
 	);
 }
 

--- a/packages/editor/src/components/post-template/swap-template-button.js
+++ b/packages/editor/src/components/post-template/swap-template-button.js
@@ -18,11 +18,11 @@ import { useAvailableTemplates, useEditedPostContext } from './hooks';
 
 export default function SwapTemplateButton( { onClick } ) {
 	const [ showModal, setShowModal ] = useState( false );
-	const availableTemplates = useAvailableTemplates();
 	const onClose = useCallback( () => {
 		setShowModal( false );
 	}, [] );
 	const { postType, postId } = useEditedPostContext();
+	const availableTemplates = useAvailableTemplates( postType );
 	const { editEntityRecord } = useDispatch( coreStore );
 	if ( ! availableTemplates?.length ) {
 		return null;
@@ -51,7 +51,10 @@ export default function SwapTemplateButton( { onClick } ) {
 					isFullScreen
 				>
 					<div className="editor-post-template__swap-template-modal-content">
-						<TemplatesList onSelect={ onTemplateSelect } />
+						<TemplatesList
+							postType={ postType }
+							onSelect={ onTemplateSelect }
+						/>
 					</div>
 				</Modal>
 			) }
@@ -59,8 +62,8 @@ export default function SwapTemplateButton( { onClick } ) {
 	);
 }
 
-function TemplatesList( { onSelect } ) {
-	const availableTemplates = useAvailableTemplates();
+function TemplatesList( { postType, onSelect } ) {
+	const availableTemplates = useAvailableTemplates( postType );
 	const templatesAsPatterns = useMemo(
 		() =>
 			availableTemplates.map( ( template ) => ( {


### PR DESCRIPTION
closes #57112 

## What?

We recently moved the template swapping modal to the post editor, this highlighted a small issue where the list of available templates was hardcoding the templates that are available for the page post type. This PR fixes that by using the right post type to fetch the available templates.

## Testing Instructions

1- Edit a post in 2024 theme, you should only see the "post" specific templates in the swap template modal.
2- For pages, you should only see "page" specific templates.
