### PR TITLE
DataViews: make `fields` dependant on `view.type`

### DIFF
--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -65,13 +65,13 @@ export default function DataViews( {
 							/>
 						) }
 						<Filters
-							fields={ fields }
+							fields={ _fields }
 							view={ view }
 							onChangeView={ onChangeView }
 						/>
 					</HStack>
 					<ViewActions
-						fields={ fields }
+						fields={ _fields }
 						view={ view }
 						onChangeView={ onChangeView }
 						supportedLayouts={ supportedLayouts }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -287,7 +287,7 @@ export default function PagePages() {
 				},
 			},
 		],
-		[ authors, view ]
+		[ authors, view.type ]
 	);
 
 	const permanentlyDeletePostAction = usePermanentlyDeletePostAction();

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -88,8 +88,8 @@ function normalizeSearchInput( input = '' ) {
 	return removeAccents( input.trim().toLowerCase() );
 }
 
-function TemplateTitle( { item, view } ) {
-	if ( view.type === LAYOUT_LIST ) {
+function TemplateTitle( { item, viewType } ) {
+	if ( viewType === LAYOUT_LIST ) {
 		return (
 			<>
 				{ decodeEntities( item.title?.rendered || item.slug ) ||
@@ -116,9 +116,9 @@ function TemplateTitle( { item, view } ) {
 	);
 }
 
-function AuthorField( { item, view } ) {
+function AuthorField( { item, viewType } ) {
 	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
-	const withIcon = view.type !== LAYOUT_LIST;
+	const withIcon = viewType !== LAYOUT_LIST;
 
 	return (
 		<HStack alignment="left" spacing={ 1 }>
@@ -212,7 +212,7 @@ export default function DataviewsTemplates() {
 				id: 'title',
 				getValue: ( { item } ) => item.title?.rendered || item.slug,
 				render: ( { item } ) => (
-					<TemplateTitle item={ item } view={ view } />
+					<TemplateTitle item={ item } viewType={ view.type } />
 				),
 				maxWidth: 400,
 				enableHiding: false,
@@ -243,14 +243,14 @@ export default function DataviewsTemplates() {
 				id: 'author',
 				getValue: ( { item } ) => item.author_text,
 				render: ( { item } ) => {
-					return <AuthorField view={ view } item={ item } />;
+					return <AuthorField viewType={ view.type } item={ item } />;
 				},
 				enableHiding: false,
 				type: ENUMERATION_TYPE,
 				elements: authors,
 			},
 		],
-		[ authors, view ]
+		[ authors, view.type ]
 	);
 
 	const { shownTemplates, paginationInfo } = useMemo( () => {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What

This PR makes the `fields` dependent on the `view.type`.

## Why

By declaring fine-grained dependencies, we reduce the number of times the `fields` are invalidated. Previously, they were invalidated every time the `view` changed, rendering the memoization wasteful.
