### PR TITLE
PostFeaturedImage: Remove unnecessary 'block-editor' store subscription

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -98,17 +98,15 @@ function PostFeaturedImage( {
 } ) {
 	const toggleRef = useRef();
 	const [ isLoading, setIsLoading ] = useState( false );
-	const mediaUpload = useSelect( ( select ) => {
-		return select( blockEditorStore ).getSettings().mediaUpload;
-	}, [] );
+	const { getSettings } = useSelect( blockEditorStore );
 	const { mediaWidth, mediaHeight, mediaSourceUrl } = getMediaDetails(
 		media,
 		currentPostId
 	);
 
 	function onDropFiles( filesList ) {
-		mediaUpload( {
-			allowedTypes: [ 'image' ],
+		getSettings().mediaUpload( {
+			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList,
 			onFileChange( [ image ] ) {
 				if ( isBlobURL( image?.url ) ) {


### PR DESCRIPTION
## What?
This is similar to #57513.

PR removes an unnecessary 'block-editor' store subscription from the `PostFeaturedImage` component.

## Why?
The media `mediaUpload` setting is only used during the `onDropFiles` event. We can use a static selector getter and grab the setting only when needed. It's a good practice to avoid store subscriptions when unnecessary.

## Testing Instructions
 1. Open a post.
 2. You should be able to upload a "Feature image" using drag and drop.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/c2809a3c-80ed-4154-93d7-188fe7783215


