### PR TITLE
Site editor: add margin to entity save panel header via a classname

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -209,7 +209,9 @@ export function EntitiesSavedStatesExtensible( {
 			</Flex>
 
 			<div className="entities-saved-states__text-prompt">
-				<strong>{ __( 'Are you ready to save?' ) }</strong>
+				<strong className="entities-saved-states__text-prompt--header">
+					{ __( 'Are you ready to save?' ) }
+				</strong>
 				{ additionalPrompt }
 				{ isDirty && (
 					<p>

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -10,7 +10,7 @@
 .entities-saved-states__text-prompt {
 	padding: $grid-unit-20;
 	padding-bottom: $grid-unit-05;
-	strong {
+	.entities-saved-states__text-prompt--header {
 		display: block;
 		margin-bottom: $grid-unit-15;
 	}


### PR DESCRIPTION


## What and how?
Follow up to:

- https://github.com/WordPress/gutenberg/pull/57471


Use a classname instead of the element on the _"Are you ready to save?"_ element in the save flow to add bottom margin.


## Why?
As @andrewserong points out, it's a better way to guard against possible regressions  in case a strong element is passed to `additionalPrompt`. 


## Testing Instructions

Test instructions copied from https://github.com/WordPress/gutenberg/pull/57471


1. Head over to the site editor, make some changes
2. Save the template to show the save flow
3. Deselect all entities to save
4. Observe that there are no regressions since https://github.com/WordPress/gutenberg/pull/57471 (the bottom padding of the _"Are you ready to save?"_ header is intact)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/6458278/77ae32f7-b5a8-48a6-8cea-6202a7f56c22


### After
https://github.com/WordPress/gutenberg/assets/6458278/5266152e-985c-44ad-aa0a-99cdeeca8b85
