### PR TITLE
Quality: avoid React warning when changing rendering mode

### DIFF
--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -37,6 +37,8 @@ const {
 	ExperimentalBlockCanvas: BlockCanvas,
 } = unlock( blockEditorPrivateApis );
 
+const noop = () => {};
+
 /**
  * Given an array of nested blocks, find the first Post Content
  * block inside it, recursing through any nesting levels,
@@ -283,12 +285,10 @@ function EditorCanvas( {
 
 	const localRef = useRef();
 	const typewriterRef = useTypewriter();
-	const contentRef = useMergeRefs(
-		[
-			localRef,
-			renderingMode === 'post-only' ? typewriterRef : undefined,
-		].filter( ( r ) => !! r )
-	);
+	const contentRef = useMergeRefs( [
+		localRef,
+		renderingMode === 'post-only' ? typewriterRef : noop,
+	] );
 
 	return (
 		<BlockCanvas


### PR DESCRIPTION
## What?
This PR fixes a React warning error that occurs when switching template preview mode.

![template-preview](https://github.com/WordPress/gutenberg/assets/54422211/379de82e-ea9f-4857-a440-b664c20f284d)

## Why?
In the current implementation, the number of elements in the array passed to `useMergeRefs` depends on whether the rendering mode is `post-only` or not. This results in a change in the number of elements in [the dependency array of `useLayoutEffect`](https://github.com/WordPress/gutenberg/blob/d7c222c09ebb94949bc205ca6ef708d201b59796/packages/compose/src/hooks/use-merge-refs/index.js#L104).

## How?
Added a noop function so that the number of elements in the dependency array does not change.

## Testing Instructions
- In the post sidebar, press the "Template preview" button.
- There should be no errors displayed in the browser console.