### PR TITLE
Global styles revisions: add individual headings translations, update tests

### DIFF
--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -16,6 +16,12 @@ const translationMap = {
 	link: __( 'Link' ),
 	button: __( 'Button' ),
 	heading: __( 'Heading' ),
+	h1: __( 'H1' ),
+	h2: __( 'H2' ),
+	h3: __( 'H3' ),
+	h4: __( 'H4' ),
+	h5: __( 'H5' ),
+	h6: __( 'H6' ),
 	'settings.color': __( 'Color settings' ),
 	'settings.typography': __( 'Typography settings' ),
 	'styles.color': __( 'Colors' ),
@@ -54,10 +60,11 @@ function getTranslation( key ) {
 	}
 
 	if ( keyArray?.[ 0 ] === 'elements' ) {
+		const elementName = translationMap[ keyArray[ 1 ] ] || keyArray[ 1 ];
 		return sprintf(
 			// translators: %s: element name, e.g., heading button, link, caption.
 			__( '%s element' ),
-			translationMap[ keyArray[ 1 ] ]
+			elementName
 		);
 	}
 

--- a/packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js
@@ -3,19 +3,31 @@
  */
 import getGlobalStylesChanges from '../get-global-styles-changes';
 
-jest.mock( '@wordpress/blocks', () => {
-	return {
-		...jest.requireActual( '@wordpress/blocks' ),
-		getBlockTypes: jest.fn( () => [
-			{
-				name: 'core/paragraph',
-				title: 'Test Paragraph',
-			},
-		] ),
-	};
-} );
+/**
+ * WordPress dependencies
+ */
+import {
+	registerBlockType,
+	unregisterBlockType,
+	getBlockTypes,
+} from '@wordpress/blocks';
 
 describe( 'getGlobalStylesChanges', () => {
+	beforeEach( () => {
+		registerBlockType( 'core/test-fiori-di-zucca', {
+			save: () => {},
+			category: 'text',
+			title: 'Test pumpkin flowers',
+			edit: () => {},
+		} );
+	} );
+
+	afterEach( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
 	const revision = {
 		id: 10,
 		styles: {
@@ -41,6 +53,11 @@ describe( 'getGlobalStylesChanges', () => {
 						letterSpacing: '37px',
 					},
 				},
+				h3: {
+					typography: {
+						lineHeight: '1.2',
+					},
+				},
 				caption: {
 					color: {
 						text: 'var(--wp--preset--color--pineapple)',
@@ -51,7 +68,7 @@ describe( 'getGlobalStylesChanges', () => {
 				text: 'var(--wp--preset--color--tomato)',
 			},
 			blocks: {
-				'core/paragraph': {
+				'core/test-fiori-di-zucca': {
 					color: {
 						text: '#000000',
 					},
@@ -96,6 +113,16 @@ describe( 'getGlobalStylesChanges', () => {
 						letterSpacing: '37px',
 					},
 				},
+				h3: {
+					typography: {
+						lineHeight: '2',
+					},
+				},
+				h6: {
+					typography: {
+						lineHeight: '1.2',
+					},
+				},
 				caption: {
 					typography: {
 						fontSize: '1.11rem',
@@ -118,7 +145,7 @@ describe( 'getGlobalStylesChanges', () => {
 				background: 'var(--wp--preset--color--pumpkin)',
 			},
 			blocks: {
-				'core/paragraph': {
+				'core/test-fiori-di-zucca': {
 					color: {
 						text: '#fff',
 					},
@@ -144,8 +171,10 @@ describe( 'getGlobalStylesChanges', () => {
 		expect( resultA ).toEqual( [
 			'Colors',
 			'Typography',
-			'Test Paragraph block',
+			'Test pumpkin flowers block',
+			'H3 element',
 			'Caption element',
+			'H6 element',
 			'Link element',
 			'Color settings',
 		] );
@@ -162,8 +191,8 @@ describe( 'getGlobalStylesChanges', () => {
 		expect( resultA ).toEqual( [
 			'Colors',
 			'Typography',
-			'Test Paragraph block',
-			'…and 3 more changes.',
+			'Test pumpkin flowers block',
+			'…and 5 more changes.',
 		] );
 	} );
 


### PR DESCRIPTION

## What?

Follow up to:

- https://github.com/WordPress/gutenberg/pull/57411

1. Updates tests to use custom, registered block
2. Adds individual headings to the elements translations


Kudos to @andrewserong for picking up on both items.

## Why?
1. Makes things more consistent with current tests, doesn't override API unnecessarily.
2. Translations don't exist. Using `key` as fallback so `undefined` doesn't appear.


## Testing Instructions
1. Open the site editor and make some changes to typography global styles for individual headings (H1 - H6).
2. Save the styles.
3. Open the global styles revisions panel, and check that the changes appear correctly, e.g., `h1 => "H1 element"`


| Before  | After |
| ------------- | ------------- |
| <img width="279" alt="Screenshot 2024-01-02 at 1 41 36 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/2bbb83af-1f95-493c-a11b-603573e8b461">  | <img width="280" alt="Screenshot 2024-01-02 at 1 41 06 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/85b66025-ae07-4cde-bb9e-84f5b8ab1263">  |





