### PR TITLE
Rich text: add HTML string methods to RichTextData

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -178,6 +178,19 @@ export class RichTextData {
 	}
 }
 
+for ( const name of Object.getOwnPropertyNames( String.prototype ) ) {
+	if ( RichTextData.prototype.hasOwnProperty( name ) ) {
+		continue;
+	}
+
+	Object.defineProperty( RichTextData.prototype, name, {
+		value( ...args ) {
+			// Should we convert back to RichTextData?
+			return this.toHTMLString()[ name ]( ...args );
+		},
+	} );
+}
+
 /**
  * Create a RichText value from an `Element` tree (DOM), an HTML string or a
  * plain text string, with optionally a `Range` object to set the selection. If


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is meant to prevent errors when people use string methods on the rich text value and so things keep working as expected for back compat. Previously these values were plain strings with HTML.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #57093, and other third party instances with errors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We just add all the string methods to the class prototype.

Extending String is not an option because we'd have to pre-serialise the HTML when initialising the instance.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

There's probably a few way to test, but here what I did:

* Add a table of contents block.
* Convert another paragraph to a heading. In trunk, the editor will crash. With this PR it will be fine.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
