### PR TITLE
Social Link block: Obfuscate email address

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -33,7 +33,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	 * The `is_email` returns false for emails with schema.
 	 */
 	if ( is_email( $url ) ) {
-		$url = 'mailto:' . $url;
+		$url = 'mailto:' . antispambot( $url );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Obfuscate the email address in the "Mail" variation of the Social Icon block. See https://github.com/WordPress/gutenberg/issues/21876#issuecomment-1176251141.

Fixes #21876.

## Why?
To make it harder for spambots to harvest email addresses.

## How?
By using Core's [`antispambot()` function](https://developer.wordpress.org/reference/functions/antispambot/).

## Testing Instructions
- Insert a "Social Links" block into a new post, and add a "Mail" child block to it.
- Set an email address for that block.
- View the post on the frontend, and check its page source (not just the element inspector!).
- Verify that the email address is obfuscated (using HTML entities). Verify that the email address still works (e.g. by clicking on it).

For example, `mailto:user@example.com` becomes

```
mailto:u&#115;e&#114;&#064;&#101;xa&#109;p&#108;e&#046;&#099;&#111;m
```

## Screenshots or screencast <!-- if applicable -->

<img width="503" alt="image" src="https://github.com/WordPress/gutenberg/assets/96308/378a6c9c-0f54-4976-b414-a8dbcc4ae1c9">

<img width="961" alt="image" src="https://github.com/WordPress/gutenberg/assets/96308/f330e5aa-c29e-407d-ae77-5b393472969d">

## Question

[`antispambot()`](https://developer.wordpress.org/reference/functions/antispambot/) has a second argument, `$hex_encoding`, to enable hex encoding (of entities). Should we use that?

FWIW, this is what `mailto:user@example.com` becomes with `$hex_encoding === 1`:

```
mailto:u&#115;&#101;&#114;&#064;e&#120;a%6dp&#108;&#101;%2ecom
```

