### PR TITLE
Commands: Allow disabling and enabling comments

### DIFF
--- a/packages/commands/CHANGELOG.md
+++ b/packages/commands/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Enhancements
+
+-   Support conditional commands and commands loaders using the "disabled" config.
+
 ## 0.19.0 (2023-12-13)
 
 ## 0.18.0 (2023-11-29)

--- a/packages/commands/src/hooks/use-command-loader.js
+++ b/packages/commands/src/hooks/use-command-loader.js
@@ -82,6 +82,9 @@ export default function useCommandLoader( loader ) {
 	const { registerCommandLoader, unregisterCommandLoader } =
 		useDispatch( commandsStore );
 	useEffect( () => {
+		if ( loader.disabled ) {
+			return;
+		}
 		registerCommandLoader( {
 			name: loader.name,
 			hook: loader.hook,
@@ -94,6 +97,7 @@ export default function useCommandLoader( loader ) {
 		loader.name,
 		loader.hook,
 		loader.context,
+		loader.disabled,
 		registerCommandLoader,
 		unregisterCommandLoader,
 	] );

--- a/packages/commands/src/hooks/use-command.js
+++ b/packages/commands/src/hooks/use-command.js
@@ -38,6 +38,9 @@ export default function useCommand( command ) {
 	}, [ command.callback ] );
 
 	useEffect( () => {
+		if ( command.disabled ) {
+			return;
+		}
 		registerCommand( {
 			name: command.name,
 			context: command.context,
@@ -55,6 +58,7 @@ export default function useCommand( command ) {
 		command.searchLabel,
 		command.icon,
 		command.context,
+		command.disabled,
 		registerCommand,
 		unregisterCommand,
 	] );

--- a/packages/commands/src/store/actions.js
+++ b/packages/commands/src/store/actions.js
@@ -11,6 +11,7 @@
  * @property {string=}     context     Command context.
  * @property {JSX.Element} icon        Command icon.
  * @property {Function}    callback    Command callback.
+ * @property {boolean}     disabled    Whether to disable the command.
  */
 
 /**
@@ -22,9 +23,10 @@
  *
  * @typedef {Object} WPCommandLoaderConfig
  *
- * @property {string}              name    Command loader name.
- * @property {string=}             context Command loader context.
- * @property {WPCommandLoaderHook} hook    Command loader hook.
+ * @property {string}              name     Command loader name.
+ * @property {string=}             context  Command loader context.
+ * @property {WPCommandLoaderHook} hook     Command loader hook.
+ * @property {boolean}             disabled Whether to disable the command loader.
  */
 
 /**


### PR DESCRIPTION
## What?

While working on some list view command, I found that it would be useful to be able to enable/disable commands based on conditions. I know we can already do that using command loaders but it felt like a small devx improvement to allow this in the `useCommand` and `useCommandLoader` hooks directly instead.

## Testing Instructions

Nothing really to test here, it's just an API addition. The API is not used right now but I'm planning to use it in a small follow-up PR.