### PR TITLE
Blocks: optimise parser by batch parsing HTML to DOM

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -97,6 +97,7 @@ _Parameters_
 -   _blockTypeOrName_ `string|Object`: Block type or name.
 -   _innerHTML_ `string|Node`: Raw block content.
 -   _attributes_ `?Object`: Known block attributes (from delimiters).
+-   _innerDom_ `?Node`: Raw block content parsed into DOM.
 
 _Returns_
 

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -286,16 +286,16 @@ export function parseWithAttributeSchema( innerHTML, attributeSchema ) {
  * @param {string|Object} blockTypeOrName Block type or name.
  * @param {string|Node}   innerHTML       Raw block content.
  * @param {?Object}       attributes      Known block attributes (from delimiters).
- *
+ * @param {?Node}         innerDom        Raw block content parsed into DOM.
  * @return {Object} All block attributes.
  */
 export function getBlockAttributes(
 	blockTypeOrName,
 	innerHTML,
-	attributes = {}
+	attributes = {},
+	innerDom
 ) {
-	const doc =
-		typeof innerHTML === 'string' ? parseHtml( innerHTML ) : innerHTML;
+	const doc = innerDom ? innerDom : parseHtml( innerHTML );
 	const blockType = normalizeBlockType( blockTypeOrName );
 
 	const blockAttributes = Object.fromEntries(

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -294,7 +294,8 @@ export function getBlockAttributes(
 	innerHTML,
 	attributes = {}
 ) {
-	const doc = parseHtml( innerHTML );
+	const doc =
+		typeof innerHTML === 'string' ? parseHtml( innerHTML ) : innerHTML;
 	const blockType = normalizeBlockType( blockTypeOrName );
 
 	const blockAttributes = Object.fromEntries(

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -233,8 +233,9 @@ export function parseRawBlock( rawBlock, options ) {
 		normalizedBlock.blockName,
 		getBlockAttributes(
 			blockType,
-			normalizedBlock.innerDom,
-			normalizedBlock.attrs
+			normalizedBlock.innerHTML,
+			normalizedBlock.attrs,
+			normalizedBlock.innerDom
 		),
 		parsedInnerBlocks
 	);

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -233,7 +233,7 @@ export function parseRawBlock( rawBlock, options ) {
 		normalizedBlock.blockName,
 		getBlockAttributes(
 			blockType,
-			normalizedBlock.innerHTML,
+			normalizedBlock.innerDom,
 			normalizedBlock.attrs
 		),
 		parsedInnerBlocks
@@ -308,7 +308,43 @@ export function parseRawBlock( rawBlock, options ) {
  * @return {Array} Block list.
  */
 export default function parse( content, options ) {
-	return grammarParse( content ).reduce( ( accumulator, rawBlock ) => {
+	const rawBlocks = grammarParse( content ).filter(
+		// Down the road, we trim content, so let's ignore empty sections
+		// between blocks early.
+		( rawBlock ) => rawBlock.innerHTML.trim() || rawBlock.blockName
+	);
+
+	let allInnerHtml = '';
+
+	function addInnerHtml( _rawBlocks ) {
+		for ( const rawBlock of _rawBlocks ) {
+			allInnerHtml += '<div>' + rawBlock.innerHTML + `</div>`;
+			if ( rawBlock.innerBlocks.length ) {
+				addInnerHtml( rawBlock.innerBlocks );
+			}
+		}
+	}
+
+	addInnerHtml( rawBlocks );
+
+	const doc = document.implementation.createHTMLDocument( '' );
+
+	doc.body.innerHTML = allInnerHtml;
+
+	allInnerHtml = Array.from( doc.body.children );
+
+	function addInnerDom( _rawBlocks ) {
+		for ( const rawBlock of _rawBlocks ) {
+			rawBlock.innerDom = allInnerHtml.shift();
+			if ( rawBlock.innerBlocks.length ) {
+				addInnerDom( rawBlock.innerBlocks );
+			}
+		}
+	}
+
+	addInnerDom( rawBlocks );
+
+	return rawBlocks.reduce( ( accumulator, rawBlock ) => {
 		const block = parseRawBlock( rawBlock, options );
 		if ( block ) {
 			accumulator.push( block );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It is much more efficient to make the browser parse all HTML of all blocks in one go. Quick testing shows that this speeds up the parser by ~2x.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

1st run: -5.6% first block load

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
