### PR TITLE
Components: replace `TabPanel` with `Tabs` in the Font Library `Modal`

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -21,7 +21,7 @@ import { search, closeSmall } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import TabLayout from './tab-layout';
+import TabPanelLayout from './tab-panel-layout';
 import { FontLibraryContext } from './context';
 import FontsGrid from './fonts-grid';
 import FontCard from './font-card';
@@ -156,7 +156,7 @@ function FontCollection( { id } ) {
 	};
 
 	return (
-		<TabLayout
+		<TabPanelLayout
 			title={
 				! selectedFont ? selectedCollection.name : selectedFont.name
 			}
@@ -270,7 +270,7 @@ function FontCollection( { id } ) {
 					) ) }
 				</FontsGrid>
 			) }
-		</TabLayout>
+		</TabPanelLayout>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Modal, TabPanel } from '@wordpress/components';
+import {
+	Modal,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -12,17 +15,18 @@ import InstalledFonts from './installed-fonts';
 import FontCollection from './font-collection';
 import UploadFonts from './upload-fonts';
 import { FontLibraryContext } from './context';
+import { unlock } from '../../../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 const DEFAULT_TABS = [
 	{
 		name: 'installed-fonts',
 		title: __( 'Library' ),
-		className: 'installed-fonts',
 	},
 	{
 		name: 'upload-fonts',
 		title: __( 'Upload' ),
-		className: 'upload-fonts',
 	},
 ];
 
@@ -33,7 +37,6 @@ const tabsFromCollections = ( collections ) =>
 			collections.length === 1 && id === 'default-font-collection'
 				? __( 'Install Fonts' )
 				: name,
