### PR TITLE
Text selection: show CSS hack to Safari only.

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -17,22 +17,26 @@
 	}
 }
 
+
+// Hide selections on this element, otherwise Safari will include it stacked
+// under your actual selection.
+// This uses a CSS hack to show the rules to Safari only. Failing here is okay,
+// it just makes the selection indication slightly less precise. That makes this
+// hack a progressive enhancement. Stylelint is disabled to allow the hack to work.
+/* stylelint-disable */
+_::-webkit-full-page-media, _:future, :root .block-editor-block-list__layout::selection,
+_::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-block-list__layout::selection {
+	background-color: transparent; 
+}
+/* stylelint-enable */
+
+
 // Note to developers refactoring this, please test navigation mode, and
 // multi selection and hovering the block switcher to highlight the block.
 // Also be sure to test partial selections in Safari, as it draws the
 // selection marker with an entirely different model than Blink.
 .block-editor-block-list__layout {
 	position: relative;
-
-	// Hide selections on this element, otherwise Safari will include it stacked
-	// under your actual selection.
-	&::selection {
-		background: transparent;
-	}
-
-	.has-multi-selection &::selection {
-		background: transparent;
-	}
 
 	// Block multi selection
 	// Apply a rounded radius to the entire block when multi selected, but with low specificity


### PR DESCRIPTION
## What?

Alternative to #57298, fixes #56408. 

There's a CSS hack that exists for making the selection style in Safari more precise. This hack has side effects in Chrome Canary, and this PR fixes that by showing the Safari hack to Safari only.

Hacks are bad, but this hack, should it fail, it would fail only in Safari, and the result would be the same as removing the hack, so the selection would still show, it would just show as the "before" image, as shown below.

Chrome base, before:

![before, chrome base](https://github.com/WordPress/gutenberg/assets/1204802/65b89343-aeb9-455b-9459-b7642df0457e)

Chrome Canary before:

![before, chrome canary](https://github.com/WordPress/gutenberg/assets/1204802/266e2cd4-5977-429e-9552-7f2747786a26)

Safari before:

![before, safari](https://github.com/WordPress/gutenberg/assets/1204802/62c60f84-487d-4b59-a72e-caa5fe37c0ae)

Safari with the hack plainly removed (without the hack that makes the selection precise, note how the selection goes edge to edge between blocks):

![safari with the bug](https://github.com/WordPress/gutenberg/assets/1204802/4ab5b0a9-c308-4c95-8232-a3936d80b9d7)

After this PR, Chrome base:

![after, chrome base](https://github.com/WordPress/gutenberg/assets/1204802/cd6d65ad-1c9e-41b2-bd77-55d0a09e51b6)

After, Chrome Canary:

![after, chrome canary](https://github.com/WordPress/gutenberg/assets/1204802/1a05c0da-167e-443e-949f-889e0f813914)

After, Safari with debugging colors to test the hack in this PR:

![after, safari with debug color](https://github.com/WordPress/gutenberg/assets/1204802/c13a19e2-4cdc-4023-9ed4-2f274b094774)

After, Safari with the transparent color:

![after, safari with transparent color](https://github.com/WordPress/gutenberg/assets/1204802/0622d281-5160-4acd-812c-15752900a375)


## Testing Instructions

Please test first, selecting across multiple paragraphs, then multiple non-text paragraphs, be sure to also test nested blocks.

Test in Chrome, Chrome Canary, Safari. The selection style should look the same across all three.
