### PR TITLE
Dataview: Change the stacking order of table header

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -117,6 +117,7 @@
 			border-top: 1px solid $gray-100;
 			padding-top: $grid-unit-05;
 			padding-bottom: $grid-unit-05;
+			z-index: 1;
 		}
 	}
 


### PR DESCRIPTION
## What?

This PR changes the stacking order by applying `z-index:1` to the Dataview table header cell. This prevents _translucent_ buttons from overlapping header cells.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/9becf809-493d-47f8-9ab7-0dd4a511e067) |  ![image](https://github.com/WordPress/gutenberg/assets/54422211/386d6139-652d-4f4b-beb1-82df77a8234a)| 

## Why?

When the button is disabled, it has `opacity:0.3` style. Strangely, only the translucent button overlaps the header cell. This may have something to do with the element being placed in a new stacking context when opacity is applied ([This article](https://www.freecodecamp.org/news/4-reasons-your-z-index-isnt-working-and-how-to-fix-it-coder-coder-6bc05f103e6c/#3-setting-some-css-properties-like-opacity-or-transform-will-put-the-element-in-a-new-stacking-context-) explains its specifications in detail).

## How?
Added `z-index: 1` to header cell.

## Testing Instructions

- Open the All Templates page.
- Reduce the browser height so that the dataview has the scrollbar.
- Theme templates that have not been updated should have a disabled button.
- Even if you scroll down the table, the header should always remain on top.