### PR TITLE
Icon: Add `currentColor` prop

### DIFF
--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -43,7 +43,7 @@ interface BaseProps {
 	size?: number;
 	/**
 	 * Whether the icon should be rendered in the CSS `currentColor`.
-	 * Only has an effect when `icon` is an SVG.
+	 * Only has an effect on SVG elements.
 	 *
 	 * @default false
 	 */
@@ -81,10 +81,11 @@ function Icon( {
 	}
 
 	if ( 'function' === typeof icon ) {
-		return createElement( icon, {
+		const element = createElement( icon, {
 			size,
 			...additionalProps,
 		} );
+		return currentColor ? withCurrentColor( element ) : element;
 	}
 
 	if ( icon && ( icon.type === 'svg' || icon.type === SVG ) ) {
@@ -99,11 +100,12 @@ function Icon( {
 	}
 
 	if ( isValidElement( icon ) ) {
-		return cloneElement( icon, {
+		const element = cloneElement( icon, {
 			// @ts-ignore Just forwarding the size prop along
 			size,
 			...additionalProps,
 		} );
+		return currentColor ? withCurrentColor( element ) : element;
 	}
 
 	return icon;

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -18,6 +18,8 @@ import { SVG } from '@wordpress/primitives';
  */
 import Dashicon from '../dashicon';
 import type { IconKey as DashiconIconKey } from '../dashicon/types';
+import { withCurrentColor } from './with-currentcolor';
+export { withCurrentColor } from './with-currentcolor';
 
 export type IconType =
 	| DashiconIconKey
@@ -39,6 +41,13 @@ interface BaseProps {
 	 * @default `20` when a Dashicon is rendered, `24` for all other icons.
 	 */
 	size?: number;
+	/**
+	 * Whether the icon should be rendered in the CSS `currentColor`.
+	 * Only has an effect when `icon` is an SVG.
+	 *
+	 * @default false
+	 */
+	currentColor?: boolean;
 }
 
 type AdditionalProps< T > = T extends ComponentType< infer U >
@@ -52,6 +61,7 @@ export type Props = BaseProps & AdditionalProps< IconType >;
 function Icon( {
 	icon = null,
 	size = 'string' === typeof icon ? 20 : 24,
+	currentColor = false,
 	...additionalProps
 }: Props ) {
 	if ( 'string' === typeof icon ) {
@@ -79,7 +89,7 @@ function Icon( {
 
 	if ( icon && ( icon.type === 'svg' || icon.type === SVG ) ) {
 		const appliedProps = {
-			...icon.props,
+			...( currentColor ? withCurrentColor( icon ) : icon ).props,
 			width: size,
 			height: size,
 			...additionalProps,

--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -32,19 +32,26 @@ Default.args = {
 	icon: wordpress,
 };
 
-export const FillColor: StoryFn< typeof Icon > = ( args ) => {
+/**
+ * When `icon` is an SVG element, the `currentColor` prop can be used to
+ * render it in the CSS `currentColor`.
+ */
+export const WithCurrentColor: StoryFn< typeof Icon > = ( args ) => {
 	return (
 		<div
 			style={ {
-				fill: 'blue',
+				background: 'blue',
+				color: 'white',
 			} }
 		>
 			<Icon { ...args } />
+			Some text
 		</div>
 	);
 };
-FillColor.args = {
+WithCurrentColor.args = {
 	...Default.args,
+	currentColor: true,
 };
 
 export const WithAFunction = Template.bind( {} );

--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -54,26 +54,60 @@ WithCurrentColor.args = {
 	currentColor: true,
 };
 
+const renderIcon = ( { size = 24, ...restProps } ) => (
+	<div style={ { width: size } } { ...restProps }>
+		<SVG viewBox="0 0 24 24">
+			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+		</SVG>
+	</div>
+);
+
 export const WithAFunction = Template.bind( {} );
 WithAFunction.args = {
 	...Default.args,
-	icon: () => (
-		<SVG>
+	icon: renderIcon,
+};
+WithAFunction.parameters = {
+	docs: {
+		source: {
+			code: `
+const renderIcon = ( { size = 24, ...restProps } ) => (
+	<div style={ { width: size } } { ...restProps }>
+		<SVG viewBox="0 0 24 24">
 			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
 		</SVG>
-	),
+	</div>
+);
+
+<Icon icon={ renderIcon } />
+			`,
+		},
+	},
 };
 
-const MyIconComponent = () => (
-	<SVG>
-		<Path d="M5 4v3h5.5v12h3V7H19V4z" />
-	</SVG>
-);
+const MyIconComponent = renderIcon;
 
 export const WithAComponent = Template.bind( {} );
 WithAComponent.args = {
 	...Default.args,
 	icon: MyIconComponent,
+};
+WithAComponent.parameters = {
+	docs: {
+		source: {
+			code: `
+const MyIconComponent = ( { size = 24, ...restProps } ) => (
+	<div style={ { width: size } } { ...restProps }>
+		<SVG viewBox="0 0 24 24">
+			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+		</SVG>
+	</div>
+);
+
+<Icon icon={ <MyIconComponent /> } />
+			`,
+		},
+	},
 };
 
 export const WithAnSVG = Template.bind( {} );

--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -55,11 +55,9 @@ WithCurrentColor.args = {
 };
 
 const renderIcon = ( { size = 24, ...restProps } ) => (
-	<div style={ { width: size } } { ...restProps }>
-		<SVG viewBox="0 0 24 24">
-			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
-		</SVG>
-	</div>
+	<SVG width={ size } height={ size } viewBox="0 0 24 24" { ...restProps }>
+		<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+	</SVG>
 );
 
 export const WithAFunction = Template.bind( {} );
@@ -72,11 +70,9 @@ WithAFunction.parameters = {
 		source: {
 			code: `
 const renderIcon = ( { size = 24, ...restProps } ) => (
-	<div style={ { width: size } } { ...restProps }>
-		<SVG viewBox="0 0 24 24">
-			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
-		</SVG>
-	</div>
+	<SVG width={ size } height={ size } viewBox="0 0 24 24" { ...restProps }>
+		<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+	</SVG>
 );
 
 <Icon icon={ renderIcon } />
@@ -97,11 +93,9 @@ WithAComponent.parameters = {
 		source: {
 			code: `
 const MyIconComponent = ( { size = 24, ...restProps } ) => (
-	<div style={ { width: size } } { ...restProps }>
-		<SVG viewBox="0 0 24 24">
-			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
-		</SVG>
-	</div>
+	<SVG width={ size } height={ size } viewBox="0 0 24 24" { ...restProps }>
+		<Path d="M5 4v3h5.5v12h3V7H19V4z" />
+	</SVG>
 );
 
 <Icon icon={ <MyIconComponent /> } />

--- a/packages/components/src/icon/style.scss
+++ b/packages/components/src/icon/style.scss
@@ -1,3 +1,3 @@
-.components-icon__svg-with-currentcolor {
+.components-icon__with-currentcolor {
 	fill: currentColor;
 }

--- a/packages/components/src/icon/style.scss
+++ b/packages/components/src/icon/style.scss
@@ -1,0 +1,3 @@
+.components-icon__svg-with-currentcolor {
+	fill: currentColor;
+}

--- a/packages/components/src/icon/with-currentcolor.tsx
+++ b/packages/components/src/icon/with-currentcolor.tsx
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { cloneElement } from '@wordpress/element';
 
 /**
- * Modifies an SVG element to use the `currentColor` for its fill.
+ * Modifies an element to use the `currentColor` for the fills in its SVG descendants.
  *
  * In most cases you should be able to use the `currentColor` prop of the `Icon` component instead.
  *
@@ -20,11 +20,11 @@ import { cloneElement } from '@wordpress/element';
  * <RangeControl beforeIcon={ withCurrentColor( wordpress ) } />
  * ```
  */
-export function withCurrentColor( svgElement: React.ReactElement ) {
-	return cloneElement( svgElement, {
+export function withCurrentColor( element: React.ReactElement ) {
+	return cloneElement( element, {
 		className: classnames(
-			'components-icon__svg-with-currentcolor',
-			svgElement.props.className
+			'components-icon__with-currentcolor',
+			element.props.className
 		),
 	} );
 }

--- a/packages/components/src/icon/with-currentcolor.tsx
+++ b/packages/components/src/icon/with-currentcolor.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { cloneElement } from '@wordpress/element';
+
+/**
+ * Modifies an SVG element to use the `currentColor` for its fill.
+ *
+ * In most cases you should be able to use the `currentColor` prop of the `Icon` component instead.
+ *
+ * ```jsx
+ * import { wordpress } from '@wordpress/icons';
+ * import { RangeControl } from '@wordpress/components';
+ *
+ * <RangeControl beforeIcon={ withCurrentColor( wordpress ) } />
+ * ```
+ */
+export function withCurrentColor( svgElement: React.ReactElement ) {
+	return cloneElement( svgElement, {
+		className: classnames(
+			'components-icon__svg-with-currentcolor',
+			svgElement.props.className
+		),
+	} );
+}

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -31,6 +31,7 @@
 @import "./form-token-field/style.scss";
 @import "./guide/style.scss";
 @import "./higher-order/navigate-regions/style.scss";
+@import "./icon/style.scss";
 @import "./menu-group/style.scss";
 @import "./menu-item/style.scss";
 @import "./menu-items-choice/style.scss";

--- a/packages/components/src/theme/styles.ts
+++ b/packages/components/src/theme/styles.ts
@@ -30,4 +30,6 @@ export const colorVariables = ( { colors }: ThemeOutputValues ) => {
 	];
 };
 
-export const Wrapper = styled.div``;
+export const Wrapper = styled.div`
+	color: var( --wp-components-color-foreground );
+`;


### PR DESCRIPTION
Closes #40102

## What?

Adds a `currentColor` boolean prop to the `Icon` component, which allows any SVGs in it to have a fill color of `currentColor`.

### TODO

- [ ] Update readme

## Why?

Neither the icons in `@wordpress/icons` nor the `Icon` component sets any fill colors, so it currently defaults to `#000000`. This means a lot of consumers are currently forced to add CSS such as `> svg { fill: currentColor; }` to set context-aware colors on the SVG icons.

## How?

When enabled, adds a CSS class that sets `fill: currentColor`.

## Testing Instructions

In the Storybook toolbar, set the Theme switcher to "Dark".

<img src="https://github.com/WordPress/gutenberg/assets/555336/0636e113-bcfc-4918-ba37-9aba6b1998a8" alt="Theme switcher dropdown" width="250">

In the stories for the Icon component, toggle the `currentColor` prop to true. The icons should change color.