### PR TITLE
Block-Editor: Enhance FontFamily Component

### DIFF
--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl } from '@wordpress/components';
+import { CustomSelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -25,21 +25,21 @@ export default function FontFamilyControl( {
 	}
 
 	const options = [
-		{ value: '', label: __( 'Default' ) },
+		{ key: '', name: __( 'Default' ) },
 		...fontFamilies.map( ( { fontFamily, name } ) => {
 			return {
-				value: fontFamily,
-				label: name || fontFamily,
+				key: fontFamily,
+				name: name || fontFamily,
 			};
 		} ),
 	];
+
 	return (
-		<SelectControl
+		<CustomSelectControl
 			label={ __( 'Font' ) }
 			options={ options }
-			value={ value }
-			onChange={ onChange }
-			labelPosition="top"
+			value={ options.find( ( { key } ) => key === value ) }
+			onChange={ ( { selectedItem } ) => onChange( selectedItem.key ) }
 			{ ...props }
 		/>
 	);


### PR DESCRIPTION
## What?
- This PR changes the `FontFamily` component in the `block-editor` package.

## Why?
- In the current version, the font list becomes too much taller (same as the screen width) in `Chrome` because `SelectControl` uses the `<select>` HTML tag.
- If we use `CustomSelectControl` then the list will not become taller, it get a scrollbar if necessary and our UI stays the same for all different browsers.

## How?
- It replaces `SelectControl` with `CustomSelectControl` to solve the issue.
- The `CustomSelectControl` uses a custom interface for the select menu, however, `SelectControl` uses the default `<select>` tag which is different in all browsers.

## Testing Instructions
1. Create a post.
2. Add paragraph block.
3. Write some text to it.
4. Select the block and open the sidebar panel.
5. Enable font family in the Typography panel.
6. Try to select different fonts from the drop-down box and see the result.

## Screenshots
<img width="1280" alt="Screenshot 2023-12-28 at 10 35 12 PM" src="https://github.com/WordPress/gutenberg/assets/55320836/d5847ace-7b67-4b0a-8b11-5eff1287a95e">


## Related issue
- #57301 
