### PR TITLE
Performance: Avoid extra `useMarkPersistent` dispatch calls

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-mark-persistent.js
+++ b/packages/block-editor/src/components/rich-text/use-mark-persistent.js
@@ -11,8 +11,7 @@ import { store as blockEditorStore } from '../../store';
 
 export function useMarkPersistent( { html, value } ) {
 	const previousText = useRef();
-	const hasActiveFormats =
-		value.activeFormats && !! value.activeFormats.length;
+	const hasActiveFormats = !! value.activeFormats?.length;
 	const { __unstableMarkLastChangeAsPersistent } =
 		useDispatch( blockEditorStore );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR tries to improve the block selection performance by avoiding extra dispatching calls. We do that by always converting the `hasActiveFormats` to a `boolean`, because at cases(like the creation of a new record) the `activeFormats` can be `undefined` and then an `array`.
