### PR TITLE
Pattern Category: change show_tagcloud to false

### DIFF
--- a/lib/compat/wordpress-6.5/block-patterns.php
+++ b/lib/compat/wordpress-6.5/block-patterns.php
@@ -72,6 +72,7 @@ function gutenberg_register_taxonomy_patterns() {
 		'show_in_nav_menus'  => false,
 		'show_in_rest'       => true,
 		'show_admin_column'  => true,
+		'show_tagcloud'      => false,
 	);
 	register_taxonomy( 'wp_pattern_category', array( 'wp_block' ), $args );
 }


### PR DESCRIPTION
Fixes #57211

## What?
~~This PR prevents the selection of taxonomies with publicly_queryable set to false in the Tag Cloud block. As a result, the "Pattern Categories" taxonomy cannot be selected.~~

This PR sets `show_tagcloud` to `false` when registering a pattern category taxonomy (`wp_pattern_category`).

## Why?
I think the Pattern Categories is only used by site administrators to categorize patterns, and should not be displayed on the front end.

## How?
~~Check if the `publicly_queryable` property is `true`. This is also used in the following places:~~

- ~~When generating variations based on the registered taxonomy in the Post terms block ([See](https://github.com/WordPress/gutenberg/blob/e31781a697d34846aeead62203aab22a8e7aeafb/packages/block-library/src/post-terms/index.php#L67))~~
- ~~When creating a new template in the Site Editor ([See](https://github.com/WordPress/gutenberg/blob/e31781a697d34846aeead62203aab22a8e7aeafb/packages/edit-site/src/components/add-new-template/utils.js#L96))~~

Added `'show_tagcloud' =>false` to `register_taxonomy()` parameter.

## Testing Instructions

### Tag Cloud Block

- Insert a Tag Cloud block.
- Open the block sidebar.
- "Pattern Categories" should not be displayed.

![tag-cloud-block](https://github.com/WordPress/gutenberg/assets/54422211/6675bec2-5bdb-4868-9e6a-a197ab9fa972)

### Tag Cloud Widget

- Activate Twenty Twenty-One theme.
- Install the Classic Widgets plugin.
- Access Appearance > Widgets and add a tag cloud widget.
- "Pattern Categories" should not be displayed.

![tag-cloud-widget](https://github.com/WordPress/gutenberg/assets/54422211/fed35f54-2f3a-467c-9bdb-47e2874d88ec)
