### PR TITLE
DataViews: Use in patterns page

### DIFF
--- a/packages/edit-site/src/components/page-main/index.js
+++ b/packages/edit-site/src/components/page-main/index.js
@@ -7,6 +7,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  * Internal dependencies
  */
 import PagePatterns from '../page-patterns';
+import DataviewsPatterns from '../page-patterns/dataviews-patterns';
 import PageTemplateParts from '../page-template-parts';
 import PageTemplates from '../page-templates';
 import PagePages from '../page-pages';
@@ -24,7 +25,11 @@ export default function PageMain() {
 	} else if ( path === '/wp_template_part/all' ) {
 		return <PageTemplateParts />;
 	} else if ( path === '/patterns' ) {
-		return <PagePatterns />;
+		return window?.__experimentalAdminViews ? (
+			<DataviewsPatterns />
+		) : (
+			<PagePatterns />
+		);
 	} else if ( window?.__experimentalAdminViews && path === '/pages' ) {
 		return <PagePages />;
 	}

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -8,11 +8,21 @@ import { paramCase as kebabCase } from 'change-case';
  */
 import { downloadBlob } from '@wordpress/blob';
 import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
-import { PATTERN_TYPES } from '../../utils/constants';
+import { PATTERN_TYPES, TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export const exportJSONaction = {
 	id: 'duplicate-pattern',
@@ -29,6 +39,91 @@ export const exportJSONaction = {
 			`${ kebabCase( item.title || item.name ) }.json`,
 			JSON.stringify( json, null, 2 ),
 			'application/json'
+		);
+	},
+};
+
+export const renameAction = {
+	id: 'rename-pattern',
+	label: __( 'Rename' ),
+	isEligible: ( item ) => {
+		const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
+		const isUserPattern = item.type === PATTERN_TYPES.user;
+		const isCustomPattern =
+			isUserPattern || ( isTemplatePart && item.isCustom );
+		const hasThemeFile = isTemplatePart && item.templatePart.has_theme_file;
+		return isCustomPattern && ! hasThemeFile;
+	},
+	RenderModal: ( { item, closeModal } ) => {
+		const [ title, setTitle ] = useState( () => item.title );
+		const { editEntityRecord, saveEditedEntityRecord } =
+			useDispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } =
+			useDispatch( noticesStore );
+		async function onRename( event ) {
+			event.preventDefault();
+			try {
+				await editEntityRecord( 'postType', item.type, item.id, {
+					title,
+				} );
+				// Update state before saving rerenders the list.
+				setTitle( '' );
+				closeModal();
+				// Persist edited entity.
+				await saveEditedEntityRecord( 'postType', item.type, item.id, {
+					throwOnError: true,
+				} );
+				createSuccessNotice(
+					item.type === TEMPLATE_PART_POST_TYPE
+						? __( 'Template part renamed.' )
+						: __( 'Pattern renamed.' ),
+					{ type: 'snackbar' }
+				);
+			} catch ( error ) {
+				const fallbackErrorMessage =
+					item.type === TEMPLATE_PART_POST_TYPE
+						? __(
+								'An error occurred while renaming the template part.'
+						  )
+						: __( 'An error occurred while renaming the pattern.' );
+				const errorMessage =
+					error.message && error.code !== 'unknown_error'
+						? error.message
+						: fallbackErrorMessage;
+				createErrorNotice( errorMessage, { type: 'snackbar' } );
+			}
+		}
+		return (
+			<form onSubmit={ onRename }>
+				<VStack spacing="5">
+					<TextControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+						required
+					/>
+					<HStack justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ () => {
+								closeModal();
+							} }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							type="submit"
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
 		);
 	},
 };

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { paramCase as kebabCase } from 'change-case';
+
+/**
+ * WordPress dependencies
+ */
+import { downloadBlob } from '@wordpress/blob';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PATTERN_TYPES } from '../../utils/constants';
+
+export const exportJSONaction = {
+	id: 'duplicate-pattern',
+	label: __( 'Export as JSON' ),
+	isEligible: ( item ) => item.type === PATTERN_TYPES.user,
+	callback: ( item ) => {
+		const json = {
+			__file: item.type,
+			title: item.title || item.name,
+			content: item.patternBlock.content.raw,
+			syncStatus: item.patternBlock.wp_pattern_sync_status,
+		};
+		return downloadBlob(
+			`${ kebabCase( item.title || item.name ) }.json`,
+			JSON.stringify( json, null, 2 ),
+			'application/json'
+		);
+	},
+};

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -7,25 +7,29 @@ import { paramCase as kebabCase } from 'change-case';
  * WordPress dependencies
  */
 import { downloadBlob } from '@wordpress/blob';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	TextControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
