### PR TITLE
Fix inconsistent Post Navigation Link Block behavior with respect to linkLabel 

### DIFF
--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -37,8 +37,12 @@ export default function PostNavigationLinkEdit( {
 	const displayArrow = arrowMap[ arrow ];
 
 	if ( showTitle ) {
-		/* translators: Label before for next and previous post. There is a space after the colon. */
-		placeholder = isNext ? __( 'Next: ' ) : __( 'Previous: ' );
+		if ( linkLabel ) {
+			/* translators: Label before for next and previous post. There is a space after the colon. */
+			placeholder = isNext ? __( 'Next: ' ) : __( 'Previous: ' );
+		} else {
+			placeholder = '';
+		}
 	}
 
 	const ariaLabel = isNext ? __( 'Next post' ) : __( 'Previous post' );


### PR DESCRIPTION
## What?

Make the Post Navigation Link Block honor `linkLabel` property when in edit mode.

## Why?

Fixes: #57439. The behavior of the Post Navigation Link Block differs on the front end and in the editor. This is confusing to users, because it's not WYSIWYG.

## How?

Conditionally apply the 'Next: ' and 'Previous: ' placeholders if and only if both `showTitle` and `linkLabel` are `true`. If only `showTitle` is `true`, blank out the placeholder.

## Testing Instructions

1. Edit the Single Post template.
2. Add a 'Next post' block.
3. Toggle on the 'Display the title as a link' option
4. Toggle on and off the 'Include the label as part of the link' option.
5. Observe that the editor preview behavior tracks the front-end behavior of a post. 

### Testing Instructions for Keyboard

All of the above actions can be performed using the keyboard. 

## Screenshots or screencast 

NB: I uploaded a screenshot, but it's not displaying here. [Direct link](https://github.com/WordPress/gutenberg/assets/403387/0ce8e8ac-fa8a-42ce-98fc-5cccca69a090).

![PostNavigationLinkFixed](https://github.com/WordPress/gutenberg/assets/403387/0ce8e8ac-fa8a-42ce-98fc-5cccca69a090)

