### PR TITLE
Navigation: Add an option to allow navigation to switch to overlay mode when wrapping

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -28,6 +28,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-no-tinymce' ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalDisableTinymce = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-navigation-overlay-auto', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalNavOverlayAuto = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -126,6 +126,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-navigation-overlay-auto',
+		__( 'Navigation overlay', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Allow navigation to switch to overlay mode when wrapping automatically', 'gutenberg' ),
+			'id'    => 'gutenberg-navigation-overlay-auto',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -11,6 +11,7 @@ import {
 	useState,
 	useEffect,
 	useRef,
+	useReducer,
 	Platform,
 } from '@wordpress/element';
 import {
@@ -42,7 +43,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { close, Icon } from '@wordpress/icons';
-import { useInstanceId, useMediaQuery } from '@wordpress/compose';
+import { debounce, useInstanceId, useMediaQuery } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -302,10 +303,16 @@ function Navigation( {
 	const isMobileBreakPoint = useMediaQuery(
 		`(max-width: ${ NAVIGATION_MOBILE_COLLAPSE })`
 	);
+
 	const isCollapsed =
 		( 'mobile' === overlayMenu && isMobileBreakPoint ) ||
 		'always' === overlayMenu ||
 		( 'auto' === overlayMenu && navigationIsWrapping( navRef.current ) );
+
+	// We need to update on window resize so that the nav collapses appropriately.
+	// eslint-disable-next-line no-unused-vars
+	const [ ignored, forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
+	window.addEventListener( 'resize', debounce( forceUpdate, 10 ) );
 
 	const blockProps = useBlockProps( {
 		ref: navRef,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -72,6 +72,7 @@ import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { NAVIGATION_MOBILE_COLLAPSE } from '../constants';
+import navigationIsWrapping from '../is-wrapping';
 import { unlock } from '../../lock-unlock';
 
 function Navigation( {
@@ -301,10 +302,10 @@ function Navigation( {
 	const isMobileBreakPoint = useMediaQuery(
 		`(max-width: ${ NAVIGATION_MOBILE_COLLAPSE })`
 	);
-
 	const isCollapsed =
 		( 'mobile' === overlayMenu && isMobileBreakPoint ) ||
-		'always' === overlayMenu;
+		'always' === overlayMenu ||
+		( 'auto' === overlayMenu && navigationIsWrapping( navRef.current ) );
 
 	const blockProps = useBlockProps( {
 		ref: navRef,
@@ -597,6 +598,10 @@ function Navigation( {
 							<ToggleGroupControlOption
 								value="mobile"
 								label={ __( 'Mobile' ) }
+							/>
+							<ToggleGroupControlOption
+								value="auto"
+								label={ __( 'Auto' ) }
 							/>
 							<ToggleGroupControlOption
 								value="always"

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -297,6 +297,9 @@ function Navigation( {
 			),
 		[ clientId ]
 	);
+	const overlayType = window?.__experimentalNavOverlayAuto
+		? 'auto'
+		: overlayMenu;
 	const isResponsive = 'never' !== overlayMenu;
 	const blockProps = useBlockProps( {
 		ref: navRef,
@@ -311,7 +314,7 @@ function Navigation( {
 				'is-vertical': orientation === 'vertical',
 				'no-wrap': flexWrap === 'nowrap',
 				'is-responsive': isResponsive,
-				'is-collapsed': useIsCollapsed( overlayMenu, navRef ),
+				'is-collapsed': useIsCollapsed( overlayType, navRef ),
 				'has-text-color': !! textColor.color || !! textColor?.class,
 				[ getColorClassName( 'color', textColor?.slug ) ]:
 					!! textColor?.slug,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -32,7 +32,7 @@ import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	PanelBody,
-	SelectControl,
+	CustomSelectControl,
 	ToggleControl,
 	Button,
 	Spinner,
@@ -524,6 +524,30 @@ function Navigation( {
 	);
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+	const overlayMenuOptions = [
+		{
+			name: __( 'Off' ),
+			key: 'never',
+			__experimentalHint: __( 'Never show the overlay' ),
+		},
+		{
+			name: __( 'Always' ),
+			key: 'always',
+			__experimentalHint: __( 'Always show the overlay' ),
+		},
+		{
+			name: __( 'On mobile' ),
+			key: 'mobile',
+			__experimentalHint: __( 'Show the overlay on mobile devices' ),
+		},
+		{
+			name: __( 'Automatic' ),
+			key: 'auto',
+			__experimentalHint: __(
+				'Use the overlay when the navigation items do not fit on one line'
+			),
+		},
+	];
 	const stylingInspectorControls = (
 		<>
 			<InspectorControls>
@@ -567,38 +591,23 @@ function Navigation( {
 								</div>
 							</>
 						) }
-						<SelectControl
+
+						<CustomSelectControl
+							className="wp-block-navigation__overlay-menu-custom-select-control"
 							label={ __( 'Navigation Overlay' ) }
 							help={ __(
-								'Specifies the point at which the navigation will collapse to an icon opening an overlay.'
+								'Replace the items with an icon that opens a full-screen navigation on click.'
 							) }
-							value={ overlayMenu }
-							options={ [
-								{
-									label: __( 'Never show the overlay' ),
-									value: 'never',
-								},
-								{
-									label: __(
-										'Show the overlay on mobile devices'
-									),
-									value: 'mobile',
-								},
-								{
-									label: __(
-										'Show the overlay when the navigation items do not fit on one line'
-									),
-									value: 'auto',
-								},
-								{
-									label: __( 'Always show the overlay' ),
-									value: 'always',
-								},
-							] }
-							onChange={ ( value ) =>
-								setAttributes( { overlayMenu: value } )
-							}
-							__nextHasNoMarginBottom
+							value={ overlayMenuOptions.find( ( option ) => {
+								return option.key === overlayMenu;
+							} ) }
+							options={ overlayMenuOptions }
+							onChange={ ( option ) => {
+								setAttributes( {
+									overlayMenu: option.selectedItem.key,
+								} );
+							} }
+							__nextUnconstrainedWidt
 						/>
 						{ hasSubmenus && (
 							<>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -32,8 +32,9 @@ import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	PanelBody,
-	CustomSelectControl,
 	ToggleControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	Button,
 	Spinner,
 	Notice,
@@ -524,28 +525,6 @@ function Navigation( {
 	);
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
-	const overlayMenuOptions = [
-		{
-			name: __( 'Off' ),
-			key: 'never',
-		},
-		{
-			name: __( 'Always' ),
-			key: 'always',
-		},
-		{
-			name: __( 'On mobile' ),
-			key: 'mobile',
-			__experimentalHint: __( 'Show the overlay on smaller screens.' ),
-		},
-		{
-			name: __( 'Automatic' ),
-			key: 'auto',
-			__experimentalHint: __(
-				'Use the overlay when the navigation items do not fit on one line.'
-			),
-		},
-	];
 	const stylingInspectorControls = (
 		<>
 			<InspectorControls>
@@ -590,23 +569,33 @@ function Navigation( {
 							</>
 						) }
 
-						<CustomSelectControl
-							className="wp-block-navigation__overlay-menu-custom-select-control"
-							label={ __( 'Navigation Overlay' ) }
+						<h3>{ __( 'Overlay Menu' ) }</h3>
+						<ToggleGroupControl
+							__nextHasNoMarginBottom
+							label={ __( 'Configure overlay menu' ) }
+							value={ overlayMenu }
 							help={ __(
-								'Replace the items with an icon that opens a full-screen navigation on click.'
+								'Collapses the navigation options in a menu icon opening an overlay.'
 							) }
-							value={ overlayMenuOptions.find( ( option ) => {
-								return option.key === overlayMenu;
-							} ) }
-							options={ overlayMenuOptions }
-							onChange={ ( option ) => {
-								setAttributes( {
-									overlayMenu: option.selectedItem.key,
-								} );
-							} }
-							__nextUnconstrainedWidt
-						/>
+							onChange={ ( value ) =>
+								setAttributes( { overlayMenu: value } )
+							}
+							isBlock
+							hideLabelFromVision
+						>
+							<ToggleGroupControlOption
+								value="never"
+								label={ __( 'Off' ) }
+							/>
+							<ToggleGroupControlOption
+								value="mobile"
+								label={ __( 'Mobile' ) }
+							/>
+							<ToggleGroupControlOption
+								value="always"
+								label={ __( 'Always' ) }
+							/>
+						</ToggleGroupControl>
 						{ hasSubmenus && (
 							<>
 								<h3>{ __( 'Submenus' ) }</h3>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -11,7 +11,6 @@ import {
 	useState,
 	useEffect,
 	useRef,
-	useReducer,
 	Platform,
 } from '@wordpress/element';
 import {
@@ -43,7 +42,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { close, Icon } from '@wordpress/icons';
-import { debounce, useInstanceId, useMediaQuery } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -72,8 +71,7 @@ import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
 import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
-import { NAVIGATION_MOBILE_COLLAPSE } from '../constants';
-import navigationIsWrapping from '../is-wrapping';
+import useIsCollapsed from '../use-is-collapsed';
 import { unlock } from '../../lock-unlock';
 
 function Navigation( {
@@ -300,20 +298,6 @@ function Navigation( {
 		[ clientId ]
 	);
 	const isResponsive = 'never' !== overlayMenu;
-	const isMobileBreakPoint = useMediaQuery(
-		`(max-width: ${ NAVIGATION_MOBILE_COLLAPSE })`
-	);
-
-	const isCollapsed =
-		( 'mobile' === overlayMenu && isMobileBreakPoint ) ||
-		'always' === overlayMenu ||
-		( 'auto' === overlayMenu && navigationIsWrapping( navRef.current ) );
-
-	// We need to update on window resize so that the nav collapses appropriately.
-	// eslint-disable-next-line no-unused-vars
-	const [ ignored, forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
-	window.addEventListener( 'resize', debounce( forceUpdate, 10 ) );
-
 	const blockProps = useBlockProps( {
 		ref: navRef,
 		className: classnames(
@@ -327,7 +311,7 @@ function Navigation( {
 				'is-vertical': orientation === 'vertical',
 				'no-wrap': flexWrap === 'nowrap',
 				'is-responsive': isResponsive,
-				'is-collapsed': isCollapsed,
+				'is-collapsed': useIsCollapsed( overlayMenu, navRef ),
 				'has-text-color': !! textColor.color || !! textColor?.class,
 				[ getColorClassName( 'color', textColor?.slug ) ]:
 					!! textColor?.slug,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -32,9 +32,8 @@ import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	PanelBody,
+	SelectControl,
 	ToggleControl,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	Button,
 	Spinner,
 	Notice,
@@ -568,37 +567,39 @@ function Navigation( {
 								</div>
 							</>
 						) }
-						<h3>{ __( 'Overlay Menu' ) }</h3>
-						<ToggleGroupControl
-							__nextHasNoMarginBottom
-							label={ __( 'Configure overlay menu' ) }
-							value={ overlayMenu }
+						<SelectControl
+							label={ __( 'Navigation Overlay' ) }
 							help={ __(
-								'Collapses the navigation options in a menu icon opening an overlay.'
+								'Specifies the point at which the navigation will collapse to an icon opening an overlay.'
 							) }
+							value={ overlayMenu }
+							options={ [
+								{
+									label: __( 'Never show the overlay' ),
+									value: 'never',
+								},
+								{
+									label: __(
+										'Show the overlay on mobile devices'
+									),
+									value: 'mobile',
+								},
+								{
+									label: __(
+										'Show the overlay when the navigation items do not fit on one line'
+									),
+									value: 'auto',
+								},
+								{
+									label: __( 'Always show the overlay' ),
+									value: 'always',
+								},
+							] }
 							onChange={ ( value ) =>
 								setAttributes( { overlayMenu: value } )
 							}
-							isBlock
-							hideLabelFromVision
-						>
-							<ToggleGroupControlOption
-								value="never"
-								label={ __( 'Off' ) }
-							/>
-							<ToggleGroupControlOption
-								value="mobile"
-								label={ __( 'Mobile' ) }
-							/>
-							<ToggleGroupControlOption
-								value="auto"
-								label={ __( 'Auto' ) }
-							/>
-							<ToggleGroupControlOption
-								value="always"
-								label={ __( 'Always' ) }
-							/>
-						</ToggleGroupControl>
+							__nextHasNoMarginBottom
+						/>
 						{ hasSubmenus && (
 							<>
 								<h3>{ __( 'Submenus' ) }</h3>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -528,23 +528,21 @@ function Navigation( {
 		{
 			name: __( 'Off' ),
 			key: 'never',
-			__experimentalHint: __( 'Never show the overlay' ),
 		},
 		{
 			name: __( 'Always' ),
 			key: 'always',
-			__experimentalHint: __( 'Always show the overlay' ),
 		},
 		{
 			name: __( 'On mobile' ),
 			key: 'mobile',
-			__experimentalHint: __( 'Show the overlay on mobile devices' ),
+			__experimentalHint: __( 'Show the overlay on smaller screens.' ),
 		},
 		{
 			name: __( 'Automatic' ),
 			key: 'auto',
 			__experimentalHint: __(
-				'Use the overlay when the navigation items do not fit on one line'
+				'Use the overlay when the navigation items do not fit on one line.'
 			),
 		},
 	];

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -645,10 +645,3 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 .wp-block-navigation__menu-inspector-controls__empty-message {
 	margin-left: 24px;
 }
-
-.wp-block-navigation__overlay-menu-custom-select-control
-.components-custom-select-control__item-hint {
-	grid-row: 2;
-	line-height: 1.4;
-	text-align: left;
-}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -645,3 +645,10 @@ body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-op
 .wp-block-navigation__menu-inspector-controls__empty-message {
 	margin-left: 24px;
 }
+
+.wp-block-navigation__overlay-menu-custom-select-control
+.components-custom-select-control__item-hint {
+	grid-row: 2;
+	line-height: 1.4;
+	text-align: left;
+}

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -28,7 +28,7 @@ function areItemsWrapping(
 			totalWidth += rowGap;
 		}
 
-		if ( totalWidth > wrapperWidth ) {
+		if ( parseInt( totalWidth ) > parseInt( wrapperWidth ) ) {
 			return true;
 		}
 	}

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -1,0 +1,101 @@
+/**
+ * Determines if the children of a wrapper element are wrapping.
+ *
+ * @param {Element} wrapper  The element to determine if its children are wrapping
+ * @param {Array}   children The children of the wrapper element
+ *
+ * @return {boolean} Whether the children of the wrapper element are wrapping.
+ */
+function areItemsWrapping(
+	wrapper,
+	children = wrapper.querySelectorAll( 'li' )
+) {
+	const wrapperDimensions = wrapper.getBoundingClientRect();
+	//we store an array with the width of each item
+	const itemsWidths = getItemWidths( children );
+	let totalWidth = 0;
+	let isWrapping = false;
+
+	//the nav block may have row-gap applied, which is not calculated in getItemWidths
+	const computedStyle = window.getComputedStyle( wrapper );
+	const rowGap = parseFloat( computedStyle.rowGap ) || 0;
+
+	for ( let i = 0, len = itemsWidths.length; i < len; i++ ) {
+		totalWidth += itemsWidths[ i ];
+		if ( rowGap > 0 && i > 0 ) {
+			totalWidth += rowGap;
+		}
+		if ( parseInt( totalWidth ) > parseInt( wrapperDimensions.width ) ) {
+			isWrapping = true;
+		}
+	}
+	return isWrapping;
+}
+
+/**
+ * Determines if the navigation element itself is wrapping.
+ *
+ * @param {Element} navElement Wrapper element of the navigation block.
+ * @return {boolean} Whether the nav element itself is wrapping.
+ */
+function isNavElementWrapping( navElement ) {
+	let isWrapping = false;
+	//how can we check if the nav element is wrapped inside its parent if we don't know anything about it (the parent)?
+	if ( navElement !== null ) {
+		const childrenWrapper = navElement.querySelector(
+			'ul.wp-block-navigation'
+		);
+		isWrapping =
+			childrenWrapper &&
+			childrenWrapper.children &&
+			areItemsWrapping(
+				navElement,
+				Array.from(
+					navElement.querySelector( 'ul.wp-block-navigation' )
+						.children
+				)
+			);
+	}
+	return isWrapping;
+}
+
+/**
+ * Returns an array with the width of each item.
+ *
+ * @param {Array} items The items to get the width of.
+ * @return {Array} An array with the width of each item.
+ */
+function getItemWidths( items ) {
+	const itemsWidths = [];
+
+	items.forEach( function ( item ) {
+		const style = item.currentStyle || window.getComputedStyle( item );
+		const itemDimensions = item.getBoundingClientRect();
+		const width = parseFloat( itemDimensions.width );
+		const marginLeft = parseFloat( style.marginLeft );
+		const marginRight = parseFloat( style.marginRight );
+		const totalWidth = width + marginLeft + marginRight;
+
+		itemsWidths.push( totalWidth );
+	} );
+	return itemsWidths;
+}
+
+/**
+ * Determines if the navigation block is wrapping.
+ *
+ * @param {Element} navElement Wrapper element of the navigation block.
+ * @return {boolean} Whether the navigation block is wrapping.
+ */
+function navigationIsWrapping( navElement ) {
+	if ( ! navElement ) {
+		return false;
+	}
+
+	return (
+		areItemsWrapping( navElement ) === true ||
+		isNavElementWrapping( navElement ) === true
+	);
+}
+
+export default navigationIsWrapping;

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -10,7 +10,7 @@ function areItemsWrapping(
 	wrapper,
 	children = wrapper.querySelectorAll( 'li' )
 ) {
-	const wrapperDimensions = wrapper.getBoundingClientRect();
+	const wrapperWidth = wrapper.offsetWidth;
 	//we store an array with the width of each item
 	const itemsWidths = getItemWidths( children );
 	let totalWidth = 0;
@@ -25,7 +25,7 @@ function areItemsWrapping(
 		if ( rowGap > 0 && i > 0 ) {
 			totalWidth += rowGap;
 		}
-		if ( parseInt( totalWidth ) > parseInt( wrapperDimensions.width ) ) {
+		if ( parseInt( totalWidth ) > wrapperWidth ) {
 			isWrapping = true;
 		}
 	}

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -41,21 +41,15 @@ function areItemsWrapping(
 function isNavElementWrapping( navElement ) {
 	let isWrapping = false;
 	//how can we check if the nav element is wrapped inside its parent if we don't know anything about it (the parent)?
-	if ( navElement !== null ) {
-		const childrenWrapper = navElement.querySelector(
-			'ul.wp-block-navigation'
+	//for debugging purposes
+	const container = getFlexParent( navElement );
+	if ( container !== null ) {
+		isWrapping = areItemsWrapping(
+			container,
+			Array.from( container.children )
 		);
-		isWrapping =
-			childrenWrapper &&
-			childrenWrapper.children &&
-			areItemsWrapping(
-				navElement,
-				Array.from(
-					navElement.querySelector( 'ul.wp-block-navigation' )
-						.children
-				)
-			);
 	}
+
 	return isWrapping;
 }
 
@@ -79,6 +73,22 @@ function getItemWidths( items ) {
 		itemsWidths.push( totalWidth );
 	} );
 	return itemsWidths;
+}
+
+function getFlexParent( element ) {
+	// We need to do this check rather than document.body to account for iframes
+	if ( element.tagName === 'BODY' ) {
+		// Base case: Stop recursion once we go all the way to the body to avoid infinite recursion
+		return null;
+	}
+	const parent = element.parentNode;
+	const containerStyles = window.getComputedStyle( parent );
+	const isFlexWrap =
+		containerStyles.getPropertyValue( 'flex-wrap' ) === 'wrap';
+	if ( isFlexWrap ) {
+		return parent;
+	}
+	return getFlexParent( parent );
 }
 
 /**

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -8,7 +8,7 @@
  */
 function areItemsWrapping(
 	wrapper,
-	children = wrapper.querySelectorAll( 'li' )
+	children = wrapper.querySelectorAll( ':scope > .wp-block-navigation-item' )
 ) {
 	const wrapperDimensions = wrapper.getBoundingClientRect();
 	const wrapperWidth = wrapperDimensions.width;

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -10,7 +10,8 @@ function areItemsWrapping(
 	wrapper,
 	children = wrapper.querySelectorAll( 'li' )
 ) {
-	const wrapperWidth = wrapper.offsetWidth;
+	const wrapperDimensions = wrapper.getBoundingClientRect();
+	const wrapperWidth = wrapperDimensions.width;
 	//we store an array with the width of each item
 	const itemsWidths = getItemWidths( children );
 	let totalWidth = 0;
@@ -24,6 +25,7 @@ function areItemsWrapping(
 		if ( rowGap > 0 && i > 0 ) {
 			totalWidth += rowGap;
 		}
+
 		if ( totalWidth > wrapperWidth ) {
 			return true;
 		}
@@ -80,9 +82,8 @@ function getFlexParent( element ) {
 	if ( isFlexWrap ) {
 		return parent;
 	}
-	// I don't think we should make this recursive
-	// because it means a nav block inside a collapsed column will always collapse.
-	return null; //getFlexParent( parent );
+	// This recursion checks whether the nav element is wrapped inside a flex container.
+	return getFlexParent( parent );
 }
 
 /**

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -39,18 +39,14 @@ function areItemsWrapping(
  * @return {boolean} Whether the nav element itself is wrapping.
  */
 function isNavElementWrapping( navElement ) {
-	let isWrapping = false;
 	//how can we check if the nav element is wrapped inside its parent if we don't know anything about it (the parent)?
 	//for debugging purposes
 	const container = getFlexParent( navElement );
 	if ( container !== null ) {
-		isWrapping = areItemsWrapping(
-			container,
-			Array.from( container.children )
-		);
+		return areItemsWrapping( container, Array.from( container.children ) );
 	}
 
-	return isWrapping;
+	return false;
 }
 
 /**
@@ -88,7 +84,9 @@ function getFlexParent( element ) {
 	if ( isFlexWrap ) {
 		return parent;
 	}
-	return getFlexParent( parent );
+	// I don't think we should make this recursive
+	// because it means a nav block inside a collapsed column will always collapse.
+	return null; //getFlexParent( parent );
 }
 
 /**

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -24,7 +24,7 @@ function areItemsWrapping(
 		if ( rowGap > 0 && i > 0 ) {
 			totalWidth += rowGap;
 		}
-		if ( parseInt( totalWidth ) > wrapperWidth ) {
+		if ( totalWidth > wrapperWidth ) {
 			return true;
 		}
 	}

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -55,9 +55,7 @@ function isNavElementWrapping( navElement ) {
  * @return {Array} An array with the width of each item.
  */
 function getItemWidths( items ) {
-	const itemsWidths = [];
-
-	items.forEach( function ( item ) {
+	return items.map( ( item ) => {
 		const style = item.currentStyle || window.getComputedStyle( item );
 		const itemDimensions = item.getBoundingClientRect();
 		const width = parseFloat( itemDimensions.width );
@@ -65,9 +63,8 @@ function getItemWidths( items ) {
 		const marginRight = parseFloat( style.marginRight );
 		const totalWidth = width + marginLeft + marginRight;
 
-		itemsWidths.push( totalWidth );
+		return totalWidth;
 	} );
-	return itemsWidths;
 }
 
 function getFlexParent( element ) {

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -55,7 +55,7 @@ function isNavElementWrapping( navElement ) {
  * @return {Array} An array with the width of each item.
  */
 function getItemWidths( items ) {
-	return items.map( ( item ) => {
+	return Array.from( items ).map( ( item ) => {
 		const style = item.currentStyle || window.getComputedStyle( item );
 		const itemDimensions = item.getBoundingClientRect();
 		const width = parseFloat( itemDimensions.width );

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -14,7 +14,6 @@ function areItemsWrapping(
 	//we store an array with the width of each item
 	const itemsWidths = getItemWidths( children );
 	let totalWidth = 0;
-	let isWrapping = false;
 
 	//the nav block may have row-gap applied, which is not calculated in getItemWidths
 	const computedStyle = window.getComputedStyle( wrapper );
@@ -26,10 +25,10 @@ function areItemsWrapping(
 			totalWidth += rowGap;
 		}
 		if ( parseInt( totalWidth ) > wrapperWidth ) {
-			isWrapping = true;
+			return true;
 		}
 	}
-	return isWrapping;
+	return false;
 }
 
 /**

--- a/packages/block-library/src/navigation/is-wrapping.js
+++ b/packages/block-library/src/navigation/is-wrapping.js
@@ -8,7 +8,9 @@
  */
 function areItemsWrapping(
 	wrapper,
-	children = wrapper.querySelectorAll( ':scope > .wp-block-navigation-item' )
+	children = wrapper.querySelectorAll(
+		'ul > .wp-block-navigation-item:not(ul ul .wp-block-navigation-item)'
+	)
 ) {
 	const wrapperDimensions = wrapper.getBoundingClientRect();
 	const wrapperWidth = wrapperDimensions.width;

--- a/packages/block-library/src/navigation/use-is-collapsed.js
+++ b/packages/block-library/src/navigation/use-is-collapsed.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { debounce, useMediaQuery } from '@wordpress/compose';
+import { useState, useLayoutEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { NAVIGATION_MOBILE_COLLAPSE } from './constants';
+import navigationIsWrapping from './is-wrapping';
+
+function useIsCollapsed( overlayMenu, navRef ) {
+	const isMobileBreakPoint = useMediaQuery(
+		`(max-width: ${ NAVIGATION_MOBILE_COLLAPSE })`
+	);
+
+	const shouldBeCollapsed = () => {
+		return (
+			( 'mobile' === overlayMenu && isMobileBreakPoint ) ||
+			'always' === overlayMenu ||
+			( 'auto' === overlayMenu && navigationIsWrapping( navRef.current ) )
+		);
+	};
+
+	const [ isCollapsed, setIsCollapsed ] = useState( shouldBeCollapsed() );
+
+	useLayoutEffect( () => {
+		function updateIsCollapsed() {
+			setIsCollapsed( shouldBeCollapsed() );
+		}
+		window.addEventListener( 'resize', debounce( updateIsCollapsed, 100 ) );
+	} );
+
+	return isCollapsed;
+}
+
+export default useIsCollapsed;

--- a/packages/block-library/src/navigation/use-is-collapsed.js
+++ b/packages/block-library/src/navigation/use-is-collapsed.js
@@ -26,6 +26,7 @@ function useIsCollapsed( overlayMenu, navRef ) {
 	const [ isCollapsed, setIsCollapsed ] = useState( shouldBeCollapsed() );
 
 	useLayoutEffect( () => {
+		updateIsCollapsed();
 		function updateIsCollapsed() {
 			setIsCollapsed( shouldBeCollapsed() );
 		}

--- a/packages/block-library/src/navigation/use-is-collapsed.js
+++ b/packages/block-library/src/navigation/use-is-collapsed.js
@@ -30,6 +30,9 @@ function useIsCollapsed( overlayMenu, navRef ) {
 			setIsCollapsed( shouldBeCollapsed() );
 		}
 		window.addEventListener( 'resize', debounce( updateIsCollapsed, 100 ) );
+		return () => {
+			window.removeEventListener( 'resize', updateIsCollapsed );
+		};
 	} );
 
 	return isCollapsed;

--- a/packages/block-library/src/navigation/use-is-collapsed.js
+++ b/packages/block-library/src/navigation/use-is-collapsed.js
@@ -15,12 +15,33 @@ function useIsCollapsed( overlayMenu, navRef ) {
 		`(max-width: ${ NAVIGATION_MOBILE_COLLAPSE })`
 	);
 
+	// Determines the conditions under which the navigation should be collapsed.
 	const shouldBeCollapsed = () => {
-		return (
-			( 'mobile' === overlayMenu && isMobileBreakPoint ) ||
-			'always' === overlayMenu ||
-			( 'auto' === overlayMenu && navigationIsWrapping( navRef.current ) )
-		);
+		// If the overlay menu is set to always, then it should always be collapsed.
+		if ( 'always' === overlayMenu ) {
+			return true;
+		}
+
+		// If the overlay menu is set to mobile and the screen is at the mobile breakpoint, then it should be collapsed.
+		if ( 'mobile' === overlayMenu && isMobileBreakPoint ) {
+			return true;
+		}
+
+		// If the overlay menu is set to auto, then we need to check if the navigation is wrapping.
+		if ( 'auto' === overlayMenu ) {
+			if ( ! navRef.current ) {
+				return false;
+			}
+
+			// If the navigation is already collapsed, then it should stay collapsed.
+			// We uncollapse it when the screen is resized so that we can measure the full width of the nav.
+			// It's not ideal to use the actual class name here.
+			if ( navRef.current.classList.contains( 'is-collapsed' ) ) {
+				return true;
+			}
+
+			return navigationIsWrapping( navRef.current );
+		}
 	};
 
 	const [ isCollapsed, setIsCollapsed ] = useState( shouldBeCollapsed() );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -7,6 +7,7 @@ import { store, getContext, getElement } from '@wordpress/interactivity';
  * Internal dependencies
  */
 import { NAVIGATION_MOBILE_COLLAPSE } from './constants';
+import navigationIsWrapping from './is-wrapping';
 
 const focusableSelectors = [
 	'a[href]',
@@ -190,7 +191,7 @@ const { state, actions } = store( 'core/navigation', {
 				focusableElements?.[ 0 ]?.focus();
 			}
 		},
-		initNav() {
+		initMobileNav() {
 			const context = getContext();
 			const mediaQuery = window.matchMedia(
 				`(max-width: ${ NAVIGATION_MOBILE_COLLAPSE })`
@@ -210,6 +211,23 @@ const { state, actions } = store( 'core/navigation', {
 			return () => {
 				mediaQuery.removeEventListener( 'change', handleCollapse );
 			};
+		},
+		initAutoNav() {
+			const context = getContext();
+			const { ref } = getElement();
+			// Set the initial state.
+			context.isCollapsed = navigationIsWrapping( ref );
+
+			// Listen for resize events.
+			window.addEventListener( 'resize', () => {
+				// We need to do this to allow us to measure the width of the nav.
+				context.isCollapsed = false;
+				// We need to wait for the next tick to check if the nav is wrapping.
+				// The problem is now we get a flickering effect when the window resizes.
+				setTimeout( () => {
+					context.isCollapsed = navigationIsWrapping( ref );
+				} );
+			} );
 		},
 	},
 } );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -224,7 +224,7 @@ const { state, actions } = store( 'core/navigation', {
 				context.isCollapsed = false;
 				// We need to wait for the next tick to check if the nav is wrapping.
 				// The problem is now we get a flickering effect when the window resizes.
-				setTimeout( () => {
+				window.requestAnimationFrame( () => {
 					context.isCollapsed = navigationIsWrapping( ref );
 				} );
 			} );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -218,8 +218,7 @@ const { state, actions } = store( 'core/navigation', {
 			// Set the initial state.
 			context.isCollapsed = navigationIsWrapping( ref );
 
-			// Listen for resize events.
-			window.addEventListener( 'resize', () => {
+			function handleResize() {
 				// We need to do this to allow us to measure the width of the nav.
 				context.isCollapsed = false;
 				// We need to wait for the next tick to check if the nav is wrapping.
@@ -227,7 +226,15 @@ const { state, actions } = store( 'core/navigation', {
 				window.requestAnimationFrame( () => {
 					context.isCollapsed = navigationIsWrapping( ref );
 				} );
-			} );
+			}
+
+			// Listen for resize events.
+			window.addEventListener( 'resize', handleResize );
+
+			// Remove the listener when the component is unmounted.
+			return () => {
+				window.removeEventListener( 'resize', handleResize );
+			};
 		},
 	},
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Addresses https://github.com/WordPress/gutenberg/issues/45040

https://codepen.io/Marga-Cabrera/pen/WNPjYYw

This PR adds a new option for the nav block overlay called "auto". When this option is enabled a script will detect if the nav block can fit within its own container. If it detects that it's wrapping, it will toggle the overlay burger automatically, instead of using the fixed breakpoint.

We do two checks here:

- First we check if the elements within our known block are wrapping. This is done simply by comparing the width of the elements with the width of the container, but this is not the only case, in fact this is the least common occurrence
- Most of the time, the nav block will be inside a group or column block and appear alongside other blocks such as the site logo or site title/tagline which could cause the wrapping to occur. We can't predict those, and I'm only making one assumption here that I think is valid (but could change in the future): the wrapping will be cause from a parent that is using `flex-wrap`. Based on that assumption I look for said parent recursively and apply the same principle to verify if the children inside it are wrapping or not. In my personal opinion, if we are not covering this case, there is very little use in continuing this path, since 90% of the time, this is what's causing the nav block to wrap ahead of time and not the amount of items inside it.

To do:
- [ ] The "Allow to wrap to multiple lines" control doesn't make sense in this context, we should hide it (can be a follow-up).
- [ ] Check that the menu is horizontal before showing the breakpoint .
- [x] Test on multiple header styles.
- [ ] Add tests. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After the discussion over at https://github.com/WordPress/gutenberg/discussions/54388 and some first explorations, it becomes really clear that we either allow our users to set a breakpoint manually or we need to use JavaScript to detect when. Given the complexity of the nav block and how many combinations of layouts it can be wrapped in, there is no way CSS can only give a solution that will work for most of the use cases.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Create a navigation menu that has a site logo and a submenu in it.
- Insert a navigation block and set it to Auto
- Resize the viewport to check that the overlay appears at the moment when the menu is about to wrap, either because the nav items no longer fit the container or because the navigation block wraps because it's too big inside its own wrapper
- Test this with different header layouts, the ones I've used are in this [gist](https://gist.github.com/MaggieCabrera/803fb7ad2fade9d47debd7f912db4cff)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
This adds a new option to the toggle:
<img width="287" alt="Screenshot 2024-01-11 at 11 11 51" src="https://github.com/WordPress/gutenberg/assets/275961/c039ae00-f030-418d-982b-a94daf865870">

I don't think this is clear enough on its own. Maybe it should be called wrap? Maybe we should use a dropdown instead of the toggle group? cc @WordPress/gutenberg-design 
