### PR TITLE
[Pattern Overrides] Fix duplication of inner blocks

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -27,7 +27,7 @@ import {
 	store as blockEditorStore,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { getBlockSupport, parse } from '@wordpress/blocks';
+import { getBlockSupport, parse, cloneBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -206,7 +206,8 @@ export default function ReusableBlockEdit( {
 	// Apply the initial overrides from the pattern block to the inner blocks.
 	useEffect( () => {
 		const initialBlocks =
-			editedRecord.blocks ??
+			// Clone the blocks to generate new client IDs.
+			editedRecord.blocks?.map( ( block ) => cloneBlock( block ) ) ??
 			( editedRecord.content && typeof editedRecord.content !== 'function'
 				? parse( editedRecord.content )
 				: [] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/57502.

The `innerBlocks` are reusing the same `clientId`s, which causes the issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's a UI bug. See https://github.com/WordPress/gutenberg/issues/57502.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Always clone the blocks to generate new `clientId`s.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Enable the "Pattern Overrides" Gutenberg experiment:
<img width="501" alt="Screenshot 2024-01-05 at 11 57 10 am" src="https://github.com/WordPress/gutenberg/assets/60436221/cad025aa-83f5-4be0-98af-5a014f2f5384">


Copied from the original issue:

> 1. Open the post editor, add a couple of paragraphs, and create a pattern from them
> 2. Click the Edit Original button from the toolbar of the pattern block
> 3. Enable Pattern Overrides for the paragraphs within the Advanced section of the block settings
> 4. Use the back button in the editor header area (important that you don't use the browser back button here) to go back to editing the post
> 5. Duplicate the pattern
> 6. Select a paragraph within the pattern
>
> Expected: The block toolbar is normal.
> Actual: The block toolbar is duplicated. List view shows the same inner block selected across both instances of the pattern.
> 
> Note - the issue goes away after reloading, so it's important when testing that you don't reload the browser.

## Screenshots or screencast <!-- if applicable -->
N/A
