### PR TITLE
[RNMobile] Ensure font is scaled on iOS when accessibility settings are changed

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -651,13 +651,14 @@ class RCTAztecView: Aztec.TextView {
     private func applyFontConstraints(to baseFont: UIFont) -> UIFont {
         let oldDescriptor = baseFont.fontDescriptor
         let newFontSize: CGFloat
+        let fontMetrics = UIFontMetrics(forTextStyle: .body)
 
         if let fontSize = fontSize {
-            newFontSize = fontSize
+            newFontSize = fontMetrics.scaledValue(for: fontSize)
         } else {
-            newFontSize = baseFont.pointSize
-        }
+            newFontSize = fontMetrics.scaledValue(for: baseFont.pointSize)
 
+        }
         var newTraits = oldDescriptor.symbolicTraits
 
         if let fontWeight = fontWeight {

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -650,10 +650,9 @@ class RCTAztecView: Aztec.TextView {
     ///
     private func applyFontConstraints(to baseFont: UIFont) -> UIFont {
         let oldDescriptor = baseFont.fontDescriptor
-        let newFontSize: CGFloat
         let fontMetrics = UIFontMetrics(forTextStyle: .body)
 
-        newFontSize = fontMetrics.scaledValue(for: fontSize ?? baseFont.pointSize)
+        let newFontSize = fontMetrics.scaledValue(for: fontSize ?? baseFont.pointSize)
 
         var newTraits = oldDescriptor.symbolicTraits
 

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -657,8 +657,8 @@ class RCTAztecView: Aztec.TextView {
             newFontSize = fontMetrics.scaledValue(for: fontSize)
         } else {
             newFontSize = fontMetrics.scaledValue(for: baseFont.pointSize)
-
         }
+
         var newTraits = oldDescriptor.symbolicTraits
 
         if let fontWeight = fontWeight {

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -653,11 +653,7 @@ class RCTAztecView: Aztec.TextView {
         let newFontSize: CGFloat
         let fontMetrics = UIFontMetrics(forTextStyle: .body)
 
-        if let fontSize = fontSize {
-            newFontSize = fontMetrics.scaledValue(for: fontSize)
-        } else {
-            newFontSize = fontMetrics.scaledValue(for: baseFont.pointSize)
-        }
+        let newFontSize = fontMetrics.scaledValue(for: fontSize ?? baseFont.pointSize)
 
         var newTraits = oldDescriptor.symbolicTraits
 

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -653,7 +653,7 @@ class RCTAztecView: Aztec.TextView {
         let newFontSize: CGFloat
         let fontMetrics = UIFontMetrics(forTextStyle: .body)
 
-        let newFontSize = fontMetrics.scaledValue(for: fontSize ?? baseFont.pointSize)
+        newFontSize = fontMetrics.scaledValue(for: fontSize ?? baseFont.pointSize)
 
         var newTraits = oldDescriptor.symbolicTraits
 


### PR DESCRIPTION
> **Note** There are times where the font appears overly large when used with custom fonts and block-based themes, this will be addressed in a separate Gutenberg PR for _both_ platforms. The scope of this specific PR is to enable support for Dynamic Type on iOS.

## Related PRs

* `Gutenberg Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6492
* `WPiOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/22272

## What?

With this PR, we ensure that font in the editor is changed when users change their accessibility settings on iOS.

## Why?

At the moment, Dynamic Type is not supported in the editor's `RichText` component for iOS. This is because the `refreshFont()` function [here](https://github.com/WordPress/gutenberg/blob/89dbd659f47b25bba62b5cd99c4e14729265d506/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift#L691-L700) is 'undoing' the scaling that takes place elsewhere in Aztec's codebase.

## How?

We ensure scaling is applied to the new font when it's set [here](https://github.com/WordPress/gutenberg/blob/60e287f84be9e416dc6705c71af1e23c0e18c4ea/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift#L654-L660) within the `applyFontConstraints()` function.

## Testing Instructions

> An installable build to test these changes can be found [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/22272).

- Navigate to the **Accessibility** section in the **Settings** app. 
- Select **Display & Text Size** then **Larger Accessibility Sizes** to on.
- Select a larger accessibility size.
- Next, open the WordPress app and select a site with a block-based theme.
- Navigate to the editor in the app.
- Either add a heading block or begin typing into a paragraph block.
- Select the block's cog/gear icon to open its settings and select a larger font size.
- Experiment with typing more text and adding more heading or paragraph blocks.
- Verify that the font has been scaled in accordance with your device and block settings.

## Screenshots or screencast

<details>
 <summary>Before and after ⤵️</summary>

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/WordPress/gutenberg/assets/2998162/7068feaa-3fba-433b-b58f-a4a321682f99" width="100%"> | <img src="https://github.com/WordPress/gutenberg/assets/2998162/d84e38a4-be0d-4d54-9e44-34fe709e5b49" width="100%"> |
</details>

<details>
 <summary>Android comparison ⤵️</summary>

| Android  | iOS |
| ------------- | ------------- |
| <img src="https://github.com/WordPress/gutenberg/assets/2998162/844b2642-cf35-4081-804f-d2cb3a0c2a29" width="100%"> | <img src="https://github.com/WordPress/gutenberg/assets/2998162/d84e38a4-be0d-4d54-9e44-34fe709e5b49" width="100%"> |
</details>

