### PR TITLE
Preferences: update accessibility scope to "core"

### DIFF
--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -129,7 +129,7 @@ export default function EditSitePreferencesModal() {
 						) }
 					>
 						<EnableFeature
-							namespace="core"
+							scope="core"
 							featureName="keepCaretInsideBlock"
 							help={ __(
 								'Keeps the text cursor within the block boundaries, aiding users with screen readers by preventing unintentional cursor movement outside the block.'
@@ -139,7 +139,7 @@ export default function EditSitePreferencesModal() {
 					</PreferencesModalSection>
 					<PreferencesModalSection title={ __( 'Interface' ) }>
 						<EnableFeature
-							namespace="core"
+							scope="core"
 							featureName="showIconLabels"
 							label={ __( 'Show button text labels' ) }
 							help={ __(


### PR DESCRIPTION

## What?
The prop "namespace" should be "scope"

## Why?
So that the preference is correctly scoped



## Testing Instructions
Clear local storage for good measure to clear preferences.

In the site editor, open the preferences options, then the accessibility panel.

Check that the `keepCaretInsideBlock` and `showIconLabels` options work as they do in the post editor.


## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/6458278/6065a5da-9c1d-4c61-8bca-1ab310308a4f


### After


https://github.com/WordPress/gutenberg/assets/6458278/fe1e4a03-4182-4768-956b-20522b6e1938


