### PR TITLE
Replace color copy button icon with visible text

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+-   `ColorPicker`: Replace color copy button icon with visible text ([#57168](https://github.com/WordPress/gutenberg/pull/57168)).
 -   `BoxControl`: Better respect for the `min` prop in the Range Slider ([#67819](https://github.com/WordPress/gutenberg/pull/67819)).
 
 ### Experimental

--- a/packages/components/src/color-picker/color-copy-button.tsx
+++ b/packages/components/src/color-picker/color-copy-button.tsx
@@ -54,7 +54,7 @@ export const ColorCopyButton = ( props: ColorCopyButtonProps ) => {
 	}, [] );
 
 	return (
-		<Button variant="secondary" ref={ copyRef } __next40pxDefaultSize>
+		<Button variant="secondary" ref={ copyRef } size="compact">
 			{ copiedColor === color.toHex() ? __( 'Copied!' ) : __( 'Copy' ) }
 		</Button>
 	);

--- a/packages/components/src/color-picker/color-copy-button.tsx
+++ b/packages/components/src/color-picker/color-copy-button.tsx
@@ -54,7 +54,7 @@ export const ColorCopyButton = ( props: ColorCopyButtonProps ) => {
 	}, [] );
 
 	return (
-		<Button variant="secondary" size="small" ref={ copyRef }>
+		<Button variant="secondary" ref={ copyRef } __next40pxDefaultSize>
 			{ copiedColor === color.toHex() ? __( 'Copied!' ) : __( 'Copy' ) }
 		</Button>
 	);

--- a/packages/components/src/color-picker/color-copy-button.tsx
+++ b/packages/components/src/color-picker/color-copy-button.tsx
@@ -3,14 +3,12 @@
  */
 import { useCopyToClipboard } from '@wordpress/compose';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { copy } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { Button } from '../button';
-import Tooltip from '../tooltip';
 
 import type { ColorCopyButtonProps } from './types';
 
@@ -55,18 +53,9 @@ export const ColorCopyButton = ( props: ColorCopyButtonProps ) => {
 		};
 	}, [] );
 
-	const label =
-		copiedColor === color.toHex() ? __( 'Copied!' ) : __( 'Copy' );
-
 	return (
-		<Tooltip delay={ 0 } hideOnClick={ false } text={ label }>
-			<Button
-				size="compact"
-				aria-label={ label }
-				ref={ copyRef }
-				icon={ copy }
-				showTooltip={ false }
-			/>
-		</Tooltip>
+		<Button variant="secondary" size="small" ref={ copyRef }>
+			{ copiedColor === color.toHex() ? __( 'Copied!' ) : __( 'Copy' ) }
+		</Button>
 	);
 };

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -99,7 +99,7 @@ const UnconnectedColorPicker = (
 					/>
 				</AuxiliaryColorArtefactHStackHeader>
 				<ColorInputWrapper
-					direction={ colorType === 'hex' ? 'row' : 'column' }
+					direction="column"
 					align="flex-start"
 					gap={ 2 }
 				>

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -97,17 +97,21 @@ const UnconnectedColorPicker = (
 						hideLabelFromVision
 						variant="minimal"
 					/>
-					<ColorCopyButton
-						color={ safeColordColor }
-						colorType={ copyFormat || colorType }
-					/>
 				</AuxiliaryColorArtefactHStackHeader>
-				<ColorInputWrapper direction="column" gap={ 2 }>
+				<ColorInputWrapper
+					direction={ colorType === 'hex' ? 'row' : 'column' }
+					align="flex-start"
+					gap={ 2 }
+				>
 					<ColorInput
 						colorType={ colorType }
 						color={ safeColordColor }
 						onChange={ handleChange }
 						enableAlpha={ enableAlpha }
+					/>
+					<ColorCopyButton
+						color={ safeColordColor }
+						colorType={ copyFormat || colorType }
 					/>
 				</ColorInputWrapper>
 			</AuxiliaryColorArtefactWrapper>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57157

## What?
<!-- In a few words, what is the PR actually doing? -->
Replaces the Copy color icon button with a button with visible text

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- For accessibility and usability, icon buttons should only be used when there's not enough spaces for visibel text. Acois icon buttons, always prefer visible text.
- Better consistency with other Copy buttons e.g. the one to copy the permalink in the post-publish panel and ohter Copy buttons in the blocks toolbar.
- The previous icon button was completely unlabeled.
- Solves a problem with the disappearing tooltip that was supposed to show the confirmation text 'Copied!' adter a successful copy operation.
- The confirmation feedback now relies on the button visible text that changes to 'Copied!' . Although that's not ideal for accessibility, it is consistent with the copy permalink button in the post-publish panel.
- Avoids to use the tooltip entirely, thus avoiding to dynamically set an aria-describedby attribute.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the icon button with a button with visible text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Select a paragraph.
- Go to the settings panel > Color > Text
- Open the coloro picker and expand it to set a custom color.
- Observe the Copy button now shows visible text.
- Click the button.
- Observe the text changes to 'Copied!' .
- Paste the clipboard content into a text editor and observe the color code has been copied and pasted correctly

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before and after:

![Screenshot 2023-12-18 at 16 23 06](https://github.com/WordPress/gutenberg/assets/1682452/7c662227-1d01-486d-a94c-8a01e06b3dfd)
