### PR TITLE
DataViews: remove `paginationInfo` prop from ViewComponent

### DIFF
--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -79,7 +79,6 @@ export default function DataViews( {
 					fields={ _fields }
 					view={ view }
 					onChangeView={ onChangeView }
-					paginationInfo={ paginationInfo }
 					actions={ actions }
 					data={ data }
 					getItemId={ getItemId }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Removes the `paginationInfo` prop from the view component.

## Why?

The view component does not use it. Pagination is handled by the pagination component instead.
