### PR TITLE
Block JSON schema: add renaming key to supports definition

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -344,6 +344,11 @@
 					"description": "By default, all blocks will appear in the inserter, block transforms menu, Style Book, etc. To hide a block from all parts of the user interface so that it can only be inserted programmatically, set inserter to false.",
 					"default": true
 				},
+				"renaming": {
+					"type": "boolean",
+					"description": "By default, a block can be renamed by a user from the block 'Options' dropdown or the 'Advanced' panel. To disable this behavior, set renaming to false.",
+					"default": true
+				},
 				"layout": {
 					"default": false,
 					"description": "This value only applies to blocks that are containers for inner blocks. If set to `true` the layout type will be `flow`. For other layout types it's necessary to set the `type` explicitly inside the `default` object.",


### PR DESCRIPTION
Related to #54426

## What?

This PR adds `renaming` key to `supports` definition in block.json schema.

## Why?

To allow developers to design block.json with reference to the correct schema.

## Testing Instructions

Create the following JSON file locally, specifying the JSON schema changed by this PR.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/block-json-schema-renaming/schemas/json/block.json",
	"apiVersion": 3,
	"name": "test/test",
	"title": "Test"
}
```

You should see the `renaming` key listed in the `supports` property.

![image](https://github.com/WordPress/gutenberg/assets/54422211/a999a889-095d-442c-aebc-2ecefadb905f)
