### PR TITLE
Add new section to the Quick Start Guide about wp-env

### DIFF
--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -25,7 +25,7 @@ Navigate to the Plugins page of your local WordPress installation and activate t
 
 ## Basic usage
 
-With the plugin activated, you can  explore how the block works. Use the following command to move into the newly created plugin folder and start the development process.
+With the plugin activated, you can explore how the block works. Use the following command to move into the newly created plugin folder and start the development process.
 
 ```sh
 cd copyright-date-block && npm start
@@ -36,6 +36,14 @@ When `create-block` scaffolds the block, it installs `wp-scripts` and adds the m
 The `npm start` command will start a development server and watch for changes in the block’s code, rebuilding the block whenever modifications are made. 
 
 When you are finished making changes, run the `npm run build` command. This optimizes the block code and makes it production-ready.
+
+## View the block in action
+
+You can use any local WordPress development environment to test your new block, but the scaffolded plugin includes configuration for `wp-env`. You must have [Docker](https://www.docker.com/products/docker-desktop) already installed and running on your machine, but if you do, run the `npx wp-env start` command. 
+
+Once the script finishes running, you can access the local environment at: `http://localhost:8888`. Log into the WordPress dashboard using username `admin` and password `password`. The plugin will already be installed and activated. Visit a page or post, and insert the Copyright Date Block as you would any other block.
+
+Visit the [Getting started](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-env/) guide to learn more about `wp-env`.
 
 ## Additional resources
 

--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -41,7 +41,7 @@ When you are finished making changes, run the `npm run build` command. This opti
 
 You can use any local WordPress development environment to test your new block, but the scaffolded plugin includes configuration for `wp-env`. You must have [Docker](https://www.docker.com/products/docker-desktop) already installed and running on your machine, but if you do, run the `npx wp-env start` command. 
 
-Once the script finishes running, you can access the local environment at: `http://localhost:8888`. Log into the WordPress dashboard using username `admin` and password `password`. The plugin will already be installed and activated. Visit a page or post, and insert the Copyright Date Block as you would any other block.
+Once the script finishes running, you can access the local environment at: `http://localhost:8888`. Log into the WordPress dashboard using username `admin` and password `password`. The plugin will already be installed and activated. Open the Editor or Site Editor, and insert the Copyright Date Block as you would any other block.
 
 Visit the [Getting started](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-env/) guide to learn more about `wp-env`.
 


### PR DESCRIPTION
This PR adds an additional section to the [Quick Start Guide](https://developer.wordpress.org/block-editor/getting-started/quick-start-guide/) about how to view the scaffolded block in WordPress using `wp-env`. 

I am also working on a short video for the Quick Start Guide, which will cover `wp-env`. So adding this written section will complement the video once complete. 
