### PR TITLE
Dependency Extraction Webpack Plugin: Add Module support

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### New Features
 
--   Add support for producing module-compatible asset files ((#57199)[https://github.com/WordPress/gutenberg/pull/57199])
+-   Add support for producing module-compatible asset files ([#57199](https://github.com/WordPress/gutenberg/pull/57199))
 
 ## 4.31.0 (2023-12-13)
 

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### New Features
 
--   Add support for producing module-compatible asset files ([#57199](https://github.com/WordPress/gutenberg/pull/57199))
+-   Add support for producing module-compatible asset files ([#57199](https://github.com/WordPress/gutenberg/pull/57199)).
 
 ## 4.31.0 (2023-12-13)
 

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### New Features
 
--   The plugin now supports generating ECMAScript modules output **@TODO @sirreal complete this**.
+-   Add support for producing module-compatible asset files ((#57199)[https://github.com/WordPress/gutenberg/pull/57199])
 
 ## 4.31.0 (2023-12-13)
 

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Breaking Changes
 
-- Drop support for webpack 4.
-- Drop support for Node.js versions < 18.
+-   Drop support for webpack 4.
+-   Drop support for Node.js versions < 18.
+
+### New Features
+
+-   The plugin now supports generating ECMAScript modules output **@TODO @sirreal complete this**.
 
 ## 4.31.0 (2023-12-13)
 
@@ -145,6 +149,6 @@
 
 ## 1.0.0 (2019-05-21)
 
-### New Feature
+### New Features
 
 -   Introduce the `@wordpress/dependency-extraction-webpack-plugin` package.

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -2,10 +2,14 @@
 
 This webpack plugin serves two purposes:
 
--   Externalize dependencies that are available as script dependencies on modern WordPress sites.
--   Add an asset file for each entry point that declares an object with the list of WordPress script dependencies for the entry point. The asset file also contains the current version calculated for the current source code.
+-   Externalize dependencies that are available as shared scripts or modules on WordPress sites.
+-   Add an asset file for each entry point that declares an object with the list of WordPress script or module dependencies for the entry point. The asset file also contains the current version calculated for the current source code.
 
 This allows JavaScript bundles produced by webpack to leverage WordPress style dependency sharing without an error-prone process of manually maintaining a dependency list.
+
+Version 5 of this plugin adds support for module bundling. [Webpack's `output.module` option](https://webpack.js.org/configuration/output/#outputmodule) should
+be used to opt-in to this behavior. This plugin will adapt it's behavior based on the
+`output.module` option, producing an asset file suitable for use with the WordPress Module API.
 
 Consult the [webpack website](https://webpack.js.org) for additional information on webpack concepts.
 
@@ -17,7 +21,7 @@ Install the module
 npm install @wordpress/dependency-extraction-webpack-plugin --save-dev
 ```
 
-**Note**: This package requires Node.js 14.0.0 or later. It also requires webpack 4.8.3 and newer. It is not compatible with older versions.
+**Note**: This package requires Node.js 18.0.0 or later. It also requires webpack 5.0.0 or newer. It is not compatible with older versions.
 
 ## Usage
 
@@ -39,7 +43,7 @@ module.exports = {
 
 ```js
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
-const config = {
+const webpackConfig = {
 	...defaultConfig,
 	plugins: [
 		...defaultConfig.plugins.filter(
@@ -56,7 +60,12 @@ const config = {
 };
 ```
 
-Each entry point in the webpack bundle will include an asset file that declares the WordPress script dependencies that should be enqueued. Such file also contains the unique version hash calculated based on the file content.
+### Behavior
+
+**Note**: This section describes the classic behavior with webpack and WordPress scripts.
+For information about usage with modules, jump to the [behavior with modules](#behavior-with-modules) section.
+
+Each entry point in the webpack bundle will include an asset file that declares the WordPress script dependencies that should be enqueued. This file also contains the unique version hash calculated based on the file content.
 
 For example:
 
@@ -85,6 +94,66 @@ By default, the following module requests are handled:
 | `react`                      | `React`              | `react`       |
 
 **Note:** This plugin overlaps with the functionality provided by [webpack `externals`](https://webpack.js.org/configuration/externals). This plugin is intended to extract script handles from bundle compilation so that a list of script dependencies does not need to be manually maintained. If you don't need to extract a list of script dependencies, use the `externals` option directly.
+
+This plugin is compatible with `externals`, but they may conflict. For example, adding `{ externals: { '@wordpress/blob': 'wp.blob' } }` to webpack configuration will effectively hide the `@wordpress/blob` module from the plugin and it will not be included in dependency lists.
+
+### Behavior with modules
+
+This section describes the behavior of this package to bundle ECMAScript modules and generate asset
+files suitable for use with the WordPress Module API.
+
+Some of this plugin's options change, and webpack requires configuration to output modules. Refer to
+[webpack's documentation](https://webpack.js.org/configuration/output/#outputmodule) for up-to-date details.
+
+```js
+const webpackConfig = {
+	...defaultConfig,
+
+	// These lines are necessary to enable module compilation at time-of-writing:
+	output: { module: true },
+	experiments: { outputModule: true },
+
+	plugins: [
+		...defaultConfig.plugins.filter(
+			( plugin ) =>
+				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
+		),
+		new DependencyExtractionWebpackPlugin( {
+			// With modules, we use `requestToExternalModule`:
+			requestToExternalModule( request ) {
+				if ( request === 'my-registered-module' ) {
+					return request;
+				}
+			},
+		} ),
+	],
+};
+```
+
+Each entry point in the webpack bundle will include an asset file that declares the WordPress module dependencies that should be enqueued. This file also contains the unique version hash calculated based on the file content.
+
+For example:
+
+```
+// Source file entrypoint.js
+import { store, getContext } from '@wordpress/interactivity';
+
+// Webpack will produce the output output/entrypoint.js
+/* bundled JavaScript output */
+
+// Webpack will also produce output/entrypoint.asset.php declaring script dependencies
+<?php return array('dependencies' => array('@wordpress/interactivity'), 'version' => 'dd4c2dc50d046ed9d4c063a7ca95702f');
+```
+
+By default, the following module requests are handled:
+
+| Request                      |
+| ---------------------------- |
+| `@wordpress/interactivity  ` |
+
+(`@wordpress/interactivity` is currently the only available WordPress module.)
+
+**Note:** This plugin overlaps with the functionality provided by [webpack `externals`](https://webpack.js.org/configuration/externals). This plugin is intended to extract module handles from bundle compilation so that a list of module dependencies does not need to be manually maintained. If you don't need to extract a list of module dependencies, use the `externals` option directly.
 
 This plugin is compatible with `externals`, but they may conflict. For example, adding `{ externals: { '@wordpress/blob': 'wp.blob' } }` to webpack configuration will effectively hide the `@wordpress/blob` module from the plugin and it will not be included in dependency lists.
 
@@ -119,7 +188,7 @@ The filename for the generated asset file. Accepts the same values as the Webpac
 -   Type: boolean
 -   Default: `false`
 
-By default, one asset file is created for each entry point. When this flag is set to `true`, all information about assets is combined into a single `assets.(json|php)` file generated in the output directory.
+By default, one asset file is created for each entry point. When this flag is set to `true`, all information about assets is combined into a single `asset.(json|php)` file generated in the output directory.
 
 ##### `combinedOutputFile`
 
@@ -142,6 +211,8 @@ Pass `useDefaults: false` to disable the default request handling.
 
 Force `wp-polyfill` to be included in each entry point's dependency list. This would be the same as adding `import '@wordpress/polyfill';` to each entry point.
 
+**Note**: This option is not available with modules.
+
 ##### `externalizedReport`
 
 -   Type: boolean | string
@@ -151,6 +222,8 @@ Report all externalized dependencies as an array in JSON format. It could be use
 You can provide a filename, or set it to `true` to report to a default `externalized-dependencies.json`.
 
 ##### `requestToExternal`
+
+**Note**: This option is not available with modules. See [`requestToExternalModule`](#requestToExternalModule) for module usage.
 
 -   Type: function
 
@@ -179,7 +252,42 @@ module.exports = {
 };
 ```
 
+##### `requestToExternalModule`
+
+**Note**: This option is only available with modules. See [`requestToExternal`](#requestToExternal) for script usage.
+
+-   Type: function
+
+`requestToExternalModule` allows the module handling to be customized. The function should accept a module request string and may return a string representing the module to use. Often, the module will have the same name.
+
+`requestToExternalModule` provided via configuration has precedence over default external handling. Unhandled requests will be handled by the default unless `useDefaults` is set to `false`.
+
+```js
+/**
+ * Externalize 'my-module'
+ *
+ * @param {string} request Requested module
+ *
+ * @return {(string|undefined)} Script global
+ */
+function requestToExternalModule( request ) {
+	// Handle imports like `import myModule from 'my-module'`
+	if ( request === 'my-module' ) {
+		// Import should be ov the form `import { something } from "myModule";` in the final bundle.
+		return 'myModule';
+	}
+}
+
+module.exports = {
+	plugins: [
+		new DependencyExtractionWebpackPlugin( { requestToExternalModule } ),
+	],
+};
+```
+
 ##### `requestToHandle`
+
+**Note**: This option is not available with modules. It has no corresponding module configuration.
 
 -   Type: function
 
@@ -231,6 +339,19 @@ $script_asset      = file_exists( $script_asset_path )
 	: array( 'dependencies' => array(), 'version' => filemtime( $script_path ) );
 $script_url = plugins_url( $script_path, __FILE__ );
 wp_enqueue_script( 'script', $script_url, $script_asset['dependencies'], $script_asset['version'] );
+```
+
+Or with modules (the Module API is not yet stable):
+
+```php
+$module_path       = 'path/to/script.js';
+$module_asset_path = 'path/to/script.asset.php';
+$module_asset      = file_exists( $script_asset_path )
+	? require( $module_asset_path )
+	: array( 'dependencies' => array(), 'version' => filemtime( $script_path ) );
+$module_url = plugins_url( $module_path, __FILE__ );
+wp_register_module( 'my-module', $module_url, $module_asset['dependencies'], $module_asset['version'] );
+wp_enqueue_module( 'my-module' );
 ```
 
 ## Contributing to this package

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -343,11 +343,11 @@ wp_enqueue_script( 'script', $script_url, $script_asset['dependencies'], $script
 Or with modules (the Module API is not yet stable):
 
 ```php
-$module_path       = 'path/to/script.js';
-$module_asset_path = 'path/to/script.asset.php';
-$module_asset      = file_exists( $script_asset_path )
+$module_path       = 'path/to/module.js';
+$module_asset_path = 'path/to/module.asset.php';
+$module_asset      = file_exists( $module_asset_path )
 	? require( $module_asset_path )
-	: array( 'dependencies' => array(), 'version' => filemtime( $script_path ) );
+	: array( 'dependencies' => array(), 'version' => filemtime( $module_path ) );
 $module_url = plugins_url( $module_path, __FILE__ );
 wp_register_module( 'my-module', $module_url, $module_asset['dependencies'], $module_asset['version'] );
 wp_enqueue_module( 'my-module' );

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -60,10 +60,7 @@ const webpackConfig = {
 };
 ```
 
-### Behavior
-
-**Note**: This section describes the classic behavior with webpack and WordPress scripts.
-For information about usage with modules, jump to the [behavior with modules](#behavior-with-modules) section.
+### Behavior with scripts
 
 Each entry point in the webpack bundle will include an asset file that declares the WordPress script dependencies that should be enqueued. This file also contains the unique version hash calculated based on the file content.
 
@@ -99,8 +96,10 @@ This plugin is compatible with `externals`, but they may conflict. For example, 
 
 ### Behavior with modules
 
+**Warning:** Modules support is considered experimental at this time.
+
 This section describes the behavior of this package to bundle ECMAScript modules and generate asset
-files suitable for use with the WordPress Module API.
+files suitable for use with the WordPress Modules API.
 
 Some of this plugin's options change, and webpack requires configuration to output modules. Refer to
 [webpack's documentation](https://webpack.js.org/configuration/output/#outputmodule) for up-to-date details.

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -187,7 +187,7 @@ The filename for the generated asset file. Accepts the same values as the Webpac
 -   Type: boolean
 -   Default: `false`
 
-By default, one asset file is created for each entry point. When this flag is set to `true`, all information about assets is combined into a single `asset.(json|php)` file generated in the output directory.
+By default, one asset file is created for each entry point. When this flag is set to `true`, all information about assets is combined into a single `assets.(json|php)` file generated in the output directory.
 
 ##### `combinedOutputFile`
 

--- a/packages/dependency-extraction-webpack-plugin/lib/.eslintrc.json
+++ b/packages/dependency-extraction-webpack-plugin/lib/.eslintrc.json
@@ -1,6 +1,4 @@
 {
-	// Use the default eslint parser. Prevent babel transforms.
-	"parser": "espree",
 	"env": {
 		"node": true
 	}

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -234,7 +234,8 @@ class DependencyExtractionWebpackPlugin {
 								! (
 									compilation.moduleGraph.getParentBlock(
 										dependency
-									) instanceof AsyncDependenciesBlock
+									).constructor.name ===
+									AsyncDependenciesBlock.name
 								)
 							) {
 								isDynamic = false;

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -225,16 +225,22 @@ class DependencyExtractionWebpackPlugin {
 				const { userRequest } = m;
 				if ( this.externalizedDeps.has( userRequest ) ) {
 					if ( this.useModules ) {
-						const isDynamic = Array.prototype.every.call(
-							compilation.moduleGraph.getIncomingConnections( m ),
-							( { dependency } ) => {
-								return (
+						let isDynamic = true;
+						for ( const incomingConnection of compilation.moduleGraph.getIncomingConnections(
+							m
+						) ) {
+							const { dependency } = incomingConnection;
+							if (
+								! (
 									compilation.moduleGraph.getParentBlock(
 										dependency
 									) instanceof AsyncDependenciesBlock
-								);
+								)
+							) {
+								isDynamic = false;
+								break;
 							}
-						);
+						}
 
 						( isDynamic ? chunkDynamicDeps : chunkStaticDeps ).add(
 							userRequest

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -11,10 +11,13 @@ const { createHash } = webpack.util;
  */
 const {
 	defaultRequestToExternal,
+	defaultRequestToExternalModule,
 	defaultRequestToHandle,
 } = require( './util' );
 
 const { RawSource } = webpack.sources;
+const { AsyncDependenciesBlock } = webpack;
+
 const defaultExternalizedReportFileName = 'externalized-dependencies.json';
 
 class DependencyExtractionWebpackPlugin {
@@ -32,27 +35,48 @@ class DependencyExtractionWebpackPlugin {
 			options
 		);
 
-		/*
+		/**
 		 * Track requests that are externalized.
 		 *
 		 * Because we don't have a closed set of dependencies, we need to track what has
 		 * been externalized so we can recognize them in a later phase when the dependency
 		 * lists are generated.
+		 *
+		 * @type {Set<string>}
 		 */
 		this.externalizedDeps = new Set();
 
-		// Offload externalization work to the ExternalsPlugin.
+		/**
+		 * Should we use modules. This will be set later to match webpack's
+		 * output.module option.
+		 *
+		 * @type {boolean}
+		 */
+		this.useModules = false;
+
+		/**
+		 * Offload externalization work to the ExternalsPlugin.
+		 */
 		this.externalsPlugin = new webpack.ExternalsPlugin(
 			'window',
 			this.externalizeWpDeps.bind( this )
 		);
 	}
 
+	/**
+	 * @param {webpack.ExternalItemFunctionData}                             data
+	 * @param { ( err?: null | Error, result?: string | string[] ) => void } callback
+	 */
 	externalizeWpDeps( { request }, callback ) {
 		let externalRequest;
 
-		// Handle via options.requestToExternal first.
-		if ( typeof this.options.requestToExternal === 'function' ) {
+		// Handle via options.requestToExternal(Module)  first.
+		if ( this.useModules ) {
+			if ( typeof this.options.requestToExternalModule === 'function' ) {
+				externalRequest =
+					this.options.requestToExternalModule( request );
+			}
+		} else if ( typeof this.options.requestToExternal === 'function' ) {
 			externalRequest = this.options.requestToExternal( request );
 		}
 
@@ -61,7 +85,9 @@ class DependencyExtractionWebpackPlugin {
 			typeof externalRequest === 'undefined' &&
 			this.options.useDefaults
 		) {
-			externalRequest = defaultRequestToExternal( request );
+			externalRequest = this.useModules
+				? defaultRequestToExternalModule( request )
+				: defaultRequestToExternal( request );
 		}
 
 		if ( externalRequest ) {
@@ -73,6 +99,10 @@ class DependencyExtractionWebpackPlugin {
 		return callback();
 	}
 
+	/**
+	 * @param {string} request
+	 * @return {string} Mapped dependency name
+	 */
 	mapRequestToDependency( request ) {
 		// Handle via options.requestToHandle first.
 		if ( typeof this.options.requestToHandle === 'function' ) {
@@ -94,6 +124,10 @@ class DependencyExtractionWebpackPlugin {
 		return request;
 	}
 
+	/**
+	 * @param {any} asset Asset Data
+	 * @return {string} Stringified asset data suitable for output
+	 */
 	stringify( asset ) {
 		if ( this.options.outputFormat === 'php' ) {
 			return `<?php return ${ json2php(
@@ -104,7 +138,14 @@ class DependencyExtractionWebpackPlugin {
 		return JSON.stringify( asset );
 	}
 
+	/** @type {webpack.WebpackPluginInstance['apply']} */
 	apply( compiler ) {
+		this.useModules = Boolean( compiler.options.output?.module );
+
+		if ( this.useModules ) {
+			this.externalsPlugin.type = 'module';
+		}
+
 		this.externalsPlugin.apply( compiler );
 
 		compiler.hooks.thisCompilation.tap(
@@ -122,6 +163,7 @@ class DependencyExtractionWebpackPlugin {
 		);
 	}
 
+	/** @param {webpack.Compilation} compilation */
 	addAssets( compilation ) {
 		const {
 			combineAssets,
@@ -160,27 +202,55 @@ class DependencyExtractionWebpackPlugin {
 		for ( const chunk of entrypointChunks ) {
 			const chunkFiles = Array.from( chunk.files );
 
-			const chunkJSFile = chunkFiles.find( ( f ) => /\.js$/i.test( f ) );
+			const jsExtensionRegExp = this.useModules ? /\.m?js$/i : /\.js$/i;
+
+			const chunkJSFile = chunkFiles.find( ( f ) =>
+				jsExtensionRegExp.test( f )
+			);
 			if ( ! chunkJSFile ) {
 				// There's no JS file in this chunk, no work for us. Typically a `style.css` from cache group.
 				continue;
 			}
 
-			const chunkDeps = new Set();
+			/** @type {Set<string>} */
+			const chunkStaticDeps = new Set();
+			/** @type {Set<string>} */
+			const chunkDynamicDeps = new Set();
+
 			if ( injectPolyfill ) {
-				chunkDeps.add( 'wp-polyfill' );
+				chunkStaticDeps.add( 'wp-polyfill' );
 			}
 
-			const processModule = ( { userRequest } ) => {
+			const processModule = ( m ) => {
+				const { userRequest } = m;
 				if ( this.externalizedDeps.has( userRequest ) ) {
-					chunkDeps.add( this.mapRequestToDependency( userRequest ) );
+					if ( this.useModules ) {
+						const isDynamic = Array.prototype.every.call(
+							compilation.moduleGraph.getIncomingConnections( m ),
+							( { dependency } ) => {
+								return (
+									compilation.moduleGraph.getParentBlock(
+										dependency
+									) instanceof AsyncDependenciesBlock
+								);
+							}
+						);
+
+						( isDynamic ? chunkDynamicDeps : chunkStaticDeps ).add(
+							userRequest
+						);
+					} else {
+						chunkStaticDeps.add(
+							this.mapRequestToDependency( userRequest )
+						);
+					}
 				}
 			};
 
 			// Search for externalized modules in all chunks.
-			const modulesIterable =
-				compilation.chunkGraph.getChunkModules( chunk );
-			for ( const chunkModule of modulesIterable ) {
+			for ( const chunkModule of compilation.chunkGraph.getChunkModulesIterable(
+				chunk
+			) ) {
 				processModule( chunkModule );
 				// Loop through submodules of ConcatenatedModule.
 				if ( chunkModule.modules ) {
@@ -209,8 +279,13 @@ class DependencyExtractionWebpackPlugin {
 				.slice( 0, hashDigestLength );
 
 			const assetData = {
-				// Get a sorted array so we can produce a stable, stringified representation.
-				dependencies: Array.from( chunkDeps ).sort(),
+				dependencies: [
+					// Sort these so we can produce a stable, stringified representation.
+					...Array.from( chunkStaticDeps ).sort(),
+					...Array.from( chunkDynamicDeps )
+						.sort()
+						.map( ( id ) => ( { id, type: 'dynamic' } ) ),
+				],
 				version: contentHash,
 			};
 
@@ -231,7 +306,7 @@ class DependencyExtractionWebpackPlugin {
 					'.asset.' + ( outputFormat === 'php' ? 'php' : 'json' );
 				assetFilename = compilation
 					.getPath( '[file]', { filename: chunkJSFile } )
-					.replace( /\.js$/i, suffix );
+					.replace( /\.m?js$/i, suffix );
 			}
 
 			// Add source and file into compilation for webpack to output.

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -289,6 +289,10 @@ class DependencyExtractionWebpackPlugin {
 				version: contentHash,
 			};
 
+			if ( this.useModules ) {
+				assetData.type = 'module';
+			}
+
 			if ( combineAssets ) {
 				combinedAssetsData[ chunkJSFile ] = assetData;
 				continue;

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -235,7 +235,7 @@ class DependencyExtractionWebpackPlugin {
 							);
 
 						( isStatic ? chunkStaticDeps : chunkDynamicDeps ).add(
-							userRequest
+							m.request
 						);
 					} else {
 						chunkStaticDeps.add(

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -53,14 +53,6 @@ class DependencyExtractionWebpackPlugin {
 		 * @type {boolean}
 		 */
 		this.useModules = false;
-
-		/**
-		 * Offload externalization work to the ExternalsPlugin.
-		 */
-		this.externalsPlugin = new webpack.ExternalsPlugin(
-			'window',
-			this.externalizeWpDeps.bind( this )
-		);
 	}
 
 	/**
@@ -142,9 +134,14 @@ class DependencyExtractionWebpackPlugin {
 	apply( compiler ) {
 		this.useModules = Boolean( compiler.options.output?.module );
 
-		if ( this.useModules ) {
-			this.externalsPlugin.type = 'module';
-		}
+		/**
+		 * Offload externalization work to the ExternalsPlugin.
+		 * @type {webpack.ExternalsPlugin}
+		 */
+		this.externalsPlugin = new webpack.ExternalsPlugin(
+			this.useModules ? 'module' : 'window',
+			this.externalizeWpDeps.bind( this )
+		);
 
 		this.externalsPlugin.apply( compiler );
 

--- a/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
+++ b/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
@@ -13,6 +13,7 @@ declare interface DependencyExtractionWebpackPluginOptions {
 	outputFormat?: 'php' | 'json';
 	outputFilename?: string | Function;
 	requestToExternal?: ( request: string ) => string | string[] | undefined;
+	requestToExternalModule?: ( request: string ) => string | undefined;
 	requestToHandle?: ( request: string ) => string | undefined;
 	combinedOutputFile?: string | null;
 	combineAssets?: boolean;

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -57,6 +57,21 @@ function defaultRequestToExternal( request ) {
 }
 
 /**
+ * Default request to external module transformation
+ *
+ * Currently only @wordpress/interactivity
+ *
+ * @param {string} request Module request (the module name in `import from`) to be transformed
+ * @return {string|undefined} The resulting external definition. Return `undefined`
+ *   to ignore the request. Return `string` to map the request to an external. This may simply be returning the request, e.g. `@wordpress/interactivity` maps to the external `@wordpress/interactivity`.
+ */
+function defaultRequestToExternalModule( request ) {
+	if ( request === '@wordpress/interactivity' ) {
+		return request;
+	}
+}
+
+/**
  * Default request to WordPress script handle transformation
  *
  * Transform @wordpress dependencies:
@@ -101,5 +116,6 @@ function camelCaseDash( string ) {
 module.exports = {
 	camelCaseDash,
 	defaultRequestToExternal,
+	defaultRequestToExternalModule,
 	defaultRequestToHandle,
 };

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -1,10 +1,11 @@
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const BUNDLED_PACKAGES = [
-	'@wordpress/icons',
-	'@wordpress/interface',
-	'@wordpress/undo-manager',
-	'@wordpress/sync',
 	'@wordpress/dataviews',
+	'@wordpress/icons',
+	'@wordpress/interactivity',
+	'@wordpress/interface',
+	'@wordpress/sync',
+	'@wordpress/undo-manager',
 ];
 
 /**

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -2,7 +2,6 @@ const WORDPRESS_NAMESPACE = '@wordpress/';
 const BUNDLED_PACKAGES = [
 	'@wordpress/dataviews',
 	'@wordpress/icons',
-	'@wordpress/interactivity',
 	'@wordpress/interface',
 	'@wordpress/sync',
 	'@wordpress/undo-manager',

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.mjs' => array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '8652d2bf4a1ea1969a6e', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array(array('id' => '@wordpress/token-list', 'type' => 'dynamic')), 'version' => '17d7d5b2c152592ff3a0', 'type' => 'module'));
+"<?php return array('fileA.mjs' => array('dependencies' => array('@wordpress/blob'), 'version' => '8652d2bf4a1ea1969a6e', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array('@wordpress/token-list'), 'version' => '17d7d5b2c152592ff3a0', 'type' => 'module'));
 "
 `;
 
@@ -21,7 +21,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '092c2bce8c247ee11100', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '092c2bce8c247ee11100', 'type' => 'module');
 "
 `;
 
@@ -36,7 +36,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
 "
 `;
 
@@ -51,7 +51,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-fil
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '9b89a3e6236b26559c4e', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '9b89a3e6236b26559c4e', 'type' => 'module');
 "
 `;
 
@@ -80,7 +80,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should pr
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
 "
 `;
 
@@ -95,7 +95,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-out
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
 "
 `;
 
@@ -114,7 +114,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic'), array('id' => '@wordpress/url', 'type' => 'dynamic'), array('id' => 'rxjs', 'type' => 'dynamic'), array('id' => 'rxjs/operators', 'type' => 'dynamic')), 'version' => '90f2e6327f4e8fb0264f', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', '@wordpress/url', 'rxjs', 'rxjs/operators'), 'version' => '90f2e6327f4e8fb0264f', 'type' => 'module');
 "
 `;
 
@@ -144,12 +144,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => 'aeadada5bf49ae3b9dc2', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => 'aeadada5bf49ae3b9dc2', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '10df52cc859c01faa91d', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '10df52cc859c01faa91d', 'type' => 'module');
 "
 `;
 
@@ -169,7 +169,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-singl
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '2d597a618aeebe7ab323', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '2d597a618aeebe7ab323', 'type' => 'module');
 "
 `;
 
@@ -184,7 +184,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` sho
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
 "
 `;
 
@@ -198,7 +198,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[{"id":"@wordpress/interactivity","type":"dynamic"}],"version":"d91ead3ebbc3853c802b","type":"module"}"`;
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[{"id":"@wordpress/interactivity","type":"dynamic"}],"version":"f0242eb6da78af6ca4b8","type":"module"}"`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
 [
@@ -211,7 +211,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interacti
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '7a320492a2396d955292', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '7a320492a2396d955292', 'type' => 'module');
 "
 `;
 
@@ -510,7 +510,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash","react","wp-dom-ready"],"version":"8d9fcb3d75d3b475913c"}"`;
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash","react"],"version":"bb0d768bc195f037eb10"}"`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
 [
@@ -523,14 +523,6 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interacti
     "externalType": "window",
     "request": "lodash",
     "userRequest": "lodash",
-  },
-  {
-    "externalType": "window",
-    "request": [
-      "wp",
-      "domReady",
-    ],
-    "userRequest": "@wordpress/dom-ready",
   },
 ]
 `;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -510,10 +510,15 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash","wp-interactivity"],"version":"ea7590e6d8a8e420f99f"}"`;
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash","react","wp-dom-ready"],"version":"8d9fcb3d75d3b475913c"}"`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
 [
+  {
+    "externalType": "window",
+    "request": "React",
+    "userRequest": "react",
+  },
   {
     "externalType": "window",
     "request": "lodash",
@@ -523,9 +528,9 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interacti
     "externalType": "window",
     "request": [
       "wp",
-      "interactivity",
+      "domReady",
     ],
-    "userRequest": "@wordpress/interactivity",
+    "userRequest": "@wordpress/dom-ready",
   },
 ]
 `;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,5 +1,230 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
+"<?php return array('fileA.mjs' => array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '8652d2bf4a1ea1969a6e'), 'fileB.mjs' => array('dependencies' => array(array('id' => '@wordpress/token-list', 'type' => 'dynamic')), 'version' => '17d7d5b2c152592ff3a0'));
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+  {
+    "externalType": "module",
+    "request": "@wordpress/token-list",
+    "userRequest": "@wordpress/token-list",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '092c2bce8c247ee11100');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '9b89a3e6236b26559c4e');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(), 'version' => '34504aa793c63cd3d73a');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(), 'version' => 'e37fbd452a6188261d74');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[],"version":"34504aa793c63cd3d73a"}"`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic'), array('id' => '@wordpress/url', 'type' => 'dynamic'), array('id' => 'rxjs', 'type' => 'dynamic'), array('id' => 'rxjs/operators', 'type' => 'dynamic')), 'version' => '90f2e6327f4e8fb0264f');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+  {
+    "externalType": "module",
+    "request": "@wordpress/url",
+    "userRequest": "@wordpress/url",
+  },
+  {
+    "externalType": "module",
+    "request": "rxjs",
+    "userRequest": "rxjs",
+  },
+  {
+    "externalType": "module",
+    "request": "rxjs/operators",
+    "userRequest": "rxjs/operators",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => 'aeadada5bf49ae3b9dc2');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '10df52cc859c01faa91d');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(), 'version' => 'd081f44e5ece6763f943');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '2d597a618aeebe7ab323');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[{"id":"@wordpress/interactivity","type":"dynamic"}],"version":"d91ead3ebbc3853c802b"}"`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/interactivity",
+    "userRequest": "@wordpress/interactivity",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '7a320492a2396d955292');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
 "<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'cbe985cf6e1a25d848e5'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '7f3970305cf0aecb54ab'));
 "
@@ -281,6 +506,26 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should 
       "blob",
     ],
     "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash","wp-interactivity"],"version":"ea7590e6d8a8e420f99f"}"`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "window",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
+  {
+    "externalType": "window",
+    "request": [
+      "wp",
+      "interactivity",
+    ],
+    "userRequest": "@wordpress/interactivity",
   },
 ]
 `;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.mjs' => array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '8652d2bf4a1ea1969a6e'), 'fileB.mjs' => array('dependencies' => array(array('id' => '@wordpress/token-list', 'type' => 'dynamic')), 'version' => '17d7d5b2c152592ff3a0'));
+"<?php return array('fileA.mjs' => array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '8652d2bf4a1ea1969a6e', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array(array('id' => '@wordpress/token-list', 'type' => 'dynamic')), 'version' => '17d7d5b2c152592ff3a0', 'type' => 'module'));
 "
 `;
 
@@ -21,7 +21,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '092c2bce8c247ee11100');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '092c2bce8c247ee11100', 'type' => 'module');
 "
 `;
 
@@ -36,7 +36,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
 "
 `;
 
@@ -51,7 +51,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-fil
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '9b89a3e6236b26559c4e');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '9b89a3e6236b26559c4e', 'type' => 'module');
 "
 `;
 
@@ -66,21 +66,21 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffi
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '34504aa793c63cd3d73a');
+"<?php return array('dependencies' => array(), 'version' => '34504aa793c63cd3d73a', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'e37fbd452a6188261d74');
+"<?php return array('dependencies' => array(), 'version' => 'e37fbd452a6188261d74', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
 "
 `;
 
@@ -95,7 +95,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-out
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
 "
 `;
 
@@ -109,12 +109,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filen
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[],"version":"34504aa793c63cd3d73a"}"`;
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[],"version":"34504aa793c63cd3d73a","type":"module"}"`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic'), array('id' => '@wordpress/url', 'type' => 'dynamic'), array('id' => 'rxjs', 'type' => 'dynamic'), array('id' => 'rxjs/operators', 'type' => 'dynamic')), 'version' => '90f2e6327f4e8fb0264f');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic'), array('id' => '@wordpress/url', 'type' => 'dynamic'), array('id' => 'rxjs', 'type' => 'dynamic'), array('id' => 'rxjs/operators', 'type' => 'dynamic')), 'version' => '90f2e6327f4e8fb0264f', 'type' => 'module');
 "
 `;
 
@@ -144,17 +144,17 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => 'aeadada5bf49ae3b9dc2');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => 'aeadada5bf49ae3b9dc2', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '10df52cc859c01faa91d');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '10df52cc859c01faa91d', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'd081f44e5ece6763f943');
+"<?php return array('dependencies' => array(), 'version' => 'd081f44e5ece6763f943', 'type' => 'module');
 "
 `;
 
@@ -169,7 +169,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-singl
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '2d597a618aeebe7ab323');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '2d597a618aeebe7ab323', 'type' => 'module');
 "
 `;
 
@@ -184,7 +184,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` sho
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '5207bcd3fdd29de25f37', 'type' => 'module');
 "
 `;
 
@@ -198,7 +198,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[{"id":"@wordpress/interactivity","type":"dynamic"}],"version":"d91ead3ebbc3853c802b"}"`;
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[{"id":"@wordpress/interactivity","type":"dynamic"}],"version":"d91ead3ebbc3853c802b","type":"module"}"`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
 [
@@ -211,7 +211,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interacti
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '7a320492a2396d955292');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '7a320492a2396d955292', 'type' => 'module');
 "
 `;
 

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -20,6 +20,21 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` sh
 ]
 `;
 
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('@wordpress/interactivity'), 'version' => '58fadee5eca3ad30aff6', 'type' => 'module');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/interactivity",
+    "userRequest": "@wordpress/interactivity",
+  },
+]
+`;
+
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '092c2bce8c247ee11100', 'type' => 'module');
 "
@@ -255,6 +270,24 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`combine-assets\` sh
       "tokenList",
     ],
     "userRequest": "@wordpress/token-list",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('wp-interactivity'), 'version' => '79a1af3afac581f52492');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "window",
+    "request": [
+      "wp",
+      "interactivity",
+    ],
+    "userRequest": "@wordpress/interactivity",
   },
 ]
 `;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -510,19 +510,22 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash","react"],"version":"bb0d768bc195f037eb10"}"`;
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash","wp-interactivity"],"version":"b16015e38aea0509f75f"}"`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
-    "request": "React",
-    "userRequest": "react",
+    "request": "lodash",
+    "userRequest": "lodash",
   },
   {
     "externalType": "window",
-    "request": "lodash",
-    "userRequest": "lodash",
+    "request": [
+      "wp",
+      "interactivity",
+    ],
+    "userRequest": "@wordpress/interactivity",
   },
 ]
 `;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -21,7 +21,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '092c2bce8c247ee11100', 'type' => 'module');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '092c2bce8c247ee11100', 'type' => 'module');
 "
 `;
 
@@ -198,7 +198,10 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[{"id":"@wordpress/interactivity","type":"dynamic"}],"version":"f0242eb6da78af6ca4b8","type":"module"}"`;
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'type' => 'dynamic')), 'version' => 'f0242eb6da78af6ca4b8', 'type' => 'module');
+"
+`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
 [
@@ -510,7 +513,10 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash","wp-interactivity"],"version":"b16015e38aea0509f75f"}"`;
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('lodash', 'wp-interactivity'), 'version' => 'b16015e38aea0509f75f');
+"
+`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
 [

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -35,6 +35,21 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-g
 ]
 `;
 
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'type' => 'dynamic')), 'version' => '293aebad4ca761cf396f', 'type' => 'module');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/interactivity",
+    "userRequest": "@wordpress/interactivity",
+  },
+]
+`;
+
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '092c2bce8c247ee11100', 'type' => 'module');
 "
@@ -280,6 +295,24 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-g
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "window",
+    "request": [
+      "wp",
+      "interactivity",
+    ],
+    "userRequest": "@wordpress/interactivity",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'ac0e2f1bcd3a6a0e7aff');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -95,6 +95,26 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffi
 ]
 `;
 
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('renamed--@my/module', 'renamed--other-module'), 'version' => '601cf94eb9a182fcc0ed', 'type' => 'module');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "renamed--@my/module",
+    "userRequest": "@my/module",
+  },
+  {
+    "externalType": "module",
+    "request": "renamed--other-module",
+    "userRequest": "other-module",
+  },
+]
+`;
+
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => '34504aa793c63cd3d73a', 'type' => 'module');
 "
@@ -385,6 +405,32 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`has-extension-suffi
       "blob",
     ],
     "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('renamed--@my/module', 'renamed--other-module'), 'version' => '34854902f36ec8e176d6');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "window",
+    "request": [
+      "my-namespace",
+      "renamed--@my/module",
+    ],
+    "userRequest": "@my/module",
+  },
+  {
+    "externalType": "window",
+    "request": [
+      "my-namespace",
+      "renamed--other-module",
+    ],
+    "userRequest": "other-module",
   },
 ]
 `;

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -13,89 +13,108 @@ const configFixtures = fs.readdirSync( fixturesPath ).sort();
 
 afterAll( () => rimraf( path.join( __dirname, 'build' ) ) );
 
-describe( 'DependencyExtractionWebpackPlugin scripts', () => {
-	describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
-		const testDirectory = path.join( fixturesPath, configCase );
-		const outputDirectory = path.join( __dirname, 'build', configCase );
-
-		beforeEach( () => {
-			rimraf( outputDirectory );
-			mkdirp( outputDirectory );
-		} );
-
-		// This afterEach is necessary to prevent watched tests from retriggering on every run.
-		afterEach( () => rimraf( outputDirectory ) );
-
-		test( 'should produce expected output', async () => {
-			const options = Object.assign(
-				{
-					target: 'web',
-					context: testDirectory,
-					entry: './index.js',
-					mode: 'production',
-					optimization: {
-						minimize: false,
-						chunkIds: 'named',
-						moduleIds: 'named',
-					},
-					output: {},
-					experiments: {},
-				},
-				require( path.join( testDirectory, 'webpack.config.js' ) )
-			);
-			options.output.path = outputDirectory;
-
-			/** @type {webpack.Stats} */
-			const stats = await new Promise( ( resolve, reject ) =>
-				webpack( options, ( err, _stats ) => {
-					if ( err ) {
-						return reject( err );
-					}
-					resolve( _stats );
-				} )
+describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
+	'DependencyExtractionWebpackPlugin %s',
+	( moduleMode ) => {
+		describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
+			const testDirectory = path.join( fixturesPath, configCase );
+			const outputDirectory = path.join(
+				__dirname,
+				'build',
+				moduleMode,
+				configCase
 			);
 
-			if ( stats.hasErrors() ) {
-				throw new Error(
-					stats.toString( { errors: true, all: false } )
-				);
-			}
-
-			const assetFiles = glob(
-				`${ outputDirectory }/+(*.asset|assets).@(json|php)`
-			);
-
-			expect( assetFiles.length ).toBeGreaterThan( 0 );
-
-			// Asset files should match.
-			assetFiles.forEach( ( assetFile ) => {
-				const assetBasename = path.basename( assetFile );
-
-				expect( fs.readFileSync( assetFile, 'utf-8' ) ).toMatchSnapshot(
-					`Asset file '${ assetBasename }' should match snapshot`
-				);
+			beforeEach( () => {
+				rimraf( outputDirectory );
+				mkdirp( outputDirectory );
 			} );
 
-			const compareByModuleIdentifier = ( m1, m2 ) => {
-				const i1 = m1.identifier();
-				const i2 = m2.identifier();
-				if ( i1 < i2 ) return -1;
-				if ( i1 > i2 ) return 1;
-				return 0;
-			};
+			// This afterEach is necessary to prevent watched tests from retriggering on every run.
+			afterEach( () => rimraf( outputDirectory ) );
 
-			// Webpack stats external modules should match.
-			const externalModules = Array.from( stats.compilation.modules )
-				.filter( ( { externalType } ) => externalType )
-				.sort( compareByModuleIdentifier )
-				.map( ( module ) => ( {
-					externalType: module.externalType,
-					request: module.request,
-					userRequest: module.userRequest,
-				} ) );
-			expect( externalModules ).toMatchSnapshot(
-				'External modules should match snapshot'
-			);
+			test( 'should produce expected output', async () => {
+				const options = Object.assign(
+					{
+						target: 'web',
+						context: testDirectory,
+						entry: './index.js',
+						mode: 'production',
+						optimization: {
+							minimize: false,
+							chunkIds: 'named',
+							moduleIds: 'named',
+						},
+						output: {},
+						experiments: {},
+					},
+					require( path.join( testDirectory, 'webpack.config.js' ) )
+				);
+				options.output.path = outputDirectory;
+
+				if ( moduleMode === 'modules' ) {
+					options.target = 'es2024';
+					options.output.module = true;
+					options.output.chunkFormat = 'module';
+					options.output.library = options.output.library || {};
+					options.output.library.type = 'module';
+					options.experiments.outputModule = true;
+				}
+
+				/** @type {webpack.Stats} */
+				const stats = await new Promise( ( resolve, reject ) =>
+					webpack( options, ( err, _stats ) => {
+						if ( err ) {
+							return reject( err );
+						}
+						resolve( _stats );
+					} )
+				);
+
+				if ( stats.hasErrors() ) {
+					throw new Error(
+						stats.toString( { errors: true, all: false } )
+					);
+				}
+
+				const assetFiles = glob(
+					`${ outputDirectory }/+(*.asset|assets).@(json|php)`
+				);
+
+				expect( assetFiles.length ).toBeGreaterThan( 0 );
+
+				// Asset files should match.
+				assetFiles.forEach( ( assetFile ) => {
+					const assetBasename = path.basename( assetFile );
+
+					expect(
+						fs.readFileSync( assetFile, 'utf-8' )
+					).toMatchSnapshot(
+						`Asset file '${ assetBasename }' should match snapshot`
+					);
+				} );
+
+				const compareByModuleIdentifier = ( m1, m2 ) => {
+					const i1 = m1.identifier();
+					const i2 = m2.identifier();
+					if ( i1 < i2 ) return -1;
+					if ( i1 > i2 ) return 1;
+					return 0;
+				};
+
+				// Webpack stats external modules should match.
+				const externalModules = Array.from( stats.compilation.modules )
+					.filter( ( { externalType } ) => externalType )
+					.sort( compareByModuleIdentifier )
+					.map( ( module ) => ( {
+						externalType: module.externalType,
+						request: module.request,
+						userRequest: module.userRequest,
+					} ) );
+				expect( externalModules ).toMatchSnapshot(
+					'External modules should match snapshot'
+				);
+			} );
 		} );
-	} );
-} );
+	}
+);

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -36,6 +36,7 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 			test( 'should produce expected output', async () => {
 				const options = Object.assign(
 					{
+						name: `${ configCase }-${ moduleMode }`,
 						target: 'web',
 						context: testDirectory,
 						entry: './index.js',

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
@@ -11,6 +11,11 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			combineAssets: true,
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
 		} ),
 	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dependency-graph/a.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dependency-graph/a.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { store } from '@wordpress/interactivity';
+
+/**
+ * Internal dependencies
+ */
+import { identity } from './b.js';
+
+identity( 1 );
+
+export { identity, store };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dependency-graph/b.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dependency-graph/b.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { store } from './a.js';
+
+export function identity( x ) {
+	return x;
+}
+
+export { store };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dependency-graph/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dependency-graph/index.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { identity as aIdentity, store as aStore } from './a.js';
+import { identity as bIdentity, store as bStore } from './b.js';
+
+aStore( aIdentity( 'a' ), { a: aIdentity( 'a' ) } );
+bStore( bIdentity( 'b' ), { b: bIdentity( 'b' ) } );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dependency-graph/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dependency-graph/webpack.config.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dynamic-dependency-graph/a.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dynamic-dependency-graph/a.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { store } from '@wordpress/interactivity';
+
+/**
+ * Internal dependencies
+ */
+import { identity } from './b.js';
+
+identity( 1 );
+
+export { identity, store };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dynamic-dependency-graph/b.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dynamic-dependency-graph/b.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+const { store } = import( './a.js' );
+
+export function identity( x ) {
+	return x;
+}
+
+export { store };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dynamic-dependency-graph/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dynamic-dependency-graph/index.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { identity as bIdentity, store as bStore } from './b.js';
+
+const { identity: aIdentity, store: aStore } = await import( './a.js' );
+
+aStore( aIdentity( 'a' ), { a: aIdentity( 'a' ) } );
+bStore( bIdentity( 'b' ), { b: bIdentity( 'b' ) } );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dynamic-dependency-graph/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/cyclic-dynamic-dependency-graph/webpack.config.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/webpack.config.js
@@ -4,5 +4,13 @@
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
-	plugins: [ new DependencyExtractionWebpackPlugin() ],
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
+		} ),
+	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
@@ -9,5 +9,13 @@ module.exports = {
 			return `chunk--${ chunkData.chunk.name }--[name].js`;
 		},
 	},
-	plugins: [ new DependencyExtractionWebpackPlugin() ],
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
+		} ),
+	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/has-extension-suffix/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/has-extension-suffix/webpack.config.js
@@ -7,5 +7,13 @@ module.exports = {
 	output: {
 		filename: 'index.min.js',
 	},
-	plugins: [ new DependencyExtractionWebpackPlugin() ],
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
+		} ),
+	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/module-renames/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/module-renames/index.js
@@ -1,0 +1,7 @@
+/**
+ * External dependencies
+ */
+import * as m from '@my/module';
+import { other } from 'other-module';
+
+m.load( other );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/module-renames/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/module-renames/webpack.config.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternal( request ) {
+				switch ( request ) {
+					case '@my/module':
+					case 'other-module':
+						return [ 'my-namespace', `renamed--${ request }` ];
+				}
+			},
+			requestToHandle( request ) {
+				switch ( request ) {
+					case '@my/module':
+					case 'other-module':
+						return `renamed--${ request }`;
+				}
+			},
+			requestToExternalModule( request ) {
+				switch ( request ) {
+					case '@my/module':
+					case 'other-module':
+						return `renamed--${ request }`;
+				}
+			},
+		} ),
+	],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/option-function-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/option-function-output-filename/webpack.config.js
@@ -9,6 +9,11 @@ module.exports = {
 			outputFilename( chunkData ) {
 				return `chunk--${ chunkData.chunk.name }--[name].asset.php`;
 			},
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
 		} ),
 	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/option-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/option-output-filename/webpack.config.js
@@ -7,6 +7,11 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			outputFilename: '[name]-foo.asset.php',
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
 		} ),
 	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
@@ -15,6 +15,18 @@ module.exports = {
 					return [ 'rxjs', 'operators' ];
 				}
 			},
+			requestToExternalModule( request ) {
+				if ( request === 'rxjs' ) {
+					return request;
+				}
+
+				if ( request === 'rxjs/operators' ) {
+					return request;
+				}
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
 			requestToHandle( request ) {
 				if ( request === 'rxjs' || request === 'rxjs/operators' ) {
 					return 'wp-script-handle-for-rxjs';

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/style-imports/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/style-imports/webpack.config.js
@@ -10,7 +10,13 @@ const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
 	plugins: [
-		new DependencyExtractionWebpackPlugin(),
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
+		} ),
 		new MiniCSSExtractPlugin(),
 	],
 	module: {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/index.js
@@ -1,0 +1,13 @@
+/* eslint-disable eslint-comments/disable-enable-pair */
+/* eslint-disable eslint-comments/no-unlimited-disable */
+/* eslint-disable */
+
+import _ from 'lodash';
+
+// This module should be externalized
+// import { store } from '@wordpress/interactivity';
+const { store, getContext } = await import( '@wordpress/interactivity' );
+
+store( _.identity( 'my-namespace' ), { state: 'is great' } );
+
+getContext();

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/index.js
@@ -5,7 +5,6 @@
 import _ from 'lodash';
 
 // This module should be externalized
-// import { store } from '@wordpress/interactivity';
 const { store, getContext } = await import( '@wordpress/interactivity' );
 
 store( _.identity( 'my-namespace' ), { state: 'is great' } );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/webpack.config.js
@@ -4,20 +4,14 @@
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
-	entry: {
-		a: './a',
-		b: './b',
-	},
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
+			outputFormat: 'json',
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
+				if ( request.startsWith( 'test-external' ) ) {
 					return request;
 				}
 			},
 		} ),
 	],
-	optimization: {
-		runtimeChunk: 'single',
-	},
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/webpack.config.js
@@ -4,14 +4,5 @@
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
-	plugins: [
-		new DependencyExtractionWebpackPlugin( {
-			outputFormat: 'json',
-			requestToExternalModule( request ) {
-				if ( request.startsWith( 'test-external' ) ) {
-					return request;
-				}
-			},
-		} ),
-	],
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
@@ -4,5 +4,13 @@
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
-	plugins: [ new DependencyExtractionWebpackPlugin() ],
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
+		} ),
+	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
@@ -4,5 +4,13 @@
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
-	plugins: [ new DependencyExtractionWebpackPlugin() ],
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				if ( request.startsWith( '@wordpress/' ) ) {
+					return request;
+				}
+			},
+		} ),
+	],
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Add support for extracting modules information with the Dependency Extraction Webpack Plugin.

Part of #57492 

## Why?

As the [modules support matures](https://github.com/WordPress/gutenberg/issues/55942), we should provide at least the same experience folks currently have with scripts.

## How?

First: Behavior with scripts remains unchanged. Folks can continue to use this plugin in exactly the same way without any changes. These changes should be low risk and the module behavior can be considered experimental. **Should we add a note about that in the README?**

We add the necessary functionality to this plugin to support modules.

To determine whether to compile in module or script mode, we check the webpack option `output.modules`. If this option is true, the plugin will compile for modules.

A new option is added `requestToExternalModule`, it serves the same purpose as `requestToExternal` for scripts. The same option could have been reused, but I created a new option to avoid confusion.

One notable difference is that, we extract information about whether a module is dynamic `const x = await import( … )` or static `import x from …` so `wp_register_module` can correctly list static and dynamic module dependencies.

## Testing Instructions

The test suite has been adapted to produce module output. You can check the snapshots added in the PR.
