### PR TITLE
Patterns: editing in focus mode - pass onSelectPost as editor setting

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -147,7 +147,6 @@ export default function ReusableBlockEdit( {
 	attributes: { ref, overrides },
 	__unstableParentLayout: parentLayout,
 	clientId: patternClientId,
-	editOriginalPattern,
 } ) {
 	const registry = useRegistry();
 	const hasAlreadyRendered = useHasRecursion( ref );
@@ -165,23 +164,36 @@ export default function ReusableBlockEdit( {
 		setBlockEditingMode,
 	} = useDispatch( blockEditorStore );
 
-	const { innerBlocks, userCanEdit, getBlockEditingMode } = useSelect(
-		( select ) => {
-			const { canUser } = select( coreStore );
-			const { getBlocks, getBlockEditingMode: editingMode } =
-				select( blockEditorStore );
-			const blocks = getBlocks( patternClientId );
-			const canEdit = canUser( 'update', 'blocks', ref );
+	const { innerBlocks, userCanEdit, getBlockEditingMode, onSelectPost } =
+		useSelect(
+			( select ) => {
+				const { canUser } = select( coreStore );
+				const {
+					getBlocks,
+					getBlockEditingMode: editingMode,
+					getSettings,
+				} = select( blockEditorStore );
+				const blocks = getBlocks( patternClientId );
+				const canEdit = canUser( 'update', 'blocks', ref );
 
-			// For editing link to the site editor if the theme and user permissions support it.
-			return {
-				innerBlocks: blocks,
-				userCanEdit: canEdit,
-				getBlockEditingMode: editingMode,
-			};
-		},
-		[ patternClientId, ref ]
-	);
+				// For editing link to the site editor if the theme and user permissions support it.
+				return {
+					innerBlocks: blocks,
+					userCanEdit: canEdit,
+					getBlockEditingMode: editingMode,
+					onSelectPost: getSettings().__experimentalOnSelectPost,
+				};
+			},
+			[ patternClientId, ref ]
+		);
+
+	const { onClick: editOriginal } = onSelectPost
+		? onSelectPost( {
+				postId: ref,
+				postType: 'wp_block',
+				canvas: 'edit',
+		  } )
+		: {};
 
 	useEffect(
 		() => setBlockEditMode( setBlockEditingMode, innerBlocks ),
@@ -289,14 +301,10 @@ export default function ReusableBlockEdit( {
 
 	return (
 		<RecursionProvider uniqueId={ ref }>
-			{ userCanEdit && editOriginalPattern && (
+			{ userCanEdit && editOriginal && (
 				<BlockControls>
 					<ToolbarGroup>
-						<ToolbarButton
-							onClick={ () =>
-								editOriginalPattern( ref, 'wp_block' )
-							}
-						>
+						<ToolbarButton onClick={ editOriginal }>
 							{ __( 'Edit original' ) }
 						</ToolbarButton>
 					</ToolbarGroup>

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -187,7 +187,7 @@ export default function ReusableBlockEdit( {
 			[ patternClientId, ref ]
 		);
 
-	const { onClick: editOriginal } = onSelectPost
+	const editOriginal = onSelectPost
 		? onSelectPost( {
 				postId: ref,
 				postType: 'wp_block',
@@ -304,7 +304,10 @@ export default function ReusableBlockEdit( {
 			{ userCanEdit && editOriginal && (
 				<BlockControls>
 					<ToolbarGroup>
-						<ToolbarButton onClick={ editOriginal }>
+						<ToolbarButton
+							href={ editOriginal.href }
+							onClick={ editOriginal.onClick }
+						>
 							{ __( 'Edit original' ) }
 						</ToolbarButton>
 					</ToolbarGroup>

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -187,7 +187,7 @@ export default function ReusableBlockEdit( {
 			[ patternClientId, ref ]
 		);
 
-	const editOriginal = onSelectPost
+	const editOriginalProps = onSelectPost
 		? onSelectPost( {
 				postId: ref,
 				postType: 'wp_block',
@@ -301,13 +301,10 @@ export default function ReusableBlockEdit( {
 
 	return (
 		<RecursionProvider uniqueId={ ref }>
-			{ userCanEdit && editOriginal && (
+			{ userCanEdit && editOriginalProps && (
 				<BlockControls>
 					<ToolbarGroup>
-						<ToolbarButton
-							href={ editOriginal.href }
-							onClick={ editOriginal.onClick }
-						>
+						<ToolbarButton { ...editOriginalProps }>
 							{ __( 'Edit original' ) }
 						</ToolbarButton>
 					</ToolbarGroup>

--- a/packages/edit-post/src/hooks/use-post-history.js
+++ b/packages/edit-post/src/hooks/use-post-history.js
@@ -49,11 +49,13 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 
 		return {
 			href: newUrl,
-			onClick: () =>
+			onClick: ( event ) => {
+				event.preventDefault();
 				dispatch( {
 					type: 'push',
 					post: { postId: params.postId, postType: params.postType },
-				} ),
+				} );
+			},
 		};
 	}, [] );
 

--- a/packages/edit-post/src/hooks/use-post-history.js
+++ b/packages/edit-post/src/hooks/use-post-history.js
@@ -47,6 +47,9 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 			action: 'edit',
 		} );
 
+		// This return signature is matched to `useLink` in the site editor to allow the onSelectPost
+		// setting to be easily shared between edit-post and edit-site. In edit-site useLink is passed in
+		// as onSelectPost in order to use the existing edit-site client side routing to move between posts.
 		return {
 			href: newUrl,
 			onClick: ( event ) => {

--- a/packages/edit-post/src/hooks/use-post-history.js
+++ b/packages/edit-post/src/hooks/use-post-history.js
@@ -34,8 +34,14 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 		[ { postId: initialPostId, postType: initialPostType } ]
 	);
 
-	const onSelectPost = useCallback( ( postId, postType ) => {
-		dispatch( { type: 'push', post: { postId, postType } } );
+	const onSelectPost = useCallback( ( params ) => {
+		return {
+			onClick: () =>
+				dispatch( {
+					type: 'push',
+					post: { postId: params.postId, postType: params.postType },
+				} ),
+		};
 	}, [] );
 
 	const goBack = useCallback( () => {

--- a/packages/edit-post/src/hooks/use-post-history.js
+++ b/packages/edit-post/src/hooks/use-post-history.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useReducer } from '@wordpress/element';
+import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 
 /**
  * A hook that records the 'entity' history in the post editor as a user
@@ -35,7 +36,19 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 	);
 
 	const onSelectPost = useCallback( ( params ) => {
+		const currentArgs = getQueryArgs( window.location.href );
+		const currentUrlWithoutArgs = removeQueryArgs(
+			window.location.href,
+			...Object.keys( currentArgs )
+		);
+
+		const newUrl = addQueryArgs( currentUrlWithoutArgs, {
+			post: params.postId,
+			action: 'edit',
+		} );
+
 		return {
+			href: newUrl,
 			onClick: () =>
 				dispatch( {
 					type: 'push',

--- a/packages/edit-site/src/components/block-editor/back-button.js
+++ b/packages/edit-site/src/components/block-editor/back-button.js
@@ -12,6 +12,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import {
 	TEMPLATE_PART_POST_TYPE,
 	NAVIGATION_POST_TYPE,
+	PATTERN_TYPES,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 
@@ -22,11 +23,12 @@ function BackButton() {
 	const history = useHistory();
 	const isTemplatePart = location.params.postType === TEMPLATE_PART_POST_TYPE;
 	const isNavigationMenu = location.params.postType === NAVIGATION_POST_TYPE;
+	const isPattern = location.params.postType === PATTERN_TYPES.user;
 	const previousTemplateId = location.state?.fromTemplateId;
 
-	const isFocusMode = isTemplatePart || isNavigationMenu;
+	const isFocusMode = isTemplatePart || isNavigationMenu || isPattern;
 
-	if ( ! isFocusMode || ! previousTemplateId ) {
+	if ( ! isFocusMode || ( ! previousTemplateId && ! isPattern ) ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -13,6 +13,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { useLink } from '../routes/link';
 
 const { useBlockEditorSettings } = unlock( editorPrivateApis );
 
@@ -159,7 +160,7 @@ export function useSpecificEditorSettings() {
 			hasFixedToolbar,
 			keepCaretInsideBlock,
 			defaultRenderingMode,
-
+			onSelectPost: useLink,
 			// I wonder if they should be set in the post editor too
 			__experimentalArchiveTitleTypeLabel: archiveLabels.archiveTypeLabel,
 			__experimentalArchiveTitleNameLabel: archiveLabels.archiveNameLabel,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -77,6 +77,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableIsBlockBasedTheme',
 	'__experimentalArchiveTitleTypeLabel',
 	'__experimentalArchiveTitleNameLabel',
+	'__experimentalOnSelectPost',
 ];
 
 /**
@@ -99,6 +100,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		userPatternCategories,
 		restBlockPatterns,
 		restBlockPatternCategories,
+		selectPost,
 	} = useSelect(
 		( select ) => {
 			const isWeb = Platform.OS === 'web';
@@ -111,6 +113,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				getBlockPatterns,
 				getBlockPatternCategories,
 			} = select( coreStore );
+			const { onSelectPost } = select( editorStore ).getEditorSettings();
 
 			const siteSettings = canUser( 'read', 'settings' )
 				? getEntityRecord( 'root', 'site' )
@@ -134,6 +137,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				userPatternCategories: getUserPatternCategories(),
 				restBlockPatterns: getBlockPatterns(),
 				restBlockPatternCategories: getBlockPatternCategories(),
+				selectPost: onSelectPost,
 			};
 		},
 		[ postType, postId ]
@@ -239,6 +243,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				postType === 'wp_navigation'
 					? [ [ 'core/navigation', {}, [] ] ]
 					: settings.template,
+			__experimentalOnSelectPost: selectPost,
 		} ),
 		[
 			settings,
@@ -254,6 +259,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			pageOnFront,
 			pageForPosts,
 			postType,
+			selectPost,
 		]
 	);
 }

--- a/packages/editor/src/hooks/pattern-partial-syncing.js
+++ b/packages/editor/src/hooks/pattern-partial-syncing.js
@@ -64,44 +64,10 @@ const withPartialSyncingControls = createHigherOrderComponent(
 	}
 );
 
-/**
- * Adds an editOriginalPattern prop which allows the block to switch between post and pattern
- * editing modes.
- *
- * @param {Component} BlockEdit Original component.
- *
- * @return {Component} Wrapped component.
- */
-const withPatternOnlyRenderMode = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const onSelectPost = useSelect(
-			( select ) =>
-				select( editorStore ).getEditorSettings().onSelectPost,
-			[]
-		);
-		if ( props.name !== 'core/block' ) {
-			return <BlockEdit { ...props } />;
-		}
-
-		const newProps = {
-			...props,
-			editOriginalPattern:
-				typeof onSelectPost === 'function' ? onSelectPost : undefined,
-		};
-
-		return <BlockEdit { ...newProps } />;
-	}
-);
-
 if ( window.__experimentalPatternPartialSyncing ) {
 	addFilter(
 		'editor.BlockEdit',
 		'core/editor/with-partial-syncing-controls',
 		withPartialSyncingControls
-	);
-	addFilter(
-		'editor.BlockEdit',
-		'core/editor/with-pattern-edit-original-mode',
-		withPatternOnlyRenderMode
 	);
 }


### PR DESCRIPTION
## What?
Switches to passing onSelectPost as editor setting instead of via filter, and also matches function signature to `useLink` to allow easier sharing between site and post editor

## Why?
Now this method is more generic it may be of use to other blocks, and this is a better approach than needing a filter for each block that wants to use it.

## How?

- Adds `_experimentalOnSelectPost` to block editor settings in `edit-post` and `edit-site`
- Matches function signature of onSelectPost in `edit-post` to `useLink` in edit-site

## Testing Instructions
 - Enable pattern overrides experiment
 - Add a synced pattern
 - Insert the pattern in post editor and make sure `Edit original` button works, and that back button in header works
 - Insert in a template in site editor and make sure `Edit original` button works and that back button at top of editor canvas works

