### PR TITLE
Fix Template preview menu item accessibility.

### DIFF
--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -90,7 +90,8 @@ export default function BlockThemeControl( { id } ) {
 					<MenuGroup>
 						<MenuItem
 							icon={ ! isTemplateHidden ? check : undefined }
-							isPressed={ ! isTemplateHidden }
+							isSelected={ ! isTemplateHidden }
+							role="menuitemcheckbox"
 							onClick={ () => {
 								setRenderingMode(
 									isTemplateHidden

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -196,15 +196,15 @@ test.describe( 'Pages', () => {
 		await templateOptionsButton.click();
 		const templatePreviewButton = page
 			.getByRole( 'menu', { name: 'Template options' } )
-			.getByRole( 'menuitem', { name: 'Template preview' } );
+			.getByRole( 'menuitemcheckbox', { name: 'Template preview' } );
 
 		await expect( templatePreviewButton ).toHaveAttribute(
-			'aria-pressed',
+			'aria-checked',
 			'true'
 		);
 		await templatePreviewButton.click();
 		await expect( templatePreviewButton ).toHaveAttribute(
-			'aria-pressed',
+			'aria-checked',
 			'false'
 		);
 
@@ -229,7 +229,7 @@ test.describe( 'Pages', () => {
 		await templateOptionsButton.click();
 		await templatePreviewButton.click();
 		await expect( templatePreviewButton ).toHaveAttribute(
-			'aria-pressed',
+			'aria-checked',
 			'true'
 		);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57455

## What?
<!-- In a few words, what is the PR actually doing? -->
The 'Template preview' menu item uses incorrect ARIA role and state.
As such, its 'checked' state is not announced by screen readers.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Screen readers users don't have any feedback about the checked state.
Te `aria-pressed` state for a `menuitem` role is invalid.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changes the menu item role to `menuitemcheckbox` and replaces `aria-pressed` with the required state `aria-checked`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Test with Safari and VoiceOver.
- Tab to the template menu in the Document settings and open it.
- Tab to the 'Template preview' menu item and press Control+Option+Spacebar to check it.
- Shift+Tab and Tab again to the 'Template preview' menu item.
- Observe that Voiceover announces the checked tate by announcing `ticked`.

Announcement before:
`Template preview, menu item`

Announcement after:
`Template preview, ticked, menu item`

Screenshot:

![Screenshot 2023-12-29 at 15 29 17](https://github.com/WordPress/gutenberg/assets/1682452/6c54e7be-6fbf-462f-bb7d-eedf7686978b)


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
