### PR TITLE
Allowed Patterns E2E test - move tests that run with a subset of allowed blocks into a group

### DIFF
--- a/test/e2e/specs/editor/various/allowed-patterns.spec.js
+++ b/test/e2e/specs/editor/various/allowed-patterns.spec.js
@@ -9,15 +9,12 @@ test.describe( 'Allowed Patterns', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.deactivatePlugin( 'gutenberg-test-allowed-patterns' ),
-			requestUtils.deactivatePlugin(
-				'gutenberg-test-allowed-patterns-disable-blocks'
-			),
-		] );
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-allowed-patterns'
+		);
 	} );
 
-	test( 'should show all patterns when blocks are not disabled', async ( {
+	test( 'should show all patterns when all blocks are allowed', async ( {
 		admin,
 		page,
 	} ) => {
@@ -47,33 +44,43 @@ test.describe( 'Allowed Patterns', () => {
 		] );
 	} );
 
-	test( 'should show only allowed patterns when blocks are disabled', async ( {
-		admin,
-		page,
-		requestUtils,
-	} ) => {
-		await requestUtils.activatePlugin(
-			'gutenberg-test-allowed-patterns-disable-blocks'
-		);
-		await admin.createNewPost();
-		await page
-			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+	test.describe( 'with a small subset of allowed blocks', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin(
+				'gutenberg-test-allowed-patterns-disable-blocks'
+			);
+		} );
 
-		await page
-			.getByRole( 'region', {
-				name: 'Block Library',
-			} )
-			.getByRole( 'searchbox', {
-				name: 'Search for blocks and patterns',
-			} )
-			.fill( 'Test:' );
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin(
+				'gutenberg-test-allowed-patterns-disable-blocks'
+			);
+		} );
 
-		await expect(
-			page
-				.getByRole( 'listbox', { name: 'Block patterns' } )
-				.getByRole( 'option' )
-		).toHaveText( [ 'Test: Single heading' ] );
+		test( 'should show only allowed patterns', async ( {
+			admin,
+			page,
+		} ) => {
+			await admin.createNewPost();
+			await page
+				.getByRole( 'toolbar', { name: 'Document tools' } )
+				.getByRole( 'button', { name: 'Toggle block inserter' } )
+				.click();
+
+			await page
+				.getByRole( 'region', {
+					name: 'Block Library',
+				} )
+				.getByRole( 'searchbox', {
+					name: 'Search for blocks and patterns',
+				} )
+				.fill( 'Test:' );
+
+			await expect(
+				page
+					.getByRole( 'listbox', { name: 'Block patterns' } )
+					.getByRole( 'option' )
+			).toHaveText( [ 'Test: Single heading' ] );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
There are some regular failures of E2E tests that seem to be happening because the 'gutenberg-test-allowed-patterns-disable-blocks' plugin isn't being deactivated at the end of this test.

See the slack convo: https://wordpress.slack.com/archives/C02QB2JS7/p1704263913300289

## How?
Try moving the subset of tests that run with limited allowed blocks into a group.