### PR TITLE
InserterListItem: use item.isDisabled to detect disabled item

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -39,15 +39,16 @@ function InserterListItem( {
 				color: item.icon.foreground,
 		  }
 		: {};
-	const blocks = useMemo( () => {
-		return [
+	const blocks = useMemo(
+		() => [
 			createBlock(
 				item.name,
 				item.initialAttributes,
 				createBlocksFromInnerBlocksTemplate( item.innerBlocks )
 			),
-		];
-	}, [ item.name, item.initialAttributes, item.initialAttributes ] );
+		],
+		[ item.name, item.initialAttributes, item.innerBlocks ]
+	);
 
 	const isSynced =
 		( isReusableBlock( item ) && item.syncStatus !== 'unsynced' ) ||
@@ -55,7 +56,7 @@ function InserterListItem( {
 
 	return (
 		<InserterDraggableBlocks
-			isEnabled={ isDraggable && ! item.disabled }
+			isEnabled={ isDraggable && ! item.isDisabled }
 			blocks={ blocks }
 			icon={ item.icon }
 		>
@@ -63,7 +64,6 @@ function InserterListItem( {
 				<div
 					className={ classnames(
 						'block-editor-block-types-list__list-item',
-
 						{
 							'is-synced': isSynced,
 						}


### PR DESCRIPTION
Fixing a little bug I noticed when working on block lazy loading. When `InserterListItem` decides whether the item should be draggable or not, it looks at `item.disabled`, but the real name of the field is `item.isDisabled`! You can see for yourself in functions like `getInserterItems` or `buildBlockTypeItem` that build these `item` objects.

Another fix is correct dependencies in `useMemo` hook that creates the blocks to insert by the drag&drop. The `innerBlocks` dependency was missing. These data also come from `buildBlockTypeItem`, and their ultimate source is the block registration info and the registered variations. They should be constants.

The `createBlocks` call leads me to another idea: as a followup, we should optimize `InserterListItem` and `InserterDraggableBlocks` to create the blocks only when we really start the drag&drop process. On the vast majority of inserter render drag&drop is not used, so the blocks are created too eagerly.

Also, if drag&drop is disabled, like it always is in the Quick Inserter, we don't need to render `InserterDraggableBlocks` at all, it acts as a pass-through noop anyway. Let's render the `InserterListboxItem` directly.

WDYT?