### PR TITLE
Update @ariakit/react to v0.3.12 and @ariakit/test to v0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
 			"devDependencies": {
 				"@actions/core": "1.9.1",
 				"@actions/github": "5.0.0",
-				"@ariakit/test": "^0.3.5",
+				"@ariakit/test": "^0.3.7",
 				"@babel/core": "7.16.0",
 				"@babel/plugin-proposal-export-namespace-from": "7.18.9",
 				"@babel/plugin-syntax-jsx": "7.16.0",
@@ -1628,13 +1628,48 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@ariakit/core": {
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.10.tgz",
+			"integrity": "sha512-AcN+GSoVXuUOzKx5d3xPL3YsEHevh4PIO6QIt/mg/nRX1XQ6cvxQEiAjO/BJQm+/MVl7/VbuGBoTFjr0tPU6NQ=="
+		},
+		"node_modules/@ariakit/react": {
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.12.tgz",
+			"integrity": "sha512-HxKMZZhWSkwwS/Sh9OdWyuNKQ2tjDAIQIy2KVI7IRa8ZQ6ze/4g3YLUHbfCxO7oDupXHfXaeZ4hWx8lP7l1U/g==",
+			"dependencies": {
+				"@ariakit/react-core": "0.3.12"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-core": {
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.12.tgz",
+			"integrity": "sha512-w6P1A7TYb1fKUe9QbwaoTOWofl13g7TEuXdV4JyefJCQL1e9HQdEw9UL67I8aXRo8/cFHH94/z0N37t8hw5Ogg==",
+			"dependencies": {
+				"@ariakit/core": "0.3.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/@ariakit/test": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.3.5.tgz",
-			"integrity": "sha512-7UCQBnJZ88JptkEnAXT7iSgtxEZiFwqdkKtxLCXDssTOJNatbFsnq0Jow324y41jGfAE2n4Lf5qY2FsZUPf9XQ==",
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.3.7.tgz",
+			"integrity": "sha512-rOa9pJA0ZfPPSI4SkDX41CsBcvxs6BmxgzFEElZWZo/uBBqtnr8ZL4oe5HySeZKEAHRH86XDqfxFISkhV76m5g==",
 			"dev": true,
 			"dependencies": {
-				"@ariakit/core": "0.3.8",
+				"@ariakit/core": "0.3.10",
 				"@testing-library/dom": "^8.0.0 || ^9.0.0"
 			},
 			"peerDependencies": {
@@ -1649,12 +1684,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@ariakit/test/node_modules/@ariakit/core": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.8.tgz",
-			"integrity": "sha512-LlSCwbyyozMX4ZEobpYGcv1LFqOdBTdTYPZw3lAVgLcFSNivsazi3NkKM9qNWNIu00MS+xTa0+RuIcuWAjlB2Q==",
-			"dev": true
 		},
 		"node_modules/@aw-web-design/x-default-browser": {
 			"version": "1.4.126",
@@ -54244,7 +54273,7 @@
 			"version": "25.14.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.3.10",
+				"@ariakit/react": "^0.3.12",
 				"@babel/runtime": "^7.16.0",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
@@ -54301,41 +54330,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/components/node_modules/@ariakit/core": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.8.tgz",
-			"integrity": "sha512-LlSCwbyyozMX4ZEobpYGcv1LFqOdBTdTYPZw3lAVgLcFSNivsazi3NkKM9qNWNIu00MS+xTa0+RuIcuWAjlB2Q=="
-		},
-		"packages/components/node_modules/@ariakit/react": {
-			"version": "0.3.10",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.10.tgz",
-			"integrity": "sha512-XRY69IOm8Oy+HSPoaspcVLAhLo3ToLhhJKSLK1voTAZtSzu5kUeUf4nUPxTzYFsvirKORZgOLAeNwuo1gPr61g==",
-			"dependencies": {
-				"@ariakit/react-core": "0.3.10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ariakit"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
-			}
-		},
-		"packages/components/node_modules/@ariakit/react-core": {
-			"version": "0.3.10",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.10.tgz",
-			"integrity": "sha512-CzSffcNlOyS2xuy21UB6fgJXi5LriJ9JrTSJzcgJmE+P9/WfQlplJC3L75d8O2yKgaGPeFnQ0hhDA6ItsI98eQ==",
-			"dependencies": {
-				"@ariakit/core": "0.3.8",
-				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
 			}
 		},
 		"packages/components/node_modules/@floating-ui/react-dom": {
@@ -57392,22 +57386,37 @@
 				}
 			}
 		},
+		"@ariakit/core": {
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.10.tgz",
+			"integrity": "sha512-AcN+GSoVXuUOzKx5d3xPL3YsEHevh4PIO6QIt/mg/nRX1XQ6cvxQEiAjO/BJQm+/MVl7/VbuGBoTFjr0tPU6NQ=="
+		},
+		"@ariakit/react": {
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.12.tgz",
+			"integrity": "sha512-HxKMZZhWSkwwS/Sh9OdWyuNKQ2tjDAIQIy2KVI7IRa8ZQ6ze/4g3YLUHbfCxO7oDupXHfXaeZ4hWx8lP7l1U/g==",
+			"requires": {
+				"@ariakit/react-core": "0.3.12"
+			}
+		},
+		"@ariakit/react-core": {
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.12.tgz",
+			"integrity": "sha512-w6P1A7TYb1fKUe9QbwaoTOWofl13g7TEuXdV4JyefJCQL1e9HQdEw9UL67I8aXRo8/cFHH94/z0N37t8hw5Ogg==",
+			"requires": {
+				"@ariakit/core": "0.3.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			}
+		},
 		"@ariakit/test": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.3.5.tgz",
-			"integrity": "sha512-7UCQBnJZ88JptkEnAXT7iSgtxEZiFwqdkKtxLCXDssTOJNatbFsnq0Jow324y41jGfAE2n4Lf5qY2FsZUPf9XQ==",
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.3.7.tgz",
+			"integrity": "sha512-rOa9pJA0ZfPPSI4SkDX41CsBcvxs6BmxgzFEElZWZo/uBBqtnr8ZL4oe5HySeZKEAHRH86XDqfxFISkhV76m5g==",
 			"dev": true,
 			"requires": {
-				"@ariakit/core": "0.3.8",
+				"@ariakit/core": "0.3.10",
 				"@testing-library/dom": "^8.0.0 || ^9.0.0"
-			},
-			"dependencies": {
-				"@ariakit/core": {
-					"version": "0.3.8",
-					"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.8.tgz",
-					"integrity": "sha512-LlSCwbyyozMX4ZEobpYGcv1LFqOdBTdTYPZw3lAVgLcFSNivsazi3NkKM9qNWNIu00MS+xTa0+RuIcuWAjlB2Q==",
-					"dev": true
-				}
 			}
 		},
 		"@aw-web-design/x-default-browser": {
@@ -69363,7 +69372,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
-				"@ariakit/react": "^0.3.10",
+				"@ariakit/react": "^0.3.12",
 				"@babel/runtime": "^7.16.0",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
@@ -69415,29 +69424,6 @@
 				"valtio": "1.7.0"
 			},
 			"dependencies": {
-				"@ariakit/core": {
-					"version": "0.3.8",
-					"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.8.tgz",
-					"integrity": "sha512-LlSCwbyyozMX4ZEobpYGcv1LFqOdBTdTYPZw3lAVgLcFSNivsazi3NkKM9qNWNIu00MS+xTa0+RuIcuWAjlB2Q=="
-				},
-				"@ariakit/react": {
-					"version": "0.3.10",
-					"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.10.tgz",
-					"integrity": "sha512-XRY69IOm8Oy+HSPoaspcVLAhLo3ToLhhJKSLK1voTAZtSzu5kUeUf4nUPxTzYFsvirKORZgOLAeNwuo1gPr61g==",
-					"requires": {
-						"@ariakit/react-core": "0.3.10"
-					}
-				},
-				"@ariakit/react-core": {
-					"version": "0.3.10",
-					"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.10.tgz",
-					"integrity": "sha512-CzSffcNlOyS2xuy21UB6fgJXi5LriJ9JrTSJzcgJmE+P9/WfQlplJC3L75d8O2yKgaGPeFnQ0hhDA6ItsI98eQ==",
-					"requires": {
-						"@ariakit/core": "0.3.8",
-						"@floating-ui/dom": "^1.0.0",
-						"use-sync-external-store": "^1.2.0"
-					}
-				},
 				"@floating-ui/react-dom": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 	"devDependencies": {
 		"@actions/core": "1.9.1",
 		"@actions/github": "5.0.0",
-		"@ariakit/test": "^0.3.5",
+		"@ariakit/test": "^0.3.7",
 		"@babel/core": "7.16.0",
 		"@babel/plugin-proposal-export-namespace-from": "7.18.9",
 		"@babel/plugin-syntax-jsx": "7.16.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Enhancements
 
 -   Update `ariakit` to version `0.3.10` ([#57325](https://github.com/WordPress/gutenberg/pull/57325)).
+-   Update `@ariakit/react` to version `0.3.12` and @ariakit/test to version `0.3.7` ([#57547](https://github.com/WordPress/gutenberg/pull/57547)).
 -   `DropdownMenuV2`: do not collapse suffix width ([#57238](https://github.com/WordPress/gutenberg/pull/57238)).
 -   `DateTimePicker`: Adjustment of the dot position on DayButton and expansion of the button area. ([#55502](https://github.com/WordPress/gutenberg/pull/55502)).
 -   `Modal`: Improve application of body class names ([#55430](https://github.com/WordPress/gutenberg/pull/55430)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
 	],
 	"types": "build-types",
 	"dependencies": {
-		"@ariakit/react": "^0.3.10",
+		"@ariakit/react": "^0.3.12",
 		"@babel/runtime": "^7.16.0",
 		"@emotion/cache": "^11.7.1",
 		"@emotion/css": "^11.7.1",

--- a/packages/components/src/alignment-matrix-control/test/index.tsx
+++ b/packages/components/src/alignment-matrix-control/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { press, click } from '@ariakit/test';
 
 /**
  * Internal dependencies
@@ -37,11 +37,9 @@ describe( 'AlignmentMatrixControl', () => {
 		} );
 
 		it( 'should be centered by default', async () => {
-			const user = userEvent.setup();
-
 			await renderAndInitCompositeStore( <AlignmentMatrixControl /> );
 
-			await user.tab();
+			await press.Tab();
 
 			expect( getCell( 'center center' ) ).toHaveFocus();
 		} );
@@ -60,7 +58,6 @@ describe( 'AlignmentMatrixControl', () => {
 					'bottom center',
 					'bottom right',
 				] )( '%s', async ( alignment ) => {
-					const user = userEvent.setup();
 					const spy = jest.fn();
 
 					await renderAndInitCompositeStore(
@@ -72,14 +69,13 @@ describe( 'AlignmentMatrixControl', () => {
 
 					const cell = getCell( alignment );
 
-					await user.click( cell );
+					await click( cell );
 
 					expect( cell ).toHaveFocus();
 					expect( spy ).toHaveBeenCalledWith( alignment );
 				} );
 
 				it( 'unless already focused', async () => {
-					const user = userEvent.setup();
 					const spy = jest.fn();
 
 					await renderAndInitCompositeStore(
@@ -91,7 +87,7 @@ describe( 'AlignmentMatrixControl', () => {
 
 					const cell = getCell( 'center center' );
 
-					await user.click( cell );
+					await click( cell );
 
 					expect( cell ).toHaveFocus();
 					expect( spy ).not.toHaveBeenCalled();
@@ -106,16 +102,15 @@ describe( 'AlignmentMatrixControl', () => {
 					[ 'ArrowLeft', 'center left' ],
 					[ 'ArrowDown', 'bottom center' ],
 					[ 'ArrowRight', 'center right' ],
-				] )( '%s', async ( keyRef, cellRef ) => {
-					const user = userEvent.setup();
+				] as const )( '%s', async ( keyRef, cellRef ) => {
 					const spy = jest.fn();
 
 					await renderAndInitCompositeStore(
 						<AlignmentMatrixControl onChange={ spy } />
 					);
 
-					await user.tab();
-					await user.keyboard( `[${ keyRef }]` );
+					await press.Tab();
+					await press[ keyRef ]();
 
 					expect( getCell( cellRef ) ).toHaveFocus();
 					expect( spy ).toHaveBeenCalledWith( cellRef );
@@ -128,8 +123,7 @@ describe( 'AlignmentMatrixControl', () => {
 					[ 'ArrowLeft', 'top left' ],
 					[ 'ArrowDown', 'bottom right' ],
 					[ 'ArrowRight', 'bottom right' ],
-				] )( '%s', async ( keyRef, cellRef ) => {
-					const user = userEvent.setup();
+				] as const )( '%s', async ( keyRef, cellRef ) => {
 					const spy = jest.fn();
 
 					await renderAndInitCompositeStore(
@@ -137,8 +131,8 @@ describe( 'AlignmentMatrixControl', () => {
 					);
 
 					const cell = getCell( cellRef );
-					await user.click( cell );
-					await user.keyboard( `[${ keyRef }]` );
+					await click( cell );
+					await press[ keyRef ]();
 
 					expect( cell ).toHaveFocus();
 					expect( spy ).toHaveBeenCalledWith( cellRef );

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen, waitFor } from '@testing-library/react';
-import { press, click, hover } from '@ariakit/test';
+import { press, click, hover, sleep } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -19,6 +19,7 @@ import {
 	ToggleGroupControlOption,
 	ToggleGroupControlOptionIcon,
 } from '../index';
+import { TOOLTIP_DELAY } from '../../tooltip';
 import type { ToggleGroupControlProps } from '../types';
 
 const hoverOutside = async () => {
@@ -157,13 +158,11 @@ describe.each( [
 		await hoverOutside();
 
 		// Tooltip should hide
-		await waitFor( () =>
-			expect(
-				screen.queryByRole( 'tooltip', {
-					name: 'Click for Delicious Gnocchi',
-				} )
-			).not.toBeInTheDocument()
-		);
+		expect(
+			screen.queryByRole( 'tooltip', {
+				name: 'Click for Delicious Gnocchi',
+			} )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'should not render tooltip', async () => {
@@ -179,11 +178,18 @@ describe.each( [
 
 		await hover( secondRadio );
 
-		await waitFor( () =>
-			expect(
-				screen.queryByText( 'Click for Sumptuous Caponata' )
-			).not.toBeInTheDocument()
-		);
+		// Tooltip shouldn't show
+		expect(
+			screen.queryByText( 'Click for Sumptuous Caponata' )
+		).not.toBeInTheDocument();
+
+		// Advance time by default delay
+		await sleep( TOOLTIP_DELAY );
+
+		// Tooltip shouldn't show.
+		expect(
+			screen.queryByText( 'Click for Sumptuous Caponata' )
+		).not.toBeInTheDocument();
 	} );
 
 	if ( mode === 'controlled' ) {

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -21,6 +21,11 @@ import {
 } from '../index';
 import type { ToggleGroupControlProps } from '../types';
 
+const hoverOutside = async () => {
+	await hover( document.body );
+	await hover( document.body, { clientX: 10, clientY: 10 } );
+};
+
 const ControlledToggleGroupControl = ( {
 	value: valueProp,
 	onChange,
@@ -149,8 +154,7 @@ describe.each( [
 		await waitFor( () => expect( tooltip ).toBeVisible() );
 
 		// hover outside of radio
-		await hover( document.body );
-		await hover( document.body, { clientX: 10, clientY: 10 } );
+		await hoverOutside();
 
 		// Tooltip should hide
 		await waitFor( () =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update `@ariakit/*` dependencies to latest version

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should keep our dependencies up to date to enjoy of the recent features and bug fixes. We should also update frequently to make sure that each update is quick and easier to test.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

As per [the docs](https://github.com/WordPress/gutenberg/blob/trunk/packages/README.md#updating-existing-dependencies):

- Removed the dependencies from the respective `package.json` files
- ran `npm run distclean && npm install`
- Added back the dependencies with the updated version
- ran `npm run distclean && npm install`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

From the official [CHANGELOG](https://github.com/ariakit/ariakit/blob/main/packages/ariakit-react/CHANGELOG.md#0312), there are no breaking changes highlighted since the previous version (`0.3.10`).

Most of the items seem to be related to the `Combobox` component (which we don't use); here are the items that could be potentially relevant to our repository:

> - Fixed [useTabStore](https://ariakit.org/reference/use-tab-store) return value not updating its own reference.
> - Fixed Maximum update depth exceeded warning when rendering multiple collection items on the page.
> - Fixed [Hovercard](https://ariakit.org/reference/hovercard) flickering when used with shadow DOM. _(this could be potentially affecting our `Tooltip`?)_
> - Fixed [CompositeItem](https://ariakit.org/reference/composite-item) triggering blur on focus.
> - Fixed [ComboboxItem](https://ariakit.org/reference/combobox-item) not triggering the onClick event when the item is partially visible.

Our ariakit-based components should be relatively well tested, so I assume that a good smoke test in Storybook and in the editor should be enough.