### PR TITLE
useBlockTypesState: divide useSelect call into two

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -23,19 +23,17 @@ import { store as blockEditorStore } from '../../../store';
  * @return {Array} Returns the block types state. (block types, categories, collections, onSelect handler)
  */
 const useBlockTypesState = ( rootClientId, onInsert ) => {
-	const { categories, collections, items } = useSelect(
-		( select ) => {
-			const { getInserterItems } = select( blockEditorStore );
-			const { getCategories, getCollections } = select( blocksStore );
-
-			return {
-				categories: getCategories(),
-				collections: getCollections(),
-				items: getInserterItems( rootClientId ),
-			};
-		},
+	const [ items ] = useSelect(
+		( select ) => [
+			select( blockEditorStore ).getInserterItems( rootClientId ),
+		],
 		[ rootClientId ]
 	);
+
+	const [ categories, collections ] = useSelect( ( select ) => {
+		const { getCategories, getCollections } = select( blocksStore );
+		return [ getCategories(), getCollections() ];
+	}, [] );
 
 	const onSelectItem = useCallback(
 		(


### PR DESCRIPTION
A little optimization, or maybe just dividing one complex functions into two simpler ones. The `categories` and `collections` are constants, they don't change when `rootClientId` changes or when `block-editor` store is updated. Avoid calling the `getCategories/Collections` selectors when not needed.