### PR TITLE
Align icon size + placement in Patterns data view

### DIFF
--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -149,7 +149,7 @@ function Title( { item, categoryId } ) {
 			item.syncStatus === PATTERN_SYNC_TYPES.full ? symbol : undefined;
 	}
 	return (
-		<HStack alignment="center" justify="flex-start" spacing={ 3 }>
+		<HStack alignment="center" justify="flex-start" spacing={ 2 }>
 			{ itemIcon && ! isNonUserPattern && (
 				<Tooltip
 					placement="top"
@@ -160,6 +160,18 @@ function Title( { item, categoryId } ) {
 					<Icon
 						className="edit-site-patterns__pattern-icon"
 						icon={ itemIcon }
+					/>
+				</Tooltip>
+			) }
+			{ item.type === PATTERN_TYPES.theme && (
+				<Tooltip
+					placement="top"
+					text={ __( 'This pattern cannot be edited.' ) }
+				>
+					<Icon
+						className="edit-site-patterns__pattern-lock-icon"
+						icon={ lockSmall }
+						size={ 24 }
 					/>
 				</Tooltip>
 			) }
@@ -178,18 +190,6 @@ function Title( { item, categoryId } ) {
 							{ item.title || item.name }
 						</Button>
 					</Heading>
-				) }
-				{ item.type === PATTERN_TYPES.theme && (
-					<Tooltip
-						placement="top"
-						text={ __( 'This pattern cannot be edited.' ) }
-					>
-						<Icon
-							className="edit-site-patterns__pattern-lock-icon"
-							icon={ lockSmall }
-							size={ 24 }
-						/>
-					</Tooltip>
 				) }
 			</Flex>
 		</HStack>

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -182,15 +182,14 @@
 		}
 	}
 
-	.edit-site-patterns__pattern-icon {
-		border-radius: $grid-unit-05;
-		background: var(--wp-block-synced-color);
-		fill: $white;
-	}
-
 	.edit-site-patterns__pattern-lock-icon {
 		fill: currentcolor;
 	}
+}
+
+.edit-site-patterns__pattern-icon {
+	fill: var(--wp-block-synced-color);
+	flex-shrink: 0;
 }
 
 .edit-site-patterns__no-results {

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -182,14 +182,15 @@
 		}
 	}
 
+	.edit-site-patterns__pattern-icon {
+		border-radius: $grid-unit-05;
+		background: var(--wp-block-synced-color);
+		fill: $white;
+	}
+
 	.edit-site-patterns__pattern-lock-icon {
 		fill: currentcolor;
 	}
-}
-
-.edit-site-patterns__pattern-icon {
-	fill: var(--wp-block-synced-color);
-	flex-shrink: 0;
 }
 
 .edit-site-patterns__no-results {
@@ -234,6 +235,11 @@
 				height: auto;
 			}
 		}
+	}
+
+	.edit-site-patterns__pattern-icon {
+		fill: var(--wp-block-synced-color);
+		flex-shrink: 0;
 	}
 
 	.edit-site-patterns__pattern-lock-icon {


### PR DESCRIPTION
## What?
1. Align the size and position of the locked/synced/template part/header/footer icon in the Patterns data view.
2. Apply 'synced purple' color to synced pattern icons.

## Why?
1. The consistent placement appears a bit neater.
3. The gap between synced pattern icon + title is currently larger than the gap between locked pattern icon + title.
4. Synced pattern icons are currently too small.
5. The 'synced purple' colorisation is consistent with the old pattern management view.

## Before
<img width="639" alt="Screenshot 2024-01-04 at 15 02 39" src="https://github.com/WordPress/gutenberg/assets/846565/4f61fe15-362c-4082-8101-dc5a571da368">


## After
<img width="640" alt="Screenshot 2024-01-04 at 15 00 33" src="https://github.com/WordPress/gutenberg/assets/846565/dc570106-d431-4c65-99fe-da154c30400a">

It goes without saying that we should also update the blue/underlined links for synced patterns, to be consistent with other data views, but that's one to address separately. 
