### PR TITLE
Block Bindings API: Add taxonomy meta source in templates

### DIFF
--- a/lib/experimental/block-bindings/index.php
+++ b/lib/experimental/block-bindings/index.php
@@ -16,5 +16,6 @@ if ( $gutenberg_experiments ) {
 	}
 	if ( array_key_exists( 'gutenberg-block-bindings', $gutenberg_experiments ) ) {
 		require_once __DIR__ . '/sources/post-meta.php';
+		require_once __DIR__ . '/sources/tax-meta.php';
 	}
 }

--- a/lib/experimental/block-bindings/sources/tax-meta.php
+++ b/lib/experimental/block-bindings/sources/tax-meta.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Add the tax_meta source to the block bindings API.
+ *
+ * @package gutenberg
+ */
+
+if ( function_exists( 'register_block_bindings_source' ) ) {
+	$term_meta_source_callback = function ( $source_attrs ) {
+		return get_metadata( 'term', $source_attrs['termId'], $source_attrs['value'] );
+	};
+	register_block_bindings_source(
+		'tax_meta',
+		array(
+			'label' => __( 'Taxonomy Meta', 'gutenberg' ),
+			'apply' => $term_meta_source_callback,
+		)
+	);
+}

--- a/lib/experimental/block-bindings/sources/tax-meta.php
+++ b/lib/experimental/block-bindings/sources/tax-meta.php
@@ -7,7 +7,15 @@
 
 if ( function_exists( 'register_block_bindings_source' ) ) {
 	$term_meta_source_callback = function ( $source_attrs ) {
-		return get_metadata( 'term', $source_attrs['termId'], $source_attrs['value'] );
+		// Use the postId attribute if available, otherwise get it from the context.
+		if ( isset( $source_attrs['termId'] ) ) {
+			$term_id = $source_attrs['termId'];
+		} else {
+			// I tried using $block_instance->context['postId'] but it wasn't available in the image block.
+			$term_id = get_queried_object_id();
+		}
+
+		return get_metadata( 'term', $term_id, $source_attrs['value'] )[0];
 	};
 	register_block_bindings_source(
 		'tax_meta',

--- a/packages/editor/src/hooks/block-bindings-sources/tax-meta.js
+++ b/packages/editor/src/hooks/block-bindings-sources/tax-meta.js
@@ -1,0 +1,161 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import BlockBindingsFill from '../../components/block-bindings/bindings-ui';
+import BlockBindingsFieldsList from '../../components/block-bindings/fields-list';
+import { store as editorStore } from '../../store';
+import { BLOCK_BINDINGS_ALLOWED_BLOCKS } from '../../store/constants';
+
+if ( window.__experimentalBlockBindings ) {
+	// External sources could do something similar.
+
+	const withCoreSources = createHigherOrderComponent(
+		( BlockEdit ) => ( props ) => {
+			const { name, isSelected, context } = props;
+			// If the block is not allowed, return the original BlockEdit.
+			if ( ! BLOCK_BINDINGS_ALLOWED_BLOCKS[ name ] ) {
+				return <BlockEdit key="edit" { ...props } />;
+			}
+			const fields = [];
+			if ( isSelected ) {
+				const data = useSelect(
+					( select ) => {
+						const postType = context.postType
+							? context.postType
+							: select( editorStore ).getCurrentPostType();
+
+						if ( postType !== 'wp_template' ) {
+							return null;
+						}
+
+						const { getEntityRecord, getEntityRecords } =
+							select( coreStore );
+						const templateId = context.postId
+							? context.postId
+							: select( editorStore ).getCurrentPostId();
+						const { slug: templateSlug } = getEntityRecord(
+							'postType',
+							'wp_template',
+							templateId
+						);
+
+						// Match "term-{slug}".
+						const patterns = [
+							{
+								term: 'archive',
+								pattern: /^archive(?:-(.+))?$/,
+							},
+							{ term: 'author', pattern: /^author(?:-(.+))?$/ },
+							{
+								term: 'category',
+								pattern: /^category(?:-(.+))?$/,
+							},
+							{ term: 'tag', pattern: /^tag(?:-(.+))?$/ },
+							{
+								term: 'taxonomy',
+								pattern: /^taxonomy(?:-(.+))?$/,
+							},
+						];
+
+						for ( let i = 0; i < patterns.length; i++ ) {
+							const { term, pattern } = patterns[ i ];
+							const match = templateSlug.match( pattern );
+							if ( match ) {
+								const [ , entitySlug ] = match;
+								if ( term === 'archive' ) {
+									// General template for all archives.
+									if ( ! entitySlug )
+										return getEntityRecords(
+											'taxonomy',
+											'category',
+											{
+												per_page: 1,
+											}
+										)?.[ 0 ];
+									// Specific archive template.
+									return getEntityRecords(
+										'taxonomy',
+										entitySlug,
+										{
+											per_page: 1,
+										}
+									)?.[ 0 ];
+								}
+								// For the rest of templates.
+								if ( ! entitySlug ) {
+									return getEntityRecords( 'taxonomy', term, {
+										per_page: 1,
+									} )?.[ 0 ];
+								}
+								return getEntityRecords( 'taxonomy', term, {
+									slug: entitySlug,
+								} )?.[ 0 ];
+							}
+						}
+
+						return null;
+					},
+					[ context.postId, context.postType ]
+				);
+
+				if ( ! data || ! data?.meta ) {
+					return <BlockEdit key="edit" { ...props } />;
+				}
+
+				// Adapt the data to the format expected by the fields list.
+				// Prettifying the name until we receive the label from the REST API endpoint.
+				const keyToLabel = ( key ) => {
+					return key
+						.split( '_' )
+						.map(
+							( word ) =>
+								word.charAt( 0 ).toUpperCase() + word.slice( 1 )
+						)
+						.join( ' ' );
+				};
+				Object.entries( data.meta ).forEach( ( [ key, value ] ) => {
+					fields.push( {
+						key,
+						label: keyToLabel( key ),
+						value: data.isTemplate ? null : value,
+						placeholder: data.isTemplate ? keyToLabel( key ) : null,
+					} );
+				} );
+			}
+
+			return (
+				<>
+					{ isSelected && fields.length !== 0 && (
+						<>
+							<BlockBindingsFill
+								source="tax_meta"
+								label="Taxonomy Meta"
+							>
+								<BlockBindingsFieldsList
+									fields={ fields }
+									source="tax_meta"
+									{ ...props }
+								/>
+							</BlockBindingsFill>
+						</>
+					) }
+					<BlockEdit key="edit" { ...props } />
+				</>
+			);
+		},
+		'withToolbarControls'
+	);
+
+	addFilter(
+		'editor.BlockEdit',
+		'core/block-bindings-ui/add-sources',
+		withCoreSources
+	);
+}

--- a/packages/editor/src/hooks/block-bindings-sources/tax-meta.js
+++ b/packages/editor/src/hooks/block-bindings-sources/tax-meta.js
@@ -72,31 +72,51 @@ if ( window.__experimentalBlockBindings ) {
 								if ( term === 'archive' ) {
 									// General template for all archives.
 									if ( ! entitySlug )
-										return getEntityRecords(
+										return {
+											usesPlaceholder: true,
+											fields: getEntityRecords(
+												'taxonomy',
+												'category',
+												{
+													per_page: 1,
+												}
+											)?.[ 0 ],
+										};
+									// Specific archive template.
+									return {
+										usesPlaceholder: true,
+										fields: getEntityRecords(
 											'taxonomy',
-											'category',
+											entitySlug,
 											{
 												per_page: 1,
 											}
-										)?.[ 0 ];
-									// Specific archive template.
-									return getEntityRecords(
-										'taxonomy',
-										entitySlug,
-										{
-											per_page: 1,
-										}
-									)?.[ 0 ];
+										)?.[ 0 ],
+									};
 								}
 								// For the rest of templates.
 								if ( ! entitySlug ) {
-									return getEntityRecords( 'taxonomy', term, {
-										per_page: 1,
-									} )?.[ 0 ];
+									return {
+										usesPlaceholder: true,
+										fields: getEntityRecords(
+											'taxonomy',
+											term,
+											{
+												per_page: 1,
+											}
+										)?.[ 0 ],
+									};
 								}
-								return getEntityRecords( 'taxonomy', term, {
-									slug: entitySlug,
-								} )?.[ 0 ];
+								return {
+									usesPlaceholder: false,
+									fields: getEntityRecords(
+										'taxonomy',
+										term,
+										{
+											slug: entitySlug,
+										}
+									)?.[ 0 ],
+								};
 							}
 						}
 
@@ -105,7 +125,7 @@ if ( window.__experimentalBlockBindings ) {
 					[ context.postId, context.postType ]
 				);
 
-				if ( ! data || ! data?.meta ) {
+				if ( ! data || ! data?.fields?.meta ) {
 					return <BlockEdit key="edit" { ...props } />;
 				}
 
@@ -120,14 +140,18 @@ if ( window.__experimentalBlockBindings ) {
 						)
 						.join( ' ' );
 				};
-				Object.entries( data.meta ).forEach( ( [ key, value ] ) => {
-					fields.push( {
-						key,
-						label: keyToLabel( key ),
-						value: data.isTemplate ? null : value,
-						placeholder: data.isTemplate ? keyToLabel( key ) : null,
-					} );
-				} );
+				Object.entries( data.fields.meta ).forEach(
+					( [ key, value ] ) => {
+						fields.push( {
+							key,
+							label: keyToLabel( key ),
+							value: ! data.usesPlaceholder ? value : null,
+							placeholder: data.usesPlaceholder
+								? keyToLabel( key )
+								: null,
+						} );
+					}
+				);
 			}
 
 			return (

--- a/packages/editor/src/hooks/index.js
+++ b/packages/editor/src/hooks/index.js
@@ -7,3 +7,4 @@ import './pattern-partial-syncing';
 
 // Block bindings sources.
 import './block-bindings-sources/post-meta';
+import './block-bindings-sources/tax-meta';


### PR DESCRIPTION
This pull request is built on top of https://github.com/WordPress/gutenberg/pull/57315

## What?
In this pull request, I'm adding a new core source to the block bindings API for the taxonomy source. This source only appears in the templates related to a taxonomy, and it retrieves the available fields for each of them. In the server, it uses the `get_metadata` function to get the value.

I'm implementing the same logic used for Post meta [here](https://github.com/WordPress/gutenberg/pull/57315), but adapted for the taxonomy. Please check that PR for more info about it.

## Why?
Sometimes, users will want to consume meta fields related to a taxonomy and not only to a page/post.

## How?
I'm creating a new source for the block bindings:
* In the server, it uses the `get_metadata` function to retrieve the value.
* In the editor, it adds some logic to only show the Taxonomy source in the templates associated with archives (category, tag, taxonomy, author...), and it retrieves the list of available fields through the REST API.


## Testing Instructions

0. Go to Gutenberg -> Experiments and enable the Test block bindings one.
1. Create different fields for different post types. For example, I'm using this code to add some fields to the "category" taxonomy.

```php
function init_taxonomy_meta_fields() {
    // Register a meta field for categories
    register_term_meta( 
        'category',
        'category_text_field',
        array(
            'type'         => 'string',
            'single'       => true,
            'show_in_rest' => true,
			'default'      => 'Category text custom field value'
        )
    );
	register_term_meta( 
        'category',
        'category_url_field',
        array(
            'type'         => 'string',
            'single'       => true,
            'show_in_rest' => true,
			'default'      => 'https://developer.wordpress.org/'
        )
    );
}

add_action( 'init', 'init_taxonomy_meta_fields' );
```

3. Check that the meta fields created appear in the templates relevant to the taxonomy.
4. Add a paragraph and add a binding to the created field.
5. Check that works in the frontend.
6. Go to different templates where the category fields shouldn't appear and ensure they are not there.