### PR TITLE
DataViews: improve naming for easy identification in React devtools

### DIFF
--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -68,7 +68,7 @@ export default function Filters( { fields, view, onChangeView } ) {
 
 			return (
 				<FilterSummary
-					key={ filter.field + '.' + filter.operator }
+					key={ filter.field }
 					filter={ filter }
 					view={ view }
 					onChangeView={ onChangeView }

--- a/packages/dataviews/src/reset-filters.js
+++ b/packages/dataviews/src/reset-filters.js
@@ -4,7 +4,7 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default ( { view, onChangeView } ) => {
+export default function ResetFilter( { view, onChangeView } ) {
 	return (
 		<Button
 			disabled={ view.search === '' && view.filters?.length === 0 }
@@ -23,4 +23,4 @@ export default ( { view, onChangeView } ) => {
 			{ __( 'Reset filters' ) }
 		</Button>
 	);
-};
+}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

- Name the default export for `ResetFilters`. https://github.com/WordPress/gutenberg/pull/57385/commits/d726b3851dc6efbc80af59e703584cdbae654a01
- Provide a stable key for `FilterSummary` component. https://github.com/WordPress/gutenberg/pull/57385/commits/d01fa45c14422171c7ccf83d43737e53a6efa570

## Why?

So it can be used and searched for in React devtools. Having a stable key also helps with performance.
