### PR TITLE
Modules API: Fix Interactivity not working on Classic Themes.

### DIFF
--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -266,11 +266,13 @@ $modules_position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
 // Prints the import map in the head tag in block themes. Otherwise in the footer.
 add_action( $modules_position, array( 'Gutenberg_Modules', 'print_import_map' ) );
 
-// Prints the enqueued modules in the head tag in block themes. Otherwise in the footer.
+// Prints the enqueued modules in the head tag in block themes.
 add_action( $modules_position, array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 
-// Prints the preloaded modules in the head tag in block themes. Otherwise in the footer.
-add_action( $modules_position, array( 'Gutenberg_Modules', 'print_module_preloads' ) );
+// Prints the preloaded modules in the head tag in block themes.
+if ( 'wp_head' === $modules_position ) {
+	add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
+}
 
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -263,14 +263,14 @@ function gutenberg_dequeue_module( $module_identifier ) {
 }
 
 $modules_position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
-// Prints the import map in the head tag.
+// Prints the import map in the head tag in block themes. Otherwise in the footer.
 add_action( $modules_position, array( 'Gutenberg_Modules', 'print_import_map' ) );
 
-// Prints the enqueued modules in the head tag.
+// Prints the enqueued modules in the head tag in block themes. Otherwise in the footer.
 add_action( $modules_position, array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 
-// Prints the preloaded modules in the head tag.
-add_action( $modules_position, array( 'Gutenberg_Modules', 'print_module_preloads' ) );
+// Prints the preloaded modules in the head tag in block themes.
+add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -269,8 +269,8 @@ add_action( $modules_position, array( 'Gutenberg_Modules', 'print_import_map' ) 
 // Prints the enqueued modules in the head tag in block themes. Otherwise in the footer.
 add_action( $modules_position, array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 
-// Prints the preloaded modules in the head tag in block themes.
-add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
+// Prints the preloaded modules in the head tag in block themes. Otherwise in the footer.
+add_action( $modules_position, array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -266,13 +266,11 @@ $modules_position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
 // Prints the import map in the head tag in block themes. Otherwise in the footer.
 add_action( $modules_position, array( 'Gutenberg_Modules', 'print_import_map' ) );
 
-// Prints the enqueued modules in the head tag in block themes.
+// Prints the enqueued modules in the head tag in block themes. Otherwise in the footer.
 add_action( $modules_position, array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 
-// Prints the preloaded modules in the head tag in block themes.
-if ( 'wp_head' === $modules_position ) {
-	add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
-}
+// Prints the preloaded modules in the head tag in block themes. Otherwise in the footer.
+add_action( $modules_position, array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -262,14 +262,15 @@ function gutenberg_dequeue_module( $module_identifier ) {
 	Gutenberg_Modules::dequeue( $module_identifier );
 }
 
+$modules_position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
 // Prints the import map in the head tag.
-add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map' ) );
+add_action( $modules_position, array( 'Gutenberg_Modules', 'print_import_map' ) );
 
 // Prints the enqueued modules in the head tag.
-add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
+add_action( $modules_position, array( 'Gutenberg_Modules', 'print_enqueued_modules' ) );
 
 // Prints the preloaded modules in the head tag.
-add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_module_preloads' ) );
+add_action( $modules_position, array( 'Gutenberg_Modules', 'print_module_preloads' ) );
 
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_footer', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #57370 and https://github.com/Automattic/wp-calypso/issues/85638


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As @t-hamano spotted in https://github.com/WordPress/gutenberg/pull/56143#issuecomment-1870135214. In classic themes, blocks are rendered on `the_content`. 

If we move the import map and the enqueued modules to the footer. Lightbox is working again.
This can be a temporary workaround before moving to WordPress Core.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add Lightbox to any image.
- Check that the Lightbox is working on both Classic (Twenty Sixteen i.e.) and Block Themes (Twenty Twenty Four).

