### PR TITLE
Remove unused parameters from useOnBlockDrop

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -133,7 +133,6 @@ export function onBlockDrop(
  * A function that returns an event handler function for block-related file drop events.
  *
  * @param {string}   targetRootClientId    The root client id where the block(s) will be inserted.
- * @param {number}   targetBlockIndex      The index where the block(s) will be inserted.
  * @param {Function} getSettings           A function that gets the block editor settings.
  * @param {Function} updateBlockAttributes A function that updates a block's attributes.
  * @param {Function} canInsertBlockType    A function that returns checks whether a block type can be inserted.
@@ -143,7 +142,6 @@ export function onBlockDrop(
  */
 export function onFilesDrop(
 	targetRootClientId,
-	targetBlockIndex,
 	getSettings,
 	updateBlockAttributes,
 	canInsertBlockType,
@@ -175,17 +173,11 @@ export function onFilesDrop(
 /**
  * A function that returns an event handler function for block-related HTML drop events.
  *
- * @param {string}   targetRootClientId    The root client id where the block(s) will be inserted.
- * @param {number}   targetBlockIndex      The index where the block(s) will be inserted.
  * @param {Function} insertOrReplaceBlocks A function that inserts or replaces blocks.
  *
  * @return {Function} The event handler for a block-related HTML drop event.
  */
-export function onHTMLDrop(
-	targetRootClientId,
-	targetBlockIndex,
-	insertOrReplaceBlocks
-) {
+export function onHTMLDrop( insertOrReplaceBlocks ) {
 	return ( HTML ) => {
 		const blocks = pasteHandler( { HTML, mode: 'BLOCKS' } );
 
@@ -309,17 +301,12 @@ export default function useOnBlockDrop(
 	);
 	const _onFilesDrop = onFilesDrop(
 		targetRootClientId,
-		targetBlockIndex,
 		getSettings,
 		updateBlockAttributes,
 		canInsertBlockType,
 		insertOrReplaceBlocks
 	);
-	const _onHTMLDrop = onHTMLDrop(
-		targetRootClientId,
-		targetBlockIndex,
-		insertOrReplaceBlocks
-	);
+	const _onHTMLDrop = onHTMLDrop( insertOrReplaceBlocks );
 
 	return ( event ) => {
 		const files = getFilesFromDataTransfer( event.dataTransfer );

--- a/packages/block-editor/src/components/use-on-block-drop/test/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/test/index.js
@@ -306,12 +306,10 @@ describe( 'onFilesDrop', () => {
 		const canInsertBlockType = noop;
 		const insertOrReplaceBlocks = jest.fn();
 		const targetRootClientId = '1';
-		const targetBlockIndex = 0;
 		const getSettings = jest.fn( () => ( {} ) );
 
 		const onFileDropHandler = onFilesDrop(
 			targetRootClientId,
-			targetBlockIndex,
 			getSettings,
 			updateBlockAttributes,
 			canInsertBlockType,
@@ -331,14 +329,12 @@ describe( 'onFilesDrop', () => {
 		const insertOrReplaceBlocks = jest.fn();
 		const canInsertBlockType = noop;
 		const targetRootClientId = '1';
-		const targetBlockIndex = 0;
 		const getSettings = jest.fn( () => ( {
 			mediaUpload: true,
 		} ) );
 
 		const onFileDropHandler = onFilesDrop(
 			targetRootClientId,
-			targetBlockIndex,
 			getSettings,
 			updateBlockAttributes,
 			canInsertBlockType,
@@ -361,14 +357,12 @@ describe( 'onFilesDrop', () => {
 		const canInsertBlockType = noop;
 		const insertOrReplaceBlocks = jest.fn();
 		const targetRootClientId = '1';
-		const targetBlockIndex = 0;
 		const getSettings = jest.fn( () => ( {
 			mediaUpload: true,
 		} ) );
 
 		const onFileDropHandler = onFilesDrop(
 			targetRootClientId,
-			targetBlockIndex,
 			getSettings,
 			updateBlockAttributes,
 			canInsertBlockType,
@@ -389,15 +383,9 @@ describe( 'onFilesDrop', () => {
 describe( 'onHTMLDrop', () => {
 	it( 'does nothing if the HTML cannot be converted into blocks', () => {
 		pasteHandler.mockImplementation( () => [] );
-		const targetRootClientId = '1';
-		const targetBlockIndex = 0;
 		const insertOrReplaceBlocks = jest.fn();
 
-		const eventHandler = onHTMLDrop(
-			targetRootClientId,
-			targetBlockIndex,
-			insertOrReplaceBlocks
-		);
+		const eventHandler = onHTMLDrop( insertOrReplaceBlocks );
 		eventHandler();
 
 		expect( insertOrReplaceBlocks ).not.toHaveBeenCalled();
@@ -406,15 +394,9 @@ describe( 'onHTMLDrop', () => {
 	it( 'inserts blocks if the HTML can be converted into blocks', () => {
 		const blocks = [ 'blocks' ];
 		pasteHandler.mockImplementation( () => blocks );
-		const targetRootClientId = '1';
-		const targetBlockIndex = 0;
 		const insertOrReplaceBlocks = jest.fn();
 
-		const eventHandler = onHTMLDrop(
-			targetRootClientId,
-			targetBlockIndex,
-			insertOrReplaceBlocks
-		);
+		const eventHandler = onHTMLDrop( insertOrReplaceBlocks );
 		eventHandler();
 
 		expect( insertOrReplaceBlocks ).toHaveBeenCalledWith( blocks );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I found unused parameters in the function (`onFilesDrop`, `onHTMLDrop`) used inside the `useOnBlockDrop` hook, so I removed it.

## Testing Instructions

When dropping HTML or files, it should still work correctly.

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/54422211/e0eb5416-4408-4933-896b-f982151dfced


