### PR TITLE
DependencyExtractionWebpackPlugin: Drop webpack4 and node<18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55067,14 +55067,13 @@
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"json2php": "^0.0.7",
-				"webpack-sources": "^3.2.2"
+				"json2php": "^0.0.7"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"webpack": "^4.8.3 || ^5.0.0"
+				"webpack": "^5.0.0"
 			}
 		},
 		"packages/deprecated": {
@@ -70399,8 +70398,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": {
 			"version": "file:packages/dependency-extraction-webpack-plugin",
 			"requires": {
-				"json2php": "^0.0.7",
-				"webpack-sources": "^3.2.2"
+				"json2php": "^0.0.7"
 			}
 		},
 		"@wordpress/deprecated": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56460,7 +56460,7 @@
 				"wp-scripts": "bin/wp-scripts.js"
 			},
 			"engines": {
-				"node": ">=14",
+				"node": ">=18",
 				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking
 
 - Drop support for webpack 4.
+- Drop support for Node.js versions < 18.
 
 ## 4.31.0 (2023-12-13)
 

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking
+
+- Drop support for webpack 4.
+
 ## 4.31.0 (2023-12-13)
 
 ## 4.30.0 (2023-11-29)

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Breaking
+### Breaking Changes
 
 - Drop support for webpack 4.
 - Drop support for Node.js versions < 18.

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -3,8 +3,6 @@
  */
 const path = require( 'path' );
 const webpack = require( 'webpack' );
-// In webpack 5 there is a `webpack.sources` field but for webpack 4 we have to fallback to the `webpack-sources` package.
-const { RawSource } = webpack.sources || require( 'webpack-sources' );
 const json2php = require( 'json2php' );
 const isWebpack4 = webpack.version.startsWith( '4.' );
 const { createHash } = webpack.util;
@@ -17,6 +15,8 @@ const {
 	defaultRequestToHandle,
 } = require( './util' );
 
+
+const { RawSource } = webpack.sources;
 const defaultExternalizedReportFileName = 'externalized-dependencies.json';
 
 class DependencyExtractionWebpackPlugin {

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -20,7 +20,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=18"
 	},
 	"files": [
 		"lib",

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -29,11 +29,10 @@
 	"main": "lib/index.js",
 	"types": "lib/types.d.ts",
 	"dependencies": {
-		"json2php": "^0.0.7",
-		"webpack-sources": "^3.2.2"
+		"json2php": "^0.0.7"
 	},
 	"peerDependencies": {
-		"webpack": "^4.8.3 || ^5.0.0"
+		"webpack": "^5.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Drop support for Node.js versions < 18.
+
 ## 26.19.0 (2023-12-13)
 
 ### Bug Fix

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -19,7 +19,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=14",
+		"node": ">=18",
 		"npm": ">=6.14.4"
 	},
 	"files": [


### PR DESCRIPTION
## What?
Dependency Extraction Webpack Plugin:

- Drop support for webpack 4
- Drop support for Node.js versions < 18

Scripts:

- Drop support for Node.js versions < 18

(dropping from the webpack plugin implies dropping support from scripts)


## Why?

Webpack 5 was released more that 3 years ago. Webpack 4 does not support modules, which blocks work on better module support and the modules API.

[Node 18 is the oldest maintained Node.js release.](https://nodejs.org/en/about/previous-releases) Drop support for older versions.

## Testing

CI tests should be sufficient for this change. I suggest reviewing changes without whitespace to see that very little code is changed.

