### PR TITLE
Fix block lock toolbar item stealing focus when mounted with StrictMode

### DIFF
--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -23,6 +23,7 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 
 	const lockButtonRef = useRef( null );
 	const isFirstRender = useRef( true );
+	const hasModalOpened = useRef( false );
 
 	const shouldHideBlockLockUI =
 		! canLock || ( canEdit && canMove && canRemove );
@@ -33,10 +34,23 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 	useEffect( () => {
 		if ( isFirstRender.current ) {
 			isFirstRender.current = false;
+			hasModalOpened.current = false;
 			return;
 		}
 
-		if ( ! isModalOpen && shouldHideBlockLockUI ) {
+		if ( isModalOpen && ! hasModalOpened.current ) {
+			hasModalOpened.current = true;
+		}
+
+		// We only want to allow this effeect to happen if the modal has been opened.
+		// The issue is when we're returning focus from the block lock modal to a toolbar,
+		// so it can only happen after a modal has been opened. Without this, the toolbar
+		// will steal focus on rerenders.
+		if (
+			hasModalOpened.current &&
+			! isModalOpen &&
+			shouldHideBlockLockUI
+		) {
 			focus.focusable
 				.find( wrapperRef.current, {
 					sequential: false,
@@ -49,7 +63,7 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 				?.focus();
 		}
 		// wrapperRef is a reference object and should be stable
-	}, [ isModalOpen, shouldHideBlockLockUI, wrapperRef ] );
+	}, [ isModalOpen, shouldHideBlockLockUI, hasModalOpened, wrapperRef ] );
 
 	if ( shouldHideBlockLockUI ) {
 		return null;

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -34,7 +34,6 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 	useEffect( () => {
 		if ( isFirstRender.current ) {
 			isFirstRender.current = false;
-			hasModalOpened.current = false;
 			return;
 		}
 
@@ -42,7 +41,7 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 			hasModalOpened.current = true;
 		}
 
-		// We only want to allow this effeect to happen if the modal has been opened.
+		// We only want to allow this effect to happen if the modal has been opened.
 		// The issue is when we're returning focus from the block lock modal to a toolbar,
 		// so it can only happen after a modal has been opened. Without this, the toolbar
 		// will steal focus on rerenders.
@@ -63,7 +62,7 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 				?.focus();
 		}
 		// wrapperRef is a reference object and should be stable
-	}, [ isModalOpen, shouldHideBlockLockUI, hasModalOpened, wrapperRef ] );
+	}, [ isModalOpen, shouldHideBlockLockUI, wrapperRef ] );
 
 	if ( shouldHideBlockLockUI ) {
 		return null;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Potential fix to https://github.com/WordPress/gutenberg/issues/57139. I'd like to use BlockToolbar and `<NavigableToolbar />` instead, but haven't looked into if this is possible. This is just a quick patch with the current implementation.

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes block toolbar stealing focus on mount when using `<StrictMode />` due to `useEffect` running twice.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixing a bug exposed during `<StrictMode />` testing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a condition to only send focus to the toolbar if the modal has been opened while the toolbar is mounted. This fixes the main issue and makes it unlikely to steal focus unexpectedly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Wrap the [`<PrivateBlockToolbar />` from `<BlockToolbarPopover />`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-tools/block-toolbar-popover.js#L69-L80) in a `<StrictMode />` component (`import { StrictMode } from 'react';`).
- Add a paragraph block
- Type
- Move the mouse to trigger the block toolbar popover to show
- Focus should not be placed on the toolbar
- Lock the block
- From the Lock icon in the toolbar, trigger the modal
- Unlock the block
- Focus should be sent to the toolbar

## Screenshots or screencast <!-- if applicable -->
