### PR TITLE
Try migrate link suggestions to use Core Data

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -374,6 +374,21 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
+### getLinkSuggestions
+
+Fetch link suggestions for a given search term.
+
+_Parameters_
+
+-   _state_ Data state.
+-   _search_ Search term.
+-   _searchOptions_
+-   _settings_
+
+_Returns_
+
+-   Link suggestions.
+
 ### getRawEntityRecord
 
 Returns the entity's record object by key, with its attributes mapped to their raw values.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -695,6 +695,21 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
+### getLinkSuggestions
+
+Fetch link suggestions for a given search term.
+
+_Parameters_
+
+-   _state_ Data state.
+-   _search_ Search term.
+-   _searchOptions_
+-   _settings_
+
+_Returns_
+
+-   Link suggestions.
+
 ### getRawEntityRecord
 
 Returns the entity's record object by key, with its attributes mapped to their raw values.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -623,6 +623,18 @@ export function defaultTemplates( state = {}, action ) {
 	return state;
 }
 
+export function linkSuggestions( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_LINK_SUGGESTIONS':
+			return {
+				...state,
+				[ action.search ]: action.suggestions,
+			};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	terms,
 	users,
@@ -644,4 +656,5 @@ export default combineReducers( {
 	userPatternCategories,
 	navigationFallbackId,
 	defaultTemplates,
+	linkSuggestions,
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -17,6 +17,7 @@ import { STORE_NAME } from './name';
 import { getOrLoadEntitiesConfig, DEFAULT_ENTITY_KEY } from './entities';
 import { forwardResolver, getNormalizedCommaSeparable } from './utils';
 import { getSyncProvider } from './sync';
+import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from './fetch';
 
 /**
  * Requests authors from the REST API.
@@ -666,6 +667,17 @@ export const getUserPatternCategories =
 			type: 'RECEIVE_USER_PATTERN_CATEGORIES',
 			patternCategories: mappedPatternCategories,
 		} );
+	};
+
+export const getLinkSuggestions =
+	( search, searchOptions, settings ) =>
+	async ( { dispatch } ) => {
+		const suggestions = await fetchLinkSuggestions(
+			search,
+			searchOptions,
+			settings
+		);
+		dispatch( { type: 'RECEIVE_LINK_SUGGESTIONS', search, suggestions } );
 	};
 
 export const getNavigationFallbackId =

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1491,3 +1491,21 @@ export const getRevision = createSelector(
 		];
 	}
 );
+
+/**
+ * Fetch link suggestions for a given search term.
+ *
+ * @param state         Data state.
+ * @param search        Search term.
+ * @param searchOptions
+ * @param settings
+ * @return Link suggestions.
+ */
+export function getLinkSuggestions(
+	state,
+	search = '',
+	searchOptions,
+	settings
+) {
+	return state.linkSuggestions[ search ];
+}

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -2,10 +2,9 @@
  * WordPress dependencies
  */
 import { Platform, useMemo, useCallback } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, resolveSelect } from '@wordpress/data';
 import {
 	store as coreStore,
-	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
@@ -215,6 +214,10 @@ function useBlockEditorSettings( settings, postType, postId ) {
 		[ saveEntityRecord, userCanCreatePages ]
 	);
 
+	const syncGetLinkSuggestions = useCallback( async ( ...args ) => {
+		return await resolveSelect( coreStore ).getLinkSuggestions( ...args );
+	}, [] );
+
 	const forceDisableFocusMode = settings.focusMode === false;
 
 	return useMemo(
@@ -232,8 +235,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
 			__experimentalUserPatternCategories: userPatternCategories,
-			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
-				fetchLinkSuggestions( search, searchOptions, settings ),
+			__experimentalFetchLinkSuggestions: syncGetLinkSuggestions,
 			inserterMediaCategories,
 			__experimentalFetchRichUrlData: fetchUrlData,
 			// Todo: This only checks the top level post, not the post within a template or any other entity that can be edited.
@@ -279,6 +281,7 @@ function useBlockEditorSettings( settings, postType, postId ) {
 			postType,
 			setIsInserterOpened,
 			getPostLinkProps,
+			syncGetLinkSuggestions,
 		]
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Implements a selector for fetching link suggestions and utilises in `<LinkControl>`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently `LinkControl` calls the `fetchLinkSuggestions` function directly. This means we don't get the benefits of caching and in Core Data so for each editor session the data is refetched for identical queries.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Implements a Core Data selector which proxies to the original `fetchLinkSuggstions` under the hood. The benefit is now we get caching for free.

## Alternatives Considered

Alternative approaches might be:

- don't do this at all - it might be fine as it is 🤷‍♂️ 
- implement a dedicated Block Editor REST API endpoint for "Link Suggestions". Then implement related Core Data selectors. This will avoid the need for multiple queries to the "search" endpoint and allow it to be customisable by extenders.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open devtools Network tab and filter by XHR and `search`.
- New Post
- Type text and select a portion of it
- CMD + K to make a link
- Now type `Sample`. You should see search results shown after a short loading delay in UI and network tab.
- Clear the search input.
- Type `Sample` again. This time there should be no loading delay and results should show instantly. Also no additional network requests should be dispatched.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
