### PR TITLE
Components: replace `TabPanel` with `Tabs` in inline color picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55121,6 +55121,7 @@
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/url": "file:../url"
 			},
@@ -69972,6 +69973,7 @@
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/url": "file:../url"
 			}

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/url": "file:../url"
 	},

--- a/packages/format-library/src/lock-unlock.js
+++ b/packages/format-library/src/lock-unlock.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'@wordpress/format-library'
+	);

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -17,13 +17,24 @@ import {
 	store as blockEditorStore,
 	useCachedTruthy,
 } from '@wordpress/block-editor';
-import { Popover, TabPanel } from '@wordpress/components';
+import {
+	Popover,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { textColor as settings, transparentValue } from './index';
+import { unlock } from '../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
+
+const TABS = [
+	{ name: 'color', title: __( 'Text' ) },
+	{ name: 'backgroundColor', title: __( 'Background' ) },
+];
 
 function parseCSS( css = '' ) {
 	return css.split( ';' ).reduce( ( accumulator, rule ) => {
@@ -158,27 +169,29 @@ export default function InlineColorUI( {
 			className="components-inline-color-popover"
 			anchor={ popoverAnchor }
 		>
-			<TabPanel
-				tabs={ [
-					{
-						name: 'color',
-						title: __( 'Text' ),
-					},
-					{
-						name: 'backgroundColor',
-						title: __( 'Background' ),
-					},
-				] }
-			>
-				{ ( tab ) => (
-					<ColorPicker
-						name={ name }
-						property={ tab.name }
-						value={ value }
-						onChange={ onChange }
-					/>
-				) }
-			</TabPanel>
+			<Tabs>
+				<Tabs.TabList>
+					{ TABS.map( ( tab ) => (
+						<Tabs.Tab tabId={ tab.name } key={ tab.name }>
+							{ tab.title }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.TabList>
+				{ TABS.map( ( tab ) => (
+					<Tabs.TabPanel
+						tabId={ tab.name }
+						focusable={ false }
+						key={ tab.name }
+					>
+						<ColorPicker
+							name={ name }
+							property={ tab.name }
+							value={ value }
+							onChange={ onChange }
+						/>
+					</Tabs.TabPanel>
+				) ) }
+			</Tabs>
 		</Popover>
 	);
 }

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -166,7 +166,7 @@ export default function InlineColorUI( {
 	return (
 		<Popover
 			onClose={ onClose }
-			className="components-inline-color-popover"
+			className="format-library__inline-color-popover"
 			anchor={ popoverAnchor }
 		>
 			<Tabs>

--- a/packages/format-library/src/text-color/style.scss
+++ b/packages/format-library/src/text-color/style.scss
@@ -1,7 +1,7 @@
 .components-inline-color-popover {
 
 	.components-popover__content {
-		.components-tab-panel__tab-content {
+		[role="tabpanel"] {
 			padding: 16px;
 		}
 

--- a/packages/format-library/src/text-color/style.scss
+++ b/packages/format-library/src/text-color/style.scss
@@ -1,23 +1,6 @@
-.components-inline-color-popover {
+.format-library__inline-color-popover {
 
-	.components-popover__content {
-		[role="tabpanel"] {
-			padding: 16px;
-		}
-
-		.components-color-palette {
-			margin-top: 0.6rem;
-		}
-
-		.components-base-control__title {
-			display: block;
-			margin-bottom: 16px;
-			font-weight: 600;
-			color: #191e23;
-		}
-
-		.component-color-indicator {
-			vertical-align: text-bottom;
-		}
+	[role="tabpanel"] {
+		padding: 16px;
 	}
 }

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -24,6 +24,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/edit-site',
 	'@wordpress/edit-widgets',
 	'@wordpress/editor',
+	'@wordpress/format-library',
 	'@wordpress/patterns',
 	'@wordpress/reusable-blocks',
 	'@wordpress/router',


### PR DESCRIPTION
## What?
Replaces the legacy TabPanel component with the new Tabs component.

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

## How?
`TabPanel` is replaced by `Tabs` and its sub-components.

## Other Stuff
This change does cause a small shift in the width of the tabs. There is a [style override](https://github.com/WordPress/gutenberg/blob/338ae241d6d167b457f364cde737f96264b9ab44/packages/edit-post/src/components/visual-editor/style.scss#L19) that no longer applies after this change because we're not rendering a `Button`, and therefore the tabs do not have the `.components-button` class associated with them.

My assumption is that we'd like to keep the buttons on these tabs consistent with the previous styling. Would it be best to do that by
- applying matching padding directly in this implementation (wouldn't stay in sync if the above override was ever changed)
- updating that override to also target `button[role=tab]` (I'm not sure if this would have unintended side effects elsewhere)
- Or perhaps something else altogether?
 
cc'ing @WordPress/gutenberg-design for input. (this isn't an urgent ping, I'll be afk for the holidays coming up, but I'll circle back to this PR in the new year).

## Testing Instructions
1. Create a new post
2. Add some text to a paragraph block
3. Highlight that test and use the block toolbar's **more** dropdown to select **Highlight**
4. Confirm that the **Text** and **Background** tabs match the look and behavior of `trunk` (pending an answer to the padding question above)

### Testing Instructions for Keyboard
1. Create a post with text in a paragraph block. Select some text and navigate to the **more** dropdown in the block toolbar. The specific navigation here might vary depending on your block toolbar settings.
2. Open the **Highlight** option and confirm that focus goes to the first tab
3. Confirm arrow keys move between tabs, selecting them automatically
4. Confirm that [Tab] moves focus to the color palette swatch/button