### PR TITLE
Site editor: add padding to entity save panel header

### DIFF
--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -10,4 +10,8 @@
 .entities-saved-states__text-prompt {
 	padding: $grid-unit-20;
 	padding-bottom: $grid-unit-05;
+	strong {
+		display: block;
+		margin-bottom: $grid-unit-15;
+	}
 }


### PR DESCRIPTION


## What and how?
Like it says on the box, add some padding to the _"Are you ready to save?"_ save panel header.

## Why?
In the absence of any `additionalPrompt` content, when you deselect all entities to save, the header sits too close to the panel border below.

The only `additionalPrompt` content I could find is a [p tag](https://github.com/WordPress/gutenberg/blob/19028bfb848ada3cdac829d05cd38801e10d5aa1/packages/edit-site/src/components/save-panel/index.js#L50-L50) that is shown when previewing a new theme in the site editor. This content has its own, default padding of `1em`. 

<img width="275" alt="Screenshot 2024-01-02 at 1 03 32 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/20386d2b-dc4c-4e21-b233-aedc45cca187">


## Testing Instructions
1. Head over to the site editor, make some changes
2. Save the template to show the save flow
3. Deselect all entities to save
4. Observe that the margin looks more balanced and there are no regressions.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/6458278/77ae32f7-b5a8-48a6-8cea-6202a7f56c22


### After
https://github.com/WordPress/gutenberg/assets/6458278/5266152e-985c-44ad-aa0a-99cdeeca8b85