### PR TITLE
Font Library: Show the scrollbar bottom edge

### DIFF
--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -196,22 +196,28 @@ function UnforwardedModal(
 	}, [ isContentScrollable, childrenContainerRef ] );
 
 	useLayoutEffect( () => {
-		// Function to calculate and update scrollbar width.
+		// Function to calculate the scrollbar width of the modal content.
+		// This calculates the difference between the offsetWidth (full width including scrollbar)
+		// and the clientWidth (width excluding scrollbar).
 		const updateScrollbarWidth = () => {
 			const scrollbarWidth = contentRef.current
 				? contentRef.current.offsetWidth -
 				  contentRef.current.clientWidth
 				: 0;
 
+			// Select or create a style tag to hold the custom CSS variable.
 			let styleTag = document.getElementById(
 				'modal-scrollbar-width-style'
 			) as HTMLStyleElement;
 			if ( ! styleTag ) {
+				// If the style tag doesn't exist, create it and append to the document head.
 				styleTag = document.createElement( 'style' );
 				styleTag.id = 'modal-scrollbar-width-style';
 				document.head.appendChild( styleTag );
 			}
 
+			// Set the CSS variable --modal-scrollbar-width on the :root selector.
+			// This variable holds the calculated width of the scrollbar.
 			styleTag.textContent = `
 				:root {
 					--modal-scrollbar-width: ${ scrollbarWidth }px;
@@ -219,22 +225,25 @@ function UnforwardedModal(
 			`;
 		};
 
-		// Set up ResizeObserver.
+		// Create a ResizeObserver to monitor changes in the size of the modal content.
+		// This is necessary to recalculate the scrollbar width when the modal's size changes.
 		const resizeObserver = new ResizeObserver( () => {
 			updateScrollbarWidth();
 		} );
 
 		const currentContentRef = contentRef.current;
 
-		// Start observing the modal content.
+		// Start observing the modal content's size.
 		if ( currentContentRef ) {
 			resizeObserver.observe( currentContentRef );
 		}
 
-		// Initial update.
+		// Perform an initial update of the scrollbar width.
 		updateScrollbarWidth();
 
-		// Cleanup function.
+		// Define a cleanup function to be executed when the component unmounts.
+		// This removes the ResizeObserver and the dynamically created style tag
+		// to prevent memory leaks and remove unused styles from the document.
 		return () => {
 			if ( currentContentRef ) {
 				resizeObserver.unobserve( currentContentRef );
@@ -246,7 +255,7 @@ function UnforwardedModal(
 				document.head.removeChild( styleTag );
 			}
 		};
-	}, [] );
+	}, [] ); // Empty dependency array to ensure this effect runs only once on mount.
 
 	function handleEscapeKeyDown( event: KeyboardEvent< HTMLDivElement > ) {
 		if (

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -195,6 +195,59 @@ function UnforwardedModal(
 		};
 	}, [ isContentScrollable, childrenContainerRef ] );
 
+	useLayoutEffect( () => {
+		// Function to calculate and update scrollbar width.
+		const updateScrollbarWidth = () => {
+			const scrollbarWidth = contentRef.current
+				? contentRef.current.offsetWidth -
+				  contentRef.current.clientWidth
+				: 0;
+
+			let styleTag = document.getElementById(
+				'modal-scrollbar-width-style'
+			) as HTMLStyleElement;
+			if ( ! styleTag ) {
+				styleTag = document.createElement( 'style' );
+				styleTag.id = 'modal-scrollbar-width-style';
+				document.head.appendChild( styleTag );
+			}
+
+			styleTag.textContent = `
+				:root {
+					--modal-scrollbar-width: ${ scrollbarWidth }px;
+				}
+			`;
+		};
+
+		// Set up ResizeObserver.
+		const resizeObserver = new ResizeObserver( () => {
+			updateScrollbarWidth();
+		} );
+
+		const currentContentRef = contentRef.current;
+
+		// Start observing the modal content.
+		if ( currentContentRef ) {
+			resizeObserver.observe( currentContentRef );
+		}
+
+		// Initial update.
+		updateScrollbarWidth();
+
+		// Cleanup function.
+		return () => {
+			if ( currentContentRef ) {
+				resizeObserver.unobserve( currentContentRef );
+			}
+			const styleTag = document.getElementById(
+				'modal-scrollbar-width-style'
+			) as HTMLStyleElement;
+			if ( styleTag ) {
+				document.head.removeChild( styleTag );
+			}
+		};
+	}, [] );
+
 	function handleEscapeKeyDown( event: KeyboardEvent< HTMLDivElement > ) {
 		if (
 			// Ignore keydowns from IMEs

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -36,7 +36,7 @@
 		padding: 16px 32px;
 		position: absolute;
 		bottom: 32px;
-		width: 100%;
+		width: calc(100% - var(--modal-scrollbar-width));
 		background-color: #fff;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Display/Unhide the Scrollbar Bottom Edge of the Font Library Modal in the Editor.

## Why?
Reference Issue - https://github.com/WordPress/gutenberg/issues/54401

## How?
The bottom edge of the scrollbar inside the modal was obscured due to an absolutely positioned div overlapping it. This was particularly problematic because the width of the scrollbar can vary between different browsers and screen sizes.

To resolve this issue, I implemented a dynamic approach to adjust the width of the overlapping div based on the actual scrollbar width. This was necessary because of the variability in scrollbar sizes across different environments.

## Testing Instructions
Appearance -> Editor -> Styles -> Edit Styles -> Typography -> Manage Fonts

## Screenshots or screencast <!-- if applicable -->
**Before**
![image](https://github.com/WordPress/gutenberg/assets/47940584/c8b6157c-87da-4c89-a835-ed8b273c7d91)

**After**
![image](https://github.com/WordPress/gutenberg/assets/47940584/c2dbfb71-fe72-4c26-88ad-6c6d4659e659)
