### PR TITLE
DataViews: prevent unnecessary re-renders of Pagination

### DIFF
--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -6,11 +6,11 @@ import {
 	__experimentalHStack as HStack,
 	SelectControl,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, memo } from '@wordpress/element';
 import { sprintf, __, _x } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 
-function Pagination( {
+const Pagination = memo( function Pagination( {
 	view,
 	onChangeView,
 	paginationInfo: { totalItems = 0, totalPages },
@@ -91,6 +91,6 @@ function Pagination( {
 			</HStack>
 		)
 	);
-}
+} );
 
 export default Pagination;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow up to https://github.com/WordPress/gutenberg/pull/57452

Prevents unnecessary re-renders of the `Pagination` component.

See https://github.com/WordPress/gutenberg/pull/57452 for a deep-dive into _why_ and _how_, and test instructions.