### PR TITLE
[#56520]Add RangeControl for width of column block.

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -20,9 +20,47 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	PanelBody,
 	__experimentalUnitControl as UnitControl,
+	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
+	Flex,
+	FlexItem,
+	RangeControl,
+	__experimentalSpacer as Spacer,
+	BaseControl,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+
+const RANGE_CONTROL_CUSTOM_SETTINGS = {
+	px: { max: 1000, step: 1 },
+	'%': { max: 100, step: 10 },
+	vw: { max: 100, step: 1 },
+	vh: { max: 100, step: 1 },
+	em: { max: 50, step: 0.1 },
+	rem: { max: 50, step: 0.1 },
+	svw: { max: 100, step: 1 },
+	lvw: { max: 100, step: 1 },
+	dvw: { max: 100, step: 1 },
+	svh: { max: 100, step: 1 },
+	lvh: { max: 100, step: 1 },
+	dvh: { max: 100, step: 1 },
+	vi: { max: 100, step: 1 },
+	svi: { max: 100, step: 1 },
+	lvi: { max: 100, step: 1 },
+	dvi: { max: 100, step: 1 },
+	vb: { max: 100, step: 1 },
+	svb: { max: 100, step: 1 },
+	lvb: { max: 100, step: 1 },
+	dvb: { max: 100, step: 1 },
+	vmin: { max: 100, step: 1 },
+	svmin: { max: 100, step: 1 },
+	lvmin: { max: 100, step: 1 },
+	dvmin: { max: 100, step: 1 },
+	vmax: { max: 100, step: 1 },
+	svmax: { max: 100, step: 1 },
+	lvmax: { max: 100, step: 1 },
+	dvmax: { max: 100, step: 1 },
+};
 
 function ColumnEdit( {
 	attributes: { verticalAlignment, width, templateLock, allowedBlocks },
@@ -37,6 +75,16 @@ function ColumnEdit( {
 	const units = useCustomUnits( {
 		availableUnits: availableUnits || [ '%', 'px', 'em', 'rem', 'vw' ],
 	} );
+
+	const customRangeValue = parseFloat( width );
+
+	const selectedUnit =
+		useMemo(
+			() => parseQuantityAndUnitFromRawValue( width ),
+			[ width ]
+		)[ 1 ] ||
+		units[ 0 ]?.value ||
+		'%';
 
 	const { columnsIds, hasChildBlocks, rootClientId } = useSelect(
 		( select ) => {
@@ -93,6 +141,65 @@ function ColumnEdit( {
 		}
 	);
 
+	const handleRangeChange = ( value ) => {
+		const nextWidth = value + selectedUnit;
+		setAttributes( { width: nextWidth } );
+	};
+
+	const handleUnitChange = ( newUnit ) => {
+		// Attempt to smooth over differences between currentUnit and newUnit.
+		// This should slightly improve the experience of switching between unit types.
+		const [ currentValue, currentUnit ] =
+			parseQuantityAndUnitFromRawValue( width );
+
+		if ( [ 'em', 'rem' ].includes( newUnit ) && currentUnit === 'px' ) {
+			// Convert pixel value to an approximate of the new unit, assuming a root size of 16px.
+			setAttributes( {
+				width: ( currentValue / 16 ).toFixed( 2 ) + newUnit,
+			} );
+		} else if (
+			[ 'em', 'rem' ].includes( currentUnit ) &&
+			newUnit === 'px'
+		) {
+			// Convert to pixel value assuming a root size of 16px.
+			setAttributes( {
+				width: Math.round( currentValue * 16 ) + newUnit,
+			} );
+		} else if (
+			[
+				'%',
+				'vw',
+				'svw',
+				'lvw',
+				'dvw',
+				'vh',
+				'svh',
+				'lvh',
+				'dvh',
+				'vi',
+				'svi',
+				'lvi',
+				'dvi',
+				'vb',
+				'svb',
+				'lvb',
+				'dvb',
+				'vmin',
+				'svmin',
+				'lvmin',
+				'dvmin',
+				'vmax',
+				'svmax',
+				'lvmax',
+				'dvmax',
+			].includes( newUnit ) &&
+			currentValue > 100
+		) {
+			// When converting to `%` or viewport-relative units, cap the new value at 100.
+			setAttributes( { width: 100 + newUnit } );
+		}
+	};
+
 	return (
 		<>
 			<BlockControls>
@@ -104,18 +211,47 @@ function ColumnEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
-					<UnitControl
-						label={ __( 'Width' ) }
-						labelPosition="edge"
-						__unstableInputWidth="80px"
-						value={ width || '' }
-						onChange={ ( nextWidth ) => {
-							nextWidth =
-								0 > parseFloat( nextWidth ) ? '0' : nextWidth;
-							setAttributes( { width: nextWidth } );
-						} }
-						units={ units }
-					/>
+					<BaseControl.VisualLabel as="legend">
+						{ __( 'Width' ) }
+					</BaseControl.VisualLabel>
+					<Flex>
+						<FlexItem>
+							<UnitControl
+								value={ width || '' }
+								onChange={ ( nextWidth ) => {
+									nextWidth =
+										0 > parseFloat( nextWidth )
+											? '0'
+											: nextWidth;
+									setAttributes( { width: nextWidth } );
+								} }
+								units={ units }
+								onUnitChange={ handleUnitChange }
+								__unstableInputWidth="80px"
+							/>
+						</FlexItem>
+						<FlexItem isBlock>
+							<Spacer marginX={ 2 } marginBottom={ 0 }>
+								<RangeControl
+									value={ customRangeValue }
+									min={ 0 }
+									onChange={ handleRangeChange }
+									max={
+										RANGE_CONTROL_CUSTOM_SETTINGS[
+											selectedUnit
+										]?.max ?? 100
+									}
+									step={
+										RANGE_CONTROL_CUSTOM_SETTINGS[
+											selectedUnit
+										]?.step ?? 0.1
+									}
+									withInputField={ false }
+									__nextHasNoMarginBottom
+								/>
+							</Spacer>
+						</FlexItem>
+					</Flex>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...innerBlocksProps } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds RangeControl to the width of the column block.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Using input + range combo control for the width of the column block will enhance the user experience while editing.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added RangeControl component and synced it with the width of the column block. So user can change the width of a column block using RangControl as well as UnitControl.
Added 10% increase when the user selects % as a unit.

## Screenshots or screencast <!-- if applicable -->
<img width="1280" alt="Screenshot 2023-12-27 at 11 31 31 AM" src="https://github.com/WordPress/gutenberg/assets/40138190/bf08689b-514d-4f76-93af-137cbfe1914d">

Fix: #56520 