### PR TITLE
Editor: Unify the show block breadcrumbs preference

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -40,7 +40,6 @@ import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as preferencesStore } from '@wordpress/preferences';
-
 import { privateApis as commandsPrivateApis } from '@wordpress/commands';
 import { privateApis as coreCommandsPrivateApis } from '@wordpress/core-commands';
 
@@ -194,9 +193,7 @@ function Layout() {
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isDistractionFree:
 				select( editPostStore ).isFeatureActive( 'distractionFree' ),
-			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
-				'showBlockBreadcrumbs'
-			),
+			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			showMostUsedBlocks:
 				select( editPostStore ).isFeatureActive( 'mostUsedBlocks' ),
 			// translators: Default label for the Document in the Block Breadcrumb.

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -109,6 +109,7 @@ export default function EditPostPreferencesModal() {
 							/>
 							{ showBlockBreadcrumbsOption && (
 								<EnableFeature
+									scope="core"
 									featureName="showBlockBreadcrumbs"
 									help={ __(
 										'Display the block hierarchy trail at the bottom of the editor.'

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -43,7 +43,8 @@ export default function useCommonCommands() {
 		showBlockBreadcrumbs,
 		isDistractionFree,
 	} = useSelect( ( select ) => {
-		const { getEditorMode, isFeatureActive } = select( editPostStore );
+		const { get } = select( preferencesStore );
+		const { getEditorMode } = select( editPostStore );
 		const { isListViewOpened } = select( editorStore );
 		return {
 			activeSidebar: select( interfaceStore ).getActiveComplementaryArea(
@@ -53,11 +54,8 @@ export default function useCommonCommands() {
 			isListViewOpen: isListViewOpened(),
 			isPublishSidebarEnabled:
 				select( editorStore ).isPublishSidebarEnabled(),
-			showBlockBreadcrumbs: isFeatureActive( 'showBlockBreadcrumbs' ),
-			isDistractionFree: select( preferencesStore ).get(
-				editPostStore.name,
-				'distractionFree'
-			),
+			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
+			isDistractionFree: get( editPostStore.name, 'distractionFree' ),
 		};
 	}, [] );
 	const { toggle } = useDispatch( preferencesStore );
@@ -177,7 +175,7 @@ export default function useCommonCommands() {
 			? __( 'Hide block breadcrumbs' )
 			: __( 'Show block breadcrumbs' ),
 		callback: ( { close } ) => {
-			toggle( 'core/edit-post', 'showBlockBreadcrumbs' );
+			toggle( 'core', 'showBlockBreadcrumbs' );
 			close();
 			createInfoNotice(
 				showBlockBreadcrumbs

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -62,7 +62,6 @@ export function initializeEditor(
 		isPublishSidebarEnabled: true,
 		openPanels: [ 'post-status' ],
 		preferredStyleVariations: {},
-		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 		themeStyles: true,
 		welcomeGuide: true,
@@ -71,6 +70,7 @@ export function initializeEditor(
 
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
+		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 	} );
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -110,6 +110,7 @@ export default function Editor( { isLoading } ) {
 		showIconLabels,
 		showBlockBreadcrumbs,
 	} = useSelect( ( select ) => {
+		const { get } = select( preferencesStore );
 		const { getEditedPostContext, getEditorMode, getCanvasMode } = unlock(
 			select( editSiteStore )
 		);
@@ -118,7 +119,6 @@ export default function Editor( { isLoading } ) {
 		const { getEntityRecord } = select( coreDataStore );
 		const { getRenderingMode, isInserterOpened, isListViewOpened } =
 			select( editorStore );
-		const { get } = select( preferencesStore );
 		const _context = getEditedPostContext();
 
 		// The currently selected entity to display.
@@ -141,11 +141,8 @@ export default function Editor( { isLoading } ) {
 			isRightSidebarOpen: getActiveComplementaryArea(
 				editSiteStore.name
 			),
+			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			showIconLabels: get( 'core', 'showIconLabels' ),
-			showBlockBreadcrumbs: get(
-				'core/edit-site',
-				'showBlockBreadcrumbs'
-			),
 		};
 	}, [] );
 

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -61,6 +61,7 @@ export default function EditSitePreferencesModal() {
 						label={ __( 'Always open list view' ) }
 					/>
 					<EnableFeature
+						scope="core"
 						featureName="showBlockBreadcrumbs"
 						help={ __(
 							'Shows block breadcrumbs at the bottom of the editor.'

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -217,6 +217,7 @@ function useEditUICommands() {
 		isListViewOpen,
 		isDistractionFree,
 	} = useSelect( ( select ) => {
+		const { get } = select( preferencesStore );
 		const { getEditorMode } = select( editSiteStore );
 		const { isListViewOpened } = select( editorStore );
 		return {
@@ -225,15 +226,9 @@ function useEditUICommands() {
 			activeSidebar: select( interfaceStore ).getActiveComplementaryArea(
 				editSiteStore.name
 			),
-			showBlockBreadcrumbs: select( preferencesStore ).get(
-				'core/edit-site',
-				'showBlockBreadcrumbs'
-			),
+			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			isListViewOpen: isListViewOpened(),
-			isDistractionFree: select( preferencesStore ).get(
-				editSiteStore.name,
-				'distractionFree'
-			),
+			isDistractionFree: get( editSiteStore.name, 'distractionFree' ),
 		};
 	}, [] );
 	const { openModal } = useDispatch( interfaceStore );
@@ -339,7 +334,7 @@ function useEditUICommands() {
 			? __( 'Hide block breadcrumbs' )
 			: __( 'Show block breadcrumbs' ),
 		callback: ( { close } ) => {
-			toggle( 'core/edit-site', 'showBlockBreadcrumbs' );
+			toggle( 'core', 'showBlockBreadcrumbs' );
 			close();
 			createInfoNotice(
 				showBlockBreadcrumbs

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -61,12 +61,12 @@ export function initializeEditor( id, settings ) {
 		welcomeGuidePage: true,
 		welcomeGuideTemplate: true,
 		showListViewByDefault: false,
-		showBlockBreadcrumbs: true,
 	} );
 
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
 		keepCaretInsideBlock: false,
+		showBlockBreadcrumbs: true,
 	} );
 
 	dispatch( interfaceStore ).setDefaultComplementaryArea(

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
@@ -7,6 +7,7 @@ export default function convertEditorSettings( data ) {
 	const settingsToMoveToCore = [
 		'allowRightClickOverrides',
 		'keepCaretInsideBlock',
+		'showBlockBreadcrumbs',
 		'showIconLabels',
 	];
 


### PR DESCRIPTION
Related #52632 
Similar to #57468 

## What?

This PR continues the work on the great unification between post and site editors. In this PR we're unifying the "Show block breadcrumb" preference. If the user enables it in the post editor, the setting should be used in the site editor as well. 

## Testing instructions

- Update the preference in the post editor (toggle the checkbox in the preferences -> general panel) (or use the command)
- Open the site editor and enter edit mode
- The block breadcrumb should be visible by default.