### PR TITLE
Fix: Empty dropdown(s) on the grid view.

### DIFF
--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -186,6 +186,9 @@ function CompactItemActions( { item, primaryActions, secondaryActions } ) {
 					size="compact"
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
+					disabled={
+						! primaryActions.length && ! secondaryActions.length
+					}
 				/>
 			}
 			placement="bottom-end"


### PR DESCRIPTION
This PR fixes the issue discovered by @ntsekouras on https://github.com/WordPress/gutenberg/pull/55625#pullrequestreview-1793256656. It adds a condition for the dropdown bottom on the compact action display to appear disabled if there are not any actions the user can execute.


## Testing Instructions
Open the templates grid view for a template that has no available actions.
Verify that the actions menu is disabled. If you are on trunk, you will see an empty dropdown.


### Testing Instructions for Keyboard

<img width="370" alt="Screenshot 2023-12-21 at 16 16 48" src="https://github.com/WordPress/gutenberg/assets/11271197/544c7953-f515-4ba5-a717-e20aaa1f7fa1">
