### PR TITLE
Fullscreen mode description: use full text instead of abbreviation.

### DIFF
--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -78,7 +78,7 @@ function WritingMenu() {
 				scope="core/edit-post"
 				name="fullscreenMode"
 				label={ __( 'Fullscreen mode' ) }
-				info={ __( 'Show and hide admin UI' ) }
+				info={ __( 'Show and hide the admin user interface' ) }
 				messageActivated={ __( 'Fullscreen mode activated' ) }
 				messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
 				shortcut={ displayShortcut.secondary( 'f' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57516

## What?
<!-- In a few words, what is the PR actually doing? -->
Changes the Fullscreen mode description to use full text instead of the unclear (for users) abbreviation 'UI'.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Abbreviations don't help make the user interface clearer.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changes the text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to Post editor > Options > Fullscreen mode
- Observe the Fullscreen mode description

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before: 

![Screenshot 2024-01-03 at 14 40 37](https://github.com/WordPress/gutenberg/assets/1682452/9261049e-4729-4943-ba53-8247673529ff)

After: 

![Screenshot 2024-01-03 at 14 55 09](https://github.com/WordPress/gutenberg/assets/1682452/28bf065a-95ec-4f28-81f2-c4c59ac73227)

