### PR TITLE
Image: Hide caption control when multi-editing images

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -755,7 +755,9 @@ export default function Image( {
 				isSelected={ isSelected }
 				insertBlocksAfter={ insertBlocksAfter }
 				label={ __( 'Image caption text' ) }
-				showToolbarButton={ hasNonContentControls }
+				showToolbarButton={
+					! multiImageSelection && hasNonContentControls
+				}
 			/>
 		</>
 	);


### PR DESCRIPTION
## What?
This is similar to #27105.

PR hides the "Add caption" option when multi-editing image blocks.

## Why?
Clicking the button currently does nothing. Editing sources like `caption` and `alt` can cause a loss of content when multiple image blocks are selected.

## Testing Instructions
1. Open a post or page.
2. Insert image blocks and select media.
3. Select multiple image blocks.
4. Confirm that the "Add caption" button isn't displayed in block controls.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-12-23 at 13 23 28](https://github.com/WordPress/gutenberg/assets/240569/42620b5a-9b2d-4aaf-ba56-29a5e5e2f3ce)
