### PR TITLE
List view: add drag cursor to draggable list items

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -63,7 +63,7 @@ function ListViewBlock( {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ settingsAnchorRect, setSettingsAnchorRect ] = useState();
 
-	const { isLocked, canEdit } = useBlockLock( clientId );
+	const { isLocked, canEdit, canMove } = useBlockLock( clientId );
 
 	const isFirstSelectedBlock =
 		isSelected && selectedClientIds[ 0 ] === clientId;
@@ -269,6 +269,7 @@ function ListViewBlock( {
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
 		'is-synced': blockInformation?.isSynced,
+		'is-draggable': canMove,
 	} );
 
 	// Only include all selected blocks if the currently clicked on block

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -15,8 +15,8 @@
 	// Use position relative for row animation.
 	position: relative;
 
-	&.is-draggable:hover .block-editor-list-view-block__contents-cell,
-	&.is-draggable:hover .block-editor-list-view-block-contents {
+	&.is-draggable,
+	&.is-draggable .block-editor-list-view-block-contents {
 		cursor: grab;
 	}
 
@@ -383,6 +383,7 @@
 	height: $icon-size;
 	margin-left: $grid-unit-05;
 	width: $icon-size;
+	cursor: pointer;
 }
 
 // First level of indentation is aria-level 2, max indent is 8.

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -15,8 +15,8 @@
 	// Use position relative for row animation.
 	position: relative;
 
-	&.is-draggable:hover,
-	&.is-draggable:hover .block-editor-list-view-block-contents * {
+	&.is-draggable:hover .block-editor-list-view-block__contents-cell,
+	&.is-draggable:hover .block-editor-list-view-block-contents {
 		cursor: grab;
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -15,6 +15,11 @@
 	// Use position relative for row animation.
 	position: relative;
 
+	&.is-draggable:hover,
+	&.is-draggable:hover .block-editor-list-view-block-contents * {
+		cursor: grab;
+	}
+
 	.block-editor-list-view-block-select-button {
 		// When a row is expanded, retain the dark color.
 		&[aria-expanded="true"] {


### PR DESCRIPTION
Perhaps resolves https://github.com/WordPress/gutenberg/issues/33686

## What?
When hovering over a list item that can be moved, change the cursor from `pointer` to `grab`.

Hovering over the list item's ellipsis menu will continue to show the `pointer` cursor.

## Why?
The intention is to make it a little more obvious to mouse users that the list item is draggable.

## How?
Classnames + CSS

## Testing Instructions

### List view (post and site editor)

1. Open the editor - site or post - and add a bunch of blocks
2. Open the list view and hover over list items. Check that the grab cursor appears, but not when you hover over the item's ellipsis icon
3. Lock a list item and disable movement
4. Check that the cursor for that list item is still a pointer
5. Points 3-4 should also apply to children of locked items

https://github.com/WordPress/gutenberg/assets/6458278/befcee08-d142-4fe2-95cc-03419cf0f9f0


### Navigation
1. In the site editor, navigate to the Navigation list view and select (or create) a navigation with a few list items
2. Check that the list items have the drag cursor
3. Edit the Navigation list in the editor, select the block
4. From the block settings menu on the right hand side, check that the list items have the drag cursor


Check in other browsers, e.g., Firefox, Safari, Edge


https://github.com/WordPress/gutenberg/assets/6458278/70a8da6c-4511-477b-804d-b416fb4daca6



https://github.com/WordPress/gutenberg/assets/6458278/d3f5a883-f644-4cfb-852c-6df07fe1d310




