### PR TITLE
Media: send numerical post id when uploading image

### DIFF
--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -36,20 +36,19 @@ export default function mediaUpload( {
 	maxUploadFileSize =
 		maxUploadFileSize || getEditorSettings().maxUploadFileSize;
 	const currentPost = getCurrentPost();
-	let currentPostId =
-		typeof currentPost?.id === 'number' ? currentPost.id : 0;
-
 	// Templates and template parts' numerical ID is stored in `wp_id`.
-	if ( ! currentPostId && typeof currentPost?.wp_id === 'number' ) {
-		currentPostId = currentPost.wp_id;
-	}
+	const currentPostId =
+		typeof currentPost?.id === 'number'
+			? currentPost.id
+			: currentPost?.wp_id;
+	const postData = currentPostId ? { post: currentPostId } : {};
 
 	uploadMedia( {
 		allowedTypes,
 		filesList,
 		onFileChange,
 		additionalData: {
-			post: currentPostId,
+			...postData,
 			...additionalData,
 		},
 		maxUploadFileSize,

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -31,17 +31,25 @@ export default function mediaUpload( {
 	onError = noop,
 	onFileChange,
 } ) {
-	const { getCurrentPostId, getEditorSettings } = select( editorStore );
+	const { getCurrentPost, getEditorSettings } = select( editorStore );
 	const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes;
 	maxUploadFileSize =
 		maxUploadFileSize || getEditorSettings().maxUploadFileSize;
-	const currentPostId = getCurrentPostId();
+	const currentPost = getCurrentPost();
+	let currentPostId =
+		typeof currentPost?.id === 'number' ? currentPost.id : 0;
+
+	// Templates and template parts' numerical ID is stored in `wp_id`.
+	if ( ! currentPostId && typeof currentPost?.wp_id === 'number' ) {
+		currentPostId = currentPost.wp_id;
+	}
+
 	uploadMedia( {
 		allowedTypes,
 		filesList,
 		onFileChange,
 		additionalData: {
-			...( ! isNaN( currentPostId ) ? { post: currentPostId } : {} ),
+			post: currentPostId,
 			...additionalData,
 		},
 		maxUploadFileSize,


### PR DESCRIPTION

## What?
Follow up to:

- https://github.com/WordPress/gutenberg/pull/57040

When uploading media, send a numerical post ID where possible. 

## Why?
The apparent purpose of the post id here is so that WordPress can assign media to a parent post.

See:

- https://github.com/WordPress/gutenberg/pull/6231

Templates and template parts have string ids comprising "theme + // + template name". Their numerical IDs — the unique ids in the database  — are stored in `wp_id` property. So let's send that.


## How?
Checking for a numerical `id` and `wp_id`. If there is none, then don't send additional data.

## Testing Instructions

As with https://github.com/WordPress/gutenberg/pull/57040

1. Go to site editor and add edit a template and add an image block
2. Selection the Upload option and make sure it succeeds
3. Do the same in the post editor and make sure that the call to the media endpoint still includes a post id