### PR TITLE
Make sure theme color palette presets are output when appearance tools are enabled.

### DIFF
--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -72,7 +72,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		 * @see wp_add_global_styles_for_blocks
 		 */
 		$origins = array( 'default', 'theme', 'custom' );
-		if ( ! $supports_theme_json ) {
+		if ( ! $supports_theme_json && ! current_theme_supports( 'appearance-tools' ) ) {
 			$origins = array( 'default' );
 		}
 		$styles_rest = $tree->get_stylesheet( $types, $origins );

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -76,7 +76,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		* If the theme doesn't have theme.json but supports both appearance tools and color palette,
 		* the 'theme' origin should be included so color palette presets are also output.
 		*/
-		if ( ! $supports_theme_json && current_theme_supports( 'appearance-tools' ) && current_theme_supports( 'editor-color-palette' ) ) {
+		if ( ! $supports_theme_json && ( current_theme_supports( 'appearance-tools' ) || current_theme_supports( 'border' ) ) && current_theme_supports( 'editor-color-palette' ) ) {
 			$origins = array( 'default', 'theme' );
 		} elseif ( ! $supports_theme_json ) {
 			$origins = array( 'default' );

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -72,7 +72,13 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		 * @see wp_add_global_styles_for_blocks
 		 */
 		$origins = array( 'default', 'theme', 'custom' );
-		if ( ! $supports_theme_json && ! current_theme_supports( 'appearance-tools' ) ) {
+		/*
+		* If the theme doesn't have theme.json but supports both appearance tools and color palette,
+		* the 'theme' origin should be included so color palette presets are also output.
+		*/
+		if ( ! $supports_theme_json && current_theme_supports( 'appearance-tools' ) && current_theme_supports( 'editor-color-palette' ) ) {
+			$origins = array( 'default', 'theme' );
+		} elseif ( ! $supports_theme_json ) {
 			$origins = array( 'default' );
 		}
 		$styles_rest = $tree->get_stylesheet( $types, $origins );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Partially addresses #56131, namely 

> Border with preset color does not show correctly on site front end due to preset CSS for border not being output

When outputting preset styles based on color palettes, only the `default` palette is used unless the theme supports `theme.json`. 

But it is possible for classic themes to define color palettes as a theme support, and it is also possible for themes to add support for appearance tools, or just for border, which enables design tools such as border that will leverage the theme color palette for their presets. This means that, if both color palette and either appearance tools or border are supported by the theme, theme preset styles should be output in addition to defaults.

Note: currently appearance tools support in themes is limited to Gutenberg. There was an attempt to add this feature to core, which was [reverted](https://core.trac.wordpress.org/ticket/57649) because not all tools worked well with classic themes. This PR is a step towards addressing these issues so that support for appearance tools can be re-enabled in core.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add `add_theme_support( 'appearance-tools' )` to the setup function of a classic theme.
2. In the block editor, check that core blocks with border support now show the border controls.
3. Try adding borders to several blocks, e.g. Group, Image, Details. Try with preset and custom colors, and also changing width, style, radius where possible.
4. Save and compare the editor with the front end: everything should match.
5. Check that the correct styles are output for preset border colors in the front end.
6. Repeat the steps above with `add_theme_support( 'border' )` instead of appearance-tools.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1224" alt="Screenshot 2023-12-19 at 4 33 18 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/e20098f6-0725-4746-b119-9dd3af5ec2a2">
