### PR TITLE
Font size picker: Fix Reset button focus loss

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,17 +4,15 @@
 
 ### Bug Fix
 
+-   `FontSizePicker`: Fix Reset button focus loss ([#57196](https://github.com/WordPress/gutenberg/pull/57196)).
 -   `PaletteEdit`: Consider digits when generating kebab-cased slug ([#56713](https://github.com/WordPress/gutenberg/pull/56713)).
+-   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
+-   `FormTokenField`: Fix a regression where the suggestion list would re-open after clicking away from the input ([#57002](https://github.com/WordPress/gutenberg/pull/57002)).
 
 ### Experimental
 
 -   `Tabs`: do not render hidden content ([#57046](https://github.com/WordPress/gutenberg/pull/57046)).
 -   `Tabs`: make sure `Tab`s are associated to the right `TabPanel`s, regardless of the order they're rendered in ([#57033](https://github.com/WordPress/gutenberg/pull/57033)).
-
-### Bug Fix
-
--   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
--   `FormTokenField`: Fix a regression where the suggestion list would re-open after clicking away from the input ([#57002](https://github.com/WordPress/gutenberg/pull/57002)).
 
 ## 25.14.0 (2023-12-13)
 

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -123,6 +123,7 @@ const UnforwardedFontSizePicker = (
 	);
 	const isValueUnitRelative =
 		!! valueUnit && [ 'em', 'rem' ].includes( valueUnit );
+	const isDisabled = value === undefined;
 
 	return (
 		<Container ref={ ref } className="components-font-size-picker">
@@ -276,10 +277,14 @@ const UnforwardedFontSizePicker = (
 						{ withReset && (
 							<FlexItem>
 								<Button
-									disabled={ value === undefined }
-									onClick={ () => {
-										onChange?.( undefined );
-									} }
+									aria-disabled={ isDisabled }
+									onClick={
+										isDisabled
+											? undefined
+											: () => {
+													onChange?.( undefined );
+											  }
+									}
 									variant="secondary"
 									__next40pxDefaultSize
 									size={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/57169

From the issue:

> The font size picker component can optionally render a 'Reset' button. When clicked, the reset button gets disabled dynamically with the addiction of a `disabled` HTML attribute.  As such, when using a keyboard, the button becomes not focusable _while_ it is focused thus triggering a focus loss.

>Long time ago we established to use another, more accessible, pattern instead:
>- Used `aria-disabled` instead of `disabled`.
>- Noop the control.


### Step-by-step reproduction instructions

- Go to the storybook at https://wordpress.github.io/gutenberg/?path=/docs/components-fontsizepicker--docs
- Set the `withReset` prop to `true`.
- Click the icon button `Set custom size`.
- Set a custom size.
- Using the keyboard, move focus to the 'Reset' button.
- Activate the button with the Spacebar key.
- Observe focus is not lost.
