### PR TITLE
Background image block support: Add tests for size and repeat output

### DIFF
--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -224,6 +224,14 @@ describe( 'getCSSRules', () => {
 		expect(
 			getCSSRules(
 				{
+					background: {
+						backgroundImage: {
+							source: 'file',
+							url: 'https://example.com/image.jpg',
+						},
+						backgroundRepeat: 'no-repeat',
+						backgroundSize: '300px',
+					},
 					color: {
 						text: '#dddddd',
 						background: '#555555',
@@ -371,6 +379,21 @@ describe( 'getCSSRules', () => {
 				key: 'boxShadow',
 				value: '10px 10px red',
 			},
+			{
+				selector: '.some-selector',
+				key: 'backgroundImage',
+				value: "url( 'https://example.com/image.jpg' )",
+			},
+			{
+				selector: '.some-selector',
+				key: 'backgroundRepeat',
+				value: 'no-repeat',
+			},
+			{
+				selector: '.some-selector',
+				key: 'backgroundSize',
+				value: '300px',
+			},
 		] );
 	} );
 
@@ -397,6 +420,70 @@ describe( 'getCSSRules', () => {
 				selector: '.some-selector a',
 				key: 'padding',
 				value: '11px',
+			},
+		] );
+	} );
+
+	it( 'should output fallback cover background size when no size is provided', () => {
+		expect(
+			getCSSRules(
+				{
+					background: {
+						backgroundImage: {
+							source: 'file',
+							url: 'https://example.com/image.jpg',
+						},
+					},
+				},
+				{
+					selector: '.some-selector',
+				}
+			)
+		).toEqual( [
+			{
+				selector: '.some-selector',
+				key: 'backgroundImage',
+				value: "url( 'https://example.com/image.jpg' )",
+			},
+			{
+				selector: '.some-selector',
+				key: 'backgroundSize',
+				value: 'cover',
+			},
+		] );
+	} );
+
+	it( 'should output fallback center position for contain background size', () => {
+		expect(
+			getCSSRules(
+				{
+					background: {
+						backgroundImage: {
+							source: 'file',
+							url: 'https://example.com/image.jpg',
+						},
+						backgroundSize: 'contain',
+					},
+				},
+				{
+					selector: '.some-selector',
+				}
+			)
+		).toEqual( [
+			{
+				selector: '.some-selector',
+				key: 'backgroundImage',
+				value: "url( 'https://example.com/image.jpg' )",
+			},
+			{
+				selector: '.some-selector',
+				key: 'backgroundSize',
+				value: 'contain',
+			},
+			{
+				selector: '.some-selector',
+				key: 'backgroundPosition',
+				value: 'center',
 			},
 		] );
 	} );

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -137,6 +137,23 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'expected_wrapper'    => '<div style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
+			'background image style with contain, position, and repeat is applied' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-rules-are-output',
+				'background_settings' => array(
+					'backgroundImage' => true,
+				),
+				'background_style'    => array(
+					'backgroundImage'  => array(
+						'url'    => 'https://example.com/image.jpg',
+						'source' => 'file',
+					),
+					'backgroundRepeat' => 'no-repeat',
+					'backgroundSize'   => 'contain',
+				),
+				'expected_wrapper'    => '<div style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:center;background-repeat:no-repeat;background-size:contain;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
 			'background image style is appended if a style attribute already exists' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-output',

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -506,18 +506,22 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'inline_background_image_url_with_background_size' => array(
 				'block_styles'    => array(
 					'background' => array(
-						'backgroundImage' => array(
+						'backgroundImage'    => array(
 							'url' => 'https://example.com/image.jpg',
 						),
-						'backgroundSize'  => 'cover',
+						'backgroundPosition' => 'center',
+						'backgroundRepeat'   => 'no-repeat',
+						'backgroundSize'     => 'cover',
 					),
 				),
 				'options'         => array(),
 				'expected_output' => array(
-					'css'          => "background-image:url('https://example.com/image.jpg');background-size:cover;",
+					'css'          => "background-image:url('https://example.com/image.jpg');background-position:center;background-repeat:no-repeat;background-size:cover;",
 					'declarations' => array(
-						'background-image' => "url('https://example.com/image.jpg')",
-						'background-size'  => 'cover',
+						'background-image'    => "url('https://example.com/image.jpg')",
+						'background-position' => 'center',
+						'background-repeat'   => 'no-repeat',
+						'background-size'     => 'cover',
 					),
 				),
 			),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: #54336, follow-up to #57005

Add tests for newly added background size and repeat features.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Ensure these features have coverage to prevent regressions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add tests to the PHP style engine to ensure output of background size, repeat, and position CSS properties.
* Add tests to the PHP background image support to ensure expected inline style is output correctly (and include fallback `center` position when `contain` is set as the background size)
* Add tests for the JS style engine to ensure fallback `backgroundSize` and fallback `backgroundPosition` values are covered

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run the tests (or just check that the Github Actions pass):

```sh
npm run test:unit -- --testPathPattern packages/style-engine/src/test/index.js
npm run test:unit:php:base -- --filter WP_Style_Engine_test
npm run test:unit:php:base -- --filter WP_Block_Supports_Background_Test
```