### PR TITLE
Fix incorrect heading level in Editor curation docs

### DIFF
--- a/docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md
+++ b/docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md
@@ -1,4 +1,4 @@
-## Disable Editor functionality
+# Disable Editor functionality
 
 This page is dedicated to the many ways you can disable specific functionality in the Post Editor and Site Editor that are not covered in other areas of the curation documentation. 
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -240,7 +240,7 @@
 		"parent": "curating-the-editor-experience"
 	},
 	{
-		"title": "DisableEditorFunctionality",
+		"title": "Disable Editor functionality",
 		"slug": "disable-editor-functionality",
 		"markdown_source": "../docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md",
 		"parent": "curating-the-editor-experience"


### PR DESCRIPTION
This is a quick PR to fix the incorrect heading level in the [Disable Editor functionality](https://developer.wordpress.org/block-editor/how-to-guides/curating-the-editor-experience/disable-editor-functionality/#disable-editor-functionality) doc.
