### PR TITLE
Block editor settings: delay selecting pageOnFront, pageForPosts

### DIFF
--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -17,6 +17,7 @@ import {
 	URL_TYPE,
 } from './constants';
 import { store as blockEditorStore } from '../../store';
+import { default as settingsKeys } from '../../private-settings-keys';
 
 export const handleNoop = () => Promise.resolve( [] );
 
@@ -113,7 +114,7 @@ export default function useSearchHandler(
 			const { getSettings } = select( blockEditorStore );
 			const settings = getSettings();
 			return {
-				usePageSettings: settings.__experimentalUsePageSettings,
+				usePageSettings: settings[ settingsKeys.usePageSettings ],
 				fetchSearchSuggestions:
 					settings.__experimentalFetchLinkSuggestions,
 			};

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -108,19 +108,19 @@ export default function useSearchHandler(
 	allowDirectEntry,
 	withCreateSuggestion
 ) {
-	const { fetchSearchSuggestions, pageOnFront, pageForPosts } = useSelect(
+	const { fetchSearchSuggestions, usePageSettings } = useSelect(
 		( select ) => {
 			const { getSettings } = select( blockEditorStore );
-
+			const settings = getSettings();
 			return {
-				pageOnFront: getSettings().pageOnFront,
-				pageForPosts: getSettings().pageForPosts,
+				usePageSettings: settings.__experimentalUsePageSettings,
 				fetchSearchSuggestions:
-					getSettings().__experimentalFetchLinkSuggestions,
+					settings.__experimentalFetchLinkSuggestions,
 			};
 		},
 		[]
 	);
+	const { pageOnFront, pageForPosts } = usePageSettings();
 
 	const directEntryHandler = allowDirectEntry
 		? handleDirectEntry

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -9,7 +9,13 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import isURLLike from './is-url-like';
-import { TEL_TYPE, MAILTO_TYPE, INTERNAL_TYPE, URL_TYPE } from './constants';
+import {
+	CREATE_TYPE,
+	TEL_TYPE,
+	MAILTO_TYPE,
+	INTERNAL_TYPE,
+	URL_TYPE,
+} from './constants';
 import { store as blockEditorStore } from '../../store';
 import { default as settingsKeys } from '../../private-settings-keys';
 
@@ -59,14 +65,42 @@ export default function useSearchHandler(
 	const handleEntitySearch = useHandleEntitySearch?.() || handleNoop;
 
 	return useCallback(
-		( val, { isInitialSuggestions } ) => {
-			return isURLLike( val )
-				? directEntryHandler( val, { isInitialSuggestions } )
-				: handleEntitySearch(
-						val,
-						{ ...suggestionsQuery, isInitialSuggestions },
-						withCreateSuggestion
-				  );
+		async ( val, { isInitialSuggestions } ) => {
+			if ( isURLLike( val ) ) {
+				return directEntryHandler( val, { isInitialSuggestions } );
+			}
+
+			const results = await handleEntitySearch( val, suggestionsQuery );
+
+			// If displaying initial suggestions just return plain results.
+			if ( isInitialSuggestions ) {
+				return results;
+			}
+
+			// Here we append a faux suggestion to represent a "CREATE" option. This
+			// is detected in the rendering of the search results and handled as a
+			// special case. This is currently necessary because the suggestions
+			// dropdown will only appear if there are valid suggestions and
+			// therefore unless the create option is a suggestion it will not
+			// display in scenarios where there are no results returned from the
+			// API. In addition promoting CREATE to a first class suggestion affords
+			// the a11y benefits afforded by `URLInput` to all suggestions (eg:
+			// keyboard handling, ARIA roles...etc).
+			//
+			// Note also that the value of the `title` and `url` properties must correspond
+			// to the text value of the `<input>`. This is because `title` is used
+			// when creating the suggestion. Similarly `url` is used when using keyboard to select
+			// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
+			return ! withCreateSuggestion
+				? results
+				: results.concat( {
+						// the `id` prop is intentionally ommitted here because it
+						// is never exposed as part of the component's public API.
+						// see: https://github.com/WordPress/gutenberg/pull/19775#discussion_r378931316.
+						title: val, // Must match the existing `<input>`s text value.
+						url: val, // Must match the existing `<input>`s text value.
+						type: CREATE_TYPE,
+				  } );
 		},
 		[
 			directEntryHandler,

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -120,7 +120,10 @@ export default function useSearchHandler(
 		},
 		[]
 	);
-	const { pageOnFront, pageForPosts } = usePageSettings();
+	// The function should either be undefined or a stable function reference
+	// throughout the editor lifetime, much like importing a function from a
+	// module. Maybe warn if this becomes a common pattern and it does change?
+	const { pageOnFront, pageForPosts } = usePageSettings?.() ?? {};
 
 	const directEntryHandler = allowDirectEntry
 		? handleDirectEntry

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -24,6 +24,7 @@ import {
 import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
+import { default as settingsKeys } from './private-settings-keys';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -52,4 +53,5 @@ lock( privateApis, {
 	ReusableBlocksRenameHint,
 	useReusableBlocksRenameHint,
 	usesContextKey,
+	settingsKeys,
 } );

--- a/packages/block-editor/src/private-apis.native.js
+++ b/packages/block-editor/src/private-apis.native.js
@@ -4,6 +4,7 @@
 import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
+import { default as settingsKeys } from './private-settings-keys';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -12,4 +13,5 @@ export const privateApis = {};
 lock( privateApis, {
 	...globalStyles,
 	ExperimentalBlockEditorProvider,
+	settingsKeys,
 } );

--- a/packages/block-editor/src/private-settings-keys.js
+++ b/packages/block-editor/src/private-settings-keys.js
@@ -1,3 +1,3 @@
 export default {
-	usePageSettings: Symbol( 'usePageSettings' ),
+	useLinkControlEntitySearch: Symbol( 'useLinkControlEntitySearch' ),
 };

--- a/packages/block-editor/src/private-settings-keys.js
+++ b/packages/block-editor/src/private-settings-keys.js
@@ -1,0 +1,3 @@
+export default {
+	usePageSettings: Symbol( 'usePageSettings' ),
+};

--- a/packages/core-data/src/fetch/index.js
+++ b/packages/core-data/src/fetch/index.js
@@ -36,17 +36,10 @@ export function __experimentalUseLinkControlEntitySearch() {
 	}, [] );
 
 	return useCallback(
-		async ( val, suggestionsQuery, withCreateSuggestion ) => {
-			const { isInitialSuggestions } = suggestionsQuery;
-
-			const results = await fetchLinkSuggestions(
-				val,
-				suggestionsQuery,
-				settings
-			);
-
-			// Identify front page and update type to match.
-			results.map( ( result ) => {
+		async ( val, suggestionsQuery ) => {
+			return (
+				await fetchLinkSuggestions( val, suggestionsQuery, settings )
+			).map( ( result ) => {
 				if ( Number( result.id ) === pageOnFront ) {
 					result.isFrontPage = true;
 					return result;
@@ -57,36 +50,6 @@ export function __experimentalUseLinkControlEntitySearch() {
 
 				return result;
 			} );
-
-			// If displaying initial suggestions just return plain results.
-			if ( isInitialSuggestions ) {
-				return results;
-			}
-
-			// Here we append a faux suggestion to represent a "CREATE" option. This
-			// is detected in the rendering of the search results and handled as a
-			// special case. This is currently necessary because the suggestions
-			// dropdown will only appear if there are valid suggestions and
-			// therefore unless the create option is a suggestion it will not
-			// display in scenarios where there are no results returned from the
-			// API. In addition promoting CREATE to a first class suggestion affords
-			// the a11y benefits afforded by `URLInput` to all suggestions (eg:
-			// keyboard handling, ARIA roles...etc).
-			//
-			// Note also that the value of the `title` and `url` properties must correspond
-			// to the text value of the `<input>`. This is because `title` is used
-			// when creating the suggestion. Similarly `url` is used when using keyboard to select
-			// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
-			return ! withCreateSuggestion
-				? results
-				: results.concat( {
-						// the `id` prop is intentionally ommitted here because it
-						// is never exposed as part of the component's public API.
-						// see: https://github.com/WordPress/gutenberg/pull/19775#discussion_r378931316.
-						title: val, // Must match the existing `<input>`s text value.
-						url: val, // Must match the existing `<input>`s text value.
-						type: '__CREATE__',
-				  } );
 		},
 		[ pageOnFront, pageForPosts, settings ]
 	);

--- a/packages/core-data/src/fetch/index.js
+++ b/packages/core-data/src/fetch/index.js
@@ -1,2 +1,93 @@
-export { default as __experimentalFetchLinkSuggestions } from './__experimental-fetch-link-suggestions';
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { store as coreStore } from '../';
+import { default as fetchLinkSuggestions } from './__experimental-fetch-link-suggestions';
+
+export const __experimentalFetchLinkSuggestions = fetchLinkSuggestions;
 export { default as __experimentalFetchUrlData } from './__experimental-fetch-url-data';
+
+export function __experimentalUseLinkControlEntitySearch() {
+	const settings = useSelect(
+		( select ) => select( blockEditorStore ).getSettings(),
+		[]
+	);
+	// The function should either be undefined or a stable function reference
+	// throughout the editor lifetime, much like importing a function from a
+	// module.
+	const { pageOnFront, pageForPosts } = useSelect( ( select ) => {
+		const { canUser, getEntityRecord } = select( coreStore );
+
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEntityRecord( 'root', 'site' )
+			: undefined;
+
+		return {
+			pageOnFront: siteSettings?.page_on_front,
+			pageForPosts: siteSettings?.page_for_posts,
+		};
+	}, [] );
+
+	return useCallback(
+		async ( val, suggestionsQuery, withCreateSuggestion ) => {
+			const { isInitialSuggestions } = suggestionsQuery;
+
+			const results = await fetchLinkSuggestions(
+				val,
+				suggestionsQuery,
+				settings
+			);
+
+			// Identify front page and update type to match.
+			results.map( ( result ) => {
+				if ( Number( result.id ) === pageOnFront ) {
+					result.isFrontPage = true;
+					return result;
+				} else if ( Number( result.id ) === pageForPosts ) {
+					result.isBlogHome = true;
+					return result;
+				}
+
+				return result;
+			} );
+
+			// If displaying initial suggestions just return plain results.
+			if ( isInitialSuggestions ) {
+				return results;
+			}
+
+			// Here we append a faux suggestion to represent a "CREATE" option. This
+			// is detected in the rendering of the search results and handled as a
+			// special case. This is currently necessary because the suggestions
+			// dropdown will only appear if there are valid suggestions and
+			// therefore unless the create option is a suggestion it will not
+			// display in scenarios where there are no results returned from the
+			// API. In addition promoting CREATE to a first class suggestion affords
+			// the a11y benefits afforded by `URLInput` to all suggestions (eg:
+			// keyboard handling, ARIA roles...etc).
+			//
+			// Note also that the value of the `title` and `url` properties must correspond
+			// to the text value of the `<input>`. This is because `title` is used
+			// when creating the suggestion. Similarly `url` is used when using keyboard to select
+			// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
+			return ! withCreateSuggestion
+				? results
+				: results.concat( {
+						// the `id` prop is intentionally ommitted here because it
+						// is never exposed as part of the component's public API.
+						// see: https://github.com/WordPress/gutenberg/pull/19775#discussion_r378931316.
+						title: val, // Must match the existing `<input>`s text value.
+						url: val, // Must match the existing `<input>`s text value.
+						type: '__CREATE__',
+				  } );
+		},
+		[ pageOnFront, pageForPosts, settings ]
+	);
+}

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -9,13 +9,10 @@ import {
 	useEntityBlockEditor,
 	store as coreStore,
 	useResourcePermissions,
-	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
+	__experimentalUseLinkControlEntitySearch as useLinkControlEntitySearch,
 } from '@wordpress/core-data';
-import { useMemo, useCallback } from '@wordpress/element';
-import {
-	privateApis as blockEditorPrivateApis,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { useMemo } from '@wordpress/element';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
 import { store as preferencesStore } from '@wordpress/preferences';
 
@@ -33,84 +30,6 @@ const { ExperimentalBlockEditorProvider, settingsKeys } = unlock(
 	blockEditorPrivateApis
 );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
-
-function useLinkControlEntitySearch() {
-	const settings = useSelect(
-		( select ) => select( blockEditorStore ).getSettings(),
-		[]
-	);
-	// The function should either be undefined or a stable function reference
-	// throughout the editor lifetime, much like importing a function from a
-	// module.
-	const { pageOnFront, pageForPosts } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord } = select( coreStore );
-
-		const siteSettings = canUser( 'read', 'settings' )
-			? getEntityRecord( 'root', 'site' )
-			: undefined;
-
-		return {
-			pageOnFront: siteSettings?.page_on_front,
-			pageForPosts: siteSettings?.page_for_posts,
-		};
-	}, [] );
-
-	return useCallback(
-		async ( val, suggestionsQuery, withCreateSuggestion ) => {
-			const { isInitialSuggestions } = suggestionsQuery;
-
-			const results = await fetchLinkSuggestions(
-				val,
-				suggestionsQuery,
-				settings
-			);
-
-			// Identify front page and update type to match.
-			results.map( ( result ) => {
-				if ( Number( result.id ) === pageOnFront ) {
-					result.isFrontPage = true;
-					return result;
-				} else if ( Number( result.id ) === pageForPosts ) {
-					result.isBlogHome = true;
-					return result;
-				}
-
-				return result;
-			} );
-
-			// If displaying initial suggestions just return plain results.
-			if ( isInitialSuggestions ) {
-				return results;
-			}
-
-			// Here we append a faux suggestion to represent a "CREATE" option. This
-			// is detected in the rendering of the search results and handled as a
-			// special case. This is currently necessary because the suggestions
-			// dropdown will only appear if there are valid suggestions and
-			// therefore unless the create option is a suggestion it will not
-			// display in scenarios where there are no results returned from the
-			// API. In addition promoting CREATE to a first class suggestion affords
-			// the a11y benefits afforded by `URLInput` to all suggestions (eg:
-			// keyboard handling, ARIA roles...etc).
-			//
-			// Note also that the value of the `title` and `url` properties must correspond
-			// to the text value of the `<input>`. This is because `title` is used
-			// when creating the suggestion. Similarly `url` is used when using keyboard to select
-			// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
-			return ! withCreateSuggestion
-				? results
-				: results.concat( {
-						// the `id` prop is intentionally ommitted here because it
-						// is never exposed as part of the component's public API.
-						// see: https://github.com/WordPress/gutenberg/pull/19775#discussion_r378931316.
-						title: val, // Must match the existing `<input>`s text value.
-						url: val, // Must match the existing `<input>`s text value.
-						type: '__CREATE__',
-				  } );
-		},
-		[ pageOnFront, pageForPosts, settings ]
-	);
-}
 
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -27,6 +27,22 @@ import { unlock } from '../../lock-unlock';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
+
+function usePageSettings() {
+	return useSelect( ( select ) => {
+		const { canUser, getEntityRecord } = select( coreStore );
+
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEntityRecord( 'root', 'site' )
+			: undefined;
+
+		return {
+			pageOnFront: siteSettings?.page_on_front,
+			pageForPosts: siteSettings?.page_for_posts,
+		};
+	}, [] );
+}
+
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,
 	children,
@@ -34,36 +50,25 @@ export default function WidgetAreasBlockEditorProvider( {
 } ) {
 	const mediaPermissions = useResourcePermissions( 'media' );
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const {
-		reusableBlocks,
-		isFixedToolbarActive,
-		keepCaretInsideBlock,
-		pageOnFront,
-		pageForPosts,
-	} = useSelect( ( select ) => {
-		const { canUser, getEntityRecord, getEntityRecords } =
-			select( coreStore );
-		const siteSettings = canUser( 'read', 'settings' )
-			? getEntityRecord( 'root', 'site' )
-			: undefined;
-		return {
-			widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
-			widgets: select( editWidgetsStore ).getWidgets(),
-			reusableBlocks: ALLOW_REUSABLE_BLOCKS
-				? getEntityRecords( 'postType', 'wp_block' )
-				: [],
-			isFixedToolbarActive: !! select( preferencesStore ).get(
-				'core/edit-widgets',
-				'fixedToolbar'
-			),
-			keepCaretInsideBlock: !! select( preferencesStore ).get(
-				'core/edit-widgets',
-				'keepCaretInsideBlock'
-			),
-			pageOnFront: siteSettings?.page_on_front,
-			pageForPosts: siteSettings?.page_for_posts,
-		};
-	}, [] );
+	const { reusableBlocks, isFixedToolbarActive, keepCaretInsideBlock } =
+		useSelect( ( select ) => {
+			const { getEntityRecords } = select( coreStore );
+			return {
+				widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
+				widgets: select( editWidgetsStore ).getWidgets(),
+				reusableBlocks: ALLOW_REUSABLE_BLOCKS
+					? getEntityRecords( 'postType', 'wp_block' )
+					: [],
+				isFixedToolbarActive: !! select( preferencesStore ).get(
+					'core/edit-widgets',
+					'fixedToolbar'
+				),
+				keepCaretInsideBlock: !! select( preferencesStore ).get(
+					'core/edit-widgets',
+					'keepCaretInsideBlock'
+				),
+			};
+		}, [] );
 	const { setIsInserterOpened } = useDispatch( editWidgetsStore );
 
 	const settings = useMemo( () => {
@@ -85,8 +90,7 @@ export default function WidgetAreasBlockEditorProvider( {
 			mediaUpload: mediaUploadBlockEditor,
 			templateLock: 'all',
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
-			pageOnFront,
-			pageForPosts,
+			__experimentalUsePageSettings: usePageSettings,
 		};
 	}, [
 		blockEditorSettings,
@@ -96,8 +100,6 @@ export default function WidgetAreasBlockEditorProvider( {
 		mediaPermissions.canCreate,
 		reusableBlocks,
 		setIsInserterOpened,
-		pageOnFront,
-		pageForPosts,
 	] );
 
 	const widgetAreaId = useLastSelectedWidgetArea();

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -25,7 +25,9 @@ import { store as editWidgetsStore } from '../../store';
 import { ALLOW_REUSABLE_BLOCKS } from '../../constants';
 import { unlock } from '../../lock-unlock';
 
-const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
+const { ExperimentalBlockEditorProvider, settingsKeys } = unlock(
+	blockEditorPrivateApis
+);
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
 
 function usePageSettings() {
@@ -90,7 +92,7 @@ export default function WidgetAreasBlockEditorProvider( {
 			mediaUpload: mediaUploadBlockEditor,
 			templateLock: 'all',
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
-			__experimentalUsePageSettings: usePageSettings,
+			[ settingsKeys.usePageSettings ]: usePageSettings,
 		};
 	}, [
 		blockEditorSettings,

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -9,9 +9,13 @@ import {
 	useEntityBlockEditor,
 	store as coreStore,
 	useResourcePermissions,
+	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
 } from '@wordpress/core-data';
-import { useMemo } from '@wordpress/element';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { useMemo, useCallback } from '@wordpress/element';
+import {
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
 import { store as preferencesStore } from '@wordpress/preferences';
 
@@ -30,8 +34,15 @@ const { ExperimentalBlockEditorProvider, settingsKeys } = unlock(
 );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
 
-function usePageSettings() {
-	return useSelect( ( select ) => {
+function useLinkControlEntitySearch() {
+	const settings = useSelect(
+		( select ) => select( blockEditorStore ).getSettings(),
+		[]
+	);
+	// The function should either be undefined or a stable function reference
+	// throughout the editor lifetime, much like importing a function from a
+	// module.
+	const { pageOnFront, pageForPosts } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord } = select( coreStore );
 
 		const siteSettings = canUser( 'read', 'settings' )
@@ -43,6 +54,62 @@ function usePageSettings() {
 			pageForPosts: siteSettings?.page_for_posts,
 		};
 	}, [] );
+
+	return useCallback(
+		async ( val, suggestionsQuery, withCreateSuggestion ) => {
+			const { isInitialSuggestions } = suggestionsQuery;
+
+			const results = await fetchLinkSuggestions(
+				val,
+				suggestionsQuery,
+				settings
+			);
+
+			// Identify front page and update type to match.
+			results.map( ( result ) => {
+				if ( Number( result.id ) === pageOnFront ) {
+					result.isFrontPage = true;
+					return result;
+				} else if ( Number( result.id ) === pageForPosts ) {
+					result.isBlogHome = true;
+					return result;
+				}
+
+				return result;
+			} );
+
+			// If displaying initial suggestions just return plain results.
+			if ( isInitialSuggestions ) {
+				return results;
+			}
+
+			// Here we append a faux suggestion to represent a "CREATE" option. This
+			// is detected in the rendering of the search results and handled as a
+			// special case. This is currently necessary because the suggestions
+			// dropdown will only appear if there are valid suggestions and
+			// therefore unless the create option is a suggestion it will not
+			// display in scenarios where there are no results returned from the
+			// API. In addition promoting CREATE to a first class suggestion affords
+			// the a11y benefits afforded by `URLInput` to all suggestions (eg:
+			// keyboard handling, ARIA roles...etc).
+			//
+			// Note also that the value of the `title` and `url` properties must correspond
+			// to the text value of the `<input>`. This is because `title` is used
+			// when creating the suggestion. Similarly `url` is used when using keyboard to select
+			// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
+			return ! withCreateSuggestion
+				? results
+				: results.concat( {
+						// the `id` prop is intentionally ommitted here because it
+						// is never exposed as part of the component's public API.
+						// see: https://github.com/WordPress/gutenberg/pull/19775#discussion_r378931316.
+						title: val, // Must match the existing `<input>`s text value.
+						url: val, // Must match the existing `<input>`s text value.
+						type: '__CREATE__',
+				  } );
+		},
+		[ pageOnFront, pageForPosts, settings ]
+	);
 }
 
 export default function WidgetAreasBlockEditorProvider( {
@@ -92,7 +159,8 @@ export default function WidgetAreasBlockEditorProvider( {
 			mediaUpload: mediaUploadBlockEditor,
 			templateLock: 'all',
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
-			[ settingsKeys.usePageSettings ]: usePageSettings,
+			[ settingsKeys.useLinkControlEntitySearch ]:
+				useLinkControlEntitySearch,
 		};
 	}, [
 		blockEditorSettings,

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -15,7 +15,6 @@ import {
 	__experimentalGetCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
-import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
 import {
 	registerLegacyWidgetBlock,
 	registerLegacyWidgetVariations,
@@ -81,9 +80,6 @@ export function initializeEditor( id, settings ) {
 	registerLegacyWidgetVariations( settings );
 	registerBlock( widgetArea );
 	registerWidgetGroupBlock();
-
-	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>
-		fetchLinkSuggestions( search, searchOptions, settings );
 
 	// As we are unregistering `core/freeform` to avoid the Classic block, we must
 	// replace it with something as the default freeform content handler. Failure to

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -15,6 +15,7 @@ import {
 	__experimentalGetCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
+import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
 import {
 	registerLegacyWidgetBlock,
 	registerLegacyWidgetVariations,
@@ -80,6 +81,9 @@ export function initializeEditor( id, settings ) {
 	registerLegacyWidgetVariations( settings );
 	registerBlock( widgetArea );
 	registerWidgetGroupBlock();
+
+	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>
+		fetchLinkSuggestions( search, searchOptions, settings );
 
 	// As we are unregistering `core/freeform` to avoid the Classic block, we must
 	// replace it with something as the default freeform content handler. Failure to

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -5,14 +5,11 @@ import { Platform, useMemo, useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
-	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
+	__experimentalUseLinkControlEntitySearch as useLinkControlEntitySearch,
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
-import {
-	privateApis as blockEditorPrivateApis,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -84,84 +81,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalArchiveTitleTypeLabel',
 	'__experimentalArchiveTitleNameLabel',
 ];
-
-function useLinkControlEntitySearch() {
-	const settings = useSelect(
-		( select ) => select( blockEditorStore ).getSettings(),
-		[]
-	);
-	// The function should either be undefined or a stable function reference
-	// throughout the editor lifetime, much like importing a function from a
-	// module.
-	const { pageOnFront, pageForPosts } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord } = select( coreStore );
-
-		const siteSettings = canUser( 'read', 'settings' )
-			? getEntityRecord( 'root', 'site' )
-			: undefined;
-
-		return {
-			pageOnFront: siteSettings?.page_on_front,
-			pageForPosts: siteSettings?.page_for_posts,
-		};
-	}, [] );
-
-	return useCallback(
-		async ( val, suggestionsQuery, withCreateSuggestion ) => {
-			const { isInitialSuggestions } = suggestionsQuery;
-
-			const results = await fetchLinkSuggestions(
-				val,
-				suggestionsQuery,
-				settings
-			);
-
-			// Identify front page and update type to match.
-			results.map( ( result ) => {
-				if ( Number( result.id ) === pageOnFront ) {
-					result.isFrontPage = true;
-					return result;
-				} else if ( Number( result.id ) === pageForPosts ) {
-					result.isBlogHome = true;
-					return result;
-				}
-
-				return result;
-			} );
-
-			// If displaying initial suggestions just return plain results.
-			if ( isInitialSuggestions ) {
-				return results;
-			}
-
-			// Here we append a faux suggestion to represent a "CREATE" option. This
-			// is detected in the rendering of the search results and handled as a
-			// special case. This is currently necessary because the suggestions
-			// dropdown will only appear if there are valid suggestions and
-			// therefore unless the create option is a suggestion it will not
-			// display in scenarios where there are no results returned from the
-			// API. In addition promoting CREATE to a first class suggestion affords
-			// the a11y benefits afforded by `URLInput` to all suggestions (eg:
-			// keyboard handling, ARIA roles...etc).
-			//
-			// Note also that the value of the `title` and `url` properties must correspond
-			// to the text value of the `<input>`. This is because `title` is used
-			// when creating the suggestion. Similarly `url` is used when using keyboard to select
-			// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
-			return ! withCreateSuggestion
-				? results
-				: results.concat( {
-						// the `id` prop is intentionally ommitted here because it
-						// is never exposed as part of the component's public API.
-						// see: https://github.com/WordPress/gutenberg/pull/19775#discussion_r378931316.
-						title: val, // Must match the existing `<input>`s text value.
-						url: val, // Must match the existing `<input>`s text value.
-						type: '__CREATE__',
-				  } );
-		},
-		[ pageOnFront, pageForPosts, settings ]
-	);
-}
 
 /**
  * React hook used to compute the block editor settings to use for the post editor.

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -78,6 +78,21 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalArchiveTitleNameLabel',
 ];
 
+function usePageSettings() {
+	return useSelect( ( select ) => {
+		const { canUser, getEntityRecord } = select( coreStore );
+
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEntityRecord( 'root', 'site' )
+			: undefined;
+
+		return {
+			pageOnFront: siteSettings?.page_on_front,
+			pageForPosts: siteSettings?.page_for_posts,
+		};
+	}, [] );
+}
+
 /**
  * React hook used to compute the block editor settings to use for the post editor.
  *
@@ -93,8 +108,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		hasUploadPermissions,
 		canUseUnfilteredHTML,
 		userCanCreatePages,
-		pageOnFront,
-		pageForPosts,
 		userPatternCategories,
 		restBlockPatterns,
 		restBlockPatternCategories,
@@ -104,16 +117,11 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			const {
 				canUser,
 				getRawEntityRecord,
-				getEntityRecord,
 				getUserPatternCategories,
 				getEntityRecords,
 				getBlockPatterns,
 				getBlockPatternCategories,
 			} = select( coreStore );
-
-			const siteSettings = canUser( 'read', 'settings' )
-				? getEntityRecord( 'root', 'site' )
-				: undefined;
 
 			return {
 				canUseUnfilteredHTML: getRawEntityRecord(
@@ -128,8 +136,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 					: EMPTY_BLOCKS_LIST, // Reusable blocks are fetched in the native version of this hook.
 				hasUploadPermissions: canUser( 'create', 'media' ) ?? true,
 				userCanCreatePages: canUser( 'create', 'pages' ),
-				pageOnFront: siteSettings?.page_on_front,
-				pageForPosts: siteSettings?.page_for_posts,
 				userPatternCategories: getUserPatternCategories(),
 				restBlockPatterns: getBlockPatterns(),
 				restBlockPatternCategories: getBlockPatternCategories(),
@@ -229,8 +235,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			// Check these two properties: they were not present in the site editor.
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
-			pageOnFront,
-			pageForPosts,
+			__experimentalUsePageSettings: usePageSettings,
 			__experimentalPreferPatternsOnRoot: postType === 'wp_template',
 			templateLock:
 				postType === 'wp_navigation' ? 'insert' : settings.templateLock,
@@ -251,8 +256,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			undo,
 			createPageEntity,
 			userCanCreatePages,
-			pageOnFront,
-			pageForPosts,
 			postType,
 			setIsInserterOpened,
 		]

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -6,6 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
 	__experimentalUseLinkControlEntitySearch as useLinkControlEntitySearch,
+	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
@@ -209,6 +210,9 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
 			__experimentalUserPatternCategories: userPatternCategories,
+			// We still need this for mobile and URLInput.
+			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
+				fetchLinkSuggestions( search, searchOptions, settings ),
 			inserterMediaCategories,
 			__experimentalFetchRichUrlData: fetchUrlData,
 			// Todo: This only checks the top level post, not the post within a template or any other entity that can be edited.

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -9,6 +9,7 @@ import {
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -16,6 +17,9 @@ import { __ } from '@wordpress/i18n';
 import inserterMediaCategories from '../media-categories';
 import { mediaUpload } from '../../utils';
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { settingsKeys } = unlock( blockEditorPrivateApis );
 
 const EMPTY_BLOCKS_LIST = [];
 
@@ -235,7 +239,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			// Check these two properties: they were not present in the site editor.
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
-			__experimentalUsePageSettings: usePageSettings,
+			[ settingsKeys.usePageSettings ]: usePageSettings,
 			__experimentalPreferPatternsOnRoot: postType === 'wp_template',
 			templateLock:
 				postType === 'wp_navigation' ? 'insert' : settings.templateLock,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -9,7 +9,10 @@ import {
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import {
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -82,8 +85,15 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalArchiveTitleNameLabel',
 ];
 
-function usePageSettings() {
-	return useSelect( ( select ) => {
+function useLinkControlEntitySearch() {
+	const settings = useSelect(
+		( select ) => select( blockEditorStore ).getSettings(),
+		[]
+	);
+	// The function should either be undefined or a stable function reference
+	// throughout the editor lifetime, much like importing a function from a
+	// module.
+	const { pageOnFront, pageForPosts } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord } = select( coreStore );
 
 		const siteSettings = canUser( 'read', 'settings' )
@@ -95,6 +105,62 @@ function usePageSettings() {
 			pageForPosts: siteSettings?.page_for_posts,
 		};
 	}, [] );
+
+	return useCallback(
+		async ( val, suggestionsQuery, withCreateSuggestion ) => {
+			const { isInitialSuggestions } = suggestionsQuery;
+
+			const results = await fetchLinkSuggestions(
+				val,
+				suggestionsQuery,
+				settings
+			);
+
+			// Identify front page and update type to match.
+			results.map( ( result ) => {
+				if ( Number( result.id ) === pageOnFront ) {
+					result.isFrontPage = true;
+					return result;
+				} else if ( Number( result.id ) === pageForPosts ) {
+					result.isBlogHome = true;
+					return result;
+				}
+
+				return result;
+			} );
+
+			// If displaying initial suggestions just return plain results.
+			if ( isInitialSuggestions ) {
+				return results;
+			}
+
+			// Here we append a faux suggestion to represent a "CREATE" option. This
+			// is detected in the rendering of the search results and handled as a
+			// special case. This is currently necessary because the suggestions
+			// dropdown will only appear if there are valid suggestions and
+			// therefore unless the create option is a suggestion it will not
+			// display in scenarios where there are no results returned from the
+			// API. In addition promoting CREATE to a first class suggestion affords
+			// the a11y benefits afforded by `URLInput` to all suggestions (eg:
+			// keyboard handling, ARIA roles...etc).
+			//
+			// Note also that the value of the `title` and `url` properties must correspond
+			// to the text value of the `<input>`. This is because `title` is used
+			// when creating the suggestion. Similarly `url` is used when using keyboard to select
+			// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
+			return ! withCreateSuggestion
+				? results
+				: results.concat( {
+						// the `id` prop is intentionally ommitted here because it
+						// is never exposed as part of the component's public API.
+						// see: https://github.com/WordPress/gutenberg/pull/19775#discussion_r378931316.
+						title: val, // Must match the existing `<input>`s text value.
+						url: val, // Must match the existing `<input>`s text value.
+						type: '__CREATE__',
+				  } );
+		},
+		[ pageOnFront, pageForPosts, settings ]
+	);
 }
 
 /**
@@ -224,8 +290,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
 			__experimentalUserPatternCategories: userPatternCategories,
-			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
-				fetchLinkSuggestions( search, searchOptions, settings ),
 			inserterMediaCategories,
 			__experimentalFetchRichUrlData: fetchUrlData,
 			// Todo: This only checks the top level post, not the post within a template or any other entity that can be edited.
@@ -239,7 +303,8 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			// Check these two properties: they were not present in the site editor.
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
-			[ settingsKeys.usePageSettings ]: usePageSettings,
+			[ settingsKeys.useLinkControlEntitySearch ]:
+				useLinkControlEntitySearch,
 			__experimentalPreferPatternsOnRoot: postType === 'wp_template',
 			templateLock:
 				postType === 'wp_navigation' ? 'insert' : settings.templateLock,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Instead of fetching site setting on page load and updating the block editor store, let's delay fetching the information until it's needed.

So what I'm doing in this PR is: instead of selecting and passing the result as a block editor setting, I'm passing a function (hook) to allow components to subscribe to the information themselves. For this to work correctly, the hook must remain a stable function of course, just as any other hook. If this becomes a more used pattern, we could consider warning if it does change.

This is part of a larger effort to reduce fetching information for block editor settings. The idea is to do something similar for patterns and reusable blocks: only fetch them when it's needed, instead of on page load.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
