### PR TITLE
Avoid using a memoized selector without dependencies

### DIFF
--- a/packages/edit-widgets/src/store/private-selectors.js
+++ b/packages/edit-widgets/src/store/private-selectors.js
@@ -1,16 +1,3 @@
-/**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
- * WordPress dependencies
- */
-import { createRef } from '@wordpress/element';
-
-export const getListViewToggleRef = createSelector(
-	() => {
-		return createRef();
-	},
-	() => []
-);
+export function getListViewToggleRef( state ) {
+	return state.listViewToggleRef;
+}

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -68,6 +68,17 @@ export function listViewPanel( state = false, action ) {
 	return state;
 }
 
+/**
+ * This reducer does nothing aside initializing a ref to the list view toggle.
+ * We will have a unique ref per "editor" instance.
+ *
+ * @param {Object} state
+ * @return {Object} Reference to the list view toggle button.
+ */
+export function listViewToggleRef( state = { current: null } ) {
+	return state;
+}
+
 export default combineReducers( {
 	blockInserterPanel,
 	listViewPanel,

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -1,14 +1,8 @@
 /**
- * External dependencies
- */
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createRegistrySelector } from '@wordpress/data';
-import { createRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -52,9 +46,6 @@ export const getInsertionPoint = createRegistrySelector(
 	}
 );
 
-export const getListViewToggleRef = createSelector(
-	() => {
-		return createRef();
-	},
-	() => []
-);
+export function getListViewToggleRef( state ) {
+	return state.listViewToggleRef;
+}

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -349,6 +349,17 @@ export function listViewPanel( state = false, action ) {
 	return state;
 }
 
+/**
+ * This reducer does nothing aside initializing a ref to the list view toggle.
+ * We will have a unique ref per "editor" instance.
+ *
+ * @param {Object} state
+ * @return {Object} Reference to the list view toggle button.
+ */
+export function listViewToggleRef( state = { current: null } ) {
+	return state;
+}
+
 export default combineReducers( {
 	postId,
 	postType,
@@ -365,4 +376,5 @@ export default combineReducers( {
 	removedPanels,
 	blockInserterPanel,
 	listViewPanel,
+	listViewToggleRef,
 } );


### PR DESCRIPTION
Addresses an issue raised here https://github.com/WordPress/gutenberg/pull/57198#discussion_r1432535499

I initially thought that a memoized selector would give a different value per "store" if there's no dependencies. It turns out that assumption is wrong and that memoized selectors without dependencies means it's just a global function. 

To address this I'm restoring the "static" reducer, I had implemented initially.

**Testing instructions**

- No functional change, focus restoration should work properly when closing the list view panel.