### PR TITLE
Remove duplicate setting for `getPostLinkProps` and prefer stable naming

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -183,8 +183,7 @@ export default function ReusableBlockEdit( {
 					innerBlocks: blocks,
 					userCanEdit: canEdit,
 					getBlockEditingMode: editingMode,
-					getPostLinkProps:
-						getSettings().__experimentalGetPostLinkProps,
+					getPostLinkProps: getSettings().getPostLinkProps,
 				};
 			},
 			[ patternClientId, ref ]

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -51,6 +51,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'fontSizes',
 	'gradients',
 	'generateAnchors',
+	'getPostLinkProps',
 	'hasFixedToolbar',
 	'hasInlineToolbar',
 	'isDistractionFree',
@@ -75,7 +76,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableIsBlockBasedTheme',
 	'__experimentalArchiveTitleTypeLabel',
 	'__experimentalArchiveTitleNameLabel',
-	'__experimentalGetPostLinkProps',
 ];
 
 /**
@@ -100,7 +100,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		userPatternCategories,
 		restBlockPatterns,
 		restBlockPatternCategories,
-		getPostLinkProps,
 	} = useSelect(
 		( select ) => {
 			const isWeb = Platform.OS === 'web';
@@ -113,8 +112,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				getBlockPatterns,
 				getBlockPatternCategories,
 			} = select( coreStore );
-			const { getPostLinkProps: postLinkProps } =
-				select( editorStore ).getEditorSettings();
 			const { get } = select( preferencesStore );
 
 			const siteSettings = canUser( 'read', 'settings' )
@@ -144,7 +141,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 				userPatternCategories: getUserPatternCategories(),
 				restBlockPatterns: getBlockPatterns(),
 				restBlockPatternCategories: getBlockPatternCategories(),
-				getPostLinkProps: postLinkProps,
 			};
 		},
 		[ postType, postId ]
@@ -253,7 +249,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 					? [ [ 'core/navigation', {}, [] ] ]
 					: settings.template,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
-			__experimentalGetPostLinkProps: getPostLinkProps,
 		} ),
 		[
 			allowRightClickOverrides,
@@ -272,7 +267,6 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			pageForPosts,
 			postType,
 			setIsInserterOpened,
-			getPostLinkProps,
 		]
 	);
 }


### PR DESCRIPTION
## What?
Tidys up some code from #57036.

That PR is passing a setting into the editor provider called `getPostLinkProps`. In the `useBlockEditorSettings` hook, it's being redeclared as `__experimentalGetPostLinkProps`, which doesn't seem necessary.

It's also good to avoid the experimental naming as mentioned in https://github.com/WordPress/gutenberg/pull/57036#discussion_r1440250223.

I'd still like to consider making this private if that's possible, as it seems like the kind of API that won't stick around for the long term.

## Testing Instructions
1. Ensure the Pattern Overrides experiment is switched on.
2. Add a synced pattern in the post editor and click the 'Edit Original' button on the toolbar, confirm it still works
3. Do the same in the site editor and confirm it still works