### PR TITLE
Data views: Make title display in grid views consistent

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -155,9 +155,13 @@
 				text-overflow: ellipsis;
 				display: block;
 				font-size: $default-font-size;
+				width: 100%;
+			}
+
+			.edit-site-grid-view__title-field a,
+			button.edit-site-grid-view__title-field {
 				font-weight: 500;
 				color: $gray-900;
-				width: 100%;
 				text-decoration: none;
 			}
 		}
@@ -180,12 +184,6 @@
 
 	.dataviews-view-grid__primary-field {
 		min-height: $grid-unit-30;
-
-		a {
-			color: $gray-900;
-			text-decoration: none;
-			font-weight: 500;
-		}
 	}
 
 	.dataviews-view-grid__fields {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -148,10 +148,18 @@
 	}
 
 	.dataviews-view-grid__card {
-		h3 { // Todo: A better way to target this
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
+		.dataviews-view-grid__primary-field { 
+			.edit-site-grid-view__title-field {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				display: block;
+				font-size: $default-font-size;
+				font-weight: 500;
+				color: $gray-900;
+				width: 100%;
+				text-decoration: none;
+			}
 		}
 	}
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -149,7 +149,7 @@
 
 	.dataviews-view-grid__card {
 		.dataviews-view-grid__primary-field { 
-			.edit-site-grid-view__title-field {
+			.dataviews-view-grid__title-field {
 				white-space: nowrap;
 				overflow: hidden;
 				text-overflow: ellipsis;
@@ -158,8 +158,8 @@
 				width: 100%;
 			}
 
-			.edit-site-grid-view__title-field a,
-			button.edit-site-grid-view__title-field {
+			.dataviews-view-grid__title-field a,
+			button.dataviews-view-grid__title-field {
 				font-weight: 500;
 				color: $gray-900;
 				text-decoration: none;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -148,7 +148,7 @@
 	}
 
 	.dataviews-view-grid__card {
-		.dataviews-view-grid__primary-field { 
+		.dataviews-view-grid__primary-field {
 			.dataviews-view-grid__title-field {
 				white-space: nowrap;
 				overflow: hidden;

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -186,8 +186,3 @@
 	display: block;
 	color: $gray-700;
 }
-
-.edit-site-list-title__customized-info {
-	font-size: $default-font-size;
-	font-weight: 500;
-}

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -222,7 +222,7 @@ export default function PagePages() {
 						<VStack spacing={ 1 }>
 							<View
 								as="span"
-								className="edit-site-grid-view__title-field"
+								className="dataviews-view-grid__title-field"
 							>
 								{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
 									view.type

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -222,7 +222,7 @@ export default function PagePages() {
 						<VStack spacing={ 1 }>
 							<View
 								as="span"
-								className="edit-site-page-pages__list-view-title-field"
+								className="edit-site-grid-view__title-field"
 							>
 								{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
 									view.type

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -3,9 +3,3 @@
 	width: $grid-unit-40;
 	height: $grid-unit-40;
 }
-
-
-.edit-site-page-pages__list-view-title-field {
-	font-size: $default-font-size;
-	font-weight: 500;
-}

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -165,7 +165,7 @@ function Title( { item, categoryId } ) {
 			) }
 			<Flex as="span" gap={ 0 } justify="left">
 				{ item.type === PATTERN_TYPES.theme ? (
-					<span className="edit-site-grid-view__title-field">
+					<span className="dataviews-view-grid__title-field">
 						{ item.title }
 					</span>
 				) : (
@@ -176,7 +176,7 @@ function Title( { item, categoryId } ) {
 							// Required for the grid's roving tab index system.
 							// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
 							tabIndex="-1"
-							className="edit-site-grid-view__title-field"
+							className="dataviews-view-grid__title-field"
 						>
 							{ item.title || item.name }
 						</Button>

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -165,7 +165,9 @@ function Title( { item, categoryId } ) {
 			) }
 			<Flex as="span" gap={ 0 } justify="left">
 				{ item.type === PATTERN_TYPES.theme ? (
-					item.title
+					<span className="edit-site-grid-view__title-field">
+						{ item.title }
+					</span>
 				) : (
 					<Heading level={ 5 }>
 						<Button
@@ -174,6 +176,7 @@ function Title( { item, categoryId } ) {
 							// Required for the grid's roving tab index system.
 							// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
 							tabIndex="-1"
+							className="edit-site-grid-view__title-field"
 						>
 							{ item.title || item.name }
 						</Button>

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -103,7 +103,7 @@ function TemplateTitle( { item, viewType } ) {
 
 	return (
 		<VStack spacing={ 1 }>
-			<View as="span" className="edit-site-grid-view__title-field">
+			<View as="span" className="dataviews-view-grid__title-field">
 				<Link
 					params={ {
 						postId: item.id,

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -103,7 +103,7 @@ function TemplateTitle( { item, viewType } ) {
 
 	return (
 		<VStack spacing={ 1 }>
-			<View as="span" className="edit-site-list-title__customized-info">
+			<View as="span" className="edit-site-grid-view__title-field">
 				<Link
 					params={ {
 						postId: item.id,


### PR DESCRIPTION
## What?
Updates some styles and classes to make it easier to apply consistent styles to titles in grid layouts. Also fixes title truncation.

## Why?
Currently the titles in the pattern management view are inconsistent with the ones in pages and templates.

## How?
Apply a new css class (`.dataviews-view-grid__title-field`) in the relevant locations, and add styles to `packages/dataviews/src/style.scss`.

## Testing instructions
1. Enable the data views experiment
2. Ensure item titles display consistently in grid layout on the following views:
  * Manage templates
  * Manage pages
  * Manage patterns 

## Before
### Templates
<img width="1298" alt="Screenshot 2024-01-04 at 16 11 31" src="https://github.com/WordPress/gutenberg/assets/846565/9f538195-e930-4c4b-886b-10b575f69ef5">


### Pages
<img width="1291" alt="Screenshot 2024-01-04 at 16 11 45" src="https://github.com/WordPress/gutenberg/assets/846565/8e66e0bd-3897-43f8-adfa-b8456a68aafa">



### Patterns
<img width="1299" alt="Screenshot 2024-01-04 at 16 12 03" src="https://github.com/WordPress/gutenberg/assets/846565/c4f0ba92-88c3-452d-b889-9f205101a6b3">



## After
### Templates
<img width="1287" alt="Screenshot 2024-01-04 at 16 09 10" src="https://github.com/WordPress/gutenberg/assets/846565/4089a05f-fe52-4eda-a4a7-a11534ef4147">

Note: Fixed truncation.

### Pages
<img width="1292" alt="Screenshot 2024-01-04 at 16 09 24" src="https://github.com/WordPress/gutenberg/assets/846565/1581ccd9-fe22-4ee8-84c7-a4ba81a57bfe">

Note: Fixed truncation.

### Patterns
<img width="1289" alt="Screenshot 2024-01-04 at 16 09 50" src="https://github.com/WordPress/gutenberg/assets/846565/79a46a65-c861-4bde-8c7b-11245a6c190e">

Note: Consistent title color, weight, decoration. Here items that do not function as links have the default `font-weight`.
