### PR TITLE
Site Editor: Add Page Attributes panel

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -13,6 +13,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import {
 	store as editorStore,
+	PageAttributesPanel,
 	PostDiscussionPanel,
 	PostExcerptPanel,
 	PostFeaturedImagePanel,
@@ -25,7 +26,6 @@ import {
  */
 import SettingsHeader from '../settings-header';
 import PostStatus from '../post-status';
-import PageAttributes from '../page-attributes';
 import MetaBoxes from '../../meta-boxes';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 import PluginSidebarEditPost from '../plugin-sidebar';
@@ -86,7 +86,7 @@ const SidebarContent = ( {
 							<PostFeaturedImagePanel />
 							<PostExcerptPanel />
 							<PostDiscussionPanel />
-							<PageAttributes />
+							<PageAttributesPanel />
 							<MetaBoxes location="side" />
 						</>
 					) }

--- a/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/page-panels/index.js
@@ -13,6 +13,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
+	PageAttributesPanel,
 	PostDiscussionPanel,
 	PostExcerptPanel,
 	PostFeaturedImagePanel,
@@ -106,6 +107,7 @@ export default function PagePanels() {
 			<PostFeaturedImagePanel />
 			<PostExcerptPanel />
 			<PostDiscussionPanel />
+			<PageAttributesPanel />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-panel/index.js
@@ -4,6 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import { PanelBody } from '@wordpress/components';
 import {
+	PageAttributesPanel,
 	PostDiscussionPanel,
 	PostExcerptPanel,
 	PostFeaturedImagePanel,
@@ -70,6 +71,7 @@ export default function TemplatePanel() {
 			<PostFeaturedImagePanel />
 			<PostExcerptPanel />
 			<PostDiscussionPanel />
+			<PageAttributesPanel />
 		</>
 	);
 }

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -23,6 +23,7 @@ export { default as ErrorBoundary } from './error-boundary';
 export { default as LocalAutosaveMonitor } from './local-autosave-monitor';
 export { default as PageAttributesCheck } from './page-attributes/check';
 export { default as PageAttributesOrder } from './page-attributes/order';
+export { default as PageAttributesPanel } from './page-attributes/panel';
 export { default as PageAttributesParent } from './page-attributes/parent';
 export { default as PageTemplate } from './post-template/classic-theme';
 export { default as PostTemplatePanel } from './post-template/panel';

--- a/packages/editor/src/components/page-attributes/panel.js
+++ b/packages/editor/src/components/page-attributes/panel.js
@@ -3,21 +3,21 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, PanelRow } from '@wordpress/components';
-import {
-	store as editorStore,
-	PageAttributesCheck,
-	PageAttributesOrder,
-	PageAttributesParent,
-} from '@wordpress/editor';
+
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
- * Module Constants
+ * Internal dependencies
  */
+import { store as editorStore } from '../../store';
+import PageAttributesCheck from './check';
+import PageAttributesOrder from './order';
+import PageAttributesParent from './parent';
+
 const PANEL_NAME = 'page-attributes';
 
-export function PageAttributes() {
+export function PageAttributesPanel() {
 	const { isEnabled, isOpened, postType } = useSelect( ( select ) => {
 		const {
 			getEditedPostAttribute,
@@ -59,4 +59,4 @@ export function PageAttributes() {
 	);
 }
 
-export default PageAttributes;
+export default PageAttributesPanel;


### PR DESCRIPTION
Related #52632 

## What?

This PR continues the work on the great unification between post and site editors. This PR moves the PageAttributes panel from the edit-post package to the editor package and reuse the same panel in the site editor as well. This means that this brings supports to discussion settings to the site editor sidebar for post types that support it. 

## Testing instructions

- Check that the "page attributes" panel is visible in the sidebar of the site editor when editing pages.