### PR TITLE
Update 'missing block' e2e tests to use the 'setContent' helper

### DIFF
--- a/test/e2e/specs/editor/blocks/missing.spec.js
+++ b/test/e2e/specs/editor/blocks/missing.spec.js
@@ -9,6 +9,7 @@ test.describe( 'missing block', () => {
 	} );
 
 	test( 'should strip potentially malicious on* attributes', async ( {
+		editor,
 		page,
 	} ) => {
 		let hasAlert = false;
@@ -17,12 +18,9 @@ test.describe( 'missing block', () => {
 			hasAlert = true;
 		} );
 
-		await page.evaluate( () => {
-			const block = window.wp.blocks.parse(
-				`<!-- wp:non-existing-block-here --><img src onerror=alert(1)>`
-			);
-			window.wp.data.dispatch( 'core/block-editor' ).resetBlocks( block );
-		} );
+		await editor.setContent(
+			`<!-- wp:non-existing-block-here --><img src onerror=alert(1)>`
+		);
 
 		// Give the browser time to show the alert.
 		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
@@ -31,6 +29,7 @@ test.describe( 'missing block', () => {
 	} );
 
 	test( 'should strip potentially malicious script tags', async ( {
+		editor,
 		page,
 	} ) => {
 		let hasAlert = false;
@@ -39,12 +38,9 @@ test.describe( 'missing block', () => {
 			hasAlert = true;
 		} );
 
-		await page.evaluate( () => {
-			const block = window.wp.blocks.parse(
-				`<!-- wp:non-existing-block-here --><script>alert("EVIL");</script>`
-			);
-			window.wp.data.dispatch( 'core/block-editor' ).resetBlocks( block );
-		} );
+		await editor.setContent(
+			`<!-- wp:non-existing-block-here --><script>alert("EVIL");</script>`
+		);
 
 		// Give the browser time to show the alert.
 		await page.evaluate( () => new Promise( window.requestIdleCallback ) );


### PR DESCRIPTION
## What?
PR updates 'missing block' e2e tests to use the `editor.setContent` helper for setting initial post content.

## Why?
The tests should use available helper methods when possible. 

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/editor/blocks/missing.spec.js
```
