### PR TITLE
Editor: Unify the top toolbar preference

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/set-is-fixed-toolbar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/set-is-fixed-toolbar.ts
@@ -15,6 +15,6 @@ export async function setIsFixedToolbar( this: Editor, isFixed: boolean ) {
 	await this.page.evaluate( ( _isFixed ) => {
 		window.wp.data
 			.dispatch( 'core/preferences' )
-			.set( 'core/edit-post', 'fixedToolbar', _isFixed );
+			.set( 'core', 'fixedToolbar', _isFixed );
 	}, isFixed );
 }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -82,7 +82,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				select( editorStore ).getRenderingMode() === 'template-only',
 			isPublishSidebarOpened:
 				select( editPostStore ).isPublishSidebarOpened(),
-			hasFixedToolbar: getPreference( 'core/edit-post', 'fixedToolbar' ),
+			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
 		};
 	}, [] );

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -27,7 +27,7 @@ function WritingMenu() {
 
 	const toggleDistractionFree = () => {
 		registry.batch( () => {
-			setPreference( 'core/edit-post', 'fixedToolbar', true );
+			setPreference( 'core', 'fixedToolbar', true );
 			setIsInserterOpened( false );
 			setIsListViewOpened( false );
 			closeGeneralSidebar();
@@ -46,7 +46,7 @@ function WritingMenu() {
 	return (
 		<MenuGroup label={ _x( 'View', 'noun' ) }>
 			<PreferenceToggleMenuItem
-				scope="core/edit-post"
+				scope="core"
 				name="fixedToolbar"
 				onToggle={ turnOffDistractionFree }
 				label={ __( 'Top toolbar' ) }

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -70,7 +70,7 @@ export default function EditPostPreferencesModal() {
 	const { set: setPreference } = useDispatch( preferencesStore );
 
 	const toggleDistractionFree = () => {
-		setPreference( 'core/edit-post', 'fixedToolbar', true );
+		setPreference( 'core', 'fixedToolbar', true );
 		setIsInserterOpened( false );
 		setIsListViewOpened( false );
 		closeGeneralSidebar();
@@ -186,6 +186,7 @@ export default function EditPostPreferencesModal() {
 						) }
 					>
 						<EnableFeature
+							scope="core"
 							featureName="fixedToolbar"
 							onToggle={ turnOffDistractionFree }
 							help={ __(

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -14,7 +14,6 @@ import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { CommandMenu } from '@wordpress/commands';
-import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -34,14 +33,12 @@ function Editor( {
 	initialEdits,
 	...props
 } ) {
-	const isLargeViewport = useViewportMatch( 'medium' );
 	const { currentPost, getPostLinkProps, goBack } = usePostHistory(
 		initialPostId,
 		initialPostType
 	);
 
 	const {
-		hasFixedToolbar,
 		isDistractionFree,
 		hasInlineToolbar,
 		post,
@@ -88,8 +85,6 @@ function Editor( {
 				getPostType( currentPost.postType )?.viewable ?? false;
 			const canEditTemplate = canUser( 'create', 'templates' );
 			return {
-				hasFixedToolbar:
-					isFeatureActive( 'fixedToolbar' ) || ! isLargeViewport,
 				isDistractionFree: isFeatureActive( 'distractionFree' ),
 				hasInlineToolbar: isFeatureActive( 'inlineToolbar' ),
 				preferredStyleVariations: select( preferencesStore ).get(
@@ -105,7 +100,7 @@ function Editor( {
 				post: postObject,
 			};
 		},
-		[ currentPost.postType, currentPost.postId, isLargeViewport ]
+		[ currentPost.postType, currentPost.postId ]
 	);
 
 	const { updatePreferredStyleVariations } = useDispatch( editPostStore );
@@ -119,7 +114,6 @@ function Editor( {
 				value: preferredStyleVariations,
 				onChange: updatePreferredStyleVariations,
 			},
-			hasFixedToolbar,
 			isDistractionFree,
 			hasInlineToolbar,
 
@@ -146,7 +140,6 @@ function Editor( {
 		return result;
 	}, [
 		settings,
-		hasFixedToolbar,
 		hasInlineToolbar,
 		isDistractionFree,
 		hiddenBlockTypes,

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -47,16 +47,10 @@ class Editor extends Component {
 		this.setTitleRef = this.setTitleRef.bind( this );
 	}
 
-	getEditorSettings(
-		settings,
-		hasFixedToolbar,
-		hiddenBlockTypes,
-		blockTypes
-	) {
+	getEditorSettings( settings, hiddenBlockTypes, blockTypes ) {
 		settings = {
 			...settings,
 			isRTL: I18nManager.isRTL,
-			hasFixedToolbar,
 		};
 
 		// Omit hidden block types if exists and non-empty.
@@ -132,7 +126,6 @@ class Editor extends Component {
 	render() {
 		const {
 			settings,
-			hasFixedToolbar,
 			initialEdits,
 			hiddenBlockTypes,
 			blockTypes,
@@ -146,7 +139,6 @@ class Editor extends Component {
 
 		const editorSettings = this.getEditorSettings(
 			settings,
-			hasFixedToolbar,
 			hiddenBlockTypes,
 			blockTypes
 		);
@@ -188,12 +180,10 @@ class Editor extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isFeatureActive, getEditorMode, getHiddenBlockTypes } =
-			select( editPostStore );
+		const { getEditorMode, getHiddenBlockTypes } = select( editPostStore );
 		const { getBlockTypes } = select( blocksStore );
 
 		return {
-			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
 			mode: getEditorMode(),
 			hiddenBlockTypes: getHiddenBlockTypes(),
 			blockTypes: getBlockTypes(),

--- a/packages/edit-post/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-post/src/hooks/commands/use-common-commands.js
@@ -134,7 +134,7 @@ export default function useCommonCommands() {
 		name: 'core/toggle-top-toolbar',
 		label: __( 'Toggle top toolbar' ),
 		callback: ( { close } ) => {
-			toggle( 'core/edit-post', 'fixedToolbar' );
+			toggle( 'core', 'fixedToolbar' );
 			if ( isDistractionFree ) {
 				toggleDistractionFree();
 			}

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -55,7 +55,6 @@ export function initializeEditor(
 
 	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
 		editorMode: 'visual',
-		fixedToolbar: false,
 		fullscreenMode: true,
 		hiddenBlockTypes: [],
 		inactivePanels: [],
@@ -69,6 +68,7 @@ export function initializeEditor(
 
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
+		fixedToolbar: false,
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		showListViewByDefault: false,

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -23,7 +23,6 @@ import Editor from './editor';
 export function initializeEditor( id, postType, postId ) {
 	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
 		editorMode: 'visual',
-		fixedToolbar: false,
 		fullscreenMode: true,
 		hiddenBlockTypes: [],
 		inactivePanels: [],
@@ -31,6 +30,10 @@ export function initializeEditor( id, postType, postId ) {
 		openPanels: [ 'post-status' ],
 		preferredStyleVariations: {},
 		welcomeGuide: true,
+	} );
+
+	dispatch( preferencesStore ).setDefaults( 'core', {
+		fixedToolbar: false,
 	} );
 
 	return <Editor postId={ postId } postType={ postType } />;

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -585,7 +585,7 @@ export const toggleDistractionFree =
 			registry.batch( () => {
 				registry
 					.dispatch( preferencesStore )
-					.set( 'core/edit-post', 'fixedToolbar', true );
+					.set( 'core', 'fixedToolbar', true );
 				registry.dispatch( editorStore ).setIsInserterOpened( false );
 				registry.dispatch( editorStore ).setIsListViewOpened( false );
 				dispatch.closeGeneralSidebar();

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -259,7 +259,7 @@ describe( 'actions', () => {
 			// Enable everything that shouldn't be enabled in distraction free mode.
 			registry
 				.dispatch( preferencesStore )
-				.set( 'core/edit-post', 'fixedToolbar', true );
+				.set( 'core', 'fixedToolbar', true );
 			registry.dispatch( editorStore ).setIsListViewOpened( true );
 			registry
 				.dispatch( editPostStore )
@@ -269,7 +269,7 @@ describe( 'actions', () => {
 			expect(
 				registry
 					.select( preferencesStore )
-					.get( 'core/edit-post', 'fixedToolbar' )
+					.get( 'core', 'fixedToolbar' )
 			).toBe( true );
 			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
 				false

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -95,7 +95,6 @@ export function useSpecificEditorSettings() {
 	const {
 		templateSlug,
 		isDistractionFree,
-		hasFixedToolbar,
 		canvasMode,
 		settings,
 		postWithTemplate,
@@ -124,9 +123,6 @@ export function useSpecificEditorSettings() {
 					'core/edit-site',
 					'distractionFree'
 				),
-				hasFixedToolbar:
-					!! getPreference( 'core/edit-site', 'fixedToolbar' ) ||
-					! isLargeViewport,
 				canvasMode: getCanvasMode(),
 				settings: getSettings(),
 				postWithTemplate: _context?.postId,
@@ -144,7 +140,6 @@ export function useSpecificEditorSettings() {
 			supportsTemplateMode: true,
 			focusMode: canvasMode !== 'view',
 			isDistractionFree,
-			hasFixedToolbar,
 			defaultRenderingMode,
 			getPostLinkProps,
 			// I wonder if they should be set in the post editor too
@@ -155,7 +150,6 @@ export function useSpecificEditorSettings() {
 		settings,
 		canvasMode,
 		isDistractionFree,
-		hasFixedToolbar,
 		defaultRenderingMode,
 		getPostLinkProps,
 		archiveLabels.archiveTypeLabel,

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -70,10 +70,7 @@ export default function HeaderEditMode() {
 			editorCanvasView: unlock(
 				select( editSiteStore )
 			).getEditorCanvasContainerView(),
-			hasFixedToolbar: getPreference(
-				editSiteStore.name,
-				'fixedToolbar'
-			),
+			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
 			isDistractionFree: getPreference(
 				editSiteStore.name,
 				'distractionFree'

--- a/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/more-menu/index.js
@@ -46,7 +46,7 @@ export default function MoreMenu( { showIconLabels } ) {
 
 	const toggleDistractionFree = () => {
 		registry.batch( () => {
-			setPreference( 'core/edit-site', 'fixedToolbar', true );
+			setPreference( 'core', 'fixedToolbar', true );
 			setIsInserterOpened( false );
 			setIsListViewOpened( false );
 			closeGeneralSidebar();
@@ -69,7 +69,7 @@ export default function MoreMenu( { showIconLabels } ) {
 					<>
 						<MenuGroup label={ _x( 'View', 'noun' ) }>
 							<PreferenceToggleMenuItem
-								scope="core/edit-site"
+								scope="core"
 								name="fixedToolbar"
 								onToggle={ turnOffDistractionFree }
 								label={ __( 'Top toolbar' ) }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -98,7 +98,7 @@ export default function Layout() {
 				'core/edit-site/next-region'
 			),
 			hasFixedToolbar: select( preferencesStore ).get(
-				'core/edit-site',
+				'core',
 				'fixedToolbar'
 			),
 			isDistractionFree: select( preferencesStore ).get(

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -36,7 +36,7 @@ export default function EditSitePreferencesModal() {
 	const { set: setPreference } = useDispatch( preferencesStore );
 	const toggleDistractionFree = () => {
 		registry.batch( () => {
-			setPreference( 'core/edit-site', 'fixedToolbar', true );
+			setPreference( 'core', 'fixedToolbar', true );
 			setIsInserterOpened( false );
 			setIsListViewOpened( false );
 			closeGeneralSidebar();

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -291,7 +291,7 @@ function useEditUICommands() {
 		name: 'core/toggle-top-toolbar',
 		label: __( 'Toggle top toolbar' ),
 		callback: ( { close } ) => {
-			toggle( 'core/edit-site', 'fixedToolbar' );
+			toggle( 'core', 'fixedToolbar' );
 			if ( isDistractionFree ) {
 				toggleDistractionFree();
 			}

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -53,7 +53,6 @@ export function initializeEditor( id, settings ) {
 	// so that we won't trigger unnecessary re-renders with useEffect.
 	dispatch( preferencesStore ).setDefaults( 'core/edit-site', {
 		editorMode: 'visual',
-		fixedToolbar: false,
 		distractionFree: false,
 		welcomeGuide: true,
 		welcomeGuideStyles: true,
@@ -63,6 +62,7 @@ export function initializeEditor( id, settings ) {
 
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
+		fixedToolbar: false,
 		focusMode: false,
 		keepCaretInsideBlock: false,
 		showBlockBreadcrumbs: true,

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -607,7 +607,7 @@ export const toggleDistractionFree =
 			registry.batch( () => {
 				registry
 					.dispatch( preferencesStore )
-					.set( 'core/edit-site', 'fixedToolbar', true );
+					.set( 'core', 'fixedToolbar', true );
 				registry.dispatch( editorStore ).setIsInserterOpened( false );
 				registry.dispatch( editorStore ).setIsListViewOpened( false );
 				dispatch.closeGeneralSidebar();

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -120,7 +120,7 @@ describe( 'actions', () => {
 			// Enable everything that shouldn't be enabled in distraction free mode.
 			registry
 				.dispatch( preferencesStore )
-				.set( 'core/edit-site', 'fixedToolbar', true );
+				.set( 'core', 'fixedToolbar', true );
 			registry.dispatch( editorStore ).setIsListViewOpened( true );
 			registry
 				.dispatch( editSiteStore )
@@ -130,7 +130,7 @@ describe( 'actions', () => {
 			expect(
 				registry
 					.select( preferencesStore )
-					.get( 'core/edit-site', 'fixedToolbar' )
+					.get( 'core', 'fixedToolbar' )
 			).toBe( true );
 			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
 				false

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -51,7 +51,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'gradients',
 	'generateAnchors',
 	'getPostLinkProps',
-	'hasFixedToolbar',
 	'hasInlineToolbar',
 	'isDistractionFree',
 	'imageDefaultSize',
@@ -90,6 +89,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 	const {
 		allowRightClickOverrides,
 		focusMode,
+		hasFixedToolbar,
 		keepCaretInsideBlock,
 		reusableBlocks,
 		hasUploadPermissions,
@@ -129,6 +129,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 					postId
 				)?._links?.hasOwnProperty( 'wp:action-unfiltered-html' ),
 				focusMode: get( 'core', 'focusMode' ),
+				hasFixedToolbar: get( 'core', 'fixedToolbar' ),
 				keepCaretInsideBlock: get( 'core', 'keepCaretInsideBlock' ),
 				reusableBlocks: isWeb
 					? getEntityRecords( 'postType', 'wp_block', {
@@ -222,6 +223,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			),
 			allowRightClickOverrides,
 			focusMode: focusMode && ! forceDisableFocusMode,
+			hasFixedToolbar,
 			keepCaretInsideBlock,
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,
@@ -258,6 +260,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			allowRightClickOverrides,
 			focusMode,
 			forceDisableFocusMode,
+			hasFixedToolbar,
 			keepCaretInsideBlock,
 			settings,
 			hasUploadPermissions,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -86,6 +87,7 @@ const BLOCK_EDITOR_SETTINGS = [
  * @return {Object} Block Editor Settings.
  */
 function useBlockEditorSettings( settings, postType, postId ) {
+	const isLargeViewport = useViewportMatch( 'medium' );
 	const {
 		allowRightClickOverrides,
 		focusMode,
@@ -129,7 +131,8 @@ function useBlockEditorSettings( settings, postType, postId ) {
 					postId
 				)?._links?.hasOwnProperty( 'wp:action-unfiltered-html' ),
 				focusMode: get( 'core', 'focusMode' ),
-				hasFixedToolbar: get( 'core', 'fixedToolbar' ),
+				hasFixedToolbar:
+					get( 'core', 'fixedToolbar' ) || ! isLargeViewport,
 				keepCaretInsideBlock: get( 'core', 'keepCaretInsideBlock' ),
 				reusableBlocks: isWeb
 					? getEntityRecords( 'postType', 'wp_block', {
@@ -145,7 +148,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				restBlockPatternCategories: getBlockPatternCategories(),
 			};
 		},
-		[ postType, postId ]
+		[ postType, postId, isLargeViewport ]
 	);
 
 	const settingsBlockPatterns =

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
@@ -6,6 +6,7 @@ export default function convertEditorSettings( data ) {
 	let newData = data;
 	const settingsToMoveToCore = [
 		'allowRightClickOverrides',
+		'fixedToolbar',
 		'focusMode',
 		'keepCaretInsideBlock',
 		'showBlockBreadcrumbs',

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/test/index.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/test/index.js
@@ -42,13 +42,15 @@ describe( 'convertPreferencesPackageData', () => {
 		expect( convertPreferencesPackageData( input ) )
 			.toMatchInlineSnapshot( `
 		{
+		  "core": {
+		    "fixedToolbar": true,
+		  },
 		  "core/customize-widgets": {
 		    "fixedToolbar": true,
 		    "welcomeGuide": false,
 		  },
 		  "core/edit-post": {
 		    "editorMode": "visual",
-		    "fixedToolbar": true,
 		    "fullscreenMode": false,
 		    "hiddenBlockTypes": [
 		      "core/audio",
@@ -67,7 +69,6 @@ describe( 'convertPreferencesPackageData', () => {
 		    "welcomeGuide": false,
 		  },
 		  "core/edit-site": {
-		    "fixedToolbar": true,
 		    "isComplementaryAreaVisible": true,
 		    "welcomeGuide": false,
 		    "welcomeGuideStyles": false,

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -1228,10 +1228,10 @@ class LinkUtils {
 		await this.page.evaluate( ( _isFixed ) => {
 			const { select, dispatch } = window.wp.data;
 			const isCurrentlyFixed =
-				select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' );
+				select( 'core/preferences' ).get( 'fixedToolbar' );
 
 			if ( isCurrentlyFixed !== _isFixed ) {
-				dispatch( 'core/edit-post' ).toggleFeature( 'fixedToolbar' );
+				dispatch( 'core/preferences' ).toggle( 'fixedToolbar' );
 			}
 		}, isFixed );
 	}


### PR DESCRIPTION
Related #52632 
Similar to #57468 

## What?

This PR continues the work on the great unification between post and site editors. In this PR we're unifying the "Top toolbar" preference. If the user enables it in the post editor, the setting should be used in the site editor as well. 

## Testing instructions

- Enable the "top toolbar" in the post editor.
- Notice that it stays enabled when you open the site editor.