### PR TITLE
Site Editor: Add the Discussion panel

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -13,6 +13,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import {
 	store as editorStore,
+	PostDiscussionPanel,
 	PostExcerptPanel,
 	PostFeaturedImagePanel,
 	PostLastRevisionPanel,
@@ -24,7 +25,6 @@ import {
  */
 import SettingsHeader from '../settings-header';
 import PostStatus from '../post-status';
-import DiscussionPanel from '../discussion-panel';
 import PageAttributes from '../page-attributes';
 import MetaBoxes from '../../meta-boxes';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
@@ -85,7 +85,7 @@ const SidebarContent = ( {
 							<PostTaxonomiesPanel />
 							<PostFeaturedImagePanel />
 							<PostExcerptPanel />
-							<DiscussionPanel />
+							<PostDiscussionPanel />
 							<PageAttributes />
 							<MetaBoxes location="side" />
 						</>

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -13,6 +13,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
+	PostDiscussionPanel,
 	PostExcerptPanel,
 	PostFeaturedImagePanel,
 	PostLastRevisionPanel,
@@ -104,6 +105,7 @@ export default function PagePanels() {
 			<PostTaxonomiesPanel />
 			<PostFeaturedImagePanel />
 			<PostExcerptPanel />
+			<PostDiscussionPanel />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -4,6 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import { PanelBody } from '@wordpress/components';
 import {
+	PostDiscussionPanel,
 	PostExcerptPanel,
 	PostFeaturedImagePanel,
 	PostLastRevisionPanel,
@@ -68,6 +69,7 @@ export default function TemplatePanel() {
 			<PostTaxonomiesPanel />
 			<PostFeaturedImagePanel />
 			<PostExcerptPanel />
+			<PostDiscussionPanel />
 		</>
 	);
 }

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -30,6 +30,7 @@ export { default as PostAuthor } from './post-author';
 export { default as PostAuthorCheck } from './post-author/check';
 export { default as PostAuthorPanel } from './post-author/panel';
 export { default as PostComments } from './post-comments';
+export { default as PostDiscussionPanel } from './post-discussion/panel';
 export { default as PostExcerpt } from './post-excerpt';
 export { default as PostExcerptCheck } from './post-excerpt/check';
 export { default as PostExcerptPanel } from './post-excerpt/panel';

--- a/packages/editor/src/components/post-discussion/panel.js
+++ b/packages/editor/src/components/post-discussion/panel.js
@@ -3,20 +3,19 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, PanelRow } from '@wordpress/components';
-import {
-	PostComments,
-	PostPingbacks,
-	PostTypeSupportCheck,
-	store as editorStore,
-} from '@wordpress/editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Module Constants
+ * Internal dependencies
  */
+import { store as editorStore } from '../../store';
+import PostTypeSupportCheck from '../post-type-support-check';
+import PostComments from '../post-comments';
+import PostPingbacks from '../post-pingbacks';
+
 const PANEL_NAME = 'discussion-panel';
 
-function DiscussionPanel() {
+function PostDiscussionPanel() {
 	const { isEnabled, isOpened } = useSelect( ( select ) => {
 		const { isEditorPanelEnabled, isEditorPanelOpened } =
 			select( editorStore );
@@ -55,4 +54,4 @@ function DiscussionPanel() {
 	);
 }
 
-export default DiscussionPanel;
+export default PostDiscussionPanel;


### PR DESCRIPTION
Related #52632 
closes #53188

## What?

This PR continues the work on the great unification between post and site editors. This PR moves the PostDiscussion panel from the edit-post package to the editor package and reuse the same panel in the site editor as well. This means that this brings supports to discussion settings to the site editor sidebar for post types that support it. 

## Testing instructions

- Check that the "discussion" panel is visible in the sidebar of the site editor when editing pages.