### PR TITLE
Keep Lock button it in the toolbar until unmounted

### DIFF
--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -3,9 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { focus } from '@wordpress/dom';
 import { useReducer, useRef, useEffect } from '@wordpress/element';
-import { lock } from '@wordpress/icons';
+import { lock, unlock } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -13,58 +12,28 @@ import { lock } from '@wordpress/icons';
 import BlockLockModal from './modal';
 import useBlockLock from './use-block-lock';
 
-export default function BlockLockToolbar( { clientId, wrapperRef } ) {
-	const { canEdit, canMove, canRemove, canLock } = useBlockLock( clientId );
+export default function BlockLockToolbar( { clientId } ) {
+	const { canLock, isLocked } = useBlockLock( clientId );
 
 	const [ isModalOpen, toggleModal ] = useReducer(
 		( isActive ) => ! isActive,
 		false
 	);
 
-	const lockButtonRef = useRef( null );
-	const isFirstRender = useRef( true );
-	const hasModalOpened = useRef( false );
+	const hasLockButtonShown = useRef( false );
 
-	const shouldHideBlockLockUI =
-		! canLock || ( canEdit && canMove && canRemove );
-
-	// Restore focus manually on the first focusable element in the toolbar
-	// when the block lock modal is closed and the block is not locked anymore.
-	// See https://github.com/WordPress/gutenberg/issues/51447
+	// If the block lock button has been shown, we don't want to remove it
+	// from the toolbar until the toolbar is rendered again without it.
+	// Removing it beforehand can cause focus loss issues, such as when
+	// unlocking the block from the modal. It needs to return focus from
+	// whence it came, and to do that, we need to leave the button in the toolbar.
 	useEffect( () => {
-		if ( isFirstRender.current ) {
-			isFirstRender.current = false;
-			return;
+		if ( isLocked ) {
+			hasLockButtonShown.current = true;
 		}
+	}, [ isLocked ] );
 
-		if ( isModalOpen && ! hasModalOpened.current ) {
-			hasModalOpened.current = true;
-		}
-
-		// We only want to allow this effect to happen if the modal has been opened.
-		// The issue is when we're returning focus from the block lock modal to a toolbar,
-		// so it can only happen after a modal has been opened. Without this, the toolbar
-		// will steal focus on rerenders.
-		if (
-			hasModalOpened.current &&
-			! isModalOpen &&
-			shouldHideBlockLockUI
-		) {
-			focus.focusable
-				.find( wrapperRef.current, {
-					sequential: false,
-				} )
-				.find(
-					( element ) =>
-						element.tagName === 'BUTTON' &&
-						element !== lockButtonRef.current
-				)
-				?.focus();
-		}
-		// wrapperRef is a reference object and should be stable
-	}, [ isModalOpen, shouldHideBlockLockUI, wrapperRef ] );
-
-	if ( shouldHideBlockLockUI ) {
+	if ( ! canLock || ( ! isLocked && ! hasLockButtonShown.current ) ) {
 		return null;
 	}
 
@@ -72,9 +41,8 @@ export default function BlockLockToolbar( { clientId, wrapperRef } ) {
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
-					ref={ lockButtonRef }
-					icon={ lock }
-					label={ __( 'Unlock' ) }
+					icon={ isLocked ? lock : unlock }
+					label={ isLocked ? __( 'Unlock' ) : __( 'Lock' ) }
 					onClick={ toggleModal }
 					aria-expanded={ isModalOpen }
 					aria-haspopup="dialog"

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -175,8 +175,7 @@ export function PrivateBlockToolbar( {
 								<BlockSwitcher clientIds={ blockClientIds } />
 								{ ! isMultiToolbar && (
 									<BlockLockToolbar
-										clientId={ blockClientIds[ 0 ] }
-										wrapperRef={ toolbarWrapperRef }
+										clientId={ blockClientId }
 									/>
 								) }
 								<BlockMover

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -82,6 +82,12 @@ test.describe( 'Block Locking', () => {
 		await page.click( 'role=checkbox[name="Lock all"]' );
 		await page.click( 'role=button[name="Apply"]' );
 
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Lock' } )
+		).toBeFocused();
+
 		expect( await editor.getEditedPostContent() )
 			.toBe( `<!-- wp:paragraph {"lock":{"move":false,"remove":false}} -->
 <p>Some paragraph</p>


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/51447 and https://github.com/WordPress/gutenberg/issues/57139
Alternative to https://github.com/WordPress/gutenberg/pull/57185/

If the block lock button has been shown, we don't want to remove it from the toolbar until the toolbar is rendered again without it. Removing it beforehand can cause focus loss issues, such as when unlocking the block from the modal. It needs to return focus from whence it came, and to do that, we need to leave the button in the toolbar.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
If the Lock Button has rendered, force it to stay in the toolbar as a "lock" action button until the component is unmounted.

 Clicking the "Unlocked" icon would trigger the lock modal again. Again, this would only show after unlocking the block. It would not show for all toolbars.

## Why?
- Improves the UX since the modal could always send focus back to the button that triggered it (and fixes https://github.com/WordPress/gutenberg/issues/57139). 
- Removes the need for trying to deduce if need to send focus to the toolbar based on a combination of states.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add a `hasLockButtonShown` ref set to `true` if the Lock Button is rendered in the toolbar.
- If the `hasLockButtonShown` and the block becomes unlocked while the toolbar is showing, preserve the button with an unlock icon to open the lock modal.
- When the toolbar is unmounted, the unlocked block will no longer show once rerendered in the unlocked state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Select a locked block
- Select the lock icon in the toolbar
- Unlock the block
- Focus should return to an "Unlock" icon in the toolbar
- Send focus to the block so it unmounts (if in popover toolbar mode)
- Send focus back to the toolbar
- Lock/Unlock icon button should not be rendered

Repeat above steps starting from an unlocked block: 
- Lock the block via the options dropdown
- Lock icon should show in the toolbar
- Repeat above steps

Repeat both of the above from the Top Toolbar


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Repeat above using Keyboard

## Screenshots or screencast <!-- if applicable -->
<img width="502" alt="Block toolbar with an 'unlocked' icon" src="https://github.com/WordPress/gutenberg/assets/967608/512608b6-d272-471d-89f5-9e557e09dec2">

https://github.com/WordPress/gutenberg/assets/967608/4f41918d-7afe-4f10-81b8-39a3ec6f0cd3

