### PR TITLE
Fix/tooltip hide on blur

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `DropdownMenuV2`: do not collapse suffix width ([#57238](https://github.com/WordPress/gutenberg/pull/57238)).
 -   `DateTimePicker`: Adjustment of the dot position on DayButton and expansion of the button area. ([#55502](https://github.com/WordPress/gutenberg/pull/55502)).
 -   `Modal`: Improve application of body class names ([#55430](https://github.com/WordPress/gutenberg/pull/55430)).
+-   `Tooltip`: add `hideOnBlur` prop ([#57204](https://github.com/WordPress/gutenberg/pull/57204)).
 
 ### Experimental
 

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -35,6 +35,13 @@ The amount of time in milliseconds to wait before showing the tooltip.
 -   Required: No
 -   Default: `700`
 
+#### `hideOnBlur`: `boolean`
+
+Option to hide the tooltip when the anchor is blurred.
+
+-   Required: No
+-   Default: `true`
+
 #### `hideOnClick`: `boolean`
 
 Option to hide the tooltip when the anchor is clicked.

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -37,10 +37,12 @@ The amount of time in milliseconds to wait before showing the tooltip.
 
 #### `hideOnBlur`: `boolean`
 
-Option to hide the tooltip when the anchor is blurred.
+By default, the tooltip will close when interacting with other elements in the same `window`. This means that the tooltip will stay open when the whole `window` loses focus — for example, this happens when the whole browser loses keyboard focus, or even when moving focus to/from an iframe.
+
+This flag, when set to `true`, will force the tooltip to always hide when the anchor is blurred.
 
 -   Required: No
--   Default: `true`
+-   Default: `false`
 
 #### `hideOnClick`: `boolean`
 

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -66,7 +66,8 @@ function Tooltip( props: TooltipProps ) {
 
 	const tooltipStore = Ariakit.useTooltipStore( {
 		placement: computedPlacement,
-		timeout: delay,
+		showTimeout: delay,
+		hideTimeout: 0,
 	} );
 
 	return (

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -28,6 +28,7 @@ function Tooltip( props: TooltipProps ) {
 		children,
 		delay = TOOLTIP_DELAY,
 		hideOnClick = true,
+		hideOnBlur = true,
 		placement,
 		position,
 		shortcut,
@@ -73,6 +74,7 @@ function Tooltip( props: TooltipProps ) {
 	return (
 		<>
 			<Ariakit.TooltipAnchor
+				onBlur={ hideOnBlur ? tooltipStore.hide : undefined }
 				onClick={ hideOnClick ? tooltipStore.hide : undefined }
 				store={ tooltipStore }
 				render={ isOnlyChild ? children : undefined }

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -28,7 +28,7 @@ function Tooltip( props: TooltipProps ) {
 		children,
 		delay = TOOLTIP_DELAY,
 		hideOnClick = true,
-		hideOnBlur = true,
+		hideOnBlur = false,
 		placement,
 		position,
 		shortcut,

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -50,34 +50,55 @@ describe( 'Tooltip', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should render the tooltip when focusing on the tooltip anchor via tab', async () => {
+	it( 'should show the tooltip when the tooltip anchor receives focus, and hide it when the anchor loses focus', async () => {
 		const user = userEvent.setup();
 
 		render( <Tooltip { ...props } /> );
 
+		const tooltipAnchor = screen.getByRole( 'button', { name: /Button/i } );
+
 		await user.tab();
 
-		expect(
-			screen.getByRole( 'button', { name: /Button/i } )
-		).toHaveFocus();
+		expect( tooltipAnchor ).toHaveFocus();
 
 		expect(
 			await screen.findByRole( 'tooltip', { name: /tooltip text/i } )
 		).toBeVisible();
 
+		await user.tab();
+		await user.tab();
+		await user.click( document.body );
+
+		expect( tooltipAnchor ).not.toHaveFocus();
+
+		expect(
+			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+		).not.toBeInTheDocument();
+
 		await cleanupTooltip( user );
 	} );
 
-	it( 'should render the tooltip when the tooltip anchor is hovered', async () => {
+	it( 'should show the tooltip when the tooltip anchor is hovered, and hide it when the anchor is not hovered anymore', async () => {
 		const user = userEvent.setup();
 
-		render( <Tooltip { ...props } /> );
+		render(
+			<>
+				<Tooltip { ...props } />
+				<button>Hover me</button>
+			</>
+		);
 
 		await user.hover( screen.getByRole( 'button', { name: /Button/i } ) );
 
 		expect(
 			await screen.findByRole( 'tooltip', { name: /tooltip text/i } )
 		).toBeVisible();
+
+		await user.hover( screen.getByRole( 'button', { name: /Hover me/i } ) );
+
+		expect(
+			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+		).not.toBeInTheDocument();
 
 		await cleanupTooltip( user );
 	} );
@@ -263,7 +284,7 @@ describe( 'Tooltip', () => {
 		await cleanupTooltip( user );
 	} );
 
-	it( 'esc should close modal even when tooltip is visible', async () => {
+	it( 'should close a parent Modal even when tooltip is visible when pressing the Escape key', async () => {
 		const user = userEvent.setup();
 		const onRequestClose = jest.fn();
 		render(

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -50,10 +50,10 @@ describe( 'Tooltip', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should show the tooltip when the tooltip anchor receives focus, and hide it when the anchor loses focus', async () => {
+	it( 'should show the tooltip when the tooltip anchor receives focus, and hide it when the anchor loses focus when the hideOnBlur prop is `true`', async () => {
 		const user = userEvent.setup();
 
-		render( <Tooltip { ...props } /> );
+		render( <Tooltip { ...props } hideOnBlur /> );
 
 		const tooltipAnchor = screen.getByRole( 'button', { name: /Button/i } );
 
@@ -65,17 +65,13 @@ describe( 'Tooltip', () => {
 			await screen.findByRole( 'tooltip', { name: /tooltip text/i } )
 		).toBeVisible();
 
-		await user.tab();
-		await user.tab();
-		await user.click( document.body );
+		await cleanupTooltip( user );
 
 		expect( tooltipAnchor ).not.toHaveFocus();
 
 		expect(
 			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
 		).not.toBeInTheDocument();
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should show the tooltip when the tooltip anchor is hovered, and hide it when the anchor is not hovered anymore', async () => {

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -23,6 +23,12 @@ export type TooltipProps = {
 	 */
 	hideOnClick?: boolean;
 	/**
+	 * Option to hide the tooltip when the anchor is blurred.
+	 *
+	 * @default true
+	 */
+	hideOnBlur?: boolean;
+	/**
 	 * The amount of time in milliseconds to wait before showing the tooltip.
 	 *
 	 * @default 700

--- a/packages/components/src/tooltip/types.ts
+++ b/packages/components/src/tooltip/types.ts
@@ -23,9 +23,14 @@ export type TooltipProps = {
 	 */
 	hideOnClick?: boolean;
 	/**
-	 * Option to hide the tooltip when the anchor is blurred.
+	 * By default, the tooltip will close when interacting with other elements
+	 * in the same `window`. This means that the tooltip will stay open when the
+	 * whole `window` loses focus — for example, this happens when the whole
+	 * browser loses keyboard focus, or even when moving focus to/from an iframe.
+	 * This flag, when set to `true`, will force the tooltip to always hide when
+	 * the anchor is blurred.
 	 *
-	 * @default true
+	 * @default false
 	 */
 	hideOnBlur?: boolean;
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #57206

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a new `hideOnBlur` prop to the `Tooltip` component which forces the tooltip to hide when its anchor loses focus

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

By default, the tooltip closes when interacting with other elements in the same `window` (see [ariakit docs](https://ariakit.org/reference/tooltip#hideoninteractoutside)). This means that the tooltip will stay open when the whole `window` loses focus — for example, this happens when the whole browser loses keyboard focus, or even when moving focus to/from an iframe.

But sometimes it's desirable to have the tooltip hide when its anchor loses focus, hence the addition of the `hideOnBlur` prop

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
