### PR TITLE
Modules API: Refactor, tests, and final dependencies array structure

### DIFF
--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -20,20 +20,20 @@ class Gutenberg_Modules {
 	private static $registered = array();
 
 	/**
-	 * An array of modules that were enqueued before they were registered.
+	 * An array of module identifiers that were enqueued before registered.
 	 *
 	 * @var array
 	 */
 	private static $enqueued_modules_before_register = array();
 
 	/**
-	 * Registers the module if no module with that module identifier already
-	 * exists.
+	 * Registers the module if no module with that module identifier has already
+	 * been registered.
 	 *
-	 * @param string           $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
-	 * @param string           $src               Full URL of the module, or path of the script relative to the WordPress root directory.
-	 * @param array            $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies that don't contain a type are considered static.
-	 * @param string|bool|null $version           Optional. Defaults to false. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
+	 * @param string            $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
+	 * @param string            $src               Full URL of the module, or path of the script relative to the WordPress root directory.
+	 * @param array             $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies that don't contain a type are considered static.
+	 * @param string|false|null $version           Optional. String specifying module version number. Defaults to false. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, the version is the current timestamp. If $version is set to false, the version number is the currently installed WordPress version. If $version is set to null, no version is added.
 	 */
 	public static function register( $module_identifier, $src, $dependencies = array(), $version = false ) {
 		if ( ! isset( self::$registered[ $module_identifier ] ) ) {
@@ -58,29 +58,41 @@ class Gutenberg_Modules {
 				'enqueued'     => in_array( $module_identifier, self::$enqueued_modules_before_register, true ),
 				'dependencies' => $deps,
 			);
-
-		} else {
-			// TODO: Check version, and if it's bigger, override.
 		}
 	}
 
 	/**
-	 * Enqueues a module in the page.
+	 * Marks the module to be enqueued in the page.
 	 *
 	 * @param string $module_identifier The identifier of the module.
 	 */
 	public static function enqueue( $module_identifier ) {
 		if ( isset( self::$registered[ $module_identifier ] ) ) {
 			self::$registered[ $module_identifier ]['enqueued'] = true;
-		} else {
+		} elseif ( ! in_array( $module_identifier, self::$enqueued_modules_before_register, true ) ) {
 			self::$enqueued_modules_before_register[] = $module_identifier;
+		}
+	}
+
+	/**
+	 * Unmarks the module so it is not longer enqueued in the page.
+	 *
+	 * @param string $module_identifier The identifier of the module.
+	 */
+	public static function dequeue( $module_identifier ) {
+		if ( isset( self::$registered[ $module_identifier ] ) ) {
+			self::$registered[ $module_identifier ]['enqueued'] = false;
+		}
+		$key = array_search( $module_identifier, self::$enqueued_modules_before_register, true );
+		if ( false !== $key ) {
+			array_splice( self::$enqueued_modules_before_register, $key, 1 );
 		}
 	}
 
 	/**
 	 * Returns the import map array.
 	 *
-	 * @return array Associative array with 'imports' key mapping to an array of module identifiers and their respective source strings.
+	 * @return array Array with an 'imports' key mapping to an array of module identifiers and their respective source URLs, including the version query.
 	 */
 	public static function get_import_map() {
 		$imports = array();
@@ -91,7 +103,7 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Prints the import map.
+	 * Prints the import map using <script type="importmap">.
 	 */
 	public static function print_import_map() {
 		$import_map = self::get_import_map();
@@ -116,12 +128,13 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Prints the link tag with rel="modulepreload" for all the static
-	 * dependencies of the enqueued modules.
+	 * Prints the the static dependencies of the enqueued modules using <link rel="modulepreload">.
 	 */
 	public static function print_preloaded_modules() {
 		foreach ( self::get_dependencies( array_keys( self::get_enqueued() ), array( 'static' ) ) as $module_identifier => $module ) {
+			if ( true !== $module['enqueued'] ) {
 				echo '<link rel="modulepreload" href="' . $module['src'] . self::get_version_query_string( $module['version'] ) . '" id="' . $module_identifier . '">';
+			}
 		}
 	}
 
@@ -146,9 +159,11 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Gets the module's version. It either returns a timestamp (if SCRIPT_DEBUG
-	 * is true), the explicit version of the module if it is set and not false, or
-	 * an empty string if none of the above conditions are met.
+	 * Gets the version of a module.
+	 *
+	 * If SCRIPT_DEBUG is true, the version is the current timestamp. If $version
+	 * is set to false, the version number is the currently installed WordPress
+	 * version. If $version is set to null, no version is added.
 	 *
 	 * @param array $version The version of the module.
 	 * @return string A string presenting the version.
@@ -167,10 +182,7 @@ class Gutenberg_Modules {
 	/**
 	 * Retrieves an array of enqueued modules.
 	 *
-	 * Compiles an associative array of modules that have been enqueued for use on
-	 * the page, containing module information such as source and version.
-	 *
-	 * @return array Associative array of enqueued modules keyed by module identifier.
+	 * @return array Array of modules keyed by module identifier.
 	 */
 	private static function get_enqueued() {
 		$enqueued = array();
@@ -183,7 +195,7 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Retrieves all unique dependencies for given modules depending on type.
+	 * Retrieves all the dependencies for given modules depending on type.
 	 *
 	 * This method is recursive to also retrieve dependencies of the dependencies.
 	 * It will consolidate an array containing unique dependencies based on the
@@ -191,7 +203,7 @@ class Gutenberg_Modules {
 	 *
 	 * @param array $module_identifiers The identifiers of the modules for which to gather dependencies.
 	 * @param array $types              Optional. Types of dependencies to retrieve: 'static', 'dynamic', or both. Default is both.
-	 * @return array Associative array of modules keyed by module identifier.
+	 * @return array Array of modules keyed by module identifier.
 	 */
 	private static function get_dependencies( $module_identifiers, $types = array( 'static', 'dynamic' ) ) {
 		return array_reduce(
@@ -199,7 +211,11 @@ class Gutenberg_Modules {
 			function ( $dependency_modules, $module_identifier ) use ( $types ) {
 				$dependencies = array();
 				foreach ( self::$registered[ $module_identifier ]['dependencies'] as $dependency ) {
-					if ( in_array( $dependency['type'], $types, true ) && isset( self::$registered[ $dependency['id'] ] ) ) {
+					if (
+						in_array( $dependency['type'], $types, true ) &&
+						isset( self::$registered[ $dependency['id'] ] ) &&
+						! isset( $dependency_modules[ $dependency['id'] ] )
+					) {
 						$dependencies[ $dependency['id'] ] = self::$registered[ $dependency['id'] ];
 					}
 				}
@@ -211,25 +227,34 @@ class Gutenberg_Modules {
 }
 
 /**
- * Registers a JavaScript module. It will be added to the import map.
+ * Registers the module if no module with that module identifier has already
+ * been registered.
  *
- * @param string           $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
- * @param string           $src               Full URL of the module, or path of the script relative to the WordPress root directory.
- * @param array            $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies are considered static.
- * @param string|bool|null $version           Optional. Defaults to false. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
+ * @param string            $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
+ * @param string            $src               Full URL of the module, or path of the script relative to the WordPress root directory.
+ * @param array             $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies that don't contain a type are considered static.
+ * @param string|false|null $version           Optional. String specifying module version number. Defaults to false. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, the version is the current timestamp. If $version is set to false, the version number is the currently installed WordPress version. If $version is set to null, no version is added.
  */
 function gutenberg_register_module( $module_identifier, $src, $dependencies = array(), $version = false ) {
 	Gutenberg_Modules::register( $module_identifier, $src, $dependencies, $version );
 }
 
 /**
- * Enqueues a JavaScript module. It will be added to both the import map and a
- * script tag with the "module" type.
+ * Marks the module to be enqueued in the page.
  *
- * @param string $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
+ * @param string $module_identifier The identifier of the module.
  */
 function gutenberg_enqueue_module( $module_identifier ) {
 	Gutenberg_Modules::enqueue( $module_identifier );
+}
+
+/**
+ * Unmarks the module so it is not longer enqueued in the page.
+ *
+ * @param string $module_identifier The identifier of the module.
+ */
+function gutenberg_dequeue_module( $module_identifier ) {
+	Gutenberg_Modules::dequeue( $module_identifier );
 }
 
 // Prints the import map in the head tag.

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -134,7 +134,11 @@ class Gutenberg_Modules {
 	public static function print_preloaded_modules() {
 		foreach ( self::get_dependencies( array_keys( self::get_enqueued() ), array( 'static' ) ) as $module_identifier => $module ) {
 			if ( true !== $module['enqueued'] ) {
-				echo '<link rel="modulepreload" href="' . $module['src'] . self::get_version_query_string( $module['version'] ) . '" id="' . $module_identifier . '">';
+				echo sprintf(
+					'<link rel="modulepreload" href="%s" id="%s">',
+					esc_attr( $module['src'] . self::get_version_query_string( $module['version'] ) ),
+					esc_attr( $module_identifier )
+				);
 			}
 		}
 	}

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -75,7 +75,7 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Unmarks the module so it is not longer enqueued in the page.
+	 * Unmarks the module so it is no longer enqueued in the page.
 	 *
 	 * @param string $module_identifier The identifier of the module.
 	 */

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -20,7 +20,9 @@ class Gutenberg_Modules {
 	private static $registered = array();
 
 	/**
+	 * An array of modules that were enqueued before they were registered.
 	 *
+	 * @var array
 	 */
 	private static $enqueued_modules_before_register = array();
 
@@ -34,7 +36,6 @@ class Gutenberg_Modules {
 	 * @param string|bool|null $version           Optional. Defaults to false. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
 	 */
 	public static function register( $module_identifier, $src, $dependencies = array(), $version = false ) {
-		// Register the module if it's not already registered.
 		if ( ! isset( self::$registered[ $module_identifier ] ) ) {
 			$deps = array();
 			foreach ( $dependencies as $dependency ) {
@@ -164,7 +165,12 @@ class Gutenberg_Modules {
 	}
 
 	/**
+	 * Retrieves an array of enqueued modules.
 	 *
+	 * Compiles an associative array of modules that have been enqueued for use on
+	 * the page, containing module information such as source and version.
+	 *
+	 * @return array Associative array of enqueued modules keyed by module identifier.
 	 */
 	private static function get_enqueued() {
 		$enqueued = array();
@@ -177,13 +183,15 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Returns all unique static and/or dynamic dependencies for the received
-	 * modules. It's recursive, so it will also get the static or dynamic
-	 * dependencies of the dependencies.
+	 * Retrieves all unique dependencies for given modules depending on type.
 	 *
-	 * @param array $modules The array of modules to get dependencies for.
-	 * @param array $types   The type of dependencies to retrieve. It can be `static`, `dynamic` or both.
-	 * @return array The array containing the unique dependencies of the modules.
+	 * This method is recursive to also retrieve dependencies of the dependencies.
+	 * It will consolidate an array containing unique dependencies based on the
+	 * requested types ('static' or 'dynamic').
+	 *
+	 * @param array $module_identifiers The identifiers of the modules for which to gather dependencies.
+	 * @param array $types              Optional. Types of dependencies to retrieve: 'static', 'dynamic', or both. Default is both.
+	 * @return array Associative array of modules keyed by module identifier.
 	 */
 	private static function get_dependencies( $module_identifiers, $types = array( 'static', 'dynamic' ) ) {
 		return array_reduce(

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -103,7 +103,7 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Prints the import map using <script type="importmap">.
+	 * Prints the import map using a script tag with an type="importmap" attribute.
 	 */
 	public static function print_import_map() {
 		$import_map = self::get_import_map();
@@ -128,7 +128,8 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Prints the the static dependencies of the enqueued modules using <link rel="modulepreload">.
+	 * Prints the the static dependencies of the enqueued modules using link tags
+	 * with rel="modulepreload" attributes.
 	 */
 	public static function print_preloaded_modules() {
 		foreach ( self::get_dependencies( array_keys( self::get_enqueued() ), array( 'static' ) ) as $module_identifier => $module ) {

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -20,11 +20,14 @@ class Gutenberg_Modules {
 	private static $registered = array();
 
 	/**
-	 * An array of queued modules.
 	 *
-	 * @var string[]
 	 */
-	private static $enqueued = array();
+	private static $script_dependencies_before_register = array();
+
+	/**
+	 *
+	 */
+	private static $enqueued_modules_before_register = array();
 
 	/**
 	 * Registers the module if no module with that module identifier already
@@ -32,22 +35,37 @@ class Gutenberg_Modules {
 	 *
 	 * @param string           $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
 	 * @param string           $src               Full URL of the module, or path of the script relative to the WordPress root directory.
-	 * @param array            $dependencies      Optional. An array of module identifiers of the static and dynamic dependencies of this module. It can be an indexed array, in which case all the dependencies are static, or it can be an associative array, in which case it has to contain the keys `static` and `dynamic`.
+	 * @param array            $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies are considered static.
 	 * @param string|bool|null $version           Optional. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
 	 */
 	public static function register( $module_identifier, $src, $dependencies = array(), $version = false ) {
 		// Register the module if it's not already registered.
 		if ( ! isset( self::$registered[ $module_identifier ] ) ) {
-			$deps = array(
-				'static'  => isset( $dependencies['static'] ) || isset( $dependencies['dynamic'] ) ? $dependencies['static'] ?? array() : $dependencies,
-				'dynamic' => isset( $dependencies['dynamic'] ) ? $dependencies['dynamic'] : array(),
-			);
+			$deps = array();
+			foreach ( $dependencies as $dependency ) {
+				if ( is_array( $dependency ) && isset( $dependency['id'] ) ) {
+					$deps[] = array(
+						'id'   => $dependency['id'],
+						'type' => isset( $dependency['type'] ) && 'dynamic' === $dependency['type'] ? 'dynamic' : 'static',
+					);
+				} elseif ( is_string( $dependency ) ) {
+					$deps[] = array(
+						'id'   => $dependency,
+						'type' => 'static',
+					);
+				}
+			}
 
 			self::$registered[ $module_identifier ] = array(
-				'src'          => $src,
-				'version'      => $version,
-				'dependencies' => $deps,
+				'src'                 => $src,
+				'version'             => $version,
+				'enqueued'            => in_array( $module_identifier, self::$enqueued_modules_before_register, true ),
+				'dependencies'        => $deps,
+				'script_dependencies' => isset( self::$script_dependencies_before_register[ $module_identifier ] ) ? self::$script_dependencies_before_register[ $module_identifier ] : array(),
 			);
+
+		} else {
+			// TODO: Check version, and if it's bigger, override.
 		}
 	}
 
@@ -57,9 +75,24 @@ class Gutenberg_Modules {
 	 * @param string $module_identifier The identifier of the module.
 	 */
 	public static function enqueue( $module_identifier ) {
-		// Add the module to the queue if it's not already there.
-		if ( ! in_array( $module_identifier, self::$enqueued, true ) ) {
-			self::$enqueued[] = $module_identifier;
+		if ( isset( self::$registered[ $module_identifier ] ) ) {
+			self::$registered[ $module_identifier ]['enqueued'] = true;
+		} else {
+			self::$enqueued_modules_before_register[] = $module_identifier;
+		}
+	}
+
+	/**
+	 *
+	 */
+	public static function add_script_dependency( $module_identifier, $script_handle ) {
+		if ( isset( self::$registered[ $module_identifier ] ) ) {
+			self::$registered[ $module_identifier ]['script_dependencies'][] = $script_handle;
+		} else {
+			if ( ! isset( self::$script_dependencies_before_register[ $module_identifier ] ) ) {
+				self::$script_dependencies_before_register[ $module_identifier ] = array();
+			}
+			self::$script_dependencies_before_register[ $module_identifier ][] = $script_handle;
 		}
 	}
 
@@ -70,7 +103,7 @@ class Gutenberg_Modules {
 	 */
 	public static function get_import_map() {
 		$imports = array();
-		foreach ( self::get_dependencies( self::$enqueued, array( 'static', 'dynamic' ) ) as $module_identifier => $module ) {
+		foreach ( self::get_dependencies( self::get_enqueued_identifiers(), array( 'static', 'dynamic' ) ) as $module_identifier => $module ) {
 			$imports[ $module_identifier ] = $module['src'] . self::get_version_query_string( $module['version'] );
 		}
 		return array( 'imports' => $imports );
@@ -90,17 +123,14 @@ class Gutenberg_Modules {
 	 * Prints all the enqueued modules using <script type="module">.
 	 */
 	public static function print_enqueued_modules() {
-		foreach ( self::$enqueued as $module_identifier ) {
-			if ( isset( self::$registered[ $module_identifier ] ) ) {
-				$module = self::$registered[ $module_identifier ];
-				wp_print_script_tag(
-					array(
-						'type' => 'module',
-						'src'  => $module['src'] . self::get_version_query_string( $module['version'] ),
-						'id'   => $module_identifier,
-					)
-				);
-			}
+		foreach ( self::get_enqueued_modules() as $module_identifier => $module ) {
+			wp_print_script_tag(
+				array(
+					'type' => 'module',
+					'src'  => $module['src'] . self::get_version_query_string( $module['version'] ),
+					'id'   => $module_identifier,
+				)
+			);
 		}
 	}
 
@@ -109,7 +139,7 @@ class Gutenberg_Modules {
 	 * dependencies of the enqueued modules.
 	 */
 	public static function print_module_preloads() {
-		foreach ( self::get_dependencies( self::$enqueued, array( 'static' ) ) as $dependency_identifier => $module ) {
+		foreach ( self::get_dependencies( self::get_enqueued_identifiers(), array( 'static' ) ) as $dependency_identifier => $module ) {
 				echo '<link rel="modulepreload" href="' . $module['src'] . self::get_version_query_string( $module['version'] ) . '" id="' . $dependency_identifier . '">';
 		}
 	}
@@ -135,6 +165,15 @@ class Gutenberg_Modules {
 	}
 
 	/**
+	 *
+	 */
+	public static function enqueue_script_dependencies() {
+		foreach ( self::$enqueued as $key => $value ) {
+			// code...
+		}
+	}
+
+	/**
 	 * Gets the module's version. It either returns a timestamp (if SCRIPT_DEBUG
 	 * is true), the explicit version of the module if it is set and not false, or
 	 * an empty string if none of the above conditions are met.
@@ -154,6 +193,32 @@ class Gutenberg_Modules {
 	}
 
 	/**
+	 *
+	 */
+	private static function get_enqueued_identifiers() {
+		$enqueued = array();
+		foreach ( self::$registered as $module_identifier => $module ) {
+			if ( true === $module['enqueued'] ) {
+				$enqueued[] = $module_identifier;
+			}
+		}
+		return $enqueued;
+	}
+
+	/**
+	 *
+	 */
+	private static function get_enqueued_modules() {
+		$enqueued = array();
+		foreach ( self::$registered as $module_identifier => $module ) {
+			if ( true === $module['enqueued'] ) {
+				$enqueued[ $module_identifier ] = $module;
+			}
+		}
+		return $enqueued;
+	}
+
+	/**
 	 * Returns all unique static and/or dynamic dependencies for the received modules. It's
 	 * recursive, so it will also get the static or dynamic dependencies of the dependencies.
 	 *
@@ -170,16 +235,28 @@ class Gutenberg_Modules {
 				}
 
 				$dependencies = array();
-				foreach ( $types as $type ) {
-					$dependencies = array_merge( $dependencies, self::$registered[ $module_identifier ]['dependencies'][ $type ] );
+				foreach ( self::$registered[ $module_identifier ]['dependencies'] as $dependency ) {
+					if ( in_array( $dependency['type'], $types, true ) ) {
+						$dependencies[] = $dependency['id'];
+					}
 				}
-				$dependencies       = array_unique( $dependencies );
-				$dependency_modules = array_intersect_key( self::$registered, array_flip( $dependencies ) );
 
-				return array_merge( $dependency_modules, $dependency_modules, self::get_dependencies( $dependencies, $types ) );
+				$dependency_modules = array_intersect_key( self::$registered, array_flip( $dependencies ) );
+				return array_merge( $dependency_modules, self::get_dependencies( $dependencies, $types ) );
 			},
 			array()
 		);
+	}
+
+	/**
+	 *
+	 */
+	private static function get_script_dependencies() {
+		$script_deps = array();
+		foreach ( self::$enqueued as $enqueued ) {
+			array_push( $script_deps, $enqueued['script_dependencies'] );
+		}
+		return $script_deps;
 	}
 }
 
@@ -188,7 +265,7 @@ class Gutenberg_Modules {
  *
  * @param string           $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
  * @param string           $src               Full URL of the module, or path of the script relative to the WordPress root directory.
- * @param array            $dependencies      Optional. An array of module identifiers of the static and dynamic dependencies of this module. It can be an indexed array, in which case all the dependencies are static, or it can be an associative array, in which case it has to contain the keys `static` and `dynamic`.
+ * @param array            $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies are considered static.
  * @param string|bool|null $version           Optional. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
  */
 function gutenberg_register_module( $module_identifier, $src, $dependencies = array(), $version = false ) {
@@ -205,6 +282,13 @@ function gutenberg_enqueue_module( $module_identifier ) {
 	Gutenberg_Modules::enqueue( $module_identifier );
 }
 
+function gutenberg_add_script_dependency_to_module( $module_identifier, $script_handle ) {
+	Gutenberg_Modules::add_script_dependency( $module_identifier, $script_handle );
+}
+
+function gutenberg_add_module_dependency_to_script( $module_identifier, $script_handle ) {
+}
+
 // Prints the import map in the head tag.
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map' ) );
 
@@ -216,3 +300,5 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );
+
+add_action( 'wp_scripts', array( 'Gutenberg_Modules', 'enqueue_script_dependencies' ) );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -39,7 +39,7 @@ class Gutenberg_Modules {
 		if ( ! isset( self::$registered[ $module_identifier ] ) ) {
 			$deps = array();
 			foreach ( $dependencies as $dependency ) {
-				if ( is_array( $dependency ) && isset( $dependency['id'] ) ) {
+				if ( isset( $dependency['id'] ) ) {
 					$deps[] = array(
 						'id'   => $dependency['id'],
 						'type' => isset( $dependency['type'] ) && 'dynamic' === $dependency['type'] ? 'dynamic' : 'static',

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -131,7 +131,7 @@ class Gutenberg_Modules {
 	 * Prints the the static dependencies of the enqueued modules using link tags
 	 * with rel="modulepreload" attributes.
 	 */
-	public static function print_preloaded_modules() {
+	public static function print_module_preloads() {
 		foreach ( self::get_dependencies( array_keys( self::get_enqueued() ), array( 'static' ) ) as $module_identifier => $module ) {
 			if ( true !== $module['enqueued'] ) {
 				echo sprintf(
@@ -269,7 +269,7 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map' ) );
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 
 // Prints the preloaded modules in the head tag.
-add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_preloaded_modules' ) );
+add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -22,11 +22,6 @@ class Gutenberg_Modules {
 	/**
 	 *
 	 */
-	private static $script_dependencies_before_register = array();
-
-	/**
-	 *
-	 */
 	private static $enqueued_modules_before_register = array();
 
 	/**
@@ -35,8 +30,8 @@ class Gutenberg_Modules {
 	 *
 	 * @param string           $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
 	 * @param string           $src               Full URL of the module, or path of the script relative to the WordPress root directory.
-	 * @param array            $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies are considered static.
-	 * @param string|bool|null $version           Optional. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
+	 * @param array            $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies that don't contain a type are considered static.
+	 * @param string|bool|null $version           Optional. Defaults to false. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
 	 */
 	public static function register( $module_identifier, $src, $dependencies = array(), $version = false ) {
 		// Register the module if it's not already registered.
@@ -57,11 +52,10 @@ class Gutenberg_Modules {
 			}
 
 			self::$registered[ $module_identifier ] = array(
-				'src'                 => $src,
-				'version'             => $version,
-				'enqueued'            => in_array( $module_identifier, self::$enqueued_modules_before_register, true ),
-				'dependencies'        => $deps,
-				'script_dependencies' => isset( self::$script_dependencies_before_register[ $module_identifier ] ) ? self::$script_dependencies_before_register[ $module_identifier ] : array(),
+				'src'          => $src,
+				'version'      => $version,
+				'enqueued'     => in_array( $module_identifier, self::$enqueued_modules_before_register, true ),
+				'dependencies' => $deps,
 			);
 
 		} else {
@@ -83,27 +77,13 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 *
-	 */
-	public static function add_script_dependency( $module_identifier, $script_handle ) {
-		if ( isset( self::$registered[ $module_identifier ] ) ) {
-			self::$registered[ $module_identifier ]['script_dependencies'][] = $script_handle;
-		} else {
-			if ( ! isset( self::$script_dependencies_before_register[ $module_identifier ] ) ) {
-				self::$script_dependencies_before_register[ $module_identifier ] = array();
-			}
-			self::$script_dependencies_before_register[ $module_identifier ][] = $script_handle;
-		}
-	}
-
-	/**
 	 * Returns the import map array.
 	 *
 	 * @return array Associative array with 'imports' key mapping to an array of module identifiers and their respective source strings.
 	 */
 	public static function get_import_map() {
 		$imports = array();
-		foreach ( self::get_dependencies( self::get_enqueued_identifiers(), array( 'static', 'dynamic' ) ) as $module_identifier => $module ) {
+		foreach ( self::get_dependencies( array_keys( self::get_enqueued() ) ) as $module_identifier => $module ) {
 			$imports[ $module_identifier ] = $module['src'] . self::get_version_query_string( $module['version'] );
 		}
 		return array( 'imports' => $imports );
@@ -123,7 +103,7 @@ class Gutenberg_Modules {
 	 * Prints all the enqueued modules using <script type="module">.
 	 */
 	public static function print_enqueued_modules() {
-		foreach ( self::get_enqueued_modules() as $module_identifier => $module ) {
+		foreach ( self::get_enqueued() as $module_identifier => $module ) {
 			wp_print_script_tag(
 				array(
 					'type' => 'module',
@@ -138,9 +118,9 @@ class Gutenberg_Modules {
 	 * Prints the link tag with rel="modulepreload" for all the static
 	 * dependencies of the enqueued modules.
 	 */
-	public static function print_module_preloads() {
-		foreach ( self::get_dependencies( self::get_enqueued_identifiers(), array( 'static' ) ) as $dependency_identifier => $module ) {
-				echo '<link rel="modulepreload" href="' . $module['src'] . self::get_version_query_string( $module['version'] ) . '" id="' . $dependency_identifier . '">';
+	public static function print_preloaded_modules() {
+		foreach ( self::get_dependencies( array_keys( self::get_enqueued() ), array( 'static' ) ) as $module_identifier => $module ) {
+				echo '<link rel="modulepreload" href="' . $module['src'] . self::get_version_query_string( $module['version'] ) . '" id="' . $module_identifier . '">';
 		}
 	}
 
@@ -150,7 +130,7 @@ class Gutenberg_Modules {
 	 *
 	 * TODO: Replace the polyfill with a simpler version that only provides
 	 * support for import maps and load it only when the browser doesn't support
-	 * import maps (https://github.com/guybedford/es-module-shims/issues/371).
+	 * import maps (https://github.com/guybedford/es-module-shims/issues/406).
 	 */
 	public static function print_import_map_polyfill() {
 		$import_map = self::get_import_map();
@@ -165,15 +145,6 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 *
-	 */
-	public static function enqueue_script_dependencies() {
-		foreach ( self::$enqueued as $key => $value ) {
-			// code...
-		}
-	}
-
-	/**
 	 * Gets the module's version. It either returns a timestamp (if SCRIPT_DEBUG
 	 * is true), the explicit version of the module if it is set and not false, or
 	 * an empty string if none of the above conditions are met.
@@ -182,7 +153,7 @@ class Gutenberg_Modules {
 	 * @return string A string presenting the version.
 	 */
 	private static function get_version_query_string( $version ) {
-		if ( SCRIPT_DEBUG ) {
+		if ( defined( 'SCRIPT_DEBUG ' ) && SCRIPT_DEBUG ) {
 			return '?ver=' . time();
 		} elseif ( false === $version ) {
 			return '?ver=' . get_bloginfo( 'version' );
@@ -195,20 +166,7 @@ class Gutenberg_Modules {
 	/**
 	 *
 	 */
-	private static function get_enqueued_identifiers() {
-		$enqueued = array();
-		foreach ( self::$registered as $module_identifier => $module ) {
-			if ( true === $module['enqueued'] ) {
-				$enqueued[] = $module_identifier;
-			}
-		}
-		return $enqueued;
-	}
-
-	/**
-	 *
-	 */
-	private static function get_enqueued_modules() {
+	private static function get_enqueued() {
 		$enqueued = array();
 		foreach ( self::$registered as $module_identifier => $module ) {
 			if ( true === $module['enqueued'] ) {
@@ -219,44 +177,28 @@ class Gutenberg_Modules {
 	}
 
 	/**
-	 * Returns all unique static and/or dynamic dependencies for the received modules. It's
-	 * recursive, so it will also get the static or dynamic dependencies of the dependencies.
+	 * Returns all unique static and/or dynamic dependencies for the received
+	 * modules. It's recursive, so it will also get the static or dynamic
+	 * dependencies of the dependencies.
 	 *
-	 * @param array $module_identifiers The identifiers of the modules to get dependencies for.
-	 * @param array $types              The type of dependencies to retrieve. It can be `static`, `dynamic` or both.
+	 * @param array $modules The array of modules to get dependencies for.
+	 * @param array $types   The type of dependencies to retrieve. It can be `static`, `dynamic` or both.
 	 * @return array The array containing the unique dependencies of the modules.
 	 */
 	private static function get_dependencies( $module_identifiers, $types = array( 'static', 'dynamic' ) ) {
 		return array_reduce(
 			$module_identifiers,
 			function ( $dependency_modules, $module_identifier ) use ( $types ) {
-				if ( ! isset( self::$registered[ $module_identifier ] ) ) {
-					return $dependency_modules;
-				}
-
 				$dependencies = array();
 				foreach ( self::$registered[ $module_identifier ]['dependencies'] as $dependency ) {
-					if ( in_array( $dependency['type'], $types, true ) ) {
-						$dependencies[] = $dependency['id'];
+					if ( in_array( $dependency['type'], $types, true ) && isset( self::$registered[ $dependency['id'] ] ) ) {
+						$dependencies[ $dependency['id'] ] = self::$registered[ $dependency['id'] ];
 					}
 				}
-
-				$dependency_modules = array_intersect_key( self::$registered, array_flip( $dependencies ) );
-				return array_merge( $dependency_modules, self::get_dependencies( $dependencies, $types ) );
+				return array_merge( $dependency_modules, $dependencies, self::get_dependencies( array_keys( $dependencies ), $types ) );
 			},
 			array()
 		);
-	}
-
-	/**
-	 *
-	 */
-	private static function get_script_dependencies() {
-		$script_deps = array();
-		foreach ( self::$enqueued as $enqueued ) {
-			array_push( $script_deps, $enqueued['script_dependencies'] );
-		}
-		return $script_deps;
 	}
 }
 
@@ -266,7 +208,7 @@ class Gutenberg_Modules {
  * @param string           $module_identifier The identifier of the module. Should be unique. It will be used in the final import map.
  * @param string           $src               Full URL of the module, or path of the script relative to the WordPress root directory.
  * @param array            $dependencies      Optional. An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies are considered static.
- * @param string|bool|null $version           Optional. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
+ * @param string|bool|null $version           Optional. Defaults to false. String specifying module version number. It is added to the URL as a query string for cache busting purposes. If SCRIPT_DEBUG is true, a timestamp is used. If it is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
  */
 function gutenberg_register_module( $module_identifier, $src, $dependencies = array(), $version = false ) {
 	Gutenberg_Modules::register( $module_identifier, $src, $dependencies, $version );
@@ -282,13 +224,6 @@ function gutenberg_enqueue_module( $module_identifier ) {
 	Gutenberg_Modules::enqueue( $module_identifier );
 }
 
-function gutenberg_add_script_dependency_to_module( $module_identifier, $script_handle ) {
-	Gutenberg_Modules::add_script_dependency( $module_identifier, $script_handle );
-}
-
-function gutenberg_add_module_dependency_to_script( $module_identifier, $script_handle ) {
-}
-
 // Prints the import map in the head tag.
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map' ) );
 
@@ -296,9 +231,7 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map' ) );
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 
 // Prints the preloaded modules in the head tag.
-add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
+add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_preloaded_modules' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );
-
-add_action( 'wp_scripts', array( 'Gutenberg_Modules', 'enqueue_script_dependencies' ) );

--- a/phpunit/experimental/modules/class-gutenberg-modules-test.php
+++ b/phpunit/experimental/modules/class-gutenberg-modules-test.php
@@ -25,12 +25,7 @@ class Gutenberg_Modules_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function test_gutenberg_enqueue_module() {
-		gutenberg_register_module( '@wordpress/some-module', '/some-module.js' );
-		gutenberg_enqueue_module( '@wordpress/some-module' );
-		gutenberg_register_module( '@wordpress/other-module', '/other-module.js' );
-		gutenberg_enqueue_module( '@wordpress/other-module' );
-
+	public function get_enqueued_modules() {
 		$modules_markup   = get_echo( array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 		$p                = new WP_HTML_Tag_Processor( $modules_markup );
 		$enqueued_modules = array();
@@ -44,122 +39,16 @@ class Gutenberg_Modules_Test extends WP_UnitTestCase {
 			$enqueued_modules[ $p->get_attribute( 'id' ) ] = $p->get_attribute( 'src' );
 		}
 
-		$this->assertEquals( 2, count( $enqueued_modules ) );
-		$this->assertEquals( true, strpos( $enqueued_modules['@wordpress/some-module'], '/some-module.js' ) === 0 );
-		$this->assertEquals( true, strpos( $enqueued_modules['@wordpress/other-module'], '/other-module.js' ) === 0 );
+		return $enqueued_modules;
 	}
 
-	public function test_gutenberg_enqueue_module_works_before_register() {
-		gutenberg_enqueue_module( '@wordpress/some-module' );
-		gutenberg_register_module( '@wordpress/some-module', '/some-module.js' );
-		gutenberg_enqueue_module( '@wordpress/other-module' ); // Not enqueued.
-
-		$modules_markup   = get_echo( array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
-		$p                = new WP_HTML_Tag_Processor( $modules_markup );
-		$enqueued_modules = array();
-
-		while ( $p->next_tag(
-			array(
-				'tag'  => 'SCRIPT',
-				'type' => 'module',
-			)
-		) ) {
-			$enqueued_modules[ $p->get_attribute( 'id' ) ] = $p->get_attribute( 'src' );
-		}
-
-		$this->assertEquals( 1, count( $enqueued_modules ) );
-		$this->assertEquals( true, strpos( $enqueued_modules['@wordpress/some-module'], '/some-module.js' ) === 0 );
-	}
-
-	public function test_gutenberg_import_map_dependencies() {
-		gutenberg_register_module( '@wordpress/no-dep', '/no-dep.js' );
-		gutenberg_register_module( '@wordpress/some-dep', '/some-dep.js' );
-		gutenberg_register_module( '@wordpress/some-module', '/some-module.js', array( '@wordpress/some-dep' ) );
-		gutenberg_enqueue_module( '@wordpress/some-module' );
-
+	public function get_import_map() {
 		$import_map_markup = get_echo( array( 'Gutenberg_Modules', 'print_import_map' ) );
 		preg_match( '/<script type="importmap">([^<]+)<\/script>/s', $import_map_markup, $import_map_string );
-		$import_map = json_decode( $import_map_string[1], true )['imports'];
-
-		$this->assertEquals( true, strpos( $import_map['@wordpress/some-dep'], '/some-dep.js' ) === 0 );
-		$this->assertEquals( false, isset( $import_map['@wordpress/no-dep'] ) );
+		return json_decode( $import_map_string[1], true )['imports'];
 	}
 
-	public function test_gutenberg_import_map_recursive_dependencies() {
-		gutenberg_register_module( '@wordpress/no-dep', '/no-dep.js' );
-		gutenberg_register_module( '@wordpress/some-nested-static-dep', '/some-nested-static-dep.js' );
-		gutenberg_register_module( '@wordpress/some-nested-dynamic-dep', '/some-nested-dynamic-dep.js' );
-		gutenberg_register_module(
-			'@wordpress/some-static-dep',
-			'/some-static-dep.js',
-			array(
-				array(
-					'id'   => '@wordpress/some-nested-static-dep',
-					'type' => 'static',
-				),
-				array(
-					'id'   => '@wordpress/some-nested-dynamic-dep',
-					'type' => 'dynamic',
-				),
-			)
-		);
-		gutenberg_register_module( '@wordpress/some-dynamic-dep', '/some-dynamic-dep.js' );
-		gutenberg_register_module(
-			'@wordpress/some-module',
-			'/some-module.js',
-			array(
-				'@wordpress/some-static-dep',
-				array(
-					'id'   => '@wordpress/some-dynamic-dep',
-					'type' => 'dynamic',
-				),
-			)
-		);
-		gutenberg_enqueue_module( '@wordpress/some-module' );
-
-		$import_map_markup = get_echo( array( 'Gutenberg_Modules', 'print_import_map' ) );
-		preg_match( '/<script type="importmap">([^<]+)<\/script>/s', $import_map_markup, $import_map_string );
-		$import_map = json_decode( $import_map_string[1], true )['imports'];
-
-		$this->assertEquals( true, strpos( $import_map['@wordpress/some-static-dep'], '/some-static-dep.js' ) === 0 );
-		$this->assertEquals( true, strpos( $import_map['@wordpress/some-dynamic-dep'], '/some-dynamic-dep.js' ) === 0 );
-		$this->assertEquals( true, strpos( $import_map['@wordpress/some-nested-static-dep'], '/some-nested-static-dep.js' ) === 0 );
-		$this->assertEquals( true, strpos( $import_map['@wordpress/some-nested-dynamic-dep'], '/some-nested-dynamic-dep.js' ) === 0 );
-		$this->assertEquals( false, isset( $import_map['@wordpress/no-dep'] ) );
-	}
-
-	public function test_gutenberg_enqueue_module_preloads_static_dependencies() {
-		gutenberg_register_module( '@wordpress/no-dep', '/no-dep.js' );
-		gutenberg_register_module( '@wordpress/some-nested-static-dep', '/some-nested-static-dep.js' );
-		gutenberg_register_module( '@wordpress/some-nested-dynamic-dep', '/some-nested-dynamic-dep.js' );
-		gutenberg_register_module(
-			'@wordpress/some-static-dep',
-			'/some-static-dep.js',
-			array(
-				array(
-					'id'   => '@wordpress/some-nested-static-dep',
-					'type' => 'static',
-				),
-				array(
-					'id'   => '@wordpress/some-nested-dynamic-dep',
-					'type' => 'dynamic',
-				),
-			)
-		);
-		gutenberg_register_module( '@wordpress/some-dynamic-dep', '/some-dynamic-dep.js', array( '@wordpress/some-nested-dep' ) );
-		gutenberg_register_module(
-			'@wordpress/some-module',
-			'/some-module.js',
-			array(
-				'@wordpress/some-static-dep',
-				array(
-					'id'   => 'some-dynamic-dep',
-					'type' => 'dynamic',
-				),
-			)
-		);
-		gutenberg_enqueue_module( '@wordpress/some-module' );
-
+	public function get_preloaded_modules() {
 		$preloaded_markup  = get_echo( array( 'Gutenberg_Modules', 'print_preloaded_modules' ) );
 		$p                 = new WP_HTML_Tag_Processor( $preloaded_markup );
 		$preloaded_modules = array();
@@ -173,12 +62,211 @@ class Gutenberg_Modules_Test extends WP_UnitTestCase {
 			$preloaded_modules[ $p->get_attribute( 'id' ) ] = $p->get_attribute( 'href' );
 		}
 
+		return $preloaded_modules;
+	}
+
+	public function test_gutenberg_enqueue_module() {
+		gutenberg_register_module( 'foo', '/foo.js' );
+		gutenberg_register_module( 'bar', '/bar.js' );
+		gutenberg_enqueue_module( 'foo' );
+		gutenberg_enqueue_module( 'bar' );
+
+		$enqueued_modules = $this->get_enqueued_modules();
+
+		$this->assertEquals( 2, count( $enqueued_modules ) );
+		$this->assertEquals( true, str_starts_with( $enqueued_modules['foo'], '/foo.js' ) );
+		$this->assertEquals( true, str_starts_with( $enqueued_modules['bar'], '/bar.js' ) );
+	}
+
+	public function test_gutenberg_dequeue_module() {
+		gutenberg_register_module( 'foo', '/foo.js' );
+		gutenberg_register_module( 'bar', '/bar.js' );
+		gutenberg_enqueue_module( 'foo' );
+		gutenberg_enqueue_module( 'bar' );
+		gutenberg_dequeue_module( 'foo' ); // Dequeued.
+
+		$enqueued_modules = $this->get_enqueued_modules();
+
+		$this->assertEquals( 1, count( $enqueued_modules ) );
+		$this->assertEquals( false, isset( $enqueued_modules['foo'] ) );
+		$this->assertEquals( true, isset( $enqueued_modules['bar'] ) );
+	}
+
+	public function test_gutenberg_enqueue_module_works_before_register() {
+		gutenberg_enqueue_module( 'foo' );
+		gutenberg_register_module( 'foo', '/foo.js' );
+		gutenberg_enqueue_module( 'bar' ); // Not registered.
+
+		$enqueued_modules = $this->get_enqueued_modules();
+
+		$this->assertEquals( 1, count( $enqueued_modules ) );
+		$this->assertEquals( true, str_starts_with( $enqueued_modules['foo'], '/foo.js' ) );
+		$this->assertEquals( false, isset( $enqueued_modules['bar'] ) );
+	}
+
+	public function test_gutenberg_dequeue_module_works_before_register() {
+		gutenberg_enqueue_module( 'foo' );
+		gutenberg_enqueue_module( 'bar' );
+		gutenberg_dequeue_module( 'foo' );
+		gutenberg_register_module( 'foo', '/foo.js' );
+		gutenberg_register_module( 'bar', '/bar.js' );
+
+		$enqueued_modules = $this->get_enqueued_modules();
+
+		$this->assertEquals( 1, count( $enqueued_modules ) );
+		$this->assertEquals( false, isset( $enqueued_modules['foo'] ) );
+		$this->assertEquals( true, isset( $enqueued_modules['bar'] ) );
+	}
+
+	public function test_gutenberg_import_map_dependencies() {
+		gutenberg_register_module( 'foo', '/foo.js', array( 'dep' ) );
+		gutenberg_register_module( 'dep', '/dep.js' );
+		gutenberg_register_module( 'no-dep', '/no-dep.js' );
+		gutenberg_enqueue_module( 'foo' );
+
+		$import_map = $this->get_import_map();
+
+		$this->assertEquals( 1, count( $import_map ) );
+		$this->assertEquals( true, str_starts_with( $import_map['dep'], '/dep.js' ) );
+		$this->assertEquals( false, isset( $import_map['no-dep'] ) );
+	}
+
+	public function test_gutenberg_import_map_no_duplicate_dependencies() {
+		gutenberg_register_module( 'foo', '/foo.js', array( 'dep' ) );
+		gutenberg_register_module( 'bar', '/bar.js', array( 'dep' ) );
+		gutenberg_register_module( 'dep', '/dep.js' );
+		gutenberg_enqueue_module( 'foo' );
+		gutenberg_enqueue_module( 'bar' );
+
+		$import_map = $this->get_import_map();
+
+		$this->assertEquals( 1, count( $import_map ) );
+		$this->assertEquals( true, str_starts_with( $import_map['dep'], '/dep.js' ) );
+	}
+
+	public function test_gutenberg_import_map_recursive_dependencies() {
+		gutenberg_register_module(
+			'foo',
+			'/foo.js',
+			array(
+				'static-dep',
+				array(
+					'id'   => 'dynamic-dep',
+					'type' => 'dynamic',
+				),
+			)
+		);
+		gutenberg_register_module(
+			'static-dep',
+			'/static-dep.js',
+			array(
+				array(
+					'id'   => 'nested-static-dep',
+					'type' => 'static',
+				),
+				array(
+					'id'   => 'nested-dynamic-dep',
+					'type' => 'dynamic',
+				),
+			)
+		);
+		gutenberg_register_module( 'dynamic-dep', '/dynamic-dep.js' );
+		gutenberg_register_module( 'nested-static-dep', '/nested-static-dep.js' );
+		gutenberg_register_module( 'nested-dynamic-dep', '/nested-dynamic-dep.js' );
+		gutenberg_register_module( 'no-dep', '/no-dep.js' );
+		gutenberg_enqueue_module( 'foo' );
+
+		$import_map = $this->get_import_map();
+
+		$this->assertEquals( true, str_starts_with( $import_map['static-dep'], '/static-dep.js' ) );
+		$this->assertEquals( true, str_starts_with( $import_map['dynamic-dep'], '/dynamic-dep.js' ) );
+		$this->assertEquals( true, str_starts_with( $import_map['nested-static-dep'], '/nested-static-dep.js' ) );
+		$this->assertEquals( true, str_starts_with( $import_map['nested-dynamic-dep'], '/nested-dynamic-dep.js' ) );
+		$this->assertEquals( false, isset( $import_map['no-dep'] ) );
+	}
+
+	public function test_gutenberg_enqueue_preloaded_static_dependencies() {
+		gutenberg_register_module(
+			'foo',
+			'/foo.js',
+			array(
+				'static-dep',
+				array(
+					'id'   => 'dynamic-dep',
+					'type' => 'dynamic',
+				),
+			)
+		);
+		gutenberg_register_module(
+			'static-dep',
+			'/static-dep.js',
+			array(
+				array(
+					'id'   => 'nested-static-dep',
+					'type' => 'static',
+				),
+				array(
+					'id'   => 'nested-dynamic-dep',
+					'type' => 'dynamic',
+				),
+			)
+		);
+		gutenberg_register_module( 'dynamic-dep', '/dynamic-dep.js' );
+		gutenberg_register_module( 'nested-static-dep', '/nested-static-dep.js' );
+		gutenberg_register_module( 'nested-dynamic-dep', '/nested-dynamic-dep.js' );
+		gutenberg_register_module( 'no-dep', '/no-dep.js' );
+		gutenberg_enqueue_module( 'foo' );
+
+		$preloaded_modules = $this->get_preloaded_modules();
+
 		$this->assertEquals( 2, count( $preloaded_modules ) );
-		$this->assertEquals( true, strpos( $preloaded_modules['@wordpress/some-static-dep'], '/some-static-dep.js' ) === 0 );
-		$this->assertEquals( true, strpos( $preloaded_modules['@wordpress/some-nested-static-dep'], '/some-nested-static-dep.js' ) === 0 );
-		$this->assertEquals( false, isset( $import_map['@wordpress/no-dep'] ) );
-		$this->assertEquals( false, isset( $import_map['@wordpress/some-dynamic-dep'] ) );
-		$this->assertEquals( false, isset( $import_map['@wordpress/some-nested-dynamic-dep'] ) );
+		$this->assertEquals( true, str_starts_with( $preloaded_modules['static-dep'], '/static-dep.js' ) );
+		$this->assertEquals( true, str_starts_with( $preloaded_modules['nested-static-dep'], '/nested-static-dep.js' ) );
+		$this->assertEquals( false, isset( $import_map['no-dep'] ) );
+		$this->assertEquals( false, isset( $import_map['dynamic-dep'] ) );
+		$this->assertEquals( false, isset( $import_map['nested-dynamic-dep'] ) );
+	}
+
+	public function test_gutenberg_preloaded_dependencies_filter_enqueued_modules() {
+		gutenberg_register_module(
+			'foo',
+			'/foo.js',
+			array(
+				'dep',
+				'enqueued-dep',
+			)
+		);
+		gutenberg_register_module( 'dep', '/dep.js' );
+		gutenberg_register_module( 'enqueued-dep', '/enqueued-dep.js' );
+		gutenberg_enqueue_module( 'foo' );
+		gutenberg_enqueue_module( 'enqueued-dep' ); // Not preloaded.
+
+		$preloaded_modules = $this->get_preloaded_modules();
+
+		$this->assertEquals( 1, count( $preloaded_modules ) );
+		$this->assertEquals( true, isset( $preloaded_modules['dep'] ) );
+		$this->assertEquals( false, isset( $preloaded_modules['enqueued-dep'] ) );
+	}
+
+	public function test_gutenberg_enqueued_modules_with_dependants_add_import_map() {
+		gutenberg_register_module(
+			'foo',
+			'/foo.js',
+			array(
+				'dep',
+				'enqueued-dep',
+			)
+		);
+		gutenberg_register_module( 'dep', '/dep.js' );
+		gutenberg_register_module( 'enqueued-dep', '/enqueued-dep.js' );
+		gutenberg_enqueue_module( 'foo' );
+		gutenberg_enqueue_module( 'enqueued-dep' ); // Also in the import map.
+
+		$import_map = $this->get_import_map();
+
+		$this->assertEquals( 2, count( $import_map ) );
+		$this->assertEquals( true, isset( $import_map['dep'] ) );
+		$this->assertEquals( true, isset( $import_map['enqueued-dep'] ) );
 	}
 
 	public function test_get_version_query_string() {
@@ -194,6 +282,4 @@ class Gutenberg_Modules_Test extends WP_UnitTestCase {
 		$result = $get_version_query_string->invoke( null, null );
 		$this->assertEquals( '', $result );
 	}
-
-	// public function test_gutenberg_dont_crash_on_missing_dependency() {}.
 }

--- a/phpunit/experimental/modules/class-gutenberg-modules-test.php
+++ b/phpunit/experimental/modules/class-gutenberg-modules-test.php
@@ -181,6 +181,19 @@ class Gutenberg_Modules_Test extends WP_UnitTestCase {
 		$this->assertEquals( false, isset( $import_map['@wordpress/some-nested-dynamic-dep'] ) );
 	}
 
-	// public function test_gutenberg_modules_get_version() {}.
+	public function test_get_version_query_string() {
+		$get_version_query_string = new ReflectionMethod( 'Gutenberg_Modules', 'get_version_query_string' );
+		$get_version_query_string->setAccessible( true );
+
+		$result = $get_version_query_string->invoke( null, '1.0' );
+		$this->assertEquals( '?ver=1.0', $result );
+
+		$result = $get_version_query_string->invoke( null, false );
+		$this->assertEquals( '?ver=' . get_bloginfo( 'version' ), $result );
+
+		$result = $get_version_query_string->invoke( null, null );
+		$this->assertEquals( '', $result );
+	}
+
 	// public function test_gutenberg_dont_crash_on_missing_dependency() {}.
 }

--- a/phpunit/experimental/modules/class-gutenberg-modules-test.php
+++ b/phpunit/experimental/modules/class-gutenberg-modules-test.php
@@ -9,58 +9,178 @@
  * Tests for the Gutenberg_Modules_Test class.
  */
 class Gutenberg_Modules_Test extends WP_UnitTestCase {
-
-	protected $old_wp_scripts;
-	protected $old_modules_markup;
+	protected $registered;
+	protected $old_registered;
 
 	public function set_up() {
 		parent::set_up();
-
-		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
-		remove_action( 'wp_default_scripts', 'wp_default_scripts' );
-		remove_action( 'wp_default_scripts', 'wp_default_packages' );
-		$GLOBALS['wp_scripts']    = new WP_Scripts();
-		$this->old_modules_markup = get_echo( array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
+		$this->registered = new ReflectionProperty( 'Gutenberg_Modules', 'registered' );
+		$this->registered->setAccessible( true );
+		$this->old_registered = $this->registered->getValue();
+		$this->registered->setValue( array() );
 	}
 
 	public function tear_down() {
-		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
-		add_action( 'wp_default_scripts', 'wp_default_scripts' );
+		$this->registered->setValue( $this->old_registered );
 		parent::tear_down();
 	}
 
-	public function test_wp_enqueue_module() {
-		global $wp_version;
-		gutenberg_register_module( 'no-deps-no-version', 'interactivity-api-1.js' );
-		gutenberg_enqueue_module( 'no-deps-no-version' );
-		gutenberg_register_module( 'deps-no-version', 'interactivity-api-2.js', array( 'no-deps-no-version' ) );
-		gutenberg_enqueue_module( 'deps-no-version' );
+	public function test_gutenberg_enqueue_module() {
+		gutenberg_register_module( '@wordpress/some-module', '/some-module.js' );
+		gutenberg_enqueue_module( '@wordpress/some-module' );
+		gutenberg_register_module( '@wordpress/other-module', '/other-module.js' );
+		gutenberg_enqueue_module( '@wordpress/other-module' );
 
-		$modules_markup    = get_echo( array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
-		$import_map_markup = get_echo( array( 'Gutenberg_Modules', 'print_import_map' ) );
-		$preload_markup    = get_echo( array( 'Gutenberg_Modules', 'print_module_preloads' ) );
+		$modules_markup   = get_echo( array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
+		$p                = new WP_HTML_Tag_Processor( $modules_markup );
+		$enqueued_modules = array();
 
-		$previous_tags      = new WP_HTML_Tag_Processor( $this->old_modules_markup );
-		$previous_src_stack = array();
-		while ( $previous_tags->next_tag( array( 'type' => 'module' ) ) ) {
-			$previous_src_stack[] = $previous_tags->get_attribute( 'src' );
+		while ( $p->next_tag(
+			array(
+				'tag'  => 'SCRIPT',
+				'type' => 'module',
+			)
+		) ) {
+			$enqueued_modules[ $p->get_attribute( 'id' ) ] = $p->get_attribute( 'src' );
 		}
-		// Test that there are 2 new <script type="module"> added to the markup.
-		$tags      = new WP_HTML_Tag_Processor( $modules_markup );
-		$src_stack = array();
-		while ( $tags->next_tag( array( 'type' => 'module' ) ) ) {
-			$src_stack[] = $tags->get_attribute( 'src' );
-		}
-		$new_src_stack = array_values( array_diff( $src_stack, $previous_src_stack ) );
-		$this->assertEquals( 2, count( $new_src_stack ) );
-		$this->assertEquals( 'interactivity-api-1.js?ver=' . $wp_version, $new_src_stack[0] );
-		$this->assertEquals( 'interactivity-api-2.js?ver=' . $wp_version, $new_src_stack[1] );
-		// Test that there is 1 <script type="importmap"> added to the markup.
-		$tags = new WP_HTML_Tag_Processor( $import_map_markup );
-		$this->assertEquals( true, $tags->next_tag( array( 'rel' => 'importmap' ) ) );
 
-		// Test that there is 1 <link type="modulepreload"> added to the markup.
-		$tags = new WP_HTML_Tag_Processor( $preload_markup );
-		$this->assertEquals( true, $tags->next_tag( array( 'rel' => 'modulepreload' ) ) );
+		$this->assertEquals( 2, count( $enqueued_modules ) );
+		$this->assertEquals( true, strpos( $enqueued_modules['@wordpress/some-module'], '/some-module.js' ) === 0 );
+		$this->assertEquals( true, strpos( $enqueued_modules['@wordpress/other-module'], '/other-module.js' ) === 0 );
 	}
+
+	public function test_gutenberg_enqueue_module_works_before_register() {
+		gutenberg_enqueue_module( '@wordpress/some-module' );
+		gutenberg_register_module( '@wordpress/some-module', '/some-module.js' );
+		gutenberg_enqueue_module( '@wordpress/other-module' ); // Not enqueued.
+
+		$modules_markup   = get_echo( array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
+		$p                = new WP_HTML_Tag_Processor( $modules_markup );
+		$enqueued_modules = array();
+
+		while ( $p->next_tag(
+			array(
+				'tag'  => 'SCRIPT',
+				'type' => 'module',
+			)
+		) ) {
+			$enqueued_modules[ $p->get_attribute( 'id' ) ] = $p->get_attribute( 'src' );
+		}
+
+		$this->assertEquals( 1, count( $enqueued_modules ) );
+		$this->assertEquals( true, strpos( $enqueued_modules['@wordpress/some-module'], '/some-module.js' ) === 0 );
+	}
+
+	public function test_gutenberg_import_map_dependencies() {
+		gutenberg_register_module( '@wordpress/no-dep', '/no-dep.js' );
+		gutenberg_register_module( '@wordpress/some-dep', '/some-dep.js' );
+		gutenberg_register_module( '@wordpress/some-module', '/some-module.js', array( '@wordpress/some-dep' ) );
+		gutenberg_enqueue_module( '@wordpress/some-module' );
+
+		$import_map_markup = get_echo( array( 'Gutenberg_Modules', 'print_import_map' ) );
+		preg_match( '/<script type="importmap">([^<]+)<\/script>/s', $import_map_markup, $import_map_string );
+		$import_map = json_decode( $import_map_string[1], true )['imports'];
+
+		$this->assertEquals( true, strpos( $import_map['@wordpress/some-dep'], '/some-dep.js' ) === 0 );
+		$this->assertEquals( false, isset( $import_map['@wordpress/no-dep'] ) );
+	}
+
+	public function test_gutenberg_import_map_recursive_dependencies() {
+		gutenberg_register_module( '@wordpress/no-dep', '/no-dep.js' );
+		gutenberg_register_module( '@wordpress/some-nested-static-dep', '/some-nested-static-dep.js' );
+		gutenberg_register_module( '@wordpress/some-nested-dynamic-dep', '/some-nested-dynamic-dep.js' );
+		gutenberg_register_module(
+			'@wordpress/some-static-dep',
+			'/some-static-dep.js',
+			array(
+				array(
+					'id'   => '@wordpress/some-nested-static-dep',
+					'type' => 'static',
+				),
+				array(
+					'id'   => '@wordpress/some-nested-dynamic-dep',
+					'type' => 'dynamic',
+				),
+			)
+		);
+		gutenberg_register_module( '@wordpress/some-dynamic-dep', '/some-dynamic-dep.js' );
+		gutenberg_register_module(
+			'@wordpress/some-module',
+			'/some-module.js',
+			array(
+				'@wordpress/some-static-dep',
+				array(
+					'id'   => '@wordpress/some-dynamic-dep',
+					'type' => 'dynamic',
+				),
+			)
+		);
+		gutenberg_enqueue_module( '@wordpress/some-module' );
+
+		$import_map_markup = get_echo( array( 'Gutenberg_Modules', 'print_import_map' ) );
+		preg_match( '/<script type="importmap">([^<]+)<\/script>/s', $import_map_markup, $import_map_string );
+		$import_map = json_decode( $import_map_string[1], true )['imports'];
+
+		$this->assertEquals( true, strpos( $import_map['@wordpress/some-static-dep'], '/some-static-dep.js' ) === 0 );
+		$this->assertEquals( true, strpos( $import_map['@wordpress/some-dynamic-dep'], '/some-dynamic-dep.js' ) === 0 );
+		$this->assertEquals( true, strpos( $import_map['@wordpress/some-nested-static-dep'], '/some-nested-static-dep.js' ) === 0 );
+		$this->assertEquals( true, strpos( $import_map['@wordpress/some-nested-dynamic-dep'], '/some-nested-dynamic-dep.js' ) === 0 );
+		$this->assertEquals( false, isset( $import_map['@wordpress/no-dep'] ) );
+	}
+
+	public function test_gutenberg_enqueue_module_preloads_static_dependencies() {
+		gutenberg_register_module( '@wordpress/no-dep', '/no-dep.js' );
+		gutenberg_register_module( '@wordpress/some-nested-static-dep', '/some-nested-static-dep.js' );
+		gutenberg_register_module( '@wordpress/some-nested-dynamic-dep', '/some-nested-dynamic-dep.js' );
+		gutenberg_register_module(
+			'@wordpress/some-static-dep',
+			'/some-static-dep.js',
+			array(
+				array(
+					'id'   => '@wordpress/some-nested-static-dep',
+					'type' => 'static',
+				),
+				array(
+					'id'   => '@wordpress/some-nested-dynamic-dep',
+					'type' => 'dynamic',
+				),
+			)
+		);
+		gutenberg_register_module( '@wordpress/some-dynamic-dep', '/some-dynamic-dep.js', array( '@wordpress/some-nested-dep' ) );
+		gutenberg_register_module(
+			'@wordpress/some-module',
+			'/some-module.js',
+			array(
+				'@wordpress/some-static-dep',
+				array(
+					'id'   => 'some-dynamic-dep',
+					'type' => 'dynamic',
+				),
+			)
+		);
+		gutenberg_enqueue_module( '@wordpress/some-module' );
+
+		$preloaded_markup  = get_echo( array( 'Gutenberg_Modules', 'print_preloaded_modules' ) );
+		$p                 = new WP_HTML_Tag_Processor( $preloaded_markup );
+		$preloaded_modules = array();
+
+		while ( $p->next_tag(
+			array(
+				'tag' => 'LINK',
+				'rel' => 'modulepreload',
+			)
+		) ) {
+			$preloaded_modules[ $p->get_attribute( 'id' ) ] = $p->get_attribute( 'href' );
+		}
+
+		$this->assertEquals( 2, count( $preloaded_modules ) );
+		$this->assertEquals( true, strpos( $preloaded_modules['@wordpress/some-static-dep'], '/some-static-dep.js' ) === 0 );
+		$this->assertEquals( true, strpos( $preloaded_modules['@wordpress/some-nested-static-dep'], '/some-nested-static-dep.js' ) === 0 );
+		$this->assertEquals( false, isset( $import_map['@wordpress/no-dep'] ) );
+		$this->assertEquals( false, isset( $import_map['@wordpress/some-dynamic-dep'] ) );
+		$this->assertEquals( false, isset( $import_map['@wordpress/some-nested-dynamic-dep'] ) );
+	}
+
+	// public function test_gutenberg_modules_get_version() {}.
+	// public function test_gutenberg_dont_crash_on_missing_dependency() {}.
 }

--- a/phpunit/experimental/modules/class-gutenberg-modules-test.php
+++ b/phpunit/experimental/modules/class-gutenberg-modules-test.php
@@ -49,7 +49,7 @@ class Gutenberg_Modules_Test extends WP_UnitTestCase {
 	}
 
 	public function get_preloaded_modules() {
-		$preloaded_markup  = get_echo( array( 'Gutenberg_Modules', 'print_preloaded_modules' ) );
+		$preloaded_markup  = get_echo( array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 		$p                 = new WP_HTML_Tag_Processor( $preloaded_markup );
 		$preloaded_modules = array();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

This is a general refactor of the code, including more test coverage and a few improvements on the API.

Starting from this PR, the dependencies array has the following structure:

> An array of module identifiers of the dependencies of this module. The dependencies can be strings or arrays. If they are arrays, they need an `id` key with the module identifier, and can contain a `type` key with either `static` or `dynamic`. By default, dependencies that don't contain a type are considered static.

Examples:

```js
// foo.js
import x from "static-dependency";
import y from "another-static-dependency";
import z from "yet-another-static-dependency";

const d = await import("dynamic-dependency");
```

```php
gutenberg_register_module( 'foo', '/foo.js', array(
  'static-dependency',
  array(
    'id' => 'another-static-dependency'
  ),
  array(
    'id'   => 'yet-another-static-dependency',
    'type' => 'static'
  ),
  array(
    'id'   => 'dynamic-dependency',
    'type' => 'dynamic'
  ),
) );
```

This opens the door for future additions, like for example dependency versions to support import map scopes:

```php
gutenberg_register_module( 'lib', '/lib.v1.js', array(), '1.2.3' );
gutenberg_register_module( 'lib', '/lib.v2.js', array(), '2.3.4' );

gutenberg_register_module( 'foo', '/foo.js', array( 'lib' ) );
gutenberg_register_module( 'bar', '/bar.js', array( array( 'id' => 'lib', 'version' => '^1.0.0' ) ) );
```

```html
<script type="importmap">
  {
    "imports": {
      "lib": "/lib.v2.js"
    },
    "scopes": {
      "/bar.js": {
        "lib": "/lib.v1.js"
      }
    }
  }
</script>
```

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Apart from the general improvements here in Gutenberg, I want to open a PR on WordPress Core as soon as this is merged, so more folks can test it out and give feedback.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I reviewed all the code, comments and tests.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Either add some interactive blocks to your page and check that the modules, preloads and import maps are added correctly to the page, or use the `gutenberg_register_module` and `gutenberg_enqueue_module` functions in your own code.
