### PR TITLE
DataViews: update docs

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -15,15 +15,15 @@ npm install @wordpress/dataviews --save
 ```js
 <DataViews
 	data={ pages }
+	paginationInfo={ { totalItems, totalPages } }
 	view={ view }
 	onChangeView={ onChangeView }
 	fields={ fields }
 	actions={ [ trashPostAction ] }
-	search={ true }
+	search={ false }
 	searchLabel="Filter list"
 	getItemId={ ( item ) => item.id }
-	isLoading={ isLoading }
-	paginationInfo={ { totalItems, totalPages } }
+	isLoading={ true }
 	supportedLayouts={ [ 'table' ] }
 	deferredRendering={ true }
 	onSelectionChange={ ( items ) => { /* ... */ } }
@@ -42,6 +42,11 @@ Example:
 	{ ... }
 ]
 ```
+
+## Pagination Info
+
+- `totalItems`: the total number of items in the datasets.
+- `totalPages`: the total number of pages, taking into account the total items in the dataset and the number of items per page provided by the user.
 
 ## View
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -226,6 +226,16 @@ Array of operations that can be performed upon each record. Each action is an ob
     - `in`: operator to be used in filters for fields of type `enumeration`.
     - `notIn`: operator to be used in filters for fields of type `enumeration`.
 
+## Other properties
+
+- `search`: whether the search input is enabled. `true` by default.
+- `searchLabel`: what text to show in the search input. "Filter list" by default.
+- `getItemId`: function that receives an item and return an unique identifier for it. Required.
+- `isLoading`: whether the data is loading. `false` by default.
+- `supportedLayouts`: array of layouts supported. By default, all are: `table`, `grid`, `list`.
+- `deferredRendering`: whether the items should be rendered asynchronously. Required.
+- `onSelectionChange`: callback that returns the selected items. So far, only the `list` view implements this.
+
 ## Contributing to this package
 
 This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -19,9 +19,13 @@ npm install @wordpress/dataviews --save
 	onChangeView={ onChangeView }
 	fields={ fields }
 	actions={ [ trashPostAction ] }
+	search={ true }
+	searchLabel="Filter list"
 	getItemId={ ( item ) => item.id }
-	isLoading={ isLoadingPages }
+	isLoading={ isLoading }
 	paginationInfo={ { totalItems, totalPages } }
+	supportedLayouts={ [ 'table' ] }
+	deferredRendering={ true }
 	onSelectionChange={ ( items ) => { /* ... */ } }
 />
 ```

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -14,7 +14,7 @@ npm install @wordpress/dataviews --save
 
 ```js
 <DataViews
-	data={ pages }
+	data={ data }
 	paginationInfo={ { totalItems, totalPages } }
 	view={ view }
 	onChangeView={ onChangeView }
@@ -23,7 +23,7 @@ npm install @wordpress/dataviews --save
 	search={ false }
 	searchLabel="Filter list"
 	getItemId={ ( item ) => item.id }
-	isLoading={ true }
+	isLoading={ isLoadingData }
 	supportedLayouts={ [ 'table' ] }
 	deferredRendering={ true }
 	onSelectionChange={ ( items ) => { /* ... */ } }

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -15,12 +15,12 @@ npm install @wordpress/dataviews --save
 ```js
 <DataViews
 	data={ pages }
-	getItemId={ ( item ) => item.id }
-	isLoading={ isLoadingPages }
 	view={ view }
 	onChangeView={ onChangeView }
 	fields={ fields }
 	actions={ [ trashPostAction ] }
+	getItemId={ ( item ) => item.id }
+	isLoading={ isLoadingPages }
 	paginationInfo={ { totalItems, totalPages } }
 	onSelectionChange={ ( items ) => { /* ... */ } }
 />
@@ -79,9 +79,11 @@ Example:
     -   `mediaField`: used by the `grid` and `list` layouts. The `id` of the field to be used for rendering each card's media.
     -   `primaryField`: used by the `grid` and `list` layouts. The `id` of the field to be highlighted in each card/list item.
 
-### View <=> data
+### onChangeView: syncing view and data
 
-The view is a representation of the visible state of the dataset. Note, however, that it's the consumer's responsibility to work with the data provider to make sure the user options defined through the view's config (sort, pagination, filters, etc.) are respected.
+The view is a representation of the visible state of the dataset: what type of layout is used to display it (table, grid, etc.), how the dataset is filtered, how it is sorted or paginated.
+
+It's the consumer's responsibility to work with the data provider to make sure the user options defined through the view's config (sort, pagination, filters, etc.) are respected. The `onChangeView` prop allows the consumer to provide a callback to be called when the view config changes, to process the data accordingly.
 
 The following example shows how a view object is used to query the WordPress REST API via the entities abstraction. The same can be done with any other data provider.
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

Updates the dataviews documentation.