### PR TITLE
ColorPicker: store internal HSLA state for better slider UX

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Enhancements
 
+-   `ColorPicker`: improve the UX around HSL sliders ([#57555](https://github.com/WordPress/gutenberg/pull/57555)).
 -   Update `ariakit` to version `0.3.10` ([#57325](https://github.com/WordPress/gutenberg/pull/57325)).
 -   Update `@ariakit/react` to version `0.3.12` and @ariakit/test to version `0.3.7` ([#57547](https://github.com/WordPress/gutenberg/pull/57547)).
 -   `DropdownMenuV2`: do not collapse suffix width ([#57238](https://github.com/WordPress/gutenberg/pull/57238)).

--- a/packages/components/src/color-picker/hsl-input.tsx
+++ b/packages/components/src/color-picker/hsl-input.tsx
@@ -25,10 +25,15 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 
 	useEffect( () => {
 		if ( ! isInternalColorSameAsReceivedColor ) {
+			// Keep internal HSLA color up to date with the received color prop
 			setInternalHSLA( colorPropHSL );
 		}
 	}, [ colorPropHSL, isInternalColorSameAsReceivedColor ] );
 
+	// If the internal color is equal to the received color prop, we can use the
+	// HSLA values from the local state which, compared to the received color prop,
+	// retain more details about the actual H and S values that the user selected,
+	// and thus allow for better UX when interacting with the H and S sliders.
 	const colorValue = isInternalColorSameAsReceivedColor
 		? internalHSLA
 		: colorPropHSL;
@@ -36,6 +41,7 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 	const updateHSLAValue = (
 		partialNewValue: Partial< typeof colorPropHSL >
 	) => {
+		// Update internal HSLA color.
 		setInternalHSLA( ( prevValue ) => ( {
 			...prevValue,
 			...partialNewValue,
@@ -46,17 +52,11 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 			...partialNewValue,
 		} );
 
-		// Avoid firing `onChange` if the resulting didn't change.
-		if ( color.isEqual( nextOnChangeValue ) ) {
-			return;
+		// Fire `onChange` only if the resulting color is different from the
+		// current one.
+		if ( ! color.isEqual( nextOnChangeValue ) ) {
+			onChange( nextOnChangeValue );
 		}
-
-		onChange(
-			colord( {
-				...colorValue,
-				...partialNewValue,
-			} )
-		);
 	};
 
 	return (

--- a/packages/components/src/color-picker/hsl-input.tsx
+++ b/packages/components/src/color-picker/hsl-input.tsx
@@ -41,12 +41,6 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 	const updateHSLAValue = (
 		partialNewValue: Partial< typeof colorPropHSLA >
 	) => {
-		// Update internal HSLA color.
-		setInternalHSLA( ( prevValue ) => ( {
-			...prevValue,
-			...partialNewValue,
-		} ) );
-
 		const nextOnChangeValue = colord( {
 			...colorValue,
 			...partialNewValue,
@@ -54,8 +48,14 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 
 		// Fire `onChange` only if the resulting color is different from the
 		// current one.
+		// Otherwise, update the internal HSLA color to cause a re-render.
 		if ( ! color.isEqual( nextOnChangeValue ) ) {
 			onChange( nextOnChangeValue );
+		} else {
+			setInternalHSLA( ( prevHSLA ) => ( {
+				...prevHSLA,
+				...partialNewValue,
+			} ) );
 		}
 	};
 

--- a/packages/components/src/color-picker/hsl-input.tsx
+++ b/packages/components/src/color-picker/hsl-input.tsx
@@ -6,7 +6,7 @@ import { colord } from 'colord';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,9 +15,9 @@ import { InputWithSlider } from './input-with-slider';
 import type { HslInputProps } from './types';
 
 export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
-	const colorPropHSL = color.toHsl();
+	const colorPropHSLA = useMemo( () => color.toHsl(), [ color ] );
 
-	const [ internalHSLA, setInternalHSLA ] = useState( { ...colorPropHSL } );
+	const [ internalHSLA, setInternalHSLA ] = useState( { ...colorPropHSLA } );
 
 	const isInternalColorSameAsReceivedColor = color.isEqual(
 		colord( internalHSLA )
@@ -26,9 +26,9 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 	useEffect( () => {
 		if ( ! isInternalColorSameAsReceivedColor ) {
 			// Keep internal HSLA color up to date with the received color prop
-			setInternalHSLA( colorPropHSL );
+			setInternalHSLA( colorPropHSLA );
 		}
-	}, [ colorPropHSL, isInternalColorSameAsReceivedColor ] );
+	}, [ colorPropHSLA, isInternalColorSameAsReceivedColor ] );
 
 	// If the internal color is equal to the received color prop, we can use the
 	// HSLA values from the local state which, compared to the received color prop,
@@ -36,10 +36,10 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 	// and thus allow for better UX when interacting with the H and S sliders.
 	const colorValue = isInternalColorSameAsReceivedColor
 		? internalHSLA
-		: colorPropHSL;
+		: colorPropHSLA;
 
 	const updateHSLAValue = (
-		partialNewValue: Partial< typeof colorPropHSL >
+		partialNewValue: Partial< typeof colorPropHSLA >
 	) => {
 		// Update internal HSLA color.
 		setInternalHSLA( ( prevValue ) => ( {

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -13,6 +13,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { ColorPicker } from '..';
+import { click } from '@ariakit/test';
 
 const hslaMatcher = expect.objectContaining( {
 	h: expect.any( Number ),
@@ -139,7 +140,7 @@ describe( 'ColorPicker', () => {
 	} );
 
 	describe( 'HSL inputs', () => {
-		it( 'sliders', async () => {
+		it( 'sliders should use accurate H and S values based on user interaction when possible', async () => {
 			const user = userEvent.setup();
 			const onChange = jest.fn();
 
@@ -155,11 +156,16 @@ describe( 'ColorPicker', () => {
 				};
 
 				return (
-					<ColorPicker
-						{ ...restProps }
-						onChange={ internalOnChange }
-						color={ colorState }
-					/>
+					<>
+						<ColorPicker
+							{ ...restProps }
+							onChange={ internalOnChange }
+							color={ colorState }
+						/>
+						<button onClick={ () => setColorState( '#4d87ba' ) }>
+							Set color to #4d87ba
+						</button>
+					</>
 				);
 			};
 
@@ -237,6 +243,67 @@ describe( 'ColorPicker', () => {
 			expect( lightnessNumberInput ).toHaveValue( 30 );
 			expect( onChange ).toHaveBeenCalledTimes( 1 );
 			expect( onChange ).toHaveBeenLastCalledWith( '#597326' );
+
+			// Interact with the Lightness slider, setting to 100 (ie. white).
+			// It should also cause the `onChange` callback to fire, and reset the
+			// hue and saturation inputs to `0`.
+			fireEvent.change( lightnessSlider, { target: { value: 100 } } );
+
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '100' )
+			);
+			expect( lightnessNumberInput ).toHaveValue( 100 );
+			expect( hueSlider ).toHaveValue( '0' );
+			expect( saturationSlider ).toHaveValue( '0' );
+			expect( hueNumberInput ).toHaveValue( 0 );
+			expect( saturationNumberInput ).toHaveValue( 0 );
+			expect( onChange ).toHaveBeenCalledTimes( 2 );
+			expect( onChange ).toHaveBeenLastCalledWith( '#ffffff' );
+
+			// Interact with the Hue slider, it should change its value (and the
+			// value of the associated number input), but it shouldn't cause the
+			// `onChange` callback to fire, since the resulting color is still white.
+			fireEvent.change( hueSlider, { target: { value: 147 } } );
+
+			expect( hueSlider ).toHaveValue( '147' );
+			expect( hueNumberInput ).toHaveValue( 147 );
+			expect( onChange ).toHaveBeenCalledTimes( 2 );
+
+			// Interact with the Saturation slider, it should change its value (and the
+			// value of the associated number input), but it shouldn't cause the
+			// `onChange` callback to fire, since the resulting color is still white.
+			fireEvent.change( saturationSlider, { target: { value: 82 } } );
+
+			expect( saturationSlider ).toHaveValue( '82' );
+			expect( saturationNumberInput ).toHaveValue( 82 );
+			expect( onChange ).toHaveBeenCalledTimes( 2 );
+
+			// Interact with the Lightness slider, it should change its value (and the
+			// value of the associated number input). It should also cause the
+			// `onChange` callback to fire, since changing the lightness actually
+			// causes the color to change.
+			fireEvent.change( lightnessSlider, { target: { value: 14 } } );
+
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '14' )
+			);
+			expect( lightnessNumberInput ).toHaveValue( 14 );
+			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			expect( onChange ).toHaveBeenLastCalledWith( '#064121' );
+
+			// Set the color externally. All inputs should update to match the H/S/L
+			// value of the new color.
+			const setColorButton = screen.getByRole( 'button', {
+				name: /set color/i,
+			} );
+			await click( setColorButton );
+
+			expect( hueSlider ).toHaveValue( '208' );
+			expect( hueNumberInput ).toHaveValue( 208 );
+			expect( saturationSlider ).toHaveValue( '44' );
+			expect( saturationNumberInput ).toHaveValue( 44 );
+			expect( lightnessSlider ).toHaveValue( '52' );
+			expect( lightnessNumberInput ).toHaveValue( 52 );
 		} );
 
 		describe.each( [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #57209

## What?
<!-- In a few words, what is the PR actually doing? -->

Improve the UX of the `ColorPicker` when using HSL sliders, so that the use can move each slider freely even when that doesn't result in a change to the final color 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The way sliders work currently represents a [bad UX](https://github.com/WordPress/gutenberg/issues/57209#issuecomment-1867917658)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The issue that we're trying to solve is caused by the fact that, when a slider's value changes, we convert from HSLA to a `colord` object in the `onChange` function, and then we convert the received `color` prop back to HSLA. Converting to a `colord` object was necessary to have a universal representation of the color, regardless of the color space that the user chooses (RGB, HSL..). But doing so causes the H and S values to get "stuck" on `0` if changing them wouldn't affect the final color value (see detailed explanation in https://github.com/WordPress/gutenberg/issues/57209#issuecomment-1867518109).

To get around this limitation, this PR stores the individual H/S/L/A values in local state. When the received color and the internal values produce the same resulting color, we can safely use the local H/S/L/A values (instead of the received color prop), which retain the values that the user selected by dragging the slider.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the `ColorPicker` storybook example
- Switch to HSL color space
- Select pure white and/or pure black as a color. Try interacting with the H and L sliders: the sliders should move when dragging the thumb, and the corresponding `NumberControl` should also update accordingly. The color should stay unchanged (since, for pure white and black, changing H and S values doesn't make a difference). The `onChange` function should not fire multiple times either, since the resulting color is not changing.
- Play around with the sliders, the number controls, and the 2d picker. The UI should update as expected, and the `onChange` callback should be fired as expected.

## Screenshots or screencast <!-- if applicable -->
,
### Trunk

https://github.com/WordPress/gutenberg/assets/1083581/80ee2116-5f3d-43f9-96aa-4487ef7d9a49


### This PR


https://github.com/WordPress/gutenberg/assets/1083581/d9414b7a-fd97-4400-92ac-b83dcd9520a9


