### PR TITLE
Site editor: add global styles changes to save flow

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -5,11 +5,18 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import EntityRecordItem from './entity-record-item';
+import { unlock } from '../../lock-unlock';
+
+const { getGlobalStylesChanges, GlobalStylesContext } = unlock(
+	blockEditorPrivateApis
+);
 
 function getEntityDescription( entity, count ) {
 	switch ( entity ) {
@@ -27,6 +34,39 @@ function getEntityDescription( entity, count ) {
 	}
 }
 
+function GlobalStylesDescription( { record } ) {
+	const { user: currentEditorGlobalStyles } =
+		useContext( GlobalStylesContext );
+	const savedRecord = useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecord(
+				record.kind,
+				record.name,
+				record.key
+			),
+		[ record.kind, record.name, record.key ]
+	);
+
+	const globalStylesChanges = getGlobalStylesChanges(
+		currentEditorGlobalStyles,
+		savedRecord,
+		{
+			maxResults: 10,
+		}
+	);
+	return globalStylesChanges.length ? (
+		<PanelRow>{ globalStylesChanges.join( ', ' ) }</PanelRow>
+	) : null;
+}
+
+function EntityDescription( { record, count } ) {
+	if ( 'globalStyles' === record?.name ) {
+		return <GlobalStylesDescription record={ record } />;
+	}
+	const description = getEntityDescription( record?.name, count );
+	return description ? <PanelRow>{ description }</PanelRow> : null;
+}
+
 export default function EntityTypeList( {
 	list,
 	unselectedEntities,
@@ -42,19 +82,16 @@ export default function EntityTypeList( {
 			),
 		[ firstRecord.kind, firstRecord.name ]
 	);
-	const { name } = firstRecord;
 
 	let entityLabel = entityConfig.label;
-	if ( name === 'wp_template_part' ) {
+	if ( firstRecord?.name === 'wp_template_part' ) {
 		entityLabel =
 			1 === count ? __( 'Template Part' ) : __( 'Template Parts' );
 	}
-	// Set description based on type of entity.
-	const description = getEntityDescription( name, count );
 
 	return (
 		<PanelBody title={ entityLabel } initialOpen={ true }>
-			{ description && <PanelRow>{ description }</PanelRow> }
+			<EntityDescription record={ firstRecord } count={ count } />
 			{ list.map( ( record ) => {
 				return (
 					<EntityRecordItem

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -55,7 +55,12 @@ function GlobalStylesDescription( { record } ) {
 		}
 	);
 	return globalStylesChanges.length ? (
-		<PanelRow>{ globalStylesChanges.join( ', ' ) }</PanelRow>
+		<>
+			<h3 className="entities-saved-states__description-heading">
+				{ __( 'Changes made to:' ) }
+			</h3>
+			<PanelRow>{ globalStylesChanges.join( ', ' ) }</PanelRow>
+		</>
 	) : null;
 }
 

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -15,3 +15,7 @@
 		margin-bottom: $grid-unit-15;
 	}
 }
+
+.entities-saved-states__description-heading {
+	font-size: $default-font-size;
+}


### PR DESCRIPTION
## What?

Follow up to:

- https://github.com/WordPress/gutenberg/pull/57411

Part of:

- https://github.com/WordPress/gutenberg/issues/55776

This PR prints current, unsaved changes to global styles in the save flow panel of the site editor.

It uses the same comparison code as the [global styles revisions change summary](https://github.com/WordPress/gutenberg/pull/56577).


## Why?
To provide the user with an overview of what's being saved, so, if I had to write a sales pitch I'd focus on "transparent and informative" as adjectival hooks, and then offer a free set of steak knives if that didn't work.

## How?

By comparing the current user global styles object, which includes any saved and unsaved changes to global styles, with the saved record. The difference should reflect the unsaved changes that will be saved in the save flow.

## Open questions

1. This PR limits the changes printed to the screen to 10, after which a `…and n more changes.` appears to communicate the existence of more. Is that limit reasonable?
2. Do we need any explanatory, preceding copy, e.g., `"Your unsaved changes include: ...."`?

## Testing Instructions

1. Head to the site editor and make a bunch of changes to global styles, e.g., elements, blocks, site-wide colors/typography. 
2. Click on the "Save" button to trigger the save flow
3. In the global styles entity panel, you should see a summary of your changes, limited to 10 changes.

Also check that the `<h3>Changes made to:</h3>` order makes sense in context:

<img width="338" alt="Screenshot 2024-01-09 at 11 29 09 am" src="https://github.com/WordPress/gutenberg/assets/6458278/3810be2d-5324-431b-aed0-3998efed7830">



## Screenshots or screencast <!-- if applicable -->




https://github.com/WordPress/gutenberg/assets/6458278/a5021221-103e-49fd-a488-7750d173d680

