### PR TITLE
POC: Create semantic HTML variations of core/group

### DIFF
--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -72,6 +72,8 @@ export default function useBlockDisplayTitle( {
 		? getBlockLabel( blockType, attributes, context )
 		: null;
 
+	const { tagName } = attributes;
+
 	const label = reusableBlockTitle || blockLabel;
 	// Label will fallback to the title if no label is defined for the current
 	// label context. If the label is defined we prioritize it over a
@@ -90,5 +92,5 @@ export default function useBlockDisplayTitle( {
 		);
 	}
 
-	return blockTitle;
+	return tagName ? blockTitle + ` (${ tagName })` : blockTitle;
 }

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -57,4 +57,41 @@ if ( window?.__experimentalEnableGroupGridVariation ) {
 	} );
 }
 
+const semanticTagNames = [
+	'section',
+	'main',
+	'article',
+	'aside',
+	'footer',
+	'header',
+];
+
+const capitalize = ( name ) =>
+	name.charAt( 0 ).toUpperCase() + name.substring( 1 );
+
+const createSemanticVariations = ( baseVariation ) => {
+	return semanticTagNames.map( ( tagName ) => ( {
+		...baseVariation,
+		isDefault: false,
+		scope: [ 'inserter' ],
+		name: baseVariation.name + `-${ tagName }`,
+		title: capitalize( tagName ),
+		attributes: { ...baseVariation.attributes, tagName },
+		isActive: ( blockAttributes ) =>
+			blockAttributes.tagName === tagName &&
+			baseVariation.isActive( blockAttributes ),
+	} ) );
+};
+
+variations.slice().forEach( ( baseVariation ) => {
+	baseVariation.tagName = 'div';
+	const baseIsActive = baseVariation.isActive;
+	baseVariation.isActive = ( blockAttributes ) =>
+		baseVariation.tagName === 'div' && baseIsActive( blockAttributes );
+
+	createSemanticVariations( baseVariation ).forEach( ( variant ) =>
+		variations.push( variant )
+	);
+} );
+
 export default variations;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

[semantic variants API.webm](https://github.com/WordPress/gutenberg/assets/6851384/6e4dba8a-b5b9-42a6-a163-c2d63be32aa4)

![image](https://github.com/WordPress/gutenberg/assets/6851384/82b6c04c-4e27-4b64-b12b-681afbcd07e6)

## What?
Create inserter variations of the `core/group` block so Groups can be added with semantic tagNames pre-set. I've labelled this POC as it can likely be improved and there are likely implications beyond my level of Gutenberg knowledge, and maybe even prior discussions. We could improve the styling of the List View and maybe use the `tagName` as the label in some cases. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Editor should encourage the use of semantic HTML but currently, semantic tags are an "advanced" option of the Group block. 

## How?
Use the [Block Variations API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/) to create more variations. 

## Testing Instructions
1. Open a page and try adding any of the[ supported elements](https://github.com/WordPress/gutenberg/pull/57299/files#diff-1076d9cb26ab701d1cbb5d6a12a12eae41f28269a67b200890703bd48ef7df2aR60). 
2. Confirm they are `inserter` scope only to avoid overloading the transformer dropdown
3. Check the List view and see that the tag name is also output where present

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
