### PR TITLE
DataViews: use DropdownMenuRadioItem component when possible

### DIFF
--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -120,7 +120,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 													name={ `add-filter-${ filter.field }` }
 													value={ element.value }
 													checked={ isActive }
-													onClick={ () => {
+													onChange={ ( e ) => {
 														onChangeView( {
 															...view,
 															page: 1,
@@ -132,7 +132,9 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 																		activeOperator,
 																	value: isActive
 																		? undefined
-																		: element.value,
+																		: e
+																				.target
+																				.value,
 																},
 															],
 														} );

--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -13,7 +13,6 @@ import { memo } from '@wordpress/element';
  */
 import { unlock } from './lock-unlock';
 import { VIEW_LAYOUTS, LAYOUT_TABLE, SORTING_DIRECTIONS } from './constants';
-import { DropdownMenuRadioItemCustom } from './dropdown-menu-helper';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -213,18 +212,25 @@ function SortMenu( { fields, view, onChangeView } ) {
 									sortedDirection === direction &&
 									field.id === currentSortedField.id;
 
+								const value = `${ field.id }-${ direction }`;
+
 								return (
-									<DropdownMenuRadioItemCustom
-										key={ direction }
-										value={ direction }
-										name={ `view-actions-sorting-${ field.id }` }
+									<DropdownMenuRadioItem
+										key={ value }
+										// All sorting radio items share the same name, so that
+										// selecting a sorting option automatically deselects the
+										// previously selected one, even if it is displayed in
+										// another submenu. The field and direction are passed via
+										// the `value` prop.
+										name="view-actions-sorting"
+										value={ value }
 										checked={ isChecked }
-										onChange={ ( e ) => {
+										onChange={ () => {
 											onChangeView( {
 												...view,
 												sort: {
 													field: field.id,
-													direction: e.target.value,
+													direction,
 												},
 											} );
 										} }
@@ -232,7 +238,7 @@ function SortMenu( { fields, view, onChangeView } ) {
 										<DropdownMenuItemLabel>
 											{ info.label }
 										</DropdownMenuItemLabel>
-									</DropdownMenuRadioItemCustom>
+									</DropdownMenuRadioItem>
 								);
 							}
 						) }

--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -19,6 +19,7 @@ const {
 	DropdownMenuV2: DropdownMenu,
 	DropdownMenuGroupV2: DropdownMenuGroup,
 	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuRadioItemV2: DropdownMenuRadioItem,
 	DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
 	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
 } = unlock( componentsPrivateApis );
@@ -50,7 +51,7 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 		>
 			{ _availableViews.map( ( availableView ) => {
 				return (
-					<DropdownMenuRadioItemCustom
+					<DropdownMenuRadioItem
 						key={ availableView.type }
 						value={ availableView.type }
 						name="view-actions-available-view"
@@ -66,7 +67,7 @@ function ViewTypeMenu( { view, onChangeView, supportedLayouts } ) {
 						<DropdownMenuItemLabel>
 							{ availableView.label }
 						</DropdownMenuItemLabel>
-					</DropdownMenuRadioItemCustom>
+					</DropdownMenuRadioItem>
 				);
 			} ) }
 		</DropdownMenu>
@@ -90,21 +91,23 @@ function PageSizeMenu( { view, onChangeView } ) {
 		>
 			{ PAGE_SIZE_VALUES.map( ( size ) => {
 				return (
-					<DropdownMenuRadioItemCustom
+					<DropdownMenuRadioItem
 						key={ size }
 						value={ size }
 						name="view-actions-page-size"
 						checked={ view.perPage === size }
-						onChange={ ( e ) => {
+						onChange={ () => {
 							onChangeView( {
 								...view,
-								perPage: e.target.value,
+								// `e.target.value` holds the same value as `size` but as a string,
+								// so we use `size` directly to avoid parsing to int.
+								perPage: size,
 								page: 1,
 							} );
 						} }
 					>
 						<DropdownMenuItemLabel>{ size }</DropdownMenuItemLabel>
-					</DropdownMenuRadioItemCustom>
+					</DropdownMenuRadioItem>
 				);
 			} ) }
 		</DropdownMenu>

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -94,18 +94,26 @@ function HeaderMenu( { field, view, onChangeView } ) {
 								const isChecked =
 									isSorted &&
 									view.sort.direction === direction;
+
+								const value = `${ field.id }-${ direction }`;
+
 								return (
-									<DropdownMenuRadioItemCustom
-										key={ direction }
-										name={ `view-table-sort-${ field.id }` }
-										value={ direction }
+									<DropdownMenuRadioItem
+										key={ value }
+										// All sorting radio items share the same name, so that
+										// selecting a sorting option automatically deselects the
+										// previously selected one, even if it is displayed in
+										// another submenu. The field and direction are passed via
+										// the `value` prop.
+										name="view-table-sorting"
+										value={ value }
 										checked={ isChecked }
-										onChange={ ( e ) => {
+										onChange={ () => {
 											onChangeView( {
 												...view,
 												sort: {
 													field: field.id,
-													direction: e.target.value,
+													direction,
 												},
 											} );
 										} }
@@ -113,7 +121,7 @@ function HeaderMenu( { field, view, onChangeView } ) {
 										<DropdownMenuItemLabel>
 											{ info.label }
 										</DropdownMenuItemLabel>
-									</DropdownMenuRadioItemCustom>
+									</DropdownMenuRadioItem>
 								);
 							}
 						) }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -23,6 +23,7 @@ const {
 	DropdownMenuV2: DropdownMenu,
 	DropdownMenuGroupV2: DropdownMenuGroup,
 	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuRadioItemV2: DropdownMenuRadioItem,
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
 } = unlock( componentsPrivateApis );
@@ -220,7 +221,7 @@ function HeaderMenu( { field, view, onChangeView } ) {
 												operator,
 												{ label, key },
 											] ) => (
-												<DropdownMenuRadioItemCustom
+												<DropdownMenuRadioItem
 													key={ key }
 													name={ `view-table-${ filter.field }-conditions` }
 													value={ operator }
@@ -248,7 +249,7 @@ function HeaderMenu( { field, view, onChangeView } ) {
 													<DropdownMenuItemLabel>
 														{ label }
 													</DropdownMenuItemLabel>
-												</DropdownMenuRadioItemCustom>
+												</DropdownMenuRadioItem>
 											)
 										) }
 									</DropdownMenu>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #55625, following [feedback](https://github.com/WordPress/gutenberg/pull/55625#discussion_r1437568495) from @oandregal .

This PR refactors code around radio menu items, using the actual `DropdownMenuRadioItem` where possible instead of the custom implementation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The custom implementation was added to workaround a limitation of the `DropdownMenuRadioItem`, which doesn't allow a radio item to be "unchecked" once it's been checked (see [this comment](https://github.com/WordPress/gutenberg/pull/55625#issuecomment-1864772748) for extra context).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By tweaking the `name` and `value` of the radio groups, we can make sure that the "sorting" radio items update correctly (ie. get deselected).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

To load the Data View UI:

- Make sure you have the "New Admin Views" Gutenberg experiment enabled
- From the WP Admin home page sidebar, click Appearance > Editor 
- In the site editor sidebar, click "Pages" > "Manage all pages" 

For this specific PR:
- Open the "Add filter" dropdown, make sure that adding filters (by both Author and Post status) works as expected, and that it is possible to deselect an option once it's been selected.
- Open the "View actions" dropdown by clicking on the icon in the top right of the screen. Make sure that all submenus work as expected. In particular, make sure that, when selecting a different sorting option, the previously selected option's radio item appears unchecked.
- Change the sorting by clicking on different table column headers. Make sure that, when selecting a different sorting option, the previously selected option's radio item appears unchecked.
- Make sure that selected options in the column header dropdown and in the "View actions" dropdowns are always in sync

