### PR TITLE
Ignore HTML Elements in ReduxDevTools

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -64,10 +64,14 @@ const mapValues = ( obj, callback ) =>
 		] )
 	);
 
-// Convert Map objects to plain objects
-const mapToObject = ( key, state ) => {
+// Convert  non serializable types to plain objects
+const devToolsReplacer = ( key, state ) => {
 	if ( state instanceof Map ) {
 		return Object.fromEntries( state );
+	}
+
+	if ( state instanceof window.HTMLElement ) {
+		return null;
 	}
 
 	return state;
@@ -421,7 +425,7 @@ function instantiateReduxStore( key, options, registry, thunkArgs ) {
 				name: key,
 				instanceId: key,
 				serialize: {
-					replacer: mapToObject,
+					replacer: devToolsReplacer,
 				},
 			} )
 		);


### PR DESCRIPTION
If you use ReduxDevTools, you may notice a JS error in the site editor because we're storing a non serializable element in the state.  This PR ignores HTML element stored in redux state from being shown in the dev tools.  There might be better ways to represent these in the dev tools though.