### PR TITLE
Block Editor: Try removing extra memoization for individual style panels

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -24,7 +24,6 @@ import { Platform, useCallback, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
-import { pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -302,7 +301,7 @@ function BackgroundImagePanelItem( { clientId, setAttributes } ) {
 	);
 }
 
-function BackgroundImagePanelPure( props ) {
+export function BackgroundImagePanel( props ) {
 	const [ backgroundImage ] = useSettings( 'background.backgroundImage' );
 	if (
 		! backgroundImage ||
@@ -317,8 +316,3 @@ function BackgroundImagePanelPure( props ) {
 		</InspectorControls>
 	);
 }
-
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-export const BackgroundImagePanel = pure( BackgroundImagePanelPure );

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import { getBlockSupport } from '@wordpress/blocks';
 import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/components';
-import { pure } from '@wordpress/compose';
 import { Platform, useCallback, useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
@@ -133,7 +132,7 @@ function BordersInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-function BorderPanelPure( { clientId, name, setAttributes, settings } ) {
+export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasBorderPanel( settings );
 	function selector( select ) {
 		const { style, borderColor } =
@@ -169,11 +168,6 @@ function BorderPanelPure( { clientId, name, setAttributes, settings } ) {
 		/>
 	);
 }
-
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-export const BorderPanel = pure( BorderPanelPure );
 
 /**
  * Determine whether there is block support for border properties.

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport } from '@wordpress/blocks';
 import { useMemo, Platform, useCallback } from '@wordpress/element';
-import { pure } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -267,7 +266,7 @@ function ColorInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-function ColorEditPure( { clientId, name, setAttributes, settings } ) {
+export function ColorEdit( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasColorPanel( settings );
 	function selector( select ) {
 		const { style, textColor, backgroundColor, gradient } =
@@ -335,11 +334,6 @@ function ColorEditPure( { clientId, name, setAttributes, settings } ) {
 		</StylesColorPanel>
 	);
 }
-
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-export const ColorEdit = pure( ColorEditPure );
 
 function useBlockProps( {
 	name,

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -5,7 +5,6 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
-import { pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -66,7 +65,7 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-function DimensionsPanelPure( { clientId, name, setAttributes, settings } ) {
+export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
 	const value = useSelect(
 		( select ) =>
@@ -125,11 +124,6 @@ function DimensionsPanelPure( { clientId, name, setAttributes, settings } ) {
 		</>
 	);
 }
-
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-export const DimensionsPanel = pure( DimensionsPanelPure );
 
 /**
  * @deprecated

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -4,7 +4,6 @@
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useMemo, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -109,7 +108,7 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-function TypographyPanelPure( { clientId, name, setAttributes, settings } ) {
+export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 	function selector( select ) {
 		const { style, fontFamily, fontSize } =
 			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
@@ -146,11 +145,6 @@ function TypographyPanelPure( { clientId, name, setAttributes, settings } ) {
 		/>
 	);
 }
-
-// We don't want block controls to re-render when typing inside a block. `pure`
-// will prevent re-renders unless props change, so only pass the needed props
-// and not the whole attributes object.
-export const TypographyPanel = pure( TypographyPanelPure );
 
 export const hasTypographySupport = ( blockName ) => {
 	return TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>


### PR DESCRIPTION
## What?
PR removes extra memoization for individual style panels.

## Why?
I think this is no longer required after #56813. The `BlockStyleControls` is already memoized; it and all its children subscribe to the `style` attribute, so they'll all re-render when the attribute changes.

## Testing Instructions
* When typing inside a block, it shouldn't re-render the panels.
* The re-render behavior should be the same as introduced in #56783.
* Most importantly, this shouldn't cause typing performance regressions.
