### PR TITLE
52365: Title Bar shifts when switching between saved and save

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -144,7 +144,11 @@ $header-toolbar-min-width: 335px;
 
 // Button text label styles
 
-.edit-site-header-edit-mode.show-icon-labels {
+.edit-site-header-edit-mode.show-icon-labels{
+	.edit-site-save-button__button {
+		min-width: 59px;
+		justify-content: center;
+	}
 	.components-button.has-icon {
 		width: auto;
 

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -144,67 +144,63 @@ $header-toolbar-min-width: 335px;
 
 // Button text label styles
 
-.edit-site-header-edit-mode.show-icon-labels{
-	.edit-site-save-button__button {
-		min-width: 59px;
-		justify-content: center;
-	}
-	.components-button.has-icon {
-		width: auto;
+.edit-site-header-edit-mode{
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    &.show-icon-labels {
+        .components-button.has-icon {
+            width: auto;
 
-		// Hide the button icons when labels are set to display...
-		svg {
-			display: none;
-		}
-		// ... and display labels.
-		&::after {
-			content: attr(aria-label);
-		}
-		&[aria-disabled="true"] {
-			background-color: transparent;
-		}
-	}
-	.is-tertiary {
-		&:active {
-			box-shadow: 0 0 0 1.5px var(--wp-admin-theme-color);
-			background-color: transparent;
-		}
-	}
-	// Some margins and padding have to be adjusted so the buttons can still fit on smaller screens.
-	.edit-site-save-button__button {
-		padding-left: 6px;
-		padding-right: 6px;
-	}
+            // Hide the button icons when labels are set to display...
+            svg {
+                display: none;
+            }
+            // ... and display labels.
+            &::after {
+                content: attr(aria-label);
+            }
+            &[aria-disabled="true"] {
+                background-color: transparent;
+            }
+        }
+        .is-tertiary {
+            &:active {
+                box-shadow: 0 0 0 1.5px var(--wp-admin-theme-color);
+                background-color: transparent;
+            }
+        }
+        // Some margins and padding have to be adjusted so the buttons can still fit on smaller screens.
+        .edit-site-save-button__button {
+            padding-left: 6px;
+            padding-right: 6px;
+        }
 
-	// The template details toggle has a custom label, different from its aria-label, so we don't want to display both.
-	.edit-site-document-actions__get-info.edit-site-document-actions__get-info.edit-site-document-actions__get-info {
-		&::after {
-			content: none;
-		}
-	}
+        // The template details toggle has a custom label, different from its aria-label, so we don't want to display both.
+        .edit-site-document-actions__get-info.edit-site-document-actions__get-info.edit-site-document-actions__get-info {
+            &::after {
+                content: none;
+            }
+        }
 
-	.edit-site-header-edit-mode__inserter-toggle.edit-site-header-edit-mode__inserter-toggle,
-	.edit-site-document-actions__get-info.edit-site-document-actions__get-info.edit-site-document-actions__get-info {
-		height: 36px;
-		padding: 0 $grid-unit-10;
-	}
+        .edit-site-header-edit-mode__inserter-toggle.edit-site-header-edit-mode__inserter-toggle,
+        .edit-site-document-actions__get-info.edit-site-document-actions__get-info.edit-site-document-actions__get-info {
+            height: 36px;
+            padding: 0 $grid-unit-10;
+        }
 
-	.edit-site-header-edit-mode__document-tools .edit-site-header-edit-mode__toolbar > * + * {
-		margin-left: $grid-unit-10;
-	}
+        .block-editor-block-mover {
+            border-left: none;
 
-	.block-editor-block-mover {
-		border-left: none;
-
-		&::before {
-			content: "";
-			width: $border-width;
-			margin-top: $grid-unit + $grid-unit-05;
-			margin-bottom: $grid-unit + $grid-unit-05;
-			background-color: $gray-300;
-			margin-left: $grid-unit;
-		}
-	}
+            &::before {
+                content: "";
+                width: $border-width;
+                margin-top: $grid-unit + $grid-unit-05;
+                margin-bottom: $grid-unit + $grid-unit-05;
+                background-color: $gray-300;
+                margin-left: $grid-unit;
+            }
+        }
+    }
 }
 
 .has-fixed-toolbar {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Modify Button style of Save which updating default font family.

## Why?
When update default -global style then it's switch bar.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open the Site Editor
2. Edit the home template
3. Open styles > typography > text
4. Change the font and then change it back to original font selection. Notice the title bar.