-		className: 'collection',
 	} ) );
 
 function FontLibraryModal( {
@@ -54,22 +57,39 @@ function FontLibraryModal( {
 			isFullScreen
 			className="font-library-modal"
 		>
-			<TabPanel
-				className="font-library-modal__tab-panel"
-				initialTabName={ initialTabName }
-				tabs={ tabs }
-			>
-				{ ( tab ) => {
-					switch ( tab.name ) {
-						case 'upload-fonts':
-							return <UploadFonts />;
-						case 'installed-fonts':
-							return <InstalledFonts />;
-						default:
-							return <FontCollection id={ tab.name } />;
-					}
-				} }
-			</TabPanel>
+			<div className="font-library-modal__tab-panel">
+				<Tabs initialTabId={ initialTabName }>
+					<Tabs.TabList>
+						{ tabs.map( ( { name, title } ) => (
+							<Tabs.Tab key={ name } tabId={ name }>
+								{ title }
+							</Tabs.Tab>
+						) ) }
+					</Tabs.TabList>
+					{ tabs.map( ( { name } ) => {
+						let contents;
+						switch ( name ) {
+							case 'upload-fonts':
+								contents = <UploadFonts />;
+								break;
+							case 'installed-fonts':
+								contents = <InstalledFonts />;
+								break;
+							default:
+								contents = <FontCollection id={ name } />;
+						}
+						return (
+							<Tabs.TabPanel
+								key={ name }
+								tabId={ name }
+								focusable="false"
+							>
+								{ contents }
+							</Tabs.TabPanel>
+						);
+					} ) }
+				</Tabs>
+			</div>
 		</Modal>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -57,7 +57,7 @@ function FontLibraryModal( {
 			isFullScreen
 			className="font-library-modal"
 		>
-			<div className="font-library-modal__tab-panel">
+			<div className="font-library-modal__tabs">
 				<Tabs initialTabId={ initialTabName }>
 					<Tabs.TabList>
 						{ tabs.map( ( { name, title } ) => (

--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -21,18 +21,18 @@ const { Tabs } = unlock( componentsPrivateApis );
 
 const DEFAULT_TABS = [
 	{
-		name: 'installed-fonts',
+		id: 'installed-fonts',
 		title: __( 'Library' ),
 	},
 	{
-		name: 'upload-fonts',
+		id: 'upload-fonts',
 		title: __( 'Upload' ),
 	},
 ];
 
 const tabsFromCollections = ( collections ) =>
 	collections.map( ( { id, name } ) => ( {
-		name: id,
+		id,
 		title:
 			collections.length === 1 && id === 'default-font-collection'
 				? __( 'Install Fonts' )
@@ -41,7 +41,7 @@ const tabsFromCollections = ( collections ) =>
 
 function FontLibraryModal( {
 	onRequestClose,
-	initialTabName = 'installed-fonts',
+	initialTabId = 'installed-fonts',
 } ) {
 	const { collections } = useContext( FontLibraryContext );
 
@@ -58,17 +58,17 @@ function FontLibraryModal( {
 			className="font-library-modal"
 		>
 			<div className="font-library-modal__tabs">
-				<Tabs initialTabId={ initialTabName }>
+				<Tabs initialTabId={ initialTabId }>
 					<Tabs.TabList>
-						{ tabs.map( ( { name, title } ) => (
-							<Tabs.Tab key={ name } tabId={ name }>
+						{ tabs.map( ( { id, title } ) => (
+							<Tabs.Tab key={ id } tabId={ id }>
 								{ title }
 							</Tabs.Tab>
 						) ) }
 					</Tabs.TabList>
-					{ tabs.map( ( { name } ) => {
+					{ tabs.map( ( { id } ) => {
 						let contents;
-						switch ( name ) {
+						switch ( id ) {
 							case 'upload-fonts':
 								contents = <UploadFonts />;
 								break;
@@ -76,12 +76,12 @@ function FontLibraryModal( {
 								contents = <InstalledFonts />;
 								break;
 							default:
-								contents = <FontCollection id={ name } />;
+								contents = <FontCollection id={ id } />;
 						}
 						return (
 							<Tabs.TabPanel
-								key={ name }
-								tabId={ name }
+								key={ id }
+								tabId={ id }
 								focusable="false"
 							>
 								{ contents }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -82,7 +82,7 @@ function FontLibraryModal( {
 							<Tabs.TabPanel
 								key={ id }
 								tabId={ id }
-								focusable="false"
+								focusable={ false }
 							>
 								{ contents }
 							</Tabs.TabPanel>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -16,7 +16,7 @@ import {
 /**
  * Internal dependencies
  */
-import TabLayout from './tab-layout';
+import TabPanelLayout from './tab-panel-layout';
 import { FontLibraryContext } from './context';
 import FontsGrid from './fonts-grid';
 import LibraryFontDetails from './library-font-details';
@@ -92,7 +92,7 @@ function InstalledFonts() {
 	}, [ notice ] );
 
 	return (
-		<TabLayout
+		<TabPanelLayout
 			title={ libraryFontSelected?.name || '' }
 			description={ tabDescription }
 			handleBack={ !! libraryFontSelected && handleUnselectFont }
@@ -173,7 +173,7 @@ function InstalledFonts() {
 					handleCancelUninstall={ handleCancelUninstall }
 				/>
 			) }
-		</TabLayout>
+		</TabPanelLayout>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -24,7 +24,7 @@
 	}
 }
 
-.font-library-modal__tab-layout {
+.font-library-modal__tabpanel-layout {
 
 	main {
 		padding-bottom: 4rem;
@@ -75,7 +75,7 @@
 	padding-bottom: 1rem;
 }
 
-.font-library-modal__tab-panel {
+.font-library-modal__tabs {
 	[role="tablist"] {
 		position: sticky;
 		top: 0;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/tab-layout.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/tab-layout.js
@@ -13,7 +13,7 @@ import { chevronLeft } from '@wordpress/icons';
 
 function TabLayout( { title, description, handleBack, children, footer } ) {
 	return (
-		<div className="font-library-modal__tab-layout">
+		<div className="font-library-modal__tabpanel-layout">
 			<Spacer margin={ 4 } />
 			<VStack spacing={ 4 } justify="space-between">
 				<header>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/tab-panel-layout.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/tab-panel-layout.js
@@ -11,7 +11,13 @@ import {
 } from '@wordpress/components';
 import { chevronLeft } from '@wordpress/icons';
 
-function TabLayout( { title, description, handleBack, children, footer } ) {
+function TabPanelLayout( {
+	title,
+	description,
+	handleBack,
+	children,
+	footer,
+} ) {
 	return (
 		<div className="font-library-modal__tabpanel-layout">
 			<Spacer margin={ 4 } />
@@ -47,4 +53,4 @@ function TabLayout( { title, description, handleBack, children, footer } ) {
 	);
 }
 
-export default TabLayout;
+export default TabPanelLayout;


### PR DESCRIPTION
## What?
Replaces the legacy TabPanel component with the new Tabs component.

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

## How?
`TabPanel` is replaced by `Tabs` and its sub-components. I've also tried to clean up the use of `name` vs `id` for tab identification. `TabPanel` used a `name` property, but `Tabs` deals exclusively with `id`s. Eliminating `name` from the code will hopefully make it easier to parse. This specifcially doesn't impact the `name` property on font collections being passed in to the library, as that _nomenclature_ still felt like it made sense.

## Testing Instructions
1. Open the site editor and the Global Styles sidebar
2. Click on **Typography**
3. Click on **Manage Fonts** to open the Font Library modal
4. Confirm all three tabs (**Library**, **Upload**, and **Install Fonts** are present). Any other tabs (if present) should represent font collections provided by your current setup.
5. Compared to `trunk`, confirm that each tab visually looks the same, that it behaves the same, and the it's displaying the correct content
6. Just for fun, modify the order of the `DEFAULT_TABS` array in `packages/edit-site/src/components/global-styles/font-library-modal/index.js` so that `installed-fonts` is no longer listed first. Reload the site editor and confirm that **Library** is still the initially selected tab even if it the first one in the list

### Testing Instructions for Keyboard
1. Open the site editor and select the Global Styles sidebar
2. Once open, press [Tab] and [Space] to reach and select the **Typography** option
3. [Tab] and [Space] again to focus and activate the **Manage Fonts** button, opening the Font Library modal
4. [Tab] twice to focus the current tab.
5. Use arrow keys to navigate between tabs. Focusing a tab should automatically activate it
6. Press [Tab] and confirm focus moves to the first tabbable element in the `tabpanel` contents.