### PR TITLE
Clean up code editor CSS.

### DIFF
--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -39,10 +39,8 @@
 	margin-right: auto;
 
 	@include break-large() {
-		padding: $grid-unit-20 $grid-unit-30 #{ $grid-unit-60 * 2 } $grid-unit-30;
 		padding: 0 $grid-unit-30 $grid-unit-30 $grid-unit-30;
 	}
-
 }
 
 // Exit code editor toolbar.
@@ -69,9 +67,5 @@
 		margin: 0 auto 0 0;
 		font-size: $default-font-size;
 		color: $gray-900;
-	}
-
-	.components-button svg {
-		order: 1;
 	}
 }

--- a/packages/edit-site/src/components/code-editor/style.scss
+++ b/packages/edit-site/src/components/code-editor/style.scss
@@ -41,10 +41,6 @@
 			font-size: $default-font-size;
 			color: $gray-900;
 		}
-
-		.components-button svg {
-			order: 1;
-		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow-up to https://github.com/WordPress/gutenberg/pull/21643

Part of an effort to remove all the CSS `order` properties from the codebase.

## What?
<!-- In a few words, what is the PR actually doing? -->
Trivial PR to clean-up some leftovers. https://github.com/WordPress/gutenberg/pull/21643 removed the icon shown in the 'Exit code editor' button but there's still a couple CSS rules to swap the position of the removed icon.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Beginning of the year cleaning.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removes unused `order` CSS property set to a no longer used SVG icon.
- Removes a duplicate `padding` declaration.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Switch the post editor and the site editor to 'Code editor'.
- Observe the 'Exit code editor' button at the top right has no changes.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
