### PR TITLE
Remove previous safari-specific fix for selection styles

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -24,10 +24,6 @@
 .block-editor-block-list__layout {
 	position: relative;
 
-	.has-multi-selection &::selection {
-		background: transparent;
-	}
-
 	// Block multi selection
 	// Apply a rounded radius to the entire block when multi selected, but with low specificity
 	// so explicit radii set by tools are preserved.

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -24,12 +24,6 @@
 .block-editor-block-list__layout {
 	position: relative;
 
-	// Hide selections on this element, otherwise Safari will include it stacked
-	// under your actual selection.
-	&::selection {
-		background: transparent;
-	}
-
 	.has-multi-selection &::selection {
 		background: transparent;
 	}


### PR DESCRIPTION
## What?
Fixes #56408

A past fix for selection styles in Safari is causing an issue in newer versions of Chrome—it results in any text selection being invisible.

## How?
I've removed the fix for Safari, but unfortunately it reintroduces an issue there. Unless someone else can fix this in a better way, then I think this is the best trade-off.

## Testing Instructions
1. Try selecting text in chrome canary and safari

Expected: Nothing weird should happen visually, text should be selected
But In Safari: Some of the selection styles do look a bit clunky

## Screenshots or screencast <!-- if applicable -->
*Before, in Chrome Canary:*

https://github.com/WordPress/gutenberg/assets/677833/48faf246-647c-4bdf-8351-205e7169bcf2

*Before, in Safari*

![Screenshot 2023-12-21 at 3 44 50 pm](https://github.com/WordPress/gutenberg/assets/677833/e312f906-f0d8-4464-b69d-b6d01ad902f2)


*After, in Chrome Canary:*
![Screenshot 2023-12-21 at 3 43 32 pm](https://github.com/WordPress/gutenberg/assets/677833/dc464f23-56a5-4fa9-b136-7e8122201687)


*After, in Safari:*
![Screenshot 2023-12-21 at 3 44 00 pm](https://github.com/WordPress/gutenberg/assets/677833/6a1d4155-08c4-4779-980e-52d03ecd58a1)

