### PR TITLE
File: Remove 'block-editor' store subscription

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -73,13 +73,13 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		displayPreview,
 		previewHeight,
 	} = attributes;
-	const { media, mediaUpload } = useSelect(
+	const { getSettings } = useSelect( blockEditorStore );
+	const { media } = useSelect(
 		( select ) => ( {
 			media:
 				id === undefined
 					? undefined
 					: select( coreStore ).getMedia( id ),
-			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
 		} ),
 		[ id ]
 	);
@@ -93,7 +93,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		if ( isBlobURL( href ) ) {
 			const file = getBlobByURL( href );
 
-			mediaUpload( {
+			getSettings().mediaUpload( {
 				filesList: [ file ],
 				onFileChange: ( [ newMedia ] ) => onSelectFile( newMedia ),
 				onError: onUploadError,


### PR DESCRIPTION
## What?
This is similar to #57449.

PR removes the `block-editor` store subscription from the File block.

## Why?
It is a micro-optimization as there are usually few usages of this block, unlike text blocks. But it's a good practice to avoid store subscriptions when unnecessary.

## How?
Use a static selector getter for the settings. The setting is only needed when uploading the file from a blob URL.

## Testing Instructions

1. Open a post or page.
2. Confirm you can PDF files by dragging and dropping them on the editor canvas.

### Testing Instructions for Keyboard
Same.