+import { decodeEntities } from '@wordpress/html-entities';
+import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies
  */
+import { store as editSiteStore } from '../../store';
 import { PATTERN_TYPES, TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
 
 export const exportJSONaction = {
-	id: 'duplicate-pattern',
+	id: 'export-pattern',
 	label: __( 'Export as JSON' ),
 	isEligible: ( item ) => item.type === PATTERN_TYPES.user,
 	callback: ( item ) => {
@@ -124,6 +128,110 @@ export const renameAction = {
 					</HStack>
 				</VStack>
 			</form>
+		);
+	},
+};
+
+const canDeleteOrReset = ( item ) => {
+	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
+	const isUserPattern = item.type === PATTERN_TYPES.user;
+	return isUserPattern || ( isTemplatePart && item.isCustom );
+};
+
+export const deleteAction = {
+	id: 'delete-pattern',
+	label: __( 'Delete' ),
+	isEligible: ( item ) => {
+		const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
+		const hasThemeFile = isTemplatePart && item.templatePart.has_theme_file;
+		return canDeleteOrReset( item ) && ! hasThemeFile;
+	},
+	hideModalHeader: true,
+	RenderModal: ( { item, closeModal } ) => {
+		const { __experimentalDeleteReusableBlock } =
+			useDispatch( reusableBlocksStore );
+		const { createErrorNotice, createSuccessNotice } =
+			useDispatch( noticesStore );
+		const { removeTemplate } = useDispatch( editSiteStore );
+
+		const deletePattern = async () => {
+			try {
+				await __experimentalDeleteReusableBlock( item.id );
+				createSuccessNotice(
+					sprintf(
+						// translators: %s: The pattern's title e.g. 'Call to action'.
+						__( '"%s" deleted.' ),
+						item.title
+					),
+					{ type: 'snackbar', id: 'edit-site-patterns-success' }
+				);
+			} catch ( error ) {
+				const errorMessage =
+					error.message && error.code !== 'unknown_error'
+						? error.message
+						: __( 'An error occurred while deleting the pattern.' );
+				createErrorNotice( errorMessage, {
+					type: 'snackbar',
+					id: 'edit-site-patterns-error',
+				} );
+			}
+		};
+		const deleteItem = () =>
+			item.type === TEMPLATE_PART_POST_TYPE
+				? removeTemplate( item )
+				: deletePattern();
+		return (
+			<VStack spacing="5">
+				<Text>
+					{ sprintf(
+						// translators: %s: The pattern or template part's title e.g. 'Call to action'.
+						__( 'Are you sure you want to delete "%s"?' ),
+						decodeEntities( item.title || item.name )
+					) }
+				</Text>
+				<HStack justify="right">
+					<Button variant="tertiary" onClick={ closeModal }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button variant="primary" onClick={ deleteItem }>
+						{ __( 'Delete' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		);
+	},
+};
+
+export const resetAction = {
+	id: 'reset-action',
+	label: __( 'Clear customizations' ),
+	isEligible: ( item ) => {
+		const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
+		const hasThemeFile = isTemplatePart && item.templatePart.has_theme_file;
+		return canDeleteOrReset( item ) && hasThemeFile;
+	},
+	hideModalHeader: true,
+	RenderModal: ( { item, closeModal } ) => {
+		const { removeTemplate } = useDispatch( editSiteStore );
+		return (
+			<VStack spacing="5">
+				<Text>
+					{ __(
+						'Are you sure you want to clear these customizations?'
+					) }
+				</Text>
+				<HStack justify="right">
+					<Button variant="tertiary" onClick={ closeModal }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ () => removeTemplate( item ) }
+					>
+						{ __( 'Clear' ) }
+					</Button>
+				</HStack>
+			</VStack>
 		);
 	},
 };

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -36,7 +36,7 @@ import {
 	PATTERN_SYNC_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 } from '../../utils/constants';
-// import { duplicatePatternAction } from './dataviews-pattern-actions';
+import { exportJSONaction } from './dataviews-pattern-actions';
 import usePatternSettings from './use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 import usePatterns from './use-patterns';
@@ -283,7 +283,7 @@ export default function DataviewsPatterns() {
 		};
 	}, [ patterns, view, fields ] );
 
