### PR TITLE
Update: Make secondary actions trigger always visible.

### DIFF
--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -120,9 +120,6 @@ export default function ItemActions( { item, actions, isCompact } ) {
 			{ primaryActions: [], secondaryActions: [] }
 		);
 	}, [ actions, item ] );
-	if ( ! primaryActions.length && ! secondaryActions.length ) {
-		return null;
-	}
 	if ( isCompact ) {
 		return (
 			<CompactItemActions
@@ -161,23 +158,22 @@ export default function ItemActions( { item, actions, isCompact } ) {
 						/>
 					);
 				} ) }
-			{ !! secondaryActions.length && (
-				<DropdownMenu
-					trigger={
-						<Button
-							size="compact"
-							icon={ moreVertical }
-							label={ __( 'Actions' ) }
-						/>
-					}
-					placement="bottom-end"
-				>
-					<ActionsDropdownMenuGroup
-						actions={ secondaryActions }
-						item={ item }
+			<DropdownMenu
+				trigger={
+					<Button
+						size="compact"
+						icon={ moreVertical }
+						label={ __( 'Actions' ) }
+						disabled={ ! secondaryActions.length }
 					/>
-				</DropdownMenu>
-			) }
+				}
+				placement="bottom-end"
+			>
+				<ActionsDropdownMenuGroup
+					actions={ secondaryActions }
+					item={ item }
+				/>
+			</DropdownMenu>
 		</HStack>
 	);
 }


### PR DESCRIPTION
Follows a discussion on https://github.com/WordPress/gutenberg/pull/57031 and makes the secondary actions trigger always visible, but disabled if there are no secondary actions.

cc: @jameskoster, @oandregal 

## Screenshots or screencast
<img width="1641" alt="Screenshot 2023-12-18 at 16 49 25" src="https://github.com/WordPress/gutenberg/assets/11271197/e9f2342c-21f9-437c-9b7b-97304f4d86ef"> <!-- if applicable -->
