### PR TITLE
Site editor: reinstate iframe CSS for editor canvas container

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -27,6 +27,14 @@
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;
 
+	// Controls height of editor and editor canvas container (style book, global styles revisions previews etc.)
+	iframe {
+		display: block;
+		width: 100%;
+		height: 100%;
+		background: $white;
+	}
+
 	.edit-site-visual-editor__editor-canvas {
 		&.is-focused {
 			outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);


### PR DESCRIPTION

## What?

I made a bug! 

In:

- https://github.com/WordPress/gutenberg/pull/57330

This PR reinstates site editor iframe styles because they influence not only the editor iframe, but the editor canvas container, e.g., style book



## Why?

https://github.com/WordPress/gutenberg/pull/57330 accidentally removed the height and width from any iframe in the site editor, moving the styles to the block editor component. 

Little did I know, the rule was also targeting other iframes. So we see this:

![image](https://github.com/WordPress/gutenberg/assets/6458278/065bfb07-43c0-4abd-b2fd-d936bcaa81d2)


## How?
Reinstating the iframe rules.

Any optimizations can come later. Let's fix it first.

## Testing Instructions
1. Open the site editor, check both the style book and global style revisions. The iframe should be full width

<img width="1471" alt="Screenshot 2024-01-03 at 9 02 56 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/0e59a9b6-0685-493e-844c-38818214e88d">
