### PR TITLE
Block editor: avoid list re-rendering on select

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -155,38 +155,25 @@ function Items( {
 	__experimentalAppenderTagName,
 	layout = defaultLayout,
 } ) {
-	const { order, selectedBlocks, visibleBlocks, temporarilyEditingAsBlocks } =
-		useSelect(
-			( select ) => {
-				const {
-					getBlockOrder,
-					getSelectedBlockClientIds,
-					__unstableGetVisibleBlocks,
-					__unstableGetTemporarilyEditingAsBlocks,
-				} = select( blockEditorStore );
-				return {
-					order: getBlockOrder( rootClientId ),
-					selectedBlocks: getSelectedBlockClientIds(),
-					visibleBlocks: __unstableGetVisibleBlocks(),
-					temporarilyEditingAsBlocks:
-						__unstableGetTemporarilyEditingAsBlocks(),
-				};
-			},
-			[ rootClientId ]
-		);
+	const { order, temporarilyEditingAsBlocks } = useSelect(
+		( select ) => {
+			const {
+				getBlockOrderWithAsyncFlag,
+				__unstableGetTemporarilyEditingAsBlocks,
+			} = unlock( select( blockEditorStore ) );
+			return {
+				order: getBlockOrderWithAsyncFlag( rootClientId ),
+				temporarilyEditingAsBlocks:
+					__unstableGetTemporarilyEditingAsBlocks(),
+			};
+		},
+		[ rootClientId ]
+	);
 
 	return (
 		<LayoutProvider value={ layout }>
-			{ order.map( ( clientId ) => (
-				<AsyncModeProvider
-					key={ clientId }
-					value={
-						// Only provide data asynchronously if the block is
-						// not visible and not selected.
-						! visibleBlocks.has( clientId ) &&
-						! selectedBlocks.includes( clientId )
-					}
-				>
+			{ order.map( ( { clientId, isAsync } ) => (
+				<AsyncModeProvider key={ clientId } value={ isAsync }>
 					<BlockListBlock
 						rootClientId={ rootClientId }
 						clientId={ clientId }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -14,6 +14,8 @@ import {
 	__experimentalGetParsedPattern,
 	canInsertBlockType,
 	__experimentalGetAllowedPatterns,
+	getSelectedBlockClientIds,
+	__unstableGetVisibleBlocks,
 } from './selectors';
 import { getAllPatterns, checkAllowListRecursive } from './utils';
 
@@ -286,3 +288,25 @@ export const hasAllowedPatterns = createSelector(
 export function getLastFocus( state ) {
 	return state.lastFocus;
 }
+
+export const getBlockOrderWithAsyncFlag = createSelector(
+	( state, rootClientId ) => {
+		const order = getBlockOrder( state, rootClientId );
+		const selectedBlocks = getSelectedBlockClientIds( state );
+		const visibleBlocks = __unstableGetVisibleBlocks( state );
+		return order.map( ( clientId ) => ( {
+			clientId,
+			// Only provide data asynchronously if the block is
+			// not visible and not selected.
+			isAsync:
+				! visibleBlocks?.has( clientId ) &&
+				! selectedBlocks?.includes( clientId ),
+		} ) );
+	},
+	( state ) => [
+		state.blocks.order,
+		state.selection.selectionStart.clientId,
+		state.selection.selectionEnd.clientId,
+		state.blockVisibility,
+	]
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR avoids the re-rendering of `Items` if the selection changes, but the list doesn't include the selected (or visible) block at all.

Note: while we could create another `useSelect` call for each block, check if it's selected, and then turn on the AsyncProvider, there's a balance to be struck between optimising type and block select. I think typing is more important that block select, so let's avoid introducing another `useSelect` per block.

But we can avoid re-renders for other block lists. For example, in the large posts, there are many list and quote blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

First run: -5% (select/focus)
Second run: -4.6%

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
