### PR TITLE
Block lib: image: remove useless border props

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -14,7 +14,6 @@ import {
 	MediaPlaceholder,
 	useBlockProps,
 	store as blockEditorStore,
-	__experimentalUseBorderProps as useBorderProps,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useState } from '@wordpress/element';
@@ -314,16 +313,10 @@ export function ImageEdit( {
 		/>
 	);
 
-	const borderProps = useBorderProps( attributes );
-
 	const classes = classnames( className, {
 		'is-transient': temporaryURL,
 		'is-resized': !! width || !! height,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
-		'has-custom-border':
-			!! borderProps.className ||
-			( borderProps.style &&
-				Object.keys( borderProps.style ).length > 0 ),
 	} );
 
 	const blockProps = useBlockProps( {
@@ -335,10 +328,7 @@ export function ImageEdit( {
 	const placeholder = ( content ) => {
 		return (
 			<Placeholder
-				className={ classnames( 'block-editor-media-placeholder', {
-					[ borderProps.className ]:
-						!! borderProps.className && ! isSelected,
-				} ) }
+				className="block-editor-media-placeholder"
 				withIllustration={ true }
 				icon={ icon }
 				label={ __( 'Image' ) }
@@ -353,7 +343,6 @@ export function ImageEdit( {
 					width: height && aspectRatio ? '100%' : width,
 					height: width && aspectRatio ? '100%' : height,
 					objectFit: scale,
-					...borderProps.style,
 				} }
 			>
 				{ content }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -25,7 +25,6 @@ import {
 	store as blockEditorStore,
 	useSettings,
 	__experimentalImageEditor as ImageEditor,
-	__experimentalUseBorderProps as useBorderProps,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
@@ -567,9 +566,6 @@ export default function Image( {
 		defaultedAlt = __( 'This image has an empty alt attribute' );
 	}
 
-	const borderProps = useBorderProps( attributes );
-	const isRounded = attributes.className?.includes( 'is-style-rounded' );
-
 	let img = (
 		// Disable reason: Image itself is not meant to be interactive, but
 		// should direct focus to block.
@@ -586,14 +582,12 @@ export default function Image( {
 					} );
 				} }
 				ref={ imageRef }
-				className={ borderProps.className }
 				style={ {
 					width:
 						( width && height ) || aspectRatio ? '100%' : undefined,
 					height:
 						( width && height ) || aspectRatio ? '100%' : undefined,
 					objectFit: scale,
-					...borderProps.style,
 				} }
 			/>
 			{ temporaryURL && <Spinner /> }
@@ -622,7 +616,6 @@ export default function Image( {
 					onFinishEditing={ () => {
 						setIsEditingImage( false );
 					} }
-					borderProps={ isRounded ? undefined : borderProps }
 				/>
 			</ImageWrapper>
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related: #31366

This is looking completely useless to me. There's no custom border controls for the image block. And if there were, the props would be added by the hook?

Why am I not seeing border controls and why are we not using the hook to pass down props? 🤔 Could anyone clarify?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In any case, this is adding a subscription to the block editor store per image block, so this would be good to remove.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
