### PR TITLE
Tooltip: improve tests

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,7 @@
 -   `Modal`: Improve application of body class names ([#55430](https://github.com/WordPress/gutenberg/pull/55430)).
 -   `InputControl`, `NumberControl`, `UnitControl`, `SelectControl`, `TreeSelect`: Add `compact` size variant ([#57398](https://github.com/WordPress/gutenberg/pull/57398)).
 -   `ToggleGroupControl`: Update button size in large variant to be 32px ([#57338](https://github.com/WordPress/gutenberg/pull/57338)).
+-   `Tooltip`: improve unit tests ([#57345](https://github.com/WordPress/gutenberg/pull/57345)).
 
 ### Experimental
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -209,7 +209,7 @@ function UnforwardedModal(
 
 		if (
 			shouldCloseOnEsc &&
-			event.code === 'Escape' &&
+			( event.code === 'Escape' || event.key === 'Escape' ) &&
 			! event.defaultPrevented
 		) {
 			event.preventDefault();

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -66,7 +66,7 @@ function Tooltip( props: TooltipProps ) {
 
 	const tooltipStore = Ariakit.useTooltipStore( {
 		placement: computedPlacement,
-		timeout: delay,
+		showTimeout: delay,
 	} );
 
 	return (

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -118,14 +118,36 @@ describe( 'Tooltip', () => {
 		await waitForTooltipToHide();
 	} );
 
-	it( 'should not show tooltip on focus as result of mouse click', async () => {
+	it( 'should hide tooltip when the tooltip anchor is clicked', async () => {
 		render( <Tooltip { ...props } /> );
 
-		await click( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
+		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
 
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument();
+		expect( anchor ).toBeVisible();
+
+		// Hover over the anchor, tooltip should show
+		await hover( anchor );
+		await waitForTooltipToShow();
+
+		// Click the anchor, tooltip should hide
+		await click( anchor );
+		await waitForTooltipToHide();
+	} );
+
+	it( 'should not hide tooltip when the tooltip anchor is clicked and the `hideOnClick` prop is `false', async () => {
+		render( <Tooltip { ...props } hideOnClick={ false } /> );
+
+		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
+
+		expect( anchor ).toBeVisible();
+
+		// Hover over the anchor, tooltip should show
+		await hover( anchor );
+		await waitForTooltipToShow();
+
+		// Click the anchor, tooltip should not hide
+		await click( anchor );
+		await waitForTooltipToShow();
 	} );
 
 	it( 'should respect custom delay prop when showing tooltip', async () => {
@@ -307,23 +329,5 @@ describe( 'Tooltip', () => {
 		expect(
 			await screen.findByRole( 'button', { description: 'tooltip text' } )
 		).toBeInTheDocument();
-	} );
-
-	it( 'should not hide tooltip when the anchor is clicked if hideOnClick is false', async () => {
-		render( <Tooltip { ...props } hideOnClick={ false } /> );
-
-		const button = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
-
-		await hover( button );
-
-		expect(
-			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
-		).toBeVisible();
-
-		await click( button );
-
-		expect(
-			screen.getByRole( 'tooltip', { name: 'tooltip text' } )
-		).toBeVisible();
 	} );
 } );

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -102,14 +102,20 @@ describe( 'Tooltip', () => {
 		await waitForTooltipToHide();
 	} );
 
-	it( 'should render the tooltip when the tooltip anchor is hovered', async () => {
+	it( 'should show the tooltip when the tooltip anchor is hovered and hide it when the cursor stops hovering the anchor', async () => {
 		render( <Tooltip { ...props } /> );
 
-		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
+		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
 
-		expect(
-			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
-		).toBeVisible();
+		expect( anchor ).toBeVisible();
+
+		// Hover over the anchor, tooltip should show
+		await hover( anchor );
+		await waitForTooltipToShow();
+
+		// Hover outside of the anchor, tooltip should hide
+		await hoverOutside();
+		await waitForTooltipToHide();
 	} );
 
 	it( 'should not show tooltip on focus as result of mouse click', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -209,62 +209,44 @@ describe( 'Tooltip', () => {
 	it( 'should not show tooltip if the mouse leaves the tooltip anchor before set delay', async () => {
 		const onMouseEnterMock = jest.fn();
 		const onMouseLeaveMock = jest.fn();
-		const MOUSE_LEAVE_DELAY = TOOLTIP_DELAY - 200;
+		const HOVER_OUTSIDE_ANTICIPATION = 200;
 
 		render(
-			<>
-				<Tooltip { ...props }>
-					<Button
-						onMouseEnter={ onMouseEnterMock }
-						onMouseLeave={ onMouseLeaveMock }
-					>
-						Tooltip anchor
-					</Button>
-				</Tooltip>
-				<Button>Other button</Button>
-			</>
+			<Tooltip { ...props }>
+				<Button
+					onMouseEnter={ onMouseEnterMock }
+					onMouseLeave={ onMouseLeaveMock }
+				>
+					Tooltip anchor
+				</Button>
+			</Tooltip>
 		);
 
-		await hover(
-			screen.getByRole( 'button', {
-				name: 'Tooltip anchor',
-			} )
-		);
+		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
+		expect( anchor ).toBeVisible();
 
-		// Tooltip hasn't appeared yet
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument();
+		// Hover over the anchor, tooltip hasn't appeared yet
+		await hover( anchor );
 		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
+		expectTooltipToBeHidden();
 
-		// Advance time by MOUSE_LEAVE_DELAY time
-		await sleep( MOUSE_LEAVE_DELAY );
+		// Advance time, tooltip hasn't appeared yet because TOOLTIP_DELAY time
+		// hasn't passed yet
+		await sleep( TOOLTIP_DELAY - HOVER_OUTSIDE_ANTICIPATION );
+		expectTooltipToBeHidden();
 
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument();
+		// Hover outside of the anchor, tooltip still hasn't appeared yet
+		await hoverOutside();
+		expectTooltipToBeHidden();
 
-		// Hover the other button, meaning that the mouse will leave the tooltip anchor
-		await hover(
-			screen.getByRole( 'button', {
-				name: 'Other button',
-			} )
-		);
-
-		// Tooltip still hasn't appeared yet
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument();
 		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
 		expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
 
 		// Advance time again, so that we reach the full TOOLTIP_DELAY time
-		await sleep( TOOLTIP_DELAY );
+		await sleep( HOVER_OUTSIDE_ANTICIPATION );
 
 		// Tooltip won't show, since the mouse has left the tooltip anchor
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument();
+		expectTooltipToBeHidden();
 	} );
 
 	it( 'should render the shortcut display text when a string is passed as the shortcut', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -161,22 +161,26 @@ describe( 'Tooltip', () => {
 			<Tooltip { ...props } delay={ TOOLTIP_DELAY + ADDITIONAL_DELAY } />
 		);
 
-		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
+		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
+		expect( anchor ).toBeVisible();
+
+		// Hover over the anchor
+		await hover( anchor );
+		expectTooltipToBeHidden();
 
 		// Advance time by default delay
 		await sleep( TOOLTIP_DELAY );
 
 		// Tooltip hasn't appeared yet
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument();
+		expectTooltipToBeHidden();
 
-		// wait for additional delay for tooltip to appear
+		// Wait for additional delay for tooltip to appear
 		await sleep( ADDITIONAL_DELAY );
+		await waitForTooltipToShow();
 
-		expect(
-			screen.getByRole( 'tooltip', { name: 'tooltip text' } )
-		).toBeVisible();
+		// Hover outside of the anchor, tooltip should hide
+		await hoverOutside();
+		await waitForTooltipToHide();
 	} );
 
 	it( 'should show tooltip when the anchor button is disabled but focusable', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -170,23 +170,27 @@ describe( 'Tooltip', () => {
 		).toBeVisible();
 	} );
 
-	it( 'should show tooltip when an element is disabled', async () => {
+	it( 'should show tooltip when the anchor button is disabled but focusable', async () => {
 		render(
 			<Tooltip { ...props }>
-				<Button aria-disabled>Button</Button>
+				<Button disabled __experimentalIsFocusable>
+					Tooltip anchor
+				</Button>
 			</Tooltip>
 		);
 
-		const button = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
+		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
 
-		expect( button ).toBeVisible();
-		expect( button ).toHaveAttribute( 'aria-disabled' );
+		expect( anchor ).toBeVisible();
+		expect( anchor ).toHaveAttribute( 'aria-disabled', 'true' );
 
-		await hover( button );
+		// Hover over the anchor, tooltip should show
+		await hover( anchor );
+		await waitForTooltipToShow();
 
-		expect(
-			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
-		).toBeVisible();
+		// Hover outside of the anchor, tooltip should hide
+		await hoverOutside();
+		await waitForTooltipToHide();
 	} );
 
 	it( 'should not show tooltip if the mouse leaves the tooltip anchor before set delay', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -249,17 +249,23 @@ describe( 'Tooltip', () => {
 		expectTooltipToBeHidden();
 	} );
 
-	it( 'should render the shortcut display text when a string is passed as the shortcut', async () => {
+	it( 'should show the shortcut in the tooltip when a string is passed as the shortcut', async () => {
 		render( <Tooltip { ...props } shortcut="shortcut text" /> );
 
+		// Hover over the anchor, tooltip should show
 		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
+		expect(
+			screen.getByRole( 'tooltip', {
+				name: 'tooltip text shortcut text',
+			} )
+		).toBeVisible();
 
-		await waitFor( () =>
-			expect( screen.getByText( 'shortcut text' ) ).toBeVisible()
-		);
+		// Hover outside of the anchor, tooltip should hide
+		await hoverOutside();
+		await waitForTooltipToHide();
 	} );
 
-	it( 'should render the keyboard shortcut display text and aria-label when an object is passed as the shortcut', async () => {
+	it( 'should show the shortcut in the tooltip when an object is passed as the shortcut', async () => {
 		render(
 			<Tooltip
 				{ ...props }
@@ -270,16 +276,17 @@ describe( 'Tooltip', () => {
 			/>
 		);
 
+		// Hover over the anchor, tooltip should show
 		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
+		const tooltip = screen.getByRole( 'tooltip', {
+			name: 'tooltip text Control + Shift + Comma',
+		} );
+		expect( tooltip ).toBeVisible();
+		expect( tooltip ).toHaveTextContent( /⇧⌘,/i );
 
-		await waitFor( () =>
-			expect( screen.getByText( '⇧⌘,' ) ).toBeVisible()
-		);
-
-		expect( screen.getByText( '⇧⌘,' ) ).toHaveAttribute(
-			'aria-label',
-			'Control + Shift + Comma'
-		);
+		// Hover outside of the anchor, tooltip should hide
+		await hoverOutside();
+		await waitForTooltipToHide();
 	} );
 
 	it( 'esc should close modal even when tooltip is visible', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -18,7 +18,7 @@ import Tooltip, { TOOLTIP_DELAY } from '..';
 import cleanupTooltip from './utils/';
 
 const props = {
-	children: <Button>Button</Button>,
+	children: <Button>Tooltip anchor</Button>,
 	text: 'tooltip text',
 };
 
@@ -34,7 +34,7 @@ describe( 'Tooltip', () => {
 		);
 
 		expect(
-			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
 	} );
 
@@ -42,11 +42,11 @@ describe( 'Tooltip', () => {
 		render( <Tooltip { ...props } /> );
 
 		expect(
-			screen.getByRole( 'button', { name: /Button/i } )
+			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
 		).toBeVisible();
 
 		expect(
-			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
 	} );
 
@@ -58,11 +58,11 @@ describe( 'Tooltip', () => {
 		await user.tab();
 
 		expect(
-			screen.getByRole( 'button', { name: /Button/i } )
+			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
 		).toHaveFocus();
 
 		expect(
-			await screen.findByRole( 'tooltip', { name: /tooltip text/i } )
+			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
 
 		await cleanupTooltip( user );
@@ -73,10 +73,12 @@ describe( 'Tooltip', () => {
 
 		render( <Tooltip { ...props } /> );
 
-		await user.hover( screen.getByRole( 'button', { name: /Button/i } ) );
+		await user.hover(
+			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+		);
 
 		expect(
-			await screen.findByRole( 'tooltip', { name: /tooltip text/i } )
+			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
 
 		await cleanupTooltip( user );
@@ -87,10 +89,12 @@ describe( 'Tooltip', () => {
 
 		render( <Tooltip { ...props } /> );
 
-		await user.click( screen.getByRole( 'button', { name: /Button/i } ) );
+		await user.click(
+			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+		);
 
 		expect(
-			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
 
 		await cleanupTooltip( user );
@@ -104,7 +108,9 @@ describe( 'Tooltip', () => {
 			<Tooltip { ...props } delay={ TOOLTIP_DELAY + ADDITIONAL_DELAY } />
 		);
 
-		await user.hover( screen.getByRole( 'button', { name: /Button/i } ) );
+		await user.hover(
+			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+		);
 
 		// Advance time by default delay
 		await new Promise( ( resolve ) =>
@@ -113,7 +119,7 @@ describe( 'Tooltip', () => {
 
 		// Tooltip hasn't appeared yet
 		expect(
-			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
 
 		// wait for additional delay for tooltip to appear
@@ -125,7 +131,7 @@ describe( 'Tooltip', () => {
 		);
 
 		expect(
-			screen.getByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.getByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
 
 		await cleanupTooltip( user );
@@ -140,7 +146,7 @@ describe( 'Tooltip', () => {
 			</Tooltip>
 		);
 
-		const button = screen.getByRole( 'button', { name: /Button/i } );
+		const button = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
 
 		expect( button ).toBeVisible();
 		expect( button ).toHaveAttribute( 'aria-disabled' );
@@ -148,7 +154,7 @@ describe( 'Tooltip', () => {
 		await user.hover( button );
 
 		expect(
-			await screen.findByRole( 'tooltip', { name: /tooltip text/i } )
+			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
 
 		await cleanupTooltip( user );
@@ -167,22 +173,22 @@ describe( 'Tooltip', () => {
 						onMouseEnter={ onMouseEnterMock }
 						onMouseLeave={ onMouseLeaveMock }
 					>
-						Button 1
+						Tooltip anchor
 					</Button>
 				</Tooltip>
-				<Button>Button 2</Button>
+				<Button>Other button</Button>
 			</>
 		);
 
 		await user.hover(
 			screen.getByRole( 'button', {
-				name: 'Button 1',
+				name: 'Tooltip anchor',
 			} )
 		);
 
 		// Tooltip hasn't appeared yet
 		expect(
-			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
 		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
 
@@ -192,19 +198,19 @@ describe( 'Tooltip', () => {
 		);
 
 		expect(
-			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
 
 		// Hover the other button, meaning that the mouse will leave the tooltip anchor
 		await user.hover(
 			screen.getByRole( 'button', {
-				name: 'Button 2',
+				name: 'Other button',
 			} )
 		);
 
 		// Tooltip still hasn't appeared yet
 		expect(
-			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
 		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
 		expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
@@ -216,7 +222,7 @@ describe( 'Tooltip', () => {
 
 		// Tooltip won't show, since the mouse has left the tooltip anchor
 		expect(
-			screen.queryByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
 
 		await cleanupTooltip( user );
@@ -227,7 +233,9 @@ describe( 'Tooltip', () => {
 
 		render( <Tooltip { ...props } shortcut="shortcut text" /> );
 
-		await user.hover( screen.getByRole( 'button', { name: /Button/i } ) );
+		await user.hover(
+			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+		);
 
 		await waitFor( () =>
 			expect( screen.getByText( 'shortcut text' ) ).toBeVisible()
@@ -249,7 +257,9 @@ describe( 'Tooltip', () => {
 			/>
 		);
 
-		await user.hover( screen.getByRole( 'button', { name: /Button/i } ) );
+		await user.hover(
+			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+		);
 
 		await waitFor( () =>
 			expect( screen.getByText( '⇧⌘,' ) ).toBeVisible()
@@ -278,7 +288,7 @@ describe( 'Tooltip', () => {
 
 		await user.hover(
 			screen.getByRole( 'button', {
-				name: /Close/i,
+				name: /close/i,
 			} )
 		);
 
@@ -302,7 +312,7 @@ describe( 'Tooltip', () => {
 
 		await user.hover(
 			screen.getByRole( 'button', {
-				name: /Button/i,
+				name: 'Tooltip anchor',
 			} )
 		);
 
@@ -316,18 +326,18 @@ describe( 'Tooltip', () => {
 
 		render( <Tooltip { ...props } hideOnClick={ false } /> );
 
-		const button = screen.getByRole( 'button', { name: /Button/i } );
+		const button = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
 
 		await user.hover( button );
 
 		expect(
-			await screen.findByRole( 'tooltip', { name: /tooltip text/i } )
+			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
 
 		await user.click( button );
 
 		expect(
-			screen.getByRole( 'tooltip', { name: /tooltip text/i } )
+			screen.getByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
 
 		await cleanupTooltip( user );

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -31,10 +31,11 @@ const expectTooltipToBeHidden = () =>
 		screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 	).not.toBeInTheDocument();
 
-const waitForTooltipToShow = ( timeout = TOOLTIP_DELAY ) =>
-	waitFor( () => expectTooltipToBeVisible(), { timeout } );
+const waitForTooltipToShow = async ( timeout = TOOLTIP_DELAY ) =>
+	await waitFor( () => expectTooltipToBeVisible(), { timeout } );
 
-const waitForTooltipToHide = () => waitFor( () => expectTooltipToBeHidden );
+const waitForTooltipToHide = async () =>
+	await waitFor( () => expectTooltipToBeHidden );
 
 const hoverOutside = async () => {
 	await hover( document.body );

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -349,11 +349,13 @@ describe( 'Tooltip', () => {
 			await hover(
 				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
 			);
-			expect(
-				screen.getByRole( 'tooltip', {
-					name: 'tooltip text shortcut text',
-				} )
-			).toBeVisible();
+			await waitFor( () =>
+				expect(
+					screen.getByRole( 'tooltip', {
+						name: 'tooltip text shortcut text',
+					} )
+				).toBeVisible()
+			);
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();
@@ -375,11 +377,18 @@ describe( 'Tooltip', () => {
 			await hover(
 				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
 			);
-			const tooltip = screen.getByRole( 'tooltip', {
-				name: 'tooltip text Control + Shift + Comma',
-			} );
-			expect( tooltip ).toBeVisible();
-			expect( tooltip ).toHaveTextContent( /⇧⌘,/i );
+			await waitFor( () =>
+				expect(
+					screen.getByRole( 'tooltip', {
+						name: 'tooltip text Control + Shift + Comma',
+					} )
+				).toBeVisible()
+			);
+			expect(
+				screen.getByRole( 'tooltip', {
+					name: 'tooltip text Control + Shift + Comma',
+				} )
+			).toHaveTextContent( /⇧⌘,/i );
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -289,7 +289,7 @@ describe( 'Tooltip', () => {
 		await waitForTooltipToHide();
 	} );
 
-	it( 'esc should close modal even when tooltip is visible', async () => {
+	it( 'should close the parent dialog component when pressing the Escape key while the tooltip is visible', async () => {
 		const onRequestClose = jest.fn();
 		render(
 			<Modal onRequestClose={ onRequestClose }>
@@ -297,25 +297,27 @@ describe( 'Tooltip', () => {
 			</Modal>
 		);
 
-		expect(
-			screen.queryByRole( 'tooltip', { name: /close/i } )
-		).not.toBeInTheDocument();
+		expectTooltipToBeHidden();
 
-		await hover(
-			screen.getByRole( 'button', {
-				name: /close/i,
-			} )
-		);
+		const closeButton = screen.getByRole( 'button', {
+			name: /close/i,
+		} );
 
+		// Hover over the anchor, tooltip should show
+		await hover( closeButton );
 		await waitFor( () =>
 			expect(
 				screen.getByRole( 'tooltip', { name: /close/i } )
 			).toBeVisible()
 		);
 
+		// Press the Escape key, Modal should request to be closed
 		await press.Escape();
-
 		expect( onRequestClose ).toHaveBeenCalled();
+
+		// Hover outside of the anchor, tooltip should hide
+		await hoverOutside();
+		await waitForTooltipToHide();
 	} );
 
 	it( 'should associate the tooltip text with its anchor via the accessible description when visible', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -42,309 +42,381 @@ const hoverOutside = async () => {
 };
 
 describe( 'Tooltip', () => {
-	it( 'should not render the tooltip if multiple children are passed', async () => {
-		render(
-			// expected TS error since Tooltip cannot have more than one child element
-			// @ts-expect-error
-			<Tooltip { ...props }>
-				<Button>First button</Button>
-				<Button>Second button</Button>
-			</Tooltip>
-		);
+	describe( 'basic behavior', () => {
+		it( 'should not render the tooltip if multiple children are passed', async () => {
+			render(
+				// expected TS error since Tooltip cannot have more than one child element
+				// @ts-expect-error
+				<Tooltip { ...props }>
+					<Button>First button</Button>
+					<Button>Second button</Button>
+				</Tooltip>
+			);
 
-		expect(
-			screen.getByRole( 'button', { name: 'First button' } )
-		).toBeVisible();
-		expect(
-			screen.getByRole( 'button', { name: 'Second button' } )
-		).toBeVisible();
-
-		await press.Tab();
-
-		expectTooltipToBeHidden();
-	} );
-
-	it( 'should associate the tooltip text with its anchor via the accessible description when visible', async () => {
-		render( <Tooltip { ...props } /> );
-
-		// The anchor can not be found by querying for its description,
-		// since that is present only when the tooltip is visible
-		expect(
-			screen.queryByRole( 'button', { description: 'tooltip text' } )
-		).not.toBeInTheDocument();
-
-		// Hover the anchor. The tooltip shows and its text is used to describe
-		// the tooltip anchor
-		await hover(
-			screen.getByRole( 'button', {
-				name: 'Tooltip anchor',
-			} )
-		);
-		expect(
-			await screen.findByRole( 'button', { description: 'tooltip text' } )
-		).toBeInTheDocument();
-
-		// Hover outside of the anchor, tooltip should hide
-		await hoverOutside();
-		await waitForTooltipToHide();
-		expect(
-			screen.queryByRole( 'button', { description: 'tooltip text' } )
-		).not.toBeInTheDocument();
-	} );
-
-	it( 'should not render the tooltip if there is no focus', () => {
-		render( <Tooltip { ...props } /> );
-
-		expect(
-			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-		).toBeVisible();
-
-		expectTooltipToBeHidden();
-	} );
-
-	it( 'should show the tooltip when focusing on the tooltip anchor and hide it the anchor loses focus', async () => {
-		render(
-			<>
-				<Tooltip { ...props } />
-				<button>Focus me</button>
-			</>
-		);
-
-		// Focus the anchor, tooltip should show
-		await press.Tab();
-		expect(
-			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-		).toHaveFocus();
-		await waitForTooltipToShow();
-
-		// Focus the other button, tooltip should hide
-		await press.Tab();
-		expect(
-			screen.getByRole( 'button', { name: 'Focus me' } )
-		).toHaveFocus();
-		await waitForTooltipToHide();
-	} );
-
-	it( 'should show the tooltip when the tooltip anchor is hovered and hide it when the cursor stops hovering the anchor', async () => {
-		render( <Tooltip { ...props } /> );
-
-		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
-
-		expect( anchor ).toBeVisible();
-
-		// Hover over the anchor, tooltip should show
-		await hover( anchor );
-		await waitForTooltipToShow();
-
-		// Hover outside of the anchor, tooltip should hide
-		await hoverOutside();
-		await waitForTooltipToHide();
-	} );
-
-	it( 'should hide tooltip when the tooltip anchor is clicked', async () => {
-		render( <Tooltip { ...props } /> );
-
-		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
-
-		expect( anchor ).toBeVisible();
-
-		// Hover over the anchor, tooltip should show
-		await hover( anchor );
-		await waitForTooltipToShow();
-
-		// Click the anchor, tooltip should hide
-		await click( anchor );
-		await waitForTooltipToHide();
-	} );
-
-	it( 'should not hide tooltip when the tooltip anchor is clicked and the `hideOnClick` prop is `false', async () => {
-		render(
-			<>
-				<Tooltip { ...props } hideOnClick={ false } />
-				<button>Click me</button>
-			</>
-		);
-
-		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
-
-		expect( anchor ).toBeVisible();
-
-		// Hover over the anchor, tooltip should show
-		await hover( anchor );
-		await waitForTooltipToShow();
-
-		// Click the anchor, tooltip should not hide
-		await click( anchor );
-		await waitForTooltipToShow();
-
-		// Click another button, tooltip should hide
-		await click( screen.getByRole( 'button', { name: 'Click me' } ) );
-		await waitForTooltipToHide();
-	} );
-
-	it( 'should respect custom delay prop when showing tooltip', async () => {
-		const ADDITIONAL_DELAY = 100;
-
-		render(
-			<Tooltip { ...props } delay={ TOOLTIP_DELAY + ADDITIONAL_DELAY } />
-		);
-
-		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
-		expect( anchor ).toBeVisible();
-
-		// Hover over the anchor
-		await hover( anchor );
-		expectTooltipToBeHidden();
-
-		// Advance time by default delay
-		await sleep( TOOLTIP_DELAY );
-
-		// Tooltip hasn't appeared yet
-		expectTooltipToBeHidden();
-
-		// Wait for additional delay for tooltip to appear
-		await sleep( ADDITIONAL_DELAY );
-		await waitForTooltipToShow();
-
-		// Hover outside of the anchor, tooltip should hide
-		await hoverOutside();
-		await waitForTooltipToHide();
-	} );
-
-	it( 'should show tooltip when the anchor button is disabled but focusable', async () => {
-		render(
-			<Tooltip { ...props }>
-				<Button disabled __experimentalIsFocusable>
-					Tooltip anchor
-				</Button>
-			</Tooltip>
-		);
-
-		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
-
-		expect( anchor ).toBeVisible();
-		expect( anchor ).toHaveAttribute( 'aria-disabled', 'true' );
-
-		// Hover over the anchor, tooltip should show
-		await hover( anchor );
-		await waitForTooltipToShow();
-
-		// Hover outside of the anchor, tooltip should hide
-		await hoverOutside();
-		await waitForTooltipToHide();
-	} );
-
-	it( 'should not show tooltip if the mouse leaves the tooltip anchor before set delay', async () => {
-		const onMouseEnterMock = jest.fn();
-		const onMouseLeaveMock = jest.fn();
-		const HOVER_OUTSIDE_ANTICIPATION = 200;
-
-		render(
-			<Tooltip { ...props }>
-				<Button
-					onMouseEnter={ onMouseEnterMock }
-					onMouseLeave={ onMouseLeaveMock }
-				>
-					Tooltip anchor
-				</Button>
-			</Tooltip>
-		);
-
-		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
-		expect( anchor ).toBeVisible();
-
-		// Hover over the anchor, tooltip hasn't appeared yet
-		await hover( anchor );
-		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
-		expectTooltipToBeHidden();
-
-		// Advance time, tooltip hasn't appeared yet because TOOLTIP_DELAY time
-		// hasn't passed yet
-		await sleep( TOOLTIP_DELAY - HOVER_OUTSIDE_ANTICIPATION );
-		expectTooltipToBeHidden();
-
-		// Hover outside of the anchor, tooltip still hasn't appeared yet
-		await hoverOutside();
-		expectTooltipToBeHidden();
-
-		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
-		expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
-
-		// Advance time again, so that we reach the full TOOLTIP_DELAY time
-		await sleep( HOVER_OUTSIDE_ANTICIPATION );
-
-		// Tooltip won't show, since the mouse has left the tooltip anchor
-		expectTooltipToBeHidden();
-	} );
-
-	it( 'should show the shortcut in the tooltip when a string is passed as the shortcut', async () => {
-		render( <Tooltip { ...props } shortcut="shortcut text" /> );
-
-		// Hover over the anchor, tooltip should show
-		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
-		expect(
-			screen.getByRole( 'tooltip', {
-				name: 'tooltip text shortcut text',
-			} )
-		).toBeVisible();
-
-		// Hover outside of the anchor, tooltip should hide
-		await hoverOutside();
-		await waitForTooltipToHide();
-	} );
-
-	it( 'should show the shortcut in the tooltip when an object is passed as the shortcut', async () => {
-		render(
-			<Tooltip
-				{ ...props }
-				shortcut={ {
-					display: '⇧⌘,',
-					ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
-				} }
-			/>
-		);
-
-		// Hover over the anchor, tooltip should show
-		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
-		const tooltip = screen.getByRole( 'tooltip', {
-			name: 'tooltip text Control + Shift + Comma',
-		} );
-		expect( tooltip ).toBeVisible();
-		expect( tooltip ).toHaveTextContent( /⇧⌘,/i );
-
-		// Hover outside of the anchor, tooltip should hide
-		await hoverOutside();
-		await waitForTooltipToHide();
-	} );
-
-	it( 'should close the parent dialog component when pressing the Escape key while the tooltip is visible', async () => {
-		const onRequestClose = jest.fn();
-		render(
-			<Modal onRequestClose={ onRequestClose }>
-				<p>Modal content</p>
-			</Modal>
-		);
-
-		expectTooltipToBeHidden();
-
-		const closeButton = screen.getByRole( 'button', {
-			name: /close/i,
-		} );
-
-		// Hover over the anchor, tooltip should show
-		await hover( closeButton );
-		await waitFor( () =>
 			expect(
-				screen.getByRole( 'tooltip', { name: /close/i } )
-			).toBeVisible()
-		);
+				screen.getByRole( 'button', { name: 'First button' } )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'button', { name: 'Second button' } )
+			).toBeVisible();
 
-		// Press the Escape key, Modal should request to be closed
-		await press.Escape();
-		expect( onRequestClose ).toHaveBeenCalled();
+			await press.Tab();
 
-		// Hover outside of the anchor, tooltip should hide
-		await hoverOutside();
-		await waitForTooltipToHide();
+			expectTooltipToBeHidden();
+		} );
+
+		it( 'should associate the tooltip text with its anchor via the accessible description when visible', async () => {
+			render( <Tooltip { ...props } /> );
+
+			// The anchor can not be found by querying for its description,
+			// since that is present only when the tooltip is visible
+			expect(
+				screen.queryByRole( 'button', { description: 'tooltip text' } )
+			).not.toBeInTheDocument();
+
+			// Hover the anchor. The tooltip shows and its text is used to describe
+			// the tooltip anchor
+			await hover(
+				screen.getByRole( 'button', {
+					name: 'Tooltip anchor',
+				} )
+			);
+			expect(
+				await screen.findByRole( 'button', {
+					description: 'tooltip text',
+				} )
+			).toBeInTheDocument();
+
+			// Hover outside of the anchor, tooltip should hide
+			await hoverOutside();
+			await waitForTooltipToHide();
+			expect(
+				screen.queryByRole( 'button', { description: 'tooltip text' } )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'keyboard focus', () => {
+		it( 'should not render the tooltip if there is no focus', () => {
+			render( <Tooltip { ...props } /> );
+
+			expect(
+				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+			).toBeVisible();
+
+			expectTooltipToBeHidden();
+		} );
+
+		it( 'should show the tooltip when focusing on the tooltip anchor and hide it the anchor loses focus', async () => {
+			render(
+				<>
+					<Tooltip { ...props } />
+					<button>Focus me</button>
+				</>
+			);
+
+			// Focus the anchor, tooltip should show
+			await press.Tab();
+			expect(
+				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+			).toHaveFocus();
+			await waitForTooltipToShow();
+
+			// Focus the other button, tooltip should hide
+			await press.Tab();
+			expect(
+				screen.getByRole( 'button', { name: 'Focus me' } )
+			).toHaveFocus();
+			await waitForTooltipToHide();
+		} );
+
+		it( 'should show tooltip when focussing a disabled (but focussable) anchor button', async () => {
+			render(
+				<>
+					<Tooltip { ...props }>
+						<Button disabled __experimentalIsFocusable>
+							Tooltip anchor
+						</Button>
+					</Tooltip>
+					<button>Focus me</button>
+				</>
+			);
+
+			const anchor = screen.getByRole( 'button', {
+				name: 'Tooltip anchor',
+			} );
+
+			expect( anchor ).toBeVisible();
+			expect( anchor ).toHaveAttribute( 'aria-disabled', 'true' );
+
+			// Focus anchor, tooltip should show
+			await press.Tab();
+			expect( anchor ).toHaveFocus();
+			await waitForTooltipToShow();
+
+			// Focus another button, tooltip should hide
+			await press.Tab();
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Focus me',
+				} )
+			).toHaveFocus();
+			await waitForTooltipToHide();
+		} );
+	} );
+
+	describe( 'mouse hover', () => {
+		it( 'should show the tooltip when the tooltip anchor is hovered and hide it when the cursor stops hovering the anchor', async () => {
+			render( <Tooltip { ...props } /> );
+
+			const anchor = screen.getByRole( 'button', {
+				name: 'Tooltip anchor',
+			} );
+
+			expect( anchor ).toBeVisible();
+
+			// Hover over the anchor, tooltip should show
+			await hover( anchor );
+			await waitForTooltipToShow();
+
+			// Hover outside of the anchor, tooltip should hide
+			await hoverOutside();
+			await waitForTooltipToHide();
+		} );
+
+		it( 'should show tooltip when hovering over a disabled (but focussable) anchor button', async () => {
+			render(
+				<>
+					<Tooltip { ...props }>
+						<Button disabled __experimentalIsFocusable>
+							Tooltip anchor
+						</Button>
+					</Tooltip>
+					<button>Focus me</button>
+				</>
+			);
+
+			const anchor = screen.getByRole( 'button', {
+				name: 'Tooltip anchor',
+			} );
+
+			expect( anchor ).toBeVisible();
+			expect( anchor ).toHaveAttribute( 'aria-disabled', 'true' );
+
+			// Hover over the anchor, tooltip should show
+			await hover( anchor );
+			await waitForTooltipToShow();
+
+			// Hover outside of the anchor, tooltip should hide
+			await hoverOutside();
+			await waitForTooltipToHide();
+		} );
+	} );
+
+	describe( 'mouse click', () => {
+		it( 'should hide tooltip when the tooltip anchor is clicked', async () => {
+			render( <Tooltip { ...props } /> );
+
+			const anchor = screen.getByRole( 'button', {
+				name: 'Tooltip anchor',
+			} );
+
+			expect( anchor ).toBeVisible();
+
+			// Hover over the anchor, tooltip should show
+			await hover( anchor );
+			await waitForTooltipToShow();
+
+			// Click the anchor, tooltip should hide
+			await click( anchor );
+			await waitForTooltipToHide();
+		} );
+
+		it( 'should not hide tooltip when the tooltip anchor is clicked and the `hideOnClick` prop is `false', async () => {
+			render(
+				<>
+					<Tooltip { ...props } hideOnClick={ false } />
+					<button>Click me</button>
+				</>
+			);
+
+			const anchor = screen.getByRole( 'button', {
+				name: 'Tooltip anchor',
+			} );
+
+			expect( anchor ).toBeVisible();
+
+			// Hover over the anchor, tooltip should show
+			await hover( anchor );
+			await waitForTooltipToShow();
+
+			// Click the anchor, tooltip should not hide
+			await click( anchor );
+			await waitForTooltipToShow();
+
+			// Click another button, tooltip should hide
+			await click( screen.getByRole( 'button', { name: 'Click me' } ) );
+			await waitForTooltipToHide();
+		} );
+	} );
+
+	describe( 'delay', () => {
+		it( 'should respect custom delay prop when showing tooltip', async () => {
+			const ADDITIONAL_DELAY = 100;
+
+			render(
+				<Tooltip
+					{ ...props }
+					delay={ TOOLTIP_DELAY + ADDITIONAL_DELAY }
+				/>
+			);
+
+			const anchor = screen.getByRole( 'button', {
+				name: 'Tooltip anchor',
+			} );
+			expect( anchor ).toBeVisible();
+
+			// Hover over the anchor
+			await hover( anchor );
+			expectTooltipToBeHidden();
+
+			// Advance time by default delay
+			await sleep( TOOLTIP_DELAY );
+
+			// Tooltip hasn't appeared yet
+			expectTooltipToBeHidden();
+
+			// Wait for additional delay for tooltip to appear
+			await sleep( ADDITIONAL_DELAY );
+			await waitForTooltipToShow();
+
+			// Hover outside of the anchor, tooltip should hide
+			await hoverOutside();
+			await waitForTooltipToHide();
+		} );
+
+		it( 'should not show tooltip if the mouse leaves the tooltip anchor before set delay', async () => {
+			const onMouseEnterMock = jest.fn();
+			const onMouseLeaveMock = jest.fn();
+			const HOVER_OUTSIDE_ANTICIPATION = 200;
+
+			render(
+				<Tooltip { ...props }>
+					<Button
+						onMouseEnter={ onMouseEnterMock }
+						onMouseLeave={ onMouseLeaveMock }
+					>
+						Tooltip anchor
+					</Button>
+				</Tooltip>
+			);
+
+			const anchor = screen.getByRole( 'button', {
+				name: 'Tooltip anchor',
+			} );
+			expect( anchor ).toBeVisible();
+
+			// Hover over the anchor, tooltip hasn't appeared yet
+			await hover( anchor );
+			expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
+			expectTooltipToBeHidden();
+
+			// Advance time, tooltip hasn't appeared yet because TOOLTIP_DELAY time
+			// hasn't passed yet
+			await sleep( TOOLTIP_DELAY - HOVER_OUTSIDE_ANTICIPATION );
+			expectTooltipToBeHidden();
+
+			// Hover outside of the anchor, tooltip still hasn't appeared yet
+			await hoverOutside();
+			expectTooltipToBeHidden();
+
+			expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
+			expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
+
+			// Advance time again, so that we reach the full TOOLTIP_DELAY time
+			await sleep( HOVER_OUTSIDE_ANTICIPATION );
+
+			// Tooltip won't show, since the mouse has left the tooltip anchor
+			expectTooltipToBeHidden();
+		} );
+	} );
+
+	describe( 'shortcut', () => {
+		it( 'should show the shortcut in the tooltip when a string is passed as the shortcut', async () => {
+			render( <Tooltip { ...props } shortcut="shortcut text" /> );
+
+			// Hover over the anchor, tooltip should show
+			await hover(
+				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+			);
+			expect(
+				screen.getByRole( 'tooltip', {
+					name: 'tooltip text shortcut text',
+				} )
+			).toBeVisible();
+
+			// Hover outside of the anchor, tooltip should hide
+			await hoverOutside();
+			await waitForTooltipToHide();
+		} );
+
+		it( 'should show the shortcut in the tooltip when an object is passed as the shortcut', async () => {
+			render(
+				<Tooltip
+					{ ...props }
+					shortcut={ {
+						display: '⇧⌘,',
+						ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
+					} }
+				/>
+			);
+
+			// Hover over the anchor, tooltip should show
+			await hover(
+				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+			);
+			const tooltip = screen.getByRole( 'tooltip', {
+				name: 'tooltip text Control + Shift + Comma',
+			} );
+			expect( tooltip ).toBeVisible();
+			expect( tooltip ).toHaveTextContent( /⇧⌘,/i );
+
+			// Hover outside of the anchor, tooltip should hide
+			await hoverOutside();
+			await waitForTooltipToHide();
+		} );
+	} );
+
+	describe( 'event propagation', () => {
+		it( 'should close the parent dialog component when pressing the Escape key while the tooltip is visible', async () => {
+			const onRequestClose = jest.fn();
+			render(
+				<Modal onRequestClose={ onRequestClose }>
+					<p>Modal content</p>
+				</Modal>
+			);
+
+			expectTooltipToBeHidden();
+
+			const closeButton = screen.getByRole( 'button', {
+				name: /close/i,
+			} );
+
+			// Hover over the anchor, tooltip should show
+			await hover( closeButton );
+			await waitFor( () =>
+				expect(
+					screen.getByRole( 'tooltip', { name: /close/i } )
+				).toBeVisible()
+			);
+
+			// Press the Escape key, Modal should request to be closed
+			await press.Escape();
+			expect( onRequestClose ).toHaveBeenCalled();
+
+			// Hover outside of the anchor, tooltip should hide
+			await hoverOutside();
+			await waitForTooltipToHide();
+		} );
 	} );
 } );

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -130,7 +130,12 @@ describe( 'Tooltip', () => {
 	} );
 
 	it( 'should not hide tooltip when the tooltip anchor is clicked and the `hideOnClick` prop is `false', async () => {
-		render( <Tooltip { ...props } hideOnClick={ false } /> );
+		render(
+			<>
+				<Tooltip { ...props } hideOnClick={ false } />
+				<button>Click me</button>
+			</>
+		);
 
 		const anchor = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
 
@@ -143,6 +148,10 @@ describe( 'Tooltip', () => {
 		// Click the anchor, tooltip should not hide
 		await click( anchor );
 		await waitForTooltipToShow();
+
+		// Click another button, tooltip should hide
+		await click( screen.getByRole( 'button', { name: 'Click me' } ) );
+		await waitForTooltipToHide();
 	} );
 
 	it( 'should respect custom delay prop when showing tooltip', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -45,8 +45,7 @@ describe( 'Tooltip', () => {
 	describe( 'basic behavior', () => {
 		it( 'should not render the tooltip if multiple children are passed', async () => {
 			render(
-				// expected TS error since Tooltip cannot have more than one child element
-				// @ts-expect-error
+				// @ts-expect-error Tooltip cannot have more than one child element
 				<Tooltip { ...props }>
 					<Button>First button</Button>
 					<Button>Second button</Button>

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen, waitFor } from '@testing-library/react';
-import { press, hover, click } from '@ariakit/test';
+import { press, hover, click, sleep } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -94,9 +94,7 @@ describe( 'Tooltip', () => {
 		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
 
 		// Advance time by default delay
-		await new Promise( ( resolve ) =>
-			setTimeout( resolve, TOOLTIP_DELAY )
-		);
+		await sleep( TOOLTIP_DELAY );
 
 		// Tooltip hasn't appeared yet
 		expect(
@@ -104,12 +102,7 @@ describe( 'Tooltip', () => {
 		).not.toBeInTheDocument();
 
 		// wait for additional delay for tooltip to appear
-		await waitFor(
-			() =>
-				new Promise( ( resolve ) =>
-					setTimeout( resolve, ADDITIONAL_DELAY )
-				)
-		);
+		await sleep( ADDITIONAL_DELAY );
 
 		expect(
 			screen.getByRole( 'tooltip', { name: 'tooltip text' } )
@@ -167,9 +160,7 @@ describe( 'Tooltip', () => {
 		expect( onMouseEnterMock ).toHaveBeenCalledTimes( 1 );
 
 		// Advance time by MOUSE_LEAVE_DELAY time
-		await new Promise( ( resolve ) =>
-			setTimeout( resolve, MOUSE_LEAVE_DELAY )
-		);
+		await sleep( MOUSE_LEAVE_DELAY );
 
 		expect(
 			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
@@ -190,9 +181,7 @@ describe( 'Tooltip', () => {
 		expect( onMouseLeaveMock ).toHaveBeenCalledTimes( 1 );
 
 		// Advance time again, so that we reach the full TOOLTIP_DELAY time
-		await new Promise( ( resolve ) =>
-			setTimeout( resolve, TOOLTIP_DELAY )
-		);
+		await sleep( TOOLTIP_DELAY );
 
 		// Tooltip won't show, since the mouse has left the tooltip anchor
 		expect(

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -15,7 +15,6 @@ import { shortcutAriaLabel } from '@wordpress/keycodes';
 import Button from '../../button';
 import Modal from '../../modal';
 import Tooltip, { TOOLTIP_DELAY } from '..';
-import cleanupTooltip from './utils/';
 
 const props = {
 	children: <Button>Tooltip anchor</Button>,

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { press, hover, click } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -51,11 +51,9 @@ describe( 'Tooltip', () => {
 	} );
 
 	it( 'should render the tooltip when focusing on the tooltip anchor via tab', async () => {
-		const user = userEvent.setup();
-
 		render( <Tooltip { ...props } /> );
 
-		await user.tab();
+		await press.Tab();
 
 		expect(
 			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
@@ -64,53 +62,36 @@ describe( 'Tooltip', () => {
 		expect(
 			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should render the tooltip when the tooltip anchor is hovered', async () => {
-		const user = userEvent.setup();
-
 		render( <Tooltip { ...props } /> );
 
-		await user.hover(
-			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-		);
+		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
 
 		expect(
 			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should not show tooltip on focus as result of mouse click', async () => {
-		const user = userEvent.setup();
-
 		render( <Tooltip { ...props } /> );
 
-		await user.click(
-			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-		);
+		await click( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
 
 		expect(
 			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should respect custom delay prop when showing tooltip', async () => {
-		const user = userEvent.setup();
 		const ADDITIONAL_DELAY = 100;
 
 		render(
 			<Tooltip { ...props } delay={ TOOLTIP_DELAY + ADDITIONAL_DELAY } />
 		);
 
-		await user.hover(
-			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-		);
+		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
 
 		// Advance time by default delay
 		await new Promise( ( resolve ) =>
@@ -133,13 +114,9 @@ describe( 'Tooltip', () => {
 		expect(
 			screen.getByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should show tooltip when an element is disabled', async () => {
-		const user = userEvent.setup();
-
 		render(
 			<Tooltip { ...props }>
 				<Button aria-disabled>Button</Button>
@@ -151,17 +128,14 @@ describe( 'Tooltip', () => {
 		expect( button ).toBeVisible();
 		expect( button ).toHaveAttribute( 'aria-disabled' );
 
-		await user.hover( button );
+		await hover( button );
 
 		expect(
 			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should not show tooltip if the mouse leaves the tooltip anchor before set delay', async () => {
-		const user = userEvent.setup();
 		const onMouseEnterMock = jest.fn();
 		const onMouseLeaveMock = jest.fn();
 		const MOUSE_LEAVE_DELAY = TOOLTIP_DELAY - 200;
@@ -180,7 +154,7 @@ describe( 'Tooltip', () => {
 			</>
 		);
 
-		await user.hover(
+		await hover(
 			screen.getByRole( 'button', {
 				name: 'Tooltip anchor',
 			} )
@@ -202,7 +176,7 @@ describe( 'Tooltip', () => {
 		).not.toBeInTheDocument();
 
 		// Hover the other button, meaning that the mouse will leave the tooltip anchor
-		await user.hover(
+		await hover(
 			screen.getByRole( 'button', {
 				name: 'Other button',
 			} )
@@ -224,29 +198,19 @@ describe( 'Tooltip', () => {
 		expect(
 			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 		).not.toBeInTheDocument();
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should render the shortcut display text when a string is passed as the shortcut', async () => {
-		const user = userEvent.setup();
-
 		render( <Tooltip { ...props } shortcut="shortcut text" /> );
 
-		await user.hover(
-			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-		);
+		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
 
 		await waitFor( () =>
 			expect( screen.getByText( 'shortcut text' ) ).toBeVisible()
 		);
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should render the keyboard shortcut display text and aria-label when an object is passed as the shortcut', async () => {
-		const user = userEvent.setup();
-
 		render(
 			<Tooltip
 				{ ...props }
@@ -257,9 +221,7 @@ describe( 'Tooltip', () => {
 			/>
 		);
 
-		await user.hover(
-			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-		);
+		await hover( screen.getByRole( 'button', { name: 'Tooltip anchor' } ) );
 
 		await waitFor( () =>
 			expect( screen.getByText( '⇧⌘,' ) ).toBeVisible()
@@ -269,12 +231,9 @@ describe( 'Tooltip', () => {
 			'aria-label',
 			'Control + Shift + Comma'
 		);
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'esc should close modal even when tooltip is visible', async () => {
-		const user = userEvent.setup();
 		const onRequestClose = jest.fn();
 		render(
 			<Modal onRequestClose={ onRequestClose }>
@@ -286,7 +245,7 @@ describe( 'Tooltip', () => {
 			screen.queryByRole( 'tooltip', { name: /close/i } )
 		).not.toBeInTheDocument();
 
-		await user.hover(
+		await hover(
 			screen.getByRole( 'button', {
 				name: /close/i,
 			} )
@@ -298,19 +257,15 @@ describe( 'Tooltip', () => {
 			).toBeVisible()
 		);
 
-		await user.keyboard( '[Escape]' );
+		await press.Escape();
 
 		expect( onRequestClose ).toHaveBeenCalled();
-
-		await cleanupTooltip( user );
 	} );
 
 	it( 'should associate the tooltip text with its anchor via the accessible description when visible', async () => {
-		const user = userEvent.setup();
-
 		render( <Tooltip { ...props } /> );
 
-		await user.hover(
+		await hover(
 			screen.getByRole( 'button', {
 				name: 'Tooltip anchor',
 			} )
@@ -322,24 +277,20 @@ describe( 'Tooltip', () => {
 	} );
 
 	it( 'should not hide tooltip when the anchor is clicked if hideOnClick is false', async () => {
-		const user = userEvent.setup();
-
 		render( <Tooltip { ...props } hideOnClick={ false } /> );
 
 		const button = screen.getByRole( 'button', { name: 'Tooltip anchor' } );
 
-		await user.hover( button );
+		await hover( button );
 
 		expect(
 			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
 
-		await user.click( button );
+		await click( button );
 
 		expect(
 			screen.getByRole( 'tooltip', { name: 'tooltip text' } )
 		).toBeVisible();
-
-		await cleanupTooltip( user );
 	} );
 } );

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -43,6 +43,14 @@ const hoverOutside = async () => {
 };
 
 describe( 'Tooltip', () => {
+	// Wait enough time to make sure that tooltips don't show immediately, ignoring
+	// the showTimeout delay. For more context, see:
+	// - https://github.com/WordPress/gutenberg/pull/57345#discussion_r1435167187
+	// - https://ariakit.org/reference/tooltip-provider#skiptimeout
+	afterEach( async () => {
+		await sleep( 300 );
+	} );
+
 	describe( 'basic behavior', () => {
 		it( 'should not render the tooltip if multiple children are passed', async () => {
 			render(

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -21,6 +21,27 @@ const props = {
 	text: 'tooltip text',
 };
 
+const waitForTooltipToShow = ( timeout = TOOLTIP_DELAY ) =>
+	waitFor(
+		() =>
+			expect(
+				screen.getByRole( 'tooltip', { name: 'tooltip text' } )
+			).toBeVisible(),
+		{ timeout }
+	);
+
+const waitForTooltipToHide = () =>
+	waitFor( () =>
+		expect(
+			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
+		).not.toBeInTheDocument()
+	);
+
+const hoverOutside = async () => {
+	await hover( document.body );
+	await hover( document.body, { clientX: 10, clientY: 10 } );
+};
+
 describe( 'Tooltip', () => {
 	it( 'should not render the tooltip if multiple children are passed', async () => {
 		render(

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -64,6 +64,34 @@ describe( 'Tooltip', () => {
 		expectTooltipToBeHidden();
 	} );
 
+	it( 'should associate the tooltip text with its anchor via the accessible description when visible', async () => {
+		render( <Tooltip { ...props } /> );
+
+		// The anchor can not be found by querying for its description,
+		// since that is present only when the tooltip is visible
+		expect(
+			screen.queryByRole( 'button', { description: 'tooltip text' } )
+		).not.toBeInTheDocument();
+
+		// Hover the anchor. The tooltip shows and its text is used to describe
+		// the tooltip anchor
+		await hover(
+			screen.getByRole( 'button', {
+				name: 'Tooltip anchor',
+			} )
+		);
+		expect(
+			await screen.findByRole( 'button', { description: 'tooltip text' } )
+		).toBeInTheDocument();
+
+		// Hover outside of the anchor, tooltip should hide
+		await hoverOutside();
+		await waitForTooltipToHide();
+		expect(
+			screen.queryByRole( 'button', { description: 'tooltip text' } )
+		).not.toBeInTheDocument();
+	} );
+
 	it( 'should not render the tooltip if there is no focus', () => {
 		render( <Tooltip { ...props } /> );
 
@@ -318,19 +346,5 @@ describe( 'Tooltip', () => {
 		// Hover outside of the anchor, tooltip should hide
 		await hoverOutside();
 		await waitForTooltipToHide();
-	} );
-
-	it( 'should associate the tooltip text with its anchor via the accessible description when visible', async () => {
-		render( <Tooltip { ...props } /> );
-
-		await hover(
-			screen.getByRole( 'button', {
-				name: 'Tooltip anchor',
-			} )
-		);
-
-		expect(
-			await screen.findByRole( 'button', { description: 'tooltip text' } )
-		).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -79,18 +79,27 @@ describe( 'Tooltip', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should render the tooltip when focusing on the tooltip anchor via tab', async () => {
-		render( <Tooltip { ...props } /> );
+	it( 'should show the tooltip when focusing on the tooltip anchor and hide it the anchor loses focus', async () => {
+		render(
+			<>
+				<Tooltip { ...props } />
+				<button>Focus me</button>
+			</>
+		);
 
+		// Focus the anchor, tooltip should show
 		await press.Tab();
-
 		expect(
 			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
 		).toHaveFocus();
+		await waitForTooltipToShow();
 
+		// Focus the other button, tooltip should hide
+		await press.Tab();
 		expect(
-			await screen.findByRole( 'tooltip', { name: 'tooltip text' } )
-		).toBeVisible();
+			screen.getByRole( 'button', { name: 'Focus me' } )
+		).toHaveFocus();
+		await waitForTooltipToHide();
 	} );
 
 	it( 'should render the tooltip when the tooltip anchor is hovered', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -48,10 +48,19 @@ describe( 'Tooltip', () => {
 			// expected TS error since Tooltip cannot have more than one child element
 			// @ts-expect-error
 			<Tooltip { ...props }>
-				<Button>This is a button</Button>
-				<Button>This is another button</Button>
+				<Button>First button</Button>
+				<Button>Second button</Button>
 			</Tooltip>
 		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'First button' } )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'button', { name: 'Second button' } )
+		).toBeVisible();
+
+		await press.Tab();
 
 		expect(
 			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -21,21 +21,20 @@ const props = {
 	text: 'tooltip text',
 };
 
-const waitForTooltipToShow = ( timeout = TOOLTIP_DELAY ) =>
-	waitFor(
-		() =>
-			expect(
-				screen.getByRole( 'tooltip', { name: 'tooltip text' } )
-			).toBeVisible(),
-		{ timeout }
-	);
+const expectTooltipToBeVisible = () =>
+	expect(
+		screen.getByRole( 'tooltip', { name: 'tooltip text' } )
+	).toBeVisible();
 
-const waitForTooltipToHide = () =>
-	waitFor( () =>
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument()
-	);
+const expectTooltipToBeHidden = () =>
+	expect(
+		screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
+	).not.toBeInTheDocument();
+
+const waitForTooltipToShow = ( timeout = TOOLTIP_DELAY ) =>
+	waitFor( () => expectTooltipToBeVisible(), { timeout } );
+
+const waitForTooltipToHide = () => waitFor( () => expectTooltipToBeHidden );
 
 const hoverOutside = async () => {
 	await hover( document.body );
@@ -62,9 +61,7 @@ describe( 'Tooltip', () => {
 
 		await press.Tab();
 
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument();
+		expectTooltipToBeHidden();
 	} );
 
 	it( 'should not render the tooltip if there is no focus', () => {
@@ -74,9 +71,7 @@ describe( 'Tooltip', () => {
 			screen.getByRole( 'button', { name: 'Tooltip anchor' } )
 		).toBeVisible();
 
-		expect(
-			screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
-		).not.toBeInTheDocument();
+		expectTooltipToBeHidden();
 	} );
 
 	it( 'should show the tooltip when focusing on the tooltip anchor and hide it the anchor loses focus', async () => {

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -31,11 +31,11 @@ const expectTooltipToBeHidden = () =>
 		screen.queryByRole( 'tooltip', { name: 'tooltip text' } )
 	).not.toBeInTheDocument();
 
-const waitForTooltipToShow = async ( timeout = TOOLTIP_DELAY ) =>
-	await waitFor( () => expectTooltipToBeVisible(), { timeout } );
+const waitExpectTooltipToShow = async ( timeout = TOOLTIP_DELAY ) =>
+	await waitFor( expectTooltipToBeVisible, { timeout } );
 
-const waitForTooltipToHide = async () =>
-	await waitFor( () => expectTooltipToBeHidden );
+const waitExpectTooltipToHide = async () =>
+	await waitFor( expectTooltipToBeHidden );
 
 const hoverOutside = async () => {
 	await hover( document.body );
@@ -97,7 +97,7 @@ describe( 'Tooltip', () => {
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 			expect(
 				screen.queryByRole( 'button', { description: 'tooltip text' } )
 			).not.toBeInTheDocument();
@@ -128,14 +128,14 @@ describe( 'Tooltip', () => {
 			expect(
 				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
 			).toHaveFocus();
-			await waitForTooltipToShow();
+			await waitExpectTooltipToShow();
 
 			// Focus the other button, tooltip should hide
 			await press.Tab();
 			expect(
 				screen.getByRole( 'button', { name: 'Focus me' } )
 			).toHaveFocus();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 
 		it( 'should show tooltip when focussing a disabled (but focussable) anchor button', async () => {
@@ -160,7 +160,7 @@ describe( 'Tooltip', () => {
 			// Focus anchor, tooltip should show
 			await press.Tab();
 			expect( anchor ).toHaveFocus();
-			await waitForTooltipToShow();
+			await waitExpectTooltipToShow();
 
 			// Focus another button, tooltip should hide
 			await press.Tab();
@@ -169,7 +169,7 @@ describe( 'Tooltip', () => {
 					name: 'Focus me',
 				} )
 			).toHaveFocus();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 	} );
 
@@ -185,11 +185,11 @@ describe( 'Tooltip', () => {
 
 			// Hover over the anchor, tooltip should show
 			await hover( anchor );
-			await waitForTooltipToShow();
+			await waitExpectTooltipToShow();
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 
 		it( 'should show tooltip when hovering over a disabled (but focussable) anchor button', async () => {
@@ -213,11 +213,11 @@ describe( 'Tooltip', () => {
 
 			// Hover over the anchor, tooltip should show
 			await hover( anchor );
-			await waitForTooltipToShow();
+			await waitExpectTooltipToShow();
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 	} );
 
@@ -233,11 +233,11 @@ describe( 'Tooltip', () => {
 
 			// Hover over the anchor, tooltip should show
 			await hover( anchor );
-			await waitForTooltipToShow();
+			await waitExpectTooltipToShow();
 
 			// Click the anchor, tooltip should hide
 			await click( anchor );
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 
 		it( 'should not hide tooltip when the tooltip anchor is clicked and the `hideOnClick` prop is `false', async () => {
@@ -256,15 +256,15 @@ describe( 'Tooltip', () => {
 
 			// Hover over the anchor, tooltip should show
 			await hover( anchor );
-			await waitForTooltipToShow();
+			await waitExpectTooltipToShow();
 
 			// Click the anchor, tooltip should not hide
 			await click( anchor );
-			await waitForTooltipToShow();
+			await waitExpectTooltipToShow();
 
 			// Click another button, tooltip should hide
 			await click( screen.getByRole( 'button', { name: 'Click me' } ) );
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 	} );
 
@@ -296,11 +296,11 @@ describe( 'Tooltip', () => {
 
 			// Wait for additional delay for tooltip to appear
 			await sleep( ADDITIONAL_DELAY );
-			await waitForTooltipToShow();
+			await waitExpectTooltipToShow();
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 
 		it( 'should not show tooltip if the mouse leaves the tooltip anchor before set delay', async () => {
@@ -367,7 +367,7 @@ describe( 'Tooltip', () => {
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 
 		it( 'should show the shortcut in the tooltip when an object is passed as the shortcut', async () => {
@@ -400,7 +400,7 @@ describe( 'Tooltip', () => {
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 	} );
 
@@ -433,7 +433,7 @@ describe( 'Tooltip', () => {
 
 			// Hover outside of the anchor, tooltip should hide
 			await hoverOutside();
-			await waitForTooltipToHide();
+			await waitExpectTooltipToHide();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related to #57206 and #57204

## What?
<!-- In a few words, what is the PR actually doing? -->

Improve Tooltip tests:
- make less flaky / hacky
- test for tooltip to hide after hover / focus / click events as expected
- tidy up code

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The conversation in #57206 brought up some added nuance to `Tooltip`'s behavior that we should add to our unit tests

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Switched to `@ariakit/test`
- Went test by test, improving assertions, adding comments, and generally proposing a better order/organisation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**Note: I recommend reviewing code changes commit by commit**

- Tooltip: No runtime changes, make sure unit tests pass
- Modal: added an extra check on detecting the Escape key => test on Storybook and in the editor that the Modal component still closes as expected when pressing the Escape key