### PR TITLE
Gallery: Hide some controls when multi-editing blocks

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -104,23 +104,38 @@ function GalleryEdit( props ) {
 		getSettings,
 		preferredStyle,
 		innerBlockImages,
-		wasBlockJustInserted,
+		blockWasJustInserted,
+		multiVGallerySelection,
 	} = useSelect(
 		( select ) => {
-			const settings = select( blockEditorStore ).getSettings();
+			const {
+				getBlockName,
+				getMultiSelectedBlockClientIds,
+				getSettings: _getSettings,
+				getBlock: _getBlock,
+				wasBlockJustInserted,
+			} = select( blockEditorStore );
 			const preferredStyleVariations =
-				settings.__experimentalPreferredStyleVariations;
+				_getSettings().__experimentalPreferredStyleVariations;
+			const multiSelectedClientIds = getMultiSelectedBlockClientIds();
+
 			return {
-				getBlock: select( blockEditorStore ).getBlock,
-				getSettings: select( blockEditorStore ).getSettings,
+				getBlock: _getBlock,
+				getSettings: _getSettings,
 				preferredStyle:
 					preferredStyleVariations?.value?.[ 'core/image' ],
 				innerBlockImages:
-					select( blockEditorStore ).getBlock( clientId )
-						?.innerBlocks ?? EMPTY_ARRAY,
-				wasBlockJustInserted: select(
-					blockEditorStore
-				).wasBlockJustInserted( clientId, 'inserter_menu' ),
+					_getBlock( clientId )?.innerBlocks ?? EMPTY_ARRAY,
+				blockWasJustInserted: wasBlockJustInserted(
+					clientId,
+					'inserter_menu'
+				),
+				multiVGallerySelection:
+					multiSelectedClientIds.length &&
+					multiSelectedClientIds.every(
+						( _clientId ) =>
+							getBlockName( _clientId ) === 'core/gallery'
+					),
 			};
 		},
 		[ clientId ]
@@ -461,7 +476,7 @@ function GalleryEdit( props ) {
 				( hasImages && ! isSelected ) || imagesUploading,
 			value: hasImageIds ? images : {},
 			autoOpenMediaUpload:
-				! hasImages && isSelected && wasBlockJustInserted,
+				! hasImages && isSelected && blockWasJustInserted,
 			onFocus,
 		},
 	} );
@@ -583,20 +598,22 @@ function GalleryEdit( props ) {
 			</InspectorControls>
 			{ Platform.isWeb && (
 				<>
-					<BlockControls group="other">
-						<MediaReplaceFlow
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							accept="image/*"
-							handleUpload={ false }
-							onSelect={ updateImages }
-							name={ __( 'Add' ) }
-							multiple={ true }
-							mediaIds={ images
-								.filter( ( image ) => image.id )
-								.map( ( image ) => image.id ) }
-							addToGallery={ hasImageIds }
-						/>
-					</BlockControls>
+					{ ! multiVGallerySelection && (
+						<BlockControls group="other">
+							<MediaReplaceFlow
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								accept="image/*"
+								handleUpload={ false }
+								onSelect={ updateImages }
+								name={ __( 'Add' ) }
+								multiple={ true }
+								mediaIds={ images
+									.filter( ( image ) => image.id )
+									.map( ( image ) => image.id ) }
+								addToGallery={ hasImageIds }
+							/>
+						</BlockControls>
+					) }
 					<GapStyles
 						blockGap={ attributes.style?.spacing?.blockGap }
 						clientId={ clientId }
@@ -614,6 +631,7 @@ function GalleryEdit( props ) {
 				}
 				blockProps={ innerBlocksProps }
 				insertBlocksAfter={ insertBlocksAfter }
+				multiVGallerySelection={ multiVGallerySelection }
 			/>
 		</>
 	);

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -105,7 +105,7 @@ function GalleryEdit( props ) {
 		preferredStyle,
 		innerBlockImages,
 		blockWasJustInserted,
-		multiVGallerySelection,
+		multiGallerySelection,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -130,7 +130,7 @@ function GalleryEdit( props ) {
 					clientId,
 					'inserter_menu'
 				),
-				multiVGallerySelection:
+				multiGallerySelection:
 					multiSelectedClientIds.length &&
 					multiSelectedClientIds.every(
 						( _clientId ) =>
@@ -598,7 +598,7 @@ function GalleryEdit( props ) {
 			</InspectorControls>
 			{ Platform.isWeb && (
 				<>
-					{ ! multiVGallerySelection && (
+					{ ! multiGallerySelection && (
 						<BlockControls group="other">
 							<MediaReplaceFlow
 								allowedTypes={ ALLOWED_MEDIA_TYPES }
@@ -631,7 +631,7 @@ function GalleryEdit( props ) {
 				}
 				blockProps={ innerBlocksProps }
 				insertBlocksAfter={ insertBlocksAfter }
-				multiVGallerySelection={ multiVGallerySelection }
+				multiGallerySelection={ multiGallerySelection }
 			/>
 		</>
 	);

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -24,6 +24,7 @@ export default function Gallery( props ) {
 		blockProps,
 		__unstableLayoutClassNames: layoutClassNames,
 		isContentLocked,
+		multiVGallerySelection,
 	} = props;
 
 	const { align, columns, imageCrop } = attributes;
@@ -54,7 +55,9 @@ export default function Gallery( props ) {
 				setAttributes={ setAttributes }
 				isSelected={ isSelected }
 				insertBlocksAfter={ insertBlocksAfter }
-				showToolbarButton={ ! isContentLocked }
+				showToolbarButton={
+					! multiVGallerySelection && ! isContentLocked
+				}
 				className="blocks-gallery-caption"
 				label={ __( 'Gallery caption text' ) }
 				placeholder={ __( 'Add gallery caption' ) }

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -24,7 +24,7 @@ export default function Gallery( props ) {
 		blockProps,
 		__unstableLayoutClassNames: layoutClassNames,
 		isContentLocked,
-		multiVGallerySelection,
+		multiGallerySelection,
 	} = props;
 
 	const { align, columns, imageCrop } = attributes;
@@ -56,7 +56,7 @@ export default function Gallery( props ) {
 				isSelected={ isSelected }
 				insertBlocksAfter={ insertBlocksAfter }
 				showToolbarButton={
-					! multiVGallerySelection && ! isContentLocked
+					! multiGallerySelection && ! isContentLocked
 				}
 				className="blocks-gallery-caption"
 				label={ __( 'Gallery caption text' ) }


### PR DESCRIPTION
## What?
Part of #57369.
Similar to #57375.

PR updates the Gallery block to hide the "Caption" and "Add" toolbar controls when multi-editing blocks.

I also did a minor clean of the `mapSelect` method and removed repeating `select( blockEditorStore )` calls.

## Why?
* The "Caption" control doesn't work when multi-editing gallery blocks.
* The "Add" only appends images to the first block, which I think is a broken behavior.

## Testing Instructions
1. Open a post or page.
2. Insert gallery blocks and select media.
3. Select multiple gallery blocks.
4. The listed controls shouldn't be displayed during multi-selection.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-12-26 at 17 27 47](https://github.com/WordPress/gutenberg/assets/240569/87d93206-f1c9-4903-9dbd-a88e7738e5f9)
