### PR TITLE
Meta boxes: don't initialise if there are none

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/index.js
+++ b/packages/edit-post/src/components/meta-boxes/index.js
@@ -34,10 +34,10 @@ export default function MetaBoxes( { location } ) {
 	// saving. This initializes all meta box locations, not just this specific
 	// one.
 	useEffect( () => {
-		if ( isEditorReady && ! areMetaBoxesInitialized ) {
+		if ( isEditorReady && metaBoxes.length && ! areMetaBoxesInitialized ) {
 			registry.dispatch( editPostStore ).initializeMetaBoxes();
 		}
-	}, [ isEditorReady, areMetaBoxesInitialized ] );
+	}, [ isEditorReady, metaBoxes, areMetaBoxesInitialized ] );
 
 	if ( ! areMetaBoxesInitialized ) {
 		return null;

--- a/packages/edit-post/src/components/meta-boxes/index.js
+++ b/packages/edit-post/src/components/meta-boxes/index.js
@@ -30,14 +30,16 @@ export default function MetaBoxes( { location } ) {
 		[ location ]
 	);
 
+	const hasMetaBoxes = metaBoxes?.length > 0;
+
 	// When editor is ready, initialize postboxes (wp core script) and metabox
 	// saving. This initializes all meta box locations, not just this specific
 	// one.
 	useEffect( () => {
-		if ( isEditorReady && metaBoxes.length && ! areMetaBoxesInitialized ) {
+		if ( isEditorReady && hasMetaBoxes && ! areMetaBoxesInitialized ) {
 			registry.dispatch( editPostStore ).initializeMetaBoxes();
 		}
-	}, [ isEditorReady, metaBoxes, areMetaBoxesInitialized ] );
+	}, [ isEditorReady, hasMetaBoxes, areMetaBoxesInitialized ] );
 
 	if ( ! areMetaBoxesInitialized ) {
 		return null;

--- a/packages/edit-post/src/components/meta-boxes/index.js
+++ b/packages/edit-post/src/components/meta-boxes/index.js
@@ -30,7 +30,7 @@ export default function MetaBoxes( { location } ) {
 		[ location ]
 	);
 
-	const hasMetaBoxes = metaBoxes?.length > 0;
+	const hasMetaBoxes = !! metaBoxes?.length;
 
 	// When editor is ready, initialize postboxes (wp core script) and metabox
 	// saving. This initializes all meta box locations, not just this specific


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently meta boxes are initializing even if there are none present. This is not really a cheap operation so let's avoid it if possible.

It's just a drop in the bucket of all load time, but it's such a small correction that I think it's worth it.


<img width="712" alt="Screenshot 2023-12-18 at 22 01 46" src="https://github.com/WordPress/gutenberg/assets/4710635/ef631a76-7869-4079-81b4-db33fdea1b15">


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
