### PR TITLE
Background image: Add has-background classname when background image is applied

### DIFF
--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -96,6 +96,7 @@ function gutenberg_render_background_support( $block_content, $block ) {
 
 			$updated_style .= $styles['css'];
 			$tags->set_attribute( 'style', $updated_style );
+			$tags->add_class( 'has-background' );
 		}
 
 		return $tags->get_updated_html();

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -145,9 +145,7 @@ function resetBackgroundSize( style = {}, setAttributes ) {
  * @return {string} CSS class name.
  */
 export function getBackgroundImageClasses( style ) {
-	return classnames( {
-		'has-background': hasBackgroundImageValue( style ),
-	} );
+	return hasBackgroundImageValue( style ) ? 'has-background' : '';
 }
 
 function InspectorImagePreview( { label, filename, url: imgUrl } ) {

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -137,6 +137,19 @@ function resetBackgroundSize( style = {}, setAttributes ) {
 	} );
 }
 
+/**
+ * Generates a CSS class name if an background image is set.
+ *
+ * @param {Object} style A block's style attribute.
+ *
+ * @return {string} CSS class name.
+ */
+export function getBackgroundImageClasses( style ) {
+	return classnames( {
+		'has-background': hasBackgroundImageValue( style ),
+	} );
+}
+
 function InspectorImagePreview( { label, filename, url: imgUrl } ) {
 	const imgLabel = label || getFilename( imgUrl );
 	return (

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -24,6 +24,7 @@ import {
 	transformStyles,
 	shouldSkipSerialization,
 } from './utils';
+import { getBackgroundImageClasses } from './background';
 import { useSettings } from '../components/use-settings';
 import InspectorControls from '../components/inspector-controls';
 import {
@@ -383,12 +384,27 @@ function useBlockProps( {
 		)?.color;
 	}
 
-	return addSaveProps( { style: extraStyles }, name, {
+	const saveProps = addSaveProps( { style: extraStyles }, name, {
 		textColor,
 		backgroundColor,
 		gradient,
 		style,
 	} );
+
+	const hasBackgroundValue =
+		backgroundColor ||
+		style?.color?.background ||
+		gradient ||
+		style?.color?.gradient;
+
+	return {
+		...saveProps,
+		className: classnames(
+			saveProps.className,
+			// Add background image classes in the editor, if not already handled by background color values.
+			! hasBackgroundValue && getBackgroundImageClasses( style )
+		),
+	};
 }
 
 export default {

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
@@ -14,7 +19,11 @@ import { getCSSRules, compileCSS } from '@wordpress/style-engine';
 /**
  * Internal dependencies
  */
-import { BACKGROUND_SUPPORT_KEY, BackgroundImagePanel } from './background';
+import {
+	BACKGROUND_SUPPORT_KEY,
+	BackgroundImagePanel,
+	getBackgroundImageClasses,
+} from './background';
 import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import {
@@ -444,7 +453,12 @@ function useBlockProps( { name, style } ) {
 	useStyleOverride( { css: styles } );
 
 	return addSaveProps(
-		{ className: blockElementsContainerIdentifier },
+		{
+			className: classnames(
+				blockElementsContainerIdentifier,
+				getBackgroundImageClasses( style )
+			),
+		},
 		name,
 		{ style },
 		skipSerializationPathsEdit

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
@@ -19,11 +14,7 @@ import { getCSSRules, compileCSS } from '@wordpress/style-engine';
 /**
  * Internal dependencies
  */
-import {
-	BACKGROUND_SUPPORT_KEY,
-	BackgroundImagePanel,
-	getBackgroundImageClasses,
-} from './background';
+import { BACKGROUND_SUPPORT_KEY, BackgroundImagePanel } from './background';
 import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import {
@@ -453,12 +444,7 @@ function useBlockProps( { name, style } ) {
 	useStyleOverride( { css: styles } );
 
 	return addSaveProps(
-		{
-			className: classnames(
-				blockElementsContainerIdentifier,
-				getBackgroundImageClasses( style )
-			),
-		},
+		{ className: blockElementsContainerIdentifier },
 		name,
 		{ style },
 		skipSerializationPathsEdit

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -134,7 +134,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'source' => 'file',
 					),
 				),
-				'expected_wrapper'    => '<div style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style with contain, position, and repeat is applied' => array(
@@ -151,7 +151,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					'backgroundRepeat' => 'no-repeat',
 					'backgroundSize'   => 'contain',
 				),
-				'expected_wrapper'    => '<div style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:center;background-repeat:no-repeat;background-size:contain;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:center;background-repeat:no-repeat;background-size:contain;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is appended if a style attribute already exists' => array(
@@ -166,8 +166,8 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'source' => 'file',
 					),
 				),
-				'expected_wrapper'    => '<div classname="wp-block-test" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
-				'wrapper'             => '<div classname="wp-block-test" style="color: red">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div class="wp-block-test" style="color: red">Content</div>',
 			),
 			'background image style is appended if a style attribute containing multiple styles already exists' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
@@ -181,8 +181,8 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'source' => 'file',
 					),
 				),
-				'expected_wrapper'    => '<div classname="wp-block-test" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
-				'wrapper'             => '<div classname="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
 			'background image style is not applied if the block does not support background image' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/56261

Add the `has-background` classname when a background image is applied

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A background image is one kind of background, and we already output `has-background` if a background color or gradient is applied to a block. For consistency, let's also output it if a background image is set without any background colors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a utility function in JS to generate the classname, and output in the `color` support's code where the `has-background` classname is handled for the editor. This ensures we only output the classname when it hasn't already been added to the classnames list.
* In the PHP output, inject the `has-background` classname if background image styles are to be output.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. WIth TT4 four theme active, add a Group block and give it a background image and no background color
2. Inspect the element in the editor, and there should be a `has-background` classname.
3. Save and publish, and inspect the element on the site frontend, there should be a `has-background` classname.
4. Add a background color to the Group block. In both the editor and site frontend there should still be only one `has-background` classname on the Group block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Editor

<img width="566" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/28e08909-1087-4c23-9eeb-7482c24c69b2">

### Site frontend

<img width="723" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/6373a795-1cfe-4d43-b008-13969b4d2733">

