### PR TITLE
DataViews: Use SelectControl for selecting a page

### DIFF
--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -55,7 +55,7 @@ function Pagination( {
 											page: +newValue,
 										} );
 									} }
-									size={ 'small' }
+									size={ 'compact' }
 									__nextHasNoMarginBottom
 								/>
 							),

--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -4,7 +4,7 @@
 import {
 	Button,
 	__experimentalHStack as HStack,
-	__experimentalNumberControl as NumberControl,
+	SelectControl,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __, _x } from '@wordpress/i18n';
@@ -40,28 +40,23 @@ function Pagination( {
 						),
 						{
 							CurrenPageControl: (
-								<NumberControl
+								<SelectControl
 									aria-label={ __( 'Current page' ) }
-									min={ 1 }
-									max={ totalPages }
-									onChange={ ( value ) => {
-										const _value = +value;
-										if (
-											! _value ||
-											_value < 1 ||
-											_value > totalPages
-										) {
-											return;
-										}
+									value={ view.page }
+									options={ Array.from(
+										Array( totalPages )
+									).map( ( _, i ) => {
+										const page = i + 1;
+										return { value: page, label: page };
+									} ) }
+									onChange={ ( newValue ) => {
 										onChangeView( {
 											...view,
-											page: _value,
+											page: +newValue,
 										} );
 									} }
-									step="1"
-									value={ view.page }
-									isDragEnabled={ false }
-									spinControls="none"
+									size={ 'small' }
+									__nextHasNoMarginBottom
 								/>
 							),
 						}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/57071

This PR uses a SelectControl for selecting a page in DataViews component.


