### PR TITLE
Truncate: improve handling of non-string children

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `Button`: Fix logic of `has-text` class addition ([#56949](https://github.com/WordPress/gutenberg/pull/56949)).
 -   `FormTokenField`: Fix a regression where the suggestion list would re-open after clicking away from the input ([#57002](https://github.com/WordPress/gutenberg/pull/57002)).
 -   `Snackbar`: Remove erroneous `__unstableHTML` prop from TypeScript definitions ([#57218](https://github.com/WordPress/gutenberg/pull/57218)).
+-   `Truncate`: improve handling of non-string `children` ([#57261](https://github.com/WordPress/gutenberg/pull/57261)).
 
 ### Enhancements
 

--- a/packages/components/src/truncate/README.md
+++ b/packages/components/src/truncate/README.md
@@ -24,6 +24,14 @@ function Example() {
 
 ## Props
 
+##### `children`: `ReactNode`
+
+The children elements.
+
+Note: text truncation will be attempted only if the `children` are either of type `string` or `number`. In any other scenarios, the component will not attempt to truncate the text, and will pass through the `children`.
+
+-   Required: Yes
+
 ##### `ellipsis`: `string`
 
 The ellipsis string when truncating the text by the `limit` prop's value.

--- a/packages/components/src/truncate/hook.ts
+++ b/packages/components/src/truncate/hook.ts
@@ -33,17 +33,24 @@ export default function useTruncate(
 
 	const cx = useCx();
 
-	const truncatedContent = truncateContent(
-		typeof children === 'string' ? children : '',
-		{
-			ellipsis,
-			ellipsizeMode,
-			limit,
-			numberOfLines,
-		}
-	);
+	let childrenAsText;
+	if ( typeof children === 'string' ) {
+		childrenAsText = children;
+	} else if ( typeof children === 'number' ) {
+		childrenAsText = children.toString();
+	}
 
-	const shouldTruncate = ellipsizeMode === TRUNCATE_TYPE.auto;
+	const truncatedContent = childrenAsText
+		? truncateContent( childrenAsText, {
+				ellipsis,
+				ellipsizeMode,
+				limit,
+				numberOfLines,
+		  } )
+		: children;
+
+	const shouldTruncate =
+		!! childrenAsText && ellipsizeMode === TRUNCATE_TYPE.auto;
 
 	const classes = useMemo( () => {
 		const truncateLines = css`

--- a/packages/components/src/truncate/hook.ts
+++ b/packages/components/src/truncate/hook.ts
@@ -39,7 +39,7 @@ export default function useTruncate(
 		childrenAsText = children;
 	} else if ( typeof children === 'number' ) {
 		childrenAsText = children.toString();
-	} else {
+	} else if ( typeof children !== 'undefined' ) {
 		warn(
 			`Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'. Received: ${ children }`
 		);

--- a/packages/components/src/truncate/hook.ts
+++ b/packages/components/src/truncate/hook.ts
@@ -38,6 +38,11 @@ export default function useTruncate(
 		childrenAsText = children;
 	} else if ( typeof children === 'number' ) {
 		childrenAsText = children.toString();
+	} else {
+		// eslint-disable-next-line no-console
+		console.warn(
+			`Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'`
+		);
 	}
 
 	const truncatedContent = childrenAsText

--- a/packages/components/src/truncate/hook.ts
+++ b/packages/components/src/truncate/hook.ts
@@ -41,7 +41,8 @@ export default function useTruncate(
 	} else {
 		// eslint-disable-next-line no-console
 		console.warn(
-			`Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'`
+			`Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'. Received:`,
+			children
 		);
 	}
 

--- a/packages/components/src/truncate/hook.ts
+++ b/packages/components/src/truncate/hook.ts
@@ -7,7 +7,6 @@ import { css } from '@emotion/react';
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
-import warn from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -39,10 +38,6 @@ export default function useTruncate(
 		childrenAsText = children;
 	} else if ( typeof children === 'number' ) {
 		childrenAsText = children.toString();
-	} else if ( typeof children !== 'undefined' ) {
-		warn(
-			`Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'. Received: ${ children }`
-		);
 	}
 
 	const truncatedContent = childrenAsText

--- a/packages/components/src/truncate/hook.ts
+++ b/packages/components/src/truncate/hook.ts
@@ -7,6 +7,7 @@ import { css } from '@emotion/react';
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
+import warn from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -39,10 +40,8 @@ export default function useTruncate(
 	} else if ( typeof children === 'number' ) {
 		childrenAsText = children.toString();
 	} else {
-		// eslint-disable-next-line no-console
-		console.warn(
-			`Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'. Received:`,
-			children
+		warn(
+			`Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'. Received: ${ children }`
 		);
 	}
 

--- a/packages/components/src/truncate/test/index.tsx
+++ b/packages/components/src/truncate/test/index.tsx
@@ -65,11 +65,6 @@ describe( 'Truncate', () => {
 				</Truncate>
 			);
 			expect( screen.getByText( 'Lorem ipsum' ) ).toBeVisible();
-			expect( console ).toHaveWarnedWith(
-				expect.stringContaining(
-					"Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'. Received:"
-				)
-			);
 		} );
 	} );
 } );

--- a/packages/components/src/truncate/test/index.tsx
+++ b/packages/components/src/truncate/test/index.tsx
@@ -66,7 +66,9 @@ describe( 'Truncate', () => {
 			);
 			expect( screen.getByText( 'Lorem ipsum' ) ).toBeVisible();
 			expect( console ).toHaveWarnedWith(
-				"Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'"
+				expect.stringContaining(
+					"Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'. Received:"
+				)
 			);
 		} );
 	} );

--- a/packages/components/src/truncate/test/index.tsx
+++ b/packages/components/src/truncate/test/index.tsx
@@ -58,13 +58,16 @@ describe( 'Truncate', () => {
 	} );
 
 	describe( 'with other children types', () => {
-		test( 'should no-op', () => {
+		test( 'should no-op and output a warning to console', () => {
 			render(
 				<Truncate>
 					<>Lorem ipsum</>
 				</Truncate>
 			);
 			expect( screen.getByText( 'Lorem ipsum' ) ).toBeVisible();
+			expect( console ).toHaveWarnedWith(
+				"Truncate: text truncation has been disabled, since it is only available when passing 'children' of type 'string' or 'number'"
+			);
 		} );
 	} );
 } );

--- a/packages/components/src/truncate/test/index.tsx
+++ b/packages/components/src/truncate/test/index.tsx
@@ -8,36 +8,63 @@ import { render, screen } from '@testing-library/react';
  */
 import { Truncate } from '..';
 
-describe( 'props', () => {
-	test( 'should render correctly', () => {
-		render( <Truncate>Lorem ipsum.</Truncate> );
-		expect( screen.getByText( 'Lorem ipsum.' ) ).toBeVisible();
+describe( 'Truncate', () => {
+	describe( 'with string or number children', () => {
+		test( 'should pass through when no truncation props are set', () => {
+			render( <Truncate>Lorem ipsum</Truncate> );
+			expect( screen.getByText( 'Lorem ipsum' ) ).toBeVisible();
+		} );
+
+		test( 'should render numbers correctly', () => {
+			render( <Truncate>{ 14 }</Truncate> );
+			expect( screen.getByText( '14' ) ).toBeVisible();
+		} );
+
+		test( 'should truncate text from the start when the limit prop is set and the ellipsizeMode is tail', () => {
+			render(
+				<Truncate limit={ 1 } ellipsizeMode="tail">
+					Lorem ipsum
+				</Truncate>
+			);
+			expect( screen.getByText( 'L…' ) ).toBeVisible();
+		} );
+
+		test( 'should truncate text from the end when the limit prop is set and the ellipsizeMode is head', () => {
+			render(
+				<Truncate limit={ 1 } ellipsizeMode="head">
+					Lorem ipsum
+				</Truncate>
+			);
+			expect( screen.getByText( '…m' ) ).toBeVisible();
+		} );
+
+		test( 'should render custom ellipsis', () => {
+			render(
+				<Truncate ellipsis="!!!" limit={ 5 } ellipsizeMode="tail">
+					Lorem ipsum.
+				</Truncate>
+			);
+			expect( screen.getByText( 'Lorem!!!' ) ).toBeVisible();
+		} );
+
+		test( 'should render custom ellipsizeMode', () => {
+			render(
+				<Truncate ellipsis="!!!" ellipsizeMode="middle" limit={ 5 }>
+					Lorem ipsum.
+				</Truncate>
+			);
+			expect( screen.getByText( 'Lo!!!m.' ) ).toBeVisible();
+		} );
 	} );
 
-	test( 'should render limit', () => {
-		render(
-			<Truncate limit={ 1 } ellipsizeMode="tail">
-				Lorem ipsum.
-			</Truncate>
-		);
-		expect( screen.getByText( 'L…' ) ).toBeVisible();
-	} );
-
-	test( 'should render custom ellipsis', () => {
-		render(
-			<Truncate ellipsis="!!!" limit={ 5 } ellipsizeMode="tail">
-				Lorem ipsum.
-			</Truncate>
-		);
-		expect( screen.getByText( 'Lorem!!!' ) ).toBeVisible();
-	} );
-
-	test( 'should render custom ellipsizeMode', () => {
-		render(
-			<Truncate ellipsis="!!!" ellipsizeMode="middle" limit={ 5 }>
-				Lorem ipsum.
-			</Truncate>
-		);
-		expect( screen.getByText( 'Lo!!!m.' ) ).toBeVisible();
+	describe( 'with other children types', () => {
+		test( 'should no-op', () => {
+			render(
+				<Truncate>
+					<>Lorem ipsum</>
+				</Truncate>
+			);
+			expect( screen.getByText( 'Lorem ipsum' ) ).toBeVisible();
+		} );
 	} );
 } );

--- a/packages/components/src/truncate/types.ts
+++ b/packages/components/src/truncate/types.ts
@@ -48,6 +48,10 @@ export type TruncateProps = {
 	numberOfLines?: number;
 	/**
 	 * The children elements.
+	 *
+	 * Note: text truncation will be attempted only if the `children` are either
+	 * of type `string` or `number`. In any other scenarios, the component will
+	 * not attempt to truncate the text, and will pass through the `children`.
 	 */
 	children: ReactNode;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR introduces a few changes to the `Truncate` component to make it more resilient to different types of `children` received:
- it makes the component able to truncate children of type `number`
- when `children` have types other than `string` or `number`, the component renders the `children` without any attempted truncation (instead of not rendering the `children` at all)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on #55625, I [discovered](https://github.com/WordPress/gutenberg/pull/55625#discussion_r1432445608) that `Truncate` only handles `children` of type `string`, and otherwise renders an empty `<span />` tag.

The component falsely advertises that its `children` are of type `ReactNode`, while in reality the component only knows how to deal with `string`.

This behaviour is not great, and can cause confusion and disruption in the consumers of `Truncate`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Tweaked the logic of the truncate hook:
- numbers are converted to string so that they can be truncated
- when detecting `children` that are not `string` of `number` type, the component simply no-ops and renders `children` as-is
- added unit tests for this new behaviour