### PR TITLE
core/group: add allowedBlocks attribute to latest deprecation

### DIFF
--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -53,6 +53,9 @@ const deprecated = [
 				type: [ 'string', 'boolean' ],
 				enum: [ 'all', 'insert', false ],
 			},
+			allowedBlocks: {
+				type: 'array',
+			},
 		},
 		supports: {
 			__experimentalOnEnter: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix allowedBlocks attribute of the core/group block

## Why?
When adding a block to a post where the template includes a core/group block with the allowedBlocks attribute, the restriction works just fine the same instance and only the allowed blocks are able to be added as a child.

But once a new editor instance is created (reload the editor), the allowedBlocks attribute is completely ignored.

The reason is, that the `migrate` function of the latest deprecation does not receive the allowedBlocks attribute if it is not defined within its own attributes definition.

## How?
I am not not sure if this commit is the correct solution to the problem. It fixes it, but it seems weird to me that i need to add a new attribute to a deprecated version in order to make it persitent during the migration.

Could someone please have a look and tell if that is expected behaviour and therefore the solution to the issue?

## Testing Instructions

1. create a custom block which has a template with a core/group block in it which makes use of the allowedBlocks attribute and which sets the layout attribute of the group like follows: ```"layout":{"inherit":true}}```
2. add that block to a post and check that only the blockTypes in the allowedBlocks are available
3. save the post and reload the editor
4. check again which blockTypes can be added as a child to the group. Now all available blocks are available and the allowedBlocks attribute has no effect anymore

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/5357139/10c82a3e-f6a1-4991-ab07-23323019c746)
