### PR TITLE
DataViews: make `deferredRendering` prop optional

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -235,7 +235,7 @@ Array of operations that can be performed upon each record. Each action is an ob
 - `getItemId`: function that receives an item and returns an unique identifier for it. By default, it uses the `id` of the item as unique identifier. If it's not, the consumer should provide their own.
 - `isLoading`: whether the data is loading. `false` by default.
 - `supportedLayouts`: array of layouts supported. By default, all are: `table`, `grid`, `list`.
-- `deferredRendering`: whether the items should be rendered asynchronously. Required.
+- `deferredRendering`: whether the items should be rendered asynchronously. Useful when there's a field that takes a lot of time (e.g.: previews). `false` by default.
 - `onSelectionChange`: callback that returns the selected items. So far, only the `list` view implements this.
 
 ## Contributing to this package

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -31,7 +31,7 @@ export default function DataViews( {
 	paginationInfo,
 	supportedLayouts,
 	onSelectionChange,
-	deferredRendering,
+	deferredRendering = false,
 } ) {
 	const [ selection, setSelection ] = useState( [] );
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -342,7 +342,6 @@ export default function PagePages() {
 					view={ view }
 					onChangeView={ onChangeView }
 					onSelectionChange={ onSelectionChange }
-					deferredRendering={ false }
 				/>
 			</Page>
 			{ view.type === LAYOUT_LIST && (


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Make the `deferredRendering` prop optional.

## Why?

So consumers don't have to provide it unless they need it.

## How?

Sets it to `false` by default.

## Testing Instructions

Verify that it works as before.

- Enable the "admin views" experiment.

- Visit "Manage all pages".
- Make the preview field visible. Observe how the preview is rendered asynchronously, 3 items at once.
- Hide the preview field, and observe how the items are rendered synchronously.

- Visit "Manage all templates". Items are rendered synchronously.
