### PR TITLE
RadioControl: Fully encapsulate styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   `Snackbar`: Remove erroneous `__unstableHTML` prop from TypeScript definitions ([#57218](https://github.com/WordPress/gutenberg/pull/57218)).
 -   `Truncate`: improve handling of non-string `children` ([#57261](https://github.com/WordPress/gutenberg/pull/57261)).
 -   `PaletteEdit`: Don't discard colors with default name and slug ([#54332](https://github.com/WordPress/gutenberg/pull/54332)).
+-   `RadioControl`: Fully encapsulate styles ([#57347](https://github.com/WordPress/gutenberg/pull/57347)).
 
 ### Enhancements
 

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -92,7 +92,10 @@ export function RadioControl(
 							}
 							{ ...additionalProps }
 						/>
-						<label htmlFor={ `${ id }-${ index }` }>
+						<label
+							className="components-radio-control__label"
+							htmlFor={ `${ id }-${ index }` }
+						>
 							{ option.label }
 						</label>
 					</div>

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -1,5 +1,32 @@
+.components-radio-control__option {
+	display: flex;
+	align-items: center;
+}
+
 .components-radio-control__input[type="radio"] {
 	@include radio-control;
-	margin-top: 0;
-	margin-right: 6px;
+
+	display: inline-flex;
+	margin: 0 6px 0 0;
+	padding: 0;
+	appearance: none;
+	cursor: pointer;
+
+	&:focus {
+		box-shadow: 0 0 0 ($border-width * 2) $components-color-background, 0 0 0 ($border-width * 2 + $border-width-focus-fallback) $components-color-accent;
+	}
+
+	&:checked {
+		background: $components-color-accent;
+		border-color: $components-color-accent;
+
+		&::before {
+			content: "";
+			border-radius: 50%;
+		}
+	}
+}
+
+.components-radio-control__label {
+	cursor: pointer;
 }


### PR DESCRIPTION
Fixes #50428
Fixes #26293

## What?

Fully encapsulates the styles required for RadioControl so that it looks like it does in a WordPress context.

## Why?

RadioControl had several stylistic issues, including not reflecting the components theme color (#50428), and having weird focus styles in Firefox (#26293). In fact, RadioControl in isolation (e.g. in Storybook) looked quite different from when rendered inside the Gutenberg editor, which was actually the correct design.

This was due to a lot of the necessary styles being provided through the [`forms.css` stylesheet](https://github.com/WordPress/WordPress/blob/master/wp-admin/css/forms.css) that is loaded globally in WordPress contexts.

## How?

Adds the necessary styles so it looks correct regardless of whether `forms.css` is loaded.


## Testing Instructions

See the RadioControl story in Storybook.

It should look the same as when [`forms.css` is loaded](https://wordpress.github.io/gutenberg/?path=/docs/components-radiocontrol--docs&globals=css:wordpress).

Component theme colors should apply correctly.

https://github.com/WordPress/gutenberg/assets/555336/7de49c01-b14a-4352-9335-492bfaba2826


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/WordPress/gutenberg/assets/555336/120b51d7-0b3c-4723-bb40-2a8b9fc6964c" alt="RadioControl with wrong styles" width="209">|<img src="https://github.com/WordPress/gutenberg/assets/555336/dad19986-4932-4b36-947c-715a2cb17bed" alt="RadioControl with correct styles" width="209">|

