### PR TITLE
Editor: Unify list view open preference

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -101,6 +101,7 @@ export default function EditPostPreferencesModal() {
 						) }
 						<PreferencesModalSection title={ __( 'Interface' ) }>
 							<EnableFeature
+								scope="core"
 								featureName="showListViewByDefault"
 								help={ __(
 									'Opens the block list view sidebar by default.'

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -62,7 +62,6 @@ export function initializeEditor(
 		isPublishSidebarEnabled: true,
 		openPanels: [ 'post-status' ],
 		preferredStyleVariations: {},
-		showListViewByDefault: false,
 		themeStyles: true,
 		welcomeGuide: true,
 		welcomeGuideTemplate: true,
@@ -72,6 +71,7 @@ export function initializeEditor(
 		allowRightClickOverrides: true,
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
+		showListViewByDefault: false,
 	} );
 
 	dispatch( blocksStore ).reapplyBlockTypeFilters();
@@ -79,7 +79,7 @@ export function initializeEditor(
 	// Check if the block list view should be open by default.
 	// If `distractionFree` mode is enabled, the block list view should not be open.
 	if (
-		select( editPostStore ).isFeatureActive( 'showListViewByDefault' ) &&
+		select( preferencesStore ).get( 'core', 'showListViewByDefault' ) &&
 		! select( editPostStore ).isFeatureActive( 'distractionFree' )
 	) {
 		dispatch( editorStore ).setIsListViewOpened( true );

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -63,7 +63,7 @@ function EditorCanvasContainer( {
 			).getEditorCanvasContainerView();
 
 			const _showListViewByDefault = select( preferencesStore ).get(
-				'core/edit-site',
+				'core',
 				'showListViewByDefault'
 			);
 

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -54,6 +54,7 @@ export default function EditSitePreferencesModal() {
 			content: (
 				<PreferencesModalSection title={ __( 'Interface' ) }>
 					<EnableFeature
+						scope="core"
 						featureName="showListViewByDefault"
 						help={ __(
 							'Opens the block list view sidebar by default.'

--- a/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/global-styles-sidebar.js
@@ -44,7 +44,7 @@ export default function GlobalStylesSidebar() {
 			'visual' === select( editSiteStore ).getEditorMode();
 		const _isEditCanvasMode = 'edit' === getCanvasMode();
 		const _showListViewByDefault = select( preferencesStore ).get(
-			'core/edit-site',
+			'core',
 			'showListViewByDefault'
 		);
 		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -60,13 +60,13 @@ export function initializeEditor( id, settings ) {
 		welcomeGuideStyles: true,
 		welcomeGuidePage: true,
 		welcomeGuideTemplate: true,
-		showListViewByDefault: false,
 	} );
 
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
 		keepCaretInsideBlock: false,
 		showBlockBreadcrumbs: true,
+		showListViewByDefault: false,
 	} );
 
 	dispatch( interfaceStore ).setDefaultComplementaryArea(

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -24,7 +24,7 @@ export const setCanvasMode =
 			mode === 'edit' &&
 			registry
 				.select( preferencesStore )
-				.get( 'core/edit-site', 'showListViewByDefault' ) &&
+				.get( 'core', 'showListViewByDefault' ) &&
 			! registry
 				.select( preferencesStore )
 				.get( 'core/edit-site', 'distractionFree' )

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
@@ -9,6 +9,7 @@ export default function convertEditorSettings( data ) {
 		'keepCaretInsideBlock',
 		'showBlockBreadcrumbs',
 		'showIconLabels',
+		'showListViewByDefault',
 	];
 
 	settingsToMoveToCore.forEach( ( setting ) => {

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Block Renaming', () => {
 			pageUtils,
 		} ) => {
 			// Turn on block list view by default.
-			await editor.setPreferences( 'core/edit-site', {
+			await editor.setPreferences( 'core', {
 				showListViewByDefault: true,
 			} );
 

--- a/test/e2e/specs/site-editor/list-view.spec.js
+++ b/test/e2e/specs/site-editor/list-view.spec.js
@@ -30,7 +30,7 @@ test.describe( 'Site Editor List View', () => {
 		).toBeHidden();
 
 		// Turn on block list view by default.
-		await editor.setPreferences( 'core/edit-site', {
+		await editor.setPreferences( 'core', {
 			showListViewByDefault: true,
 		} );
 
@@ -41,7 +41,7 @@ test.describe( 'Site Editor List View', () => {
 		).toBeVisible();
 
 		// The preferences cleanup.
-		await editor.setPreferences( 'core/edit-site', {
+		await editor.setPreferences( 'core', {
 			showListViewByDefault: false,
 		} );
 	} );


### PR DESCRIPTION
Related #52632 
Similar to #57468 

## What?

This PR continues the work on the great unification between post and site editors. In this PR we're unifying the "Always open list view" preference. If the user enables it in the post editor, the setting should be used in the site editor as well. 

## Testing instructions

- Update the preference in the post editor (toggle the checkbox in the preferences -> general panel)
- Open the site editor and enter edit mode
- The list view should be open by default.