### PR TITLE
Add: Bulk actions to dataviews with the new design.

### DIFF
--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -80,14 +80,10 @@ function ActionsMenuGroup( {
 	onMenuOpenChange,
 	setActionWithModal,
 } ) {
-	const bulkActions = actions.filter( ( action ) => action.supportsBulk );
-	if ( bulkActions.length === 0 ) {
-		return null;
-	}
 	return (
 		<>
 			<DropdownMenuGroup>
-				{ bulkActions.map( ( action ) => (
+				{ actions.map( ( action ) => (
 					<BulkActionItem
 						key={ action.id }
 						action={ action }
@@ -109,6 +105,10 @@ export default function BulkActions( {
 	onSelectionChange,
 	getItemId,
 } ) {
+	const bulkActions = useMemo(
+		() => actions.filter( ( action ) => action.supportsBulk ),
+		[ actions ]
+	);
 	const areAllSelected = selection && selection.length === data.length;
 	const [ isMenuOpen, onMenuOpenChange ] = useState( false );
 	const [ actionWithModal, setActionWithModal ] = useState();
@@ -117,6 +117,9 @@ export default function BulkActions( {
 			selection.includes( getItemId( item ) )
 		);
 	}, [ selection, data, getItemId ] );
+	if ( bulkActions.length === 0 ) {
+		return null;
+	}
 	return (
 		<>
 			<DropdownMenu
@@ -140,7 +143,7 @@ export default function BulkActions( {
 				}
 			>
 				<ActionsMenuGroup
-					actions={ actions }
+					actions={ bulkActions }
 					data={ data }
 					selection={ selection }
 					getItemId={ getItemId }

--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -67,7 +67,6 @@ function BulkActionItem( { action, selectedItems, setActionWithModal } ) {
 					setActionWithModal( action );
 				} else {
 					await action.callback( eligibleItems );
-					onSelectionChange( [] );
 				}
 			} }
 			suffix={

--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -124,7 +124,7 @@ export default function BulkActions( {
 				onOpenChange={ onMenuOpenChange }
 				label={ __( 'Filters' ) }
 				trigger={
-					<Button>
+					<Button variant="secondary">
 						{ selection.length
 							? sprintf(
 									/* translators: %d: Number of items. */

--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -56,7 +56,7 @@ function BulkActionItem( {
 		<DropdownMenuItem
 			key={ action.id }
 			disabled={ eligibleItems.length === 0 }
-			onSelect={ async ( event ) => {
+			onClick={ async ( event ) => {
 				event.preventDefault();
 				if ( !! action.RenderModal ) {
 					onMenuOpenChange( false );
@@ -151,7 +151,7 @@ export default function BulkActions( {
 				<DropdownMenuGroup>
 					<DropdownMenuItem
 						disabled={ areAllSelected }
-						onSelect={ ( event ) => {
+						onClick={ ( event ) => {
 							event.preventDefault();
 							onSelectionChange( data );
 						} }
@@ -161,7 +161,7 @@ export default function BulkActions( {
 					</DropdownMenuItem>
 					<DropdownMenuItem
 						disabled={ selection.length === 0 }
-						onSelect={ ( event ) => {
+						onClick={ ( event ) => {
 							event.preventDefault();
 							onSelectionChange( [] );
 						} }

--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -1,0 +1,182 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	privateApis as componentsPrivateApis,
+	Button,
+	Modal,
+} from '@wordpress/components';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from './lock-unlock';
+
+const {
+	DropdownMenuV2: DropdownMenu,
+	DropdownMenuGroupV2: DropdownMenuGroup,
+	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuSeparatorV2: DropdownMenuSeparator,
+} = unlock( componentsPrivateApis );
+
+function ActionWithModal( { action, selectedItems, setActionWithModal } ) {
+	const eligibleItems = useMemo( () => {
+		return selectedItems.filter( ( item ) => action.isEligible( item ) );
+	}, [ action, selectedItems ] );
+	const { RenderModal, hideModalHeader } = action;
+	return (
+		<Modal
+			title={ ! hideModalHeader && action.label }
+			__experimentalHideHeader={ !! hideModalHeader }
+			onRequestClose={ () => {
+				setActionWithModal( undefined );
+			} }
+			overlayClassName="dataviews-action-modal"
+		>
+			<RenderModal
+				items={ eligibleItems }
+				closeModal={ () => setActionWithModal( undefined ) }
+			/>
+		</Modal>
+	);
+}
+
+function BulkActionItem( {
+	action,
+	selectedItems,
+	onMenuOpenChange,
+	setActionWithModal,
+} ) {
+	const eligibleItems = useMemo( () => {
+		return selectedItems.filter( ( item ) => action.isEligible( item ) );
+	}, [ action, selectedItems ] );
+	return (
+		<DropdownMenuItem
+			key={ action.id }
+			disabled={ eligibleItems.length === 0 }
+			onSelect={ async ( event ) => {
+				event.preventDefault();
+				if ( !! action.RenderModal ) {
+					onMenuOpenChange( false );
+					setActionWithModal( action );
+				} else {
+					await action.callback( eligibleItems );
+				}
+			} }
+			suffix={
+				eligibleItems.length > 0 ? eligibleItems.length : undefined
+			}
+		>
+			{ action.label }
+		</DropdownMenuItem>
+	);
+}
+
+function ActionsMenuGroup( {
+	actions,
+	selectedItems,
+	onMenuOpenChange,
+	setActionWithModal,
+} ) {
+	const bulkActions = actions.filter( ( action ) => action.supportsBulk );
+	if ( bulkActions.length === 0 ) {
+		return null;
+	}
+	return (
+		<>
+			<DropdownMenuGroup>
+				{ bulkActions.map( ( action ) => (
+					<BulkActionItem
+						key={ action.id }
+						action={ action }
+						selectedItems={ selectedItems }
+						onMenuOpenChange={ onMenuOpenChange }
+						setActionWithModal={ setActionWithModal }
+					/>
+				) ) }
+			</DropdownMenuGroup>
+			<DropdownMenuSeparator />
+		</>
+	);
+}
+
+export default function BulkActions( {
+	data,
+	actions,
+	selection,
+	onSelectionChange,
+	getItemId,
+} ) {
+	const areAllSelected = selection && selection.length === data.length;
+	const [ isMenuOpen, onMenuOpenChange ] = useState( false );
+	const [ actionWithModal, setActionWithModal ] = useState();
+	const selectedItems = useMemo( () => {
+		return data.filter( ( item ) =>
+			selection.includes( getItemId( item ) )
+		);
+	}, [ selection, data, getItemId ] );
+	return (
+		<>
+			<DropdownMenu
+				open={ isMenuOpen }
+				onOpenChange={ onMenuOpenChange }
+				label={ __( 'Filters' ) }
+				trigger={
+					<Button>
+						{ selection.length
+							? sprintf(
+									/* translators: %d: Number of items. */
+									_n(
+										'Edit %d item',
+										'Edit %d items',
+										selection.length
+									),
+									selection.length
+							  )
+							: __( 'Bulk edit' ) }
+					</Button>
+				}
+			>
+				<ActionsMenuGroup
+					actions={ actions }
+					data={ data }
+					selection={ selection }
+					getItemId={ getItemId }
+					onMenuOpenChange={ onMenuOpenChange }
+					setActionWithModal={ setActionWithModal }
+					selectedItems={ selectedItems }
+				/>
+				<DropdownMenuGroup>
+					<DropdownMenuItem
+						disabled={ areAllSelected }
+						onSelect={ ( event ) => {
+							event.preventDefault();
+							onSelectionChange( data );
+						} }
+						suffix={ data.length }
+					>
+						{ __( 'Select all' ) }
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						disabled={ selection.length === 0 }
+						onSelect={ ( event ) => {
+							event.preventDefault();
+							onSelectionChange( [] );
+						} }
+					>
+						{ __( 'Deselect' ) }
+					</DropdownMenuItem>
+				</DropdownMenuGroup>
+			</DropdownMenu>
+			{ actionWithModal && (
+				<ActionWithModal
+					action={ actionWithModal }
+					selectedItems={ selectedItems }
+					setActionWithModal={ setActionWithModal }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/dataviews/src/bulk-actions.js
+++ b/packages/dataviews/src/bulk-actions.js
@@ -124,12 +124,14 @@ export default function BulkActions( {
 			<DropdownMenu
 				open={ isMenuOpen }
 				onOpenChange={ onMenuOpenChange }
-				label={ __( 'Filters' ) }
+				label={ __( 'Bulk actions' ) }
+				style={ { minWidth: '240px' } }
 				trigger={
 					<Button
 						className="dataviews-bulk-edit-button"
 						__next40pxDefaultSize
-						variant="secondary"
+						variant="tertiary"
+						size="compact"
 					>
 						{ selection.length
 							? sprintf(

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -14,7 +14,8 @@ import Pagination from './pagination';
 import ViewActions from './view-actions';
 import Filters from './filters';
 import Search from './search';
-import { VIEW_LAYOUTS } from './constants';
+import { VIEW_LAYOUTS, LAYOUT_TABLE } from './constants';
+import BulkActions from './bulk-actions';
 
 const defaultGetItemId = ( item ) => item.id;
 const defaultOnSelectionChange = () => {};
@@ -34,6 +35,7 @@ export default function DataViews( {
 	onSelectionChange = defaultOnSelectionChange,
 	onDetailsChange = null,
 	deferredRendering = false,
+	labels,
 } ) {
 	const [ selection, setSelection ] = useState( [] );
 
@@ -62,6 +64,15 @@ export default function DataViews( {
 					className="dataviews-filters__view-actions"
 				>
 					<HStack justify="start" wrap>
+						{ view.type === LAYOUT_TABLE && (
+							<BulkActions
+								actions={ actions }
+								data={ data }
+								onSelectionChange={ onSetSelection }
+								selection={ selection }
+								getItemId={ getItemId }
+							/>
+						) }
 						{ search && (
 							<Search
 								label={ searchLabel }
@@ -94,6 +105,7 @@ export default function DataViews( {
 					onDetailsChange={ onDetailsChange }
 					selection={ selection }
 					deferredRendering={ deferredRendering }
+					labels={ labels }
 				/>
 				<Pagination
 					view={ view }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -29,6 +29,7 @@ export default function DataViews( {
 	actions,
 	data,
 	getItemId = defaultGetItemId,
+	getItemTitle,
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
@@ -117,6 +118,7 @@ export default function DataViews( {
 					actions={ actions }
 					data={ data }
 					getItemId={ getItemId }
+					getItemTitle={ getItemTitle }
 					isLoading={ isLoading }
 					onSelectionChange={ onSetSelection }
 					onDetailsChange={ onDetailsChange }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -43,9 +43,7 @@ export default function DataViews( {
 	useEffect( () => {
 		if (
 			selection.length > 0 &&
-			selection.some(
-				( id ) => ! data.some( ( item ) => item.id === id )
-			)
+			selection.some( ( id ) => ! data.includes( id ) )
 		) {
 			const newSelection = selection.filter( ( id ) =>
 				data.some( ( item ) => item.id === id )

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -5,7 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { useMemo, useState, useCallback } from '@wordpress/element';
+import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -38,6 +38,23 @@ export default function DataViews( {
 	labels,
 } ) {
 	const [ selection, setSelection ] = useState( [] );
+
+	useEffect( () => {
+		if (
+			selection.length > 0 &&
+			selection.some(
+				( id ) => ! data.some( ( item ) => item.id === id )
+			)
+		) {
+			const newSelection = selection.filter( ( id ) =>
+				data.some( ( item ) => item.id === id )
+			);
+			setSelection( newSelection );
+			onSelectionChange(
+				data.filter( ( item ) => newSelection.includes( item.id ) )
+			);
+		}
+	}, [ selection, data, onSelectionChange ] );
 
 	const onSetSelection = useCallback(
 		( items ) => {

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -29,21 +29,21 @@ export default function DataViews( {
 	actions,
 	data,
 	getItemId = defaultGetItemId,
-	getItemTitle,
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
 	onSelectionChange = defaultOnSelectionChange,
 	onDetailsChange = null,
 	deferredRendering = false,
-	labels,
 } ) {
 	const [ selection, setSelection ] = useState( [] );
 
 	useEffect( () => {
 		if (
 			selection.length > 0 &&
-			selection.some( ( id ) => ! data.includes( id ) )
+			selection.some(
+				( id ) => ! data.some( ( item ) => item.id === id )
+			)
 		) {
 			const newSelection = selection.filter( ( id ) =>
 				data.some( ( item ) => item.id === id )
@@ -116,13 +116,11 @@ export default function DataViews( {
 					actions={ actions }
 					data={ data }
 					getItemId={ getItemId }
-					getItemTitle={ getItemTitle }
 					isLoading={ isLoading }
 					onSelectionChange={ onSetSelection }
 					onDetailsChange={ onDetailsChange }
 					selection={ selection }
 					deferredRendering={ deferredRendering }
-					labels={ labels }
 				/>
 				<Pagination
 					view={ view }

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -64,15 +64,6 @@ export default function DataViews( {
 					className="dataviews-filters__view-actions"
 				>
 					<HStack justify="start" wrap>
-						{ view.type === LAYOUT_TABLE && (
-							<BulkActions
-								actions={ actions }
-								data={ data }
-								onSelectionChange={ onSetSelection }
-								selection={ selection }
-								getItemId={ getItemId }
-							/>
-						) }
 						{ search && (
 							<Search
 								label={ searchLabel }
@@ -86,6 +77,15 @@ export default function DataViews( {
 							onChangeView={ onChangeView }
 						/>
 					</HStack>
+					{ view.type === LAYOUT_TABLE && (
+						<BulkActions
+							actions={ actions }
+							data={ data }
+							onSelectionChange={ onSetSelection }
+							selection={ selection }
+							getItemId={ getItemId }
+						/>
+					) }
 					<ViewActions
 						fields={ _fields }
 						view={ view }

--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -69,7 +69,7 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 					) }` }
 				>
 					<RenderModal
-						item={ item }
+						items={ [ item ] }
 						closeModal={ () => setIsModalOpen( false ) }
 					/>
 				</Modal>
@@ -96,7 +96,7 @@ function ActionsDropdownMenuGroup( { actions, item } ) {
 					<DropdownMenuItemTrigger
 						key={ action.id }
 						action={ action }
-						onClick={ () => action.callback( item ) }
+						onClick={ () => action.callback( [ item ] ) }
 					/>
 				);
 			} ) }
@@ -157,7 +157,7 @@ export default function ItemActions( { item, actions, isCompact } ) {
 						<ButtonTrigger
 							key={ action.id }
 							action={ action }
-							onClick={ () => action.callback( item ) }
+							onClick={ () => action.callback( [ item ] ) }
 						/>
 					);
 				} ) }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -18,6 +18,10 @@
 	}
 }
 
+.dataviews__filters-view-actions.components-h-stack{
+	align-items: center;
+} 
+
 .dataviews-filters-button {
 	position: relative;
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -401,3 +401,7 @@
 	display: block;
 	width: 24px;
 }
+
+.dataviews-bulk-edit-button.components-button.is-secondary {
+	padding-right: $grid-unit-15 + 2px;
+}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -117,6 +117,9 @@
 				background-color: #f8f8f8;
 			}
 		}
+		&.is-selected {
+			background-color: #f7f8fe;
+		}
 	}
 	thead {
 		tr {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -18,7 +18,7 @@
 	}
 }
 
-.dataviews__filters-view-actions.components-h-stack {
+.dataviews-filters__view-actions.components-h-stack {
 	align-items: center;
 }
 
@@ -377,7 +377,7 @@
 	padding: 0 $grid-unit-40;
 }
 
-.dataviews-table-selection-checkbox label {
+.dataviews-view-table-selection-checkbox label {
 	position: absolute;
 	width: 1px;
 	height: 1px;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -18,7 +18,7 @@
 	}
 }
 
-.dataviews__filters-view-actions.components-h-stack{
+.dataviews__filters-view-actions.components-h-stack {
 	align-items: center;
 } 
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -403,5 +403,5 @@
 }
 
 .dataviews-bulk-edit-button.components-button.is-secondary {
-	padding-right: $grid-unit-15 + 2px;
+	flex-shrink: 0;
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -20,7 +20,7 @@
 
 .dataviews__filters-view-actions.components-h-stack {
 	align-items: center;
-} 
+}
 
 .dataviews-filters-button {
 	position: relative;
@@ -375,18 +375,6 @@
 .dataviews-no-results,
 .dataviews-loading {
 	padding: 0 $grid-unit-40;
-}
-
-.dataviews-table-selection-checkbox label {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
 }
 
 .dataviews-table-selection-checkbox label {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -85,6 +85,14 @@
 		&[data-field-id="actions"] {
 			text-align: right;
 		}
+
+		&.dataviews-view-table__checkbox-column {
+			padding-right: 0;
+		}
+
+		.components-checkbox-control__input-container {
+			margin: $grid-unit-05;
+		}
 	}
 	tr {
 		border-bottom: 1px solid $gray-100;
@@ -113,12 +121,33 @@
 		}
 
 		&:hover {
-			td {
-				background-color: #f8f8f8;
+			background-color: #f8f8f8;
+		}
+
+		.components-checkbox-control__input {
+			opacity: 0;
+
+			&:checked,
+			&:indeterminate,
+			&:focus {
+				opacity: 1;
 			}
 		}
+
+		&:focus-within,
+		&:hover {
+			.components-checkbox-control__input {
+				opacity: 1;
+			}
+		}
+
 		&.is-selected {
-			background-color: #f7f8fe;
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			color: $gray-700;
+
+			&:hover {
+				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
+			}
 		}
 	}
 	thead {
@@ -397,6 +426,6 @@
 	width: 24px;
 }
 
-.dataviews-bulk-edit-button.components-button.is-secondary {
+.dataviews-bulk-edit-button.components-button {
 	flex-shrink: 0;
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -373,6 +373,30 @@
 	padding: 0 $grid-unit-40;
 }
 
+.dataviews-table-selection-checkbox label {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.dataviews-table-selection-checkbox label {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
 .dataviews-filters__custom-menu-radio-item-prefix {
 	display: block;
 	width: 24px;

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -311,7 +311,7 @@ function BulkSelectionCheckbox( { selection, onSelectionChange, data } ) {
 	const areAllSelected = selection && selection.length === data.length;
 	return (
 		<CheckboxControl
-			className="dataviews-table-selection-checkbox"
+			className="dataviews-view-table-selection-checkbox"
 			__nextHasNoMarginBottom
 			checked={ areAllSelected }
 			indeterminate={ ! areAllSelected && selection.length }
@@ -352,7 +352,7 @@ function SingleSelectionCheckbox( {
 	}
 	return (
 		<CheckboxControl
-			className="dataviews-table-selection-checkbox"
+			className="dataviews-view-table-selection-checkbox"
 			__nextHasNoMarginBottom
 			checked={ isSelected }
 			label={ selectionLabel }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
 import { unseen, funnel } from '@wordpress/icons';
 import {
@@ -23,7 +23,6 @@ import {
 	useId,
 	useRef,
 	useState,
-	useMemo,
 } from '@wordpress/element';
 
 /**
@@ -335,18 +334,28 @@ function SingleSelectionCheckbox( {
 	labels,
 	data,
 	getItemId,
+	getItemTitle,
 } ) {
 	const id = getItemId?.( item );
 	const isSelected = selection.includes( id );
 	let selectionLabel;
-	if ( isSelected ) {
-		selectionLabel = labels?.getDeselectLabel
-			? labels?.getDeselectLabel( item )
-			: __( 'Deselect item' );
+	if ( getItemTitle && labels.selectItem ) {
+		// eslint-disable-next-line @wordpress/valid-sprintf
+		selectionLabel = sprintf(
+			isSelected ? labels.deselectItem : labels.selectItem,
+			getItemTitle( item )
+		);
+	} else if ( getItemTitle ) {
+		// eslint-disable-next-line @wordpress/valid-sprintf
+		selectionLabel = sprintf(
+			/* translators: %s: item title. */
+			isSelected ? __( 'Deselect item: %s' ) : __( 'Select item: %s' ),
+			getItemTitle( item )
+		);
 	} else {
-		selectionLabel = labels?.getSelectLabel
-			? labels?.getSelectLabel( item )
-			: __( 'Select a new item' );
+		selectionLabel = isSelected
+			? __( 'Select a new item' )
+			: __( 'Deselect item' );
 	}
 	return (
 		<CheckboxControl
@@ -386,6 +395,7 @@ function ViewTable( {
 	actions,
 	data,
 	getItemId,
+	getItemTitle,
 	isLoading = false,
 	deferredRendering,
 	selection,
@@ -526,6 +536,7 @@ function ViewTable( {
 											item={ item }
 											labels={ labels }
 											selection={ selection }
+											getItemTitle={ getItemTitle }
 											onSelectionChange={
 												onSelectionChange
 											}

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -516,7 +516,7 @@ function ViewTable( {
 				<tbody>
 					{ hasData &&
 						usedData.map( ( item, index ) => (
-							<tr key={ getItemId( item ) }>
+							<tr key={ getItemId( item ) } className={ classnames({'is-selected': selection.includes( getItemId( item ) || index ) })}>
 								{ hasBulkActions && (
 									<td
 										style={ {
@@ -525,7 +525,7 @@ function ViewTable( {
 										} }
 									>
 										<SingleSelectionCheckbox
-											id={ getItemId?.( item ) || index }
+											id={ getItemId( item ) || index }
 											item={ item }
 											selection={ selection }
 											onSelectionChange={
@@ -566,7 +566,7 @@ function ViewTable( {
 				</tbody>
 			</table>
 			<div
-				className={ classNames( {
+				className={ classnames( {
 					'dataviews-loading': isLoading,
 					'dataviews-no-results': ! hasData && ! isLoading,
 				} ) }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -333,17 +333,17 @@ function SingleSelectionCheckbox( {
 	item,
 	data,
 	getItemId,
-	getItemTitle,
+	primaryField,
 } ) {
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
 	let selectionLabel;
-	if ( getItemTitle ) {
+	if ( primaryField?.getValue && item ) {
 		// eslint-disable-next-line @wordpress/valid-sprintf
 		selectionLabel = sprintf(
 			/* translators: %s: item title. */
 			isSelected ? __( 'Deselect item: %s' ) : __( 'Select item: %s' ),
-			getItemTitle( item )
+			primaryField.getValue( { item } )
 		);
 	} else {
 		selectionLabel = isSelected
@@ -388,7 +388,6 @@ function ViewTable( {
 	actions,
 	data,
 	getItemId,
-	getItemTitle,
 	isLoading = false,
 	deferredRendering,
 	selection,
@@ -427,13 +426,15 @@ function ViewTable( {
 	const visibleFields = fields.filter(
 		( field ) =>
 			! view.hiddenFields.includes( field.id ) &&
-			! [ view.layout.mediaField, view.layout.primaryField ].includes(
-				field.id
-			)
+			! [ view.layout.mediaField ].includes( field.id )
 	);
 	const usedData = deferredRendering ? asyncData : data;
 	const hasData = !! usedData?.length;
 	const sortValues = { asc: 'ascending', desc: 'descending' };
+
+	const primaryField = fields.find(
+		( field ) => field.id === view.layout.primaryField
+	);
 
 	return (
 		<div>
@@ -527,12 +528,12 @@ function ViewTable( {
 											id={ getItemId?.( item ) || index }
 											item={ item }
 											selection={ selection }
-											getItemTitle={ getItemTitle }
 											onSelectionChange={
 												onSelectionChange
 											}
 											getItemId={ getItemId }
 											data={ data }
+											primaryField={ primaryField }
 										/>
 									</td>
 								) }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -444,9 +444,10 @@ function ViewTable( {
 				aria-describedby={ tableNoticeId }
 			>
 				<thead>
-					<tr>
+					<tr className="dataviews-view-table__row">
 						{ hasBulkActions && (
 							<th
+								className="dataviews-view-table__checkbox-column"
 								style={ {
 									width: 20,
 									minWidth: 20,
@@ -518,14 +519,18 @@ function ViewTable( {
 						usedData.map( ( item, index ) => (
 							<tr
 								key={ getItemId( item ) }
-								className={ classnames( {
-									'is-selected': selection.includes(
-										getItemId( item ) || index
-									),
-								} ) }
+								className={ classnames(
+									'dataviews-view-table__row',
+									{
+										'is-selected': selection.includes(
+											getItemId( item ) || index
+										),
+									}
+								) }
 							>
 								{ hasBulkActions && (
 									<td
+										className="dataviews-view-table__checkbox-column"
 										style={ {
 											width: 20,
 											minWidth: 20,

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -23,6 +23,7 @@ import {
 	useId,
 	useRef,
 	useState,
+	useMemo,
 } from '@wordpress/element';
 
 /**
@@ -391,6 +392,9 @@ function ViewTable( {
 	onSelectionChange,
 	labels,
 } ) {
+	const hasBulkActions = useMemo( () => {
+		return actions?.some( ( action ) => action.supportsBulk );
+	}, [ actions ] );
 	const headerMenuRefs = useRef( new Map() );
 	const headerMenuToFocusRef = useRef();
 	const [ nextHeaderMenuToFocus, setNextHeaderMenuToFocus ] = useState();
@@ -440,7 +444,7 @@ function ViewTable( {
 			>
 				<thead>
 					<tr>
-						{ !! selection && (
+						{ !! selection && hasBulkActions && (
 							<th
 								style={ {
 									width: 20,
@@ -510,7 +514,7 @@ function ViewTable( {
 				</thead>
 				<tbody>
 					{ hasData &&
-						usedData.map( ( item ) => (
+						usedData.map( ( item, index ) => (
 							<tr key={ getItemId( item ) }>
 								{ !! selection && hasBulkActions && (
 									<td

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -392,9 +392,7 @@ function ViewTable( {
 	onSelectionChange,
 	labels,
 } ) {
-	const hasBulkActions = useMemo( () => {
-		return actions?.some( ( action ) => action.supportsBulk );
-	}, [ actions ] );
+	const hasBulkActions = actions?.some( ( action ) => action.supportsBulk );
 	const headerMenuRefs = useRef( new Map() );
 	const headerMenuToFocusRef = useRef();
 	const [ nextHeaderMenuToFocus, setNextHeaderMenuToFocus ] = useState();

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -516,7 +516,14 @@ function ViewTable( {
 				<tbody>
 					{ hasData &&
 						usedData.map( ( item, index ) => (
-							<tr key={ getItemId( item ) } className={ classnames({'is-selected': selection.includes( getItemId( item ) || index ) })}>
+							<tr
+								key={ getItemId( item ) }
+								className={ classnames( {
+									'is-selected': selection.includes(
+										getItemId( item ) || index
+									),
+								} ) }
+							>
 								{ hasBulkActions && (
 									<td
 										style={ {

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -335,7 +335,7 @@ function SingleSelectionCheckbox( {
 	getItemId,
 	getItemTitle,
 } ) {
-	const id = getItemId?.( item );
+	const id = getItemId( item );
 	const isSelected = selection.includes( id );
 	let selectionLabel;
 	if ( getItemTitle ) {
@@ -444,7 +444,7 @@ function ViewTable( {
 			>
 				<thead>
 					<tr>
-						{ !! selection && hasBulkActions && (
+						{ hasBulkActions && (
 							<th
 								style={ {
 									width: 20,
@@ -516,7 +516,7 @@ function ViewTable( {
 					{ hasData &&
 						usedData.map( ( item, index ) => (
 							<tr key={ getItemId( item ) }>
-								{ !! selection && hasBulkActions && (
+								{ hasBulkActions && (
 									<td
 										style={ {
 											width: 20,

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -308,7 +308,7 @@ function WithSeparators( { children } ) {
 }
 
 function BulkSelectionCheckbox( { selection, onSelectionChange, data } ) {
-	const areAllSelected = selection && selection.length === data.length;
+	const areAllSelected = selection.length === data.length;
 	return (
 		<CheckboxControl
 			className="dataviews-view-table-selection-checkbox"

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -331,7 +331,6 @@ function SingleSelectionCheckbox( {
 	selection,
 	onSelectionChange,
 	item,
-	labels,
 	data,
 	getItemId,
 	getItemTitle,
@@ -339,13 +338,7 @@ function SingleSelectionCheckbox( {
 	const id = getItemId?.( item );
 	const isSelected = selection.includes( id );
 	let selectionLabel;
-	if ( getItemTitle && labels.selectItem ) {
-		// eslint-disable-next-line @wordpress/valid-sprintf
-		selectionLabel = sprintf(
-			isSelected ? labels.deselectItem : labels.selectItem,
-			getItemTitle( item )
-		);
-	} else if ( getItemTitle ) {
+	if ( getItemTitle ) {
 		// eslint-disable-next-line @wordpress/valid-sprintf
 		selectionLabel = sprintf(
 			/* translators: %s: item title. */
@@ -400,7 +393,6 @@ function ViewTable( {
 	deferredRendering,
 	selection,
 	onSelectionChange,
-	labels,
 } ) {
 	const hasBulkActions = actions?.some( ( action ) => action.supportsBulk );
 	const headerMenuRefs = useRef( new Map() );
@@ -534,7 +526,6 @@ function ViewTable( {
 										<SingleSelectionCheckbox
 											id={ getItemId?.( item ) || index }
 											item={ item }
-											labels={ labels }
 											selection={ selection }
 											getItemTitle={ getItemTitle }
 											onSelectionChange={

--- a/packages/edit-site/src/components/actions/index.js
+++ b/packages/edit-site/src/components/actions/index.js
@@ -33,7 +33,9 @@ export const trashPostAction = {
 		return status !== 'trash';
 	},
 	hideModalHeader: true,
-	RenderModal: ( { item: post, closeModal } ) => {
+	RenderModal: ( { items: posts, closeModal } ) => {
+		// Todo - handle multiple posts
+		const post = posts[ 0 ];
 		const { createSuccessNotice, createErrorNotice } =
 			useDispatch( noticesStore );
 		const { deleteEntityRecord } = useDispatch( coreStore );
@@ -109,7 +111,9 @@ export function usePermanentlyDeletePostAction() {
 			isEligible( { status } ) {
 				return status === 'trash';
 			},
-			async callback( post ) {
+			async callback( posts ) {
+				// Todo - handle multiple posts
+				const post = posts[ 0 ];
 				try {
 					await deleteEntityRecord(
 						'postType',
@@ -160,7 +164,9 @@ export function useRestorePostAction() {
 			isEligible( { status } ) {
 				return status === 'trash';
 			},
-			async callback( post ) {
+			async callback( posts ) {
+				// Todo - handle multiple posts
+				const post = posts[ 0 ];
 				await editEntityRecord( 'postType', post.type, post.id, {
 					status: 'draft',
 				} );
@@ -211,7 +217,8 @@ export const viewPostAction = {
 	isEligible( post ) {
 		return post.status !== 'trash';
 	},
-	callback( post ) {
+	callback( posts ) {
+		const post = posts[ 0 ];
 		document.location.href = post.link;
 	},
 };
@@ -225,7 +232,8 @@ export function useEditPostAction() {
 			isEligible( { status } ) {
 				return status !== 'trash';
 			},
-			callback( post ) {
+			callback( posts ) {
+				const post = posts[ 0 ];
 				history.push( {
 					postId: post.id,
 					postType: post.type,
@@ -250,7 +258,8 @@ export const postRevisionsAction = {
 			post?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
 		return lastRevisionId && revisionsCount > 1;
 	},
-	callback( post ) {
+	callback( posts ) {
+		const post = posts[ 0 ];
 		const href = addQueryArgs( 'revision.php', {
 			revision: post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id,
 		} );

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -6,7 +6,7 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -381,9 +381,6 @@ export default function PagePages() {
 					view={ view }
 					onChangeView={ onChangeView }
 					onSelectionChange={ onSelectionChange }
-					getItemTitle={ ( item ) => {
-						return item.title?.rendered;
-					} }
 					onDetailsChange={ onDetailsChange }
 				/>
 			</Page>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -381,21 +381,14 @@ export default function PagePages() {
 					view={ view }
 					onChangeView={ onChangeView }
 					onSelectionChange={ onSelectionChange }
+					getItemTitle={ ( item ) => {
+						return item.title?.rendered;
+					} }
 					labels={ {
-						getSelectLabel: ( item ) => {
-							return sprintf(
-								// translators: %s: The title of the page.
-								__( 'Select page: %s' ),
-								item.title?.rendered || item.slug
-							);
-						},
-						getDeselectLabel: ( item ) => {
-							return sprintf(
-								// translators: %s: The title of the page.
-								__( 'Deselect page: %s' ),
-								item.title?.rendered || item.slug
-							);
-						},
+						/* translators: %s: Title of the page. */
+						selectItem: __( 'Select page: %s' ),
+						/* translators: %s: Title of the page. */
+						deselectItem: __( 'Deselect page: %s' ),
 					} }
 					onDetailsChange={ onDetailsChange }
 				/>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -6,7 +6,7 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
@@ -381,6 +381,22 @@ export default function PagePages() {
 					view={ view }
 					onChangeView={ onChangeView }
 					onSelectionChange={ onSelectionChange }
+					labels={ {
+						getSelectLabel: ( item ) => {
+							return sprintf(
+								// translators: %s: The title of the page.
+								__( 'Select page: %s' ),
+								item.title?.rendered || item.slug
+							);
+						},
+						getDeselectLabel: ( item ) => {
+							return sprintf(
+								// translators: %s: The title of the page.
+								__( 'Deselect page: %s' ),
+								item.title?.rendered || item.slug
+							);
+						},
+					} }
 					onDetailsChange={ onDetailsChange }
 				/>
 			</Page>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -384,12 +384,6 @@ export default function PagePages() {
 					getItemTitle={ ( item ) => {
 						return item.title?.rendered;
 					} }
-					labels={ {
-						/* translators: %s: Title of the page. */
-						selectItem: __( 'Select page: %s' ),
-						/* translators: %s: Title of the page. */
-						deselectItem: __( 'Deselect page: %s' ),
-					} }
 					onDetailsChange={ onDetailsChange }
 				/>
 			</Page>

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -45,7 +45,7 @@ export const exportJSONaction = {
 	id: 'export-pattern',
 	label: __( 'Export as JSON' ),
 	isEligible: ( item ) => item.type === PATTERN_TYPES.user,
-	callback: ( item ) => {
+	callback: ( [ item ] ) => {
 		const json = {
 			__file: item.type,
 			title: item.title || item.name,
@@ -71,7 +71,8 @@ export const renameAction = {
 		const hasThemeFile = isTemplatePart && item.templatePart.has_theme_file;
 		return isCustomPattern && ! hasThemeFile;
 	},
-	RenderModal: ( { item, closeModal } ) => {
+	RenderModal: ( { items, closeModal } ) => {
+		const [ item ] = items;
 		const [ title, setTitle ] = useState( () => item.title );
 		const { editEntityRecord, saveEditedEntityRecord } =
 			useDispatch( coreStore );
@@ -160,7 +161,8 @@ export const deleteAction = {
 		return canDeleteOrReset( item ) && ! hasThemeFile;
 	},
 	hideModalHeader: true,
-	RenderModal: ( { item, closeModal } ) => {
+	RenderModal: ( { items, closeModal } ) => {
+		const [ item ] = items;
 		const { __experimentalDeleteReusableBlock } =
 			useDispatch( reusableBlocksStore );
 		const { createErrorNotice, createSuccessNotice } =
@@ -224,7 +226,8 @@ export const resetAction = {
 		return canDeleteOrReset( item ) && hasThemeFile;
 	},
 	hideModalHeader: true,
-	RenderModal: ( { item, closeModal } ) => {
+	RenderModal: ( { items, closeModal } ) => {
+		const [ item ] = items;
 		const { removeTemplate } = useDispatch( editSiteStore );
 		return (
 			<VStack spacing="5">
@@ -254,7 +257,8 @@ export const duplicatePatternAction = {
 	label: _x( 'Duplicate', 'action label' ),
 	isEligible: ( item ) => item.type !== TEMPLATE_PART_POST_TYPE,
 	modalHeader: _x( 'Duplicate pattern', 'action label' ),
-	RenderModal: ( { item, closeModal } ) => {
+	RenderModal: ( { items, closeModal } ) => {
+		const [ item ] = items;
 		const { categoryId = PATTERN_DEFAULT_CATEGORY } = getQueryArgs(
 			window.location.href
 		);
@@ -288,7 +292,8 @@ export const duplicateTemplatePartAction = {
 	label: _x( 'Duplicate', 'action label' ),
 	isEligible: ( item ) => item.type === TEMPLATE_PART_POST_TYPE,
 	modalHeader: _x( 'Duplicate template part', 'action label' ),
-	RenderModal: ( { item, closeModal } ) => {
+	RenderModal: ( { items, closeModal } ) => {
+		const [ item ] = items;
 		const { createSuccessNotice } = useDispatch( noticesStore );
 		const { categoryId = PATTERN_DEFAULT_CATEGORY } = getQueryArgs(
 			window.location.href

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -14,7 +14,7 @@ import {
 	__experimentalVStack as VStack,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -375,6 +375,22 @@ export default function DataviewsTemplates() {
 					deferredRendering={
 						! view.hiddenFields?.includes( 'preview' )
 					}
+					labels={ {
+						getSelectLabel: ( item ) => {
+							return sprintf(
+								// translators: %s: The title of the template.
+								__( 'Select template: %s' ),
+								item.title?.rendered || item.slug
+							);
+						},
+						getDeselectLabel: ( item ) => {
+							return sprintf(
+								// translators: %s: The title of the template.
+								__( 'Deselect template: %s' ),
+								item.title?.rendered || item.slug
+							);
+						},
+					} }
 				/>
 			</Page>
 			{ view.type === LAYOUT_LIST && (

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -65,7 +65,9 @@ const { useHistory } = unlock( routerPrivateApis );
 const EMPTY_ARRAY = [];
 
 const defaultConfigPerViewType = {
-	[ LAYOUT_TABLE ]: {},
+	[ LAYOUT_TABLE ]: {
+		primaryField: 'title',
+	},
 	[ LAYOUT_GRID ]: {
 		mediaField: 'preview',
 		primaryField: 'title',
@@ -84,7 +86,7 @@ const DEFAULT_VIEW = {
 	// All fields are visible by default, so it's
 	// better to keep track of the hidden ones.
 	hiddenFields: [ 'preview' ],
-	layout: {},
+	layout: defaultConfigPerViewType[ LAYOUT_TABLE ],
 	filters: [],
 };
 
@@ -375,9 +377,6 @@ export default function DataviewsTemplates() {
 					deferredRendering={
 						! view.hiddenFields?.includes( 'preview' )
 					}
-					getItemTitle={ ( item ) => {
-						return item.title?.rendered;
-					} }
 				/>
 			</Page>
 			{ view.type === LAYOUT_LIST && (

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -14,7 +14,7 @@ import {
 	__experimentalVStack as VStack,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -378,12 +378,6 @@ export default function DataviewsTemplates() {
 					getItemTitle={ ( item ) => {
 						return item.title?.rendered;
 					} }
-					labels={ {
-						/* translators: %s: Title of the template. */
-						selectItem: __( 'Select template: %s' ),
-						/* translators: %s: Title of the page. */
-						deselectItem: __( 'Deselect template: %s' ),
-					} }
 				/>
 			</Page>
 			{ view.type === LAYOUT_LIST && (

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -375,21 +375,14 @@ export default function DataviewsTemplates() {
 					deferredRendering={
 						! view.hiddenFields?.includes( 'preview' )
 					}
+					getItemTitle={ ( item ) => {
+						return item.title?.rendered;
+					} }
 					labels={ {
-						getSelectLabel: ( item ) => {
-							return sprintf(
-								// translators: %s: The title of the template.
-								__( 'Select template: %s' ),
-								item.title?.rendered || item.slug
-							);
-						},
-						getDeselectLabel: ( item ) => {
-							return sprintf(
-								// translators: %s: The title of the template.
-								__( 'Deselect template: %s' ),
-								item.title?.rendered || item.slug
-							);
-						},
+						/* translators: %s: Title of the template. */
+						selectItem: __( 'Select template: %s' ),
+						/* translators: %s: Title of the page. */
+						deselectItem: __( 'Deselect template: %s' ),
 					} }
 				/>
 			</Page>

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -39,22 +39,16 @@ export function useResetTemplateAction() {
 			supportsBulk: true,
 			async callback( templates ) {
 				try {
-					await Promise.all(
-						templates.map( ( template ) => {
-							return revertTemplate( template, {
-								allowUndo: false,
-							} );
-						} )
-					);
-					await Promise.all(
-						templates.map( ( template ) => {
-							return saveEditedEntityRecord(
-								'postType',
-								template.type,
-								template.id
-							);
-						} )
-					);
+					for ( const template of templates ) {
+						await revertTemplate( template, {
+							allowUndo: false,
+						} );
+						await saveEditedEntityRecord(
+							'postType',
+							template.type,
+							template.id
+						);
+					}
 
 					createSuccessNotice(
 						templates.length > 1
@@ -147,7 +141,7 @@ export const deleteTemplateAction = {
 						onClick={ async () => {
 							if ( templates.length > 1 ) {
 								try {
-									await Promise.all(
+									await Promise.allSettled(
 										templates.map( ( template ) => {
 											return deleteEntityRecord(
 												'postType',

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -114,7 +114,7 @@ export const deleteTemplateAction = {
 	isEligible: isTemplateRemovable,
 	supportsBulk: true,
 	hideModalHeader: true,
-	RenderModal: ( { items: templates, closeModal } ) => {
+	RenderModal: ( { items: templates, closeModal, onPerform } ) => {
 		const { removeTemplate } = useDispatch( editSiteStore );
 		const { createSuccessNotice, createErrorNotice } =
 			useDispatch( noticesStore );
@@ -185,6 +185,7 @@ export const deleteTemplateAction = {
 									allowUndo: false,
 								} );
 							}
+							onPerform();
 							closeModal();
 						} }
 					>

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -61,7 +61,7 @@ export function useResetTemplateAction() {
 							? sprintf(
 									/* translators: The number of items. */
 									__( '%s items reverted.' ),
-									decodeEntities( templates.length )
+									templates.length
 							  )
 							: sprintf(
 									/* translators: The template/part's name. */
@@ -128,7 +128,7 @@ export const deleteTemplateAction = {
 								__(
 									'Are you sure you want to delete %s items?'
 								),
-								decodeEntities( templates.length )
+								templates.length
 						  )
 						: sprintf(
 								// translators: %s: The template or template part's title.

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -126,15 +126,15 @@ export const deleteTemplateAction = {
 						? sprintf(
 								// translators: %d: number of items to delete.
 								_n(
-									'delete %d item?',
-									'delete %d items?',
+									'Delete %d item?',
+									'Delete %d items?',
 									templates.length
 								),
 								templates.length
 						  )
 						: sprintf(
 								// translators: %s: The template or template part's titles
-								__( 'delete "%s"?' ),
+								__( 'Delete "%s"?' ),
 								decodeEntities(
 									templates?.[ 0 ]?.title?.rendered
 								)

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -70,18 +70,26 @@ export function useResetTemplateAction() {
 						}
 					);
 				} catch ( error ) {
-					const fallbackErrorMessage =
-						templates[ 0 ].type === TEMPLATE_POST_TYPE
-							? _n(
-									'An error occurred while reverting the template.',
-									'An error occurred while reverting the templates.',
-									templates.length
-							  )
-							: _n(
-									'An error occurred while reverting the template part.',
-									'An error occurred while reverting the template parts.',
-									templates.length
-							  );
+					let fallbackErrorMessage;
+					if ( templates[ 0 ].type === TEMPLATE_POST_TYPE ) {
+						fallbackErrorMessage =
+							templates.length === 1
+								? __(
+										'An error occurred while reverting the template.'
+								  )
+								: __(
+										'An error occurred while reverting the templates.'
+								  );
+					} else {
+						fallbackErrorMessage =
+							templates.length === 1
+								? __(
+										'An error occurred while reverting the template part.'
+								  )
+								: __(
+										'An error occurred while reverting the template parts.'
+								  );
+					}
 					const errorMessage =
 						error.message && error.code !== 'unknown_error'
 							? error.message
@@ -118,17 +126,19 @@ export const deleteTemplateAction = {
 				<Text>
 					{ templates.length > 1
 						? sprintf(
-								// translators: %s: The template or template part's title.
-								__(
-									'Are you sure you want to delete %s items?'
+								// translators: %d: number of items to delete.
+								_n(
+									'delete %d item?',
+									'delete %d items?',
+									templates.length
 								),
 								templates.length
 						  )
 						: sprintf(
-								// translators: %s: The template or template part's title.
-								__( 'Are you sure you want to delete "%s"?' ),
+								// translators: %s: The template or template part's titles
+								__( 'delete "%s"?' ),
 								decodeEntities(
-									templates && templates[ 0 ]?.title?.rendered
+									templates?.[ 0 ]?.title?.rendered
 								)
 						  ) }
 				</Text>
@@ -153,9 +163,7 @@ export const deleteTemplateAction = {
 										} )
 									);
 									createSuccessNotice(
-										__(
-											'The selected items were deleted with success.'
-										),
+										__( 'Items deleted.' ),
 										{
 											type: 'snackbar',
 											id: 'edit-site-page-trashed',

--- a/packages/edit-site/src/components/page-templates/template-actions.js
+++ b/packages/edit-site/src/components/page-templates/template-actions.js
@@ -33,7 +33,7 @@ export function useResetTemplateAction() {
 	return useMemo(
 		() => ( {
 			id: 'reset-template',
-			label: __( 'Reset template' ),
+			label: __( 'Reset' ),
 			isPrimary: true,
 			icon: backup,
 			isEligible: isTemplateRevertable,
@@ -111,7 +111,7 @@ export function useResetTemplateAction() {
 
 export const deleteTemplateAction = {
 	id: 'delete-template',
-	label: __( 'Delete template' ),
+	label: __( 'Delete' ),
 	isPrimary: true,
 	icon: trash,
 	isEligible: isTemplateRemovable,

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -5,7 +5,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 import { addQueryArgs } from '@wordpress/url';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -13,7 +13,6 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import { speak } from '@wordpress/a11y';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -25,6 +25,8 @@ import {
 	TEMPLATE_PART_POST_TYPE,
 	NAVIGATION_POST_TYPE,
 } from '../utils/constants';
+import { removeTemplates } from './private-actions';
+
 /**
  * Dispatches an action that toggles a feature flag.
  *
@@ -133,54 +135,9 @@ export const addTemplate =
  *
  * @param {Object} template The template object.
  */
-export const removeTemplate =
-	( template ) =>
-	async ( { registry } ) => {
-		try {
-			await registry
-				.dispatch( coreStore )
-				.deleteEntityRecord( 'postType', template.type, template.id, {
-					force: true,
-				} );
-
-			const lastError = registry
-				.select( coreStore )
-				.getLastEntityDeleteError(
-					'postType',
-					template.type,
-					template.id
-				);
-
-			if ( lastError ) {
-				throw lastError;
-			}
-
-			// Depending on how the entity was retrieved it's title might be
-			// an object or simple string.
-			const templateTitle =
-				typeof template.title === 'string'
-					? template.title
-					: template.title?.rendered;
-
-			registry.dispatch( noticesStore ).createSuccessNotice(
-				sprintf(
-					/* translators: The template/part's name. */
-					__( '"%s" deleted.' ),
-					decodeEntities( templateTitle )
-				),
-				{ type: 'snackbar', id: 'site-editor-template-deleted-success' }
-			);
-		} catch ( error ) {
-			const errorMessage =
-				error.message && error.code !== 'unknown_error'
-					? error.message
-					: __( 'An error occurred while deleting the template.' );
-
-			registry
-				.dispatch( noticesStore )
-				.createErrorNotice( errorMessage, { type: 'snackbar' } );
-		}
-	};
+export const removeTemplate = ( template ) => {
+	return removeTemplates( [ template ] );
+};
 
 /**
  * Action that sets a template part.

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -4,6 +4,10 @@
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Action that switches the canvas mode.
@@ -48,4 +52,71 @@ export const setEditorCanvasContainerView =
 			type: 'SET_EDITOR_CANVAS_CONTAINER_VIEW',
 			view,
 		} );
+	};
+
+/**
+ * Action that removes an array of templates.
+ *
+ * @param {Array} templates An array of template objects to remove.
+ */
+export const removeTemplates =
+	( templates ) =>
+	async ( { registry } ) => {
+		try {
+			await Promise.allSettled(
+				templates.map( ( template ) => {
+					return registry
+						.dispatch( coreStore )
+						.deleteEntityRecord(
+							'postType',
+							template.type,
+							template.id,
+							{ force: true },
+							{ throwOnError: true }
+						);
+				} )
+			);
+
+			let successMessage;
+
+			if ( templates.length === 1 ) {
+				// Depending on how the entity was retrieved it's title might be
+				// an object or simple string.
+				const templateTitle =
+					typeof templates[ 0 ].title === 'string'
+						? templates[ 0 ].title
+						: templates[ 0 ].title?.rendered;
+				successMessage = sprintf(
+					/* translators: The template/part's name. */
+					__( '"%s" deleted.' ),
+					decodeEntities( templateTitle )
+				);
+			} else {
+				successMessage = __( 'Templates deleted.' );
+			}
+
+			registry
+				.dispatch( noticesStore )
+				.createSuccessNotice( successMessage, {
+					type: 'snackbar',
+					id: 'site-editor-template-deleted-success',
+				} );
+		} catch ( error ) {
+			let errorMessage;
+			if ( error.message && error.code !== 'unknown_error' ) {
+				errorMessage = error.message;
+			} else if ( templates.length === 1 ) {
+				errorMessage = __(
+					'An error occurred while deleting the template.'
+				);
+			} else {
+				errorMessage = __(
+					'An error occurred while deleting the templates.'
+				);
+			}
+
+			registry
+				.dispatch( noticesStore )
+				.createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
 	};

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -62,88 +62,93 @@ export const setEditorCanvasContainerView =
 export const removeTemplates =
 	( templates ) =>
 	async ( { registry } ) => {
-			const promiseResult = await Promise.allSettled(
-				templates.map( ( template ) => {
-					return registry
-						.dispatch( coreStore )
-						.deleteEntityRecord(
-							'postType',
-							template.type,
-							template.id,
-							{ force: true },
-							{ throwOnError: true }
-						);
-				} )
-			);
-			
-			// If all the promises were fulfilled with sucess.
-			if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
-				let successMessage;
+		const promiseResult = await Promise.allSettled(
+			templates.map( ( template ) => {
+				return registry
+					.dispatch( coreStore )
+					.deleteEntityRecord(
+						'postType',
+						template.type,
+						template.id,
+						{ force: true },
+						{ throwOnError: true }
+					);
+			} )
+		);
 
-				if ( templates.length === 1 ) {
-					// Depending on how the entity was retrieved its title might be
-					// an object or simple string.
-					const templateTitle =
-						typeof templates[ 0 ].title === 'string'
-							? templates[ 0 ].title
-							: templates[ 0 ].title?.rendered;
-					successMessage = sprintf(
-						/* translators: The template/part's name. */
-						__( '"%s" deleted.' ),
-						decodeEntities( templateTitle )
+		// If all the promises were fulfilled with sucess.
+		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
+			let successMessage;
+
+			if ( templates.length === 1 ) {
+				// Depending on how the entity was retrieved its title might be
+				// an object or simple string.
+				const templateTitle =
+					typeof templates[ 0 ].title === 'string'
+						? templates[ 0 ].title
+						: templates[ 0 ].title?.rendered;
+				successMessage = sprintf(
+					/* translators: The template/part's name. */
+					__( '"%s" deleted.' ),
+					decodeEntities( templateTitle )
+				);
+			} else {
+				successMessage = __( 'Templates deleted.' );
+			}
+
+			registry
+				.dispatch( noticesStore )
+				.createSuccessNotice( successMessage, {
+					type: 'snackbar',
+					id: 'site-editor-template-deleted-success',
+				} );
+		} else {
+			// If there was at lease one failure.
+			let errorMessage;
+			// If we were trying to delete a single template.
+			if ( promiseResult.length === 1 ) {
+				if ( promiseResult[ 0 ].reason?.message ) {
+					errorMessage = promiseResult[ 0 ].reason.message;
+				} else {
+					errorMessage = __(
+						'An error occurred while deleting the template.'
+					);
+				}
+				// If we were trying to delete a multiple templates
+			} else {
+				const errorMessages = new Set();
+				const failedPromises = promiseResult.filter(
+					( { status } ) => status === 'rejected'
+				);
+				for ( const failedPromise of failedPromises ) {
+					if ( failedPromise.reason?.message ) {
+						errorMessages.add( failedPromise.reason.message );
+					}
+				}
+				if ( errorMessages.size === 0 ) {
+					errorMessage = __(
+						'An error occurred while deleting the templates.'
+					);
+				} else if ( errorMessages.size === 1 ) {
+					errorMessage = sprintf(
+						/* translators: %s: an error message */
+						__(
+							'An error occurred while deleting the templates: %s'
+						),
+						[ ...errorMessages ][ 0 ]
 					);
 				} else {
-					successMessage = __( 'Templates deleted.' );
+					errorMessage = sprintf(
+						/* translators: %s: a list of comma separated error messages */
+						__(
+							'Some errors occurred while deleting the templates: %s'
+						),
+						[ ...errorMessages ].join( ',' )
+					);
 				}
-	
-				registry
-					.dispatch( noticesStore )
-					.createSuccessNotice( successMessage, {
-						type: 'snackbar',
-						id: 'site-editor-template-deleted-success',
-					} );		
-			} else {
-				// If there was at lease one failure.
-				let errorMessage;
-				// If we were trying to delete a single template.
-				if ( promiseResult.length === 1 ) {
-					if( promiseResult[0].reason?.message ) {
-						errorMessage = promiseResult[0].reason.message;
-					} else {
-						errorMessage = __(
-							'An error occurred while deleting the template.'
-						);
-					}
-					// If we were trying to delete a multiple templates
-				} else {
-					const errorMessages = new Set();
-					const failedPromises = promiseResult.filter( ( { status } ) => status === 'rejected' );
-					console.error({failedPromises});
-					for( const failedPromise of failedPromises ) {
-						if( failedPromise.reason?.message ) {
-							errorMessages.add( failedPromise.reason.message )
-						}
-					}
-					if( errorMessages.size === 0 ) {
-						errorMessage = __(
-							'An error occurred while deleting the templates.'
-						);
-					} else if ( errorMessages.size === 1 ) {
-						errorMessage = sprintf(
-							/* translators: %s: an error message */
-							__( 'An error occurred while deleting the templates: %s'),
-							[ ...errorMessages][0]
-						)
-					} else {
-						errorMessage = sprintf(
-							/* translators: %s: a list of comma separated error messages */
-							__( 'Some errors occurred while deleting the templates: %s'),
-							[ ...errorMessages].join( ',' )
-						)
-					}
-				}	
-				registry
-				.dispatch( noticesStore )
-				.createErrorNotice( errorMessage, { type: 'snackbar' } );	
 			}
-		};
+			registry
+				.dispatch( noticesStore )
+				.createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
+	};

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -81,7 +81,7 @@ export const removeTemplates =
 				let successMessage;
 
 				if ( templates.length === 1 ) {
-					// Depending on how the entity was retrieved it's title might be
+					// Depending on how the entity was retrieved its title might be
 					// an object or simple string.
 					const templateTitle =
 						typeof templates[ 0 ].title === 'string'


### PR DESCRIPTION
Supersedes: https://github.com/WordPress/gutenberg/pull/56476, https://github.com/WordPress/gutenberg/pull/56615

This PR proposes a bulk actions implementation using the DropDownMenuV2 component trying to follow the design proposed at https://github.com/WordPress/gutenberg/pull/56476#issuecomment-1845606302.

For now, bulk actions are implemented only for templates.
If multiple items are selected, each one supporting different bulk actions, we show the number of elements the action applies to and only apply the action to the eligible elements.

The actions API was expanded with a supportsBulk option. We need to know if the action supports a bulk option or one to decide if it appears in the bulk edit menu. E.g.: A see revisions action would not make sense under bulk edit.

The actions API callback and Render modal were also changed so the items are an array (support multiple items instead of just one).

## Screenshots or screencast <!-- if applicable -->

<img width="1407" alt="Screenshot 2023-12-20 at 10 56 51" src="https://github.com/WordPress/gutenberg/assets/11271197/53ecdfae-421a-4e11-91d9-85b465dbef73">
