### PR TITLE
Editor: Move and unify the inserter and list view states

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -214,6 +214,8 @@ _Returns_
 
 ### isInserterOpened
 
+> **Deprecated**
+
 Returns true if the inserter is opened.
 
 _Parameters_
@@ -446,29 +448,23 @@ Returns an action object used to switch to template editing.
 
 ### setIsInserterOpened
 
+> **Deprecated**
+
 Returns an action object used to open/close the inserter.
 
 _Parameters_
 
--   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false). To specify an insertion point, use an object.
--   _value.rootClientId_ `string`: The root client ID to insert at.
--   _value.insertionIndex_ `number`: The index to insert at.
-
-_Returns_
-
--   `Object`: Action object.
+-   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false).
 
 ### setIsListViewOpened
+
+> **Deprecated**
 
 Returns an action object used to open/close the list view.
 
 _Parameters_
 
 -   _isOpen_ `boolean`: A boolean representing whether the list view should be opened or closed.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### showBlockTypes
 

--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -157,7 +157,9 @@ _Returns_
 
 ### isInserterOpened
 
-Returns the current opened/closed state of the inserter panel.
+> **Deprecated**
+
+Returns true if the inserter is opened.
 
 _Parameters_
 
@@ -165,11 +167,11 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: True if the inserter panel should be open; false if closed.
+-   `boolean`: Whether the inserter is opened.
 
 ### isListViewOpened
 
-Returns the current opened/closed state of the list view panel.
+Returns true if the list view is opened.
 
 _Parameters_
 
@@ -177,7 +179,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: True if the list view panel should be open; false if closed.
+-   `boolean`: Whether the list view is opened.
 
 ### isNavigationOpened
 
@@ -307,25 +309,23 @@ _Parameters_
 
 ### setIsInserterOpened
 
-Opens or closes the inserter.
+> **Deprecated**
+
+Returns an action object used to open/close the inserter.
 
 _Parameters_
 
--   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false). To specify an insertion point, use an object.
--   _value.rootClientId_ `string`: The root client ID to insert at.
--   _value.insertionIndex_ `number`: The index to insert at.
-
-_Returns_
-
--   `Object`: Action object.
+-   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false).
 
 ### setIsListViewOpened
 
-Sets whether the list view panel should be open.
+> **Deprecated**
+
+Returns an action object used to open/close the list view.
 
 _Parameters_
 
--   _isOpen_ `boolean`: If true, opens the list view. If false, closes it. It does not toggle the state, but sets it directly.
+-   _isOpen_ `boolean`: A boolean representing whether the list view should be opened or closed.
 
 ### setIsNavigationPanelOpened
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -924,6 +924,30 @@ _Related_
 
 -   isFirstMultiSelectedBlock in core/block-editor store.
 
+### isInserterOpened
+
+Returns true if the inserter is opened.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `boolean`: Whether the inserter is opened.
+
+### isListViewOpened
+
+Returns true if the list view is opened.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `boolean`: Whether the list view is opened.
+
 ### isMultiSelecting
 
 _Related_
@@ -1344,6 +1368,32 @@ _Parameters_
 
 -   _postType_ `string`: Post Type.
 -   _postId_ `string`: Post ID.
