### PR TITLE
Audio: Hide some controls when multi-editing blocks

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -47,9 +47,19 @@ function AudioEdit( {
 } ) {
 	const { id, autoplay, loop, preload, src } = attributes;
 	const isTemporaryAudio = ! id && isBlobURL( src );
-	const mediaUpload = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return getSettings().mediaUpload;
+	const { mediaUpload, multiAudioSelection } = useSelect( ( select ) => {
+		const { getSettings, getMultiSelectedBlockClientIds, getBlockName } =
+			select( blockEditorStore );
+		const multiSelectedClientIds = getMultiSelectedBlockClientIds();
+
+		return {
+			mediaUpload: getSettings().mediaUpload,
+			multiAudioSelection:
+				multiSelectedClientIds.length &&
+				multiSelectedClientIds.every(
+					( _clientId ) => getBlockName( _clientId ) === 'core/audio'
+				),
+		};
 	}, [] );
 
 	useEffect( () => {
@@ -146,17 +156,19 @@ function AudioEdit( {
 
 	return (
 		<>
-			<BlockControls group="other">
-				<MediaReplaceFlow
-					mediaId={ id }
-					mediaURL={ src }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					accept="audio/*"
-					onSelect={ onSelectAudio }
-					onSelectURL={ onSelectURL }
-					onError={ onUploadError }
-				/>
-			</BlockControls>
+			{ ! multiAudioSelection && (
+				<BlockControls group="other">
+					<MediaReplaceFlow
+						mediaId={ id }
+						mediaURL={ src }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						accept="audio/*"
+						onSelect={ onSelectAudio }
+						onSelectURL={ onSelectURL }
+						onError={ onUploadError }
+					/>
+				</BlockControls>
+			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
@@ -210,6 +222,7 @@ function AudioEdit( {
 					isSelected={ isSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Audio caption text' ) }
+					showToolbarButton={ ! multiAudioSelection }
 				/>
 			</figure>
 		</>


### PR DESCRIPTION
## What?
Part of #57369.
Similar to #57375.

PR updates the Audio block to hide the "Caption" and "Replace" toolbar controls when multi-editing blocks.

## Why?
The "Caption" control doesn't work; the "Replace" doesn't make sense when multi-editing and can cause content loss.

## Testing Instructions

1. Open a post or page.
2. Insert audio blocks and select media.
3. Select multiple audio blocks.
4. The listed controls shouldn't be displayed during multi-selection.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-12-26 at 16 44 03](https://github.com/WordPress/gutenberg/assets/240569/279b15cb-55c0-4adc-baab-3bc03aa1f30e)
