### PR TITLE
Site Logo: Remove unnecessary  'block-editor' store subscription

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -412,7 +412,6 @@ export default function LogoEdit( {
 		siteIconId,
 		mediaItemData,
 		isRequestingMediaItem,
-		mediaUpload,
 	} = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -444,9 +443,9 @@ export default function LogoEdit( {
 			mediaItemData: mediaItem,
 			isRequestingMediaItem: _isRequestingMediaItem,
 			siteIconId: _siteIconId,
-			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
 		};
 	}, [] );
+	const { getSettings } = useSelect( blockEditorStore );
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
@@ -511,8 +510,8 @@ export default function LogoEdit( {
 	};
 
 	const onFilesDrop = ( filesList ) => {
-		mediaUpload( {
-			allowedTypes: [ 'image' ],
+		getSettings().mediaUpload( {
+			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList,
 			onFileChange( [ image ] ) {
 				if ( isBlobURL( image?.url ) ) {


### PR DESCRIPTION
## What?
This is similar to #57449.

PR removes an unnecessary  'block-editor' store subscription from the `LogoEdit` component.

## Why?
The media `mediaUpload` setting is only used during the `onFilesDrop` event. We can use a static selector getter and grab the setting only when needed. It's a good practice to avoid store subscriptions when unnecessary.

P.S. There's another store subscription in the `SiteLogo` component, but settings are used during the render, so the same optimization cannot be applied.

## Testing Instructions
1. Open a post or page.
2. Insert a Site Logo block.
3. Confirm you can add media by dragging and dropping a file in inspector controls. See #49992.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/b025e58f-c9f8-4a09-ba65-a62ac66b40d5

