### PR TITLE
Components: replace `TabPanel` with `Tabs` in the Editor Preferences Modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55216,6 +55216,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/plugins": "file:../plugins",
 				"@wordpress/preferences": "file:../preferences",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/viewport": "file:../viewport",
 				"classnames": "^2.3.1"
 			},
@@ -70031,6 +70032,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/plugins": "file:../plugins",
 				"@wordpress/preferences": "file:../preferences",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/viewport": "file:../viewport",
 				"classnames": "^2.3.1"
 			}

--- a/packages/interface/lock-unlock.js
+++ b/packages/interface/lock-unlock.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'@wordpress/interface'
+	);

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -42,6 +42,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/preferences": "file:../preferences",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.3.1"
 	},

--- a/packages/interface/src/components/preferences-modal-tabs/index.js
+++ b/packages/interface/src/components/preferences-modal-tabs/index.js
@@ -72,9 +72,13 @@ export default function PreferencesModalTabs( { sections } ) {
 					onSelect={ setActiveMenu }
 					orientation="vertical"
 				>
-					<Tabs.TabList>
+					<Tabs.TabList className="interface-preferences__tabs-tablist">
 						{ tabs.map( ( tab ) => (
-							<Tabs.Tab tabId={ tab.name } key={ tab.name }>
+							<Tabs.Tab
+								tabId={ tab.name }
+								key={ tab.name }
+								className="interface-preferences__tabs-tab"
+							>
 								{ tab.title }
 							</Tabs.Tab>
 						) ) }
@@ -83,6 +87,7 @@ export default function PreferencesModalTabs( { sections } ) {
 						<Tabs.TabPanel
 							tabId={ tab.name }
 							key={ tab.name }
+							className="interface-preferences__tabs-tabpanel"
 							focusable={ false }
 						>
 							{ sectionsContentMap[ tab.name ] || null }

--- a/packages/interface/src/components/preferences-modal-tabs/index.js
+++ b/packages/interface/src/components/preferences-modal-tabs/index.js
@@ -39,7 +39,7 @@ export default function PreferencesModalTabs( { sections } ) {
 	const [ activeMenu, setActiveMenu ] = useState( PREFERENCES_MENU );
 	/**
 	 * Create helper objects from `sections` for easier data handling.
-	 * `tabs` is used for creating the `TabPanel` and `sectionsContentMap`
+	 * `tabs` is used for creating the `Tabs` and `sectionsContentMap`
 	 * is used for easier access to active tab's content.
 	 */
 	const { tabs, sectionsContentMap } = useMemo( () => {

--- a/packages/interface/src/components/preferences-modal-tabs/index.js
+++ b/packages/interface/src/components/preferences-modal-tabs/index.js
@@ -13,14 +13,21 @@ import {
 	__experimentalText as Text,
 	__experimentalTruncate as Truncate,
 	FlexItem,
-	TabPanel,
 	Card,
 	CardHeader,
 	CardBody,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { useMemo, useCallback, useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { isRTL, __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../../lock-unlock';
+
+const { Tabs } = unlock( componentsPrivateApis );
 
 const PREFERENCES_MENU = 'preferences-menu';
 
@@ -53,26 +60,36 @@ export default function PreferencesModalTabs( { sections } ) {
 		return mappedTabs;
 	}, [ sections ] );
 
-	const getCurrentTab = useCallback(
-		( tab ) => sectionsContentMap[ tab.name ] || null,
-		[ sectionsContentMap ]
-	);
-
 	let modalContent;
 	// We render different components based on the viewport size.
 	if ( isLargeViewport ) {
 		modalContent = (
-			<TabPanel
-				className="interface-preferences__tabs"
-				tabs={ tabs }
-				initialTabName={
-					activeMenu !== PREFERENCES_MENU ? activeMenu : undefined
-				}
-				onSelect={ setActiveMenu }
-				orientation="vertical"
-			>
-				{ getCurrentTab }
-			</TabPanel>
+			<div className="interface-preferences__tabs">
+				<Tabs
+					initialTabId={
+						activeMenu !== PREFERENCES_MENU ? activeMenu : undefined
+					}
+					onSelect={ setActiveMenu }
+					orientation="vertical"
+				>
+					<Tabs.TabList>
+						{ tabs.map( ( tab ) => (
+							<Tabs.Tab tabId={ tab.name } key={ tab.name }>
+								{ tab.title }
+							</Tabs.Tab>
+						) ) }
+					</Tabs.TabList>
+					{ tabs.map( ( tab ) => (
+						<Tabs.TabPanel
+							tabId={ tab.name }
+							key={ tab.name }
+							focusable={ false }
+						>
+							{ sectionsContentMap[ tab.name ] || null }
+						</Tabs.TabPanel>
+					) ) }
+				</Tabs>
+			</div>
 		);
 	} else {
 		modalContent = (

--- a/packages/interface/src/components/preferences-modal-tabs/style.scss
+++ b/packages/interface/src/components/preferences-modal-tabs/style.scss
@@ -1,24 +1,24 @@
 $vertical-tabs-width: 160px;
 
 .interface-preferences__tabs {
-	.components-tab-panel__tabs {
+	[role="tablist"] {
 		position: absolute;
 		top: $header-height + $grid-unit-30;
 		// Aligns button text instead of button box.
 		left: $grid-unit-20;
 		width: $vertical-tabs-width;
 
-		.components-tab-panel__tabs-item {
+		[role="tab"] {
 			border-radius: $radius-block-ui;
 			font-weight: 400;
 
-			&.is-active {
+			&[aria-selected="true"] {
 				background: $gray-100;
 				box-shadow: none;
 				font-weight: 500;
 			}
 
-			&.is-active::after {
+			&[aria-selected="true"]::after {
 				content: none;
 			}
 
@@ -34,7 +34,7 @@ $vertical-tabs-width: 160px;
 		}
 	}
 
-	.components-tab-panel__tab-content {
+	[role="tabpanel"] {
 		padding-left: $grid-unit-30;
 		margin-left: $vertical-tabs-width;
 	}

--- a/packages/interface/src/components/preferences-modal-tabs/style.scss
+++ b/packages/interface/src/components/preferences-modal-tabs/style.scss
@@ -1,43 +1,42 @@
 $vertical-tabs-width: 160px;
 
-.interface-preferences__tabs {
-	.interface-preferences__tabs-tablist {
-		position: absolute;
-		top: $header-height + $grid-unit-30;
-		// Aligns button text instead of button box.
-		left: $grid-unit-20;
-		width: $vertical-tabs-width;
+.interface-preferences__tabs-tablist {
+	position: absolute;
+	top: $header-height + $grid-unit-30;
+	// Aligns button text instead of button box.
+	left: $grid-unit-20;
+	width: $vertical-tabs-width;
 
-		.interface-preferences__tabs-tab {
-			border-radius: $radius-block-ui;
-			font-weight: 400;
+}
 
-			&[aria-selected="true"] {
-				background: $gray-100;
-				box-shadow: none;
-				font-weight: 500;
-			}
+.interface-preferences__tabs-tab {
+	border-radius: $radius-block-ui;
+	font-weight: 400;
 
-			&[aria-selected="true"]::after {
-				content: none;
-			}
-
-			&:focus:not(:disabled) {
-				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-				// Windows high contrast mode.
-				outline: 2px solid transparent;
-			}
-
-			&:focus-visible::before {
-				content: none;
-			}
-		}
+	&[aria-selected="true"] {
+		background: $gray-100;
+		box-shadow: none;
+		font-weight: 500;
 	}
 
-	.interface-preferences__tabs-tabpanel {
-		padding-left: $grid-unit-30;
-		margin-left: $vertical-tabs-width;
+	&[aria-selected="true"]::after {
+		content: none;
 	}
+
+	&[role="tab"]:focus:not(:disabled) {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		// Windows high contrast mode.
+		outline: 2px solid transparent;
+	}
+
+	&:focus-visible::before {
+		content: none;
+	}
+}
+
+.interface-preferences__tabs-tabpanel {
+	padding-left: $grid-unit-30;
+	margin-left: $vertical-tabs-width;
 }
 
 @media (max-width: #{ ($break-medium - 1) }) {

--- a/packages/interface/src/components/preferences-modal-tabs/style.scss
+++ b/packages/interface/src/components/preferences-modal-tabs/style.scss
@@ -1,14 +1,14 @@
 $vertical-tabs-width: 160px;
 
 .interface-preferences__tabs {
-	[role="tablist"] {
+	.interface-preferences__tabs-tablist {
 		position: absolute;
 		top: $header-height + $grid-unit-30;
 		// Aligns button text instead of button box.
 		left: $grid-unit-20;
 		width: $vertical-tabs-width;
 
-		[role="tab"] {
+		.interface-preferences__tabs-tab {
 			border-radius: $radius-block-ui;
 			font-weight: 400;
 
@@ -34,7 +34,7 @@ $vertical-tabs-width: 160px;
 		}
 	}
 
-	[role="tabpanel"] {
+	.interface-preferences__tabs-tabpanel {
 		padding-left: $grid-unit-30;
 		margin-left: $vertical-tabs-width;
 	}

--- a/packages/private-apis/src/implementation.js
+++ b/packages/private-apis/src/implementation.js
@@ -25,6 +25,7 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/edit-widgets',
 	'@wordpress/editor',
 	'@wordpress/format-library',
+	'@wordpress/interface',
 	'@wordpress/patterns',
 	'@wordpress/reusable-blocks',
 	'@wordpress/router',


### PR DESCRIPTION
## What?
Replaces the legacy TabPanel component with the new Tabs component.

## Why?
Part of the work outlined in https://github.com/WordPress/gutenberg/issues/52997

## How?
`TabPanel` is replaced by `Tabs` and its sub-components.

## Testing Instructions
1. Create a new post
2. Click on the **Options** button in the top right corner, then **Preferences** at the bottom of the menu that opens
3. Test the tabs (this set is aligned vertically, unlike other similar, recent PRs), confirming that their appearance and behavior matches `trunk`	

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
1. Make sure your browser window is full-height, and your devtools are not open in a way that shortens the heights of the viewport. Scroll behavior will impact some of these tests.
2. Create a new post
3. Use <kbd>Tab</kbd> to navigate across the top toolbar to the **Options** button on the far right, and press <kbd>Space</kbd> to activate it.
4. <kbd>ArrowDown</kbd> to the **Preferences** option and once again press <kbd>Space</kbd> to activate it.
5. Assuming the **General** tab (which should be displayed by default) is not scrollable, confirm that pressing <kbd>Tab</kbd> cycles thought the **Close** button, then over to the **General** tab itself, and then to the first toggle being displayed in the tab contents. From there, <kbd>Tab</kbd> should navigate through all of the displayed toggles for this tab.
6. Now, using <kbd>Shift</kbd>+<kbd>Tab</kbd>, confirm that the opposite focus is applied in the opposite order. Reversing through the contents of the `tabpanel`, then to the **General** tab itself, then to the **Close** button.
8. Confirm that during that during all of this, the `tabpanel` itself does not get a tab stop, nor does the wrapper around the contents of the Preferences`Modal`.
9. <kbd>Tab</kbd> or <kbd>Shift</kbd>+<kbd>Tab</kbd> back to focusing on the **General** tab.
10. <kbd>ArrowDown</kbd> to the **Blocks** tab, which has a lot more content and should be scrollable.
11. Repeate the above <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> tests. This time, because the tab is scrollable, the `Modal` contents wrapper should get a tab stop between the last element in the `tabpanel` contenst and the **Close** button. Effectively, focusing the **Close** button and pressing <kbd>Shift</kbd>+<kbd>Tab</kbd> should focus the wrapper. Pressing <kbd>Shift</kbd>+<kbd>Tab</kbd> should go to the last toggle of the currently displayed options.