### PR TITLE
DataViews: memoize `onSelectionChange` callback

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -133,8 +133,10 @@ export default function PagePages() {
 	const [ pageId, setPageId ] = useState( null );
 	const history = useHistory();
 
-	const onSelectionChange = ( items ) =>
-		setPageId( items?.length === 1 ? items[ 0 ].id : null );
+	const onSelectionChange = useCallback(
+		( items ) => setPageId( items?.length === 1 ? items[ 0 ].id : null ),
+		[ setPageId ]
+	);
 
 	const queryArgs = useMemo( () => {
 		const filters = {};

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -170,8 +170,11 @@ export default function DataviewsTemplates() {
 		} );
 	const history = useHistory();
 
-	const onSelectionChange = ( items ) =>
-		setTemplateId( items?.length === 1 ? items[ 0 ].id : null );
+	const onSelectionChange = useCallback(
+		( items ) =>
+			setTemplateId( items?.length === 1 ? items[ 0 ].id : null ),
+		[ setTemplateId ]
+	);
 
 	const authors = useMemo( () => {
 		if ( ! allTemplates ) {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Memoize `onSelectionChange` callback.

## Why?

Otherwise, each time the Pages or Templates pages are re-rendered is a new function.

## How?

By means of `useCallback`.
