### PR TITLE
resolve pullquote block padding issue

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -1,5 +1,5 @@
 .wp-block-pullquote {
-	padding: 3em 0;
+	padding: 36px 0;
 	text-align: center; // Default text-alignment where the `textAlign` attribute value isn't specified.
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 	box-sizing: border-box;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Resolve the issue mentioned here :- #52830

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Whenever we change the font size in pullquote block it can add spacing above and below I have resolved this issue according to mentioned solution in the issue and after adding that padding value in px the issue is resolved.

## Testing Instructions
1.Add Pullquote Block
2.Open Typography section from the Inspector Controls
3.Tried to change the Size
