### PR TITLE
Core Data: Pass the 'options' argument to data action shortcuts

### DIFF
--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -44,10 +44,10 @@ const entityResolvers = rootEntitiesConfig.reduce( ( result, entity ) => {
 
 const entityActions = rootEntitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
-	result[ getMethodName( kind, name, 'save' ) ] = ( key ) =>
-		actions.saveEntityRecord( kind, name, key );
-	result[ getMethodName( kind, name, 'delete' ) ] = ( key, query ) =>
-		actions.deleteEntityRecord( kind, name, key, query );
+	result[ getMethodName( kind, name, 'save' ) ] = ( record, options ) =>
+		actions.saveEntityRecord( kind, name, record, options );
+	result[ getMethodName( kind, name, 'delete' ) ] = ( key, query, options ) =>
+		actions.deleteEntityRecord( kind, name, key, query, options );
 	return result;
 }, {} );
 


### PR DESCRIPTION
## What?
PR allows passing the `options` argument to the auto-generated action shortcuts like `saveUser` and `deleteUser`.

## Why?
The shortcuts should accept the same arguments as the general actions.

## Testing Instructions
1. Open a post or page.
2. Run code examples via DevTools.
3. The action will throw on error and log correct values. This doesn't work on `trunk`.


### Code examples
```js
wp.data.dispatch('core').saveUser({}, {throwOnError: true})
	.then( (user) => console.log('in then', {user}) )
	.catch( e => console.log('in catch', {e}) );
```

```js
wp.data.dispatch('core').deleteUser('hello', undefined, {throwOnError: true})
	.then( (user) => console.log('in then', {user}) )
	.catch( e => console.log('in catch', {e}) );
```
