### PR TITLE
Exclude disabled buttons when setting initialIndex of NavigableToolbar

### DIFF
--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -25,7 +25,7 @@ function hasOnlyToolbarItem( elements ) {
 	return ! elements.some( ( element ) => ! ( dataProp in element.dataset ) );
 }
 
-function getAllToolbarItemsIn( container ) {
+function getAllFocusableToolbarItemsIn( container ) {
 	return Array.from(
 		container.querySelectorAll(
 			'[data-toolbar-item]:not([disabled]):not([aria-disabled="true"])'
@@ -145,7 +145,8 @@ function useToolbarFocus( {
 		let raf = 0;
 		if ( ! initialFocusOnMount ) {
 			raf = window.requestAnimationFrame( () => {
-				const items = getAllToolbarItemsIn( navigableToolbarRef );
+				const items =
+					getAllFocusableToolbarItemsIn( navigableToolbarRef );
 				const index = initialIndex || 0;
 				if ( items[ index ] && hasFocusWithin( navigableToolbarRef ) ) {
 					items[ index ].focus( {
@@ -162,7 +163,7 @@ function useToolbarFocus( {
 			if ( ! onIndexChange || ! navigableToolbarRef ) return;
 			// When the toolbar element is unmounted and onIndexChange is passed, we
 			// pass the focused toolbar item index so it can be hydrated later.
-			const items = getAllToolbarItemsIn( navigableToolbarRef );
+			const items = getAllFocusableToolbarItemsIn( navigableToolbarRef );
 			const index = items.findIndex( ( item ) => item.tabIndex === 0 );
 			onIndexChange( index );
 		};

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -26,7 +26,11 @@ function hasOnlyToolbarItem( elements ) {
 }
 
 function getAllToolbarItemsIn( container ) {
-	return Array.from( container.querySelectorAll( '[data-toolbar-item]' ) );
+	return Array.from(
+		container.querySelectorAll(
+			'[data-toolbar-item]:not([disabled]):not([aria-disabled="true"])'
+		)
+	);
 }
 
 function hasFocusWithin( container ) {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/57235.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
When the `BlockToolbarPopover` is rendered, it sends focus to the `initialIndex` (default 0). When the first toolbar item is disabled and can't receive focus, such as when the block is locked, `<NavigableToolbar />` is still trying to send focus to this item. To fix this, 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When the first item in a toolbar is disabled, the focus will be sent to the last item rather than the first focusable item when the toolbar is mounted.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Exclude disabled toolbar items when setting focus to the `<NavigableToolbar />` when an `initialIndex` is set.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Using the default block toolbar popover
- Type in a paragraph block
- Shift+tab to the block toolbar
- Focus should be on the first item
- Arrow right to another item
- Escape or Tab to send focus back to the block
- Type to hide the toolbar
- Shift+tab to the block toolbar
- Focus should be on the previously focused toolbar item

Repeat this for a Locked block (Block options -> Lock -> Lock modal)
