### PR TITLE
Snackbar: Remove `__unstableHTML` prop from TS

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `PaletteEdit`: Consider digits when generating kebab-cased slug ([#56713](https://github.com/WordPress/gutenberg/pull/56713)).
 -   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
 -   `FormTokenField`: Fix a regression where the suggestion list would re-open after clicking away from the input ([#57002](https://github.com/WordPress/gutenberg/pull/57002)).
+-   `Snackbar`: Remove erroneous `__unstableHTML` prop from TypeScript definitions ([#57218](https://github.com/WordPress/gutenberg/pull/57218)).
 
 ### Experimental
 

--- a/packages/components/src/snackbar/types.ts
+++ b/packages/components/src/snackbar/types.ts
@@ -28,7 +28,8 @@ type SnackbarOnlyProps = {
 	listRef?: MutableRefObject< HTMLDivElement | null >;
 };
 
-export type SnackbarProps = NoticeProps & SnackbarOnlyProps;
+export type SnackbarProps = Omit< NoticeProps, '__unstableHTML' > &
+	SnackbarOnlyProps;
 
 export type SnackbarListProps = {
 	notices: Array<


### PR DESCRIPTION
Fixes #56767

## What?

Removes the `__unstableHTML` prop from the TypeScript type definitions for `Snackbar`, which was erroneously included from the `Notice` types.

## Why?

The feature has never been implemented for `Snackbar`, and a discussion in #57067 led us to decide to keep it unimplemented for now.

## Testing Instructions

See that `__unstableHTML` is no longer included in the props table for the `Snackbar` Storybook docs. Alternatively, verify in your IDE that adding a `__unstableHTML` prop to a Snackbar results in a TS error.