### PR TITLE
Block Bindings API: Add components for the editor UI and create basic UI for the existing sources

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -88,7 +88,6 @@ if ( $gutenberg_experiments && (
 ) ) {
 
 	require_once __DIR__ . '/block-bindings/index.php';
-		// Allowed blocks that support block bindings.
 	// TODO: Look for a mechanism to opt-in for this. Maybe adding a property to block attributes?
 	global $block_bindings_allowed_blocks;
 	$block_bindings_allowed_blocks = array(
@@ -127,7 +126,15 @@ if ( $gutenberg_experiments && (
 			//     }
 			//   }
 			// }
-			//
+			// },
+			// "url": {
+			// "source": {
+			// "name": "post_meta",
+			// "attributes": { "value": "text_custom_field" }
+			// }
+			// }
+			// },
+			// .
 			global $block_bindings_allowed_blocks;
 			global $block_bindings_sources;
 			$modified_block_content = $block_content;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -88,6 +88,7 @@ if ( $gutenberg_experiments && (
 ) ) {
 
 	require_once __DIR__ . '/block-bindings/index.php';
+	// Allowed blocks that support block bindings.
 	// TODO: Look for a mechanism to opt-in for this. Maybe adding a property to block attributes?
 	global $block_bindings_allowed_blocks;
 	$block_bindings_allowed_blocks = array(
@@ -126,15 +127,7 @@ if ( $gutenberg_experiments && (
 			//     }
 			//   }
 			// }
-			// },
-			// "url": {
-			// "source": {
-			// "name": "post_meta",
-			// "attributes": { "value": "text_custom_field" }
-			// }
-			// }
-			// },
-			// .
+			//
 			global $block_bindings_allowed_blocks;
 			global $block_bindings_sources;
 			$modified_block_content = $block_content;

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -812,6 +812,18 @@ _Properties_
 
 Ensures that the text selection keeps the same vertical distance from the viewport during keyboard events within this component. The vertical distance can vary. It is the last clicked or scrolled to position.
 
+### updateBlockBindingsAttribute
+
+Helper to update the bindings attribute used by the Block Bindings API.
+
+_Parameters_
+
+-   _blockAttributes_ `Object`: - The original block attributes.
+-   _setAttributes_ `Function`: - setAttributes function to modify the bindings property.
+-   _attributeName_ `string`: - The attribute in the bindings object to update.
+-   _sourceName_ `string`: - The source name added to the bindings property.
+-   _sourceAttributes_ `string`: - The source attributes added to the bindings property.
+
 ### URLInput
 
 _Related_

--- a/packages/block-editor/src/utils/index.js
+++ b/packages/block-editor/src/utils/index.js
@@ -1,3 +1,4 @@
 export { default as transformStyles } from './transform-styles';
 export * from './block-variation-transforms';
 export { default as getPxFromCssUnit } from './get-px-from-css-unit';
+export * from './update-block-bindings';

--- a/packages/block-editor/src/utils/update-block-bindings.js
+++ b/packages/block-editor/src/utils/update-block-bindings.js
@@ -1,0 +1,68 @@
+/**
+ * Helper to update the bindings attribute used by the Block Bindings API.
+ *
+ * @param {Object}   blockAttributes  - The original block attributes.
+ * @param {Function} setAttributes    - setAttributes function to modify the bindings property.
+ * @param {string}   attributeName    - The attribute in the bindings object to update.
+ * @param {string}   sourceName       - The source name added to the bindings property.
+ * @param {string}   sourceAttributes - The source attributes added to the bindings property.
+ */
+export const updateBlockBindingsAttribute = (
+	blockAttributes,
+	setAttributes,
+	attributeName,
+	sourceName,
+	sourceAttributes
+) => {
+	// TODO: Review if we can create a React Hook for this.
+
+	// Assuming the following format for the bindings property of the "metadata" attribute:
+	//
+	// "bindings": {
+	//   "title": {
+	//       "source": {
+	//         "name": "metadata",
+	//         "attributes": { "value": "text_custom_field" }
+	//       }
+	//   },
+	//   "url": {
+	//       "source": {
+	//         "name": "metadata",
+	//         "attributes": { "value": "text_custom_field" }
+	//       }
+	//   }
+	// },
+	// .
+
+	let updatedBindings = {};
+	// // If no sourceName is provided, remove the attribute from the bindings.
+	if ( sourceName === null ) {
+		if ( ! blockAttributes?.metadata.bindings ) {
+			return blockAttributes?.metadata;
+		}
+
+		updatedBindings = {
+			...blockAttributes?.metadata?.bindings,
+			[ attributeName ]: undefined,
+		};
+		if ( Object.keys( updatedBindings ).length === 1 ) {
+			updatedBindings = undefined;
+		}
+	} else {
+		updatedBindings = {
+			...blockAttributes?.metadata?.bindings,
+			[ attributeName ]: {
+				source: { name: sourceName, attributes: sourceAttributes },
+			},
+		};
+	}
+
+	setAttributes( {
+		metadata: {
+			...blockAttributes.metadata,
+			bindings: updatedBindings,
+		},
+	} );
+
+	return blockAttributes.metadata;
+};

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -27,7 +27,7 @@
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",
-		"{src,build,build-module}/{index.js,store/index.js,hooks/**}"
+		"{src,build,build-module}/{index.js,store/index.js,hooks/**,hooks/block-bindings-sources/**}"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",

--- a/packages/editor/src/components/block-bindings/bindings-ui.js
+++ b/packages/editor/src/components/block-bindings/bindings-ui.js
@@ -19,13 +19,10 @@ import {
 	chevronUp,
 } from '@wordpress/icons';
 import { addFilter } from '@wordpress/hooks';
-
-const blockBindingsAllowedBlocks = {
-	'core/paragraph': [ 'content' ],
-	'core/heading': [ 'content' ],
-	'core/image': [ 'url', 'title' ],
-	'core/button': [ 'url', 'text' ],
-};
+/**
+ * Internal dependencies
+ */
+import { BLOCK_BINDINGS_ALLOWED_BLOCKS } from '../../store/constants';
 
 const { Slot, Fill } = createSlotFill( 'BlockBindingsUI' );
 
@@ -93,108 +90,116 @@ function AttributesLayer( props ) {
 	const [ activeSource, setIsActiveSource ] = useState( false );
 	return (
 		<MenuGroup>
-			{ blockBindingsAllowedBlocks[ props.name ].map( ( attribute ) => (
-				<div
-					key={ attribute }
-					className="block-bindings-attribute-picker-container"
-				>
-					<MenuItem
-						icon={
-							activeAttribute === attribute
-								? chevronUp
-								: chevronDown
-						}
-						isSelected={ activeAttribute === attribute }
-						onClick={ () =>
-							setIsActiveAttribute(
-								activeAttribute === attribute
-									? false
-									: attribute
-							)
-						}
-						className="block-bindings-attribute-picker-button"
+			{ BLOCK_BINDINGS_ALLOWED_BLOCKS[ props.name ].map(
+				( attribute ) => (
+					<div
+						key={ attribute }
+						className="block-bindings-attribute-picker-container"
 					>
-						{ attribute }
-					</MenuItem>
-					{ activeAttribute === attribute && (
-						<>
-							<MenuGroup>
-								{ /* Sources can fill this slot */ }
-								<Slot
-									fillProps={ {
-										...props,
-										currentAttribute: attribute,
-										setIsActiveAttribute,
-									} }
-								>
-									{ ( fills ) => {
-										if ( ! fills.length ) {
-											return null;
-										}
+						<MenuItem
+							icon={
+								activeAttribute === attribute
+									? chevronUp
+									: chevronDown
+							}
+							isSelected={ activeAttribute === attribute }
+							onClick={ () =>
+								setIsActiveAttribute(
+									activeAttribute === attribute
+										? false
+										: attribute
+								)
+							}
+							className="block-bindings-attribute-picker-button"
+						>
+							{ attribute }
+						</MenuItem>
+						{ activeAttribute === attribute && (
+							<>
+								<MenuGroup>
+									{ /* Sources can fill this slot */ }
+									<Slot
+										fillProps={ {
+											...props,
+											currentAttribute: attribute,
+											setIsActiveAttribute,
+										} }
+									>
+										{ ( fills ) => {
+											if ( ! fills.length ) {
+												return null;
+											}
 
-										return (
-											<>
-												{ fills.map(
-													( fill, index ) => {
-														// TODO: Check better way to get the source and label.
-														const source =
-															fill[ 0 ].props
-																.children.props
-																.source;
-														const sourceLabel =
-															fill[ 0 ].props
-																.children.props
-																.label;
-														const isSourceSelected =
-															activeSource ===
-															source;
+											return (
+												<>
+													{ fills.map(
+														( fill, index ) => {
+															// TODO: Check better way to get the source and label.
+															const source =
+																fill[ 0 ].props
+																	.children
+																	.props
+																	.source;
+															const sourceLabel =
+																fill[ 0 ].props
+																	.children
+																	.props
+																	.label;
+															const isSourceSelected =
+																activeSource ===
+																source;
 
-														return (
-															<Fragment
-																key={ index }
-															>
-																<MenuItem
-																	icon={
-																		isSourceSelected
-																			? chevronUp
-																			: chevronDown
+															return (
+																<Fragment
+																	key={
+																		index
 																	}
-																	isSelected={
-																		isSourceSelected
-																	}
-																	onClick={ () =>
-																		setIsActiveSource(
-																			isSourceSelected
-																				? false
-																				: source
-																		)
-																	}
-																	className="block-bindings-source-picker-button"
 																>
-																	{
-																		sourceLabel
-																	}
-																</MenuItem>
-																{ isSourceSelected &&
-																	fill }
-															</Fragment>
-														);
-													}
-												) }
-											</>
-										);
-									} }
-								</Slot>
-							</MenuGroup>
-							<RemoveBindingButton
-								{ ...props }
-								currentAttribute={ attribute }
-								setIsActiveAttribute={ setIsActiveAttribute }
-							/>
-						</>
-					) }
-				</div>
-			) ) }
+																	<MenuItem
+																		icon={
+																			isSourceSelected
+																				? chevronUp
+																				: chevronDown
+																		}
+																		isSelected={
+																			isSourceSelected
+																		}
+																		onClick={ () =>
+																			setIsActiveSource(
+																				isSourceSelected
+																					? false
+																					: source
+																			)
+																		}
+																		className="block-bindings-source-picker-button"
+																	>
+																		{
+																			sourceLabel
+																		}
+																	</MenuItem>
+																	{ isSourceSelected &&
+																		fill }
+																</Fragment>
+															);
+														}
+													) }
+												</>
+											);
+										} }
+									</Slot>
+								</MenuGroup>
+								<RemoveBindingButton
+									{ ...props }
+									currentAttribute={ attribute }
+									setIsActiveAttribute={
+										setIsActiveAttribute
+									}
+								/>
+							</>
+						) }
+					</div>
+				)
+			) }
 		</MenuGroup>
 	);
 }
@@ -239,7 +244,7 @@ if ( window.__experimentalBlockBindings ) {
 		'blocks.registerBlockType',
 		'core/block-bindings-ui',
 		( settings, name ) => {
-			if ( ! ( name in blockBindingsAllowedBlocks ) ) {
+			if ( ! ( name in BLOCK_BINDINGS_ALLOWED_BLOCKS ) ) {
 				return settings;
 			}
 

--- a/packages/editor/src/components/block-bindings/bindings-ui.js
+++ b/packages/editor/src/components/block-bindings/bindings-ui.js
@@ -1,0 +1,274 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, cloneElement, Fragment } from '@wordpress/element';
+import {
+	BlockControls,
+	updateBlockBindingsAttribute,
+} from '@wordpress/block-editor';
+import {
+	Button,
+	createSlotFill,
+	MenuItem,
+	MenuGroup,
+	Popover,
+} from '@wordpress/components';
+import {
+	plugins as pluginsIcon,
+	chevronDown,
+	chevronUp,
+} from '@wordpress/icons';
+import { addFilter } from '@wordpress/hooks';
+
+const blockBindingsWhitelist = {
+	'core/paragraph': [ 'content' ],
+	'core/heading': [ 'content' ],
+	'core/image': [ 'url', 'title' ],
+	'core/button': [ 'url', 'text' ],
+};
+
+const { Slot, Fill } = createSlotFill( 'BlockBindingsUI' );
+
+const BlockBindingsFill = ( { children, source, label } ) => {
+	return (
+		<Fill>
+			{ ( props ) => {
+				return (
+					<>
+						{ cloneElement( children, {
+							source,
+							label,
+							...props,
+						} ) }
+					</>
+				);
+			} }
+		</Fill>
+	);
+};
+
+export default BlockBindingsFill;
+
+const BlockBindingsUI = ( props ) => {
+	const [ addingBinding, setAddingBinding ] = useState( false );
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	return (
+		<>
+			<BlockControls group="other">
+				<Button
+					onClick={ () => {
+						setAddingBinding( ! addingBinding );
+					} }
+					aria-expanded={ true }
+					icon={ pluginsIcon }
+					ref={ setPopoverAnchor }
+				></Button>
+				{ addingBinding && (
+					<Popover
+						popoverAnchor={ popoverAnchor }
+						onClose={ () => {
+							setAddingBinding( false );
+						} }
+						onFocusOutside={ () => {
+							setAddingBinding( false );
+						} }
+						placement="bottom"
+						shift
+						className="block-bindings-ui-popover"
+						{ ...props }
+					>
+						<AttributesLayer
+							{ ...props }
+							setAddingBinding={ setAddingBinding }
+						/>
+					</Popover>
+				) }
+			</BlockControls>
+		</>
+	);
+};
+
+function AttributesLayer( props ) {
+	const [ activeAttribute, setIsActiveAttribute ] = useState( false );
+	const [ activeSource, setIsActiveSource ] = useState( false );
+	return (
+		<MenuGroup>
+			{ blockBindingsWhitelist[ props.name ].map( ( attribute ) => (
+				<div
+					key={ attribute }
+					className="block-bindings-attribute-picker-container"
+				>
+					<MenuItem
+						icon={
+							activeAttribute === attribute
+								? chevronUp
+								: chevronDown
+						}
+						isSelected={ activeAttribute === attribute }
+						onClick={ () =>
+							setIsActiveAttribute(
+								activeAttribute === attribute
+									? false
+									: attribute
+							)
+						}
+						className="block-bindings-attribute-picker-button"
+					>
+						{ attribute }
+					</MenuItem>
+					{ activeAttribute === attribute && (
+						<>
+							<MenuGroup>
+								{ /* Sources can fill this slot */ }
+								<Slot
+									fillProps={ {
+										...props,
+										currentAttribute: attribute,
+										setIsActiveAttribute,
+									} }
+								>
+									{ ( fills ) => {
+										if ( ! fills.length ) {
+											return null;
+										}
+
+										return (
+											<>
+												{ fills.map(
+													( fill, index ) => {
+														// TODO: Check better way to get the source and label.
+														const source =
+															fill[ 0 ].props
+																.children.props
+																.source;
+														const sourceLabel =
+															fill[ 0 ].props
+																.children.props
+																.label;
+														const isSourceSelected =
+															activeSource ===
+															source;
+
+														return (
+															<Fragment
+																key={ index }
+															>
+																<MenuItem
+																	icon={
+																		isSourceSelected
+																			? chevronUp
+																			: chevronDown
+																	}
+																	isSelected={
+																		isSourceSelected
+																	}
+																	onClick={ () =>
+																		setIsActiveSource(
+																			isSourceSelected
+																				? false
+																				: source
+																		)
+																	}
+																	className="block-bindings-source-picker-button"
+																>
+																	{
+																		sourceLabel
+																	}
+																</MenuItem>
+																{ isSourceSelected &&
+																	fill }
+															</Fragment>
+														);
+													}
+												) }
+											</>
+										);
+									} }
+								</Slot>
+							</MenuGroup>
+							<RemoveBindingButton
+								{ ...props }
+								currentAttribute={ attribute }
+								setIsActiveAttribute={ setIsActiveAttribute }
+							/>
+						</>
+					) }
+				</div>
+			) ) }
+		</MenuGroup>
+	);
+}
+
+function RemoveBindingButton( props ) {
+	return (
+		<Button
+			className="block-bindings-remove-button"
+			onClick={ () => {
+				if ( ! props.attributes?.metadata.bindings ) {
+					return;
+				}
+
+				const {
+					currentAttribute,
+					attributes,
+					setAttributes,
+					setAddingBinding,
+				} = props;
+				// Modify the attribute we are binding.
+				const newAttributes = {};
+				newAttributes[ currentAttribute ] = '';
+				props.setAttributes( newAttributes );
+
+				updateBlockBindingsAttribute(
+					attributes,
+					setAttributes,
+					currentAttribute,
+					null
+				);
+
+				setAddingBinding( false );
+			} }
+		>
+			Remove binding
+		</Button>
+	);
+}
+
+if ( window.__experimentalBlockBindings ) {
+	addFilter(
+		'blocks.registerBlockType',
+		'core/block-bindings-ui',
+		( settings, name ) => {
+			if ( ! ( name in blockBindingsWhitelist ) ) {
+				return settings;
+			}
+
+			// TODO: Review the implications of this and the code.
+			// Add the necessary context to the block.
+			const contextItems = [ 'postId', 'postType', 'queryId' ];
+			const usesContextArray = settings.usesContext;
+			const oldUsesContextArray = new Set( usesContextArray );
+			contextItems.forEach( ( item ) => {
+				if ( ! oldUsesContextArray.has( item ) ) {
+					usesContextArray.push( item );
+				}
+			} );
+			settings.usesContext = usesContextArray;
+
+			// Add bindings button to the block toolbar.
+			const OriginalComponent = settings.edit;
+			settings.edit = ( props ) => {
+				return (
+					<>
+						<OriginalComponent { ...props } />
+						<BlockBindingsUI { ...props } />
+					</>
+				);
+			};
+
+			return settings;
+		}
+	);
+}
+
+// TODO: Add also some components to the sidebar.

--- a/packages/editor/src/components/block-bindings/bindings-ui.js
+++ b/packages/editor/src/components/block-bindings/bindings-ui.js
@@ -20,7 +20,7 @@ import {
 } from '@wordpress/icons';
 import { addFilter } from '@wordpress/hooks';
 
-const blockBindingsWhitelist = {
+const blockBindingsAllowedBlocks = {
 	'core/paragraph': [ 'content' ],
 	'core/heading': [ 'content' ],
 	'core/image': [ 'url', 'title' ],
@@ -93,7 +93,7 @@ function AttributesLayer( props ) {
 	const [ activeSource, setIsActiveSource ] = useState( false );
 	return (
 		<MenuGroup>
-			{ blockBindingsWhitelist[ props.name ].map( ( attribute ) => (
+			{ blockBindingsAllowedBlocks[ props.name ].map( ( attribute ) => (
 				<div
 					key={ attribute }
 					className="block-bindings-attribute-picker-container"
@@ -239,7 +239,7 @@ if ( window.__experimentalBlockBindings ) {
 		'blocks.registerBlockType',
 		'core/block-bindings-ui',
 		( settings, name ) => {
-			if ( ! ( name in blockBindingsWhitelist ) ) {
+			if ( ! ( name in blockBindingsAllowedBlocks ) ) {
 				return settings;
 			}
 

--- a/packages/editor/src/components/block-bindings/bindings-ui.js
+++ b/packages/editor/src/components/block-bindings/bindings-ui.js
@@ -243,18 +243,6 @@ if ( window.__experimentalBlockBindings ) {
 				return settings;
 			}
 
-			// TODO: Review the implications of this and the code.
-			// Add the necessary context to the block.
-			const contextItems = [ 'postId', 'postType', 'queryId' ];
-			const usesContextArray = settings.usesContext;
-			const oldUsesContextArray = new Set( usesContextArray );
-			contextItems.forEach( ( item ) => {
-				if ( ! oldUsesContextArray.has( item ) ) {
-					usesContextArray.push( item );
-				}
-			} );
-			settings.usesContext = usesContextArray;
-
 			// Add bindings button to the block toolbar.
 			const OriginalComponent = settings.edit;
 			settings.edit = ( props ) => {

--- a/packages/editor/src/components/block-bindings/bindings-ui.js
+++ b/packages/editor/src/components/block-bindings/bindings-ui.js
@@ -248,6 +248,18 @@ if ( window.__experimentalBlockBindings ) {
 				return settings;
 			}
 
+			// TODO: Review the implications of this and the code.
+			// Add the necessary context to the block.
+			const contextItems = [ 'postId', 'postType', 'queryId' ];
+			const usesContextArray = settings.usesContext;
+			const oldUsesContextArray = new Set( usesContextArray );
+			contextItems.forEach( ( item ) => {
+				if ( ! oldUsesContextArray.has( item ) ) {
+					usesContextArray.push( item );
+				}
+			} );
+			settings.usesContext = usesContextArray;
+
 			// Add bindings button to the block toolbar.
 			const OriginalComponent = settings.edit;
 			settings.edit = ( props ) => {

--- a/packages/editor/src/components/block-bindings/fields-list.js
+++ b/packages/editor/src/components/block-bindings/fields-list.js
@@ -17,9 +17,7 @@ export default function BlockBindingsFieldsList( props ) {
 
 	// TODO: Try to abstract this function to be reused across all the sources.
 	function selectItem( item ) {
-		// Modify the attribute we are binding.
-		// TODO: Not sure if we should do this. We might need to process the bindings attribute somehow in the editor to modify the content with context.
-		// TODO: Get the type from the block attribute definition and modify/validate the value returned by the source if needed.
+		// Modify the attribute binded.
 		const newAttributes = {};
 		newAttributes[ currentAttribute ] = item.value;
 		setAttributes( newAttributes );

--- a/packages/editor/src/components/block-bindings/fields-list.js
+++ b/packages/editor/src/components/block-bindings/fields-list.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { updateBlockBindingsAttribute } from '@wordpress/block-editor';
+import { MenuItem, MenuGroup } from '@wordpress/components';
+
+export default function BlockBindingsFieldsList( props ) {
+	const {
+		attributes,
+		setAttributes,
+		setIsActiveAttribute,
+		currentAttribute,
+		fields,
+		source,
+		setAddingBinding,
+	} = props;
+
+	// TODO: Try to abstract this function to be reused across all the sources.
+	function selectItem( item ) {
+		// Modify the attribute we are binding.
+		// TODO: Not sure if we should do this. We might need to process the bindings attribute somehow in the editor to modify the content with context.
+		// TODO: Get the type from the block attribute definition and modify/validate the value returned by the source if needed.
+		const newAttributes = {};
+		newAttributes[ currentAttribute ] = item.value;
+		setAttributes( newAttributes );
+
+		// Update the bindings property.
+		updateBlockBindingsAttribute(
+			attributes,
+			setAttributes,
+			currentAttribute,
+			source,
+			{ value: item.key }
+		);
+
+		setIsActiveAttribute( false );
+		setAddingBinding( false );
+	}
+
+	return (
+		<MenuGroup className="block-bindings-fields-list-ui">
+			{ fields.map( ( item ) => (
+				<MenuItem
+					key={ item.key }
+					onClick={ () => selectItem( item ) }
+					className={
+						attributes.metadata?.bindings?.[ currentAttribute ]
+							?.source?.name === source &&
+						attributes.metadata?.bindings?.[ currentAttribute ]
+							?.source?.attributes?.value === item.key
+							? 'selected-meta-field'
+							: ''
+					}
+				>
+					{ item.label }
+				</MenuItem>
+			) ) }
+		</MenuGroup>
+	);
+}

--- a/packages/editor/src/components/block-bindings/index.js
+++ b/packages/editor/src/components/block-bindings/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+export { default as BlockBindingsFill } from './bindings-ui';

--- a/packages/editor/src/components/block-bindings/index.js
+++ b/packages/editor/src/components/block-bindings/index.js
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 export { default as BlockBindingsFill } from './bindings-ui';
+export { default as BlockBindingsFieldsList } from './fields-list';

--- a/packages/editor/src/components/block-bindings/style.scss
+++ b/packages/editor/src/components/block-bindings/style.scss
@@ -1,0 +1,30 @@
+// TODO: Change the styles.
+.block-bindings-ui-popover {
+	margin-top: 12px;
+	width: 300px;
+	.components-popover__content {
+		width: 100%;
+	}
+
+	.block-bindings-attribute-picker-container {
+		border-bottom: 1px solid #0002;
+	}
+
+	.block-bindings-fields-list-ui {
+		padding: 12px;
+		li {
+			margin: 20px 8px;
+			cursor: pointer;
+		}
+		.selected-meta-field {
+			font-weight: bold;
+		}
+		.selected-meta-field::before {
+			content: "✔  ";
+			margin-left: -16px;
+		}
+	}
+	.block-bindings-remove-button {
+		color: var(--wp-admin-theme-color, #3858e9);
+	}
+}

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -102,3 +102,6 @@ export { default as EditorProvider } from './provider';
 export * from './deprecated';
 export const VisualEditorGlobalKeyboardShortcuts = EditorKeyboardShortcuts;
 export const TextEditorGlobalKeyboardShortcuts = EditorKeyboardShortcuts;
+
+// Block Bindings Components.
+export * from './block-bindings';

--- a/packages/editor/src/hooks/block-bindings-sources/post-meta.js
+++ b/packages/editor/src/hooks/block-bindings-sources/post-meta.js
@@ -39,7 +39,6 @@ if ( window.__experimentalBlockBindings ) {
 					[ context.postId, context.postType ]
 				);
 
-				// TODO: Explore how to get the list of available fields depending on the template.
 				if ( ! data || ! data.meta ) {
 					return <BlockEdit key="edit" { ...props } />;
 				}

--- a/packages/editor/src/hooks/block-bindings-sources/post-meta.js
+++ b/packages/editor/src/hooks/block-bindings-sources/post-meta.js
@@ -1,0 +1,90 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import BlockBindingsFill from '../../components/block-bindings/bindings-ui';
+import BlockBindingsFieldsList from '../../components/block-bindings/fields-list';
+
+const PostMeta = ( props ) => {
+	const { context } = props;
+
+	// Fetching the REST API to get the available custom fields.
+	// TODO: Explore how it should work in templates.
+	// TODO: Explore if it makes sense to create a custom endpoint for this.
+	const data = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( coreStore );
+			return getEntityRecord(
+				'postType',
+				context.postType,
+				context.postId
+			);
+		},
+		[ context.postType, context.postId ]
+	);
+
+	// Adapt the data to the format expected by the fields list.
+	const fields = [];
+	// Prettifying the name until we receive the label from the REST API endpoint.
+	const keyToLabel = ( key ) => {
+		return key
+			.split( '_' )
+			.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+			.join( ' ' );
+	};
+	Object.entries( data.meta ).forEach( ( [ key, value ] ) => {
+		fields.push( {
+			key,
+			label: keyToLabel( key ),
+			value,
+		} );
+	} );
+
+	return (
+		<BlockBindingsFieldsList
+			fields={ fields }
+			source="post_meta"
+			{ ...props }
+		/>
+	);
+};
+
+if ( window.__experimentalBlockBindings ) {
+	// TODO: Read the context somehow to decide if we should add the source.
+	// const data = useSelect( editorStore );
+
+	// External sources could do something similar.
+	const withCoreSources = createHigherOrderComponent(
+		( BlockEdit ) => ( props ) => {
+			const { isSelected } = props;
+			return (
+				<>
+					{ isSelected && (
+						<>
+							<BlockBindingsFill
+								source="post_meta"
+								label="Post Meta"
+							>
+								<PostMeta />
+							</BlockBindingsFill>
+						</>
+					) }
+					<BlockEdit key="edit" { ...props } />
+				</>
+			);
+		},
+		'withToolbarControls'
+	);
+
+	addFilter(
+		'editor.BlockEdit',
+		'core/block-bindings-ui/add-sources',
+		withCoreSources
+	);
+}

--- a/packages/editor/src/hooks/block-bindings-sources/post-meta.js
+++ b/packages/editor/src/hooks/block-bindings-sources/post-meta.js
@@ -11,21 +11,16 @@ import { addFilter } from '@wordpress/hooks';
 import BlockBindingsFill from '../../components/block-bindings/bindings-ui';
 import BlockBindingsFieldsList from '../../components/block-bindings/fields-list';
 import { store as editorStore } from '../../store';
+import { BLOCK_BINDINGS_ALLOWED_BLOCKS } from '../../store/constants';
 
 if ( window.__experimentalBlockBindings ) {
 	// External sources could do something similar.
 
 	const withCoreSources = createHigherOrderComponent(
 		( BlockEdit ) => ( props ) => {
-			const blockBindingsAllowedBlocks = {
-				'core/paragraph': [ 'content' ],
-				'core/heading': [ 'content' ],
-				'core/image': [ 'url', 'title' ],
-				'core/button': [ 'url', 'text' ],
-			};
 			const { name, isSelected, context } = props;
 			// If the block is not allowed, return the original BlockEdit.
-			if ( ! blockBindingsAllowedBlocks[ name ] ) {
+			if ( ! BLOCK_BINDINGS_ALLOWED_BLOCKS[ name ] ) {
 				return <BlockEdit key="edit" { ...props } />;
 			}
 			const fields = [];

--- a/packages/editor/src/hooks/block-bindings-sources/post-meta.js
+++ b/packages/editor/src/hooks/block-bindings-sources/post-meta.js
@@ -10,68 +10,77 @@ import { addFilter } from '@wordpress/hooks';
  */
 import BlockBindingsFill from '../../components/block-bindings/bindings-ui';
 import BlockBindingsFieldsList from '../../components/block-bindings/fields-list';
-
-const PostMeta = ( props ) => {
-	const { context } = props;
-
-	// Fetching the REST API to get the available custom fields.
-	// TODO: Explore how it should work in templates.
-	// TODO: Explore if it makes sense to create a custom endpoint for this.
-	const data = useSelect(
-		( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			return getEntityRecord(
-				'postType',
-				context.postType,
-				context.postId
-			);
-		},
-		[ context.postType, context.postId ]
-	);
-
-	// Adapt the data to the format expected by the fields list.
-	const fields = [];
-	// Prettifying the name until we receive the label from the REST API endpoint.
-	const keyToLabel = ( key ) => {
-		return key
-			.split( '_' )
-			.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
-			.join( ' ' );
-	};
-	Object.entries( data.meta ).forEach( ( [ key, value ] ) => {
-		fields.push( {
-			key,
-			label: keyToLabel( key ),
-			value,
-		} );
-	} );
-
-	return (
-		<BlockBindingsFieldsList
-			fields={ fields }
-			source="post_meta"
-			{ ...props }
-		/>
-	);
-};
+import { store as editorStore } from '../../store';
 
 if ( window.__experimentalBlockBindings ) {
-	// TODO: Read the context somehow to decide if we should add the source.
-	// const data = useSelect( editorStore );
-
 	// External sources could do something similar.
+
 	const withCoreSources = createHigherOrderComponent(
 		( BlockEdit ) => ( props ) => {
-			const { isSelected } = props;
+			const blockBindingsAllowedBlocks = {
+				'core/paragraph': [ 'content' ],
+				'core/heading': [ 'content' ],
+				'core/image': [ 'url', 'title' ],
+				'core/button': [ 'url', 'text' ],
+			};
+			const { name, isSelected, context } = props;
+			// If the block is not allowed, return the original BlockEdit.
+			if ( ! blockBindingsAllowedBlocks[ name ] ) {
+				return <BlockEdit key="edit" { ...props } />;
+			}
+			const fields = [];
+			if ( isSelected ) {
+				const data = useSelect( ( select ) => {
+					const postId = context.postId
+						? context.postId
+						: select( editorStore ).getCurrentPostId();
+					const postType = context.postType
+						? context.postType
+						: select( editorStore ).getCurrentPostType();
+					// If not a post type, return null.
+					if ( postType !== 'post' && postType !== 'page' ) {
+						return null;
+					}
+					const { getEntityRecord } = select( coreStore );
+					return getEntityRecord( 'postType', postType, postId );
+				}, [] );
+
+				if ( data ) {
+					// Adapt the data to the format expected by the fields list.
+					// Prettifying the name until we receive the label from the REST API endpoint.
+					const keyToLabel = ( key ) => {
+						return key
+							.split( '_' )
+							.map(
+								( word ) =>
+									word.charAt( 0 ).toUpperCase() +
+									word.slice( 1 )
+							)
+							.join( ' ' );
+					};
+					Object.entries( data.meta ).forEach( ( [ key, value ] ) => {
+						fields.push( {
+							key,
+							label: keyToLabel( key ),
+							value,
+						} );
+					} );
+				}
+			}
+
 			return (
 				<>
-					{ isSelected && (
+					{ isSelected && fields.length !== 0 && (
 						<>
 							<BlockBindingsFill
 								source="post_meta"
 								label="Post Meta"
 							>
-								<PostMeta />
+								<BlockBindingsFieldsList
+									fields={ fields }
+									source="post_meta"
+									{ ...props }
+								/>
 							</BlockBindingsFill>
 						</>
 					) }

--- a/packages/editor/src/hooks/block-bindings-sources/post-meta.js
+++ b/packages/editor/src/hooks/block-bindings-sources/post-meta.js
@@ -25,42 +25,43 @@ if ( window.__experimentalBlockBindings ) {
 			}
 			const fields = [];
 			if ( isSelected ) {
-				const data = useSelect( ( select ) => {
-					const postId = context.postId
-						? context.postId
-						: select( editorStore ).getCurrentPostId();
-					const postType = context.postType
-						? context.postType
-						: select( editorStore ).getCurrentPostType();
-					// If not a post type, return null.
-					if ( postType !== 'post' && postType !== 'page' ) {
-						return null;
-					}
-					const { getEntityRecord } = select( coreStore );
-					return getEntityRecord( 'postType', postType, postId );
-				}, [] );
+				const data = useSelect(
+					( select ) => {
+						const postId = context.postId
+							? context.postId
+							: select( editorStore ).getCurrentPostId();
+						const postType = context.postType
+							? context.postType
+							: select( editorStore ).getCurrentPostType();
+						const { getEntityRecord } = select( coreStore );
+						return getEntityRecord( 'postType', postType, postId );
+					},
+					[ context.postId, context.postType ]
+				);
 
-				if ( data ) {
-					// Adapt the data to the format expected by the fields list.
-					// Prettifying the name until we receive the label from the REST API endpoint.
-					const keyToLabel = ( key ) => {
-						return key
-							.split( '_' )
-							.map(
-								( word ) =>
-									word.charAt( 0 ).toUpperCase() +
-									word.slice( 1 )
-							)
-							.join( ' ' );
-					};
-					Object.entries( data.meta ).forEach( ( [ key, value ] ) => {
-						fields.push( {
-							key,
-							label: keyToLabel( key ),
-							value,
-						} );
-					} );
+				// TODO: Explore how to get the list of available fields depending on the template.
+				if ( ! data || ! data.meta ) {
+					return <BlockEdit key="edit" { ...props } />;
 				}
+
+				// Adapt the data to the format expected by the fields list.
+				// Prettifying the name until we receive the label from the REST API endpoint.
+				const keyToLabel = ( key ) => {
+					return key
+						.split( '_' )
+						.map(
+							( word ) =>
+								word.charAt( 0 ).toUpperCase() + word.slice( 1 )
+						)
+						.join( ' ' );
+				};
+				Object.entries( data.meta ).forEach( ( [ key, value ] ) => {
+					fields.push( {
+						key,
+						label: keyToLabel( key ),
+						value,
+					} );
+				} );
 			}
 
 			return (
@@ -86,6 +87,8 @@ if ( window.__experimentalBlockBindings ) {
 		'withToolbarControls'
 	);
 
+	// TODO: Review if there is a better filter for this.
+	// This runs for every block.
 	addFilter(
 		'editor.BlockEdit',
 		'core/block-bindings-ui/add-sources',

--- a/packages/editor/src/hooks/index.js
+++ b/packages/editor/src/hooks/index.js
@@ -4,3 +4,6 @@
 import './custom-sources-backwards-compatibility';
 import './default-autocompleters';
 import './pattern-partial-syncing';
+
+// Block bindings sources.
+import './block-bindings-sources/post-meta';

--- a/packages/editor/src/store/constants.js
+++ b/packages/editor/src/store/constants.js
@@ -18,3 +18,9 @@ export const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 export const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
 export const ONE_MINUTE_IN_MS = 60 * 1000;
 export const AUTOSAVE_PROPERTIES = [ 'title', 'excerpt', 'content' ];
+export const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
+	'core/paragraph': [ 'content' ],
+	'core/heading': [ 'content' ],
+	'core/image': [ 'url', 'title' ],
+	'core/button': [ 'url', 'text' ],
+};

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -1,4 +1,5 @@
 @import "./components/autocompleters/style.scss";
+@import "./components/block-bindings/style.scss";
 @import "./components/document-bar/style.scss";
 @import "./components/document-outline/style.scss";
 @import "./components/document-tools/style.scss";

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -76,6 +76,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 					id,
 				},
 			} );
+			return;
 		}
 	}
 

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -6,7 +6,10 @@ import { nanoid } from 'nanoid';
 /**
  * WordPress dependencies
  */
-import { InspectorControls } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	updateBlockBindingsAttribute,
+} from '@wordpress/block-editor';
 import { BaseControl, CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -31,59 +34,49 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 	}
 
 	function updateBindings( isChecked ) {
-		let updatedBindings = {
-			...attributes?.metadata?.bindings,
-		};
-
 		if ( ! isChecked ) {
 			for ( const attributeName of Object.keys( syncedAttributes ) ) {
-				if (
-					updatedBindings[ attributeName ]?.source?.name ===
-					'pattern_attributes'
-				) {
-					delete updatedBindings[ attributeName ];
-				}
+				updateBlockBindingsAttribute(
+					attributes,
+					setAttributes,
+					attributeName,
+					null,
+					null
+				);
 			}
-			if ( ! Object.keys( updatedBindings ).length ) {
-				updatedBindings = undefined;
-			}
-			setAttributes( {
-				metadata: {
-					...attributes.metadata,
-					bindings: updatedBindings,
-				},
-			} );
 			return;
 		}
 
-		for ( const attributeName of Object.keys( syncedAttributes ) ) {
-			if ( ! updatedBindings[ attributeName ] ) {
-				updatedBindings[ attributeName ] = {
-					source: {
-						name: 'pattern_attributes',
-					},
-				};
-			}
-		}
-
 		if ( typeof attributes.metadata?.id === 'string' ) {
-			setAttributes( {
-				metadata: {
-					...attributes.metadata,
-					bindings: updatedBindings,
-				},
-			} );
+			for ( const attributeName of Object.keys( syncedAttributes ) ) {
+				updateBlockBindingsAttribute(
+					attributes,
+					setAttributes,
+					attributeName,
+					'pattern_attributes',
+					null
+				);
+			}
 			return;
 		}
 
 		const id = nanoid( 6 );
-		setAttributes( {
-			metadata: {
-				...attributes.metadata,
-				id,
-				bindings: updatedBindings,
-			},
-		} );
+		for ( const attributeName of Object.keys( syncedAttributes ) ) {
+			const newMetadata = updateBlockBindingsAttribute(
+				attributes,
+				setAttributes,
+				attributeName,
+				'pattern_attributes',
+				null
+			);
+
+			setAttributes( {
+				metadata: {
+					...newMetadata,
+					id,
+				},
+			} );
+		}
 	}
 
 	return (


### PR DESCRIPTION
This pull request is built on top of https://github.com/WordPress/gutenberg/pull/57249. 

## What?

Related issues:

https://github.com/WordPress/gutenberg/issues/54536
https://github.com/WordPress/gutenberg/issues/53300
https://github.com/WordPress/gutenberg/pull/56867

I'm splitting https://github.com/WordPress/gutenberg/pull/56867/ into smaller PRs so they are more manageable and discussions can be kept separately. You can find more information in the original PR.

**Bear in mind that the UI created in this PR is really basic and still needs to be discussed. I'd like to iterate on it in a later phase.**

It covers:
* Adding a basic UI for the block bindings that allows users to add the bindings attribute by clicking some buttons. For all the blocks in the whitelist, it adds a new button in the toolbar that triggers a popover with the list of available attributes.
* Provide a `BlockBindingsFill` component that allows different sources to hook into that interface and add their own UI.
* Provide a `BlockBindingsFieldsList` component that sources can use if they just want to list some fields.
* Provide a `updateBlockBindingsAttribute` helper that sources can use to update the bindings property. It'd be great to explore if we can move it into a React hook.
* Use the `updateBlockBindingsAttribute` helper in the pattern source.
* Add the UI for the Post meta source using the `BlockBindingsFill` and `BlockBindingsFieldsList` components.

## Why?
The basis pull request allows to process the bindings in the server but there is no way to add the attributes in the editor without writing them directly in the code editor.

Additionally, providing some tools for creating sources will help to add support for site data, user data, or other plugins that want to use it.

## How?
The most relevant aspects of the technical implementation are:
* I used the `createSlotFill` hook to provide the Slot that sources can Fill.
* I used the `blocks.registerBlockType` to inject the Bindings button in the blocks in the whitelist. It also add the context to the blocks without it, although that needs to be reviewed as discussed [here](https://github.com/WordPress/gutenberg/pull/56867/files#r1432373227).
* For the post meta source, I used the `editor.BlockEdit` to inject the Fill.

## Testing Instructions

For all the testing we have to go to Gutenberg-Experiments and enable the Test Block Bindings option.

**Test that adding the bindings attribute works**

1. Register a new custom field however you prefer. You can use a snippet similar to this:

```PHP
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'This is the content of the text custom field',
	)
);
register_meta(
	'post',
	'url_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

2. Create a new post/page and insert a paragraph.
3. In the toolbar, click the new Bindings button.
4. Check that the available attributes are there and select the content attribute.
5. Check that the available sources are there (only post meta so far), and select it.
6. Select the custom field you created.
7. Check the value is applied in the editor and in the frontend.
8. Change the value of the custom field.
9. Check that the value is updated in the frontend (won't update the editor yet).

**Test that multiple attributes values can be connected**

Repeat the same process but using a button (or an image) to bind the content and the URL.

**Test that partially synced patterns keep working as expected**

Partially synced patterns experiment should keep working as it does before this PR.

1. Go to the Site Editor -> Patterns -> Create a new synced pattern.
2. Add a heading and a paragraph.
3. In the block settings of the paragraph -> Advanced -> Toggle Synced Attribute "content" to enable editing the paragraph.
4. Insert that pattern into a post/page multiple times and define different values for the paragraphs.
5. Check in the frontend that the value persists.
6. Modify something in the synced pattern (layout for example) and check that is applied to the post/page you created.

**Test creating a new source**

You can try creating a new source using the post meta as reference and using the helpers created: `BlockBindingsFill` and `BlockBindingsFieldsList`. Once created, it should appear in the block bindings UI, as the post meta does.

## Remaining issues

* Review how to pass source and label from the Fill component.
* Explore the possibility of using a dropdown menu for the UI: [link](https://wordpress.github.io/gutenberg/?path=/story/components-experimental-dropdownmenu-v2--with-submenu).
* Move the `updateBlockBindings` to a React hook.
* Ensure the filters used in the editor are correct.
* Process the bindings property in the editor. Right now, we are using setAttributes when an item is selected, but it’d be great if the editor is able to understand it directly.
* Fix Query Loop.

