### PR TITLE
Components: replace `TabPanel` with `Tabs` in the Style Book

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -269,6 +269,7 @@ function StyleBook( {
 								<Tabs.TabPanel
 									key={ tab.name }
 									tabId={ tab.name }
+									focusable={ false }
 								>
 									<StyleBookBody
 										category={ tab.name }

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import {
 	Disabled,
-	TabPanel,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -48,6 +47,7 @@ const {
 	CompositeV2: Composite,
 	CompositeItemV2: CompositeItem,
 	useCompositeStoreV2: useCompositeStore,
+	Tabs,
 } = unlock( componentsPrivateApis );
 
 // The content area of the Style Book is rendered within an iframe so that global styles
@@ -253,22 +253,36 @@ function StyleBook( {
 			>
 				{ resizeObserver }
 				{ showTabs ? (
-					<TabPanel
-						className="edit-site-style-book__tab-panel"
-						tabs={ tabs }
-					>
-						{ ( tab ) => (
-							<StyleBookBody
-								category={ tab.name }
-								examples={ examples }
-								isSelected={ isSelected }
-								onSelect={ onSelect }
-								settings={ settings }
-								sizes={ sizes }
-								title={ tab.title }
-							/>
-						) }
-					</TabPanel>
+					<div className="edit-site-style-book__tabs">
+						<Tabs>
+							<Tabs.TabList>
+								{ tabs.map( ( tab ) => (
+									<Tabs.Tab
+										tabId={ tab.name }
+										key={ tab.name }
+									>
+										{ tab.title }
+									</Tabs.Tab>
+								) ) }
+							</Tabs.TabList>
+							{ tabs.map( ( tab ) => (
+								<Tabs.TabPanel
+									key={ tab.name }
+									tabId={ tab.name }
+								>
+									<StyleBookBody
+										category={ tab.name }
+										examples={ examples }
+										isSelected={ isSelected }
+										onSelect={ onSelect }
+										settings={ settings }
+										sizes={ sizes }
+										title={ tab.title }
+									/>
+								</Tabs.TabPanel>
+							) ) }
+						</Tabs>
+					</div>
 				) : (
 					<StyleBookBody
 						examples={ examples }

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -17,13 +17,13 @@
 	}
 }
 
-.edit-site-style-book__tab-panel {
-	.components-tab-panel__tabs {
+.edit-site-style-book__tabs {
+	[role="tablist"] {
 		background: $white;
 		color: $gray-900;
 	}
 
-	.components-tab-panel__tab-content {
+	[role="tabpanel"] {
 		bottom: 0;
 		left: 0;
 		overflow: auto;


### PR DESCRIPTION
## What?
Replaces the legacy TabPanel component with the new Tabs component.

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

## How?
`TabPanel` is replaced by `Tabs` and its sub-components.

## Testing Instructions
1. Launch the Site Editor and the Global Styles sidebar
2. Use the Style Book button to open the modal
3. Test the various tabs, and confirm they look and behave the same as trunk, loading the correct content and maintaining the same appearance

### Testing Instructions for Keyboard
1. Open the Site Editor, Global Styles, then Style Book
2. Press [Tab] to focus the current tab
3. Confirm arrow keys navigate between tabs
4. Confirm tabs are automatically selected when focused
5. Confirm [Tab] again will focus the first element in the selected tab contents