### PR TITLE
Make the Replace featured image button perceivable by assistive technologies

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -208,8 +208,6 @@ function PostFeaturedImage( {
 										<Button
 											className="editor-post-featured-image__action"
 											onClick={ open }
-											// Prefer that screen readers use the .editor-post-featured-image__preview button.
-											aria-hidden="true"
 										>
 											{ __( 'Replace' ) }
 										</Button>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57451
Follow-up to https://github.com/WordPress/gutenberg/pull/50269

## What?
<!-- In a few words, what is the PR actually doing? -->
The featured image 'Replace' button is (intentionally) hidden from assistive technology via an `aria-hidden="true"` attribute. This is not recommended as the button is still focusable and in the tab sequence. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There is no good way to hide interactive controls from assistive technologies and it's not recommended to do tha tin the first place. Generally, controls that are visually presented to users should also be available to screen reader users. Controls that are in the Tab sequence should never use `aria-hidden="true"`.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove `aria-hidden="true"` from the Replace button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post and add a featured image.
- Test with Safari and VoiceOver.
- Tab to the Document settings panel > Featured image.
- Tan and Shift+Tab multiple times through the Replace and Remove buttons.
- Observe that the Replace button is consistently announced by VoiceOver.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
