### PR TITLE
Commands: Combine selectors in 'useTransformCommands'

### DIFF
--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -26,40 +26,37 @@ import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 
 export const useTransformCommands = () => {
-	const { clientIds } = useSelect( ( select ) => {
-		const { getSelectedBlockClientIds } = select( blockEditorStore );
-		const selectedBlockClientIds = getSelectedBlockClientIds();
-
-		return {
-			clientIds: selectedBlockClientIds,
-		};
-	}, [] );
-	const blocks = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlocksByClientId( clientIds ),
-		[ clientIds ]
-	);
 	const { replaceBlocks, multiSelect } = useDispatch( blockEditorStore );
-	const { possibleBlockTransformations, canRemove } = useSelect(
-		( select ) => {
+	const { blocks, clientIds, canRemove, possibleBlockTransformations } =
+		useSelect( ( select ) => {
 			const {
 				getBlockRootClientId,
 				getBlockTransformItems,
+				getSelectedBlockClientIds,
+				getBlocksByClientId,
 				canRemoveBlocks,
 			} = select( blockEditorStore );
+
+			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const selectedBlocks = getBlocksByClientId(
+				selectedBlockClientIds
+			);
 			const rootClientId = getBlockRootClientId(
-				Array.isArray( clientIds ) ? clientIds[ 0 ] : clientIds
+				selectedBlockClientIds[ 0 ]
 			);
 			return {
+				blocks: selectedBlocks,
+				clientIds: selectedBlockClientIds,
 				possibleBlockTransformations: getBlockTransformItems(
-					blocks,
+					selectedBlocks,
 					rootClientId
 				),
-				canRemove: canRemoveBlocks( clientIds, rootClientId ),
+				canRemove: canRemoveBlocks(
+					selectedBlockClientIds,
+					rootClientId
+				),
 			};
-		},
-		[ clientIds, blocks ]
-	);
+		}, [] );
 
 	const isTemplate = blocks.length === 1 && isTemplatePart( blocks[ 0 ] );
 


### PR DESCRIPTION
## What?
PR combines `block-editor` store selectors in the `useTransformCommands` hook.

## Why?
* Selectors depend on data returned by other selectors for the same store. Combining them removes this dependency.
* Create one store subscription instead of three. A cherry on the top 🍒

## Testing Instructions
1. Open a post or page.
2. Select some block.
3. Press CMD + K
4. Type - `transform`
5. Confirm that the block transformation command works as before.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2023-12-28 at 17 31 11](https://github.com/WordPress/gutenberg/assets/240569/3d42df21-b944-43d0-a0e7-47024799076c)
