### PR TITLE
Live Preview: Show the current theme name on the theme activation modal

### DIFF
--- a/packages/api-fetch/src/middlewares/theme-preview.js
+++ b/packages/api-fetch/src/middlewares/theme-preview.js
@@ -7,7 +7,7 @@ import { addQueryArgs, getQueryArg, removeQueryArgs } from '@wordpress/url';
  * This appends a `wp_theme_preview` parameter to the REST API request URL if
  * the admin URL contains a `theme` GET parameter.
  *
- * If the REST API request URL has contained the `wp_theme_preview` parameter,
+ * If the REST API request URL has contained the `wp_theme_preview` parameter as `''`,
  * then bypass this middleware.
  *
  * @param {Record<string, any>} themePath

--- a/packages/api-fetch/src/middlewares/theme-preview.js
+++ b/packages/api-fetch/src/middlewares/theme-preview.js
@@ -1,32 +1,39 @@
 /**
  * WordPress dependencies
  */
-import { addQueryArgs, hasQueryArg } from '@wordpress/url';
+import { addQueryArgs, getQueryArg, removeQueryArgs } from '@wordpress/url';
 
 /**
  * This appends a `wp_theme_preview` parameter to the REST API request URL if
  * the admin URL contains a `theme` GET parameter.
  *
+ * If the REST API request URL has contained the `wp_theme_preview` parameter,
+ * then bypass this middleware.
+ *
  * @param {Record<string, any>} themePath
  * @return {import('../types').APIFetchMiddleware} Preloading middleware.
  */
 const createThemePreviewMiddleware = ( themePath ) => ( options, next ) => {
-	if (
-		typeof options.url === 'string' &&
-		! hasQueryArg( options.url, 'wp_theme_preview' )
-	) {
-		options.url = addQueryArgs( options.url, {
-			wp_theme_preview: themePath,
-		} );
+	if ( typeof options.url === 'string' ) {
+		const wpThemePreview = getQueryArg( options.url, 'wp_theme_preview' );
+		if ( wpThemePreview === undefined ) {
+			options.url = addQueryArgs( options.url, {
+				wp_theme_preview: themePath,
+			} );
+		} else if ( wpThemePreview === '' ) {
+			options.url = removeQueryArgs( options.url, 'wp_theme_preview' );
+		}
 	}
 
-	if (
-		typeof options.path === 'string' &&
-		! hasQueryArg( options.path, 'wp_theme_preview' )
-	) {
-		options.path = addQueryArgs( options.path, {
-			wp_theme_preview: themePath,
-		} );
+	if ( typeof options.path === 'string' ) {
+		const wpThemePreview = getQueryArg( options.path, 'wp_theme_preview' );
+		if ( wpThemePreview === undefined ) {
+			options.path = addQueryArgs( options.path, {
+				wp_theme_preview: themePath,
+			} );
+		} else if ( wpThemePreview === '' ) {
+			options.path = removeQueryArgs( options.path, 'wp_theme_preview' );
+		}
 	}
 
 	return next( options );

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -49,7 +49,7 @@ const EntitiesSavedStatesForPreview = ( { onClose } ) => {
 			{ sprintf(
 				/* translators: %1$s: The name of active theme, %2$s: The name of theme to be activated. */
 				__(
-					'Saving your changes will change your active theme from %1$s to %2$s'
+					'Saving your changes will change your active theme from %1$s to %2$s.'
 				),
 				currentTheme?.name?.rendered ?? '...',
 				previewingTheme?.name?.rendered ?? '...'

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -23,10 +23,8 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editSiteStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { useActivateTheme } from '../../utils/use-activate-theme';
-import {
-	currentlyPreviewingTheme,
-	isPreviewingTheme,
-} from '../../utils/is-previewing-theme';
+import { useActualCurrentTheme } from '../../utils/use-actual-current-theme';
+import { isPreviewingTheme } from '../../utils/is-previewing-theme';
 
 const { EntitiesSavedStatesExtensible } = unlock( privateApis );
 
@@ -39,19 +37,22 @@ const EntitiesSavedStatesForPreview = ( { onClose } ) => {
 		activateSaveLabel = __( 'Activate' );
 	}
 
-	const themeName = useSelect( ( select ) => {
-		const theme = select( coreStore ).getTheme(
-			currentlyPreviewingTheme()
-		);
+	const currentTheme = useActualCurrentTheme();
 
-		return theme?.name?.rendered;
-	}, [] );
+	const previewingTheme = useSelect(
+		( select ) => select( coreStore ).getCurrentTheme(),
+		[]
+	);
 
 	const additionalPrompt = (
 		<p>
 			{ sprintf(
-				'Saving your changes will change your active theme to %s.',
-				themeName
+				/* translators: %1$s: The name of active theme, %2$s: The name of theme to be activated. */
+				__(
+					'Saving your changes will change your active theme from %1$s to %2$s'
+				),
+				currentTheme?.name?.rendered ?? '...',
+				previewingTheme?.name?.rendered ?? '...'
 			) }
 		</p>
 	);

--- a/packages/edit-site/src/utils/use-actual-current-theme.js
+++ b/packages/edit-site/src/utils/use-actual-current-theme.js
@@ -17,9 +17,10 @@ export function useActualCurrentTheme() {
 			wp_theme_preview: '',
 		} );
 
-		apiFetch( { path } ).then( ( activeThemes ) =>
-			setCurrentTheme( activeThemes[ 0 ] )
-		);
+		apiFetch( { path } )
+			.then( ( activeThemes ) => setCurrentTheme( activeThemes[ 0 ] ) )
+			// Do nothing
+			.catch( () => {} );
 	}, [] );
 
 	return currentTheme;

--- a/packages/edit-site/src/utils/use-actual-current-theme.js
+++ b/packages/edit-site/src/utils/use-actual-current-theme.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+
+const ACTIVE_THEMES_URL = '/wp/v2/themes?status=active';
+
+export function useActualCurrentTheme() {
+	const [ currentTheme, setCurrentTheme ] = useState();
+
+	useEffect( () => {
+		// Set the `wp_theme_preview` to empty string to bypass the createThemePreviewMiddleware.
+		const path = addQueryArgs( ACTIVE_THEMES_URL, {
+			context: 'edit',
+			wp_theme_preview: '',
+		} );
+
+		apiFetch( { path } ).then( ( activeThemes ) =>
+			setCurrentTheme( activeThemes[ 0 ] )
+		);
+	}, [] );
+
+	return currentTheme;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Display the name of the currently active theme on the theme activation modal

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Resolved https://github.com/Automattic/wp-calypso/issues/81878

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the `apiFetch` with `wp_theme_preview=` to bypass the `createThemePreviewMiddleware` and get the currently active theme.

Another way is to create a new resolver, selector, and reducer to get the raw current theme and save it into the redux store. But I think it's only used by this modal now so we don't need to introduce new variable into the redux store.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to /wp-admin/themes.php
2. Preview a theme
3. Click the “Activate” button
4. Make sure the name of the currently active theme is shown in the description

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/WordPress/gutenberg/assets/13596067/a86acdb8-711b-4294-a1c7-368c3988a89e)