+
+_Returns_
+
+-   `Object`: Action object.
+
+### setIsInserterOpened
+
+Returns an action object used to open/close the inserter.
+
+_Parameters_
+
+-   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false). To specify an insertion point, use an object.
+-   _value.rootClientId_ `string`: The root client ID to insert at.
+-   _value.insertionIndex_ `number`: The index to insert at.
+
+_Returns_
+
+-   `Object`: Action object.
+
+### setIsListViewOpened
+
+Returns an action object used to open/close the list view.
+
+_Parameters_
+
+-   _isOpen_ `boolean`: A boolean representing whether the list view should be opened or closed.
 
 _Returns_
 

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -35,7 +35,7 @@ const preventDefault = ( event ) => {
 function HeaderToolbar( { hasFixedToolbar, setListViewToggleElement } ) {
 	const inserterButton = useRef();
 	const { setIsInserterOpened, setIsListViewOpened } =
-		useDispatch( editPostStore );
+		useDispatch( editorStore );
 	const {
 		isInserterEnabled,
 		isInserterOpened,
@@ -46,9 +46,8 @@ function HeaderToolbar( { hasFixedToolbar, setListViewToggleElement } ) {
 	} = useSelect( ( select ) => {
 		const { hasInserterItems, getBlockRootClientId, getBlockSelectionEnd } =
 			select( blockEditorStore );
-		const { getEditorSettings } = select( editorStore );
-		const { getEditorMode, isFeatureActive, isListViewOpened } =
-			select( editPostStore );
+		const { getEditorSettings, isListViewOpened } = select( editorStore );
+		const { getEditorMode, isFeatureActive } = select( editPostStore );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
 
 		return {
@@ -59,7 +58,7 @@ function HeaderToolbar( { hasFixedToolbar, setListViewToggleElement } ) {
 				hasInserterItems(
 					getBlockRootClientId( getBlockSelectionEnd() )
 				),
-			isInserterOpened: select( editPostStore ).isInserterOpened(),
+			isInserterOpened: select( editorStore ).isInserterOpened(),
 			isTextModeEnabled: getEditorMode() === 'text',
 			showIconLabels: isFeatureActive( 'showIconLabels' ),
 			isListViewOpen: isListViewOpened(),

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -10,6 +10,7 @@ import {
 	PreferenceToggleMenuItem,
 	store as preferencesStore,
 } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -19,9 +20,10 @@ import { store as postEditorStore } from '../../../store';
 function WritingMenu() {
 	const registry = useRegistry();
 
-	const { setIsInserterOpened, setIsListViewOpened, closeGeneralSidebar } =
-		useDispatch( postEditorStore );
+	const { closeGeneralSidebar } = useDispatch( postEditorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
+	const { setIsInserterOpened, setIsListViewOpened } =
+		useDispatch( editorStore );
 
 	const toggleDistractionFree = () => {
 		registry.batch( () => {

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -18,24 +18,22 @@ import { createBlock } from '@wordpress/blocks';
 import { store as editPostStore } from '../../store';
 
 function KeyboardShortcuts() {
-	const { getEditorMode, isEditorSidebarOpened, isListViewOpened } =
-		useSelect( editPostStore );
+	const { getEditorMode, isEditorSidebarOpened } = useSelect( editPostStore );
 	const isModeToggleDisabled = useSelect( ( select ) => {
 		const { richEditingEnabled, codeEditingEnabled } =
 			select( editorStore ).getEditorSettings();
 		return ! richEditingEnabled || ! codeEditingEnabled;
 	}, [] );
-
+	const { isListViewOpened } = useSelect( editorStore );
 	const {
 		switchEditorMode,
 		openGeneralSidebar,
 		closeGeneralSidebar,
 		toggleFeature,
-		setIsListViewOpened,
 		toggleDistractionFree,
 	} = useDispatch( editPostStore );
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
-
+	const { setIsListViewOpened } = useDispatch( editorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const {
 		getBlockName,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -142,9 +142,10 @@ function Layout() {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 
-	const { openGeneralSidebar, closeGeneralSidebar, setIsInserterOpened } =
+	const { openGeneralSidebar, closeGeneralSidebar } =
 		useDispatch( editPostStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const { setIsInserterOpened } = useDispatch( editorStore );
 	const {
 		mode,
 		isFullscreenActive,
@@ -176,8 +177,8 @@ function Layout() {
 			),
 			isFullscreenActive:
 				select( editPostStore ).isFeatureActive( 'fullscreenMode' ),
-			isInserterOpened: select( editPostStore ).isInserterOpened(),
-			isListViewOpened: select( editPostStore ).isListViewOpened(),
+			isInserterOpened: select( editorStore ).isInserterOpened(),
+			isListViewOpened: select( editorStore ).isListViewOpened(),
 			mode: select( editPostStore ).getEditorMode(),
 			isRichEditingEnabled: editorSettings.richEditingEnabled,
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -64,9 +64,9 @@ export default function EditPostPreferencesModal() {
 		[ isLargeViewport ]
 	);
 
-	const { closeGeneralSidebar, setIsListViewOpened, setIsInserterOpened } =
-		useDispatch( editPostStore );
-
+	const { closeGeneralSidebar } = useDispatch( editPostStore );
+	const { setIsListViewOpened, setIsInserterOpened } =
+		useDispatch( editorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
 
 	const toggleDistractionFree = () => {

--- a/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
@@ -11,22 +11,24 @@ import {
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import { store as editPostStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 export default function InserterSidebar() {
 	const { insertionPoint, showMostUsedBlocks } = useSelect( ( select ) => {
-		const { isFeatureActive, __experimentalGetInsertionPoint } =
-			select( editPostStore );
+		const { isFeatureActive } = select( editPostStore );
+		const { getInsertionPoint } = unlock( select( editorStore ) );
 		return {
-			insertionPoint: __experimentalGetInsertionPoint(),
+			insertionPoint: getInsertionPoint(),
 			showMostUsedBlocks: isFeatureActive( 'mostUsedBlocks' ),
 		};
 	}, [] );
-	const { setIsInserterOpened } = useDispatch( editPostStore );
+	const { setIsInserterOpened } = useDispatch( editorStore );
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const TagName = ! isMobileViewport ? VisuallyHidden : 'div';

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -11,15 +11,15 @@ import { __, _x } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { ESCAPE } from '@wordpress/keycodes';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import { store as editPostStore } from '../../store';
 import ListViewOutline from './list-view-outline';
 
 export default function ListViewSidebar( { listViewToggleElement } ) {
-	const { setIsListViewOpened } = useDispatch( editPostStore );
+	const { setIsListViewOpened } = useDispatch( editorStore );
 
 	// This hook handles focus when the sidebar first renders.
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -96,8 +96,7 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		[ postType, postId, isLargeViewport ]
 	);
 
-	const { updatePreferredStyleVariations, setIsInserterOpened } =
-		useDispatch( editPostStore );
+	const { updatePreferredStyleVariations } = useDispatch( editPostStore );
 
 	const editorSettings = useMemo( () => {
 		const result = {
@@ -112,8 +111,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 			hasInlineToolbar,
 			allowRightClickOverrides,
 
-			// This is marked as experimental to give time for the quick inserter to mature.
-			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			keepCaretInsideBlock,
 			// Keep a reference of the `allowedBlockTypes` from the server to handle use cases
 			// where we need to differentiate if a block is disabled by the user or some plugin.
@@ -146,7 +143,6 @@ function Editor( { postId, postType, settings, initialEdits, ...props } ) {
 		hiddenBlockTypes,
 		blockTypes,
 		preferredStyleVariations,
-		setIsInserterOpened,
 		updatePreferredStyleVariations,
 		keepCaretInsideBlock,
 	] );

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -32,7 +32,6 @@ export default function useCommonCommands() {
 		openGeneralSidebar,
 		closeGeneralSidebar,
 		switchEditorMode,
-		setIsListViewOpened,
 		toggleDistractionFree,
 	} = useDispatch( editPostStore );
 	const { openModal } = useDispatch( interfaceStore );
@@ -44,8 +43,8 @@ export default function useCommonCommands() {
 		showBlockBreadcrumbs,
 		isDistractionFree,
 	} = useSelect( ( select ) => {
-		const { getEditorMode, isListViewOpened, isFeatureActive } =
-			select( editPostStore );
+		const { getEditorMode, isFeatureActive } = select( editPostStore );
+		const { isListViewOpened } = select( editorStore );
 		return {
 			activeSidebar: select( interfaceStore ).getActiveComplementaryArea(
 				editPostStore.name
@@ -63,7 +62,8 @@ export default function useCommonCommands() {
 	}, [] );
 	const { toggle } = useDispatch( preferencesStore );
 	const { createInfoNotice } = useDispatch( noticesStore );
-	const { __unstableSaveForPreview } = useDispatch( editorStore );
+	const { __unstableSaveForPreview, setIsListViewOpened } =
+		useDispatch( editorStore );
 	const { getCurrentPostId } = useSelect( editorStore );
 
 	useCommand( {

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -79,7 +79,7 @@ export function initializeEditor(
 		select( editPostStore ).isFeatureActive( 'showListViewByDefault' ) &&
 		! select( editPostStore ).isFeatureActive( 'distractionFree' )
 	) {
-		dispatch( editPostStore ).setIsListViewOpened( true );
+		dispatch( editorStore ).setIsListViewOpened( true );
 	}
 
 	registerCoreBlocks();

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -438,8 +438,6 @@ export function metaBoxUpdatesFailure() {
  * @deprecated
  *
  * @param {string} deviceType
- *
- * @return {Object} Action object.
  */
 export const __experimentalSetPreviewDeviceType =
 	( deviceType ) =>
@@ -458,41 +456,35 @@ export const __experimentalSetPreviewDeviceType =
 /**
  * Returns an action object used to open/close the inserter.
  *
- * @param {boolean|Object} value                Whether the inserter should be
- *                                              opened (true) or closed (false).
- *                                              To specify an insertion point,
- *                                              use an object.
- * @param {string}         value.rootClientId   The root client ID to insert at.
- * @param {number}         value.insertionIndex The index to insert at.
+ * @deprecated
  *
- * @return {Object} Action object.
+ * @param {boolean|Object} value Whether the inserter should be opened (true) or closed (false).
  */
-export function setIsInserterOpened( value ) {
-	return {
-		type: 'SET_IS_INSERTER_OPENED',
-		value,
+export const setIsInserterOpened =
+	( value ) =>
+	( { registry } ) => {
+		deprecated( "dispatch( 'core/edit-post' ).setIsInserterOpened", {
+			since: '6.5',
+			alternative: "dispatch( 'core/editor').setIsInserterOpened",
+		} );
+		registry.dispatch( editorStore ).setIsInserterOpened( value );
 	};
-}
 
 /**
  * Returns an action object used to open/close the list view.
  *
+ * @deprecated
+ *
  * @param {boolean} isOpen A boolean representing whether the list view should be opened or closed.
- * @return {Object} Action object.
  */
 export const setIsListViewOpened =
 	( isOpen ) =>
-	( { dispatch, registry } ) => {
-		const isDistractionFree = registry
-			.select( preferencesStore )
-			.get( 'core/edit-post', 'distractionFree' );
-		if ( isDistractionFree && isOpen ) {
-			dispatch.toggleDistractionFree();
-		}
-		dispatch( {
-			type: 'SET_IS_LIST_VIEW_OPENED',
-			isOpen,
+	( { registry } ) => {
+		deprecated( "dispatch( 'core/edit-post' ).setIsListViewOpened", {
+			since: '6.5',
+			alternative: "dispatch( 'core/editor').setIsListViewOpened",
 		} );
+		registry.dispatch( editorStore ).setIsListViewOpened( isOpen );
 	};
 
 /**
@@ -594,8 +586,8 @@ export const toggleDistractionFree =
 				registry
 					.dispatch( preferencesStore )
 					.set( 'core/edit-post', 'fixedToolbar', true );
-				dispatch.setIsInserterOpened( false );
-				dispatch.setIsListViewOpened( false );
+				registry.dispatch( editorStore ).setIsInserterOpened( false );
+				registry.dispatch( editorStore ).setIsListViewOpened( false );
 				dispatch.closeGeneralSidebar();
 			} );
 		}

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -80,44 +80,6 @@ export function metaBoxLocations( state = {}, action ) {
 }
 
 /**
- * Reducer to set the block inserter panel open or closed.
- *
- * Note: this reducer interacts with the list view panel reducer
- * to make sure that only one of the two panels is open at the same time.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- */
-export function blockInserterPanel( state = false, action ) {
-	switch ( action.type ) {
-		case 'SET_IS_LIST_VIEW_OPENED':
-			return action.isOpen ? false : state;
-		case 'SET_IS_INSERTER_OPENED':
-			return action.value;
-	}
-	return state;
-}
-
-/**
- * Reducer to set the list view panel open or closed.
- *
- * Note: this reducer interacts with the inserter panel reducer
- * to make sure that only one of the two panels is open at the same time.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- */
-export function listViewPanel( state = false, action ) {
-	switch ( action.type ) {
-		case 'SET_IS_INSERTER_OPENED':
-			return action.value ? false : state;
-		case 'SET_IS_LIST_VIEW_OPENED':
-			return action.isOpen;
-	}
-	return state;
-}
-
-/**
  * Reducer tracking whether meta boxes are initialized.
  *
  * @param {boolean} state
@@ -142,6 +104,4 @@ const metaBoxes = combineReducers( {
 export default combineReducers( {
 	metaBoxes,
 	publishSidebarActive,
-	blockInserterPanel,
-	listViewPanel,
 } );

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -13,13 +13,13 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import deprecated from '@wordpress/deprecated';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
 const EMPTY_ARRAY = [];
 const EMPTY_OBJECT = {};
-const EMPTY_INSERTION_POINT = {
-	rootClientId: undefined,
-	insertionIndex: undefined,
-	filterValue: undefined,
-};
 
 /**
  * Returns the current editing mode.
@@ -487,28 +487,41 @@ export const __experimentalGetPreviewDeviceType = createRegistrySelector(
 /**
  * Returns true if the inserter is opened.
  *
+ * @deprecated
+ *
  * @param {Object} state Global application state.
  *
  * @return {boolean} Whether the inserter is opened.
  */
-export function isInserterOpened( state ) {
-	return !! state.blockInserterPanel;
-}
+export const isInserterOpened = createRegistrySelector( ( select ) => () => {
+	deprecated( `select( 'core/edit-post' ).isInserterOpened`, {
+		since: '6.5',
+		alternative: `select( 'core/editor' ).isInserterOpened`,
+	} );
+	return select( editorStore ).isInserterOpened();
+} );
 
 /**
  * Get the insertion point for the inserter.
+ *
+ * @deprecated
  *
  * @param {Object} state Global application state.
  *
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
-export function __experimentalGetInsertionPoint( state ) {
-	if ( typeof state.blockInserterPanel === 'boolean' ) {
-		return EMPTY_INSERTION_POINT;
+export const __experimentalGetInsertionPoint = createRegistrySelector(
+	( select ) => () => {
+		deprecated(
+			`select( 'core/edit-post' ).__experimentalGetInsertionPoint`,
+			{
+				since: '6.5',
+				version: '6.7',
+			}
+		);
+		return unlock( select( editorStore ) ).getInsertionPoint();
 	}
-
-	return state.blockInserterPanel;
-}
+);
 
 /**
  * Returns true if the list view is opened.
@@ -517,9 +530,13 @@ export function __experimentalGetInsertionPoint( state ) {
  *
  * @return {boolean} Whether the list view is opened.
  */
-export function isListViewOpened( state ) {
-	return state.listViewPanel;
-}
+export const isListViewOpened = createRegistrySelector( ( select ) => () => {
+	deprecated( `select( 'core/edit-post' ).isListViewOpened`, {
+		since: '6.5',
+		alternative: `select( 'core/editor' ).isListViewOpened`,
+	} );
+	return select( editorStore ).isListViewOpened();
+} );
 
 /**
  * Returns true if the template editing mode is enabled.

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -271,7 +271,7 @@ describe( 'actions', () => {
 					.select( preferencesStore )
 					.get( 'core/edit-post', 'fixedToolbar' )
 			).toBe( true );
-			expect( registry.select( editPostStore ).isListViewOpened() ).toBe(
+			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
 				false
 			);
 			expect( registry.select( editorStore ).isInserterOpened() ).toBe(

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -260,7 +260,7 @@ describe( 'actions', () => {
 			registry
 				.dispatch( preferencesStore )
 				.set( 'core/edit-post', 'fixedToolbar', true );
-			registry.dispatch( editPostStore ).setIsListViewOpened( true );
+			registry.dispatch( editorStore ).setIsListViewOpened( true );
 			registry
 				.dispatch( editPostStore )
 				.openGeneralSidebar( 'edit-post/block' );
@@ -274,7 +274,7 @@ describe( 'actions', () => {
 			expect( registry.select( editPostStore ).isListViewOpened() ).toBe(
 				false
 			);
-			expect( registry.select( editPostStore ).isInserterOpened() ).toBe(
+			expect( registry.select( editorStore ).isInserterOpened() ).toBe(
 				false
 			);
 			expect(
@@ -287,20 +287,6 @@ describe( 'actions', () => {
 					.select( preferencesStore )
 					.get( 'core/edit-post', 'distractionFree' )
 			).toBe( true );
-		} );
-	} );
-
-	describe( 'setIsListViewOpened', () => {
-		it( 'should turn off distraction free mode when opening the list view', () => {
-			registry
-				.dispatch( preferencesStore )
-				.set( 'core/edit-post', 'distractionFree', true );
-			registry.dispatch( editPostStore ).setIsListViewOpened( true );
-			expect(
-				registry
-					.select( preferencesStore )
-					.get( 'core/edit-post', 'distractionFree' )
-			).toBe( false );
 		} );
 	} );
 } );

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -1,14 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	isSavingMetaBoxes,
-	metaBoxLocations,
-	blockInserterPanel,
-	listViewPanel,
-} from '../reducer';
-
-import { setIsInserterOpened } from '../actions';
+import { isSavingMetaBoxes, metaBoxLocations } from '../reducer';
 
 describe( 'state', () => {
 	describe( 'isSavingMetaBoxes', () => {
@@ -86,80 +79,6 @@ describe( 'state', () => {
 				advanced: [ { id: 'd', title: 'D' } ],
 				side: [ { id: 's', title: 'S' } ],
 			} );
-		} );
-	} );
-
-	describe( 'blockInserterPanel()', () => {
-		it( 'should apply default state', () => {
-			expect( blockInserterPanel( undefined, {} ) ).toEqual( false );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			expect( blockInserterPanel( true, {} ) ).toBe( true );
-		} );
-
-		it( 'should set the open state of the inserter panel', () => {
-			expect(
-				blockInserterPanel( false, setIsInserterOpened( true ) )
-			).toBe( true );
-			expect(
-				blockInserterPanel( true, setIsInserterOpened( false ) )
-			).toBe( false );
-		} );
-
-		it( 'should close the inserter when opening the list view panel', () => {
-			expect(
-				blockInserterPanel( true, {
-					type: 'SET_IS_LIST_VIEW_OPENED',
-					isOpen: true,
-				} )
-			).toBe( false );
-		} );
-
-		it( 'should not change the state when closing the list view panel', () => {
-			expect(
-				blockInserterPanel( true, {
-					type: 'SET_IS_LIST_VIEW_OPENED',
-					isOpen: false,
-				} )
-			).toBe( true );
-		} );
-	} );
-
-	describe( 'listViewPanel()', () => {
-		it( 'should apply default state', () => {
-			expect( listViewPanel( undefined, {} ) ).toEqual( false );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			expect( listViewPanel( true, {} ) ).toBe( true );
-		} );
-
-		it( 'should set the open state of the list view panel', () => {
-			expect(
-				listViewPanel( false, {
-					type: 'SET_IS_LIST_VIEW_OPENED',
-					isOpen: true,
-				} )
-			).toBe( true );
-			expect(
-				listViewPanel( true, {
-					type: 'SET_IS_LIST_VIEW_OPENED',
-					isOpen: false,
-				} )
-			).toBe( false );
-		} );
-
-		it( 'should close the list view when opening the inserter panel', () => {
-			expect( listViewPanel( true, setIsInserterOpened( true ) ) ).toBe(
-				false
-			);
-		} );
-
-		it( 'should not change the state when closing the inserter panel', () => {
-			expect( listViewPanel( true, setIsInserterOpened( false ) ) ).toBe(
-				true
-			);
 		} );
 	} );
 } );

--- a/packages/edit-post/src/store/test/selectors.js
+++ b/packages/edit-post/src/store/test/selectors.js
@@ -6,8 +6,6 @@ import {
 	isSavingMetaBoxes,
 	getActiveMetaBoxLocations,
 	isMetaBoxLocationActive,
-	isInserterOpened,
-	isListViewOpened,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -105,28 +103,6 @@ describe( 'selectors', () => {
 			const result = isMetaBoxLocationActive( state, 'side' );
 
 			expect( result ).toBe( true );
-		} );
-	} );
-
-	describe( 'isInserterOpened', () => {
-		it( 'returns the block inserter panel isOpened state', () => {
-			const state = {
-				blockInserterPanel: true,
-			};
-			expect( isInserterOpened( state ) ).toBe( true );
-			state.blockInserterPanel = false;
-			expect( isInserterOpened( state ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'isListViewOpened', () => {
-		it( 'returns the list view panel isOpened state', () => {
-			const state = {
-				listViewPanel: true,
-			};
-			expect( isListViewOpened( state ) ).toBe( true );
-			state.listViewPanel = false;
-			expect( isListViewOpened( state ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useViewportMatch } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
@@ -89,7 +89,6 @@ function useArchiveLabel( templateSlug ) {
 }
 
 export function useSpecificEditorSettings() {
-	const { setIsInserterOpened } = useDispatch( editSiteStore );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const {
 		templateSlug,
@@ -152,7 +151,6 @@ export function useSpecificEditorSettings() {
 			...settings,
 
 			supportsTemplateMode: true,
-			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
 			allowRightClickOverrides,
 			isDistractionFree,
@@ -166,7 +164,6 @@ export function useSpecificEditorSettings() {
 		};
 	}, [
 		settings,
-		setIsInserterOpened,
 		focusMode,
 		allowRightClickOverrides,
 		isDistractionFree,

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -13,6 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
 import { useFocusOnMount, useFocusReturn } from '@wordpress/compose';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -76,14 +77,14 @@ function EditorCanvasContainer( {
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
+	const { setIsListViewOpened } = useDispatch( editorStore );
+
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const sectionFocusReturnRef = useFocusReturn();
 	const title = useMemo(
 		() => getEditorCanvasContainerTitle( editorCanvasContainerView ),
 		[ editorCanvasContainerView ]
 	);
-
-	const { setIsListViewOpened } = useDispatch( editSiteStore );
 
 	function onCloseContainer() {
 		if ( typeof onClose === 'function' ) {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -108,17 +108,14 @@ export default function Editor( { listViewToggleElement, isLoading } ) {
 		showIconLabels,
 		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
-		const {
-			getEditedPostContext,
-			getEditorMode,
-			getCanvasMode,
-			isInserterOpened,
-			isListViewOpened,
-		} = unlock( select( editSiteStore ) );
+		const { getEditedPostContext, getEditorMode, getCanvasMode } = unlock(
+			select( editSiteStore )
+		);
 		const { __unstableGetEditorMode } = select( blockEditorStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const { getEntityRecord } = select( coreDataStore );
-		const { getRenderingMode } = select( editorStore );
+		const { getRenderingMode, isInserterOpened, isListViewOpened } =
+			select( editorStore );
 		const _context = getEditedPostContext();
 
 		// The currently selected entity to display.

--- a/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
@@ -40,11 +40,12 @@ export default function DocumentTools( {
 	const inserterButton = useRef();
 	const { isInserterOpen, isListViewOpen, listViewShortcut, isVisualMode } =
 		useSelect( ( select ) => {
-			const { isInserterOpened, isListViewOpened, getEditorMode } =
-				select( editSiteStore );
+			const { getEditorMode } = select( editSiteStore );
 			const { getShortcutRepresentation } = select(
 				keyboardShortcutsStore
 			);
+			const { isInserterOpened, isListViewOpened } =
+				select( editorStore );
 
 			return {
 				isInserterOpen: isInserterOpened(),
@@ -55,11 +56,9 @@ export default function DocumentTools( {
 				isVisualMode: getEditorMode() === 'visual',
 			};
 		}, [] );
-
-	const { setIsInserterOpened, setIsListViewOpened } =
-		useDispatch( editSiteStore );
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
-	const { setDeviceType } = useDispatch( editorStore );
+	const { setDeviceType, setIsInserterOpened, setIsListViewOpened } =
+		useDispatch( editorStore );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 

--- a/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
@@ -15,6 +15,7 @@ import {
 	PreferenceToggleMenuItem,
 	store as preferencesStore,
 } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -37,8 +38,9 @@ import { store as siteEditorStore } from '../../../store';
 export default function MoreMenu( { showIconLabels } ) {
 	const registry = useRegistry();
 
-	const { setIsInserterOpened, setIsListViewOpened, closeGeneralSidebar } =
-		useDispatch( siteEditorStore );
+	const { closeGeneralSidebar } = useDispatch( siteEditorStore );
+	const { setIsInserterOpened, setIsListViewOpened } =
+		useDispatch( editorStore );
 	const { openModal } = useDispatch( interfaceStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
 

--- a/packages/edit-site/src/components/keyboard-shortcuts/edit-mode.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/edit-mode.js
@@ -6,6 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as editorStore } from '@wordpress/editor';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -18,7 +19,7 @@ import { STORE_NAME } from '../../store/constants';
 function KeyboardShortcutsEditMode() {
 	const { getEditorMode } = useSelect( editSiteStore );
 	const isListViewOpen = useSelect(
-		( select ) => select( editSiteStore ).isListViewOpened(),
+		( select ) => select( editorStore ).isListViewOpened(),
 		[]
 	);
 	const isBlockInspectorOpen = useSelect(
@@ -29,11 +30,11 @@ function KeyboardShortcutsEditMode() {
 		[]
 	);
 	const { redo, undo } = useDispatch( coreStore );
-	const { setIsListViewOpened, switchEditorMode, toggleDistractionFree } =
+	const { switchEditorMode, toggleDistractionFree } =
 		useDispatch( editSiteStore );
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
-
+	const { setIsListViewOpened } = useDispatch( editorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const { getBlockName, getSelectedBlockClientId, getBlockAttributes } =
 		useSelect( blockEditorStore );

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -11,6 +11,7 @@ import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -28,8 +29,9 @@ export default function EditSitePreferencesModal() {
 	const toggleModal = () =>
 		isModalActive ? closeModal() : openModal( PREFERENCES_MODAL_NAME );
 	const registry = useRegistry();
-	const { closeGeneralSidebar, setIsListViewOpened, setIsInserterOpened } =
-		useDispatch( editSiteStore );
+	const { closeGeneralSidebar } = useDispatch( editSiteStore );
+	const { setIsListViewOpened, setIsInserterOpened } =
+		useDispatch( editorStore );
 
 	const { set: setPreference } = useDispatch( preferencesStore );
 	const toggleDistractionFree = () => {

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -11,16 +11,17 @@ import {
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 export default function InserterSidebar() {
-	const { setIsInserterOpened } = useDispatch( editSiteStore );
+	const { setIsInserterOpened } = useDispatch( editorStore );
 	const insertionPoint = useSelect(
-		( select ) => select( editSiteStore ).__experimentalGetInsertionPoint(),
+		( select ) => unlock( select( editorStore ) ).getInsertionPoint(),
 		[]
 	);
 

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -11,17 +11,17 @@ import { closeSmall } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
 import { focus } from '@wordpress/dom';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { PrivateListView } = unlock( blockEditorPrivateApis );
 
 export default function ListViewSidebar( { listViewToggleElement } ) {
-	const { setIsListViewOpened } = useDispatch( editSiteStore );
+	const { setIsListViewOpened } = useDispatch( editorStore );
 
 	// This hook handles focus when the sidebar first renders.
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -14,6 +14,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -77,7 +78,7 @@ export default function GlobalStylesSidebar() {
 		}
 	}, [ shouldClearCanvasContainerView ] );
 
-	const { setIsListViewOpened } = useDispatch( editSiteStore );
+	const { setIsListViewOpened } = useDispatch( editorStore );
 	const { goTo } = useNavigator();
 	const loadRevisions = () => {
 		setIsListViewOpened( false );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -9,6 +9,7 @@ import { __experimentalNavigatorButton as NavigatorButton } from '@wordpress/com
 import { useViewportMatch } from '@wordpress/compose';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { useCallback } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -86,8 +87,8 @@ function SidebarNavigationScreenGlobalStylesContent() {
 export default function SidebarNavigationScreenGlobalStyles() {
 	const { revisions, isLoading: isLoadingRevisions } =
 		useGlobalStylesRevisions();
-	const { openGeneralSidebar, setIsListViewOpened } =
-		useDispatch( editSiteStore );
+	const { openGeneralSidebar } = useDispatch( editSiteStore );
+	const { setIsListViewOpened } = useDispatch( editorStore );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const { setCanvasMode, setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -217,7 +217,8 @@ function useEditUICommands() {
 		isListViewOpen,
 		isDistractionFree,
 	} = useSelect( ( select ) => {
-		const { isListViewOpened, getEditorMode } = select( editSiteStore );
+		const { getEditorMode } = select( editSiteStore );
+		const { isListViewOpened } = select( editorStore );
 		return {
 			canvasMode: unlock( select( editSiteStore ) ).getCanvasMode(),
 			editorMode: getEditorMode(),

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -608,7 +608,7 @@ export const toggleDistractionFree =
 				registry
 					.dispatch( preferencesStore )
 					.set( 'core/edit-site', 'fixedToolbar', true );
-				dispatch.dispatch( editorStore ).setIsInserterOpened( false );
+				registry.dispatch( editorStore ).setIsInserterOpened( false );
 				registry.dispatch( editorStore ).setIsListViewOpened( false );
 				dispatch.closeGeneralSidebar();
 			} );

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -321,23 +321,38 @@ export function setIsNavigationPanelOpened() {
 }
 
 /**
- * Opens or closes the inserter.
+ * Returns an action object used to open/close the inserter.
  *
- * @param {boolean|Object} value                Whether the inserter should be
- *                                              opened (true) or closed (false).
- *                                              To specify an insertion point,
- *                                              use an object.
- * @param {string}         value.rootClientId   The root client ID to insert at.
- * @param {number}         value.insertionIndex The index to insert at.
+ * @deprecated
  *
- * @return {Object} Action object.
+ * @param {boolean|Object} value Whether the inserter should be opened (true) or closed (false).
  */
-export function setIsInserterOpened( value ) {
-	return {
-		type: 'SET_IS_INSERTER_OPENED',
-		value,
+export const setIsInserterOpened =
+	( value ) =>
+	( { registry } ) => {
+		deprecated( "dispatch( 'core/edit-site' ).setIsInserterOpened", {
+			since: '6.5',
+			alternative: "dispatch( 'core/editor').setIsInserterOpened",
+		} );
+		registry.dispatch( editorStore ).setIsInserterOpened( value );
 	};
-}
+
+/**
+ * Returns an action object used to open/close the list view.
+ *
+ * @deprecated
+ *
+ * @param {boolean} isOpen A boolean representing whether the list view should be opened or closed.
+ */
+export const setIsListViewOpened =
+	( isOpen ) =>
+	( { registry } ) => {
+		deprecated( "dispatch( 'core/edit-site' ).setIsListViewOpened", {
+			since: '6.5',
+			alternative: "dispatch( 'core/editor').setIsListViewOpened",
+		} );
+		registry.dispatch( editorStore ).setIsListViewOpened( isOpen );
+	};
 
 /**
  * Returns an action object used to update the settings.
@@ -352,27 +367,6 @@ export function updateSettings( settings ) {
 		settings,
 	};
 }
-
-/**
- * Sets whether the list view panel should be open.
- *
- * @param {boolean} isOpen If true, opens the list view. If false, closes it.
- *                         It does not toggle the state, but sets it directly.
- */
-export const setIsListViewOpened =
-	( isOpen ) =>
-	( { dispatch, registry } ) => {
-		const isDistractionFree = registry
-			.select( preferencesStore )
-			.get( 'core/edit-site', 'distractionFree' );
-		if ( isDistractionFree && isOpen ) {
-			dispatch.toggleDistractionFree();
-		}
-		dispatch( {
-			type: 'SET_IS_LIST_VIEW_OPENED',
-			isOpen,
-		} );
-	};
 
 /**
  * Sets whether the save view panel should be open.
@@ -614,8 +608,8 @@ export const toggleDistractionFree =
 				registry
 					.dispatch( preferencesStore )
 					.set( 'core/edit-site', 'fixedToolbar', true );
-				dispatch.setIsInserterOpened( false );
-				dispatch.setIsListViewOpened( false );
+				dispatch.dispatch( editorStore ).setIsInserterOpened( false );
+				registry.dispatch( editorStore ).setIsListViewOpened( false );
 				dispatch.closeGeneralSidebar();
 			} );
 		}

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -3,6 +3,7 @@
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Action that switches the canvas mode.
@@ -28,8 +29,11 @@ export const setCanvasMode =
 				.select( preferencesStore )
 				.get( 'core/edit-site', 'distractionFree' )
 		) {
-			dispatch.setIsListViewOpened( true );
+			registry.dispatch( editorStore ).setIsListViewOpened( true );
+		} else {
+			registry.dispatch( editorStore ).setIsListViewOpened( false );
 		}
+		registry.dispatch( editorStore ).setIsInserterOpened( false );
 	};
 
 /**

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -51,48 +51,6 @@ export function editedPost( state = {}, action ) {
 }
 
 /**
- * Reducer to set the block inserter panel open or closed.
- *
- * Note: this reducer interacts with the navigation and list view panels reducers
- * to make sure that only one of the three panels is open at the same time.
- *
- * @param {boolean|Object} state  Current state.
- * @param {Object}         action Dispatched action.
- */
-export function blockInserterPanel( state = false, action ) {
-	switch ( action.type ) {
-		case 'SET_IS_LIST_VIEW_OPENED':
-			return action.isOpen ? false : state;
-		case 'SET_IS_INSERTER_OPENED':
-			return action.value;
-		case 'SET_CANVAS_MODE':
-			return false;
-	}
-	return state;
-}
-
-/**
- * Reducer to set the list view panel open or closed.
- *
- * Note: this reducer interacts with the navigation and inserter panels reducers
- * to make sure that only one of the three panels is open at the same time.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- */
-export function listViewPanel( state = false, action ) {
-	switch ( action.type ) {
-		case 'SET_IS_INSERTER_OPENED':
-			return action.value ? false : state;
-		case 'SET_IS_LIST_VIEW_OPENED':
-			return action.isOpen;
-		case 'SET_CANVAS_MODE':
-			return false;
-	}
-	return state;
-}
-
-/**
  * Reducer to set the save view panel open or closed.
  *
  * @param {Object} state  Current state.
@@ -143,8 +101,6 @@ function editorCanvasContainerView( state = undefined, action ) {
 export default combineReducers( {
 	settings,
 	editedPost,
-	blockInserterPanel,
-	listViewPanel,
 	saveViewPanel,
 	canvasMode,
 	editorCanvasContainerView,

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -14,6 +14,8 @@ import { store as editorStore } from '@wordpress/editor';
  */
 import { getFilteredTemplatePartBlocks } from './utils';
 import { TEMPLATE_PART_POST_TYPE } from '../utils/constants';
+import { unlock } from '../lock-unlock';
+
 /**
  * @typedef {'template'|'template_type'} TemplateType Template type.
  */
@@ -169,66 +171,58 @@ export function getPage( state ) {
 }
 
 /**
- * Returns the current opened/closed state of the inserter panel.
+ * Returns true if the inserter is opened.
+ *
+ * @deprecated
  *
  * @param {Object} state Global application state.
  *
- * @return {boolean} True if the inserter panel should be open; false if closed.
+ * @return {boolean} Whether the inserter is opened.
  */
-export function isInserterOpened( state ) {
-	return !! state.blockInserterPanel;
-}
+export const isInserterOpened = createRegistrySelector( ( select ) => () => {
+	deprecated( `select( 'core/edit-site' ).isInserterOpened`, {
+		since: '6.5',
+		alternative: `select( 'core/editor' ).isInserterOpened`,
+	} );
+	return select( editorStore ).isInserterOpened();
+} );
 
 /**
  * Get the insertion point for the inserter.
+ *
+ * @deprecated
  *
  * @param {Object} state Global application state.
  *
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
 export const __experimentalGetInsertionPoint = createRegistrySelector(
-	( select ) => ( state ) => {
-		if ( typeof state.blockInserterPanel === 'object' ) {
-			const { rootClientId, insertionIndex, filterValue } =
-				state.blockInserterPanel;
-			return { rootClientId, insertionIndex, filterValue };
-		}
-
-		if (
-			isPage( state ) &&
-			select( editorStore ).getRenderingMode() !== 'template-only'
-		) {
-			const [ postContentClientId ] =
-				select( blockEditorStore ).__experimentalGetGlobalBlocksByName(
-					'core/post-content'
-				);
-			if ( postContentClientId ) {
-				return {
-					rootClientId: postContentClientId,
-					insertionIndex: undefined,
-					filterValue: undefined,
-				};
+	( select ) => () => {
+		deprecated(
+			`select( 'core/edit-site' ).__experimentalGetInsertionPoint`,
+			{
+				since: '6.5',
+				version: '6.7',
 			}
-		}
-
-		return {
-			rootClientId: undefined,
-			insertionIndex: undefined,
-			filterValue: undefined,
-		};
+		);
+		return unlock( select( editorStore ) ).getInsertionPoint();
 	}
 );
 
 /**
- * Returns the current opened/closed state of the list view panel.
+ * Returns true if the list view is opened.
  *
  * @param {Object} state Global application state.
  *
- * @return {boolean} True if the list view panel should be open; false if closed.
+ * @return {boolean} Whether the list view is opened.
  */
-export function isListViewOpened( state ) {
-	return state.listViewPanel;
-}
+export const isListViewOpened = createRegistrySelector( ( select ) => () => {
+	deprecated( `select( 'core/edit-site' ).isListViewOpened`, {
+		since: '6.5',
+		alternative: `select( 'core/editor' ).isListViewOpened`,
+	} );
+	return select( editorStore ).isListViewOpened();
+} );
 
 /**
  * Returns the current opened/closed state of the save panel.

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -76,34 +76,6 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'setIsListViewOpened', () => {
-		it( 'should set the list view opened state', () => {
-			const registry = createRegistryWithStores();
-
-			registry.dispatch( editSiteStore ).setIsListViewOpened( true );
-			expect( registry.select( editSiteStore ).isListViewOpened() ).toBe(
-				true
-			);
-
-			registry.dispatch( editSiteStore ).setIsListViewOpened( false );
-			expect( registry.select( editSiteStore ).isListViewOpened() ).toBe(
-				false
-			);
-		} );
-		it( 'should turn off distraction free mode when opening the list view', () => {
-			const registry = createRegistryWithStores();
-			registry
-				.dispatch( preferencesStore )
-				.set( 'core/edit-site', 'distractionFree', true );
-			registry.dispatch( editSiteStore ).setIsListViewOpened( true );
-			expect(
-				registry
-					.select( preferencesStore )
-					.get( 'core/edit-site', 'distractionFree' )
-			).toBe( false );
-		} );
-	} );
-
 	describe( 'openGeneralSidebar', () => {
 		it( 'should turn off distraction free mode when opening a general sidebar', () => {
 			const registry = createRegistryWithStores();
@@ -160,10 +132,10 @@ describe( 'actions', () => {
 					.select( preferencesStore )
 					.get( 'core/edit-site', 'fixedToolbar' )
 			).toBe( true );
-			expect( registry.select( editSiteStore ).isListViewOpened() ).toBe(
+			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
 				false
 			);
-			expect( registry.select( editSiteStore ).isInserterOpened() ).toBe(
+			expect( registry.select( editorStore ).isInserterOpened() ).toBe(
 				false
 			);
 			expect(

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -121,7 +121,7 @@ describe( 'actions', () => {
 			registry
 				.dispatch( preferencesStore )
 				.set( 'core/edit-site', 'fixedToolbar', true );
-			registry.dispatch( editSiteStore ).setIsListViewOpened( true );
+			registry.dispatch( editorStore ).setIsListViewOpened( true );
 			registry
 				.dispatch( editSiteStore )
 				.openGeneralSidebar( 'edit-site/global-styles' );

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -6,14 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import {
-	settings,
-	editedPost,
-	blockInserterPanel,
-	listViewPanel,
-} from '../reducer';
-
-import { setIsInserterOpened } from '../actions';
+import { settings, editedPost } from '../reducer';
 
 describe( 'state', () => {
 	describe( 'settings()', () => {
@@ -71,80 +64,6 @@ describe( 'state', () => {
 				id: 2,
 				context: { templateSlug: 'slug' },
 			} );
-		} );
-	} );
-
-	describe( 'blockInserterPanel()', () => {
-		it( 'should apply default state', () => {
-			expect( blockInserterPanel( undefined, {} ) ).toEqual( false );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			expect( blockInserterPanel( true, {} ) ).toBe( true );
-		} );
-
-		it( 'should set the open state of the inserter panel', () => {
-			expect(
-				blockInserterPanel( false, setIsInserterOpened( true ) )
-			).toBe( true );
-			expect(
-				blockInserterPanel( true, setIsInserterOpened( false ) )
-			).toBe( false );
-		} );
-
-		it( 'should close the inserter when opening the list view panel', () => {
-			expect(
-				blockInserterPanel( true, {
-					type: 'SET_IS_LIST_VIEW_OPENED',
-					isOpen: true,
-				} )
-			).toBe( false );
-		} );
-
-		it( 'should not change the state when closing the list view panel', () => {
-			expect(
-				blockInserterPanel( true, {
-					type: 'SET_IS_LIST_VIEW_OPENED',
-					isOpen: false,
-				} )
-			).toBe( true );
-		} );
-	} );
-
-	describe( 'listViewPanel()', () => {
-		it( 'should apply default state', () => {
-			expect( listViewPanel( undefined, {} ) ).toEqual( false );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			expect( listViewPanel( true, {} ) ).toBe( true );
-		} );
-
-		it( 'should set the open state of the list view panel', () => {
-			expect(
-				listViewPanel( false, {
-					type: 'SET_IS_LIST_VIEW_OPENED',
-					isOpen: true,
-				} )
-			).toBe( true );
-			expect(
-				listViewPanel( true, {
-					type: 'SET_IS_LIST_VIEW_OPENED',
-					isOpen: false,
-				} )
-			).toBe( false );
-		} );
-
-		it( 'should close the list view when opening the inserter panel', () => {
-			expect( listViewPanel( true, setIsInserterOpened( true ) ) ).toBe(
-				false
-			);
-		} );
-
-		it( 'should not change the state when closing the inserter panel', () => {
-			expect( listViewPanel( true, setIsInserterOpened( false ) ) ).toBe(
-				true
-			);
 		} );
 	} );
 } );

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -10,8 +10,6 @@ import {
 	getCanUserCreateMedia,
 	getEditedPostType,
 	getEditedPostId,
-	isInserterOpened,
-	isListViewOpened,
 	isPage,
 } from '../selectors';
 
@@ -42,28 +40,6 @@ describe( 'selectors', () => {
 		it( 'returns the template type', () => {
 			const state = { editedPost: { postType: 'wp_template' } };
 			expect( getEditedPostType( state ) ).toBe( 'wp_template' );
-		} );
-	} );
-
-	describe( 'isInserterOpened', () => {
-		it( 'returns the block inserter panel isOpened state', () => {
-			const state = {
-				blockInserterPanel: true,
-			};
-			expect( isInserterOpened( state ) ).toBe( true );
-			state.blockInserterPanel = false;
-			expect( isInserterOpened( state ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'isListViewOpened', () => {
-		it( 'returns the list view panel isOpened state', () => {
-			const state = {
-				listViewPanel: true,
-			};
-			expect( isListViewOpened( state ) ).toBe( true );
-			state.listViewPanel = false;
-			expect( isListViewOpened( state ) ).toBe( false );
 		} );
 	} );
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -25,7 +25,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalFeatures',
 	'__experimentalGlobalStylesBaseStyles',
 	'__experimentalPreferredStyleVariations',
-	'__experimentalSetIsInserterOpened',
 	'__unstableGalleryWithImageBlocks',
 	'alignWide',
 	'allowedBlockTypes',
@@ -178,7 +177,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		[ settingsBlockPatternCategories, restBlockPatternCategories ]
 	);
 
-	const { undo } = useDispatch( editorStore );
+	const { undo, setIsInserterOpened } = useDispatch( editorStore );
 
 	const { saveEntityRecord } = useDispatch( coreStore );
 
@@ -239,6 +238,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				postType === 'wp_navigation'
 					? [ [ 'core/navigation', {}, [] ] ]
 					: settings.template,
+			__experimentalSetIsInserterOpened: setIsInserterOpened,
 		} ),
 		[
 			settings,
@@ -254,6 +254,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			pageOnFront,
 			pageForPosts,
 			postType,
+			setIsInserterOpened,
 		]
 	);
 }

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -690,6 +690,38 @@ export function removeEditorPanel( panelName ) {
 }
 
 /**
+ * Returns an action object used to open/close the inserter.
+ *
+ * @param {boolean|Object} value                Whether the inserter should be
+ *                                              opened (true) or closed (false).
+ *                                              To specify an insertion point,
+ *                                              use an object.
+ * @param {string}         value.rootClientId   The root client ID to insert at.
+ * @param {number}         value.insertionIndex The index to insert at.
+ *
+ * @return {Object} Action object.
+ */
+export function setIsInserterOpened( value ) {
+	return {
+		type: 'SET_IS_INSERTER_OPENED',
+		value,
+	};
+}
+
+/**
+ * Returns an action object used to open/close the list view.
+ *
+ * @param {boolean} isOpen A boolean representing whether the list view should be opened or closed.
+ * @return {Object} Action object.
+ */
+export function setIsListViewOpened( isOpen ) {
+	return {
+		type: 'SET_IS_LIST_VIEW_OPENED',
+		isOpen,
+	};
+}
+
+/**
  * Backward compatibility
  */
 

--- a/packages/editor/src/store/index.js
+++ b/packages/editor/src/store/index.js
@@ -10,6 +10,7 @@ import reducer from './reducer';
 import * as selectors from './selectors';
 import * as actions from './actions';
 import * as privateActions from './private-actions';
+import * as privateSelectors from './private-selectors';
 import { STORE_NAME } from './constants';
 import { unlock } from '../lock-unlock';
 
@@ -39,3 +40,4 @@ export const store = createReduxStore( STORE_NAME, {
 
 register( store );
 unlock( store ).registerPrivateActions( privateActions );
+unlock( store ).registerPrivateSelectors( privateSelectors );

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createRegistrySelector } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getRenderingMode } from './selectors';
+
+const EMPTY_INSERTION_POINT = {
+	rootClientId: undefined,
+	insertionIndex: undefined,
+	filterValue: undefined,
+};
+
+/**
+ * Get the insertion point for the inserter.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} The root client ID, index to insert at and starting filter value.
+ */
+export const getInsertionPoint = createRegistrySelector(
+	( select ) => ( state ) => {
+		if ( typeof state.blockInserterPanel === 'object' ) {
+			return state.blockInserterPanel;
+		}
+
+		if ( getRenderingMode( state ) === 'template-locked' ) {
+			const [ postContentClientId ] =
+				select( blockEditorStore ).__experimentalGetGlobalBlocksByName(
+					'core/post-content'
+				);
+			if ( postContentClientId ) {
+				return {
+					rootClientId: postContentClientId,
+					insertionIndex: undefined,
+					filterValue: undefined,
+				};
+			}
+		}
+
+		return EMPTY_INSERTION_POINT;
+	}
+);

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -311,6 +311,44 @@ export function removedPanels( state = [], action ) {
 	return state;
 }
 
+/**
+ * Reducer to set the block inserter panel open or closed.
+ *
+ * Note: this reducer interacts with the list view panel reducer
+ * to make sure that only one of the two panels is open at the same time.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ */
+export function blockInserterPanel( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_IS_LIST_VIEW_OPENED':
+			return action.isOpen ? false : state;
+		case 'SET_IS_INSERTER_OPENED':
+			return action.value;
+	}
+	return state;
+}
+
+/**
+ * Reducer to set the list view panel open or closed.
+ *
+ * Note: this reducer interacts with the inserter panel reducer
+ * to make sure that only one of the two panels is open at the same time.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ */
+export function listViewPanel( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_IS_INSERTER_OPENED':
+			return action.value ? false : state;
+		case 'SET_IS_LIST_VIEW_OPENED':
+			return action.isOpen;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	postId,
 	postType,
@@ -325,4 +363,6 @@ export default combineReducers( {
 	renderingMode,
 	deviceType,
 	removedPanels,
+	blockInserterPanel,
+	listViewPanel,
 } );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1279,6 +1279,28 @@ export function getDeviceType( state ) {
 	return state.deviceType;
 }
 
+/**
+ * Returns true if the list view is opened.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the list view is opened.
+ */
+export function isListViewOpened( state ) {
+	return state.listViewPanel;
+}
+
+/**
+ * Returns true if the inserter is opened.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the inserter is opened.
+ */
+export function isInserterOpened( state ) {
+	return !! state.blockInserterPanel;
+}
+
 /*
  * Backward compatibility
  */

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -15,7 +15,10 @@ import {
 	postSavingLock,
 	postAutosavingLock,
 	removedPanels,
+	blockInserterPanel,
+	listViewPanel,
 } from '../reducer';
+import { setIsInserterOpened } from '../actions';
 
 describe( 'state', () => {
 	describe( 'hasSameKeys()', () => {
@@ -283,6 +286,80 @@ describe( 'state', () => {
 				panelName: 'post-status',
 			} );
 			expect( state ).toBe( original );
+		} );
+	} );
+
+	describe( 'blockInserterPanel()', () => {
+		it( 'should apply default state', () => {
+			expect( blockInserterPanel( undefined, {} ) ).toEqual( false );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			expect( blockInserterPanel( true, {} ) ).toBe( true );
+		} );
+
+		it( 'should set the open state of the inserter panel', () => {
+			expect(
+				blockInserterPanel( false, setIsInserterOpened( true ) )
+			).toBe( true );
+			expect(
+				blockInserterPanel( true, setIsInserterOpened( false ) )
+			).toBe( false );
+		} );
+
+		it( 'should close the inserter when opening the list view panel', () => {
+			expect(
+				blockInserterPanel( true, {
+					type: 'SET_IS_LIST_VIEW_OPENED',
+					isOpen: true,
+				} )
+			).toBe( false );
+		} );
+
+		it( 'should not change the state when closing the list view panel', () => {
+			expect(
+				blockInserterPanel( true, {
+					type: 'SET_IS_LIST_VIEW_OPENED',
+					isOpen: false,
+				} )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'listViewPanel()', () => {
+		it( 'should apply default state', () => {
+			expect( listViewPanel( undefined, {} ) ).toEqual( false );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			expect( listViewPanel( true, {} ) ).toBe( true );
+		} );
+
+		it( 'should set the open state of the list view panel', () => {
+			expect(
+				listViewPanel( false, {
+					type: 'SET_IS_LIST_VIEW_OPENED',
+					isOpen: true,
+				} )
+			).toBe( true );
+			expect(
+				listViewPanel( true, {
+					type: 'SET_IS_LIST_VIEW_OPENED',
+					isOpen: false,
+				} )
+			).toBe( false );
+		} );
+
+		it( 'should close the list view when opening the inserter panel', () => {
+			expect( listViewPanel( true, setIsInserterOpened( true ) ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'should not change the state when closing the inserter panel', () => {
+			expect( listViewPanel( true, setIsInserterOpened( false ) ) ).toBe(
+				true
+			);
 		} );
 	} );
 } );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -193,6 +193,8 @@ const {
 	__experimentalGetTemplateInfo,
 	__experimentalGetDefaultTemplatePartAreas,
 	isEditorPanelRemoved,
+	isInserterOpened,
+	isListViewOpened,
 } = selectors;
 
 const defaultTemplateTypes = [
@@ -3033,6 +3035,28 @@ describe( 'selectors', () => {
 			} );
 
 			expect( isEditorPanelRemoved( state, 'post-status' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isInserterOpened', () => {
+		it( 'returns the block inserter panel isOpened state', () => {
+			const state = {
+				blockInserterPanel: true,
+			};
+			expect( isInserterOpened( state ) ).toBe( true );
+			state.blockInserterPanel = false;
+			expect( isInserterOpened( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isListViewOpened', () => {
+		it( 'returns the list view panel isOpened state', () => {
+			const state = {
+				listViewPanel: true,
+			};
+			expect( isListViewOpened( state ) ).toBe( true );
+			state.listViewPanel = false;
+			expect( isListViewOpened( state ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related #52632 

## What?

This PR continues the work on the great unification between post and site editors. This is a preparation PR. In order to unify the inserters and the list views and the headers of the editors, we need to ensure they're using the same state. So this PR moves the list view and inserter states (selectors and actions) to the editor package. There should be no functional change, e2e tests should help us validate the change.
