### PR TITLE
isShallowEqual: always do === comparison first

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
-import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { keyboardReturn } from '@wordpress/icons';
@@ -196,7 +196,7 @@ function LinkControl( {
 	] = useInternalValue( value );
 
 	const valueHasChanges =
-		value && ! isShallowEqualObjects( internalControlValue, value );
+		value && ! isShallowEqual( internalControlValue, value );
 
 	const [ isEditingLink, setIsEditingLink ] = useState(
 		forceIsEditingLink !== undefined

--- a/packages/is-shallow-equal/benchmark/index.js
+++ b/packages/is-shallow-equal/benchmark/index.js
@@ -20,6 +20,9 @@ const beforeArray = [ 1, 2, 3, 4, 5, 6, 7 ];
 const afterArraySame = beforeArray;
 const afterArrayEqual = [ 1, 2, 3, 4, 5, 6, 7 ];
 const afterArrayUnequal = [ 1, 2, 3, 4, 5, 'Unequal', 7 ];
+const beforeString = 'code is poetry';
+const afterStringEqual = 'code is poetry';
+const afterStringUnequal = 'poetry is code';
 
 Promise.all( [
 	lazyImport( 'shallowequal@^1.1.0' ),
@@ -81,6 +84,14 @@ Promise.all( [
 
 				suite.add( name + ' (array, unequal)', () => {
 					isShallowEqualArrays( beforeArray, afterArrayUnequal );
+				} );
+
+				suite.add( name + ' (string, equal)', () => {
+					isShallowEqualObjects( beforeString, afterStringEqual );
+				} );
+
+				suite.add( name + ' (string, unequal)', () => {
+					isShallowEqualObjects( beforeString, afterStringUnequal );
 				} );
 			}
 		);

--- a/packages/is-shallow-equal/src/arrays.js
+++ b/packages/is-shallow-equal/src/arrays.js
@@ -7,10 +7,6 @@
  * @return {boolean} Whether the two arrays are shallow equal.
  */
 export default function isShallowEqualArrays( a, b ) {
-	if ( a === b ) {
-		return true;
-	}
-
 	if ( a.length !== b.length ) {
 		return false;
 	}

--- a/packages/is-shallow-equal/src/index.js
+++ b/packages/is-shallow-equal/src/index.js
@@ -21,13 +21,17 @@ export { default as isShallowEqualArrays } from './arrays';
  * @return {boolean} Whether the two values are shallow equal.
  */
 export default function isShallowEqual( a, b ) {
-	if ( a && b ) {
-		if ( a.constructor === Object && b.constructor === Object ) {
-			return isShallowEqualObjects( a, b );
-		} else if ( Array.isArray( a ) && Array.isArray( b ) ) {
-			return isShallowEqualArrays( a, b );
-		}
+	if ( a === b ) {
+		return true;
 	}
 
-	return a === b;
+	if ( a?.constructor === Object && b?.constructor === Object ) {
+		return isShallowEqualObjects( a, b );
+	}
+
+	if ( Array.isArray( a ) && Array.isArray( b ) ) {
+		return isShallowEqualArrays( a, b );
+	}
+
+	return false;
 }

--- a/packages/is-shallow-equal/src/objects.js
+++ b/packages/is-shallow-equal/src/objects.js
@@ -7,10 +7,6 @@
  * @return {boolean} Whether the two objects are shallow equal.
  */
 export default function isShallowEqualObjects( a, b ) {
-	if ( a === b ) {
-		return true;
-	}
-
 	const aKeys = Object.keys( a );
 	const bKeys = Object.keys( b );
 
@@ -18,25 +14,17 @@ export default function isShallowEqualObjects( a, b ) {
 		return false;
 	}
 
-	let i = 0;
-
-	while ( i < aKeys.length ) {
+	for ( let i = 0, len = aKeys.length; i < len; i++ ) {
 		const key = aKeys[ i ];
-		const aValue = a[ key ];
 
-		if (
-			// In iterating only the keys of the first object after verifying
-			// equal lengths, account for the case that an explicit `undefined`
-			// value in the first is implicitly undefined in the second.
-			//
-			// Example: isShallowEqualObjects( { a: undefined }, { b: 5 } )
-			( aValue === undefined && ! b.hasOwnProperty( key ) ) ||
-			aValue !== b[ key ]
-		) {
+		// In iterating only the keys of the first object after verifying
+		// equal lengths, account for the case that an explicit `undefined`
+		// value in the first is implicitly undefined in the second.
+		//
+		// Example: isShallowEqualObjects( { a: undefined, b: 5 }, { b: 5 } )
+		if ( ! b.hasOwnProperty( key ) || a[ key ] !== b[ key ] ) {
 			return false;
 		}
-
-		i++;
 	}
 
 	return true;


### PR DESCRIPTION
Something we talked about with @mamaduka in https://github.com/WordPress/gutenberg/pull/57163#discussion_r1430215515. The first thing that `isShallowEqual` should do is to do `===` comparison and return `true` immediately if the values are identical. Only after that it should do the "slow" key-by-key comparison.

The `===` comparison is in fact there, but only after the "is object" or "is array" check. This PR moves it to the very beginning of the function.

I'm also updating the only usage of `isShallowEqualObjects` in Gutenberg to just use `isShallowEqual` instead. The comparison functions for objects and arrays are exported as public API, but probably for legacy reasons. I don't see much value in them -- everyone should just call `isShallowEqual`.

Maybe this is also a performance optimization, but only for `useSelect` calls that return the selector value directly. I don't expect measurable outcomes.