### PR TITLE
Docs/tutorial: Fix opposite condition for content generation in render.php

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -203,7 +203,7 @@ Before you start building the functionality of the block itself, let's do a bit 
 
 Open the [`index.js`](https://developer.wordpress.org/block-editor/getting-started/fundamentals/file-structure-of-a-block/#index-js) file. This is the main JavaScript file of the block and is used to register it on the client. You can learn more about client-side and server-side registration in the [Registration of a block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/registration-of-a-block/) documentation.
 
-Start by looking at the [`registerBlockType`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/) function. This function accepts the name of the block, which we are getting from the imported `block.js` file, and the block configuration object.
+Start by looking at the [`registerBlockType`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/) function. This function accepts the name of the block, which we are getting from the imported `block.json` file, and the block configuration object.
 
 ```js
 import Edit from './edit';
@@ -392,7 +392,7 @@ Next, update the Edit function to return the current block content and an `Inspe
 
 ```js
 export default function Edit() {
-const currentYear = new Date().getFullYear().toString();
+	const currentYear = new Date().getFullYear().toString();
 
 	return (
 		<>
@@ -422,7 +422,7 @@ Then wrap the "Testing" message in the `PanelBody` component and set the `title`
 
 ```js
 export default function Edit() {
-const currentYear = new Date().getFullYear().toString();
+	const currentYear = new Date().getFullYear().toString();
 
 	return (
 		<>
@@ -965,9 +965,9 @@ You will not get any block validation errors, but the Editor will detect that ch
 
 #### Optimizing render.php
 
-The final step is to optimize the `render.php` file. If the `currentYear` and the `fallbackCurrentYear` attribute are the same, then there is no need to dynamically create the block content. It is already saved in the database and is available in the  `render.php` file via the `$block_content` variable.
+The final step is to optimize the `render.php` file. If the `currentYear` and the `fallbackCurrentYear` attribute are the same, then there is no need to dynamically create the block content. It is already saved in the database and is available in the  `render.php` file via the `$content` variable.
 
-Therefore, update the file to render the `$block_content` if `currentYear` and `fallbackCurrentYear` match.
+Therefore, update the file to render the generated content if `currentYear` and `fallbackCurrentYear` do not match.
 
 ```php
 $current_year = date( "Y" );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the "Optimizing render.php" section,

> Therefore, update the file to render the `$block_content` if `currentYear` and `fallbackCurrentYear` match.

But, the block content should be updated if `currentYear` and `fallbackCurrentYear` do not match.
Also, the previous sentence of it says:

> It is already saved in the database and is available in the  `render.php` file via the `$block_content` variable.

It must be `$content`, not `$block_content`.

And, some minor fixes were included.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
