### PR TITLE
Blocks: Add handling for block.json viewModule

### DIFF
--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -386,7 +386,7 @@ function gutenberg_register_block_module_handle( $metadata, $field_name, $index 
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				// This is a translation from core. See `register_block_script_handle`jk.
+				// This is a translation from core. See `register_block_script_handle`.
 				__( 'The asset file (%1$s) for the "%2$s" defined in "%3$s" block definition is missing.', 'default' ),
 				$module_asset_raw_path,
 				$field_name,

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -281,6 +281,15 @@ add_action( $modules_position, array( 'Gutenberg_Modules', 'print_module_preload
 // Prints the script that loads the import map polyfill in the footer.
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );
 
+/**
+ * Add module fields from block metadata to WP_Block_Type settings
+ *
+ * This filter allows us to register modules from block metadata and attach additional fields to
+ * WP_Block_Type instances.
+ *
+ * @param array $settings Array of determined settings for registering a block type.
+ * @param array $metadata Metadata provided for registering a block type.
+ */
 function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
 	$module_fields = array(
 		'viewModule' => 'view_module_handles',
@@ -315,6 +324,13 @@ function gutenberg_filter_block_type_metadata_settings_register_modules( $settin
 
 add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_register_modules', 10, 2 );
 
+/**
+ * Enqueue modules associated with the block.
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The full block, including name and attributes.
+ * @param WP_Block $instance      The block instance.
+ */
 function gutenberg_filter_render_block_enqueue_view_modules( $block_content, $parsed_block, $block_instance ) {
 	$block_type = $block_instance->block_type;
 

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -404,9 +404,9 @@ function gutenberg_register_block_module_handle( $metadata, $field_name, $index 
 
 	// @todo This in_array may not work with module_dependencies.
 	// @todo @wordpress/i18n isn't module compatible anyways…
-	if ( ! empty( $metadata['textdomain'] ) && in_array( '@wordpress/i18n', $module_dependencies, true ) ) {
-		wp_set_script_translations( $module_id, $metadata['textdomain'] );
-	}
+	// if ( ! empty( $metadata['textdomain'] ) && in_array( '@wordpress/i18n', $module_dependencies, true ) ) {
+	// 	wp_set_script_translations( $module_id, $metadata['textdomain'] );
+	// }
 
 	return $module_id;
 }

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -283,12 +283,9 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map_polyfill' )
 
 function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
 	$module_fields = array(
-		'editorModule' => 'editor_module_handles',
-		'module'       => 'module_handles',
-		'viewModule'   => 'view_module_handles',
+		'viewModule' => 'view_module_handles',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
-
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {
 			$metadata[ $metadata_field_name ] = $settings[ $metadata_field_name ];
 		}
@@ -320,12 +317,6 @@ add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadat
 
 function gutenberg_filter_render_block_enqueue_view_modules( $block_content, $parsed_block, $block_instance ) {
 	$block_type = $block_instance->block_type;
-
-	if ( ! empty( $block_type->module_handles ) ) {
-		foreach ( $block_type->module_handles as $module_id ) {
-			gutenberg_enqueue_module( $module_id );
-		}
-	}
 
 	if ( ! empty( $block_type->view_module_handles ) ) {
 		foreach ( $block_type->view_module_handles as $module_id ) {

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -379,8 +379,8 @@ function gutenberg_register_block_module_handle( $metadata, $field_name, $index 
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				/* translators: 1: Asset file location, 2: Field name, 3: Block name.  */
-				__( 'The asset file (%1$s) for the "%2$s" defined in "%3$s" block definition is missing.' ),
+				// This is a translation from core. See `register_block_script_handle`jk.
+				__( 'The asset file (%1$s) for the "%2$s" defined in "%3$s" block definition is missing.', 'default' ),
 				$module_asset_raw_path,
 				$field_name,
 				$metadata['name']

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -400,7 +400,7 @@ function gutenberg_register_block_module_handle( $metadata, $field_name, $index 
 		$module_id,
 		$module_uri,
 		$module_dependencies,
-		isset( $module_asset['version'] ) ? $module_asset['version'] : false,
+		isset( $module_asset['version'] ) ? $module_asset['version'] : false
 	);
 
 	// @todo This in_array may not work with module_dependencies.

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -450,3 +450,21 @@ function gutenberg_generate_block_asset_module_id( $block_name, $field_name, $in
 	}
 	return $asset_handle;
 }
+
+function gutenberg_register_view_module_ids_rest_field() {
+	register_rest_field(
+		'block-type',
+		'view_module_ids',
+		array(
+			'get_callback' => function ( $object ) {
+				 $block_type = WP_Block_Type_Registry::get_instance()->get_registered( $object['name'] );
+				if ( isset( $block_type->view_module_ids ) ) {
+					return $block_type->view_module_ids;
+				}
+				return array();
+			},
+		)
+	);
+}
+
+add_action( 'rest_api_init', 'gutenberg_register_view_module_ids_rest_field' );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -390,9 +390,8 @@ function gutenberg_register_block_module_handle( $metadata, $field_name, $index 
 		return false;
 	}
 
-	$module_path_norm = wp_normalize_path( realpath( $path . '/' . $module_path ) );
-	$module_uri       = get_block_asset_url( $module_path_norm );
-
+	$module_path_norm    = wp_normalize_path( realpath( $path . '/' . $module_path ) );
+	$module_uri          = get_block_asset_url( $module_path_norm );
 	$module_asset        = require $module_asset_path;
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
 

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -292,7 +292,7 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map_polyfill' )
  */
 function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
 	$module_fields = array(
-		'viewModule' => 'view_module_handles',
+		'viewModule' => 'view_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {
@@ -303,14 +303,14 @@ function gutenberg_filter_block_type_metadata_settings_register_modules( $settin
 			$processed_modules = array();
 			if ( is_array( $modules ) ) {
 				for ( $index = 0; $index < count( $modules ); $index++ ) {
-					$processed_modules[] = gutenberg_register_block_module_handle(
+					$processed_modules[] = gutenberg_register_block_module_id(
 						$metadata,
 						$metadata_field_name,
 						$index
 					);
 				}
 			} else {
-				$processed_modules[] = gutenberg_register_block_module_handle(
+				$processed_modules[] = gutenberg_register_block_module_id(
 					$metadata,
 					$metadata_field_name
 				);
@@ -334,8 +334,8 @@ add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadat
 function gutenberg_filter_render_block_enqueue_view_modules( $block_content, $parsed_block, $block_instance ) {
 	$block_type = $block_instance->block_type;
 
-	if ( ! empty( $block_type->view_module_handles ) ) {
-		foreach ( $block_type->view_module_handles as $module_id ) {
+	if ( ! empty( $block_type->view_module_ids ) ) {
+		foreach ( $block_type->view_module_ids as $module_id ) {
 			gutenberg_enqueue_module( $module_id );
 		}
 	}

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -351,13 +351,15 @@ add_filter( 'render_block', 'gutenberg_filter_render_block_enqueue_view_modules'
  * with details necessary to register the module under an automatically
  * generated module ID.
  *
+ * This is analogous to the `register_block_script_handle` in WordPress Core.
+ *
  * @param array  $metadata   Block metadata.
  * @param string $field_name Field name to pick from metadata.
  * @param int    $index      Optional. Index of the script to register when multiple items passed.
  *                           Default 0.
  * @return string Module ID.
  */
-function gutenberg_register_block_module_handle( $metadata, $field_name, $index = 0 ) {
+function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 ) {
 	if ( empty( $metadata[ $field_name ] ) ) {
 		return false;
 	}
@@ -421,6 +423,8 @@ function gutenberg_register_block_module_handle( $metadata, $field_name, $index 
 /**
  * Generates the module ID for an asset based on the name of the block
  * and the field name provided.
+ *
+ * This is analogous to the `generate_block_asset_handle` in WordPress Core.
  *
  * @param string $block_name Name of the block.
  * @param string $field_name Name of the metadata field.

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -441,7 +441,7 @@ function gutenberg_generate_block_asset_module_id( $block_name, $field_name, $in
 	}
 
 	$field_mappings = array(
-		'viewModule'   => 'view-module',
+		'viewModule' => 'view-module',
 	);
 	$asset_handle   = str_replace( '/', '-', $block_name ) .
 		'-' . $field_mappings[ $field_name ];

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -444,8 +444,6 @@ function gutenberg_generate_block_asset_module_id( $block_name, $field_name, $in
 	}
 
 	$field_mappings = array(
-		'editorModule' => 'editor-module',
-		'module'       => 'module',
 		'viewModule'   => 'view-module',
 	);
 	$asset_handle   = str_replace( '/', '-', $block_name ) .

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -456,8 +456,8 @@ function gutenberg_register_view_module_ids_rest_field() {
 		'block-type',
 		'view_module_ids',
 		array(
-			'get_callback' => function ( $object ) {
-				 $block_type = WP_Block_Type_Registry::get_instance()->get_registered( $object['name'] );
+			'get_callback' => function ( $item ) {
+				 $block_type = WP_Block_Type_Registry::get_instance()->get_registered( $item['name'] );
 				if ( isset( $block_type->view_module_ids ) ) {
 					return $block_type->view_module_ids;
 				}

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -282,7 +282,7 @@ add_action( $modules_position, array( 'Gutenberg_Modules', 'print_module_preload
 add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map_polyfill' ), 11 );
 
 /**
- * Add module fields from block metadata to WP_Block_Type settings
+ * Add module fields from block metadata to WP_Block_Type settings.
  *
  * This filter allows us to register modules from block metadata and attach additional fields to
  * WP_Block_Type instances.

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -380,15 +380,14 @@ function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 
 	$path                  = dirname( $metadata['file'] );
 	$module_asset_raw_path = $path . '/' . substr_replace( $module_path, '.asset.php', - strlen( '.js' ) );
 	$module_id             = gutenberg_generate_block_asset_module_id( $metadata['name'], $field_name, $index );
-	$module_asset_path     = wp_normalize_path(
-		realpath( $module_asset_raw_path )
-	);
+	$module_asset_path     = wp_normalize_path( realpath( $module_asset_raw_path ) );
 
 	if ( empty( $module_asset_path ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				// This is a translation from core. See `register_block_script_handle`.
+				// This string is from WordPress Core. See `register_block_script_handle`.
+				// Translators: This is a translation from WordPress Core (default). No need to translate.
 				__( 'The asset file (%1$s) for the "%2$s" defined in "%3$s" block definition is missing.', 'default' ),
 				$module_asset_raw_path,
 				$field_name,
@@ -410,12 +409,6 @@ function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 
 		$module_dependencies,
 		isset( $module_asset['version'] ) ? $module_asset['version'] : false
 	);
-
-	// @todo This in_array may not work with module_dependencies.
-	// @todo @wordpress/i18n isn't module compatible anyways…
-	// if ( ! empty( $metadata['textdomain'] ) && in_array( '@wordpress/i18n', $module_dependencies, true ) ) {
-	// 	wp_set_script_translations( $module_id, $metadata['textdomain'] );
-	// }
 
 	return $module_id;
 }

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -292,7 +292,7 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map_polyfill' )
  */
 function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
 	$module_fields = array(
-		'viewModule' => 'view_module_ids',
+		'viewModule' => 'view_module_identifiers',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {
@@ -303,14 +303,14 @@ function gutenberg_filter_block_type_metadata_settings_register_modules( $settin
 			$processed_modules = array();
 			if ( is_array( $modules ) ) {
 				for ( $index = 0; $index < count( $modules ); $index++ ) {
-					$processed_modules[] = gutenberg_register_block_module_id(
+					$processed_modules[] = gutenberg_register_block_module_identifier(
 						$metadata,
 						$metadata_field_name,
 						$index
 					);
 				}
 			} else {
-				$processed_modules[] = gutenberg_register_block_module_id(
+				$processed_modules[] = gutenberg_register_block_module_identifier(
 					$metadata,
 					$metadata_field_name
 				);
@@ -334,9 +334,9 @@ add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadat
 function gutenberg_filter_render_block_enqueue_view_modules( $block_content, $parsed_block, $block_instance ) {
 	$block_type = $block_instance->block_type;
 
-	if ( ! empty( $block_type->view_module_ids ) ) {
-		foreach ( $block_type->view_module_ids as $module_id ) {
-			gutenberg_enqueue_module( $module_id );
+	if ( ! empty( $block_type->view_module_identifiers ) ) {
+		foreach ( $block_type->view_module_identifiers as $module_identifier ) {
+			gutenberg_enqueue_module( $module_identifier );
 		}
 	}
 
@@ -359,27 +359,27 @@ add_filter( 'render_block', 'gutenberg_filter_render_block_enqueue_view_modules'
  *                           Default 0.
  * @return string Module ID.
  */
-function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 ) {
+function gutenberg_register_block_module_identifier( $metadata, $field_name, $index = 0 ) {
 	if ( empty( $metadata[ $field_name ] ) ) {
 		return false;
 	}
 
-	$module_id = $metadata[ $field_name ];
-	if ( is_array( $module_id ) ) {
-		if ( empty( $module_id[ $index ] ) ) {
+	$module_identifier = $metadata[ $field_name ];
+	if ( is_array( $module_identifier ) ) {
+		if ( empty( $module_identifier[ $index ] ) ) {
 			return false;
 		}
-		$module_id = $module_id[ $index ];
+		$module_identifier = $module_identifier[ $index ];
 	}
 
-	$module_path = remove_block_asset_path_prefix( $module_id );
-	if ( $module_id === $module_path ) {
-		return $module_id;
+	$module_path = remove_block_asset_path_prefix( $module_identifier );
+	if ( $module_identifier === $module_path ) {
+		return $module_identifier;
 	}
 
 	$path                  = dirname( $metadata['file'] );
 	$module_asset_raw_path = $path . '/' . substr_replace( $module_path, '.asset.php', - strlen( '.js' ) );
-	$module_id             = gutenberg_generate_block_asset_module_id( $metadata['name'], $field_name, $index );
+	$module_identifier     = gutenberg_generate_block_asset_module_identifier( $metadata['name'], $field_name, $index );
 	$module_asset_path     = wp_normalize_path( realpath( $module_asset_raw_path ) );
 
 	if ( empty( $module_asset_path ) ) {
@@ -404,13 +404,13 @@ function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
 
 	gutenberg_register_module(
-		$module_id,
+		$module_identifier,
 		$module_uri,
 		$module_dependencies,
 		isset( $module_asset['version'] ) ? $module_asset['version'] : false
 	);
 
-	return $module_id;
+	return $module_identifier;
 }
 
 /**
@@ -425,7 +425,7 @@ function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 
  *                           Default 0.
  * @return string Generated module ID for the block's field.
  */
-function gutenberg_generate_block_asset_module_id( $block_name, $field_name, $index = 0 ) {
+function gutenberg_generate_block_asset_module_identifier( $block_name, $field_name, $index = 0 ) {
 	if ( str_starts_with( $block_name, 'core/' ) ) {
 		$asset_handle = str_replace( 'core/', 'wp-block-', $block_name );
 		if ( str_starts_with( $field_name, 'editor' ) ) {
@@ -451,15 +451,15 @@ function gutenberg_generate_block_asset_module_id( $block_name, $field_name, $in
 	return $asset_handle;
 }
 
-function gutenberg_register_view_module_ids_rest_field() {
+function gutenberg_register_view_module_identifiers_rest_field() {
 	register_rest_field(
 		'block-type',
-		'view_module_ids',
+		'view_module_identifiers',
 		array(
 			'get_callback' => function ( $item ) {
 				 $block_type = WP_Block_Type_Registry::get_instance()->get_registered( $item['name'] );
-				if ( isset( $block_type->view_module_ids ) ) {
-					return $block_type->view_module_ids;
+				if ( isset( $block_type->view_module_identifiers ) ) {
+					return $block_type->view_module_identifiers;
 				}
 				return array();
 			},
@@ -467,4 +467,4 @@ function gutenberg_register_view_module_ids_rest_field() {
 	);
 }
 
-add_action( 'rest_api_init', 'gutenberg_register_view_module_ids_rest_field' );
+add_action( 'rest_api_init', 'gutenberg_register_view_module_identifiers_rest_field' );

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -457,7 +457,7 @@ function gutenberg_register_view_module_ids_rest_field() {
 		'view_module_ids',
 		array(
 			'get_callback' => function ( $item ) {
-				 $block_type = WP_Block_Type_Registry::get_instance()->get_registered( $item['name'] );
+				$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $item['name'] );
 				if ( isset( $block_type->view_module_ids ) ) {
 					return $block_type->view_module_ids;
 				}

--- a/lib/experimental/modules/class-gutenberg-modules.php
+++ b/lib/experimental/modules/class-gutenberg-modules.php
@@ -292,7 +292,7 @@ add_action( 'wp_head', array( 'Gutenberg_Modules', 'print_import_map_polyfill' )
  */
 function gutenberg_filter_block_type_metadata_settings_register_modules( $settings, $metadata = null ) {
 	$module_fields = array(
-		'viewModule' => 'view_module_identifiers',
+		'viewModule' => 'view_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {
@@ -303,14 +303,14 @@ function gutenberg_filter_block_type_metadata_settings_register_modules( $settin
 			$processed_modules = array();
 			if ( is_array( $modules ) ) {
 				for ( $index = 0; $index < count( $modules ); $index++ ) {
-					$processed_modules[] = gutenberg_register_block_module_identifier(
+					$processed_modules[] = gutenberg_register_block_module_id(
 						$metadata,
 						$metadata_field_name,
 						$index
 					);
 				}
 			} else {
-				$processed_modules[] = gutenberg_register_block_module_identifier(
+				$processed_modules[] = gutenberg_register_block_module_id(
 					$metadata,
 					$metadata_field_name
 				);
@@ -334,9 +334,9 @@ add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadat
 function gutenberg_filter_render_block_enqueue_view_modules( $block_content, $parsed_block, $block_instance ) {
 	$block_type = $block_instance->block_type;
 
-	if ( ! empty( $block_type->view_module_identifiers ) ) {
-		foreach ( $block_type->view_module_identifiers as $module_identifier ) {
-			gutenberg_enqueue_module( $module_identifier );
+	if ( ! empty( $block_type->view_module_ids ) ) {
+		foreach ( $block_type->view_module_ids as $module_id ) {
+			gutenberg_enqueue_module( $module_id );
 		}
 	}
 
@@ -359,27 +359,27 @@ add_filter( 'render_block', 'gutenberg_filter_render_block_enqueue_view_modules'
  *                           Default 0.
  * @return string Module ID.
  */
-function gutenberg_register_block_module_identifier( $metadata, $field_name, $index = 0 ) {
+function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 ) {
 	if ( empty( $metadata[ $field_name ] ) ) {
 		return false;
 	}
 
-	$module_identifier = $metadata[ $field_name ];
-	if ( is_array( $module_identifier ) ) {
-		if ( empty( $module_identifier[ $index ] ) ) {
+	$module_id = $metadata[ $field_name ];
+	if ( is_array( $module_id ) ) {
+		if ( empty( $module_id[ $index ] ) ) {
 			return false;
 		}
-		$module_identifier = $module_identifier[ $index ];
+		$module_id = $module_id[ $index ];
 	}
 
-	$module_path = remove_block_asset_path_prefix( $module_identifier );
-	if ( $module_identifier === $module_path ) {
-		return $module_identifier;
+	$module_path = remove_block_asset_path_prefix( $module_id );
+	if ( $module_id === $module_path ) {
+		return $module_id;
 	}
 
 	$path                  = dirname( $metadata['file'] );
 	$module_asset_raw_path = $path . '/' . substr_replace( $module_path, '.asset.php', - strlen( '.js' ) );
-	$module_identifier     = gutenberg_generate_block_asset_module_identifier( $metadata['name'], $field_name, $index );
+	$module_id             = gutenberg_generate_block_asset_module_id( $metadata['name'], $field_name, $index );
 	$module_asset_path     = wp_normalize_path( realpath( $module_asset_raw_path ) );
 
 	if ( empty( $module_asset_path ) ) {
@@ -404,13 +404,13 @@ function gutenberg_register_block_module_identifier( $metadata, $field_name, $in
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
 
 	gutenberg_register_module(
-		$module_identifier,
+		$module_id,
 		$module_uri,
 		$module_dependencies,
 		isset( $module_asset['version'] ) ? $module_asset['version'] : false
 	);
 
-	return $module_identifier;
+	return $module_id;
 }
 
 /**
@@ -425,7 +425,7 @@ function gutenberg_register_block_module_identifier( $metadata, $field_name, $in
  *                           Default 0.
  * @return string Generated module ID for the block's field.
  */
-function gutenberg_generate_block_asset_module_identifier( $block_name, $field_name, $index = 0 ) {
+function gutenberg_generate_block_asset_module_id( $block_name, $field_name, $index = 0 ) {
 	if ( str_starts_with( $block_name, 'core/' ) ) {
 		$asset_handle = str_replace( 'core/', 'wp-block-', $block_name );
 		if ( str_starts_with( $field_name, 'editor' ) ) {
@@ -451,15 +451,15 @@ function gutenberg_generate_block_asset_module_identifier( $block_name, $field_n
 	return $asset_handle;
 }
 
-function gutenberg_register_view_module_identifiers_rest_field() {
+function gutenberg_register_view_module_ids_rest_field() {
 	register_rest_field(
 		'block-type',
-		'view_module_identifiers',
+		'view_module_ids',
 		array(
 			'get_callback' => function ( $item ) {
 				 $block_type = WP_Block_Type_Registry::get_instance()->get_registered( $item['name'] );
-				if ( isset( $block_type->view_module_identifiers ) ) {
-					return $block_type->view_module_identifiers;
+				if ( isset( $block_type->view_module_ids ) ) {
+					return $block_type->view_module_ids;
 				}
 				return array();
 			},
@@ -467,4 +467,4 @@ function gutenberg_register_view_module_identifiers_rest_field() {
 	);
 }
 
-add_action( 'rest_api_init', 'gutenberg_register_view_module_identifiers_rest_field' );
+add_action( 'rest_api_init', 'gutenberg_register_view_module_ids_rest_field' );


### PR DESCRIPTION
## What?

Add `viewModule` support for registering blocks from metadata.

Part of https://github.com/WordPress/gutenberg/issues/57492

**To do:**
- [x] Add viewModule field to REST API

## Why?

As we introduce module support and the Interactivity API (only available as a module at this time), we should provide at least a similar experience to what we currently have with scripts.

## How?

This follows a similar pattern to how WordPress Core manages block scripts. Different script handles are attached to the WP_Block_Type instance. Then those are enqueued when the block is rendered.

We use some filters to achieve the same result. I'd expect this functionality to move to Core when Modules support lands (https://github.com/WordPress/wordpress-develop/pull/5818). See https://github.com/sirreal/wordpress-develop/pull/2 for an example of what that might look like.

## Testing Instructions

Add a block using `block.json` with a `viewModule` field pointing to its view module. I've compiled a block (with #57461) that's available [at this gist](https://gist.github.com/sirreal/940bb5917c3c5449c98626a8878bf071). It can be unzipped as a plugin and used for testing.

We should be able to add our block in the editor. If we use the REST API to query block types and search for `view_module_ids` we should find our block:

```js
(await wp.apiFetch( { path: '/wp/v2/block-types' }))
  .filter( ({ view_module_ids }) => view_module_ids.length )
  .map(blockType => ({
    name: blockType.name,
    view_module_ids: blockType.view_module_ids,
  }))[0]
// { "name": "jon/the-block", "view_module_ids": [ "jon-the-block-view-module" ] }
```

If the block is added to a post and we visit it on the frontend, we should see it working as expected (a counter in our example).

We should also see the expected modules added to the importmap and module preloads on our post with the block. I used an older theme to ensure nothing else was enqueuing the interactivity module:

```js
document.querySelector('[type=importmap]');
// <script type=​"importmap">​{"imports":{"@wordpress\/interactivity":"…"}}</script>​
document.querySelector('#\\@wordpress\\/interactivity[rel=modulepreload]');
// <link rel="modulepreload" href="…" id="@wordpress/interactivity">
```