### PR TITLE
Disable lock button if user cannot control lock state

### DIFF
--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -57,11 +57,6 @@
 
 .block-editor-block-toolbar__block-controls .block-editor-block-lock-toolbar {
 	margin-left: -$grid-unit-15 * 0.5 !important;
-
-	.components-button:disabled,
-	.components-button[aria-disabled="true"] {
-		opacity: 1;
-	}
 }
 
 .show-icon-labels {

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -57,6 +57,11 @@
 
 .block-editor-block-toolbar__block-controls .block-editor-block-lock-toolbar {
 	margin-left: -$grid-unit-15 * 0.5 !important;
+
+	.components-button:disabled,
+	.components-button[aria-disabled="true"] {
+		opacity: 1;
+	}
 }
 
 .show-icon-labels {

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -33,7 +33,7 @@ export default function BlockLockToolbar( { clientId } ) {
 		}
 	}, [ isLocked ] );
 
-	if ( ! canLock || ( ! isLocked && ! hasLockButtonShown.current ) ) {
+	if ( ! isLocked && ! hasLockButtonShown.current ) {
 		return null;
 	}
 
@@ -41,6 +41,7 @@ export default function BlockLockToolbar( { clientId } ) {
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
+					disabled={ ! canLock }
 					icon={ isLocked ? lock : unlock }
 					label={ isLocked ? __( 'Unlock' ) : __( 'Lock' ) }
 					onClick={ toggleModal }

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -37,13 +37,20 @@ export default function BlockLockToolbar( { clientId } ) {
 		return null;
 	}
 
+	let label = isLocked ? __( 'Unlock' ) : __( 'Lock' );
+
+	if ( ! canLock && isLocked ) {
+		label = __( 'Locked' );
+	}
+
 	return (
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
+					accessibleWhenDisabled
 					disabled={ ! canLock }
 					icon={ isLocked ? lock : unlock }
-					label={ isLocked ? __( 'Unlock' ) : __( 'Lock' ) }
+					label={ label }
 					onClick={ toggleModal }
 					aria-expanded={ isModalOpen }
 					aria-haspopup="dialog"


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/57229

The `canLockBlocks` setting allows a user to manage the block locked state. Admins always have it set to true, but some users are not allowed to unlock blocks. If they can't unlock a block, there is nothing in the toolbar that suggests a block is locked as there is for admins. I think it's useful to have some kind of indicator that the block is locked, so if a block is locked but a user cannot edit it, show a disabled lock icon in the toolbar.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Display a disabled lock icon in the toolbar if the toolbar is locked and a user can't control lock state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's helpful UI to know if the block is locked or not, even if you can't control that state.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check for `canLock`, and disable the button if the user cannot control lock state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Lock a block
- Save the post
- Set `canLockBlocks` to `false` in `packages/block-editor/src/store/defaults.js`.
- Reload the post
- Check for a disabled lock button in the toolbar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
