### PR TITLE
DataViews: prevent unnecessary re-renders

### DIFF
--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { memo } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import FilterSummary from './filter-summary';
@@ -21,7 +26,7 @@ const sanitizeOperators = ( field ) => {
 	);
 };
 
-export default function Filters( { fields, view, onChangeView } ) {
+const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 	const filters = [];
 	fields.forEach( ( field ) => {
 		if ( ! field.type ) {
@@ -88,4 +93,6 @@ export default function Filters( { fields, view, onChangeView } ) {
 	}
 
 	return filterComponents;
-}
+} );
+
+export default Filters;

--- a/packages/dataviews/src/search.js
+++ b/packages/dataviews/src/search.js
@@ -2,11 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, memo } from '@wordpress/element';
 import { SearchControl } from '@wordpress/components';
 import { useDebouncedInput } from '@wordpress/compose';
 
-export default function Search( { label, view, onChangeView } ) {
+const Search = memo( function Search( { label, view, onChangeView } ) {
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput(
 		view.search
 	);
@@ -35,4 +35,6 @@ export default function Search( { label, view, onChangeView } ) {
 			size="compact"
 		/>
 	);
-}
+} );
+
+export default Search;

--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -6,6 +6,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { memo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -239,7 +240,7 @@ function SortMenu( { fields, view, onChangeView } ) {
 	);
 }
 
-export default function ViewActions( {
+const ViewActions = memo( function ViewActions( {
 	fields,
 	view,
 	onChangeView,
@@ -282,4 +283,6 @@ export default function ViewActions( {
 			</DropdownMenuGroup>
 		</DropdownMenu>
 	);
-}
+} );
+
+export default ViewActions;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/pull/57390 https://github.com/WordPress/gutenberg/pull/57393 https://github.com/WordPress/gutenberg/pull/57450 https://github.com/WordPress/gutenberg/pull/57454 https://github.com/WordPress/gutenberg/pull/57458

## What

Memoize Search, ViewActions, and Filters components.

## Why

By preventing unnecessary re-renders, `DataViews` is ~33% faster in events that trigger data retrieval.

| | Before | After |
| --- | --- | --- |
| Time it takes to render `DataViews` (one round, not median) | 87.5ms | 58.5ms |
| # of renders for `DataViews` | 4 | 4 |
| `DataViews` | <img width="711" alt="Captura de ecrã 2023-12-29, às 13 21 05" src="https://github.com/WordPress/gutenberg/assets/583546/38e38b15-82cc-4e46-8d4f-c8cfb34796ff"> | <img width="711" alt="Captura de ecrã 2023-12-29, às 13 21 13" src="https://github.com/WordPress/gutenberg/assets/583546/d4780764-417b-49ec-9024-7c18ae8503b4"> |
| # of renders for `ViewActions` (same for `Search` and `Filters`) | 4 | 1 |
| `ViewActions` | <img width="765" alt="Captura de ecrã 2023-12-29, às 13 48 05" src="https://github.com/WordPress/gutenberg/assets/583546/21a26b8a-54c8-4a60-bb61-fb7db14c7f7d"> | <img width="765" alt="Captura de ecrã 2023-12-29, às 13 47 57" src="https://github.com/WordPress/gutenberg/assets/583546/513f6e8b-8b8e-4488-804b-09a6db93ddc0"> |
| Profile | [before.json](https://github.com/WordPress/gutenberg/files/13793448/profiling-data.29-12-2023.12-49-54.json) | [after.json](https://github.com/WordPress/gutenberg/files/13793447/profiling-data.29-12-2023.12-54-25.json) |

## How

The data retrieval hook (`useEntityRecords`) may trigger up to 4 updates, according to its lifecycle (idle, resolving with old data, resolving with new data, success). Each cause the Pages component to render, and so `DataViews`.

The data props (`data`, `isLoading`) may change in any of those updates, but the `view` and `field` props are updated only once (the first). There are some `DataViews` components that do not depend on data props, they only depend on `field` & `view`. This PR prevents them from re-rendering if `field` and `view` props have not changed.

## How to test

You can load the profiles in the React DevTools Profiler and take a look at the `DataViews` components. Alternatively, you can test it by:

- Enable the "new admin views" experiment and visit "Manage all pages".
- Open the React DevTools Profiler and start a profiling session.
- Open the view actions menu and change pagination to 10 elements.
- Go to the React DevTools Profiler and search for `DataViews`, `Search`, `Filters`, and `ViewActions` components.
- The expected result is that `DataViews` is rendered 4 times while `Search`, `Filters`, and `ViewActions` is only rendered once. Before this PR, they'd render 4 times as well.
- Note that `Search`, `Filters`, and `ViewActions` are still rendered once: this is correct, as the `view` changes (`view.perPage` is updated from 20 to 10). Fine-grained rendering for `DataViews` needs to be looked at separately.

https://github.com/WordPress/gutenberg/assets/583546/0b720363-0d20-4498-804a-ddd9755f4029

