### PR TITLE
Fix flaky 'Post publish button' e2e test

### DIFF
--- a/test/e2e/specs/editor/various/publish-button.spec.js
+++ b/test/e2e/specs/editor/various/publish-button.spec.js
@@ -42,18 +42,20 @@ test.describe( 'Post publish button', () => {
 			topBar.getByRole( 'button', { name: 'Publish' } )
 		).toBeEnabled();
 
-		const postId = new URL( page.url() ).searchParams.get( 'post' );
 		const deferred = defer();
 
 		await page.route(
 			( url ) =>
-				url.searchParams.has(
-					'rest_route',
-					encodeURIComponent( `/wp/v2/posts/${ postId }` )
+				url.href.includes(
+					`rest_route=${ encodeURIComponent( '/wp/v2/posts/' ) }`
 				),
-			async ( route ) => {
-				await deferred;
-				await route.continue();
+			async ( route, request ) => {
+				if ( request.method() === 'POST' ) {
+					await deferred;
+					await route.continue();
+				} else {
+					await route.continue();
+				}
 			}
 		);
 


### PR DESCRIPTION
## What?
Fixes #35641.

PR fixes flaky `should be disabled when post is being saved` e2e test.

## Why?
The e2e test failed a few dozen times in two weeks due to incorrect route interception. The draft posts only have the post ID available in the page URL once saved for the first time.

P.S. I realized that later, UI Mode provides hints in the Network tab when a route is intercepted. Best tool for debugging 🐛

## How?
Switch to more generic URL matches and only intercept `POST` requests.

## Testing Instructions

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-12-27 at 22 55 33](https://github.com/WordPress/gutenberg/assets/240569/4672606e-82f9-40ae-9ba9-0d7661930b93)
