### PR TITLE
Tag Cloud: Replace 'withSelect' HoC with 'useSelect'

### DIFF
--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -13,7 +13,7 @@ import {
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 	Disabled,
 } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	InspectorControls,
@@ -40,7 +40,7 @@ const MAX_TAGS = 100;
 const MIN_FONT_SIZE = 0.1;
 const MAX_FONT_SIZE = 100;
 
-function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
+function TagCloudEdit( { attributes, setAttributes } ) {
 	const {
 		taxonomy,
 		showTagCounts,
@@ -53,6 +53,10 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 	const units = useCustomUnits( {
 		availableUnits: availableUnits || [ '%', 'px', 'em', 'rem' ],
 	} );
+	const taxonomies = useSelect(
+		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ),
+		[]
+	);
 
 	const getTaxonomyOptions = () => {
 		const selectOption = {
@@ -174,8 +178,4 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 	);
 }
 
-export default withSelect( ( select ) => {
-	return {
-		taxonomies: select( coreStore ).getTaxonomies( { per_page: -1 } ),
-	};
-} )( TagCloudEdit );
+export default TagCloudEdit;


### PR DESCRIPTION
## What?
PR replaces `withSelect` HoC usage with `useSelect` for the Tag Cloud block.

## Why?
Using data hooks should be preferable over their legacy counterparts.

## Testing Instructions
1. Open a post or page.
2. Insert a Tag Cloud block.
3. Confirm taxonomies are listed correctly in the settings sidebar.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-12-19 at 12 23 40](https://github.com/WordPress/gutenberg/assets/240569/7fc3d47c-62a3-45d2-abd1-604eae347883)
