### PR TITLE
DataViews: make it the root for pages and add details

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -236,7 +236,8 @@ Array of operations that can be performed upon each record. Each action is an ob
 - `isLoading`: whether the data is loading. `false` by default.
 - `supportedLayouts`: array of layouts supported. By default, all are: `table`, `grid`, `list`.
 - `deferredRendering`: whether the items should be rendered asynchronously. Useful when there's a field that takes a lot of time (e.g.: previews). `false` by default.
-- `onSelectionChange`: callback that returns the selected items. So far, only the `list` view implements this.
+- `onSelectionChange`: callback that signals the user selected one of more items, and takes them as parameter. So far, only the `list` view implements it.
+- `onDetailsChange`: callback that signals the user triggered the details for one of more items, and takes them as paremeter. So far, only the `list` view implements it.
 
 ## Contributing to this package
 

--- a/packages/dataviews/src/dataviews.js
+++ b/packages/dataviews/src/dataviews.js
@@ -17,6 +17,7 @@ import Search from './search';
 import { VIEW_LAYOUTS } from './constants';
 
 const defaultGetItemId = ( item ) => item.id;
+const defaultOnSelectionChange = () => {};
 
 export default function DataViews( {
 	view,
@@ -30,7 +31,8 @@ export default function DataViews( {
 	isLoading = false,
 	paginationInfo,
 	supportedLayouts,
-	onSelectionChange,
+	onSelectionChange = defaultOnSelectionChange,
+	onDetailsChange = null,
 	deferredRendering = false,
 } ) {
 	const [ selection, setSelection ] = useState( [] );
@@ -89,6 +91,7 @@ export default function DataViews( {
 					getItemId={ getItemId }
 					isLoading={ isLoading }
 					onSelectionChange={ onSetSelection }
+					onDetailsChange={ onDetailsChange }
 					selection={ selection }
 					deferredRendering={ deferredRendering }
 				/>

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -245,7 +245,7 @@
 		&:focus {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
-		.edit-site-page-pages__list-view-title-field {
+		h3 {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -344,7 +344,11 @@
 	li:focus-within {
 		.dataviews-view-list__details-button {
 			opacity: 1;
+		}
+	}
 
+	li.is-selected {
+		.dataviews-view-list__details-button {
 			&:focus {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) currentColor;
 			}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -224,7 +224,7 @@
 .dataviews-view-list {
 	margin: 0;
 
-	li {
+	.dataviews-list-view__item {
 		border-bottom: $border-width solid $gray-100;
 		margin: 0;
 		&:first-child {
@@ -239,30 +239,37 @@
 		}
 	}
 
-	li.is-selected,
-	li.is-selected:hover,
-	li.is-selected:focus-within {
+	.dataviews-list-view__item.is-selected,
+	.dataviews-list-view__item.is-selected:hover,
+	.dataviews-list-view__item.is-selected:focus-within {
 		background-color: $gray-100;
+
 	}
 
-	.dataviews-view-list__item {
+	.dataviews-view-list__item-content {
 		padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
 		width: 100%;
 		cursor: default;
-		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		}
 		h3 {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
 		}
-	}
 
-	.dataviews-view-list__item-selected,
-	.dataviews-view-list__item-selected:hover {
 		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: none;
+			position: relative;
+
+			&::after {
+				content: "";
+				position: absolute;
+				top: 0;
+				right: -32px; // Button width.
+				bottom: 0;
+				left: 0;
+				pointer-events: none;
+				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			}
 		}
 	}
 
@@ -307,18 +314,19 @@
 		}
 	}
 
-	.dataviews-list-view__details-button {
+	.dataviews-list-view__item-details {
 		align-self: center;
 		opacity: 0;
 	}
 
-	li.is-selected,
-	li:hover,
-	li:focus-within {
-		.dataviews-list-view__details-button {
+	.dataviews-list-view__item.is-selected,
+	.dataviews-list-view__item:hover,
+	.dataviews-list-view__item:focus-within {
+		.dataviews-list-view__item-details {
 			opacity: 1;
 		}
 	}
+
 }
 
 .dataviews-action-modal {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -245,7 +245,7 @@
 		&:focus {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
-		h3 {
+		.edit-site-page-pages__list-view-title-field {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
@@ -300,6 +300,10 @@
 				margin-right: 0;
 			}
 		}
+	}
+
+	.dataviews-list-view__details-button {
+		align-self: center;
 	}
 }
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -223,53 +223,74 @@
 
 .dataviews-view-list {
 	margin: 0;
+	padding: $grid-unit-10;
 
-	.dataviews-list-view__item {
-		border-bottom: $border-width solid $gray-100;
+	li {
 		margin: 0;
-		&:first-child {
-			border-top: $border-width solid $gray-100;
+
+		.dataviews-list-view__item-wrapper {
+			position: relative;
+			padding-right: $grid-unit-30;
+			border-radius: $grid-unit-05;
+
+			&::after {
+				position: absolute;
+				content: "";
+				top: 100%;
+				left: $grid-unit-30;
+				right: $grid-unit-30;
+				background: $gray-100;
+				height: 1px;
+			}
 		}
-		&:last-child {
-			border-bottom: 0;
-		}
-		&:hover,
-		&:focus-within {
-			background-color: lighten($gray-100, 3%);
+
+		&:not(.is-selected):hover {
+			color: var(--wp-admin-theme-color);
+
+			.dataviews-list-view__fields {
+				color: var(--wp-admin-theme-color);
+			}
 		}
 	}
 
-	.dataviews-list-view__item.is-selected,
-	.dataviews-list-view__item.is-selected:hover,
-	.dataviews-list-view__item.is-selected:focus-within {
-		background-color: $gray-100;
+	li.is-selected,
+	li.is-selected:focus-within {
+		.dataviews-list-view__item-wrapper {
+			background-color: var(--wp-admin-theme-color);
+			color: $white;
 
+			.dataviews-list-view__fields,
+			.components-button {
+				color: $white;
+			}
+			
+			&::after {
+				background: transparent;
+			}
+		}
 	}
 
-	.dataviews-view-list__item-content {
-		padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
+	.dataviews-view-list__item {
+		padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-30;
 		width: 100%;
-		cursor: default;
+		cursor: pointer;
+		&:focus {
+			&:before {
+				position: absolute;
+				content: "";
+				top: -1px;
+				right: -1px;
+				bottom: -1px;
+				left: -1px;
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+				z-index: -1;
+				border-radius: $grid-unit-05;
+			}
+		}
 		h3 {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
-		}
-
-		&:focus {
-			box-shadow: none;
-			position: relative;
-
-			&::after {
-				content: "";
-				position: absolute;
-				top: 0;
-				right: -32px; // Button width.
-				bottom: 0;
-				left: 0;
-				pointer-events: none;
-				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			}
 		}
 	}
 
@@ -279,7 +300,6 @@
 		border-radius: $grid-unit-05;
 		overflow: hidden;
 		position: relative;
-		margin-top: $grid-unit-05;
 
 		&::after {
 			content: "";
@@ -314,19 +334,18 @@
 		}
 	}
 
-	.dataviews-list-view__item-details {
+	.dataviews-list-view__details-button {
 		align-self: center;
 		opacity: 0;
 	}
 
-	.dataviews-list-view__item.is-selected,
-	.dataviews-list-view__item:hover,
-	.dataviews-list-view__item:focus-within {
-		.dataviews-list-view__item-details {
+	li.is-selected,
+	li:hover,
+	li:focus-within {
+		.dataviews-list-view__details-button {
 			opacity: 1;
 		}
 	}
-
 }
 
 .dataviews-action-modal {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -309,6 +309,15 @@
 
 	.dataviews-list-view__details-button {
 		align-self: center;
+		opacity: 0;
+	}
+
+	li.is-selected,
+	li:hover,
+	li:focus-within {
+		.dataviews-list-view__details-button {
+			opacity: 1;
+		}
 	}
 }
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -263,7 +263,7 @@
 			.components-button {
 				color: $white;
 			}
-			
+
 			&::after {
 				background: transparent;
 			}
@@ -275,7 +275,7 @@
 		width: 100%;
 		cursor: pointer;
 		&:focus {
-			&:before {
+			&::before {
 				position: absolute;
 				content: "";
 				top: -1px;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -236,7 +236,8 @@
 	}
 
 	.dataviews-view-list__item {
-		padding: $grid-unit-15 $grid-unit-40;
+		padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
+		width: 100%;
 		cursor: default;
 		&:focus,
 		&:hover {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -344,6 +344,10 @@
 	li:focus-within {
 		.dataviews-view-list__details-button {
 			opacity: 1;
+
+			&:focus {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) currentColor;
+			}
 		}
 	}
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -228,7 +228,7 @@
 	li {
 		margin: 0;
 
-		.dataviews-list-view__item-wrapper {
+		.dataviews-view-list__item-wrapper {
 			position: relative;
 			padding-right: $grid-unit-30;
 			border-radius: $grid-unit-05;
@@ -247,7 +247,7 @@
 		&:not(.is-selected):hover {
 			color: var(--wp-admin-theme-color);
 
-			.dataviews-list-view__fields {
+			.dataviews-view-list__fields {
 				color: var(--wp-admin-theme-color);
 			}
 		}
@@ -255,11 +255,11 @@
 
 	li.is-selected,
 	li.is-selected:focus-within {
-		.dataviews-list-view__item-wrapper {
+		.dataviews-view-list__item-wrapper {
 			background-color: var(--wp-admin-theme-color);
 			color: $white;
 
-			.dataviews-list-view__fields,
+			.dataviews-view-list__fields,
 			.components-button {
 				color: $white;
 			}
@@ -334,7 +334,7 @@
 		}
 	}
 
-	.dataviews-list-view__details-button {
+	.dataviews-view-list__details-button {
 		align-self: center;
 		opacity: 0;
 	}
@@ -342,7 +342,7 @@
 	li.is-selected,
 	li:hover,
 	li:focus-within {
-		.dataviews-list-view__details-button {
+		.dataviews-view-list__details-button {
 			opacity: 1;
 		}
 	}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -233,16 +233,22 @@
 		&:last-child {
 			border-bottom: 0;
 		}
+		&:hover,
+		&:focus-within {
+			background-color: lighten($gray-100, 3%);
+		}
+	}
+
+	li.is-selected,
+	li.is-selected:hover,
+	li.is-selected:focus-within {
+		background-color: $gray-100;
 	}
 
 	.dataviews-view-list__item {
 		padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
 		width: 100%;
 		cursor: default;
-		&:focus,
-		&:hover {
-			background-color: lighten($gray-100, 3%);
-		}
 		&:focus {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
@@ -255,8 +261,6 @@
 
 	.dataviews-view-list__item-selected,
 	.dataviews-view-list__item-selected:hover {
-		background-color: $gray-100;
-
 		&:focus {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -10,8 +10,11 @@ import { useAsyncList } from '@wordpress/compose';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	Button,
 } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { isRTL, __ } from '@wordpress/i18n';
 
 export default function ViewList( {
 	view,
@@ -19,6 +22,7 @@ export default function ViewList( {
 	data,
 	getItemId,
 	onSelectionChange,
+	onDetailsChange,
 	selection,
 	deferredRendering,
 } ) {
@@ -89,6 +93,19 @@ export default function ViewList( {
 										</div>
 									</VStack>
 								</HStack>
+								{ onDetailsChange && (
+									<Button
+										className="dataviews-list-view__details-button"
+										onClick={ () =>
+											onDetailsChange( [ item ] )
+										}
+										icon={
+											isRTL() ? chevronLeft : chevronRight
+										}
+										label={ __( 'View details' ) }
+										size="compact"
+									/>
+								) }
 							</HStack>
 						</div>
 					</li>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -55,23 +55,17 @@ export default function ViewList( {
 				return (
 					<li
 						key={ getItemId( item ) }
-						className={ classNames( {
+						className={ classNames( 'dataviews-list-view__item', {
 							'is-selected': selection.includes( item.id ),
 						} ) }
 					>
-						<HStack>
+						<HStack spacing={ 0 }>
 							<div
 								role="button"
 								tabIndex={ 0 }
 								aria-pressed={ selection.includes( item.id ) }
 								onKeyDown={ onEnter( item ) }
-								className={ classNames(
-									'dataviews-view-list__item',
-									{
-										'dataviews-view-list__item-selected':
-											selection.includes( item.id ),
-									}
-								) }
+								className="dataviews-view-list__item-content"
 								onClick={ () => onSelectionChange( [ item ] ) }
 							>
 								<HStack spacing={ 3 } justify="start">
@@ -101,7 +95,7 @@ export default function ViewList( {
 							</div>
 							{ onDetailsChange && (
 								<Button
-									className="dataviews-view-list__details-button"
+									className="dataviews-view-list__item-details"
 									onClick={ () =>
 										onDetailsChange( [ item ] )
 									}

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -59,7 +59,7 @@ export default function ViewList( {
 							'is-selected': selection.includes( item.id ),
 						} ) }
 					>
-						<HStack className="dataviews-list-view__item-wrapper">
+						<HStack className="dataviews-view-list__item-wrapper">
 							<div
 								role="button"
 								tabIndex={ 0 }

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -65,13 +65,7 @@ export default function ViewList( {
 								tabIndex={ 0 }
 								aria-pressed={ selection.includes( item.id ) }
 								onKeyDown={ onEnter( item ) }
-								className={ classNames(
-									'dataviews-view-list__item',
-									{
-										'dataviews-view-list__item-selected':
-											selection.includes( item.id ),
-									}
-								) }
+								className="dataviews-view-list__item"
 								onClick={ () => onSelectionChange( [ item ] ) }
 							>
 								<HStack spacing={ 3 } justify="start">

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -13,8 +13,8 @@ import {
 	Button,
 } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
-import { chevronRight, chevronLeft } from '@wordpress/icons';
-import { isRTL, __ } from '@wordpress/i18n';
+import { info } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 export default function ViewList( {
 	view,
@@ -55,17 +55,23 @@ export default function ViewList( {
 				return (
 					<li
 						key={ getItemId( item ) }
-						className={ classNames( 'dataviews-list-view__item', {
+						className={ classNames( {
 							'is-selected': selection.includes( item.id ),
 						} ) }
 					>
-						<HStack spacing={ 0 }>
+						<HStack className="dataviews-list-view__item-wrapper">
 							<div
 								role="button"
 								tabIndex={ 0 }
 								aria-pressed={ selection.includes( item.id ) }
 								onKeyDown={ onEnter( item ) }
-								className="dataviews-view-list__item-content"
+								className={ classNames(
+									'dataviews-view-list__item',
+									{
+										'dataviews-view-list__item-selected':
+											selection.includes( item.id ),
+									}
+								) }
 								onClick={ () => onSelectionChange( [ item ] ) }
 							>
 								<HStack spacing={ 3 } justify="start">
@@ -95,13 +101,11 @@ export default function ViewList( {
 							</div>
 							{ onDetailsChange && (
 								<Button
-									className="dataviews-view-list__item-details"
+									className="dataviews-view-list__details-button"
 									onClick={ () =>
 										onDetailsChange( [ item ] )
 									}
-									icon={
-										isRTL() ? chevronLeft : chevronRight
-									}
+									icon={ info }
 									label={ __( 'View details' ) }
 									size="compact"
 								/>

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -53,7 +53,12 @@ export default function ViewList( {
 		<ul className="dataviews-view-list">
 			{ usedData.map( ( item ) => {
 				return (
-					<li key={ getItemId( item ) }>
+					<li
+						key={ getItemId( item ) }
+						className={ classNames( {
+							'is-selected': selection.includes( item.id ),
+						} ) }
+					>
 						<HStack>
 							<div
 								role="button"

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -54,27 +54,27 @@ export default function ViewList( {
 			{ usedData.map( ( item ) => {
 				return (
 					<li key={ getItemId( item ) }>
-						<div
-							role="button"
-							tabIndex={ 0 }
-							aria-pressed={ selection.includes( item.id ) }
-							onKeyDown={ onEnter( item ) }
-							className={ classNames(
-								'dataviews-view-list__item',
-								{
-									'dataviews-view-list__item-selected':
-										selection.includes( item.id ),
-								}
-							) }
-							onClick={ () => onSelectionChange( [ item ] ) }
-						>
-							<HStack spacing={ 3 } alignment="flex-start">
-								<div className="dataviews-view-list__media-wrapper">
-									{ mediaField?.render( { item } ) || (
-										<div className="dataviews-view-list__media-placeholder"></div>
-									) }
-								</div>
-								<HStack>
+						<HStack>
+							<div
+								role="button"
+								tabIndex={ 0 }
+								aria-pressed={ selection.includes( item.id ) }
+								onKeyDown={ onEnter( item ) }
+								className={ classNames(
+									'dataviews-view-list__item',
+									{
+										'dataviews-view-list__item-selected':
+											selection.includes( item.id ),
+									}
+								) }
+								onClick={ () => onSelectionChange( [ item ] ) }
+							>
+								<HStack spacing={ 3 } justify="start">
+									<div className="dataviews-view-list__media-wrapper">
+										{ mediaField?.render( { item } ) || (
+											<div className="dataviews-view-list__media-placeholder"></div>
+										) }
+									</div>
 									<VStack spacing={ 1 }>
 										{ primaryField?.render( { item } ) }
 										<div className="dataviews-view-list__fields">
@@ -93,21 +93,21 @@ export default function ViewList( {
 										</div>
 									</VStack>
 								</HStack>
-								{ onDetailsChange && (
-									<Button
-										className="dataviews-list-view__details-button"
-										onClick={ () =>
-											onDetailsChange( [ item ] )
-										}
-										icon={
-											isRTL() ? chevronLeft : chevronRight
-										}
-										label={ __( 'View details' ) }
-										size="compact"
-									/>
-								) }
-							</HStack>
-						</div>
+							</div>
+							{ onDetailsChange && (
+								<Button
+									className="dataviews-view-list__details-button"
+									onClick={ () =>
+										onDetailsChange( [ item ] )
+									}
+									icon={
+										isRTL() ? chevronLeft : chevronRight
+									}
+									label={ __( 'View details' ) }
+									size="compact"
+								/>
+							) }
+						</HStack>
 					</li>
 				);
 			} ) }

--- a/packages/edit-site/src/components/page-main/index.js
+++ b/packages/edit-site/src/components/page-main/index.js
@@ -30,7 +30,7 @@ export default function PageMain() {
 		) : (
 			<PagePatterns />
 		);
-	} else if ( window?.__experimentalAdminViews && path === '/pages' ) {
+	} else if ( window?.__experimentalAdminViews && path === '/page' ) {
 		return <PagePages />;
 	}
 

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -138,6 +138,18 @@ export default function PagePages() {
 		[ setPageId ]
 	);
 
+	const onDetailsChange = useCallback(
+		( items ) => {
+			if ( !! postType && items?.length === 1 ) {
+				history.push( {
+					postId: items[ 0 ].id,
+					postType,
+				} );
+			}
+		},
+		[ history, postType ]
+	);
+
 	const queryArgs = useMemo( () => {
 		const filters = {};
 		view.filters.forEach( ( filter ) => {
@@ -339,6 +351,7 @@ export default function PagePages() {
 					view={ view }
 					onChangeView={ onChangeView }
 					onSelectionChange={ onSelectionChange }
+					onDetailsChange={ onDetailsChange }
 				/>
 			</Page>
 			{ view.type === LAYOUT_LIST && (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -20,7 +20,10 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
  */
 import Page from '../page';
 import Link from '../routes/link';
-import { default as DEFAULT_VIEWS } from '../sidebar-dataviews/default-views';
+import {
+	DEFAULT_VIEWS,
+	DEFAULT_CONFIG_PER_VIEW_TYPE,
+} from '../sidebar-dataviews/default-views';
 import {
 	ENUMERATION_TYPE,
 	LAYOUT_GRID,
@@ -44,17 +47,6 @@ import { unlock } from '../../lock-unlock';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
-const defaultConfigPerViewType = {
-	[ LAYOUT_TABLE ]: {},
-	[ LAYOUT_GRID ]: {
-		mediaField: 'featured-image',
-		primaryField: 'title',
-	},
-	[ LAYOUT_LIST ]: {
-		primaryField: 'title',
-		mediaField: 'featured-image',
-	},
-};
 
 function useView( type ) {
 	const {
@@ -63,9 +55,6 @@ function useView( type ) {
 	const selectedDefaultView =
 		isCustom === 'false' &&
 		DEFAULT_VIEWS[ type ].find( ( { slug } ) => slug === activeView )?.view;
-	selectedDefaultView.layout = {
-		...defaultConfigPerViewType[ selectedDefaultView.type ],
-	};
 	const [ view, setView ] = useState( selectedDefaultView );
 
 	useEffect( () => {
@@ -324,7 +313,7 @@ export default function PagePages() {
 				newView = {
 					...newView,
 					layout: {
-						...defaultConfigPerViewType[ newView.type ],
+						...DEFAULT_CONFIG_PER_VIEW_TYPE[ newView.type ],
 					},
 				};
 			}

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -63,6 +63,9 @@ function useView( type ) {
 	const selectedDefaultView =
 		isCustom === 'false' &&
 		DEFAULT_VIEWS[ type ].find( ( { slug } ) => slug === activeView )?.view;
+	selectedDefaultView.layout = {
+		...defaultConfigPerViewType[ selectedDefaultView.type ],
+	};
 	const [ view, setView ] = useState( selectedDefaultView );
 
 	useEffect( () => {

--- a/packages/edit-site/src/components/sidebar-dataviews/add-new-view.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/add-new-view.js
@@ -19,7 +19,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  * Internal dependencies
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
-import DEFAULT_VIEWS from './default-views';
+import { DEFAULT_VIEWS } from './default-views';
 import { unlock } from '../../lock-unlock';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -7,10 +7,10 @@ import { trash } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { LAYOUT_TABLE, OPERATOR_IN } from '../../utils/constants';
+import { LAYOUT_LIST, OPERATOR_IN } from '../../utils/constants';
 
 const DEFAULT_PAGE_BASE = {
-	type: LAYOUT_TABLE,
+	type: LAYOUT_LIST,
 	search: '',
 	filters: [],
 	page: 1,

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -7,7 +7,24 @@ import { trash } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { LAYOUT_LIST, OPERATOR_IN } from '../../utils/constants';
+import {
+	LAYOUT_LIST,
+	LAYOUT_TABLE,
+	LAYOUT_GRID,
+	OPERATOR_IN,
+} from '../../utils/constants';
+
+export const DEFAULT_CONFIG_PER_VIEW_TYPE = {
+	[ LAYOUT_TABLE ]: {},
+	[ LAYOUT_GRID ]: {
+		mediaField: 'featured-image',
+		primaryField: 'title',
+	},
+	[ LAYOUT_LIST ]: {
+		primaryField: 'title',
+		mediaField: 'featured-image',
+	},
+};
 
 const DEFAULT_PAGE_BASE = {
 	type: LAYOUT_LIST,
@@ -22,10 +39,12 @@ const DEFAULT_PAGE_BASE = {
 	// All fields are visible by default, so it's
 	// better to keep track of the hidden ones.
 	hiddenFields: [ 'date', 'featured-image' ],
-	layout: {},
+	layout: {
+		...DEFAULT_CONFIG_PER_VIEW_TYPE[ LAYOUT_LIST ],
+	},
 };
 
-const DEFAULT_VIEWS = {
+export const DEFAULT_VIEWS = {
 	page: [
 		{
 			title: __( 'All' ),
@@ -55,5 +74,3 @@ const DEFAULT_VIEWS = {
 		},
 	],
 };
-
-export default DEFAULT_VIEWS;

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -8,7 +8,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  * Internal dependencies
  */
 
-import { default as DEFAULT_VIEWS } from './default-views';
+import { DEFAULT_VIEWS } from './default-views';
 import { unlock } from '../../lock-unlock';
 const { useLocation } = unlock( routerPrivateApis );
 import DataViewItem from './dataview-item';

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -15,7 +15,7 @@ import DataViewItem from './dataview-item';
 import CustomDataViewsList from './custom-dataviews-list';
 
 const PATH_TO_TYPE = {
-	'/pages': 'page',
+	'/page': 'page',
 };
 
 export default function DataViewsSidebarContent() {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -61,7 +61,11 @@ export default function SidebarNavigationScreenMain() {
 						</SidebarNavigationItemGlobalStyles>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/page"
+							path={
+								window?.__experimentalAdminViews
+									? '/pages'
+									: '/page'
+							}
 							withChevron
 							icon={ page }
 						>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -61,11 +61,7 @@ export default function SidebarNavigationScreenMain() {
 						</SidebarNavigationItemGlobalStyles>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path={
-								window?.__experimentalAdminViews
-									? '/pages'
-									: '/page'
-							}
+							path="/page"
 							withChevron
 							icon={ page }
 						>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-page/index.js
@@ -31,7 +31,7 @@ import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-d
 
 const { useHistory } = unlock( routerPrivateApis );
 
-export default function SidebarNavigationScreenPage() {
+export default function SidebarNavigationScreenPage( { backPath } ) {
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
 	const history = useHistory();
 	const {
@@ -88,6 +88,7 @@ export default function SidebarNavigationScreenPage() {
 
 	return record ? (
 		<SidebarNavigationScreen
+			backPath={ backPath }
 			title={ decodeEntities(
 				record?.title?.rendered || __( '(no title)' )
 			) }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -81,7 +81,7 @@ function SidebarScreens() {
 				<SidebarScreenWrapper path="/pages">
 					<SidebarNavigationScreen
 						title={ __( 'Pages' ) }
-						backPath="/page"
+						backPath="/"
 						content={ <DataViewsSidebarContent /> }
 					/>
 				</SidebarScreenWrapper>

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -71,7 +71,11 @@ function SidebarScreens() {
 				<SidebarNavigationScreenPages />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page/:postId">
-				<SidebarNavigationScreenPage />
+				<SidebarNavigationScreenPage
+					backPath={
+						window.__experimentalAdminViews ? '/pages' : '/page'
+					}
+				/>
 			</SidebarScreenWrapper>
 			{ window?.__experimentalAdminViews && (
 				<SidebarScreenWrapper path="/pages">

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -68,20 +68,18 @@ function SidebarScreens() {
 				<SidebarNavigationScreenGlobalStyles />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page">
-				<SidebarNavigationScreenPages />
+				{ window?.__experimentalAdminViews ? (
+					<SidebarNavigationScreen
+						title={ __( 'Pages' ) }
+						content={ <DataViewsSidebarContent /> }
+					/>
+				) : (
+					<SidebarNavigationScreenPages />
+				) }
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page/:postId">
 				<SidebarNavigationScreenPage />
 			</SidebarScreenWrapper>
-			{ window?.__experimentalAdminViews && (
-				<SidebarScreenWrapper path="/pages">
-					<SidebarNavigationScreen
-						title={ __( 'Pages' ) }
-						backPath="/"
-						content={ <DataViewsSidebarContent /> }
-					/>
-				</SidebarScreenWrapper>
-			) }
 			<SidebarScreenWrapper path="/:postType(wp_template)">
 				<SidebarNavigationScreenTemplates />
 			</SidebarScreenWrapper>

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -71,11 +71,7 @@ function SidebarScreens() {
 				<SidebarNavigationScreenPages />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page/:postId">
-				<SidebarNavigationScreenPage
-					backPath={
-						window.__experimentalAdminViews ? '/pages' : '/page'
-					}
-				/>
+				<SidebarNavigationScreenPage />
 			</SidebarScreenWrapper>
 			{ window?.__experimentalAdminViews && (
 				<SidebarScreenWrapper path="/pages">

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -14,9 +14,8 @@ export default function getIsListPage(
 	isMobileViewport
 ) {
 	return (
-		[ '/wp_template/all', '/wp_template_part/all', '/pages' ].includes(
-			path
-		) ||
+		[ '/wp_template/all', '/wp_template_part/all' ].includes( path ) ||
+		( path === '/page' && window?.__experimentalAdminViews ) ||
 		( path === '/patterns' &&
 			// Don't treat "/patterns" without categoryType and categoryId as a
 			// list page in mobile because the sidebar covers the whole page.


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Supersedes https://github.com/WordPress/gutenberg/pull/57523 https://github.com/WordPress/gutenberg/pull/57589

## What?

Updates the root "Pages" section to go to pages dataviews. It also adds a "details" button to support the whole flow:

https://github.com/WordPress/gutenberg/assets/583546/92b90857-545b-42ca-95de-9912363f0c1e

## Why?

It's the target flow we want.

## How?

1. Makes the `list` layout the default.

2. Adds a "details" button to the list view item.

    - It requires a `onDetailChange` callback to the DataViews API, so consumers can handle this action. Note that, at the moment, the details event redirects the user to the existing details page (see [conversation](https://github.com/WordPress/gutenberg/pull/57523#issuecomment-1877299712)). The immediate follow-up is to open this in the content frame, as per the mockup below.
    - To make it accessible, this follows the pattern of the existing block editor list view, to make it accessible (interactive elements cannot be nested). See [conversation](https://github.com/WordPress/gutenberg/pull/57578#discussion_r1442701932).

4. Updates the flows, so the back button works as follows: "Pages < DataViews < Details".

## Testing Instructions

Test pages show the details:

- Enable the "new admin view".
- Navigate to "Pages" and experiment with dataviews.
- Click on the "Details" button.

Test the templates do **not** have the details button and works as before:

- Enable the "new admin view" experiment and visit "Manage all templates".
- Switch to the list layout. This is how it should look like (no details button):

<img width="1510" alt="Captura de ecrã 2024-01-04, às 12 23 11" src="https://github.com/WordPress/gutenberg/assets/583546/e64e8257-5705-4d61-b5a2-3eb2fa040fe7">

## Follow-ups

1. Implement details as per this mockup:

![240103-page-list-page-detail](https://github.com/WordPress/gutenberg/assets/583546/c549c5b0-6f2d-4425-b385-ebb8cf93e3ad)

2. Add the "Add page" button in the content frame ([conversation](https://github.com/WordPress/gutenberg/pull/57589#issuecomment-1878834946)). https://github.com/WordPress/gutenberg/pull/57685

~What'd be the best place? In the sidebar (like the current design) or in the content frame (like we do for templates)? [Related conversation](https://github.com/WordPress/gutenberg/pull/56241#issuecomment-1816762258).~

| Sidebar | Content frame |
| --- | --- |
| <img width="1507" alt="Captura de ecrã 2024-01-05, às 13 38 16" src="https://github.com/WordPress/gutenberg/assets/583546/33be9ed9-cc8a-469d-8e25-207fd05578c1"> | <img width="1507" alt="Captura de ecrã 2024-01-05, às 13 38 55" src="https://github.com/WordPress/gutenberg/assets/583546/27bd4c12-133c-4d5f-a266-795c358a6430"> | 

3. Add the"special Front page" to the list of pages ([conversation](https://github.com/WordPress/gutenberg/pull/57589#issuecomment-1878834946)).

<img width="311" alt="Captura de ecrã 2024-01-05, às 13 41 52" src="https://github.com/WordPress/gutenberg/assets/583546/b4a79ccf-dc92-498f-878d-044b61ecbc24">

5. Add the footer to the sidebar linking to 404 and search pages ([conversation](https://github.com/WordPress/gutenberg/pull/57589#issuecomment-1878834946)). https://github.com/WordPress/gutenberg/pull/57690

<img width="309" alt="Captura de ecrã 2024-01-05, às 14 58 39" src="https://github.com/WordPress/gutenberg/assets/583546/766bb62b-72b1-4411-bff4-e59e92c48548">

6. Keyboard navigation

Make it work like the block editor list view: use arrow keys to move up/down the list and right/left to move to/from details.
