### PR TITLE
NavigatorProvider: Exclude size value from contain CSS rule

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `PaletteEdit`: Don't discard colors with default name and slug ([#54332](https://github.com/WordPress/gutenberg/pull/54332)).
 -   `RadioControl`: Fully encapsulate styles ([#57347](https://github.com/WordPress/gutenberg/pull/57347)).
 -   `GradientPicker`: Use slug while iterating over gradient entries to avoid React "duplicated key" warning ([#57361](https://github.com/WordPress/gutenberg/pull/57361)).
+-   `NavigatorProvider`: Exclude `size` value from `contain` CSS rule ([#57498](https://github.com/WordPress/gutenberg/pull/57498)).
 
 ### Enhancements
 

--- a/packages/components/src/navigator/styles.ts
+++ b/packages/components/src/navigator/styles.ts
@@ -7,10 +7,10 @@ export const navigatorProviderWrapper = css`
 	/* Prevents horizontal overflow while animating screen transitions */
 	overflow-x: hidden;
 	/* Mark this subsection of the DOM as isolated, providing performance benefits
-	 * by limiting calculations of layout, style, paint, size, or any combination
-	 * to a DOM subtree rather than the entire page.
+	 * by limiting calculations of layout, style and paint to a DOM subtree rather
+	 * than the entire page.
 	 */
-	contain: strict;
+	contain: content;
 `;
 
 const fadeInFromRight = keyframes( {


### PR DESCRIPTION
Fixes #57494
Related to #56909

## What?

This PR excludes the `size` value by changing the value of the [`contain` CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) applied to the `NavigatorProvider` component from `strict` (equivalent to `size layout paint style`) to `content` (equivalent to `layout paint style`).

As a result, this PR solves the following three problems as far as I've researched.

### The Preferences modal content does not display at all in the mobile viewport

Reported by #57494. The Preferences modal component uses the `NavigatorProvider` when it's a mobile viewport.

### Global style sidebar layout

- Go to the Site Editor and go to Global Styles > Blocks
- Fixes unintended changes to sidebar width and scrollbar edge position

| trunk | this PR |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/fce8fa55-5490-402a-89b2-7424dfba98d9) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/ddddad74-d4ce-460b-bf68-5533cf145127) |

### Content of one story is not displayed in Storybook

When you access the URL below, nothing should be displayed.

https://wordpress.github.io/gutenberg/?path=/story/components-experimental-navigator--skip-focus

## Why?

`contain: strict` is equivalent to `contain: size layout paint style`. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment#size_containment), if a value contains `size`, it appears to have a size of zero if no size is explicitly specified for that element.

> If you turn on contain: size you need to also specify the size of the element you have applied this to using contain-intrinsic-size (or the equivalent longhand properties). It will end up being zero-sized in most cases, if you don't manually give it a size.

It's not a problem if the element has an explicit height or `flex-glow:1` etc., but if not, problems like those reported by #57494 will occur.

## How?

We can probably fix the problem by leaving it as `contain: strict` and adjusting the CSS that is causing the problem. However, I think we should change from `strict` to `content` to avoid such issues at the component level, to avoid impacting consumers and forcing them to set an explicit height. There may be a performance drop compared to `strict`, but I personally think this is acceptable.

## Testing Instructions

Please confirm that the three issues mentioned at the beginning of the explanation have been resolved.