### PR TITLE
Gallery Block: Remove unused attributes property in shortcode transformation

### DIFF
--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -13,10 +13,6 @@ import {
 	LINK_DESTINATION_NONE,
 	LINK_DESTINATION_MEDIA,
 } from './constants';
-import {
-	LINK_DESTINATION_ATTACHMENT as DEPRECATED_LINK_DESTINATION_ATTACHMENT,
-	LINK_DESTINATION_MEDIA as DEPRECATED_LINK_DESTINATION_MEDIA,
-} from './v1/constants';
 import { pickRelevantMediaFiles, isGalleryV2Enabled } from './shared';
 
 const parseShortcodeIds = ( ids ) => {
@@ -177,56 +173,6 @@ const transforms = {
 		{
 			type: 'shortcode',
 			tag: 'gallery',
-
-			attributes: {
-				images: {
-					type: 'array',
-					shortcode: ( { named: { ids } } ) => {
-						if ( ! isGalleryV2Enabled() ) {
-							return parseShortcodeIds( ids ).map( ( id ) => ( {
-								id: id.toString(),
-							} ) );
-						}
-					},
-				},
-				ids: {
-					type: 'array',
-					shortcode: ( { named: { ids } } ) => {
-						if ( ! isGalleryV2Enabled() ) {
-							return parseShortcodeIds( ids );
-						}
-					},
-				},
-				columns: {
-					type: 'number',
-					shortcode: ( { named: { columns = '3' } } ) => {
-						return parseInt( columns, 10 );
-					},
-				},
-				linkTo: {
-					type: 'string',
-					shortcode: ( { named: { link } } ) => {
-						if ( ! isGalleryV2Enabled() ) {
-							switch ( link ) {
-								case 'post':
-									return DEPRECATED_LINK_DESTINATION_ATTACHMENT;
-								case 'file':
-									return DEPRECATED_LINK_DESTINATION_MEDIA;
-								default:
-									return DEPRECATED_LINK_DESTINATION_ATTACHMENT;
-							}
-						}
-						switch ( link ) {
-							case 'post':
-								return LINK_DESTINATION_ATTACHMENT;
-							case 'file':
-								return LINK_DESTINATION_MEDIA;
-							default:
-								return LINK_DESTINATION_NONE;
-						}
-					},
-				},
-			},
 			transform( { named: { ids, columns = 3, link } } ) {
 				const imageIds = parseShortcodeIds( ids ).map( ( id ) =>
 					parseInt( id, 10 )


### PR DESCRIPTION
Related to #57345 
Noticed this while investigating #9701

## What?

This PR removes unused `attributes` property during the process of transforming the gallery shortcode to the Gallery block.

## Why?

When I tried to update the gallery shortcode transformation process, I noticed that `attributes.X.shortcode` was not working. This is because [transforms take precedence over attributes](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-transforms.md#shortcode), and you can see that they are implemented that way by looking at [the code](https://github.com/WordPress/gutenberg/blob/f572440cbb8b1d6c1b999acf08873f4203483528/packages/blocks/src/api/raw-handling/shortcode-converter.js#L85-L103).

## How?

I just deleted it.

## Testing Instructions

- When pasting the shortcode below, confirm that it is correctly converted to a gallery block as before. For ids, specify a media ID that exists in your environment.
  `[gallery columns="2" link="post" size="large" ids="46,45,44,43,42"]`
- Confirm that undo and redo, which was resolved by #42001, still work as before.