### PR TITLE
Add: Footnotes support for other CPT's.

### DIFF
--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -14,10 +14,11 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 		'meta',
 		postId
 	);
+	const footnotesSupported = 'string' === typeof meta?.footnotes;
 	const footnotes = meta?.footnotes ? JSON.parse( meta.footnotes ) : [];
 	const blockProps = useBlockProps();
 
-	if ( postType !== 'post' && postType !== 'page' ) {
+	if ( ! footnotesSupported ) {
 		return (
 			<div { ...blockProps }>
 				<Placeholder

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -15,6 +15,7 @@ import {
 	privateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 
 /**
@@ -38,12 +39,12 @@ export const format = {
 	},
 	interactive: true,
 	contentEditable: false,
-	[ usesContextKey ]: [ 'postType' ],
+	[ usesContextKey ]: [ 'postType', 'postId' ],
 	edit: function Edit( {
 		value,
 		onChange,
 		isObjectActive,
-		context: { postType },
+		context: { postType, postId },
 	} ) {
 		const registry = useRegistry();
 		const {
@@ -74,6 +75,9 @@ export const format = {
 			return parentCoreBlocks && parentCoreBlocks.length > 0;
 		}, [] );
 
+		const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId );
+		const footnotesSupported = 'string' === typeof meta?.footnotes;
+
 		const { selectionChange, insertBlock } =
 			useDispatch( blockEditorStore );
 
@@ -81,7 +85,7 @@ export const format = {
 			return null;
 		}
 
-		if ( postType !== 'post' && postType !== 'page' ) {
+		if ( ! footnotesSupported ) {
 			return null;
 		}
 

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -68,17 +68,26 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
  * @since 6.3.0
  */
 function register_block_core_footnotes() {
-	foreach ( array( 'post', 'page' ) as $post_type ) {
-		register_post_meta(
-			$post_type,
-			'footnotes',
-			array(
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'string',
-				'revisions_enabled' => true,
-			)
-		);
+	$post_types = get_post_types(
+		array(
+			'show_in_rest' => true,
+			'public'       => true,
+		)
+	);
+	foreach ( $post_types as $post_type ) {
+		// Only register the meta field if the post type supports the editor, custom fields, and revisions.
+		if ( post_type_supports( $post_type, 'editor' ) && post_type_supports( $post_type, 'custom-fields' ) && post_type_supports( $post_type, 'revisions' ) ) {
+			register_post_meta(
+				$post_type,
+				'footnotes',
+				array(
+					'show_in_rest'      => true,
+					'single'            => true,
+					'type'              => 'string',
+					'revisions_enabled' => true,
+				)
+			);
+		}
 	}
 	register_block_type_from_metadata(
 		__DIR__ . '/footnotes',


### PR DESCRIPTION
This pull request adds support for footnotes in all custom post types (CPTs) that meet the following requirements:

- The post type must be public and appear in the REST API.
- The post type must support all of the following: editor, custom-fields, and revisions.

Additionally, this pull request allows plugins to remove footnotes support from any post type by removing the footnotes meta key from the post type. For example, to remove footnotes support from pages, use the following code:
```
function remove_footnotes_support_from_pages() {
	unregister_post_meta( 'page', 'footnotes' );
}
add_action( 'init', 'remove_footnotes_support_from_pages', 100 );
```

## Testing

Added the following post type:
```

function cptui_register_my_cpts_testfootnotes() {

	/**
	 * Post Type: Test foot notes.
	 */

	$labels = [
		"name" => esc_html__( "Test foot notes", "twentytwentyfour" ),
		"singular_name" => esc_html__( "Test foot note", "twentytwentyfour" ),
	];

	$args = [
		"label" => esc_html__( "Test foot notes", "twentytwentyfour" ),
		"labels" => $labels,
		"description" => "",
		"public" => true,
		"publicly_queryable" => true,
		"show_ui" => true,
		"show_in_rest" => true,
		"rest_base" => "",
		"rest_controller_class" => "WP_REST_Posts_Controller",
		"rest_namespace" => "wp/v2",
		"has_archive" => false,
		"show_in_menu" => true,
		"show_in_nav_menus" => true,
		"delete_with_user" => false,
		"exclude_from_search" => false,
		"capability_type" => "post",
		"map_meta_cap" => true,
		"hierarchical" => false,
		"can_export" => false,
		"rewrite" => [ "slug" => "testfootnotes", "with_front" => true ],
		"query_var" => true,
		"supports" => [ "title", "editor", "thumbnail", "custom-fields", "revisions" ],
		"show_in_graphql" => false,
	];

	register_post_type( "testfootnotes", $args );
}

add_action( 'init', 'cptui_register_my_cpts_testfootnotes' );
```

I have confirmed that the footnotes are functioning correctly on the specified post type.

Furthermore, I have removed the "custom-fields" support from the post type and confirmed that the footnotes are no longer available on the post type.

In addition, I have verified that the example mentioned earlier successfully removes footnotes support from pages.

