### PR TITLE
Entities: Add config to read and write transient edits from edited post

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -249,7 +249,7 @@ _Parameters_
 
 _Returns_
 
--   `any`: Entity config
+-   `EntityConfig | undefined`: Entity config
 
 ### getEntityRecord
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -570,7 +570,7 @@ _Parameters_
 
 _Returns_
 
--   `any`: Entity config
+-   `EntityConfig | undefined`: Entity config
 
 ### getEntityRecord
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -9,6 +9,7 @@ import { capitalCase, pascalCase } from 'change-case';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { RichTextData } from '@wordpress/rich-text';
+import { __unstableSerializeAndClean, parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -19,6 +20,13 @@ import { getSyncProvider } from './sync';
 export const DEFAULT_ENTITY_KEY = 'id';
 
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
+const blocksTransientEntity = {
+	read: ( record ) => parse( record.content ),
+	write: ( record ) => ( {
+		...record,
+		content: __unstableSerializeAndClean( record.content ),
+	} ),
+};
 
 export const rootEntitiesConfig = [
 	{
@@ -138,7 +146,9 @@ export const rootEntitiesConfig = [
 		baseURL: '/wp/v2/sidebars',
 		baseURLParams: { context: 'edit' },
 		plural: 'sidebars',
-		transientEdits: { blocks: true },
+		transientEdits: {
+			blocks: blocksTransientEntity,
+		},
 		label: __( 'Widget areas' ),
 	},
 	{
@@ -147,7 +157,7 @@ export const rootEntitiesConfig = [
 		baseURL: '/wp/v2/widgets',
 		baseURLParams: { context: 'edit' },
 		plural: 'widgets',
-		transientEdits: { blocks: true },
+		transientEdits: { blocks: blocksTransientEntity },
 		label: __( 'Widgets' ),
 	},
 	{
@@ -320,7 +330,7 @@ async function loadPostTypeEntities() {
 			name,
 			label: postType.name,
 			transientEdits: {
-				blocks: true,
+				blocks: blocksTransientEntity,
 				selection: true,
 			},
 			mergedEdits: { meta: true },

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -8,7 +8,7 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
+import { __unstableSerializeAndClean } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -153,7 +153,7 @@ export function useEntityProp( kind, name, prop, _id ) {
 export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
-	const { content, editedBlocks, meta } = useSelect(
+	const { editedBlocks, meta } = useSelect(
 		( select ) => {
 			if ( ! id ) {
 				return {};
@@ -162,7 +162,6 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			const editedRecord = getEditedEntityRecord( kind, name, id );
 			return {
 				editedBlocks: editedRecord.blocks,
-				content: editedRecord.content,
 				meta: editedRecord.meta,
 			};
 		},
@@ -180,10 +179,8 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return editedBlocks;
 		}
 
-		return content && typeof content !== 'function'
-			? parse( content )
-			: EMPTY_ARRAY;
-	}, [ id, editedBlocks, content ] );
+		return EMPTY_ARRAY;
+	}, [ id, editedBlocks ] );
 
 	const updateFootnotes = useCallback(
 		( _blocks ) => updateFootnotesFromMeta( _blocks, meta ),

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -10,7 +10,6 @@ import {
 	getFreeformContentHandlerName,
 	getDefaultBlockName,
 	__unstableSerializeAndClean,
-	parse,
 } from '@wordpress/blocks';
 import { isInTheFuture, getDate } from '@wordpress/date';
 import { addQueryArgs, cleanForSlug } from '@wordpress/url';
@@ -1112,18 +1111,9 @@ export const isPublishSidebarEnabled = createRegistrySelector(
  * @param {Object} state
  * @return {Array} Block list.
  */
-export const getEditorBlocks = createSelector(
-	( state ) => {
-		return (
-			getEditedPostAttribute( state, 'blocks' ) ||
-			parse( getEditedPostContent( state ) )
-		);
-	},
-	( state ) => [
-		getEditedPostAttribute( state, 'blocks' ),
-		getEditedPostContent( state ),
-	]
-);
+export function getEditorBlocks( state ) {
+	return getEditedPostAttribute( state, 'blocks' );
+}
 
 /**
  * Returns true if the given panel was programmatically removed, or false otherwise.


### PR DESCRIPTION
## What?

In several places, we want to access the "blocks" properly of a post/page before making any edits. the problem is the "blocks" property is not a regular post/page property, it's just a temporary property that is set when editing the post/page in a block editor. We used to solve this by either:

 - Performing an edit on mount (even without the user making any change)
 - Parsing the blocks from content when needed.

Both are bad solutions:

 - Edits should represent the user edits
 - Parsing blocks can lead to either performance waste (unnecessary multiple parsing) or create inconsistencies: in some places we need access to the exact same instance that is rendered within the block editor.

## How?

This PR is an attempt to a third alternative. Basically we add awareness of how to read and write these transient properties to the core-data framework and ensure the selectors returns the transient properties as prefilled from the start with or without edits.

## Testing Instructions

Mostly relying on e2e tests here and previous experiences.
