### PR TITLE
Add missing block/theme json $schema property

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": false,

--- a/packages/e2e-tests/plugins/iframed-block/block.json
+++ b/packages/e2e-tests/plugins/iframed-block/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "test/iframed-block",
 	"title": "Iframed Block",

--- a/packages/e2e-tests/plugins/iframed-inline-styles/block.json
+++ b/packages/e2e-tests/plugins/iframed-inline-styles/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "test/iframed-inline-styles",
 	"title": "Iframed Inline Styles",

--- a/packages/e2e-tests/plugins/iframed-masonry-block/block.json
+++ b/packages/e2e-tests/plugins/iframed-masonry-block/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "test/iframed-masonry-block",
 	"title": "Iframed Masonry Block",

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "test/iframed-multiple-stylesheets",
 	"title": "Iframed Multiple Stylesheets",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-bind",
 	"title": "E2E Interactivity tests - directive bind",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-body/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-body/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-body",
 	"title": "E2E Interactivity tests - directive body",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-class/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-class/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-class",
 	"title": "E2E Interactivity tests - directive class",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-context",
 	"title": "E2E Interactivity tests - directive context",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-init/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-init/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-init",
 	"title": "E2E Interactivity tests - directive init",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-key/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-key/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-key",
 	"title": "E2E Interactivity tests - directive key",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-on",
 	"title": "E2E Interactivity tests - directive on",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-priorities",
 	"title": "E2E Interactivity tests - directive priorities",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-slots/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-slots/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-slots",
 	"title": "E2E Interactivity tests - directive slots",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-style",
 	"title": "E2E Interactivity tests - directive style",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-text",
 	"title": "E2E Interactivity tests - directive text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-watch/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-watch/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/directive-watch",
 	"title": "E2E Interactivity tests - directive watch",

--- a/packages/e2e-tests/plugins/interactive-blocks/negation-operator/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/negation-operator/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/negation-operator",
 	"title": "E2E Interactivity tests - negation operator",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/router-navigate",
 	"title": "E2E Interactivity tests - router navigate",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/router-regions",
 	"title": "E2E Interactivity tests - router regions",

--- a/packages/e2e-tests/plugins/interactive-blocks/store-tag/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/store-tag/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/store-tag",
 	"title": "E2E Interactivity tests - store tag",

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/tovdom-islands",
 	"title": "E2E Interactivity tests - tovdom islands",

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "test/tovdom",
 	"title": "E2E Interactivity tests - tovdom",

--- a/packages/edit-widgets/src/blocks/widget-area/block.json
+++ b/packages/edit-widgets/src/blocks/widget-area/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "core/widget-area",
 	"category": "widgets",
 	"attributes": {

--- a/packages/widgets/src/blocks/legacy-widget/block.json
+++ b/packages/widgets/src/blocks/legacy-widget/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/legacy-widget",
 	"title": "Legacy Widget",

--- a/packages/widgets/src/blocks/widget-group/block.json
+++ b/packages/widgets/src/blocks/widget-group/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/widget-group",
 	"category": "widgets",

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-layout/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-layout/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,

--- a/phpunit/data/themedir1/block-theme-child/theme.json
+++ b/phpunit/data/themedir1/block-theme-child/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"color": {

--- a/phpunit/data/themedir1/block-theme/theme.json
+++ b/phpunit/data/themedir1/block-theme/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"color": {

--- a/phpunit/data/themedir1/fonts-block-theme/theme.json
+++ b/phpunit/data/themedir1/fonts-block-theme/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "my-plugin/notice",
 	"title": "Notice",

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -12,7 +12,7 @@
 	"icon": "star",
 	"description": "Shows warning, error or success notices…",
 	"keywords": [ "alert", "message" ],
-	"textDomain": "my-plugin",
+	"textdomain": "my-plugin",
 	"attributes": {
 		"message": {
 			"type": "string",

--- a/phpunit/fixtures/hooked-block/block.json
+++ b/phpunit/fixtures/hooked-block/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "tests/hooked-block",
 	"blockHooks": {
 		"tests/group-first-child": "firstChild",

--- a/phpunit/fixtures/hooked-block/block.json
+++ b/phpunit/fixtures/hooked-block/block.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"title": "Hooked Block",
 	"name": "tests/hooked-block",
 	"blockHooks": {
 		"tests/group-first-child": "firstChild",

--- a/test/gutenberg-test-themes/style-variations/theme.json
+++ b/test/gutenberg-test-themes/style-variations/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"styles": {
 		"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Add $schema to block.json and theme.json files to leverage JSON schema support.

## Why?

Schemas help ensure that these files conform to expectations. They can help provide autocomplete and documentation if editors are configured to do so.

We provide and maintain these schemas, we should be using them. This can help to ensure that our own declarations are correct and that the schemas are also correct.

## Testing Instructions

If you have an editor configured to show JSON schema information, you can open up one of these files and confirm it works as expected. I believe Visual Studio Code provides this behavior by default.

This change is a developer experience improvement and should not otherwise impact the behavior of Gutenberg or its packages.

## Screenshots or screencast

![Screenshot 2023-12-19 at 12 50 21](https://github.com/WordPress/gutenberg/assets/841763/c1dc0d6d-5399-44aa-8324-fb881cb1be05)

