### PR TITLE
PoC: Show media previews in the List View via new API

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -251,6 +251,19 @@ _Returns_
 
 -   `string`: Root client ID
 
+### getBlockImage
+
+Returns the list of the block images.
+
+_Parameters_
+
+-   _state_ `Record<string,boolean>`: Current state.
+-   _clientId_ `string`: Client Id of the block.
+
+_Returns_
+
+-   `Record<string,boolean>`: Block images.
+
 ### getBlockIndex
 
 Returns the index at which the block corresponding to the specified client ID occurs within the block order, or `-1` if the block does not exist.
@@ -1637,6 +1650,15 @@ _Parameters_
 _Returns_
 
 -   `Object`: Action object.
+
+### setBlockImage
+
+Action that sets block image.
+
+_Parameters_
+
+-   _clientId_ `string`: A block client ID.
+-   _images_ `string|string[]`: Block images.
 
 ### setBlockMovingClientId
 

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -291,9 +291,9 @@ function ListViewBlockSelectButton(
 							{ images.map( ( image, index ) => (
 								<span
 									className="block-editor-list-view-block-select-button__image"
-									key={ image.clientId }
+									key={ index }
 									style={ {
-										backgroundImage: `url(${ image.url })`,
+										backgroundImage: `url(${ image })`,
 										zIndex: images.length - index, // Ensure the first image is on top, and subsequent images are behind.
 									} }
 								/>

--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -12,48 +12,6 @@ import { store as blockEditorStore } from '../../store';
 // Maximum number of images to display in a list view row.
 const MAX_IMAGES = 3;
 
-function getImage( block ) {
-	if ( block.name !== 'core/image' ) {
-		return;
-	}
-
-	if ( block.attributes?.url ) {
-		return {
-			url: block.attributes.url,
-			alt: block.attributes.alt,
-			clientId: block.clientId,
-		};
-	}
-}
-
-function getImagesFromGallery( block ) {
-	if ( block.name !== 'core/gallery' || ! block.innerBlocks ) {
-		return [];
-	}
-
-	const images = [];
-
-	for ( const innerBlock of block.innerBlocks ) {
-		const img = getImage( innerBlock );
-		if ( img ) {
-			images.push( img );
-		}
-		if ( images.length >= MAX_IMAGES ) {
-			return images;
-		}
-	}
-
-	return images;
-}
-
-function getImagesFromBlock( block, isExpanded ) {
-	const img = getImage( block );
-	if ( img ) {
-		return [ img ];
-	}
-	return isExpanded ? [] : getImagesFromGallery( block );
-}
-
 /**
  * Get a block's preview images for display within a list view row.
  *
@@ -67,17 +25,15 @@ function getImagesFromBlock( block, isExpanded ) {
  * @return {Array} Images.
  */
 export default function useListViewImages( { clientId, isExpanded } ) {
-	const { block } = useSelect(
+	const images = useSelect(
 		( select ) => {
-			const _block = select( blockEditorStore ).getBlock( clientId );
-			return { block: _block };
+			return select( blockEditorStore ).getBlockImage( clientId ) || [];
 		},
 		[ clientId ]
 	);
-
-	const images = useMemo( () => {
-		return getImagesFromBlock( block, isExpanded );
-	}, [ block, isExpanded ] );
-
-	return images;
+	const filteredImages = useMemo(
+		() => images.slice( 0, MAX_IMAGES ),
+		[ images ]
+	);
+	return isExpanded ? [] : filteredImages;
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1679,6 +1679,20 @@ export function setBlockVisibility( updates ) {
 }
 
 /**
+ * Action that sets block image.
+ *
+ * @param {string}          clientId A block client ID.
+ * @param {string|string[]} images   Block images.
+ */
+export function setBlockImage( clientId, images ) {
+	return {
+		type: 'SET_BLOCK_IMAGE',
+		images: castArray( images ),
+		clientId,
+	};
+}
+
+/**
  * Action that sets whether a block is being temporaritly edited as blocks.
  *
  * DO-NOT-USE in production.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1286,6 +1286,26 @@ export function blockVisibility( state = {}, action ) {
 }
 
 /**
+ * Reducer tracking the block images.
+ *
+ * @param {Record<string,boolean>} state  Current state.
+ * @param {Object}                 action Dispatched action.
+ *
+ * @return {Record<string,boolean>} Block images.
+ */
+export function blockImage( state = {}, action ) {
+	if ( action.type === 'SET_BLOCK_IMAGE' ) {
+		const { clientId, images } = action;
+		return {
+			...state,
+			[ clientId ]: images,
+		};
+	}
+
+	return state;
+}
+
+/**
  * Internal helper reducer for selectionStart and selectionEnd. Can hold a block
  * selection, represented by an object with property clientId.
  *
@@ -2026,6 +2046,7 @@ const combinedReducers = combineReducers( {
 	temporarilyEditingAsBlocks,
 	blockVisibility,
 	blockEditingModes,
+	blockImage,
 	styleOverrides,
 	removalPromptData,
 	blockRemovalRules,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2710,6 +2710,17 @@ export function isBlockVisible( state, clientId ) {
 }
 
 /**
+ * Returns the list of the block images.
+ *
+ * @param {Record<string,boolean>} state    Current state.
+ * @param {string}                 clientId Client Id of the block.
+ * @return {Record<string,boolean>} Block images.
+ */
+export function getBlockImage( state, clientId ) {
+	return state?.blockImage?.[ clientId ];
+}
+
+/**
  * Returns the list of all hidden blocks.
  *
  * @param {Object} state Global application state.

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -91,6 +91,7 @@ function GalleryEdit( props ) {
 	const { columns, imageCrop, linkTarget, linkTo, sizeSlug } = attributes;
 
 	const {
+		setBlockImage,
 		__unstableMarkNextChangeAsNotPersistent,
 		replaceInnerBlocks,
 		updateBlockAttributes,
@@ -168,6 +169,11 @@ function GalleryEdit( props ) {
 			} );
 		} );
 	}, [ newImages ] );
+
+	useEffect( () => {
+		const imageUrls = images.map( ( { url } ) => url );
+		setBlockImage( clientId, imageUrls );
+	}, [ images, clientId, setBlockImage ] );
 
 	const imageSizeOptions = useImageSizes(
 		imageData,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -124,7 +124,7 @@ export function ImageEdit( {
 		captionRef.current = caption;
 	}, [ caption ] );
 
-	const { __unstableMarkNextChangeAsNotPersistent } =
+	const { setBlockImage, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
 	useEffect( () => {
@@ -138,6 +138,10 @@ export function ImageEdit( {
 			} );
 		}
 	}, [ align ] );
+
+	useEffect( () => {
+		setBlockImage( clientId, url );
+	}, [ url, clientId, setBlockImage ] );
 
 	const ref = useRef();
 	const { imageDefaultSize, mediaUpload } = useSelect( ( select ) => {


### PR DESCRIPTION
Note: This PR is incomplete, so do not merge it.

Related to #53381
Hopefully #53684 will be resolved in the future.

## What?
This PR allows the media preview in the List View implemented in #53381 to be used in blocks other than the Image block and the Gallery block.

If this approach makes sense, I would like to consider the following:

- Make the API private
- Add tests
- Improve API name (`getImageUrl`, `getBlockMediaPreview` etc.) and specifications
- Necessary to measure whether it affects performance

Please let me know if this approach makes sense.

## Why?

Media preview in the List View is currently limited to the Image block and the Gallery block only. To apply this feature to other blocks such as Cover, Media & Text, including third-party blocks, we cannot rely on block names or specific attributes.

## How?

To make this functionality universally available, I added new APIs: `getBlockImage`/`setBlockImage`.  If we want to add this media preview to other blocks in the future, we could use the following implementation.

```javascript
/**
 * WordPress dependencies
 */
import { useDispatch } from '@wordpress/data';
import {
	useBlockProps,
	store as blockEditorStore,
} from '@wordpress/block-editor';
import { useEffect } from '@wordpress/element';

export function Edit( { attributes, clientId } ) {
	const { url } = attributes;
	const { setBlockImage } = useDispatch( blockEditorStore );

	useEffect( () => {
		setBlockImage( clientId, url );
	}, [ url, clientId, setBlockImage ] );

	return <div { ...useBlockProps() }>{ /* ... */ }</div>;
}

export default Edit;
```

## Testing Instructions

The Gallery and Image blocks that support media previews have been updated to use this new API. The behavior in the List View should remain as before.