### PR TITLE
Remove LastFocus from Block Editor store in favor of useLastFocus

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -588,20 +588,6 @@ _Properties_
 -   _isDisabled_ `boolean`: Whether or not the user should be prevented from inserting this item.
 -   _frecency_ `number`: Heuristic that combines frequency and recency.
 
-### getLastFocus
-
-> **Deprecated**
-
-Returns the element of the last element that had focus when focus left the editor canvas. Warning: Using an element within Redux will break ReactDev Tools: <https://github.com/WordPress/gutenberg/pull/55712#discussion_r1439557418>
-
-_Parameters_
-
--   _state_ `Object`: Block editor state.
-
-_Returns_
-
--   `Object`: Element.
-
 ### getLastMultiSelectedBlockClientId
 
 Returns the client ID of the last block in the multi-selection set, or null if there is no multi-selection.
@@ -1664,20 +1650,6 @@ _Parameters_
 
 -   _clientId_ `string`: The block's clientId.
 -   _hasControlledInnerBlocks_ `boolean`: True if the block's inner blocks are controlled.
-
-### setLastFocus
-
-> **Deprecated**
-
-Action that sets the element that had focus when focus leaves the editor canvas.
-
-_Parameters_
-
--   _lastFocus_ `Object`: The last focused element.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### setNavigationMode
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -590,7 +590,9 @@ _Properties_
 
 ### getLastFocus
 
-Returns the element of the last element that had focus when focus left the editor canvas.
+> **Deprecated**
+
+Returns the element of the last element that had focus when focus left the editor canvas. Warning: Using an element within Redux will break ReactDev Tools: <https://github.com/WordPress/gutenberg/pull/55712#discussion_r1439557418>
 
 _Parameters_
 
@@ -1664,6 +1666,8 @@ _Parameters_
 -   _hasControlledInnerBlocks_ `boolean`: True if the block's inner blocks are controlled.
 
 ### setLastFocus
+
+> **Deprecated**
 
 Action that sets the element that had focus when focus leaves the editor canvas.
 

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -9,7 +9,6 @@ import {
 	useEffect,
 	useCallback,
 } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { focus } from '@wordpress/dom';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
