### PR TITLE
resolved image block alignment issue

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -25,6 +25,7 @@
 
 	&.aligncenter {
 		text-align: center;
+		justify-content: center;
 	}
 
 	&.alignfull img,
@@ -39,7 +40,7 @@
 	.alignleft,
 	.alignright,
 	.aligncenter {
-		display: table;
+		display: flex;
 
 		> figcaption {
 			display: table-caption;
@@ -49,7 +50,7 @@
 
 	.alignleft {
 		/*rtl:ignore*/
-		float: left;
+		justify-content: flex-end;
 		/*rtl:ignore*/
 		margin-left: 0;
 		/*rtl:ignore*/
@@ -60,7 +61,7 @@
 
 	.alignright {
 		/*rtl:ignore*/
-		float: right;
+		justify-content: flex-start;
 		/*rtl:ignore*/
 		margin-right: 0;
 		/*rtl:ignore*/


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Resolve the issue mentioned here :- #56705

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Whenever we use alignment to the image it is not looking proper.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When we use alignment it will mess up with other content as per the alignment.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a new page and take the new image block.
2. Select small size image and change alignment setting.
3. Checked with Align right or Align left setting.
4. Checked front side image position out of container.

