### PR TITLE
Make sure command palette toggle does not disappear while being clicked.

### DIFF
--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -73,7 +73,10 @@
 .edit-site-site-hub_toggle-command-center {
 	color: $gray-200;
 
-	&:hover {
-		color: $gray-100;
+	&:hover,
+	&:active {
+		svg {
+			fill: $gray-100;
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57415

## What?
<!-- In a few words, what is the PR actually doing? -->
The icon of the Open Command Palette button in the 'site hub' disappears while the button is being activated. Screenshot:

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It should not disappear.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Targets the svg icon to set its fill color, much like the View Site link.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Follow the reproduction instructions from the issue https://github.com/WordPress/gutenberg/issues/57415
- Observe the icon does not disappeaer any longer.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
