### PR TITLE
DataViews: fallback to `(no title)` is there's no rendered title

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -216,7 +216,7 @@ export default function PagePages() {
 			{
 				header: __( 'Title' ),
 				id: 'title',
-				getValue: ( { item } ) => item.title?.rendered || item.slug,
+				getValue: ( { item } ) => item.title?.rendered,
 				render: ( { item } ) => {
 					return (
 						<VStack spacing={ 1 }>
@@ -235,13 +235,12 @@ export default function PagePages() {
 										} }
 									>
 										{ decodeEntities(
-											item.title?.rendered || item.slug
+											item.title?.rendered
 										) || __( '(no title)' ) }
 									</Link>
 								) : (
-									decodeEntities(
-										item.title?.rendered || item.slug
-									) || __( '(no title)' )
+									decodeEntities( item.title?.rendered ) ||
+									__( '(no title)' )
 								) }
 							</View>
 						</VStack>

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -92,8 +92,7 @@ function TemplateTitle( { item, view } ) {
 	if ( view.type === LAYOUT_LIST ) {
 		return (
 			<>
-				{ decodeEntities( item.title?.rendered || item.slug ) ||
-					__( '(no title)' ) }
+				{ decodeEntities( item.title?.rendered ) || __( '(no title)' ) }
 			</>
 		);
 	}
@@ -108,7 +107,7 @@ function TemplateTitle( { item, view } ) {
 						canvas: 'edit',
 					} }
 				>
-					{ decodeEntities( item.title?.rendered || item.slug ) ||
+					{ decodeEntities( item.title?.rendered ) ||
 						__( '(no title)' ) }
 				</Link>
 			</View>
@@ -210,7 +209,7 @@ export default function DataviewsTemplates() {
 			{
 				header: __( 'Template' ),
 				id: 'title',
-				getValue: ( { item } ) => item.title?.rendered || item.slug,
+				getValue: ( { item } ) => item.title?.rendered,
 				render: ( { item } ) => (
 					<TemplateTitle item={ item } view={ view } />
 				),


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Extract from https://github.com/WordPress/gutenberg/pull/56942/

If there is no rendered `title` field, we should no fallback to the slug but render `(no title)` instead.
