### PR TITLE
DataViews: update names for `DropdownMenuRadioItemCustom`

### DIFF
--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -117,7 +117,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 											return (
 												<DropdownMenuRadioItemCustom
 													key={ element.value }
-													name={ `add-filter-${ filter.field.id }` }
+													name={ `add-filter-${ filter.field }` }
 													value={ element.value }
 													checked={ isActive }
 													onClick={ () => {
@@ -172,7 +172,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 												] ) => (
 													<DropdownMenuRadioItem
 														key={ key }
-														name={ `add-filter-${ filter.name }-conditions` }
+														name={ `add-filter-${ filter.field }-conditions` }
 														value={ operator }
 														checked={
 															activeOperator ===

--- a/packages/dataviews/src/dropdown-menu-helper.js
+++ b/packages/dataviews/src/dropdown-menu-helper.js
@@ -28,7 +28,10 @@ const radioCheck = (
  * component, which allows deselecting selected values.
  */
 export const DropdownMenuRadioItemCustom = forwardRef(
-	( { checked, name, value, onChange, onClick, ...props }, ref ) => {
+	function DropdownMenuRadioItemCustom(
+		{ checked, name, value, onChange, onClick, ...props },
+		ref
+	) {
 		const onClickHandler = ( e ) => {
 			onClick?.( e );
 			onChange?.( { ...e, target: { ...e.target, value } } );

--- a/packages/dataviews/src/filter-summary.js
+++ b/packages/dataviews/src/filter-summary.js
@@ -103,7 +103,7 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 						return (
 							<DropdownMenuRadioItemCustom
 								key={ element.value }
-								name={ `filter-summary-${ filter.field.id }` }
+								name={ `filter-summary-${ filter.field }` }
 								value={ element.value }
 								checked={ isActive }
 								onClick={ () =>
@@ -150,7 +150,7 @@ export default function FilterSummary( { filter, view, onChangeView } ) {
 							( [ operator, { label, key } ] ) => (
 								<DropdownMenuRadioItemCustom
 									key={ key }
-									name={ `filter-summary-${ filter.name }-conditions` }
+									name={ `filter-summary-${ filter.field }-conditions` }
 									value={ operator }
 									checked={ activeOperator === operator }
 									onChange={ ( e ) => {

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -167,7 +167,7 @@ function HeaderMenu( { field, view, onChangeView } ) {
 										return (
 											<DropdownMenuRadioItemCustom
 												key={ element.value }
-												name={ `view-table-${ filter.field.id }` }
+												name={ `view-table-${ filter.field }` }
 												value={ element.value }
 												checked={ isActive }
 												onClick={ () => {
@@ -222,7 +222,7 @@ function HeaderMenu( { field, view, onChangeView } ) {
 											] ) => (
 												<DropdownMenuRadioItemCustom
 													key={ key }
-													name={ `view-table-${ filter.name }-conditions` }
+													name={ `view-table-${ filter.field }-conditions` }
 													value={ operator }
 													checked={
 														activeOperator ===


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Update the `name` attribute in use for `DropdownMenuRadioItemCustom` as well as use a named function for the forwarded component.

## Why?

- The existing names render either as `undefined` or use a key that can contain spaces.
- Having the component name displayed in React devtools makes it easier to debug.
