### PR TITLE
ResizableEditor: Fix tab order for resize handles

### DIFF
--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -46,8 +46,8 @@ function ResizableEditor( { enableResizing, height, children } ) {
 			maxWidth="100%"
 			maxHeight="100%"
 			enable={ {
-				right: enableResizing,
 				left: enableResizing,
+				right: enableResizing,
 			} }
 			showHandle={ enableResizing }
 			// The editor is centered horizontally, resizing it only


### PR DESCRIPTION
Found while searching for a solution to #52602

## What?

This PR is a small improvement that fixes the order of tab focus in canvases that have resizing handles on both sides, such as Pattern editor, Template Part editor, and Style book.

In other words, when you press the Tab key, instead of focusing on the right handle and then the left handle, it focuses on the left handle and then the right handle.

## Why?

The `ResizableBox` component uses `re-resizable` component [internally](https://github.com/WordPress/gutenberg/blob/2d43054e0343cfdc9c3ad9d055e8ba23d2979b34/packages/components/src/resizable-box/index.tsx#L11). This component renders resize handles based on the `enable` prop, but the order in which each handle is rendered depends on[ the order of the enable prop's keys](https://github.com/bokuweb/re-resizable/blob/0f6b2ddcbab2a2864c209e0a59a67b6d51adab86/src/index.tsx#L891-L904). In the object currently being passed, the `right` key is before the `left` key, so the right handle is rendered before the left handle, causing confusion in the tab focus order.

## How?
Relying on the internal implementation of the library and the order of the keys may be a little unstable, but I changed the order of the keys.

This PR does not solve #52602 because [the resize handles are rendered after the child](https://github.com/bokuweb/re-resizable/blob/0f6b2ddcbab2a2864c209e0a59a67b6d51adab86/src/index.tsx#L952-L953) (iframe). In the future, we may need to look for a better solution.

### Testing Instructions for Keyboard

- Access the template part's editor canvas.
- Click in the canvas area and press the Tab key repeatedly.
- The focus should move in the following order:
  - trunk:
  - This PR:
- Change the site language to RTL language.
- The order of focus should be reversed.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/54422211/f6ef6781-0b80-4a8d-b12e-3bee5ce5bab9

