### PR TITLE
useInputRules: remove unneeded check for inputRule

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -142,8 +142,8 @@ export function useInputRules( props ) {
 				return;
 			}
 
-			if ( __unstableAllowPrefixTransformations ) {
-				if ( inputRule() ) return;
+			if ( __unstableAllowPrefixTransformations && inputRule() ) {
+				return;
 			}
 
 			const value = getValue();

--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -142,7 +142,7 @@ export function useInputRules( props ) {
 				return;
 			}
 
-			if ( __unstableAllowPrefixTransformations && inputRule ) {
+			if ( __unstableAllowPrefixTransformations ) {
 				if ( inputRule() ) return;
 			}
 


### PR DESCRIPTION
One-liner that removes a check for existence of `inputRule`. It's a local function defined few lines above, it always exists. Originally added in #31752.