### PR TITLE
Allow default duotone styles in classic themes.

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -322,9 +322,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			}
 			$theme_support_data['settings']['color']['defaultGradients'] = $default_gradients;
 
-			// Classic themes without a theme.json don't support global duotone.
-			$theme_support_data['settings']['color']['defaultDuotone'] = false;
-
 			// Allow themes to enable all border settings via theme_support.
 			if ( current_theme_supports( 'border' ) ) {
 				$theme_support_data['settings']['border']['color']  = true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes one of the issues detected in #56131, although it's not specific to classic themes with support for appearance tools, but all classic themes _and_ block themes without theme duotone presets.

This allows the default duotone presets to display if they're not explicitly disabled in theme.json.

I don't know all the history behind the decision to not have defaults enabled for themes without their own, but it seems that at least since #49103 filters are no longer output on every page, so if that was the concern it should be OK to enable now.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With a classic theme, add an Image block and open the duotone dropdown from the block toolbar;
2. Verify that default duotone options appear in the dropdown;
3. Select one, save and check that editor matches front end.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="766" alt="Screenshot 2023-12-19 at 6 32 06 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/5ae914ea-a92b-49e2-a15e-4ad03b435a33">


<img width="763" alt="Screenshot 2023-12-19 at 6 32 29 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/ef40046b-79b7-4ab1-b41c-89577850503c">

