### PR TITLE
Dataviews: Add some client side data handling utils

### DIFF
--- a/packages/dataviews/src/index.js
+++ b/packages/dataviews/src/index.js
@@ -1,2 +1,3 @@
 export { default as DataViews } from './dataviews';
+export { sortByTextFields, getPaginationResults } from './utils';
 export { VIEW_LAYOUTS } from './constants';

--- a/packages/dataviews/src/utils.js
+++ b/packages/dataviews/src/utils.js
@@ -1,0 +1,51 @@
+/**
+ * Helper util to sort items by text fields, when sorting is done client side.
+ *
+ * @param {Object}   params            Function params.
+ * @param {Object[]} params.items      Array of items to sort.
+ * @param {Object}   params.view       Current view object.
+ * @param {Object[]} params.fields     Array of available fields.
+ * @param {string[]} params.textFields Array of the field ids to sort.
+ *
+ * @return {Object[]} Sorted items.
+ */
+export const sortByTextFields = ( { items, view, fields, textFields } ) => {
+	const sortedItems = [ ...items ];
+	const fieldId = view.sort.field;
+	if ( textFields.includes( fieldId ) ) {
+		const fieldToSort = fields.find( ( field ) => {
+			return field.id === fieldId;
+		} );
+		sortedItems.sort( ( a, b ) => {
+			const valueA = fieldToSort.getValue( { item: a } ) ?? '';
+			const valueB = fieldToSort.getValue( { item: b } ) ?? '';
+			return view.sort.direction === 'asc'
+				? valueA.localeCompare( valueB )
+				: valueB.localeCompare( valueA );
+		} );
+	}
+	return sortedItems;
+};
+
+/**
+ * Helper util to get the paginated items and the paginateInfo needed,
+ * when pagination is done client side.
+ *
+ * @param {Object}   params       Function params.
+ * @param {Object[]} params.items Array of available items.
+ * @param {Object}   params.view  Current view object.
+ *
+ * @return {Object} Paginated items and paginationInfo.
+ */
+export function getPaginationResults( { items, view } ) {
+	const start = ( view.page - 1 ) * view.perPage;
+	const totalItems = items?.length || 0;
+	items = items?.slice( start, start + view.perPage );
+	return {
+		items,
+		paginationInfo: {
+			totalItems,
+			totalPages: Math.ceil( totalItems / view.perPage ),
+		},
+	};
+}

--- a/packages/dataviews/src/utils.js
+++ b/packages/dataviews/src/utils.js
@@ -1,22 +1,22 @@
 /**
- * Helper util to sort items by text fields, when sorting is done client side.
+ * Helper util to sort data by text fields, when sorting is done client side.
  *
  * @param {Object}   params            Function params.
- * @param {Object[]} params.items      Array of items to sort.
+ * @param {Object[]} params.data       Data to sort.
  * @param {Object}   params.view       Current view object.
  * @param {Object[]} params.fields     Array of available fields.
  * @param {string[]} params.textFields Array of the field ids to sort.
  *
- * @return {Object[]} Sorted items.
+ * @return {Object[]} Sorted data.
  */
