### PR TITLE
DropdownMenu V2: add fallback styles for when subgrid is not supported

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   `DropdownMenu V2 `: better fallback on browsers that don't support CSS subgrif ([#57327](https://github.com/WordPress/gutenberg/pull/57327)).
 -   `FontSizePicker`: Use Button API for keeping focus on reset ([#57221](https://github.com/WordPress/gutenberg/pull/57221)).
 -   `FontSizePicker`: Fix Reset button focus loss ([#57196](https://github.com/WordPress/gutenberg/pull/57196)).
 -   `PaletteEdit`: Consider digits when generating kebab-cased slug ([#56713](https://github.com/WordPress/gutenberg/pull/56713)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
--   `DropdownMenu V2 `: better fallback on browsers that don't support CSS subgrif ([#57327](https://github.com/WordPress/gutenberg/pull/57327)).
+-   `DropdownMenu V2 `: better fallback on browsers that don't support CSS subgrid([#57327](https://github.com/WordPress/gutenberg/pull/57327)).
 -   `FontSizePicker`: Use Button API for keeping focus on reset ([#57221](https://github.com/WordPress/gutenberg/pull/57221)).
 -   `FontSizePicker`: Fix Reset button focus loss ([#57196](https://github.com/WordPress/gutenberg/pull/57196)).
 -   `PaletteEdit`: Consider digits when generating kebab-cased slug ([#56713](https://github.com/WordPress/gutenberg/pull/56713)).

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -130,13 +130,17 @@ const baseItem = css`
 	/* Occupy the width of all grid columns (ie. full width) */
 	grid-column: 1 / -1;
 
-	/*
-	 * Define a grid layout which inherits the same columns configuration
-	 * from the parent layout (ie. subgrid).
-	 */
-	display: grid;
-	grid-template-columns: subgrid;
+	display: flex;
 	align-items: center;
+
+	@supports ( grid-template-columns: subgrid ) {
+		/*
+		 * Define a grid layout which inherits the same columns configuration
+		 * from the parent layout (ie. subgrid).
+		 */
+		display: grid;
+		grid-template-columns: subgrid;
+	}
 
 	font-size: ${ font( 'default.fontSize' ) };
 	font-family: inherit;
@@ -246,11 +250,17 @@ export const ItemPrefixWrapper = styled.span`
 `;
 
 export const DropdownMenuItemContentWrapper = styled.div`
-	/*
-	 * Always occupy the second column, since the first column
-	 * is taken by the prefix wrapper (when displayed).
-	 */
-	grid-column: 2;
+	flex: 1;
+
+	@supports ( grid-template-columns: subgrid ) {
+		/* Revert flex rule */
+		flex: none;
+		/*
+		* Always occupy the second column, since the first column
+		* is taken by the prefix wrapper (when displayed).
+		*/
+		grid-column: 2;
+	}
 
 	display: flex;
 	align-items: center;

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -35,6 +35,8 @@ const TOOLBAR_VARIANT_BORDER_COLOR = COLORS.gray[ '900' ];
 const DEFAULT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ DEFAULT_BORDER_COLOR }, ${ CONFIG.popoverShadow }`;
 const TOOLBAR_VARIANT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ TOOLBAR_VARIANT_BORDER_COLOR }`;
 
+const GRID_TEMPLATE_COLS = 'minmax( 0, max-content ) 1fr';
+
 const slideUpAndFade = keyframes( {
 	'0%': {
 		opacity: 0,
@@ -76,7 +78,7 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 	z-index: 1000000;
 
 	display: grid;
-	grid-template-columns: minmax( 0, max-content ) 1fr;
+	grid-template-columns: ${ GRID_TEMPLATE_COLS };
 	grid-template-rows: auto;
 
 	box-sizing: border-box;
@@ -131,7 +133,7 @@ const baseItem = css`
 	grid-column: 1 / -1;
 
 	display: grid;
-	grid-template-columns: minmax( 0, max-content ) 1fr;
+	grid-template-columns: ${ GRID_TEMPLATE_COLS };
 	align-items: center;
 
 	@supports ( grid-template-columns: subgrid ) {

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -254,9 +254,9 @@ export const ItemPrefixWrapper = styled.span`
 
 export const DropdownMenuItemContentWrapper = styled.div`
 	/*
-   * Always occupy the second column, since the first column
-   * is taken by the prefix wrapper (when displayed).
-   */
+	 * Always occupy the second column, since the first column
+	 * is taken by the prefix wrapper (when displayed).
+	 */
 	grid-column: 2;
 
 	display: flex;

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -130,15 +130,16 @@ const baseItem = css`
 	/* Occupy the width of all grid columns (ie. full width) */
 	grid-column: 1 / -1;
 
-	display: flex;
+	display: grid;
+	grid-template-columns: minmax( 0, max-content ) 1fr;
 	align-items: center;
 
 	@supports ( grid-template-columns: subgrid ) {
 		/*
 		 * Define a grid layout which inherits the same columns configuration
-		 * from the parent layout (ie. subgrid).
+		 * from the parent layout (ie. subgrid). This allows the menu
+		 * to synchronize the indentation of all its items.
 		 */
-		display: grid;
 		grid-template-columns: subgrid;
 	}
 
@@ -250,17 +251,11 @@ export const ItemPrefixWrapper = styled.span`
 `;
 
 export const DropdownMenuItemContentWrapper = styled.div`
-	flex: 1;
-
-	@supports ( grid-template-columns: subgrid ) {
-		/* Revert flex rule */
-		flex: none;
-		/*
-		* Always occupy the second column, since the first column
-		* is taken by the prefix wrapper (when displayed).
-		*/
-		grid-column: 2;
-	}
+	/*
+   * Always occupy the second column, since the first column
+   * is taken by the prefix wrapper (when displayed).
+   */
+	grid-column: 2;
 
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add fallback styles to the experimental `DropdownMenu` v2 component for browsers that don't support CSS subgrid

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As of today, there are still [a few browsers with > 1% usage that don't support CSS subgrid](https://caniuse.com/?search=subgrid) (old safari versions, opera mobile, Samsung internet) that we should still support

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add some fallback styles so that the menu items don't look broken in browsers that don't support CSS subgrid. The main difference is that the auto-indentation is not supported in those browsers.

_**Note: these are fallback styles that only a very small (and decreasing every day) percentage of folks are going to experience. The goal is to provide a non-broken experience, even if the overall look is not as refined as in modern browsers**_

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

To test what it's like to use the DropdownMenu component in an environment that doesn't support CSS subgrid:

- use an older version of a web browser locally (ie. install Chrome 116), or;
- use an older version of a web browser via a cloud service (ie. Browserstack), or;
- manually delete from this PR the code inside `@supports ( grid-template-columns: subgrid )` query


Test the DropdownMenu V2 Ariakit component both in Storybook and in the editor, on both a browser that doesn't support CSS subgrid and on one that supports it.
- Make sure that the fallback layout works well enough
- Make sure that the "standard" layout looks exactly like on `trunk`

## Screenshots or screencast <!-- if applicable -->

| In a browser with no CSS subgrid support (`trunk`) | In a browser with no CSS subgrid support (This PR) |
|---|---|
| ![Screenshot 2023-12-22 at 00 11 57](https://github.com/WordPress/gutenberg/assets/1083581/33e6d17b-c629-4abc-9267-4aa31859b1dd) | ![Screenshot 2023-12-22 at 00 13 00](https://github.com/WordPress/gutenberg/assets/1083581/b09f4de4-1f74-4c81-b70a-9c55e9f1864d) | 