### PR TITLE
Code Quality: Improve inserter pattern constants

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -24,7 +24,7 @@ import { unlock } from '../../lock-unlock';
 import BlockPreview from '../block-preview';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 import BlockPatternsPaging from '../block-patterns-paging';
-import { PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
+import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
 
 const {
 	CompositeV2: Composite,
@@ -78,7 +78,8 @@ function BlockPattern( {
 				>
 					<WithToolTip
 						showTooltip={
-							showTooltip && ! pattern.type !== PATTERN_TYPES.user
+							showTooltip &&
+							! pattern.type !== INSERTER_PATTERN_TYPES.user
 						}
 						title={ pattern.title }
 					>
@@ -97,7 +98,7 @@ function BlockPattern( {
 										{
 											'block-editor-block-patterns-list__list-item-synced':
 												pattern.type ===
-													PATTERN_TYPES.user &&
+													INSERTER_PATTERN_TYPES.user &&
 												! pattern.syncStatus,
 										}
 									) }
@@ -122,7 +123,8 @@ function BlockPattern( {
 							/>
 
 							<HStack className="block-editor-patterns__pattern-details">
-								{ pattern.type === PATTERN_TYPES.user &&
+								{ pattern.type ===
+									INSERTER_PATTERN_TYPES.user &&
 									! pattern.syncStatus && (
 										<div className="block-editor-patterns__pattern-icon-wrapper">
 											<Icon
@@ -132,7 +134,8 @@ function BlockPattern( {
 										</div>
 									) }
 								{ ( ! showTooltip ||
-									pattern.type === PATTERN_TYPES.user ) && (
+									pattern.type ===
+										INSERTER_PATTERN_TYPES.user ) && (
 									<div className="block-editor-block-patterns-list__item-title">
 										{ pattern.title }
 									</div>

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -12,7 +12,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import BlockDraggableChip from '../block-draggable/draggable-chip';
-import { PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
+import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
 
 const InserterDraggableBlocks = ( {
 	isEnabled,
@@ -42,7 +42,7 @@ const InserterDraggableBlocks = ( {
 			transferData={ transferData }
 			onDragStart={ ( event ) => {
 				const parsedBlocks =
-					pattern?.type === PATTERN_TYPES.user &&
+					pattern?.type === INSERTER_PATTERN_TYPES.user &&
 					pattern?.syncStatus !== 'unsynced'
 						? [ createBlock( 'core/block', { ref: pattern.id } ) ]
 						: blocks;

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
@@ -18,7 +18,7 @@ import { searchItems } from '../search-items';
 import BlockPatternsPaging from '../../block-patterns-paging';
 import usePatternsPaging from '../hooks/use-patterns-paging';
 import {
-	PATTERN_TYPES,
+	INSERTER_PATTERN_TYPES,
 	allPatternsCategory,
 	myPatternsCategory,
 } from '../block-patterns-tab/utils';
@@ -73,7 +73,7 @@ function PatternList( { searchValue, selectedCategory, patternCategories } ) {
 			}
 			if (
 				selectedCategory === myPatternsCategory.name &&
-				pattern.type === PATTERN_TYPES.user
+				pattern.type === INSERTER_PATTERN_TYPES.user
 			) {
 				return true;
 			}

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -30,7 +30,7 @@ import {
 	isPatternFiltered,
 	allPatternsCategory,
 	myPatternsCategory,
-	PATTERN_TYPES,
+	INSERTER_PATTERN_TYPES,
 } from './utils';
 
 const noop = () => {};
@@ -73,7 +73,7 @@ export function PatternCategoryPreviews( {
 
 				if (
 					category.name === myPatternsCategory.name &&
-					pattern.type === PATTERN_TYPES.user
+					pattern.type === INSERTER_PATTERN_TYPES.user
 				) {
 					return true;
 				}

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -16,7 +16,11 @@ import { useMemo, createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { myPatternsCategory, SYNC_TYPES, PATTERN_TYPES } from './utils';
+import {
+	myPatternsCategory,
+	SYNC_TYPES,
+	INSERTER_PATTERN_TYPES,
+} from './utils';
 
 const getShouldDisableSyncFilter = ( sourceFilter ) => sourceFilter !== 'all';
 const getShouldDisableNonUserSources = ( category ) => {
@@ -37,7 +41,7 @@ export function PatternsFilter( {
 	// this filter themselves.
 	const currentPatternSourceFilter =
 		category.name === myPatternsCategory.name
-			? PATTERN_TYPES.user
+			? INSERTER_PATTERN_TYPES.user
 			: patternSourceFilter;
 
 	// We need to disable the sync filter option if the source filter is not 'all' or 'user'
@@ -85,17 +89,17 @@ export function PatternsFilter( {
 				disabled: shouldDisableNonUserSources,
 			},
 			{
-				value: PATTERN_TYPES.directory,
+				value: INSERTER_PATTERN_TYPES.directory,
 				label: __( 'Pattern Directory' ),
 				disabled: shouldDisableNonUserSources,
 			},
 			{
-				value: PATTERN_TYPES.theme,
+				value: INSERTER_PATTERN_TYPES.theme,
 				label: __( 'Theme & Plugins' ),
 				disabled: shouldDisableNonUserSources,
 			},
 			{
-				value: PATTERN_TYPES.user,
+				value: INSERTER_PATTERN_TYPES.user,
 				label: __( 'User' ),
 			},
 		],

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -54,7 +54,7 @@ export function PatternsFilter( {
 	const patternSyncMenuOptions = useMemo(
 		() => [
 			{
-				value: SYNC_TYPES.all,
+				value: 'all',
 				label: _x( 'All', 'Option that shows all patterns' ),
 			},
 			{
@@ -105,7 +105,7 @@ export function PatternsFilter( {
 	function handleSetSourceFilterChange( newSourceFilter ) {
 		setPatternSourceFilter( newSourceFilter );
 		if ( getShouldDisableSyncFilter( newSourceFilter ) ) {
-			setPatternSyncFilter( SYNC_TYPES.all );
+			setPatternSyncFilter( 'all' );
 		}
 	}
 

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -18,9 +18,7 @@ import { useMemo, createInterpolateElement } from '@wordpress/element';
  */
 import { myPatternsCategory, SYNC_TYPES, PATTERN_TYPES } from './utils';
 
-const getShouldDisableSyncFilter = ( sourceFilter ) =>
-	sourceFilter !== PATTERN_TYPES.all && sourceFilter !== PATTERN_TYPES.user;
-
+const getShouldDisableSyncFilter = ( sourceFilter ) => sourceFilter !== 'all';
 const getShouldDisableNonUserSources = ( category ) => {
 	return category.name === myPatternsCategory.name;
 };
@@ -82,7 +80,7 @@ export function PatternsFilter( {
 	const patternSourceMenuOptions = useMemo(
 		() => [
 			{
-				value: PATTERN_TYPES.all,
+				value: 'all',
 				label: __( 'All' ),
 				disabled: shouldDisableNonUserSources,
 			},

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -18,7 +18,7 @@ import { useMemo, createInterpolateElement } from '@wordpress/element';
  */
 import {
 	myPatternsCategory,
-	SYNC_TYPES,
+	INSERTER_SYNC_TYPES,
 	INSERTER_PATTERN_TYPES,
 } from './utils';
 
@@ -62,7 +62,7 @@ export function PatternsFilter( {
 				label: _x( 'All', 'Option that shows all patterns' ),
 			},
 			{
-				value: SYNC_TYPES.full,
+				value: INSERTER_SYNC_TYPES.full,
 				label: _x(
 					'Synced',
 					'Option that shows all synchronized patterns'
@@ -70,7 +70,7 @@ export function PatternsFilter( {
 				disabled: shouldDisableSyncFilter,
 			},
 			{
-				value: SYNC_TYPES.unsynced,
+				value: INSERTER_SYNC_TYPES.unsynced,
 				label: _x(
 					'Not synced',
 					'Option that shows all patterns that are not synchronized'

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
@@ -14,7 +14,7 @@ import {
 	isPatternFiltered,
 	allPatternsCategory,
 	myPatternsCategory,
-	PATTERN_TYPES,
+	INSERTER_PATTERN_TYPES,
 } from './utils';
 
 function hasRegisteredCategory( pattern, allCategories ) {
@@ -69,7 +69,7 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 		}
 		if (
 			filteredPatterns.some(
-				( pattern ) => pattern.type === PATTERN_TYPES.user
+				( pattern ) => pattern.type === INSERTER_PATTERN_TYPES.user
 			)
 		) {
 			categories.unshift( myPatternsCategory );

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -4,7 +4,7 @@
 
 import { __ } from '@wordpress/i18n';
 
-export const PATTERN_TYPES = {
+export const INSERTER_PATTERN_TYPES = {
 	user: 'user',
 	theme: 'theme',
 	directory: 'directory',
@@ -34,7 +34,7 @@ export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 	// If theme source selected, filter out user created patterns and those from
 	// the core patterns directory.
 	if (
-		sourceFilter === PATTERN_TYPES.theme &&
+		sourceFilter === INSERTER_PATTERN_TYPES.theme &&
 		( isUserPattern || isDirectoryPattern )
 	) {
 		return true;
@@ -43,7 +43,7 @@ export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 	// If the directory source is selected, filter out user created patterns
 	// and those bundled with the theme.
 	if (
-		sourceFilter === PATTERN_TYPES.directory &&
+		sourceFilter === INSERTER_PATTERN_TYPES.directory &&
 		( isUserPattern || ! isDirectoryPattern )
 	) {
 		return true;
@@ -51,8 +51,8 @@ export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 
 	// If user source selected, filter out theme patterns.
 	if (
-		sourceFilter === PATTERN_TYPES.user &&
-		pattern.type !== PATTERN_TYPES.user
+		sourceFilter === INSERTER_PATTERN_TYPES.user &&
+		pattern.type !== INSERTER_PATTERN_TYPES.user
 	) {
 		return true;
 	}

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -5,7 +5,6 @@
 import { __ } from '@wordpress/i18n';
 
 export const PATTERN_TYPES = {
-	all: 'all',
 	user: 'user',
 	theme: 'theme',
 	directory: 'directory',

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -10,7 +10,7 @@ export const INSERTER_PATTERN_TYPES = {
 	directory: 'directory',
 };
 
-export const SYNC_TYPES = {
+export const INSERTER_SYNC_TYPES = {
 	full: 'fully',
 	unsynced: 'unsynced',
 };
@@ -58,12 +58,15 @@ export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 	}
 
 	// Filter by sync status.
-	if ( syncFilter === SYNC_TYPES.full && pattern.syncStatus !== '' ) {
+	if (
+		syncFilter === INSERTER_SYNC_TYPES.full &&
+		pattern.syncStatus !== ''
+	) {
 		return true;
 	}
 
 	if (
-		syncFilter === SYNC_TYPES.unsynced &&
+		syncFilter === INSERTER_SYNC_TYPES.unsynced &&
 		pattern.syncStatus !== 'unsynced' &&
 		isUserPattern
 	) {

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -11,7 +11,6 @@ export const PATTERN_TYPES = {
 };
 
 export const SYNC_TYPES = {
-	all: 'all',
 	full: 'fully',
 	unsynced: 'unsynced',
 };

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -6,8 +6,6 @@ import { __ } from '@wordpress/i18n';
 
 export const PATTERN_TYPES = {
 	all: 'all',
-	synced: 'synced',
-	unsynced: 'unsynced',
 	user: 'user',
 	theme: 'theme',
 	directory: 'directory',

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -11,7 +11,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../../store';
-import { PATTERN_TYPES } from '../block-patterns-tab/utils';
+import { INSERTER_PATTERN_TYPES } from '../block-patterns-tab/utils';
 
 /**
  * Retrieves the block patterns inserter state.
@@ -58,7 +58,7 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 	const onClickPattern = useCallback(
 		( pattern, blocks ) => {
 			const patternBlocks =
-				pattern.type === PATTERN_TYPES.user &&
+				pattern.type === INSERTER_PATTERN_TYPES.user &&
 				pattern.syncStatus !== 'unsynced'
 					? [ createBlock( 'core/block', { ref: pattern.id } ) ]
 					: blocks;

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
+import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 
 const EMPTY_ARRAY = [];
 
@@ -18,7 +18,7 @@ export function getUserPatterns( state ) {
 		return {
 			name: `core/block/${ userPattern.id }`,
 			id: userPattern.id,
-			type: PATTERN_TYPES.user,
+			type: INSERTER_PATTERN_TYPES.user,
 			title: userPattern.title.raw,
 			categories: userPattern.wp_pattern_category.map( ( catId ) =>
 				categories && categories.get( catId )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Across the codebase there were two constant objects called `PATTERN_TYPES`, confusingly containing different values. This PR changes the name of the one defined in `packages/block-editor/src/components/inserter/block-patterns-tab/utils.js` to `INSERTER_PATTERN_TYPES` to help indicate that it's used for inserter items.

I've also removed the 'synced' and 'unsynced' values from this constant which were unused.

I've removed the 'all' value from these constants, as this isn't a value that can be set on pattern inserter items. Instead this is a value that is used by the filter UI.

Finally, the `SYNC_TYPES` constant is renamed to `INSERTER_SYNC_TYPES`.
