### PR TITLE
Editor: Use visibility selector for PostTemplatePanel

### DIFF
--- a/packages/editor/src/components/post-template/panel.js
+++ b/packages/editor/src/components/post-template/panel.js
@@ -23,8 +23,7 @@ export default function PostTemplatePanel() {
 		};
 	}, [] );
 
-	const isVisible = true;
-	useSelect( ( select ) => {
+	const isVisible = useSelect( ( select ) => {
 		const postTypeSlug = select( editorStore ).getCurrentPostType();
 		const postType = select( coreStore ).getPostType( postTypeSlug );
 		if ( ! postType?.viewable ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
https://github.com/WordPress/gutenberg/pull/56817 (likely unintentionally) introduced [a hardcoded visibility flag](https://github.com/WordPress/gutenberg/pull/56817/files#diff-dc25327d1de40d0a3a942ee80d11c7cf681af63d50d8048f0431552397a47091R26) for the PostTemplatePanel, causing it to be always visible on non-block themes for all post types.

## How?
Assign the `useSelect()` call to the `isVisible` variable.

## Testing Instructions
1. Using a non-block theme (for example, `twentyfourteen`), open the block editor for a post type that's not expected to allow setting a page template, e.g. `post`.
2. Confirm the PostTemplatePanel is visible.
3. Apply the changes from this PR and repeat the steps.
4. Confirm the PostTemplatePanel is only visible when expected to - e.g. it should be visible for `page`, and not visible for `post`.

