### PR TITLE
DataViews: remove `getItemId` prop

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -22,7 +22,6 @@ npm install @wordpress/dataviews --save
 	actions={ [ trashPostAction ] }
 	search={ false }
 	searchLabel="Filter list"
-	getItemId={ ( item ) => item.id }
 	isLoading={ isLoadingData }
 	supportedLayouts={ [ 'table' ] }
 	deferredRendering={ true }
@@ -230,7 +229,6 @@ Array of operations that can be performed upon each record. Each action is an ob
 
 - `search`: whether the search input is enabled. `true` by default.
 - `searchLabel`: what text to show in the search input. "Filter list" by default.
-- `getItemId`: function that receives an item and return an unique identifier for it. Required.
 - `isLoading`: whether the data is loading. `false` by default.
 - `supportedLayouts`: array of layouts supported. By default, all are: `table`, `grid`, `list`.
 - `deferredRendering`: whether the items should be rendered asynchronously. Required.

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -24,7 +24,6 @@ export default function DataViews( {
 	searchLabel = undefined,
 	actions,
 	data,
-	getItemId,
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
@@ -82,7 +81,6 @@ export default function DataViews( {
 					paginationInfo={ paginationInfo }
 					actions={ actions }
 					data={ data }
-					getItemId={ getItemId }
 					isLoading={ isLoading }
 					onSelectionChange={ onSetSelection }
 					selection={ selection }

--- a/packages/dataviews/src/stories/index.story.js
+++ b/packages/dataviews/src/stories/index.story.js
@@ -131,7 +131,6 @@ export const Default = ( props ) => {
 };
 Default.args = {
 	actions,
-	getItemId: ( item ) => item.id,
 	isLoading: false,
 	supportedLayouts: [ LAYOUT_TABLE, LAYOUT_GRID ],
 };

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -19,7 +19,6 @@ export default function ViewGrid( {
 	fields,
 	view,
 	actions,
-	getItemId,
 	deferredRendering,
 } ) {
 	const mediaField = fields.find(
@@ -47,7 +46,7 @@ export default function ViewGrid( {
 			{ usedData.map( ( item, index ) => (
 				<VStack
 					spacing={ 3 }
-					key={ getItemId?.( item ) || index }
+					key={ index }
 					className="dataviews-view-grid__card"
 				>
 					<div className="dataviews-view-grid__media">

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -17,7 +17,6 @@ export default function ViewList( {
 	view,
 	fields,
 	data,
-	getItemId,
 	onSelectionChange,
 	selection,
 	deferredRendering,
@@ -49,7 +48,7 @@ export default function ViewList( {
 		<ul className="dataviews-list-view">
 			{ usedData.map( ( item, index ) => {
 				return (
-					<li key={ getItemId?.( item ) || index }>
+					<li key={ index }>
 						<div
 							role="button"
 							tabIndex={ 0 }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -327,7 +327,6 @@ function ViewTable( {
 	fields,
 	actions,
 	data,
-	getItemId,
 	isLoading = false,
 	deferredRendering,
 } ) {
@@ -387,7 +386,7 @@ function ViewTable( {
 					</thead>
 					<tbody>
 						{ usedData.map( ( item, index ) => (
-							<tr key={ getItemId?.( item ) || index }>
+							<tr key={ index }>
 								{ visibleFields.map( ( field ) => (
 									<td
 										key={ field.id }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -338,7 +338,6 @@ export default function PagePages() {
 					fields={ fields }
 					actions={ actions }
 					data={ pages || EMPTY_ARRAY }
-					getItemId={ ( item ) => item.id }
 					isLoading={ isLoadingPages || isLoadingAuthors }
 					view={ view }
 					onChangeView={ onChangeView }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -382,7 +382,6 @@ export default function DataviewsTemplates() {
 					fields={ fields }
 					actions={ actions }
 					data={ shownTemplates }
-					getItemId={ ( item ) => item.id }
 					isLoading={ isLoadingData }
 					view={ view }
 					onChangeView={ onChangeView }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Removes the `getItemId` public property.

## Why?

This function is used to return a unique identifier for each record in the dataset. This identifier is used for assigning a key to the React component that renders it, but it isn't helping with controlling re-renders.

https://github.com/WordPress/gutenberg/assets/583546/cafa2a83-c148-4791-a9da-5163351b648a

## Testing Instructions

- Enable the "new admin views" experiment and visit "Manage all templates" or "Manage all pages".
- Interact with dataviews and verify everything works as expected.
