### PR TITLE
Use `is-layout` pattern on layout generated classname

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -639,7 +639,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	* for features like the enhanced pagination of the Query block.
 	*/
 	$container_class = gutenberg_incremental_id_per_prefix(
-		'wp-container-' . sanitize_title( $block['blockName'] ) . '-layout-'
+		'wp-container-' . sanitize_title( $block['blockName'] ) . '-is-layout-'
 	);
 
 	// Set the correct layout type for blocks using legacy content width.
@@ -893,7 +893,7 @@ function gutenberg_restore_group_inner_container( $block_content, $block ) {
 			if ( $classes ) {
 				$classes = explode( ' ', $classes );
 				foreach ( $classes as $class_name ) {
-					if ( str_contains( $class_name, 'layout' ) ) {
+					if ( str_contains( $class_name, 'is-layout-' ) ) {
 						array_push( $layout_classes, $class_name );
 						$processor->remove_class( $class_name );
 					}

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -351,7 +351,7 @@ function BlockWithLayoutStyles( { block: BlockListBlock, props } ) {
 	const layoutClasses = useLayoutClasses( attributes, name );
 
 	const { kebabCase } = unlock( componentsPrivateApis );
-	const selectorPrefix = `wp-container-${ kebabCase( name ) }-layout-`;
+	const selectorPrefix = `wp-container-${ kebabCase( name ) }-is-layout-`;
 	// Higher specificity to override defaults from theme.json.
 	const selector = `.${ selectorPrefix }${ id }.${ selectorPrefix }${ id }`;
 	const [ blockGapSupport ] = useSettings( 'spacing.blockGap' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Syncs update to generated layout classname from https://github.com/WordPress/wordpress-develop/pull/5812. The idea is that all layout classnames can now share the `is-layout-` string, so that they can more easily be identified. The change is applied when searching for the layout classes in the legacy group inner container support function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add appearance-tools support to a classic theme with `add_theme_support( 'appearance-tools');` in the theme's setup function.
2. Add a Group block to a post, and change its spacing under Styles > Dimensions in the sidebar. Save and check that all the layout classnames are added to the block inner container on the front end.
3. Tests in `phpunit/block-supports/layout-test.php` should still pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
