### PR TITLE
Font Library: Update font uninstall modal text.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/confirm-delete-dialog.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/confirm-delete-dialog.js
@@ -13,8 +13,8 @@ function ConfirmDeleteDialog( {
 	return (
 		<ConfirmDialog
 			isOpen={ isConfirmDeleteOpen }
-			cancelButtonText={ __( 'No, keep the font' ) }
-			confirmButtonText={ __( 'Yes, uninstall' ) }
+			cancelButtonText={ __( 'Cancel' ) }
+			confirmButtonText={ __( 'Delete' ) }
 			onCancel={ handleCancelUninstall }
 			onConfirm={ handleConfirmUninstall }
 		>
@@ -22,7 +22,7 @@ function ConfirmDeleteDialog( {
 				sprintf(
 					/* translators: %s: Name of the font. */
 					__(
-						'Would you like to remove %s and all its variants and assets?'
+						'Are you sure you want to delete "%s" font and all its variants and assets?'
 					),
 					font.name
 				) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update the confirmation dialog that appears when uninstalling a font in the Site Editor.


## Why?
It feels a little redundant compared to other modals in the Site Editor. 
Fixes: https://github.com/WordPress/gutenberg/issues/54528

## How?
I have updated the copy of the confirmation dialogue and the button labels.

## Testing Instructions
Appearance -> Editor -> Styles -> Edit Styles -> Typography ->  Manage Fonts -> Select a Font -> Delete

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/47940584/b7eb3816-24f0-4314-b88a-16403da72ac1)

