### PR TITLE
[Pattern overrides] Allow multiple attributes overrides

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -150,7 +150,7 @@ if ( $gutenberg_experiments && (
 					continue;
 				}
 
-				$custom_value = $connection_sources[ $attribute_value['source'] ]( $block_instance );
+				$custom_value = $connection_sources[ $attribute_value['source'] ]( $block_instance, $attribute_name );
 			} else {
 				// If the attribute does not specify the name of the custom field, skip it.
 				if ( ! isset( $attribute_value['value'] ) ) {

--- a/lib/experimental/connection-sources/index.php
+++ b/lib/experimental/connection-sources/index.php
@@ -12,8 +12,12 @@ return array(
 		// if it doesn't, `get_post_meta()` will just return an empty string.
 		return get_post_meta( $block_instance->context['postId'], $meta_field, true );
 	},
-	'pattern_attributes' => function ( $block_instance ) {
+	'pattern_attributes' => function ( $block_instance, $attribute_name ) {
 		$block_id = $block_instance->attributes['metadata']['id'];
-		return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id ), false );
+		return _wp_array_get(
+			$block_instance->context,
+			array( 'pattern/overrides', $block_id, $attribute_name ),
+			false
+		);
 	},
 );

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -97,9 +97,12 @@ function applyInitialOverrides( blocks, overrides = {}, defaultValues ) {
 		const attributes = getPartiallySyncedAttributes( block );
 		const newAttributes = { ...block.attributes };
 		for ( const attributeKey of attributes ) {
-			defaultValues[ blockId ] = block.attributes[ attributeKey ];
+			defaultValues[ blockId ] ??= {};
+			defaultValues[ blockId ][ attributeKey ] =
+				block.attributes[ attributeKey ];
 			if ( overrides[ blockId ] ) {
-				newAttributes[ attributeKey ] = overrides[ blockId ];
+				newAttributes[ attributeKey ] =
+					overrides[ blockId ][ attributeKey ];
 			}
 		}
 		return {
@@ -111,7 +114,7 @@ function applyInitialOverrides( blocks, overrides = {}, defaultValues ) {
 }
 
 function getOverridesFromBlocks( blocks, defaultValues ) {
-	/** @type {Record<string, unknown>} */
+	/** @type {Record<string, Record<string, unknown>>} */
 	const overrides = {};
 	for ( const block of blocks ) {
 		Object.assign(
@@ -123,9 +126,12 @@ function getOverridesFromBlocks( blocks, defaultValues ) {
 		const attributes = getPartiallySyncedAttributes( block );
 		for ( const attributeKey of attributes ) {
 			if (
-				block.attributes[ attributeKey ] !== defaultValues[ blockId ]
+				block.attributes[ attributeKey ] !==
+				defaultValues[ blockId ][ attributeKey ]
 			) {
-				overrides[ blockId ] = block.attributes[ attributeKey ];
+				overrides[ blockId ] ??= {};
+				overrides[ blockId ][ attributeKey ] =
+					block.attributes[ attributeKey ];
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #53705. Based on https://github.com/WordPress/gutenberg/pull/56235.

Allow multiple attributes for a given block (`core/image' for instance).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As requested in https://github.com/WordPress/gutenberg/pull/57249#issuecomment-1877674385.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Store `overrides` as an object for each id.

There might be some manual updates needed in the backend in https://github.com/WordPress/gutenberg/pull/57249 to support this.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Pattern overrides should still work.

1. Enable the "Pattern overrides" gutenberg experiment.
2. Go to Editor -> Patterns -> create a new synced pattern.
3. Add some blocks that include the paragraph block.
4. Open the block inspector and check the "Pattern overrides" checkbox under "Advanced".
Save the (partially) synced pattern.
5. Open a post editor and insert a couple of the just-created synced patterns.
6. Edit the contents of the abovementioned blocks on the pattern instance and save the post.
7. Visit the saved post (the frontend) and expect the content to be synced to each instance separately.

## Screenshots or screencast <!-- if applicable -->
N/A