-	// const actions = useMemo( () => [ duplicatePatternAction ], [] );
+	const actions = useMemo( () => [ exportJSONaction ], [] );
 	const onChangeView = useCallback(
 		( viewUpdater ) => {
 			let updatedView =
@@ -303,8 +303,6 @@ export default function DataviewsPatterns() {
 		[ view, setView ]
 	);
 	const id = useId();
-	const titleId = `${ id }-title`;
-	const descriptionId = `${ id }-description`;
 	const settings = usePatternSettings();
 	// Wrap everything in a block editor provider.
 	// This ensures 'styles' that are needed for the previews are synced
@@ -320,13 +318,13 @@ export default function DataviewsPatterns() {
 				<PatternsHeader
 					categoryId={ categoryId }
 					type={ type }
-					titleId={ titleId }
-					descriptionId={ descriptionId }
+					titleId={ `${ id }-title` }
+					descriptionId={ `${ id }-description` }
 				/>
 				<DataViews
 					paginationInfo={ paginationInfo }
 					fields={ fields }
-					// actions={ actions }
+					actions={ actions }
 					data={ data || EMPTY_ARRAY }
 					getItemId={ ( item ) => item.name }
 					isLoading={ isResolving }

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -1,0 +1,341 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	Button,
+	__experimentalHeading as Heading,
+	Tooltip,
+	Flex,
+} from '@wordpress/components';
+import { getQueryArgs } from '@wordpress/url';
+import { __ } from '@wordpress/i18n';
+import { useState, useMemo, useCallback, useId } from '@wordpress/element';
+import {
+	BlockPreview,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { DataViews } from '@wordpress/dataviews';
+import {
+	Icon,
+	header,
+	footer,
+	symbolFilled as uncategorized,
+	symbol,
+	lockSmall,
+} from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Page from '../page';
+import {
+	LAYOUT_GRID,
+	PATTERN_TYPES,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_SYNC_TYPES,
+	PATTERN_DEFAULT_CATEGORY,
+} from '../../utils/constants';
+// import { duplicatePatternAction } from './dataviews-pattern-actions';
+import usePatternSettings from './use-pattern-settings';
+import { unlock } from '../../lock-unlock';
+import usePatterns from './use-patterns';
+import PatternsHeader from './header';
+
+const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
+	blockEditorPrivateApis
+);
+
+const templatePartIcons = { header, footer, uncategorized };
+const EMPTY_ARRAY = [];
+const defaultConfigPerViewType = {
+	[ LAYOUT_GRID ]: {
+		mediaField: 'preview',
+		primaryField: 'title',
+	},
+};
+const DEFAULT_VIEW = {
+	type: LAYOUT_GRID,
+	search: '',
+	page: 1,
+	perPage: 20,
+	hiddenFields: [],
+	layout: {
+		...defaultConfigPerViewType[ LAYOUT_GRID ],
+	},
+	filters: [],
+};
+
+function Preview( { item, viewType } ) {
+	const descriptionId = useId();
+	const isUserPattern = item.type === PATTERN_TYPES.user;
+	const isNonUserPattern = item.type === PATTERN_TYPES.theme;
+	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
+	const isEmpty = ! item.blocks?.length;
+	// Only custom patterns or custom template parts can be renamed or deleted.
+	const isCustomPattern =
+		isUserPattern || ( isTemplatePart && item.isCustom );
+	const ariaDescriptions = [];
+	if ( isCustomPattern ) {
+		// User patterns don't have descriptions, but can be edited and deleted, so include some help text.
+		ariaDescriptions.push(
+			__( 'Press Enter to edit, or Delete to delete the pattern.' )
+		);
+	} else if ( item.description ) {
+		ariaDescriptions.push( item.description );
+	}
+
+	if ( isNonUserPattern ) {
+		ariaDescriptions.push(
+			__( 'Theme & plugin patterns cannot be edited.' )
+		);
+	}
+	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
+	return (
+		<>
+			<div
+				className={ `page-patterns-preview-field is-viewtype-${ viewType }` }
+				style={ { backgroundColor } }
+			>
+				{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
+				{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
+				{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
+			</div>
+			{ ariaDescriptions.map( ( ariaDescription, index ) => (
+				<div
+					key={ index }
+					hidden
+					id={ `${ descriptionId }-${ index }` }
+				>
+					{ ariaDescription }
+				</div>
+			) ) }
+		</>
+	);
+}
+
+function Title( { item, onClick, categoryId } ) {
+	const isUserPattern = item.type === PATTERN_TYPES.user;
+	const isNonUserPattern = item.type === PATTERN_TYPES.theme;
+	let itemIcon;
+	if ( ! isUserPattern && templatePartIcons[ categoryId ] ) {
+		itemIcon = templatePartIcons[ categoryId ];
+	} else {
+		itemIcon =
+			item.syncStatus === PATTERN_SYNC_TYPES.full ? symbol : undefined;
+	}
+	return (
+		<HStack alignment="center" justify="flex-start" spacing={ 3 }>
+			{ itemIcon && ! isNonUserPattern && (
+				<Tooltip
+					placement="top"
+					text={ __(
+						'Editing this pattern will also update anywhere it is used'
+					) }
+				>
+					<Icon
+						className="edit-site-patterns__pattern-icon"
+						icon={ itemIcon }
+					/>
+				</Tooltip>
+			) }
+			<Flex as="span" gap={ 0 } justify="left">
+				{ item.type === PATTERN_TYPES.theme ? (
+					item.title
+				) : (
+					<Heading level={ 5 }>
+						<Button
+							variant="link"
+							onClick={ onClick }
+							// Required for the grid's roving tab index system.
+							// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
+							tabIndex="-1"
+						>
+							{ item.title || item.name }
+						</Button>
+					</Heading>
+				) }
+				{ item.type === PATTERN_TYPES.theme && (
+					<Tooltip
+						placement="top"
+						text={ __( 'This pattern cannot be edited.' ) }
+					>
+						<Icon
+							className="edit-site-patterns__pattern-lock-icon"
+							icon={ lockSmall }
+							size={ 24 }
+						/>
+					</Tooltip>
+				) }
+			</Flex>
+		</HStack>
+	);
+}
+
+export default function DataviewsPatterns() {
+	const { categoryType, categoryId = PATTERN_DEFAULT_CATEGORY } =
+		getQueryArgs( window.location.href );
+	const type = categoryType || PATTERN_TYPES.theme;
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const isUncategorizedThemePatterns =
+		type === PATTERN_TYPES.theme && categoryId === 'uncategorized';
+	const { patterns, isResolving } = usePatterns(
+		type,
+		isUncategorizedThemePatterns ? '' : categoryId,
+		{
+			search: view.search,
+			// syncStatus:
+			// 	deferredSyncedFilter === 'all'
+			// 		? undefined
+			// 		: deferredSyncedFilter,
+		}
+	);
+	const fields = useMemo(
+		() => [
+			{
+				header: __( 'Preview' ),
+				id: 'preview',
+				render: ( { item } ) => (
+					<Preview item={ item } viewType={ view.type } />
+				),
+				minWidth: 120,
+				maxWidth: 120,
+				enableSorting: false,
+				enableHiding: false,
+			},
+			{
+				header: __( 'Title' ),
+				id: 'title',
+				getValue: ( { item } ) => item.title,
+				render: ( { item } ) => (
+					<Title
+						item={ item }
+						onClick={ () => {} }
+						categoryId={ categoryId }
+					/>
+				),
+				maxWidth: 400,
+				enableHiding: false,
+			},
+		],
+		[ view.type, categoryId ]
+	);
+
+	const { data, paginationInfo } = useMemo( () => {
+		if ( ! patterns ) {
+			return {
+				data: EMPTY_ARRAY,
+				paginationInfo: { totalItems: 0, totalPages: 0 },
+			};
+		}
+		let filteredData = [ ...patterns ];
+		// Handle filters.
+		if ( view.filters.length > 0 ) {
+			// view.filters.forEach( ( filter ) => {
+			// 	if (
+			// 		filter.field === 'author' &&
+			// 		filter.operator === OPERATOR_IN &&
+			// 		!! filter.value
+			// 	) {
+			// 		filteredData = filteredData.filter( ( item ) => {
+			// 			return item.author_text === filter.value;
+			// 		} );
+			// 	} else if (
+			// 		filter.field === 'author' &&
+			// 		filter.operator === OPERATOR_NOT_IN &&
+			// 		!! filter.value
+			// 	) {
+			// 		filteredData = filteredData.filter( ( item ) => {
+			// 			return item.author_text !== filter.value;
+			// 		} );
+			// 	}
+			// } );
+		}
+
+		// Handle sorting.
+		if ( view.sort ) {
+			const stringSortingFields = [ 'title' ];
+			const fieldId = view.sort.field;
+			if ( stringSortingFields.includes( fieldId ) ) {
+				const fieldToSort = fields.find( ( field ) => {
+					return field.id === fieldId;
+				} );
+				filteredData.sort( ( a, b ) => {
+					const valueA = fieldToSort.getValue( { item: a } ) ?? '';
+					const valueB = fieldToSort.getValue( { item: b } ) ?? '';
+					return view.sort.direction === 'asc'
+						? valueA.localeCompare( valueB )
+						: valueB.localeCompare( valueA );
+				} );
+			}
+		}
+
+		// Handle pagination.
+		const start = ( view.page - 1 ) * view.perPage;
+		const totalItems = filteredData?.length || 0;
+		filteredData = filteredData?.slice( start, start + view.perPage );
+		return {
+			data: filteredData,
+			paginationInfo: {
+				totalItems,
+				totalPages: Math.ceil( totalItems / view.perPage ),
+			},
+		};
+	}, [ patterns, view, fields ] );
+
+	// const actions = useMemo( () => [ duplicatePatternAction ], [] );
+	const onChangeView = useCallback(
+		( viewUpdater ) => {
+			let updatedView =
+				typeof viewUpdater === 'function'
+					? viewUpdater( view )
+					: viewUpdater;
+			if ( updatedView.type !== view.type ) {
+				updatedView = {
+					...updatedView,
+					layout: {
+						...defaultConfigPerViewType[ updatedView.type ],
+					},
+				};
+			}
+			setView( updatedView );
+		},
+		[ view, setView ]
+	);
+	const id = useId();
+	const titleId = `${ id }-title`;
+	const descriptionId = `${ id }-description`;
+	const settings = usePatternSettings();
+	// Wrap everything in a block editor provider.
+	// This ensures 'styles' that are needed for the previews are synced
+	// from the site editor store to the block editor store.
+	// TODO: check if I add the provider in every preview like in templates...
+	return (
+		<ExperimentalBlockEditorProvider settings={ settings }>
+			<Page
+				title={ __( 'Patterns content' ) }
+				className="edit-site-page-patterns-dataviews"
+				hideTitleFromUI
+			>
+				<PatternsHeader
+					categoryId={ categoryId }
+					type={ type }
+					titleId={ titleId }
+					descriptionId={ descriptionId }
+				/>
+				<DataViews
+					paginationInfo={ paginationInfo }
+					fields={ fields }
+					// actions={ actions }
+					data={ data || EMPTY_ARRAY }
+					getItemId={ ( item ) => item.name }
+					isLoading={ isResolving }
+					view={ view }
+					onChangeView={ onChangeView }
+					deferredRendering={ true }
+					supportedLayouts={ [ LAYOUT_GRID ] }
+				/>
+			</Page>
+		</ExperimentalBlockEditorProvider>
+	);
+}

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -36,7 +36,7 @@ import {
 	PATTERN_SYNC_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 } from '../../utils/constants';
-import { exportJSONaction } from './dataviews-pattern-actions';
+import { exportJSONaction, renameAction } from './dataviews-pattern-actions';
 import usePatternSettings from './use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 import usePatterns from './use-patterns';
@@ -283,7 +283,7 @@ export default function DataviewsPatterns() {
 		};
 	}, [ patterns, view, fields ] );
 
-	const actions = useMemo( () => [ exportJSONaction ], [] );
+	const actions = useMemo( () => [ renameAction, exportJSONaction ], [] );
 	const onChangeView = useCallback(
 		( viewUpdater ) => {
 			let updatedView =

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -238,29 +238,6 @@ export default function DataviewsPatterns() {
 			};
 		}
 		let filteredData = [ ...patterns ];
-		// Handle filters.
-		if ( view.filters.length > 0 ) {
-			// view.filters.forEach( ( filter ) => {
-			// 	if (
-			// 		filter.field === 'author' &&
-			// 		filter.operator === OPERATOR_IN &&
-			// 		!! filter.value
-			// 	) {
-			// 		filteredData = filteredData.filter( ( item ) => {
-			// 			return item.author_text === filter.value;
-			// 		} );
-			// 	} else if (
-			// 		filter.field === 'author' &&
-			// 		filter.operator === OPERATOR_NOT_IN &&
-			// 		!! filter.value
-			// 	) {
-			// 		filteredData = filteredData.filter( ( item ) => {
-			// 			return item.author_text !== filter.value;
-			// 		} );
-			// 	}
-			// } );
-		}
-
 		// Handle sorting.
 		if ( view.sort ) {
 			const stringSortingFields = [ 'title' ];
@@ -278,7 +255,6 @@ export default function DataviewsPatterns() {
 				} );
 			}
 		}
-
 		// Handle pagination.
 		const start = ( view.page - 1 ) * view.perPage;
 		const totalItems = filteredData?.length || 0;
@@ -306,7 +282,6 @@ export default function DataviewsPatterns() {
 					},
 				};
 			}
