### PR TITLE
Modules: Load the import map polyfill when needed

### DIFF
--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -152,15 +152,21 @@ class Gutenberg_Modules {
 	 * import maps (https://github.com/guybedford/es-module-shims/issues/406).
 	 */
 	public static function print_import_map_polyfill() {
-		$import_map = self::get_import_map();
-		if ( ! empty( $import_map['imports'] ) ) {
-			wp_print_script_tag(
-				array(
-					'src'   => gutenberg_url( '/build/modules/importmap-polyfill.min.js' ),
-					'defer' => true,
-				)
-			);
-		}
+		$test = 'HTMLScriptElement.supports?.("importmap")';
+		$src  = gutenberg_url( '/build/modules/importmap-polyfill.min.js' );
+
+		echo (
+			// Test presence of feature...
+			'<script>( ' . $test . ' ) || ' .
+			/*
+			 * ...appending polyfill on any failures. Cautious viewers may balk
+			 * at the `document.write`. Its caveat of synchronous mid-stream
+			 * blocking write is exactly the behavior we need though.
+			 */
+			'document.write( \'<script src="' .
+			$src .
+			'"></scr\' + \'ipt>\' );</script>'
+		);
 	}
 
 	/**
@@ -273,4 +279,4 @@ add_action( $modules_position, array( 'Gutenberg_Modules', 'print_enqueued_modul
 add_action( $modules_position, array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
-add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );
+add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -152,7 +152,7 @@ class Gutenberg_Modules {
 	 * import maps (https://github.com/guybedford/es-module-shims/issues/406).
 	 */
 	public static function print_import_map_polyfill() {
-		$test = 'HTMLScriptElement.supports?.("importmap")';
+		$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
 		$src  = gutenberg_url( '/build/modules/importmap-polyfill.min.js' );
 
 		echo (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Explores whether there is a simple way to address the issue raised by @felixarntz in https://github.com/WordPress/gutenberg/issues/55942#issuecomment-1863602182:

> For the import maps polyfill, it looks like that JS file is always loaded? I was using latest Chrome and it loaded for me, which it probably shouldn't (since Chrome supports import maps). Is there a way to perform a quick support check with inline JS instead so that the polyfill can only be loaded as needed? It's over 12kB, so if we can avoid that for most sites, that would be a good win.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It should be easier to handle in WordPress core, but as a quick experiment I replicated how we handle conditional polyfills in the past:

https://github.com/WordPress/wordpress-develop/blob/1bca32e30ede3f8731290b052b35c431d091e2f7/src/wp-includes/script-loader.php#L204-L214


## How?

I used the conditional check for feature detection included on MDN:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#feature_detection



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

It works correctly with browsers that support import maps. I tested with Safari and Chrome:

https://github.com/WordPress/gutenberg/assets/699132/3486fed3-4fc0-40f1-b98f-54d7d91f9b4a
