### PR TITLE
Block editor: give iframe fallback background color

### DIFF
--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -63,8 +63,6 @@ export function ExperimentalBlockCanvas( {
 				ref={ resetTypingRef }
 				contentRef={ contentRef }
 				style={ {
-					width: '100%',
-					height: '100%',
 					...iframeProps?.style,
 				} }
 				name="editor-canvas"

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -2,4 +2,5 @@ iframe[name="editor-canvas"] {
 	width: 100%;
 	height: 100%;
 	background-color: $white;
+	display: block;
 }

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -1,0 +1,5 @@
+iframe[name="editor-canvas"] {
+	width: 100%;
+	height: 100%;
+	background-color: $white;
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -1,5 +1,6 @@
 @import "./autocompleters/style.scss";
 @import "./components/block-alignment-control/style.scss";
+@import "./components/block-canvas/style.scss";
 @import "./components/block-icon/style.scss";
 @import "./components/block-inspector/style.scss";
 @import "./components/block-tools/style.scss";

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -27,16 +27,7 @@
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;
 
-	iframe {
-		display: block;
-		width: 100%;
-		height: 100%;
-		background: $white;
-	}
-
 	.edit-site-visual-editor__editor-canvas {
-		height: 100%;
-
 		&.is-focused {
 			outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
 			outline-offset: calc(-2 * var(--wp-admin-border-width-focus));


### PR DESCRIPTION
## What?
I think it fixes https://github.com/WordPress/gutenberg/issues/56981



## Why?
For themes that do not set a background, the [dark background color](https://github.com/WordPress/gutenberg/blob/81852a55e700afdaaca7657a2382dd38c0e52b5a/packages/edit-post/src/components/visual-editor/style.scss#L14-L14) (`background-color: $gray-900;`) from `.edit-post-visual-editor` is visible.

If the text color is also dark, it's hard to read.

## How?

By setting a default background color to the editor iframe of `#fff` (white).

Ad mentioned above, currently that default color is `background-color: $gray-900;`

Any theme that sets a background color on the html or body element or wherever, will always override this. 

## Testing Instructions

1. Activate a theme that doesn't set a background, like `emptytheme`
2. Open the post and site editors.
3. Check that the background of the editor Iframe is `#fff`
4. Try out a few other themes, classic/block to ensure they appear as expected.
5. Add a site background color to theme.json or via the site editor. Your color should be visible when opening the post or site editor.
6. Activate the tablet/mobile preview to ensure there's a dark/white contrast.
7. If you're super keen, apply the diff below to ensure `iframeProps` take precedence. The iframe should be pink and narrow.


<details>

<summary>Example diff to check that iframeProps still work</summary>

```diff
diff --git a/packages/block-editor/src/components/block-canvas/index.js b/packages/block-editor/src/components/block-canvas/index.js
index fea9689cea..1bdf8e28c6 100644
--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -53,6 +53,11 @@ export function ExperimentalBlockCanvas( {
 		);
 	}
 
+	const testStyle = {
+		...iframeProps?.style,
+		background: 'pink',
+		width: '200px',
+	};
 	return (
 		<BlockTools
 			__unstableContentRef={ localRef }
@@ -63,7 +68,7 @@ export function ExperimentalBlockCanvas( {
 				ref={ resetTypingRef }
 				contentRef={ contentRef }
 				style={ {
-					...iframeProps?.style,
+					...testStyle,
 				} }
 				name="editor-canvas"
 			>

```

</details>






### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Trunk  | This PR | With background color |
| ------------- | ------------- | ------------- |
| <img width="300" alt="Screenshot 2023-12-22 at 3 56 33 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/73344564-6141-4e2e-b5f8-77b5239f9d69"> | <img width="300" alt="Screenshot 2023-12-22 at 3 56 06 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/09283cae-891d-4698-9f00-034e65ccd0f1">  | <img width="300" alt="Screenshot 2023-12-22 at 3 56 11 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/a61283ac-08cc-4213-888c-246ce8e07803"> |


### Constrast in mobile view

<img width="1132" alt="Screenshot 2023-12-22 at 3 44 58 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/64f79116-655d-4426-b868-20fdaae6becc">

