### PR TITLE
Code Quality: Update: Reuse view revisions action on templates and pages

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -45,8 +45,8 @@ import {
 	useResetTemplateAction,
 	deleteTemplateAction,
 	renameTemplateAction,
-	seeRevisionsAction,
 } from './template-actions';
+import { postRevisionsAction } from '../actions';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 import PostPreview from '../post-preview';
@@ -333,7 +333,7 @@ export default function DataviewsTemplates() {
 			resetTemplateAction,
 			deleteTemplateAction,
 			renameTemplateAction,
-			seeRevisionsAction,
+			postRevisionsAction,
 		],
 		[ resetTemplateAction ]
 	);

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -15,7 +15,6 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -206,25 +205,5 @@ export const renameTemplateAction = {
 				</VStack>
 			</form>
 		);
-	},
-};
-
-export const seeRevisionsAction = {
-	id: 'see-revisions',
-	label: __( 'See revisions' ),
-	isEligible: ( template ) => {
-		if ( template?._links && template?._links[ 'predecessor-version' ] ) {
-			const predecessorVersions =
-				template._links[ 'predecessor-version' ];
-			return predecessorVersions.length > 0;
-		}
-		return false;
-	},
-	callback( template ) {
-		const lastRevisionId =
-			template?._links[ 'predecessor-version' ][ 0 ].id;
-		document.location.href = addQueryArgs( 'revision.php', {
-			revision: lastRevisionId,
-		} );
 	},
 };


### PR DESCRIPTION
While following @oandregal suggestion to add view revisions action to pages on https://github.com/WordPress/gutenberg/pull/57175#issuecomment-1862453907. I noticed the action was already available for pages and in fact, could just be reused for templates, so this PR just improves the code quality by removing the equivalent action from templates and reusing the one from pages.