### PR TITLE
Disable webpack perf hints when compiling packages

### DIFF
--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -129,10 +129,10 @@ const vendorsCopyConfig = Object.entries( vendors ).flatMap(
 module.exports = {
 	...baseConfig,
 	name: 'packages',
-	entry: gutenbergPackages.reduce( ( memo, packageName ) => {
-		return {
-			...memo,
-			[ packageName ]: {
+	entry: Object.fromEntries(
+		gutenbergPackages.map( ( packageName ) => [
+			packageName,
+			{
 				import: `./packages/${ packageName }`,
 				library: {
 					name: [ 'wp', camelCaseDash( packageName ) ],
@@ -142,8 +142,8 @@ module.exports = {
 						: undefined,
 				},
 			},
-		};
-	}, {} ),
+		] )
+	),
 	output: {
 		devtoolNamespace: 'wp',
 		filename: './build/[name]/index.min.js',

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -157,6 +157,9 @@ module.exports = {
 			return `webpack://${ info.namespace }/${ info.resourcePath }`;
 		},
 	},
+	performance: {
+		hints: false, // disable warnings about package sizes
+	},
 	plugins: [
 		...plugins,
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),


### PR DESCRIPTION
When webpack builds the `packages` directory, it outputs some performance warnings because the bundles are larger than the default limit:

<img width="1112" alt="Screenshot 2023-12-18 at 12 29 19" src="https://github.com/WordPress/gutenberg/assets/664258/b2868dff-32a0-4130-a0c8-852394fc1547">

This PR disables these warnings because they are mostly spam, we don't really look at and act on them.

As a drive-by, I'm refactoring `.reduce` to `Object.fromEntries` a few lines up in the same webpack config. Not logically related, just code that's physically close 🙂 