### PR TITLE
Update copyright year to 2024 in `license.md`.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## Gutenberg
 
-    Copyright 2016-2023 by the contributors
+    Copyright 2016-2024 by the contributors
 
 **License for Contributions (on and after April 15, 2021)**
 


### PR DESCRIPTION
## What?
Updates the license copyright to 2024

Same as WP core: https://github.com/WordPress/wordpress-develop/commit/7aa146dfad180ead7ecdc537b413331ce8d2ef60