### PR TITLE
DataViews: update `onChangeView` memoization

### DIFF
--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -209,16 +209,14 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 										disabled={ ! activeElement }
 										hideOnClick={ false }
 										onClick={ () => {
-											onChangeView( ( currentView ) => ( {
-												...currentView,
+											onChangeView( {
+												...view,
 												page: 1,
-												filters:
-													currentView.filters.filter(
-														( f ) =>
-															f.field !==
-															filter.field
-													),
-											} ) );
+												filters: view.filters.filter(
+													( f ) =>
+														f.field !== filter.field
+												),
+											} );
 										} }
 									>
 										<DropdownMenuItemLabel>
@@ -240,11 +238,11 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					}
 					hideOnClick={ false }
 					onClick={ () => {
-						onChangeView( ( currentView ) => ( {
-							...currentView,
+						onChangeView( {
+							...view,
 							page: 1,
 							filters: [],
-						} ) );
+						} );
 					} }
 				>
 					<DropdownMenuItemLabel>

--- a/packages/dataviews/src/reset-filters.js
+++ b/packages/dataviews/src/reset-filters.js
@@ -12,12 +12,12 @@ export default function ResetFilter( { view, onChangeView } ) {
 			size="compact"
 			variant="tertiary"
 			onClick={ () => {
-				onChangeView( ( currentView ) => ( {
-					...currentView,
+				onChangeView( {
+					...view,
 					page: 1,
 					search: '',
 					filters: [],
-				} ) );
+				} );
 			} }
 		>
 			{ __( 'Reset filters' ) }

--- a/packages/dataviews/src/search.js
+++ b/packages/dataviews/src/search.js
@@ -18,11 +18,11 @@ export default function Search( { label, view, onChangeView } ) {
 		onChangeViewRef.current = onChangeView;
 	}, [ onChangeView ] );
 	useEffect( () => {
-		onChangeViewRef.current( ( currentView ) => ( {
-			...currentView,
+		onChangeViewRef.current( {
+			...view,
 			page: 1,
 			search: debouncedSearch,
-		} ) );
+		} );
 	}, [ debouncedSearch ] );
 	const searchLabel = label || __( 'Filter list' );
 	return (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -305,23 +305,19 @@ export default function PagePages() {
 		[ permanentlyDeletePostAction, restorePostAction, editPostAction ]
 	);
 	const onChangeView = useCallback(
-		( viewUpdater ) => {
-			let updatedView =
-				typeof viewUpdater === 'function'
-					? viewUpdater( view )
-					: viewUpdater;
-			if ( updatedView.type !== view.type ) {
-				updatedView = {
-					...updatedView,
+		( newView ) => {
+			if ( newView.type !== view.type ) {
+				newView = {
+					...newView,
 					layout: {
-						...defaultConfigPerViewType[ updatedView.type ],
+						...defaultConfigPerViewType[ newView.type ],
 					},
 				};
 			}
 
-			setView( updatedView );
+			setView( newView );
 		},
-		[ view, setView ]
+		[ view.type, setView ]
 	);
 
 	// TODO: we need to handle properly `data={ data || EMPTY_ARRAY }` for when `isLoading`.

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -344,25 +344,23 @@ export default function DataviewsTemplates() {
 		],
 		[ resetTemplateAction ]
 	);
+
 	const onChangeView = useCallback(
-		( viewUpdater ) => {
-			let updatedView =
-				typeof viewUpdater === 'function'
-					? viewUpdater( view )
-					: viewUpdater;
-			if ( updatedView.type !== view.type ) {
-				updatedView = {
-					...updatedView,
+		( newView ) => {
+			if ( newView.type !== view.type ) {
+				newView = {
+					...newView,
 					layout: {
-						...defaultConfigPerViewType[ updatedView.type ],
+						...defaultConfigPerViewType[ newView.type ],
 					},
 				};
 			}
 
-			setView( updatedView );
+			setView( newView );
 		},
-		[ view, setView ]
+		[ view.type, setView ]
 	);
+
 	return (
 		<>
 			<Page


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What

This PR modifies `onChangeView` memoization to make it dependent on `view.type` and not the whole `view` object.

It also simplifies the API for consumers, that no longer have to care about whether DataViews passes a new view or a function as parameter: it always passes a new view now.

## Why

If it is dependent on the whole `view` object, `onChangeView` is new every time the `view` changes – defeating the memoization.

## How

- Consumers can no longer use a function as parameter to `onChangeView`, they have to provide a new view object.
- `onChangeView` memoization dependencies are updated.
