### PR TITLE
DataViews: make `getItemId` optional

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -43,6 +43,8 @@ Example:
 ]
 ```
 
+By default, dataviews would use each record's `id` as an unique identifier. If it's not, the consumer should provide a `getItemId` function that returns one. See "Other props" section.
+
 ## Pagination Info
 
 - `totalItems`: the total number of items in the datasets.
@@ -230,7 +232,7 @@ Array of operations that can be performed upon each record. Each action is an ob
 
 - `search`: whether the search input is enabled. `true` by default.
 - `searchLabel`: what text to show in the search input. "Filter list" by default.
-- `getItemId`: function that receives an item and return an unique identifier for it. Required.
+- `getItemId`: function that receives an item and returns an unique identifier for it. By default, it uses the `id` of the item as unique identifier. If it's not, the consumer should provide their own.
 - `isLoading`: whether the data is loading. `false` by default.
 - `supportedLayouts`: array of layouts supported. By default, all are: `table`, `grid`, `list`.
 - `deferredRendering`: whether the items should be rendered asynchronously. Required.

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -24,7 +24,7 @@ export default function DataViews( {
 	searchLabel = undefined,
 	actions,
 	data,
-	getItemId,
+	getItemId = ( item ) => item.id,
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -16,6 +16,8 @@ import Filters from './filters';
 import Search from './search';
 import { VIEW_LAYOUTS } from './constants';
 
+const defaultGetItemId = ( item ) => item.id;
+
 export default function DataViews( {
 	view,
 	onChangeView,
@@ -24,7 +26,7 @@ export default function DataViews( {
 	searchLabel = undefined,
 	actions,
 	data,
-	getItemId = ( item ) => item.id,
+	getItemId = defaultGetItemId,
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -44,10 +44,10 @@ export default function ViewGrid( {
 			alignment="top"
 			className="dataviews-grid-view"
 		>
-			{ usedData.map( ( item, index ) => (
+			{ usedData.map( ( item ) => (
 				<VStack
 					spacing={ 3 }
-					key={ getItemId?.( item ) || index }
+					key={ getItemId( item ) }
 					className="dataviews-view-grid__card"
 				>
 					<div className="dataviews-view-grid__media">

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -47,9 +47,9 @@ export default function ViewList( {
 
 	return (
 		<ul className="dataviews-list-view">
-			{ usedData.map( ( item, index ) => {
+			{ usedData.map( ( item ) => {
 				return (
-					<li key={ getItemId?.( item ) || index }>
+					<li key={ getItemId( item ) }>
 						<div
 							role="button"
 							tabIndex={ 0 }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -386,8 +386,8 @@ function ViewTable( {
 						</tr>
 					</thead>
 					<tbody>
-						{ usedData.map( ( item, index ) => (
-							<tr key={ getItemId?.( item ) || index }>
+						{ usedData.map( ( item ) => (
+							<tr key={ getItemId( item ) }>
 								{ visibleFields.map( ( field ) => (
 									<td
 										key={ field.id }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -338,7 +338,6 @@ export default function PagePages() {
 					fields={ fields }
 					actions={ actions }
 					data={ pages || EMPTY_ARRAY }
-					getItemId={ ( item ) => item.id }
 					isLoading={ isLoadingPages || isLoadingAuthors }
 					view={ view }
 					onChangeView={ onChangeView }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -382,7 +382,6 @@ export default function DataviewsTemplates() {
 					fields={ fields }
 					actions={ actions }
 					data={ shownTemplates }
-					getItemId={ ( item ) => item.id }
 					isLoading={ isLoadingData }
 					view={ view }
 					onChangeView={ onChangeView }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/57307

## What?

This makes `getItemId` prop optional, by providing a default implementation.

## Why?

Dataviews uses `getItemId` as a mechanism to provide a stable reference to the React components that render the data. By providing a default implementation, the API is simpler for consumers.

## How?

Provide a default implementation for `getItemId: ( item ) => item.id `.

## Testing Instructions

- Enable the "new admin views" experiment and visit "Manage all templates" or "Manage all pages".
- Interact with dataviews and verify everything works as expected.
