### PR TITLE
Block list settings: fall back to block type defaults

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -72,12 +72,10 @@ function UncontrolledInnerBlocks( props ) {
 		name,
 		blockType,
 		innerBlocks,
-		parentLock,
 	} = props;
 
 	useNestedSettingsUpdate(
 		clientId,
-		parentLock,
 		allowedBlocks,
 		prioritizedInserterBlocks,
 		defaultBlock,
@@ -195,7 +193,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		name,
 		blockType,
 		innerBlocks,
-		parentLock,
 		parentClientId,
 		isDropZoneDisabled,
 	} = useSelect(
@@ -210,7 +207,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				hasSelectedInnerBlock,
 				__unstableGetEditorMode,
 				getBlocks,
-				getTemplateLock,
 				getBlockRootClientId,
 				__unstableIsWithinBlockOverlay,
 				__unstableHasActiveBlockOverlayActive,
@@ -225,9 +221,10 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			return {
 				__experimentalCaptureToolbars: hasBlockSupport(
 					blockName,
-					'__experimentalExposeControlsToChildren',
-					false
-				),
+					'__experimentalExposeControlsToChildren'
+				)
+					? true
+					: undefined,
 				hasOverlay:
 					blockName !== 'core/template' &&
 					! isBlockSelected( clientId ) &&
@@ -236,7 +233,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				name: blockName,
 				blockType: getBlockType( blockName ),
 				innerBlocks: getBlocks( clientId ),
-				parentLock: getTemplateLock( _parentClientId ),
 				parentClientId: _parentClientId,
 				isDropZoneDisabled:
 					blockEditingMode !== 'default' ||
@@ -265,7 +261,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		name,
 		blockType,
 		innerBlocks,
-		parentLock,
 		...options,
 	};
 	const InnerBlocks =

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -32,7 +32,6 @@ function useShallowMemo( value ) {
  * came from props.
  *
  * @param {string}               clientId                   The client ID of the block to update.
- * @param {string}               parentLock
  * @param {string[]}             allowedBlocks              An array of block names which are permitted
  *                                                          in inner blocks.
  * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritized in the inserter, in the format {blockName}/{variationName}.
@@ -54,7 +53,6 @@ function useShallowMemo( value ) {
  */
 export default function useNestedSettingsUpdate(
 	clientId,
-	parentLock,
 	allowedBlocks,
 	prioritizedInserterBlocks,
 	defaultBlock,
@@ -85,17 +83,22 @@ export default function useNestedSettingsUpdate(
 		prioritizedInserterBlocks
 	);
 
-	const _templateLock =
-		templateLock === undefined || parentLock === 'contentOnly'
-			? parentLock
-			: templateLock;
+	const _templateLock = templateLock;
 
 	useLayoutEffect( () => {
-		const newSettings = {
-			allowedBlocks: _allowedBlocks,
-			prioritizedInserterBlocks: _prioritizedInserterBlocks,
-			templateLock: _templateLock,
-		};
+		const newSettings = {};
+
+		if ( _templateLock !== undefined ) {
+			newSettings.templateLock = _templateLock;
+		}
+
+		if ( _allowedBlocks !== undefined ) {
+			newSettings.allowedBlocks = _allowedBlocks;
+		}
+
+		if ( prioritizedInserterBlocks !== undefined ) {
+			newSettings.prioritizedInserterBlocks = prioritizedInserterBlocks;
+		}
 
 		// These values are not defined for RN, so only include them if they
 		// are defined.
@@ -109,7 +112,11 @@ export default function useNestedSettingsUpdate(
 			newSettings.orientation = orientation;
 		} else {
 			const layoutType = getLayoutType( layout?.type );
-			newSettings.orientation = layoutType.getOrientation( layout );
+			const _orientation = layoutType.getOrientation( layout );
+
+			if ( _orientation !== 'vertical' ) {
+				newSettings.orientation = _orientation;
+			}
 		}
 
 		if ( __experimentalDefaultBlock !== undefined ) {
@@ -136,6 +143,10 @@ export default function useNestedSettingsUpdate(
 
 		if ( directInsert !== undefined ) {
 			newSettings.directInsert = directInsert;
+		}
+
+		if ( ! Object.keys( newSettings ).length ) {
+			return;
 		}
 
 		// Batch updates to block list settings to avoid triggering cascading renders
@@ -176,5 +187,6 @@ export default function useNestedSettingsUpdate(
 		updateBlockListSettings,
 		layout,
 		registry,
+		prioritizedInserterBlocks,
 	] );
 }

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -81,7 +81,6 @@ export default function ListItemEdit( {
 	const { placeholder, content } = attributes;
 	const blockProps = useBlockProps( { ref: useCopy( clientId ) } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: [ 'core/list' ],
 		renderAppender: false,
 		__unstableDisableDropZone: true,
 	} );

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -17,6 +17,9 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
+	innerBlocks: {
+		allowedBlocks: [ 'core/list' ],
+	},
 	icon,
 	edit,
 	save,

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -29,7 +29,6 @@ import OrderedListSettings from './ordered-list-settings';
 import { migrateToListV2 } from './utils';
 import TagName from './tag-name';
 
-const TEMPLATE = [ [ 'core/list-item' ] ];
 const NATIVE_MARGIN_SPACING = 8;
 
 /**
@@ -125,16 +124,12 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: [ 'core/list-item' ],
-		template: TEMPLATE,
-		templateLock: false,
 		templateInsertUpdatesSelection: true,
 		...( Platform.isNative && {
 			marginVertical: NATIVE_MARGIN_SPACING,
 			marginHorizontal: NATIVE_MARGIN_SPACING,
 			renderAppender: false,
 		} ),
-		__experimentalCaptureToolbars: true,
 	} );
 	useMigrateOnLoad( attributes, clientId );
 

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -19,6 +19,12 @@ const { name } = metadata;
 export { metadata, name };
 
 const settings = {
+	innerBlocks: {
+		allowedBlocks: [ 'core/list-item' ],
+		template: [ [ 'core/list-item' ] ],
+		templateLock: false,
+		__experimentalCaptureToolbars: true,
+	},
 	icon,
 	example: {
 		innerBlocks: [

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -28,8 +28,6 @@ import { migrateToQuoteV2 } from './deprecated';
 
 const isWebPlatform = Platform.OS === 'web';
 
-const TEMPLATE = [ [ 'core/paragraph', {} ] ];
-
 /**
  * At the moment, deprecations don't handle create blocks from attributes
  * (like when using CPT templates). For this reason, this hook is necessary
@@ -91,9 +89,7 @@ export default function QuoteEdit( {
 		...( ! isWebPlatform && { style } ),
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		template: TEMPLATE,
 		templateInsertUpdatesSelection: true,
-		__experimentalCaptureToolbars: true,
 	} );
 
 	return (

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -19,6 +19,10 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
+	innerBlocks: {
+		template: [ [ 'core/paragraph', {} ] ],
+		__experimentalCaptureToolbars: true,
+	},
 	icon,
 	example: {
 		attributes: {

--- a/packages/data/src/factory.js
+++ b/packages/data/src/factory.js
@@ -39,11 +39,19 @@
  * @return {Function} Registry selector that can be registered with a store.
  */
 export function createRegistrySelector( registrySelector ) {
+	// Cache the registry selector so that memoized selectors created with
+	// `createSelector` work.
+	let cachedSelector;
+
 	// Create a selector function that is bound to the registry referenced by `selector.registry`
 	// and that has the same API as a regular selector. Binding it in such a way makes it
 	// possible to call the selector directly from another selector.
-	const selector = ( ...args ) =>
-		registrySelector( selector.registry.select )( ...args );
+	const selector = ( ...args ) => {
+		if ( ! cachedSelector ) {
+			cachedSelector = registrySelector( selector.registry.select );
+		}
+		return cachedSelector( ...args );
+	};
 
 	/**
 	 * Flag indicating that the selector is a registry selector that needs the correct registry


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently we perform a huge batch update of block settings on page load. Most of the time, block list settings are not dynamic, so this PR sets them on the block type instead of on InnerBlocks and changes the selector to fall back to that.

It removes the big block in red, though for some reason only speeds up load by ~1.5%.

<img width="1062" alt="Screenshot 2023-12-18 at 19 26 01" src="https://github.com/WordPress/gutenberg/assets/4710635/fbb06e6b-8206-4249-b0a2-0c08fae34b6f">


I think in a follow-up PR we should try to eliminate settings like `orientation` and `__experimentalCaptureToolbars` entirely. It's only needed for UI for the selected blocks, so maybe for `orientation` there's a way to sync only if needed. And for `__experimentalCaptureToolbars` I don't think it should even be possible to set dynamically? 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

First run: -1.4%
Second run: -1.6%

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
