### PR TITLE
Update block-registration.md

### DIFF
--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -292,7 +292,7 @@ The key is the name of the block (`string`) to hook into, and the value is the p
 ```js
 {
 	blockHooks: {
-		'core/verse': 'before'
+		'core/verse': 'before',
 		'core/spacer': 'after',
 		'core/column': 'firstChild',
 		'core/group': 'lastChild',


### PR DESCRIPTION
Missing Comma

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
There is a missing comma for JSON in the developer resources.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes # https://github.com/WordPress/Documentation-Issue-Tracker/issues/1397

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="751" alt="289514184-df61ccc2-61f5-4491-8819-89335480da0d" src="https://github.com/WordPress/gutenberg/assets/33965848/6bbc2388-08ea-4df1-b8c8-099e091877a6">
