### PR TITLE
Tabs: update styling to more closely match previous implementation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Experimental
 
 -   `Tabs`: do not render hidden content ([#57046](https://github.com/WordPress/gutenberg/pull/57046)).
+-   `Tabs`: improve hover and text alignment styles ([#57275](https://github.com/WordPress/gutenberg/pull/57275)).
 -   `Tabs`: make sure `Tab`s are associated to the right `TabPanel`s, regardless of the order they're rendered in ([#57033](https://github.com/WordPress/gutenberg/pull/57033)).
 
 ## 25.14.0 (2023-12-13)

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -22,7 +22,9 @@ export const TabListWrapper = styled.div`
 `;
 
 export const Tab = styled( Ariakit.Tab )`
-	&& {
+	& {
+		display: inline-flex;
+		align-items: center;
 		position: relative;
 		border-radius: 0;
 		height: ${ space( 12 ) };
@@ -37,6 +39,10 @@ export const Tab = styled( Ariakit.Tab )`
 		&[aria-disabled='true'] {
 			cursor: default;
 			opacity: 0.3;
+		}
+
+		&:hover {
+			color: ${ COLORS.theme.accent };
 		}
 
 		&:focus:not( :disabled ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Replaces #57121
## What?
Updates the styling on `Tabs` to match the legacy `TabPanel` component

## Why?
To avoid being overly opinionated, `Tabs` is set up to render a vanilla `button` element, allowing consumers to opt for a `Button` component if they wish, via the `render` prop.

This caused a few styles to be lost, such as the hover color and the alignment of the text on tabs when the tab is wider than its contents.

## How?
Add the hover color and necessary layout attributes directly to the default `tab` element.

## Testing Instructions
1. Launch Storybook
2. Add a `flex-grow:1` style to each of the `Tabs.Tab` components in the Default story (making them wide enough for text alignment to be noticeable)
3. Confirm that the correct accent color is applied to the text when the tab is hovered
4. Confirm that the text is properly left-aligned