### PR TITLE
Editor: Unify context text cursor preference

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -228,6 +228,7 @@ export default function EditPostPreferencesModal() {
 							) }
 						>
 							<EnableFeature
+								scope="core"
 								featureName="keepCaretInsideBlock"
 								help={ __(
 									'Keeps the text cursor within the block boundaries, aiding users with screen readers by preventing unintentional cursor movement outside the block.'

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -49,7 +49,6 @@ function Editor( {
 		preferredStyleVariations,
 		hiddenBlockTypes,
 		blockTypes,
-		keepCaretInsideBlock,
 		template,
 	} = useSelect(
 		( select ) => {
@@ -101,7 +100,6 @@ function Editor( {
 				),
 				hiddenBlockTypes: getHiddenBlockTypes(),
 				blockTypes: getBlockTypes(),
-				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
 				template:
 					supportsTemplateMode && isViewable && canEditTemplate
 						? getEditedPostTemplate()
@@ -128,7 +126,6 @@ function Editor( {
 			isDistractionFree,
 			hasInlineToolbar,
 
-			keepCaretInsideBlock,
 			// Keep a reference of the `allowedBlockTypes` from the server to handle use cases
 			// where we need to differentiate if a block is disabled by the user or some plugin.
 			defaultAllowedBlockTypes: settings.allowedBlockTypes,
@@ -156,7 +153,6 @@ function Editor( {
 		hasInlineToolbar,
 		focusMode,
 		isDistractionFree,
-		keepCaretInsideBlock,
 		hiddenBlockTypes,
 		blockTypes,
 		preferredStyleVariations,

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -97,7 +97,6 @@ export function useSpecificEditorSettings() {
 		focusMode,
 		isDistractionFree,
 		hasFixedToolbar,
-		keepCaretInsideBlock,
 		canvasMode,
 		settings,
 		postWithTemplate,
@@ -130,10 +129,6 @@ export function useSpecificEditorSettings() {
 				hasFixedToolbar:
 					!! getPreference( 'core/edit-site', 'fixedToolbar' ) ||
 					! isLargeViewport,
-				keepCaretInsideBlock: !! getPreference(
-					'core/edit-site',
-					'keepCaretInsideBlock'
-				),
 				canvasMode: getCanvasMode(),
 				settings: getSettings(),
 				postWithTemplate: _context?.postId,
@@ -152,7 +147,6 @@ export function useSpecificEditorSettings() {
 			focusMode: canvasMode === 'view' && focusMode ? false : focusMode,
 			isDistractionFree,
 			hasFixedToolbar,
-			keepCaretInsideBlock,
 			defaultRenderingMode,
 			getPostLinkProps,
 			// I wonder if they should be set in the post editor too
@@ -165,7 +159,6 @@ export function useSpecificEditorSettings() {
 		focusMode,
 		isDistractionFree,
 		hasFixedToolbar,
-		keepCaretInsideBlock,
 		defaultRenderingMode,
 		getPostLinkProps,
 		archiveLabels.archiveTypeLabel,

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -126,6 +126,7 @@ export default function EditSitePreferencesModal() {
 						) }
 					>
 						<EnableFeature
+							namespace="core"
 							featureName="keepCaretInsideBlock"
 							help={ __(
 								'Keeps the text cursor within the block boundaries, aiding users with screen readers by preventing unintentional cursor movement outside the block.'

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -56,7 +56,6 @@ export function initializeEditor( id, settings ) {
 		fixedToolbar: false,
 		focusMode: false,
 		distractionFree: false,
-		keepCaretInsideBlock: false,
 		welcomeGuide: true,
 		welcomeGuideStyles: true,
 		welcomeGuidePage: true,
@@ -64,8 +63,10 @@ export function initializeEditor( id, settings ) {
 		showListViewByDefault: false,
 		showBlockBreadcrumbs: true,
 	} );
+
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
+		keepCaretInsideBlock: false,
 	} );
 
 	dispatch( interfaceStore ).setDefaultComplementaryArea(

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -59,7 +59,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'imageEditing',
 	'imageSizes',
 	'isRTL',
-	'keepCaretInsideBlock',
 	'locale',
 	'maxWidth',
 	'onUpdateDefaultBlockStyles',
@@ -91,6 +90,7 @@ const BLOCK_EDITOR_SETTINGS = [
 function useBlockEditorSettings( settings, postType, postId ) {
 	const {
 		allowRightClickOverrides,
+		keepCaretInsideBlock,
 		reusableBlocks,
 		hasUploadPermissions,
 		canUseUnfilteredHTML,
@@ -115,13 +115,14 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			} = select( coreStore );
 			const { getPostLinkProps: postLinkProps } =
 				select( editorStore ).getEditorSettings();
+			const { get } = select( preferencesStore );
 
 			const siteSettings = canUser( 'read', 'settings' )
 				? getEntityRecord( 'root', 'site' )
 				: undefined;
 
 			return {
-				allowRightClickOverrides: select( preferencesStore ).get(
+				allowRightClickOverrides: get(
 					'core',
 					'allowRightClickOverrides'
 				),
@@ -130,6 +131,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 					postType,
 					postId
 				)?._links?.hasOwnProperty( 'wp:action-unfiltered-html' ),
+				keepCaretInsideBlock: get( 'core', 'keepCaretInsideBlock' ),
 				reusableBlocks: isWeb
 					? getEntityRecords( 'postType', 'wp_block', {
 							per_page: -1,
@@ -220,6 +222,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				)
 			),
 			allowRightClickOverrides,
+			keepCaretInsideBlock,
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalBlockPatterns: blockPatterns,
@@ -254,6 +257,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		} ),
 		[
 			allowRightClickOverrides,
+			keepCaretInsideBlock,
 			settings,
 			hasUploadPermissions,
 			reusableBlocks,

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
@@ -4,7 +4,10 @@
 
 export default function convertEditorSettings( data ) {
 	let newData = data;
-	const settingsToMoveToCore = [ 'allowRightClickOverrides' ];
+	const settingsToMoveToCore = [
+		'allowRightClickOverrides',
+		'keepCaretInsideBlock',
+	];
 
 	settingsToMoveToCore.forEach( ( setting ) => {
 		if ( data?.[ 'core/edit-post' ]?.[ setting ] !== undefined ) {


### PR DESCRIPTION
Related #52632 
Similar to #57468 

## What?

This PR continues the work on the great unification between post and site editors. In this PR we're unifying the "contain text cursor inside block" preference. If the user enables it in the post editor, the setting should be used in the site editor as well. 

## Testing instructions

- Update the "contain text inside block" preference in the post editor (toggle the checkbox in the preferences -> accessibility panel)
- Open the site editor and notice the preference is set there as well.