### PR TITLE
Fix Link UI displaying out of sync results

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -66,7 +66,6 @@ class URLInput extends Component {
 		this.state = {
 			suggestions: [],
 			showSuggestions: false,
-			isUpdatingSuggestions: false,
 			suggestionsValue: null,
 			selectedSuggestion: null,
 			suggestionsListboxId: '',
@@ -102,11 +101,7 @@ class URLInput extends Component {
 		}
 
 		// Update suggestions when the value changes.
-		if (
-			prevProps.value !== value &&
-			! this.props.disableSuggestions &&
-			! this.state.isUpdatingSuggestions
-		) {
+		if ( prevProps.value !== value && ! this.props.disableSuggestions ) {
 			if ( value?.length ) {
 				// If the new value is not empty we need to update with suggestions for it.
 				this.updateSuggestions( value );
@@ -183,7 +178,6 @@ class URLInput extends Component {
 		}
 
 		this.setState( {
-			isUpdatingSuggestions: true,
 			selectedSuggestion: null,
 			loading: true,
 		} );
@@ -203,7 +197,6 @@ class URLInput extends Component {
 
 				this.setState( {
 					suggestions,
-					isUpdatingSuggestions: false,
 					suggestionsValue: value,
 					loading: false,
 					showSuggestions: !! suggestions.length,
@@ -235,7 +228,6 @@ class URLInput extends Component {
 				}
 
 				this.setState( {
-					isUpdatingSuggestions: false,
 					loading: false,
 				} );
 			} );
@@ -258,7 +250,6 @@ class URLInput extends Component {
 		if (
 			value &&
 			! disableSuggestions &&
-			! this.state.isUpdatingSuggestions &&
 			! ( suggestions && suggestions.length )
 		) {
 			// Ensure the suggestions are updated with the current input value.

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -230,6 +230,13 @@ class URLInput extends Component {
 				this.setState( {
 					loading: false,
 				} );
+			} )
+			.finally( () => {
+				// If this is the current promise then reset the reference
+				// to allow for checking if a new request is made.
+				if ( this.suggestionsRequest === request ) {
+					this.suggestionsRequest = null;
+				}
 			} );
 
 		// Note that this assignment is handled *before* the async search request
@@ -247,10 +254,12 @@ class URLInput extends Component {
 
 		// When opening the link editor, if there's a value present, we want to load the suggestions pane with the results for this input search value
 		// Don't re-run the suggestions on focus if there are already suggestions present (prevents searching again when tabbing between the input and buttons)
+		// or there is already a request in progress.
 		if (
 			value &&
 			! disableSuggestions &&
-			! ( suggestions && suggestions.length )
+			! ( suggestions && suggestions.length ) &&
+			this.suggestionsRequest === null
 		) {
 			// Ensure the suggestions are updated with the current input value.
 			this.updateSuggestions( value );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensures requests to fetch link suggestions are kept in sync with the current value in the `<input>` used in the `<URLInput>` component. Avoids value becoming out of sync with displayed results.

This fixes a problem evidenced in the Link UI `<LinkControl>` component which _may_ have been introduced in https://github.com/WordPress/gutenberg/pull/45806.

Fixes https://github.com/WordPress/gutenberg/issues/56695

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently [it is possible](https://github.com/WordPress/gutenberg/issues/56695#issuecomment-1875540051) to have a value in the Link Control which is out of sync with the results being displayed. This is most obvious when the "Create page" option is displayed as it's possible to have the text of the Page being offered for creation to be out of sync with the value shown in the `<input>`.

We always want the search results to be reflective of whatever is typed into the input by the user, even if that means more  fetch requests are dispatched overall.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes unwanted state which has historically been used to "block" additional fetch requests being dispatched when the input value changes _if_ a current request is in progress. 

After some investigation I realised that this state is not serving the component well. Currently if you type in the input (the initial search) and a fetch request gets dispatched (note: you have to wait for the `200ms` debounce) and then you immediately type something else there is only a request for the initial search query. The updated link value never triggers a fetch for search results because it is blocked by the state conditional.

By removing this state, we allow the most _recent_ value of the input to trigger a fetch request for search results. It is then this request which fulfills the search suggestons in the UI. 

Race conditions are already handled as the code of `updateSuggestions` will abort in the `.then/catch` if the current request is not the same as the request stored in the instance property. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


First on `trunk` ensure you can [replicate the Issue](https://github.com/WordPress/gutenberg/issues/56695#issuecomment-1875540051).

Then verify the fix in **this PR**:

- New Post
- Add some text
- Using dev tools set your network speed to Slow
- Select text and press Cmd + K to trigger the Link UI.
- The next bit requires good typing speed and timing so prepare in advance!
- Type `wordpress is` then _as soon as_ you see the **loading spinner** display, type ` so cool` (note the specific text doesn't matter - you just need to ensure you type more text when the loading spinner first shows).
- You should see the UI "resolve" and display a search result for `Create: wordpress is so cool`.
- Now try testing searching for pages and make sure you can still find them and things work as per `trunk`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/51aba733-8b20-4118-bc1a-d2aa4487965e

