### PR TITLE
Block Library: Remove store subscriptions from Audio and Video blocks

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -42,7 +42,7 @@ function AudioEdit( {
 	className,
 	setAttributes,
 	onReplace,
-	isSelected: isSignleSelected,
+	isSelected: isSingleSelected,
 	insertBlocksAfter,
 } ) {
 	const { id, autoplay, loop, preload, src } = attributes;
@@ -143,7 +143,7 @@ function AudioEdit( {
 
 	return (
 		<>
-			{ isSignleSelected && (
+			{ isSingleSelected && (
 				<BlockControls group="other">
 					<MediaReplaceFlow
 						mediaId={ id }
@@ -199,17 +199,17 @@ function AudioEdit( {
 					so the user clicking on it won't play the
 					file or change the position slider when the controls are enabled.
 				*/ }
-				<Disabled isDisabled={ ! isSignleSelected }>
+				<Disabled isDisabled={ ! isSingleSelected }>
 					<audio controls="controls" src={ src } />
 				</Disabled>
 				{ isTemporaryAudio && <Spinner /> }
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					isSelected={ isSignleSelected }
+					isSelected={ isSingleSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Audio caption text' ) }
-					showToolbarButton={ isSignleSelected }
+					showToolbarButton={ isSingleSelected }
 				/>
 			</figure>
 		</>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -42,32 +42,19 @@ function AudioEdit( {
 	className,
 	setAttributes,
 	onReplace,
-	isSelected,
+	isSelected: isSignleSelected,
 	insertBlocksAfter,
 } ) {
 	const { id, autoplay, loop, preload, src } = attributes;
 	const isTemporaryAudio = ! id && isBlobURL( src );
-	const { mediaUpload, multiAudioSelection } = useSelect( ( select ) => {
-		const { getSettings, getMultiSelectedBlockClientIds, getBlockName } =
-			select( blockEditorStore );
-		const multiSelectedClientIds = getMultiSelectedBlockClientIds();
-
-		return {
-			mediaUpload: getSettings().mediaUpload,
-			multiAudioSelection:
-				multiSelectedClientIds.length &&
-				multiSelectedClientIds.every(
-					( _clientId ) => getBlockName( _clientId ) === 'core/audio'
-				),
-		};
-	}, [] );
+	const { getSettings } = useSelect( blockEditorStore );
 
 	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {
 			const file = getBlobByURL( src );
 
 			if ( file ) {
-				mediaUpload( {
+				getSettings().mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ media ] ) => onSelectAudio( media ),
 					onError: ( e ) => onUploadError( e ),
@@ -156,7 +143,7 @@ function AudioEdit( {
 
 	return (
 		<>
-			{ ! multiAudioSelection && (
+			{ isSignleSelected && (
 				<BlockControls group="other">
 					<MediaReplaceFlow
 						mediaId={ id }
@@ -212,17 +199,17 @@ function AudioEdit( {
 					so the user clicking on it won't play the
 					file or change the position slider when the controls are enabled.
 				*/ }
-				<Disabled isDisabled={ ! isSelected }>
+				<Disabled isDisabled={ ! isSignleSelected }>
 					<audio controls="controls" src={ src } />
 				</Disabled>
 				{ isTemporaryAudio && <Spinner /> }
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					isSelected={ isSelected }
+					isSelected={ isSignleSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Audio caption text' ) }
-					showToolbarButton={ ! multiAudioSelection }
+					showToolbarButton={ isSignleSelected }
 				/>
 			</figure>
 		</>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -63,7 +63,7 @@ const ALLOWED_MEDIA_TYPES = [ 'video' ];
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 function VideoEdit( {
-	isSelected: isSignleSelected,
+	isSelected: isSingleSelected,
 	attributes,
 	className,
 	setAttributes,
@@ -182,7 +182,7 @@ function VideoEdit( {
 
 	return (
 		<>
-			{ isSignleSelected && (
+			{ isSingleSelected && (
 				<>
 					<BlockControls>
 						<TracksEditor
@@ -268,7 +268,7 @@ function VideoEdit( {
 					so the user clicking on it won't play the
 					video when the controls are enabled.
 				*/ }
-				<Disabled isDisabled={ ! isSignleSelected }>
+				<Disabled isDisabled={ ! isSingleSelected }>
 					<video
 						controls={ controls }
 						poster={ poster }
@@ -282,10 +282,10 @@ function VideoEdit( {
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					isSelected={ isSignleSelected }
+					isSelected={ isSingleSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Video caption text' ) }
-					showToolbarButton={ isSignleSelected }
+					showToolbarButton={ isSingleSelected }
 				/>
 			</figure>
 		</>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -63,7 +63,7 @@ const ALLOWED_MEDIA_TYPES = [ 'video' ];
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 function VideoEdit( {
-	isSelected,
+	isSelected: isSignleSelected,
 	attributes,
 	className,
 	setAttributes,
@@ -75,26 +75,13 @@ function VideoEdit( {
 	const posterImageButton = useRef();
 	const { id, controls, poster, src, tracks } = attributes;
 	const isTemporaryVideo = ! id && isBlobURL( src );
-	const { mediaUpload, multiVideoSelection } = useSelect( ( select ) => {
-		const { getSettings, getMultiSelectedBlockClientIds, getBlockName } =
-			select( blockEditorStore );
-		const multiSelectedClientIds = getMultiSelectedBlockClientIds();
-
-		return {
-			mediaUpload: getSettings().mediaUpload,
-			multiVideoSelection:
-				multiSelectedClientIds.length &&
-				multiSelectedClientIds.every(
-					( _clientId ) => getBlockName( _clientId ) === 'core/video'
-				),
-		};
-	}, [] );
+	const { getSettings } = useSelect( blockEditorStore );
 
 	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {
 			const file = getBlobByURL( src );
 			if ( file ) {
-				mediaUpload( {
+				getSettings().mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ media ] ) => onSelectVideo( media ),
 					onError: onUploadError,
@@ -195,7 +182,7 @@ function VideoEdit( {
 
 	return (
 		<>
-			{ ! multiVideoSelection && (
+			{ isSignleSelected && (
 				<>
 					<BlockControls>
 						<TracksEditor
@@ -281,7 +268,7 @@ function VideoEdit( {
 					so the user clicking on it won't play the
 					video when the controls are enabled.
 				*/ }
-				<Disabled isDisabled={ ! isSelected }>
+				<Disabled isDisabled={ ! isSignleSelected }>
 					<video
 						controls={ controls }
 						poster={ poster }
@@ -295,10 +282,10 @@ function VideoEdit( {
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					isSelected={ isSelected }
+					isSelected={ isSignleSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Video caption text' ) }
-					showToolbarButton={ ! multiVideoSelection }
+					showToolbarButton={ isSignleSelected }
 				/>
 			</figure>
 		</>


### PR DESCRIPTION
## What?
This is a follow-up for #57375 and #57376.
Inspired by #57232.

PR removes store subscriptions from Audio and Video blocks.

## Why?
It is a micro-optimization as there are usually few usages of these blocks, unlike text blocks. But it's a good practice to avoid store subscriptions when unnecessary.

## How?
* Use the `isSelected` prop to check multi-selection.
* Use static selector getter for the settings.

## Testing Instructions
1. Open a post or page.
2. Confirm you can upload audio or video files by dragging and dropping them on the editor canvas.
3. Confirm caption block toolbar control isn't displayed when multi-selecting Audio or Video blocks.
