### PR TITLE
Account for top toolbar block selection with no block toolbar

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { useViewportMatch, useReducedMotion } from '@wordpress/compose';
 import {
 	BlockToolbar,
+	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -43,6 +44,7 @@ import { unlock } from '../../lock-unlock';
 import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
 const { PostViewLink, PreviewDropdown } = unlock( editorPrivateApis );
+const { useCanBlockToolbarBeFocused } = unlock( blockEditorPrivateApis );
 
 export default function HeaderEditMode() {
 	const {
@@ -99,7 +101,7 @@ export default function HeaderEditMode() {
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
 
-	const hasBlockSelected = !! blockSelectionStart;
+	const hasBlockToolbar = useCanBlockToolbarBeFocused();
 
 	useEffect( () => {
 		// If we have a new block selection, show the block tools
@@ -154,7 +156,7 @@ export default function HeaderEditMode() {
 								ref={ blockToolbarRef }
 								name="block-toolbar"
 							/>
-							{ hasBlockSelected && (
+							{ hasBlockToolbar && (
 								<Button
 									className="edit-site-header-edit-mode__block-tools-toggle"
 									icon={
@@ -183,7 +185,9 @@ export default function HeaderEditMode() {
 						'edit-site-header-edit-mode__center',
 						{
 							'is-collapsed':
-								! isBlockToolsCollapsed && isLargeViewport,
+								! isBlockToolsCollapsed &&
+								isLargeViewport &&
+								hasBlockToolbar,
 						}
 					) }
 				>


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/57288.

## What?
There are some instances where a block can be selected but no block toolbar shows in the header. 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Bug fix to show the central document command center in the template editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This is a messy approach but duplicates the return null check from BlockToolbar into useCanBlockToolbarBeFocused. I think it would be better to combine the null check from BlockToolbar into its own hook so that hook can be used within useCanBlockToolbarBeFocused.

## TODO

- [ ] Refactor `null` check in `<BlockToolbar />` to its own check and use it within `useCanBlockToolbarBeFocused`?
- [ ] Implement this check anywhere else it needs to be (Post Editor -> Edit Template is the only other one, I think)

## Testing Instructions
- Go to Site Editor
- Turn on Top Toolbar
- Edit Navigation Template Part
- Click navigation item
- Press Up Arrow until the block toolbar disappears and the central document command center reappears
