### PR TITLE
Fix permalink input field text overflow ellipsis for Firefox

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -152,7 +152,7 @@
 	}
 
 	input[readonly] {
-		padding: $grid-unit-20;
+		padding: $grid-unit-15;
 		background: $gray-100;
 		border-color: $gray-400;
 		overflow: hidden;

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -152,6 +152,8 @@
 	}
 
 	input[readonly] {
+		// Do not increase top and bottom padding otherwise Firefox won't show the text overflow ellipsis.
+		// See https://github.com/WordPress/gutenberg/pull/57310
 		padding: $grid-unit-15;
 		background: $gray-100;
 		border-color: $gray-400;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow up to https://github.com/WordPress/gutenberg/pull/53245
See comment https://github.com/WordPress/gutenberg/pull/53245#issuecomment-1866303594

Ping: @WordPress/gutenberg-design 

## What?
<!-- In a few words, what is the PR actually doing? -->
The text overflow ellipsis in the post-publish panel permalink input field is broken in Firefox

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Showing the ellipsis should work in all major browsers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Reduce the padding that prevents the ellipsis to work in Firefox.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Test with Firefox
- Publish a post that has a slug long enough to not fit in the URL input shown in the post-publish panel.
- In the post publish panel, observe the ellipsis at the end of the permalink is now visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Screenshots before and after:

![firefox](https://github.com/WordPress/gutenberg/assets/1682452/dbd0e7a3-fcc5-4f06-b177-a70b8b9513f5)