-
 			setView( newView );
 		},
 		[ view.type, setView ]

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -223,3 +223,30 @@
 		}
 	}
 }
+
+/**
+ * DataViews patterns styles
+ * TODO: when this becomes stable, consolidate styles with the above.
+ */
+.edit-site-page-patterns-dataviews {
+	.page-patterns-preview-field {
+		&.is-viewtype-grid {
+			.block-editor-block-preview__container {
+				height: auto;
+			}
+		}
+	}
+
+	.edit-site-patterns__pattern-lock-icon {
+		min-width: min-content;
+	}
+
+	.edit-site-patterns__section-header {
+		border-bottom: 1px solid #f0f0f0;
+		min-height: 72px;
+		padding: $grid-unit-20 $grid-unit-40;
+		position: sticky;
+		top: 0;
+		z-index: 2;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/55083

This PR is the starting point of using DataViews in patterns page. There is a lots of stuff going on with patterns and this might be also an opportunity to try to simplify the code, but I'm planning to explore this iteratively.


**This is a WIP so the description/screenshots and code will change.** 

## Testing Instructions
1. Enable the admin views experiment and go to patterns page

### Tasks
- [ ] Add actions - some of the actions will probably be in follow ups.
- [ ] Add synced filter

## Screenshots or screencast <!-- if applicable -->
<img width="1220" alt="Screenshot 2023-12-22 at 10 22 16 AM" src="https://github.com/WordPress/gutenberg/assets/16275880/9927bbe1-4cdb-4978-bee8-f3390cdb9752">

