### PR TITLE
[Fix-#56884] Gallery block with class columns-default should also output columns-x

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -333,7 +333,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 -	**Name:** core/gallery
 -	**Category:** media
 -	**Supports:** align, anchor, color (background, gradients, ~~text~~), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
--	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, shortCodeTransforms, sizeSlug
+-	**Attributes:** allowResize, caption, columns, defaultColumns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, shortCodeTransforms, sizeSlug
 
 ## Group
 

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -71,6 +71,11 @@
 			"minimum": 1,
 			"maximum": 8
 		},
+		"defaultColumns": {
+			"type": "number",
+			"minimum": 1,
+			"maximum": 8
+		},
 		"caption": {
 			"type": "rich-text",
 			"source": "rich-text",

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -88,7 +88,8 @@ function GalleryEdit( props ) {
 		onFocus,
 	} = props;
 
-	const { columns, imageCrop, linkTarget, linkTo, sizeSlug } = attributes;
+	const { columns, defaultColumns, imageCrop, linkTarget, linkTo, sizeSlug } =
+		attributes;
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
@@ -167,7 +168,12 @@ function GalleryEdit( props ) {
 				align: undefined,
 			} );
 		} );
-	}, [ newImages ] );
+
+		if ( images?.length > 1 ) {
+			const defaultColumnCount = defaultColumnsNumber( images.length );
+			setAttributes( { defaultColumns: defaultColumnCount } );
+		}
+	}, [ newImages, images ] );
 
 	const imageSizeOptions = useImageSizes(
 		imageData,
@@ -532,11 +538,7 @@ function GalleryEdit( props ) {
 						<RangeControl
 							__nextHasNoMarginBottom
 							label={ __( 'Columns' ) }
-							value={
-								columns
-									? columns
-									: defaultColumnsNumber( images.length )
-							}
+							value={ columns ? columns : defaultColumns }
 							onChange={ setColumnsNumber }
 							min={ 1 }
 							max={ Math.min( MAX_COLUMNS, images.length ) }

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -27,7 +27,7 @@ export default function Gallery( props ) {
 		multiGallerySelection,
 	} = props;
 
-	const { align, columns, imageCrop } = attributes;
+	const { align, columns, defaultColumns, imageCrop } = attributes;
 
 	return (
 		<figure
@@ -39,7 +39,10 @@ export default function Gallery( props ) {
 				{
 					[ `align${ align }` ]: align,
 					[ `columns-${ columns }` ]: columns !== undefined,
-					[ `columns-default` ]: columns === undefined,
+					[ `columns-default` ]:
+						columns === undefined && defaultColumns === undefined,
+					[ `columns-default columns-${ defaultColumns }` ]:
+						columns === undefined && defaultColumns !== undefined,
 					'is-cropped': imageCrop,
 				}
 			) }

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -24,11 +24,14 @@ export default function saveWithInnerBlocks( { attributes } ) {
 		return saveWithoutInnerBlocks( { attributes } );
 	}
 
-	const { caption, columns, imageCrop } = attributes;
+	const { caption, columns, defaultColumns, imageCrop } = attributes;
 
 	const className = classnames( 'has-nested-images', {
 		[ `columns-${ columns }` ]: columns !== undefined,
-		[ `columns-default` ]: columns === undefined,
+		[ `columns-default` ]:
+			columns === undefined && defaultColumns === undefined,
+		[ `columns-default columns-${ defaultColumns }` ]:
+			columns === undefined && defaultColumns !== undefined,
 		'is-cropped': imageCrop,
 	} );
 	const blockProps = useBlockProps.save( { className } );


### PR DESCRIPTION
Fix: #56884 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
When adding a new gallery block instance and not changing the columns, the container element includes the class "columns-default", but does not include a class for the number of columns that the default is set to (for example, "columns-3"). If you switch the columns manually to a number other than the default (3) and then switch back to the 3. The instance will now be output with the class "columns-3" but will not include "columns-default".

Arguably the initial instance should display "columns-default" and "columns-3" to make styling easier, and to be of use to and custom JavaScript that needs to determine the number of columns the gallery block is intended to display. Also, after the column count being changed to a value other than 3 and then set to 3 again, the class "columns-default" should probably be added back.

## How?
- Added default column count attribute to add column-{default-column-column} along with column-default class while column is not set explicitly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a gallery block.
3. Select images ( Without changing the columns from inspectorControl )
4. Save the post/page and check the classes added in Gallery>figure HTML element using inspect element.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1502" alt="Screenshot 2023-12-29 at 2 08 28 PM" src="https://github.com/WordPress/gutenberg/assets/86941664/9119ed8f-aa71-462c-b610-027d28563b47">

