### PR TITLE
Add: Feature to modify the comment form title

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -584,7 +584,7 @@ Display a post's comments form. ([Source](https://github.com/WordPress/gutenberg
 -	**Name:** core/post-comments-form
 -	**Category:** theme
 -	**Supports:** color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** textAlign
+-	**Attributes:** commentFormTitle, textAlign
 
 ## Comments Link
 

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -9,6 +9,10 @@
 	"attributes": {
 		"textAlign": {
 			"type": "string"
+		},
+		"commentFormTitle": {
+			"type": "string",
+			"default": "Leave a Reply"
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -11,8 +11,7 @@
 			"type": "string"
 		},
 		"commentFormTitle": {
-			"type": "string",
-			"default": "Leave a Reply"
+			"type": "string"
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -31,7 +31,7 @@ export default function PostCommentsFormEdit( {
 	const instanceId = useInstanceId( PostCommentsFormEdit );
 	const instanceIdDesc = sprintf( 'comments-form-edit-%d-desc', instanceId );
 
-	const commentFormTitleObject = {
+	const commentFormTitleActions = {
 		title: commentFormTitle,
 		setTitle: ( nextTitle ) => {
 			setAttributes( { commentFormTitle: nextTitle } );
@@ -59,7 +59,7 @@ export default function PostCommentsFormEdit( {
 				<CommentsForm
 					postId={ postId }
 					postType={ postType }
-					commentFormTitleObject={ commentFormTitleObject }
+					commentFormTitleActions={ commentFormTitleActions }
 				/>
 				<VisuallyHidden id={ instanceIdDesc }>
 					{ __( 'Comments form disabled in editor.' ) }

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -25,11 +25,18 @@ export default function PostCommentsFormEdit( {
 	context,
 	setAttributes,
 } ) {
-	const { textAlign } = attributes;
+	const { textAlign, commentFormTitle } = attributes;
 	const { postId, postType } = context;
 
 	const instanceId = useInstanceId( PostCommentsFormEdit );
 	const instanceIdDesc = sprintf( 'comments-form-edit-%d-desc', instanceId );
+
+	const commentFormTitleObject = {
+		title: commentFormTitle,
+		setTitle: ( nextTitle ) => {
+			setAttributes( { commentFormTitle: nextTitle } );
+		},
+	};
 
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -49,7 +56,11 @@ export default function PostCommentsFormEdit( {
 				/>
 			</BlockControls>
 			<div { ...blockProps }>
-				<CommentsForm postId={ postId } postType={ postType } />
+				<CommentsForm
+					postId={ postId }
+					postType={ postType }
+					commentFormTitleObject={ commentFormTitleObject }
+				/>
 				<VisuallyHidden id={ instanceIdDesc }>
 					{ __( 'Comments form disabled in editor.' ) }
 				</VisuallyHidden>

--- a/packages/block-library/src/post-comments-form/editor.scss
+++ b/packages/block-library/src/post-comments-form/editor.scss
@@ -1,6 +1,16 @@
 .wp-block-post-comments-form * {
 	pointer-events: none;
 
+	.comment-reply-title {
+		pointer-events: visible;
+		cursor: text;
+
+		&.disabled {
+			pointer-events: none;
+			cursor: default;
+		}
+	}
+
 	&.block-editor-warning * {
 		pointer-events: auto;
 	}

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -18,28 +18,28 @@ import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
-const CommentsFormPlaceholder = ( { commentFormTitleObject } ) => {
+const CommentsFormPlaceholder = ( { commentFormTitleActions } ) => {
 	const instanceId = useInstanceId( CommentsFormPlaceholder );
 
-	let isCommentFormTitleObjectEmpty = false;
+	let isCommentFormTitleActionsEmpty = false;
 
-	if ( ! commentFormTitleObject ) {
-		isCommentFormTitleObjectEmpty = true;
+	if ( ! commentFormTitleActions ) {
+		isCommentFormTitleActionsEmpty = true;
 
-		commentFormTitleObject = {
+		commentFormTitleActions = {
 			title: __( 'Leave a reply' ),
 			setTitle: null,
 		};
 	} else if (
-		null === commentFormTitleObject.title ||
-		undefined === commentFormTitleObject.title
+		null === commentFormTitleActions.title ||
+		undefined === commentFormTitleActions.title
 	) {
-		commentFormTitleObject.title = '';
+		commentFormTitleActions.title = '';
 	} else if (
-		null === commentFormTitleObject.setTitle ||
-		undefined === commentFormTitleObject.setTitle
+		null === commentFormTitleActions.setTitle ||
+		undefined === commentFormTitleActions.setTitle
 	) {
-		commentFormTitleObject.setTitle = null;
+		commentFormTitleActions.setTitle = null;
 	}
 
 	return (
@@ -48,13 +48,13 @@ const CommentsFormPlaceholder = ( { commentFormTitleObject } ) => {
 				tagName="h3"
 				className={
 					'comment-reply-title' +
-					( isCommentFormTitleObjectEmpty ? ' disabled' : '' )
+					( isCommentFormTitleActionsEmpty ? ' disabled' : '' )
 				}
 				placeholder={ __( 'Leave a reply' ) }
-				value={ commentFormTitleObject.title }
+				value={ commentFormTitleActions.title }
 				onChange={ ( text ) => {
-					if ( commentFormTitleObject.setTitle !== null ) {
-						commentFormTitleObject.setTitle( text );
+					if ( commentFormTitleActions.setTitle !== null ) {
+						commentFormTitleActions.setTitle( text );
 					}
 				} }
 			/>
@@ -93,7 +93,7 @@ const CommentsFormPlaceholder = ( { commentFormTitleObject } ) => {
 	);
 };
 
-const CommentsForm = ( { postId, postType, commentFormTitleObject } ) => {
+const CommentsForm = ( { postId, postType, commentFormTitleActions } ) => {
 	const [ commentStatus, setCommentStatus ] = useEntityProp(
 		'postType',
 		postType,
@@ -161,7 +161,7 @@ const CommentsForm = ( { postId, postType, commentFormTitleObject } ) => {
 
 	return (
 		<CommentsFormPlaceholder
-			commentFormTitleObject={ commentFormTitleObject }
+			commentFormTitleActions={ commentFormTitleActions }
 		/>
 	);
 };

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -11,18 +11,53 @@ import {
 	Warning,
 	store as blockEditorStore,
 	__experimentalGetElementClassName,
+	RichText,
 } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
-const CommentsFormPlaceholder = () => {
+const CommentsFormPlaceholder = ( { commentFormTitleObject } ) => {
 	const instanceId = useInstanceId( CommentsFormPlaceholder );
+
+	let isCommentFormTitleObjectEmpty = false;
+
+	if ( ! commentFormTitleObject ) {
+		isCommentFormTitleObjectEmpty = true;
+
+		commentFormTitleObject = {
+			title: __( 'Leave a reply' ),
+			setTitle: null,
+		};
+	} else if (
+		null === commentFormTitleObject.title ||
+		undefined === commentFormTitleObject.title
+	) {
+		commentFormTitleObject.title = '';
+	} else if (
+		null === commentFormTitleObject.setTitle ||
+		undefined === commentFormTitleObject.setTitle
+	) {
+		commentFormTitleObject.setTitle = null;
+	}
 
 	return (
 		<div className="comment-respond">
-			<h3 className="comment-reply-title">{ __( 'Leave a Reply' ) }</h3>
+			<RichText
+				tagName="h3"
+				className={
+					'comment-reply-title' +
+					( isCommentFormTitleObjectEmpty ? ' disabled' : '' )
+				}
+				placeholder={ __( 'Leave a reply' ) }
+				value={ commentFormTitleObject.title }
+				onChange={ ( text ) => {
+					if ( commentFormTitleObject.setTitle !== null ) {
+						commentFormTitleObject.setTitle( text );
+					}
+				} }
+			/>
 			<form
 				noValidate
 				className="comment-form"
@@ -58,7 +93,7 @@ const CommentsFormPlaceholder = () => {
 	);
 };
 
-const CommentsForm = ( { postId, postType } ) => {
+const CommentsForm = ( { postId, postType, commentFormTitleObject } ) => {
 	const [ commentStatus, setCommentStatus ] = useEntityProp(
 		'postType',
 		postType,
@@ -124,7 +159,11 @@ const CommentsForm = ( { postId, postType } ) => {
 		}
 	}
 
-	return <CommentsFormPlaceholder />;
+	return (
+		<CommentsFormPlaceholder
+			commentFormTitleObject={ commentFormTitleObject }
+		/>
+	);
 };
 
 export default CommentsForm;

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -34,7 +34,11 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	add_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );
 
 	ob_start();
-	comment_form( array(), $block->context['postId'] );
+	$args = array();
+	if ( ! empty( $attributes['commentFormTitle'] ) ) {
+		$args['title_reply'] = $attributes['commentFormTitle'];
+	}
+	comment_form( $args, $block->context['postId'] );
 	$form = ob_get_clean();
 
 	remove_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- This PR will add support for the comment form title to be editable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- This is an enhancement PR which will allow to change the comment form title.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR adds block attribute and RichText component from the static H3 tag.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open editor.
2. Insert the comment form block
3. Add the title in a place where it says Leave a reply.
4. Publish the post
5. And preview it on frontend title will reflect on frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
https://github.com/WordPress/gutenberg/assets/56588503/ffc5758e-0521-4747-83e5-113a478eaca4

## Covers
- Fixes https://github.com/WordPress/gutenberg/issues/56715

