### PR TITLE
feat: Added command to set featured image

### DIFF
--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -13,6 +13,7 @@ import {
 	listView,
 	external,
 	formatListBullets,
+	image,
 } from '@wordpress/icons';
 import { useCommand } from '@wordpress/commands';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -62,9 +63,62 @@ export default function useCommonCommands() {
 	}, [] );
 	const { toggle } = useDispatch( preferencesStore );
 	const { createInfoNotice } = useDispatch( noticesStore );
-	const { __unstableSaveForPreview, setIsListViewOpened } =
+	const { __unstableSaveForPreview, setIsListViewOpened, editPost } =
 		useDispatch( editorStore );
-	const { getCurrentPostId } = useSelect( editorStore );
+	const { getCurrentPostId, getEditedPostAttribute } =
+		useSelect( editorStore );
+
+	/**
+	 * Sets the featured image for the current post.
+	 *
+	 * @param {number} currentFeaturedImageId - The ID of the currently selected featured image.
+	 * @return {void}
+	 */
+	const setFeaturedImage = ( currentFeaturedImageId ) => {
+		const { wp } = window;
+		const frame = wp.media( {
+			title: __( 'Select Featured Image' ),
+			button: {
+				text: __( 'Use this image' ),
+			},
+			multiple: false,
+		} );
+
+		frame.on( 'open', () => {
+			// Get the selection object.
+			const selection = frame.state().get( 'selection' );
+
+			// If there's a previously selected featured image, pre-select it in the media modal.
+			if ( currentFeaturedImageId ) {
+				const attachment = wp.media.attachment(
+					currentFeaturedImageId
+				);
+				attachment.fetch();
+				selection.add( attachment ? [ attachment ] : [] );
+			}
+		} );
+
+		// When an image is selected, setting the featured image.
+		frame.on( 'select', () => {
+			const attachment = frame
+				.state()
+				.get( 'selection' )
+				.first()
+				.toJSON();
+
+			// If the selected image is different from the current featured image, update it.
+			if ( attachment.id !== currentFeaturedImageId ) {
+				// Update the featured image ID of the current post.
+				editPost( { featured_media: attachment.id } );
+			}
+
+			// Close the media modal.
+			frame.close();
+		} );
+
+		// Open the media uploader.
+		frame.open();
+	};
 
 	useCommand( {
 		name: 'core/open-settings-sidebar',
@@ -221,6 +275,18 @@ export default function useCommonCommands() {
 			const postId = getCurrentPostId();
 			const link = await __unstableSaveForPreview();
 			window.open( link, `wp-preview-${ postId }` );
+		},
+	} );
+
+	useCommand( {
+		name: 'core/open-featured-image-modal',
+		label: __( 'Select Featured Image' ),
+		icon: image,
+		callback: ( { close } ) => {
+			const currentFeaturedImageId =
+				getEditedPostAttribute( 'featured_media' );
+			setFeaturedImage( currentFeaturedImageId );
+			close();
 		},
 	} );
 }


### PR DESCRIPTION
## What?
- Creating a command to set the featured image of the post and pages

- Used `useCommand` hook from `@wordpress/commands` package to create the command.

## Why?

- Setting featured image using direct command instead of manually following the below steps:

    - Click on “post” in the sidebar.
    - Scroll down.
    - Click on “Set Featured Image”.
    - Pick whether I want to select or upload.

## How?
- This PR addresses [Issue](https://github.com/WordPress/gutenberg/issues/56930)

## Testing Instructions

- In the post editor open command palette.
- Search 'Select Featured Image'.
- Media dialog box will appear asking to select the featured image.
- On selecting, it will edit/add a featured image.

### Testing Instructions for Keyboard

- In the post editor press `cmd + k` or `ctrl + k` to open command palette.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/61490175/5deb1a1e-9d6c-47b5-b297-ebaa581334ad
