### PR TITLE
Make the site hub View Site link always visible.

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -180,7 +180,10 @@ const SiteHub = memo( ( { isTransparent, className } ) => {
 								'View site (opens in a new tab)'
 							) }
 							icon={ external }
-							className="edit-site-site-hub__site-view-link"
+							className={ classnames(
+								'edit-site-site-hub__site-view-link',
+								{ 'is-transparent': isTransparent }
+							) }
 						/>
 					) }
 				</HStack>

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -9,6 +9,7 @@
 	}
 
 	.edit-site-site-hub__site-title,
+	.edit-site-site-hub__site-view-link,
 	.edit-site-site-hub_toggle-command-center {
 		transition: opacity ease 0.1s;
 
@@ -20,20 +21,8 @@
 	.edit-site-site-hub__site-view-link {
 		flex-grow: 0;
 		margin-right: var(--wp-admin-border-width-focus);
-		@include break-mobile() {
-			opacity: 0;
-			transition: opacity 0.2s ease-in-out;
-		}
-		&:focus {
-			opacity: 1;
-		}
 		svg {
 			fill: $gray-200;
-		}
-	}
-	&:hover {
-		.edit-site-site-hub__site-view-link {
-			opacity: 1;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57421

## What?
<!-- In a few words, what is the PR actually doing? -->
Makes the site hub View Site link always visible instead of showing it only on hover or focus.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Interactive controls that appear and disappear are always a problem for general usability and accessibility.
Revealing the View Site link only on hover and focus appears to have the side effect of making the functionality less disoverable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Makes the View Site link always visible, Make it behave like the Command Center toggle when resizing the editor canvas.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site Editor.
- Observe in the top part of the navigation panel the View Site link is always visible.
- Using your pointing device, drag resize the editor canvas to be wider so that the navigation panel gets narrower.
- Observe both the View Site link and the Command Palette toggle become hidden while resizing.
- Test also with Firefox, see https://github.com/WordPress/gutenberg/pull/52700


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
