### PR TITLE
[RNMobile] Ensure keyboard opens after requesting focus on Android

### DIFF
--- a/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -303,7 +303,9 @@ public class ReactAztecText extends AztecText {
     }
 
     private void hideSoftKeyboard() {
-        mInputMethodManager.hideSoftInputFromWindow(getWindowToken(), 0);
+        if (mInputMethodManager != null) {
+            mInputMethodManager.hideSoftInputFromWindow(getWindowToken(), 0);
+        }
     }
 
     public void setScrollWatcher(ScrollWatcher scrollWatcher) {

--- a/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -1,5 +1,7 @@
 package org.wordpress.mobile.ReactNativeAztec;
 
+import static android.content.ClipData.Item;
+
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -10,17 +12,18 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.Looper;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import android.text.Editable;
 import android.text.InputType;
 import android.text.Spannable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
@@ -41,12 +44,10 @@ import org.wordpress.aztec.plugins.IToolbarButton;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
-import java.util.HashSet;
-import java.util.HashMap;
-
-import static android.content.ClipData.*;
 
 public class ReactAztecText extends AztecText {
 
@@ -64,6 +65,7 @@ public class ReactAztecText extends AztecText {
     private @Nullable TextWatcherDelegator mTextWatcherDelegator;
     private @Nullable ContentSizeWatcher mContentSizeWatcher;
     private @Nullable ScrollWatcher mScrollWatcher;
+    private @Nullable Runnable mKeyboardRunnable;
 
     // FIXME: Used in `incrementAndGetEventCounter` but never read. I guess we can get rid of it, but before this
     // check when it's used in EditText in RN. (maybe tests?)
@@ -264,14 +266,40 @@ public class ReactAztecText extends AztecText {
     }
 
     private void showSoftKeyboard() {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
+        // If the text input is already focused we can show the keyboard.
+        if(hasWindowFocus()) {
+            showSoftKeyboardNow();
+        }
+        // Otherwise, we'll wait until it gets focused.
+        else {
+            getViewTreeObserver().addOnWindowFocusChangeListener(new ViewTreeObserver.OnWindowFocusChangeListener() {
+                @Override
+                public void onWindowFocusChanged(boolean hasFocus) {
+                    if (hasFocus) {
+                        showSoftKeyboardNow();
+                        getViewTreeObserver().removeOnWindowFocusChangeListener(this);
+                    }
+                }
+            });
+        }
+    }
+
+    private void showSoftKeyboardNow() {
+        // Cancel any previously scheduled Runnable
+        if (mKeyboardRunnable != null) {
+            removeCallbacks(mKeyboardRunnable);
+        }
+
+        mKeyboardRunnable = new Runnable() {
             @Override
             public void run() {
                 if (mInputMethodManager != null) {
-                    mInputMethodManager.showSoftInput(ReactAztecText.this, 0);
+                    mInputMethodManager.showSoftInput(ReactAztecText.this, InputMethodManager.SHOW_IMPLICIT);
                 }
             }
-        });
+        };
+
+        post(mKeyboardRunnable);
     }
 
     private void hideSoftKeyboard() {

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
@@ -113,6 +113,8 @@ public class MainActivity extends ReactActivity {
         LinearLayout linearLayout = new LinearLayout(this);
         linearLayout.setOrientation(LinearLayout.VERTICAL);
         linearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        linearLayout.setFocusable(false);
+        linearLayout.setFocusableInTouchMode(true);
 
         // Create a Toolbar instance
         Toolbar toolbar = new Toolbar(this);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensure the keyboard always opens after the focus is requested in an Aztec view.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This issue was spotted while running the E2E tests that will be introduced in https://github.com/WordPress/gutenberg/pull/57460. As far as we tested, seems to be only reproducible in the Android emulator. However, we decided to implement the fix to make the keyboard show logic more reliable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The function `showSoftKeyboard` has been updated with the following conditions:
1. If the Aztec view is already focused, then open the keyboard.
2. Otherwise, listen for focus changes, and when it gets focused open the keyboard.

ℹ️ This approach has been based on [this article](https://developer.squareup.com/blog/showing-the-android-keyboard-reliably/).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Build the demo app and run it on an emulator.
2. Remove all blocks.
3. Select the first and default paragraph.
4. Observe that the keyboard opens.
5. Tap on ➕ button to open the block inserter modal.
6. Dismiss the modal.
7. Observe that the paragraph is focused and the keyboard opens.
8. Add an Image block and select it.
9. Tap on ➕ button to open the block inserter modal.
10. Insert a Paragraph block.
11. Observe that the new paragraph is focused and the keyboard opens.
12. Remove the paragraph by pressing backspace.
13. Observe that the Image block gets selected and the keyboard closes.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A