-export const sortByTextFields = ( { items, view, fields, textFields } ) => {
-	const sortedItems = [ ...items ];
+export const sortByTextFields = ( { data, view, fields, textFields } ) => {
+	const sortedData = [ ...data ];
 	const fieldId = view.sort.field;
 	if ( textFields.includes( fieldId ) ) {
 		const fieldToSort = fields.find( ( field ) => {
 			return field.id === fieldId;
 		} );
-		sortedItems.sort( ( a, b ) => {
+		sortedData.sort( ( a, b ) => {
 			const valueA = fieldToSort.getValue( { item: a } ) ?? '';
 			const valueB = fieldToSort.getValue( { item: b } ) ?? '';
 			return view.sort.direction === 'asc'
@@ -24,25 +24,25 @@ export const sortByTextFields = ( { items, view, fields, textFields } ) => {
 				: valueB.localeCompare( valueA );
 		} );
 	}
-	return sortedItems;
+	return sortedData;
 };
 
 /**
- * Helper util to get the paginated items and the paginateInfo needed,
+ * Helper util to get the paginated data and the paginateInfo needed,
  * when pagination is done client side.
  *
- * @param {Object}   params       Function params.
- * @param {Object[]} params.items Array of available items.
- * @param {Object}   params.view  Current view object.
+ * @param {Object}   params      Function params.
+ * @param {Object[]} params.data Available data.
+ * @param {Object}   params.view Current view object.
  *
- * @return {Object} Paginated items and paginationInfo.
+ * @return {Object} Paginated data and paginationInfo.
  */
-export function getPaginationResults( { items, view } ) {
+export function getPaginationResults( { data, view } ) {
 	const start = ( view.page - 1 ) * view.perPage;
-	const totalItems = items?.length || 0;
-	items = items?.slice( start, start + view.perPage );
+	const totalItems = data?.length || 0;
+	data = data?.slice( start, start + view.perPage );
 	return {
-		items,
+		data,
 		paginationInfo: {
 			totalItems,
 			totalPages: Math.ceil( totalItems / view.perPage ),

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -243,10 +243,10 @@ export default function DataviewsPatterns() {
 	);
 	// Reset the page number when the category changes.
 	useEffect( () => {
-		if ( previousCategoryId !== categoryId && view.page !== 1 ) {
-			setView( { ...view, page: 1 } );
+		if ( previousCategoryId !== categoryId ) {
+			setView( DEFAULT_VIEW );
 		}
-	}, [ categoryId, previousCategoryId, view ] );
+	}, [ categoryId, previousCategoryId ] );
 	const { data, paginationInfo } = useMemo( () => {
 		if ( ! patterns ) {
 			return {

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -245,21 +245,17 @@ export default function DataviewsPatterns() {
 		// Handle sorting.
 		if ( view.sort ) {
 			filteredData = sortByTextFields( {
-				items: filteredData,
+				data: filteredData,
 				view,
 				fields,
 				textFields: [ 'title', 'author' ],
 			} );
 		}
 		// Handle pagination.
-		const paginationResults = getPaginationResults( {
-			items: filteredData,
+		return getPaginationResults( {
+			data: filteredData,
 			view,
 		} );
-		return {
-			data: paginationResults.items,
-			paginationInfo: paginationResults.paginationInfo,
-		};
 	}, [ patterns, view, fields ] );
 
 	const actions = useMemo(

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -15,7 +15,11 @@ import {
 	BlockPreview,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { DataViews } from '@wordpress/dataviews';
+import {
+	DataViews,
+	sortByTextFields,
+	getPaginationResults,
+} from '@wordpress/dataviews';
 import {
 	Icon,
 	header,
@@ -240,31 +244,21 @@ export default function DataviewsPatterns() {
 		let filteredData = [ ...patterns ];
 		// Handle sorting.
 		if ( view.sort ) {
-			const stringSortingFields = [ 'title' ];
-			const fieldId = view.sort.field;
-			if ( stringSortingFields.includes( fieldId ) ) {
-				const fieldToSort = fields.find( ( field ) => {
-					return field.id === fieldId;
-				} );
-				filteredData.sort( ( a, b ) => {
-					const valueA = fieldToSort.getValue( { item: a } ) ?? '';
-					const valueB = fieldToSort.getValue( { item: b } ) ?? '';
-					return view.sort.direction === 'asc'
-						? valueA.localeCompare( valueB )
-						: valueB.localeCompare( valueA );
-				} );
-			}
+			filteredData = sortByTextFields( {
+				items: filteredData,
+				view,
+				fields,
+				textFields: [ 'title', 'author' ],
+			} );
 		}
 		// Handle pagination.
-		const start = ( view.page - 1 ) * view.perPage;
-		const totalItems = filteredData?.length || 0;
-		filteredData = filteredData?.slice( start, start + view.perPage );
+		const paginationResults = getPaginationResults( {
+			items: filteredData,
+			view,
+		} );
 		return {
-			data: filteredData,
-			paginationInfo: {
-				totalItems,
-				totalPages: Math.ceil( totalItems / view.perPage ),
-			},
+			data: paginationResults.items,
+			paginationInfo: paginationResults.paginationInfo,
 		};
 	}, [ patterns, view, fields ] );
 

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -10,7 +10,13 @@ import {
 } from '@wordpress/components';
 import { getQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo, useCallback, useId } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	useCallback,
+	useId,
+	useEffect,
+} from '@wordpress/element';
 import {
 	BlockPreview,
 	privateApis as blockEditorPrivateApis,
@@ -28,6 +34,7 @@ import {
 	symbol,
 	lockSmall,
 } from '@wordpress/icons';
+import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -196,6 +203,7 @@ export default function DataviewsPatterns() {
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const isUncategorizedThemePatterns =
 		type === PATTERN_TYPES.theme && categoryId === 'uncategorized';
+	const previousCategoryId = usePrevious( categoryId );
 	const { patterns, isResolving } = usePatterns(
 		type,
 		isUncategorizedThemePatterns ? '' : categoryId,
@@ -233,7 +241,12 @@ export default function DataviewsPatterns() {
 		],
 		[ view.type, categoryId ]
 	);
-
+	// Reset the page number when the category changes.
+	useEffect( () => {
+		if ( previousCategoryId !== categoryId && view.page !== 1 ) {
+			setView( { ...view, page: 1 } );
+		}
+	}, [ categoryId, previousCategoryId, view ] );
 	const { data, paginationInfo } = useMemo( () => {
 		if ( ! patterns ) {
 			return {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -24,7 +24,11 @@ import {
 	BlockPreview,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { DataViews } from '@wordpress/dataviews';
+import {
+	DataViews,
+	sortByTextFields,
+	getPaginationResults,
+} from '@wordpress/dataviews';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -301,35 +305,21 @@ export default function DataviewsTemplates() {
 
 		// Handle sorting.
 		if ( view.sort ) {
-			const stringSortingFields = [ 'title', 'author' ];
-			const fieldId = view.sort.field;
-			if ( stringSortingFields.includes( fieldId ) ) {
-				const fieldToSort = fields.find( ( field ) => {
-					return field.id === fieldId;
-				} );
-				filteredTemplates.sort( ( a, b ) => {
-					const valueA = fieldToSort.getValue( { item: a } ) ?? '';
-					const valueB = fieldToSort.getValue( { item: b } ) ?? '';
-					return view.sort.direction === 'asc'
-						? valueA.localeCompare( valueB )
-						: valueB.localeCompare( valueA );
-				} );
-			}
+			filteredTemplates = sortByTextFields( {
+				items: filteredTemplates,
+				view,
+				fields,
+				textFields: [ 'title', 'author' ],
+			} );
 		}
-
 		// Handle pagination.
-		const start = ( view.page - 1 ) * view.perPage;
-		const totalItems = filteredTemplates?.length || 0;
-		filteredTemplates = filteredTemplates?.slice(
-			start,
-			start + view.perPage
-		);
+		const paginationResults = getPaginationResults( {
+			items: filteredTemplates,
+			view,
+		} );
 		return {
-			shownTemplates: filteredTemplates,
-			paginationInfo: {
-				totalItems,
-				totalPages: Math.ceil( totalItems / view.perPage ),
-			},
+			shownTemplates: paginationResults.items,
+			paginationInfo: paginationResults.paginationInfo,
 		};
 	}, [ allTemplates, view, fields ] );
 

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -309,7 +309,7 @@ export default function DataviewsTemplates() {
 				data: filteredTemplates,
 				view,
 				fields,
-				textFields: [ 'title', 'author' ],
+				textFields: [ 'title' ],
 			} );
 		}
 		// Handle pagination.

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -256,10 +256,10 @@ export default function DataviewsTemplates() {
 		[ authors, view.type ]
 	);
 
-	const { shownTemplates, paginationInfo } = useMemo( () => {
+	const { data, paginationInfo } = useMemo( () => {
 		if ( ! allTemplates ) {
 			return {
-				shownTemplates: EMPTY_ARRAY,
+				data: EMPTY_ARRAY,
 				paginationInfo: { totalItems: 0, totalPages: 0 },
 			};
 		}
@@ -313,14 +313,10 @@ export default function DataviewsTemplates() {
 			} );
 		}
 		// Handle pagination.
-		const paginationResults = getPaginationResults( {
-			items: filteredTemplates,
+		return getPaginationResults( {
+			data: filteredTemplates,
 			view,
 		} );
-		return {
-			shownTemplates: paginationResults.items,
-			paginationInfo: paginationResults.paginationInfo,
-		};
 	}, [ allTemplates, view, fields ] );
 
 	const resetTemplateAction = useResetTemplateAction();
@@ -371,7 +367,7 @@ export default function DataviewsTemplates() {
 					paginationInfo={ paginationInfo }
 					fields={ fields }
 					actions={ actions }
-					data={ shownTemplates }
+					data={ data }
 					isLoading={ isLoadingData }
 					view={ view }
 					onChangeView={ onChangeView }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -306,7 +306,7 @@ export default function DataviewsTemplates() {
 		// Handle sorting.
 		if ( view.sort ) {
 			filteredTemplates = sortByTextFields( {
-				items: filteredTemplates,
+				data: filteredTemplates,
 				view,
 				fields,
 				textFields: [ 'title', 'author' ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/57333

When data handling is done client side there is some code that can be abstracted and reused. In this PR I introduce two of them:
1. Get the pagination info and the paginated results based on the current view
2. Sort text items.






## Testing Instructions
1. Enable the admin views experiment
4. Sorting and pagination(both pagination info like the number of pages etc.. and the paginated results) should work as before.
