### PR TITLE
[Fix:#32787] Gradient backgrounds should be set with background-image instead of background

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -77,7 +77,7 @@
 	}
 
 	@if $direction == "bottom" {
-		background: linear-gradient(to top, transparent, $color 90%);
+		background-image: linear-gradient(to top, transparent, $color 90%);
 		left: $edge;
 		right: $edge;
 		top: $edge;
@@ -86,7 +86,7 @@
 	}
 
 	@if $direction == "top" {
-		background: linear-gradient(to bottom, transparent, $color 90%);
+		background-image: linear-gradient(to bottom, transparent, $color 90%);
 		top: calc(100% - $size);
 		left: $edge;
 		right: $edge;
@@ -95,7 +95,7 @@
 	}
 
 	@if $direction == "left" {
-		background: linear-gradient(to left, transparent, $color 90%);
+		background-image: linear-gradient(to left, transparent, $color 90%);
 		top: $edge;
 		left: $edge;
 		bottom: $edge;
@@ -105,7 +105,7 @@
 	}
 
 	@if $direction == "right" {
-		background: linear-gradient(to right, transparent, $color 90%);
+		background-image: linear-gradient(to right, transparent, $color 90%);
 		top: $edge;
 		bottom: $edge;
 		right: $edge;
@@ -522,31 +522,31 @@
 
 	/* stylelint-disable function-comma-space-after */
 	.has-vivid-green-cyan-to-vivid-cyan-blue-gradient-background {
-		background: linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%);
+		background-image: linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%);
 	}
 
 	.has-purple-crush-gradient-background {
-		background: linear-gradient(135deg,rgb(52,226,228) 0%,rgb(71,33,251) 50%,rgb(171,29,254) 100%);
+		background-image: linear-gradient(135deg,rgb(52,226,228) 0%,rgb(71,33,251) 50%,rgb(171,29,254) 100%);
 	}
 
 	.has-hazy-dawn-gradient-background {
-		background: linear-gradient(135deg,rgb(250,172,168) 0%,rgb(218,208,236) 100%);
+		background-image: linear-gradient(135deg,rgb(250,172,168) 0%,rgb(218,208,236) 100%);
 	}
 
 	.has-subdued-olive-gradient-background {
-		background: linear-gradient(135deg,rgb(250,250,225) 0%,rgb(103,166,113) 100%);
+		background-image: linear-gradient(135deg,rgb(250,250,225) 0%,rgb(103,166,113) 100%);
 	}
 
 	.has-atomic-cream-gradient-background {
-		background: linear-gradient(135deg,rgb(253,215,154) 0%,rgb(0,74,89) 100%);
+		background-image: linear-gradient(135deg,rgb(253,215,154) 0%,rgb(0,74,89) 100%);
 	}
 
 	.has-nightshade-gradient-background {
-		background: linear-gradient(135deg,rgb(51,9,104) 0%,rgb(49,205,207) 100%);
+		background-image: linear-gradient(135deg,rgb(51,9,104) 0%,rgb(49,205,207) 100%);
 	}
 
 	.has-midnight-gradient-background {
-		background: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
+		background-image: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
 	}
 	/* stylelint-enable function-comma-space-after */
 }

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -58,7 +58,7 @@ $swatch-gap: 12px;
 
 .block-editor-panel-color-gradient-settings__color-indicator {
 	// Show a diagonal line (crossed out) for empty swatches.
-	background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
+	background-image: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 }
 
 /**

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -33,5 +33,5 @@ $swatch-columns: math.floor(math.div($popover-width + $swatch-gap - 2 * $popover
 
 .block-editor-duotone-control__unset-indicator {
 	// Show a diagonal line (crossed out) for empty swatches.
-	background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
+	background-image: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -60,7 +60,7 @@
 	}
 	&.is-branch-selected:not(.is-selected) {
 		// Lighten a CSS variable without introducing a new SASS variable
-		background:
+		background-image:
 			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
 			linear-gradient(var(--wp-admin-theme-color), var(--wp-admin-theme-color));
 	}

--- a/packages/block-library/src/gallery/deprecated.scss
+++ b/packages/block-library/src/gallery/deprecated.scss
@@ -51,7 +51,7 @@
 			color: $white;
 			text-align: center;
 			font-size: 0.8em;
-			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
+			background-image: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
 			box-sizing: border-box;
 			margin: 0;
 			z-index: 2;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -44,7 +44,7 @@ figure.wp-block-gallery.has-nested-images {
 		}
 
 		figcaption {
-			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
+			background-image: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
 			bottom: 0;
 			color: $white;
 			font-size: $default-font-size;

--- a/packages/components/src/duotone-picker/style.scss
+++ b/packages/components/src/duotone-picker/style.scss
@@ -4,12 +4,12 @@
 
 .components-duotone-picker__color-indicator > .components-button {
 	// Show a diagonal line (crossed out) for empty swatches.
-	background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
+	background-image: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 	color: transparent;
 
 	&.is-pressed:hover:not(:disabled) {
 		// Hover state has to be overridden too.
-		background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
+		background-image: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 		color: transparent;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR changes the gradient background to background-image.

## Why?
Because background affects other properties like background-attachment, background-clip, background-color etc. So instead of just using background we can specify our need.

## How?
- Use background-image instead of background, we can resolve this.

Fix: #32787