@@ -18,7 +17,7 @@ import { ESCAPE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../../store';
+import { useLastFocus } from '../../utils/use-last-focus';
 
 function hasOnlyToolbarItem( elements ) {
 	const dataProp = 'toolbarItem';
@@ -169,7 +168,8 @@ function useToolbarFocus( {
 		};
 	}, [ initialIndex, initialFocusOnMount, onIndexChange, toolbarRef ] );
 
-	const { getLastFocus } = useSelect( blockEditorStore );
+	const { lastFocus } = useLastFocus();
+
 	/**
 	 * Handles returning focus to the block editor canvas when pressing escape.
 	 */
@@ -178,7 +178,6 @@ function useToolbarFocus( {
 
 		if ( focusEditorOnEscape ) {
 			const handleKeyDown = ( event ) => {
-				const lastFocus = getLastFocus();
 				if ( event.keyCode === ESCAPE && lastFocus?.current ) {
 					// Focus the last focused element when pressing escape.
 					event.preventDefault();
@@ -193,7 +192,7 @@ function useToolbarFocus( {
 				);
 			};
 		}
-	}, [ focusEditorOnEscape, getLastFocus, toolbarRef ] );
+	}, [ focusEditorOnEscape, lastFocus, toolbarRef ] );
 }
 
 export default function NavigableToolbar( {

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -12,6 +12,7 @@ import { useRef } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../../store';
 import { isInSameBlock, isInsideRootBlock } from '../../utils/dom';
+import { useLastFocus } from '../../utils/use-last-focus';
 
 export default function useTabNav() {
 	const container = useRef();
@@ -20,14 +21,10 @@ export default function useTabNav() {
 
 	const { hasMultiSelection, getSelectedBlockClientId, getBlockCount } =
 		useSelect( blockEditorStore );
-	const { setNavigationMode, setLastFocus } = useDispatch( blockEditorStore );
+	const { lastFocus, setLastFocus } = useLastFocus();
+	const { setNavigationMode } = useDispatch( blockEditorStore );
 	const isNavigationMode = useSelect(
 		( select ) => select( blockEditorStore ).isNavigationMode(),
-		[]
-	);
-
-	const lastFocus = useSelect(
-		( select ) => select( blockEditorStore ).getLastFocus(),
 		[]
 	);
 
@@ -45,7 +42,7 @@ export default function useTabNav() {
 		} else if ( hasMultiSelection() ) {
 			container.current.focus();
 		} else if ( getSelectedBlockClientId() ) {
-			lastFocus.current.focus();
+			lastFocus?.current.focus();
 		} else {
 			setNavigationMode( true );
 
@@ -163,7 +160,7 @@ export default function useTabNav() {
 		}
 
 		function onFocusOut( event ) {
-			setLastFocus( { ...lastFocus, current: event.target } );
+			setLastFocus( event.target );
 
 			const { ownerDocument } = node;
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1919,23 +1919,3 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
-
-/**
- * Action that sets the element that had focus when focus leaves the editor canvas.
- *
- * @deprecated
- * @param {Object} lastFocus The last focused element.
- *
- *
- * @return {Object} Action object.
- */
-export function setLastFocus( lastFocus = null ) {
-	deprecated( 'setLastFocus', {
-		since: '6.4',
-		version: '6.6',
-	} );
-	return {
-		type: 'LAST_FOCUS',
-		lastFocus,
-	};
-}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1923,12 +1923,17 @@ export function unsetBlockEditingMode( clientId = '' ) {
 /**
  * Action that sets the element that had focus when focus leaves the editor canvas.
  *
+ * @deprecated
  * @param {Object} lastFocus The last focused element.
  *
  *
  * @return {Object} Action object.
  */
 export function setLastFocus( lastFocus = null ) {
+	deprecated( 'setLastFocus', {
+		since: '6.4',
+		version: '6.6',
+	} );
 	return {
 		type: 'LAST_FOCUS',
 		lastFocus,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2949,11 +2949,17 @@ export const isGroupable = createRegistrySelector(
 
 /**
  * Returns the element of the last element that had focus when focus left the editor canvas.
+ * Warning: Using an element within Redux will break ReactDev Tools: https://github.com/WordPress/gutenberg/pull/55712#discussion_r1439557418
  *
+ * @deprecated
  * @param {Object} state Block editor state.
  *
  * @return {Object} Element.
  */
 export function getLastFocus( state ) {
+	deprecated( 'getLastFocus', {
+		since: '6.4',
+		version: '6.6',
+	} );
 	return state.lastFocus;
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2946,20 +2946,3 @@ export const isGroupable = createRegistrySelector(
 			);
 		}
 );
-
-/**
- * Returns the element of the last element that had focus when focus left the editor canvas.
- * Warning: Using an element within Redux will break ReactDev Tools: https://github.com/WordPress/gutenberg/pull/55712#discussion_r1439557418
- *
- * @deprecated
- * @param {Object} state Block editor state.
- *
- * @return {Object} Element.
- */
-export function getLastFocus( state ) {
-	deprecated( 'getLastFocus', {
-		since: '6.4',
-		version: '6.6',
-	} );
-	return state.lastFocus;
-}

--- a/packages/block-editor/src/utils/use-last-focus.js
+++ b/packages/block-editor/src/utils/use-last-focus.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { createRef } from '@wordpress/element';
+
+/**
+ * Returns the element of the last element that had focus when focus left the editor canvas.
+ *
+ * @return {Object} Object with a lastFocus ref and setLastFocus.
+ */
+const lastFocus = createRef();
+
+export function useLastFocus() {
+	const setLastFocus = ( node ) => {
+		lastFocus.current = node;
+	};
+	return { lastFocus, setLastFocus };
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds useLastFocus in the utils to store a lastFocus ref and a setLastFocus for setting the ref.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Fixes an issue where storing a ref in a Redux store would break React DevTools: https://github.com/WordPress/gutenberg/pull/55712#discussion_r1439557418
- Removes `getLastFocus`/`setLastFocus` from the public API [per request](https://github.com/WordPress/gutenberg/pull/55712#discussion_r1440134527).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a `useLastFocus` to the Block Editor utils as a global Ref that can be set like:

```
const { setLastFocus } = useLastFocus();`
…
setLastFocus( event.target );
```

Then retrieved via:

```
const { lastFocus } = useLastFocus();`

lastFocus?.current.focus();
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
There should be no change from trunk. This mostly impacts pressing the Escape toolbar

- For both default and top toolbar modes...
- Press alt+F10 from a block
- Press Escape from the block toolbar
- Focus should return to the block
