### PR TITLE
DataViews: hide actions menu upon selecting a layout

### DIFF
--- a/packages/dataviews/src/dropdown-menu-helper.js
+++ b/packages/dataviews/src/dropdown-menu-helper.js
@@ -42,7 +42,7 @@ export const DropdownMenuRadioItemCustom = forwardRef(
 				role="menuitemradio"
 				name={ name }
 				aria-checked={ checked }
-				hideOnClick={ hideOnClick || false }
+				hideOnClick={ !! hideOnClick }
 				prefix={
 					checked ? (
 						<Icon icon={ radioCheck } />

--- a/packages/dataviews/src/dropdown-menu-helper.js
+++ b/packages/dataviews/src/dropdown-menu-helper.js
@@ -29,7 +29,7 @@ const radioCheck = (
  */
 export const DropdownMenuRadioItemCustom = forwardRef(
 	function DropdownMenuRadioItemCustom(
-		{ checked, name, value, onChange, onClick, ...props },
+		{ checked, name, value, hideOnClick, onChange, onClick, ...props },
 		ref
 	) {
 		const onClickHandler = ( e ) => {
@@ -42,7 +42,7 @@ export const DropdownMenuRadioItemCustom = forwardRef(
 				role="menuitemradio"
 				name={ name }
 				aria-checked={ checked }
-				hideOnClick={ false }
+				hideOnClick={ hideOnClick || false }
 				prefix={
 					checked ? (
 						<Icon icon={ radioCheck } />

--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -54,6 +54,7 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 						value={ availableView.type }
 						name="view-actions-available-view"
 						checked={ availableView.type === view.type }
+						hideOnClick={ true }
 						onChange={ ( e ) => {
 							onChangeView( {
 								...view,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/issues/55083 and https://github.com/WordPress/gutenberg/pull/55625

## What?

Hide the view actions menu upon selecting a layout.

## Why?

Upon selecting a layout, the position of the view actions menu trigger could change. For example, when switching from table to list. This leaves the dropdown in a weird visual position.

This had been fixed at https://github.com/WordPress/gutenberg/pull/57015 but resurfaced after https://github.com/WordPress/gutenberg/pull/55625

## How?

Use `hideOnClick` to hide the dropdown upon selection a layout option.

## Testing Instructions

- Enable the "new admin view" experiment and go to "Manage all pages" or "Manage all templates".
- Select a different layout and verify that the dropdown is closed.
- Select any other option (number of items per page, for example) and verify that the dropdown is kept open.

