### PR TITLE
[Type] Developer Documentation - Fix removeAllNotices dispatch on the removeAllNotices doc section of @wordpress/notices

### DIFF
--- a/docs/reference-guides/data/data-core-notices.md
+++ b/docs/reference-guides/data/data-core-notices.md
@@ -277,7 +277,7 @@ export const ExampleComponent = () => {
 	const notices = useSelect( ( select ) =>
 		select( noticesStore ).getNotices()
 	);
-	const { removeNotices } = useDispatch( noticesStore );
+	const { removeAllNotices } = useDispatch( noticesStore );
 	return (
 		<>
 			<ul>

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -330,7 +330,7 @@ export function removeNotice( id, context = DEFAULT_CONTEXT ) {
  * 	const notices = useSelect( ( select ) =>
  * 		select( noticesStore ).getNotices()
  * 	);
- * 	const { removeNotices } = useDispatch( noticesStore );
+ * 	const { removeAllNotices } = useDispatch( noticesStore );
  * 	return (
  * 		<>
  * 			<ul>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR replaces the missed `removeNotices` from `useDispatch( noticesStore )`with the `removeAllNotices` on the removeAllNotices section of the [Gutenberg Reference Guide of the @wordpress/notices package](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/data/data-core-notices.md#removeallnotices).

## Why?
The Usage example of the `removeAllNotices` section has a bug that prevents the code from working properly. It dispatches the `removeNotices` from `noticesStore` but it tries to use the `removeAllNotices()` method when clicking on the buttons below.

It seems that this `removeAllNotices` section was copied from the `removeNotices` section, but it missed replacing all the occurrences of the `removeNotices` method. 

## How?
It just replaces the `removeNotices` with `removeAllNotices` on the [removeAllNotices doc section](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/data/data-core-notices.md#removeallnotices).

## Testing Instructions
Not relevant as it doesn't change any working code. 
But if you want to test the provided example, you must copy the code and paste it into a new React component, then, import it to be used in a React page (e.g. a WordPress admin page). 

### Testing Instructions for Keyboard
Not relevant

## Screenshots or screencast <!-- if applicable -->
<img width="918" alt="image" src="https://github.com/WordPress/gutenberg/assets/4562945/235f0fd7-3735-431d-b840-fdda1246b5d5">

<img width="1274" alt="image" src="https://github.com/WordPress/gutenberg/assets/4562945/71f30135-ef15-427b-904c-9027ef286dcc">

