### PR TITLE
Custom field connections: better description on Experiments page

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -133,7 +133,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Test Connections', 'gutenberg' ),
+			'label' => __( 'Test connecting block attribute values to a custom field value', 'gutenberg' ),
 			'id'    => 'gutenberg-connections',
 		)
 	);


### PR DESCRIPTION
I noticed that on the Gutenberg Experiments page there is an option to enable the "Connections" experiment, but the setting doesn't explain at all what Connections are. Other settings usually do a better job, explaining the experiment in one sentence:

<img width="522" alt="Screenshot 2024-01-03 at 10 28 32" src="https://github.com/WordPress/gutenberg/assets/664258/7d3ab7d8-7359-4ba7-8a7b-3194fe5e2338">

This PR adds that kind of explanation to Connections, too.

<img width="505" alt="Screenshot 2024-01-03 at 10 30 38" src="https://github.com/WordPress/gutenberg/assets/664258/f0f53ac4-d9ae-4e62-815a-e7337cfd39b7">
