### PR TITLE
Code Quality: Rename `patternBlock` to `patternPost`

### DIFF
--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -36,8 +36,8 @@ export const exportJSONaction = {
 		const json = {
 			__file: item.type,
 			title: item.title || item.name,
-			content: item.patternBlock.content.raw,
-			syncStatus: item.patternBlock.wp_pattern_sync_status,
+			content: item.patternPost.content.raw,
+			syncStatus: item.patternPost.wp_pattern_sync_status,
 		};
 		return downloadBlob(
 			`${ kebabCase( item.title || item.name ) }.json`,

--- a/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
+++ b/packages/edit-site/src/components/page-patterns/duplicate-menu-item.js
@@ -81,7 +81,7 @@ export default function DuplicateMenuItem( {
 				<DuplicatePatternModal
 					onClose={ closeModal }
 					onSuccess={ onPatternSuccess }
-					pattern={ isThemePattern ? item : item.patternBlock }
+					pattern={ isThemePattern ? item : item.patternPost }
 				/>
 			) }
 			{ isModalOpen && isTemplatePart && (

--- a/packages/edit-site/src/components/page-patterns/grid-item.js
+++ b/packages/edit-site/src/components/page-patterns/grid-item.js
@@ -114,8 +114,8 @@ function GridItem( { categoryId, item, ...props } ) {
 		const json = {
 			__file: item.type,
 			title: item.title || item.name,
-			content: item.patternBlock.content.raw,
-			syncStatus: item.patternBlock.wp_pattern_sync_status,
+			content: item.patternPost.content.raw,
+			syncStatus: item.patternPost.wp_pattern_sync_status,
 		};
 
 		return downloadBlob(

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -184,29 +184,38 @@ const selectPatterns = createSelector(
 	]
 );
 
-const patternBlockToPattern = ( patternBlock, categories ) => ( {
-	blocks: parse( patternBlock.content.raw, {
+/**
+ * Converts a post of type `wp_block` to a 'pattern item' that more closely
+ * matches the structure of theme provided patterns.
+ *
+ * @param {Object} patternPost The `wp_block` record being normalized.
+ * @param {Map}    categories  A Map of user created categories.
+ *
+ * @return {Object} The normalized item.
+ */
+const convertPatternPostToItem = ( patternPost, categories ) => ( {
+	blocks: parse( patternPost.content.raw, {
 		__unstableSkipMigrationLogs: true,
 	} ),
-	...( patternBlock.wp_pattern_category.length > 0 && {
-		categories: patternBlock.wp_pattern_category.map(
+	...( patternPost.wp_pattern_category.length > 0 && {
+		categories: patternPost.wp_pattern_category.map(
 			( patternCategoryId ) =>
 				categories && categories.get( patternCategoryId )
 					? categories.get( patternCategoryId ).slug
 					: patternCategoryId
 		),
 	} ),
-	termLabels: patternBlock.wp_pattern_category.map( ( patternCategoryId ) =>
+	termLabels: patternPost.wp_pattern_category.map( ( patternCategoryId ) =>
 		categories?.get( patternCategoryId )
 			? categories.get( patternCategoryId ).label
 			: patternCategoryId
 	),
-	id: patternBlock.id,
-	name: patternBlock.slug,
-	syncStatus: patternBlock.wp_pattern_sync_status || PATTERN_SYNC_TYPES.full,
-	title: patternBlock.title.raw,
-	type: PATTERN_TYPES.user,
-	patternBlock,
+	id: patternPost.id,
+	name: patternPost.slug,
+	syncStatus: patternPost.wp_pattern_sync_status || PATTERN_SYNC_TYPES.full,
+	title: patternPost.title.raw,
+	type: patternPost.type,
+	patternBlock: patternPost,
 } );
 
 const selectUserPatterns = createSelector(
@@ -215,7 +224,7 @@ const selectUserPatterns = createSelector(
 			select( coreStore );
 
 		const query = { per_page: -1 };
-		const records = getEntityRecords(
+		const patternPosts = getEntityRecords(
 			'postType',
 			PATTERN_TYPES.user,
 			query
@@ -225,9 +234,9 @@ const selectUserPatterns = createSelector(
 		userPatternCategories.forEach( ( userCategory ) =>
 			categories.set( userCategory.id, userCategory )
 		);
-		let patterns = records
-			? records.map( ( record ) =>
-					patternBlockToPattern( record, categories )
+		let patterns = patternPosts
+			? patternPosts.map( ( record ) =>
+					convertPatternPostToItem( record, categories )
 			  )
 			: EMPTY_PATTERN_LIST;
 

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -215,7 +215,7 @@ const convertPatternPostToItem = ( patternPost, categories ) => ( {
 	syncStatus: patternPost.wp_pattern_sync_status || PATTERN_SYNC_TYPES.full,
 	title: patternPost.title.raw,
 	type: patternPost.type,
-	patternBlock: patternPost,
+	patternPost,
 } );
 
 const selectUserPatterns = createSelector(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed in the patterns code some confusing naming. There's something called a `patternBlock`, which a reader might expect to be a block object, but instead it's a post object.

In this PR I rename the property to `patternPost`.

I think there are further improvements that can be made - I don't think the entire post object should be passed around as the property of another 'item'. I'll try to keep this PR small to avoid breaking things.

## Testing Instructions
1. Open the patterns screen in the site editor
2. Try duplicating patterns
3. It should work
4. Try exporting a pattern as JSON
5. It should work (check the data is correct)