### PR TITLE
Block Editor: Combine selectors in the 'BackgroundImagePanelItem' component

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -144,20 +144,21 @@ function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 }
 
 function BackgroundImagePanelItem( { clientId, setAttributes } ) {
-	const style = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
+	const { style, mediaUpload } = useSelect(
+		( select ) => {
+			const { getBlockAttributes, getSettings } =
+				select( blockEditorStore );
+
+			return {
+				style: getBlockAttributes( clientId )?.style,
+				mediaUpload: getSettings().mediaUpload,
+			};
+		},
 		[ clientId ]
 	);
 	const { id, title, url } = style?.background?.backgroundImage || {};
 
 	const replaceContainerRef = useRef();
-
-	const { mediaUpload } = useSelect( ( select ) => {
-		return {
-			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
-		};
-	} );
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const onUploadError = ( message ) => {


### PR DESCRIPTION
## What?
A micro-optimization. PR combines two `block-editor` store subscriptions into one for the `BackgroundImagePanelItem` component.

## Why?
Reduces the number of store subscriptions each time the panel is rendered. See https://github.com/WordPress/gutenberg/pull/54819#issuecomment-1761202859.

## Testing Instructions
1. Open a post or page.
2. Insert a Group block.
3. Confirm uploading and settings background image works as before.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-12-18 at 16 25 38](https://github.com/WordPress/gutenberg/assets/240569/7c0e341d-5159-4a3b-a166-64057472dd48)
