### PR TITLE
DropdownMenuV2: do not collapse suffix width

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Enhancements
 
+-   `DropdownMenuV2`: do not collapse suffix width ([#57238](https://github.com/WordPress/gutenberg/pull/57238)).
 -   `DateTimePicker`: Adjustment of the dot position on DayButton and expansion of the button area. ([#55502](https://github.com/WordPress/gutenberg/pull/55502)).
 
 ### Experimental

--- a/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
+++ b/packages/components/src/dropdown-menu-v2-ariakit/styles.ts
@@ -269,8 +269,9 @@ export const DropdownMenuItemChildrenWrapper = styled.div`
 `;
 
 export const ItemSuffixWrapper = styled.span`
-	flex: 0;
-	width: max-content;
+	flex: 0 1 fit-content;
+	min-width: 0;
+	width: fit-content;
 
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Splitting from #55625, this PR tweaks the styles of suffix in the new experimental `DropdownMenu` item styles, so that the suffix doesn't collapse its width.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Better look

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- By tweaking the `flex-grow` and `flex-basis` CSS properties
- By using the `fit-content` keyword for both the `width` and the `flex-basis` CSS properties

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add more content to a menu item suffix, observe how the dropdown menu item deals with resizing its suffix and contents.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2023-12-20 at 00 33 18](https://github.com/WordPress/gutenberg/assets/1083581/09379906-31a1-4f58-aa1f-54e0c0e82564) | ![Screenshot 2023-12-20 at 00 33 00](https://github.com/WordPress/gutenberg/assets/1083581/ed4181d3-9aa9-4476-bf5c-1441ce6aae53) |
