### PR TITLE
Fix: Inconsistent tooltips for block options control

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -122,11 +122,7 @@ function ListViewBlock( {
 		  )
 		: blockTitle;
 
-	const settingsAriaLabel = sprintf(
-		// translators: %s: The title of the block.
-		__( 'Options for %s' ),
-		blockTitle
-	);
+	const settingsAriaLabel = __( 'Options' );
 
 	const {
 		expand,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - #57078 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Need to consistency across list view and block toolbar for the `Options` tooltip dropdown.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removed the `Block Name` from the list view more options dropdown.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open any post/page in Editor.
2. Add any block, check the block toolbar. You would see `options` in tooltip.
3. Open the list view, hover on dots at the end of a block, you would see now `options` as a tooltip.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None.

## Screenshots

| Block View | List View |
| :-------------: | :-------------: |
| <img width="386" alt="Screenshot 2023-12-19 at 5 35 41 PM" src="https://github.com/WordPress/gutenberg/assets/58802366/85f7d353-b210-4f32-bf4a-0e57414d1886"> | <img width="504" alt="Screenshot 2023-12-19 at 5 35 32 PM" src="https://github.com/WordPress/gutenberg/assets/58802366/7f5756e1-0252-4d1e-98ad-34136a46e8dd"> |
