### PR TITLE
[RNMobile] Ensure Aztec input state function `blurOnUnmount` updates its state

### DIFF
--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -142,7 +142,7 @@ export const focus = ( element ) => {
 	// will take precedence and cancels pending blur events.
 	blur.cancel();
 	// Similar to blur events, we also need to cancel potential keyboard dismiss.
-	dismissKeyboardDebounce.cancel();
+	blurOnUnmountDebounce.cancel();
 
 	TextInputState.focusTextInput( element );
 	notifyInputChange();
@@ -164,13 +164,6 @@ export const blur = debounce( ( element ) => {
 /**
  * Unfocuses the specified element in case it's about to be unmounted.
  *
- * On iOS text inputs are automatically unfocused and keyboard dismissed when they
- * are removed. However, this is not the case on Android, where text inputs are
- * unfocused but the keyboard remains open.
- *
- * For dismissing the keyboard, we use debounce to avoid conflicts with the focus
- * event when both are triggered at the same time.
- *
  * Note that we can't trigger the blur event, as it's likely that the Aztec view is no
  * longer available when the event is executed and will produce an exception.
  *
@@ -181,15 +174,24 @@ export const blurOnUnmount = ( element ) => {
 		// If a blur event was triggered before unmount, we need to cancel them to avoid
 		// exceptions.
 		blur.cancel();
-		if ( Platform.OS === 'android' ) {
-			dismissKeyboardDebounce();
-		}
+		blurOnUnmountDebounce();
 	}
 };
 
-const dismissKeyboardDebounce = debounce( () => {
-	hideAndroidSoftKeyboard();
+// For updating the input state and dismissing the keyboard, we use debounce to avoid
+// conflicts with the focus event when both are triggered at the same time.
+const blurOnUnmountDebounce = debounce( () => {
+	// At this point, the text input will be destroyed but it's still focused. Hence, we
+	// have to explicitly notify listeners and update internal input state.
+	notifyListeners( { isFocused: false } );
 	currentFocusedElement = null;
+
+	// On iOS text inputs are automatically unfocused and keyboard dismissed when they
+	// are removed. However, this is not the case on Android, where text inputs are
+	// unfocused but the keyboard remains open.
+	if ( Platform.OS === 'android' ) {
+		hideAndroidSoftKeyboard();
+	}
 }, 0 );
 
 /**

--- a/packages/react-native-aztec/src/test/AztecInputState.test.js
+++ b/packages/react-native-aztec/src/test/AztecInputState.test.js
@@ -12,6 +12,7 @@ import {
 	isFocused,
 	focus,
 	blur,
+	blurOnUnmount,
 	notifyInputChange,
 	removeFocusChangeListener,
 } from '../AztecInputState';
@@ -100,5 +101,17 @@ describe( 'Aztec Input State', () => {
 		blur( ref );
 		jest.runAllTimers();
 		expect( TextInputState.blurTextInput ).toHaveBeenCalledWith( ref );
+	} );
+
+	it( 'unfocuses an element when unmounted', () => {
+		const listener = jest.fn();
+		addFocusChangeListener( listener );
+
+		updateCurrentFocusedInput( ref );
+		blurOnUnmount( ref );
+		jest.runAllTimers();
+
+		expect( listener ).toHaveBeenCalledWith( { isFocused: false } );
+		expect( isFocused() ).toBeFalsy();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates `blurOnUnmount` function to ensure the input state is updated due to the blur event.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, if an Aztec view is unmounted the Aztec input state still references the removed view as focused.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The function `dismissKeyboardDebounce` has been replaced with `blurOnUnmountDebounce`, which implements the following logic:
* Notify listeners of the blur event. Note that this is not performed by calling `notifyInputChange` as we can't rely on the state of the internal `TextInputState` due to not actively triggering the blur event.
* Remove the current focused element reference derived from the blur event.
* On Android, dismiss the keyboard as it's not performed when removing the text input.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
* Smoke test text-based blocks, especially creating and removing them.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A