### PR TITLE
Video: Hide some controls when multi-editing blocks

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -75,10 +75,20 @@ function VideoEdit( {
 	const posterImageButton = useRef();
 	const { id, controls, poster, src, tracks } = attributes;
 	const isTemporaryVideo = ! id && isBlobURL( src );
-	const mediaUpload = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
-		[]
-	);
+	const { mediaUpload, multiVideoSelection } = useSelect( ( select ) => {
+		const { getSettings, getMultiSelectedBlockClientIds, getBlockName } =
+			select( blockEditorStore );
+		const multiSelectedClientIds = getMultiSelectedBlockClientIds();
+
+		return {
+			mediaUpload: getSettings().mediaUpload,
+			multiVideoSelection:
+				multiSelectedClientIds.length &&
+				multiSelectedClientIds.every(
+					( _clientId ) => getBlockName( _clientId ) === 'core/video'
+				),
+		};
+	}, [] );
 
 	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {
@@ -185,25 +195,29 @@ function VideoEdit( {
 
 	return (
 		<>
-			<BlockControls>
-				<TracksEditor
-					tracks={ tracks }
-					onChange={ ( newTracks ) => {
-						setAttributes( { tracks: newTracks } );
-					} }
-				/>
-			</BlockControls>
-			<BlockControls group="other">
-				<MediaReplaceFlow
-					mediaId={ id }
-					mediaURL={ src }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					accept="video/*"
-					onSelect={ onSelectVideo }
-					onSelectURL={ onSelectURL }
-					onError={ onUploadError }
-				/>
-			</BlockControls>
+			{ ! multiVideoSelection && (
+				<>
+					<BlockControls>
+						<TracksEditor
+							tracks={ tracks }
+							onChange={ ( newTracks ) => {
+								setAttributes( { tracks: newTracks } );
+							} }
+						/>
+					</BlockControls>
+					<BlockControls group="other">
+						<MediaReplaceFlow
+							mediaId={ id }
+							mediaURL={ src }
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							accept="video/*"
+							onSelect={ onSelectVideo }
+							onSelectURL={ onSelectURL }
+							onError={ onUploadError }
+						/>
+					</BlockControls>
+				</>
+			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<VideoCommonSettings
@@ -284,6 +298,7 @@ function VideoEdit( {
 					isSelected={ isSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Video caption text' ) }
+					showToolbarButton={ ! multiVideoSelection }
 				/>
 			</figure>
 		</>


### PR DESCRIPTION
## What?
Part of #57369.
Similar to #57357.

PR updates the Video block to hide the "Caption", "Text tracks", and "Replace" toolbar controls when multi-editing blocks.

## Why?
The "Caption" control doesn't work; the other two don't make sense when multi-editing and can cause content loss.

## Testing Instructions
1. Open a post or page.
2. Insert video blocks and select media.
3. Select multiple video blocks.
4. The listed controls shouldn't be displayed during multi-selection.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-12-26 at 16 28 27](https://github.com/WordPress/gutenberg/assets/240569/317d8181-6a07-443f-83d9-a7c72995686b)

