### PR TITLE
Add: See revisions template action.

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -45,6 +45,7 @@ import {
 	useResetTemplateAction,
 	deleteTemplateAction,
 	renameTemplateAction,
+	seeRevisionsAction,
 } from './template-actions';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
@@ -332,6 +333,7 @@ export default function DataviewsTemplates() {
 			resetTemplateAction,
 			deleteTemplateAction,
 			renameTemplateAction,
+			seeRevisionsAction,
 		],
 		[ resetTemplateAction ]
 	);

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -15,6 +15,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -205,5 +206,25 @@ export const renameTemplateAction = {
 				</VStack>
 			</form>
 		);
+	},
+};
+
+export const seeRevisionsAction = {
+	id: 'see-revisions',
+	label: __( 'See revisions' ),
+	isEligible: ( template ) => {
+		if ( template?._links && template?._links[ 'predecessor-version' ] ) {
+			const predecessorVersions =
+				template._links[ 'predecessor-version' ];
+			return predecessorVersions.length > 0;
+		}
+		return false;
+	},
+	callback( template ) {
+		const lastRevisionId =
+			template?._links[ 'predecessor-version' ][ 0 ].id;
+		document.location.href = addQueryArgs( 'revision.php', {
+			revision: lastRevisionId,
+		} );
 	},
 };


### PR DESCRIPTION
Applies a suggestion from @jameskoster and implements a see revisions secondary action for templates.
cc: @oandregal 

## Testing Instructions
Create a custom template.
Create multiple revisions to it by updating it and saving it.
Verify the see revisions action works as expected and navigates to the template revisions.


## Screenshots or screencast
<img width="808" alt="Screenshot 2023-12-18 at 17 42 02" src="https://github.com/WordPress/gutenberg/assets/11271197/8d8a8271-dbd8-4dbb-8eed-a145db356c27">


