### PR TITLE
DataViews: use pages dataviews for the "Pages" section

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -7,10 +7,10 @@ import { trash } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { LAYOUT_TABLE, OPERATOR_IN } from '../../utils/constants';
+import { LAYOUT_LIST, OPERATOR_IN } from '../../utils/constants';
 
 const DEFAULT_PAGE_BASE = {
-	type: LAYOUT_TABLE,
+	type: LAYOUT_LIST,
 	search: '',
 	filters: [],
 	page: 1,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -61,7 +61,11 @@ export default function SidebarNavigationScreenMain() {
 						</SidebarNavigationItemGlobalStyles>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/page"
+							path={
+								window?.__experimentalAdminViews
+									? '/pages'
+									: '/page'
+							}
 							withChevron
 							icon={ page }
 						>

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -77,7 +77,7 @@ function SidebarScreens() {
 				<SidebarScreenWrapper path="/pages">
 					<SidebarNavigationScreen
 						title={ __( 'Pages' ) }
-						backPath="/page"
+						backPath="/"
 						content={ <DataViewsSidebarContent /> }
 					/>
 				</SidebarScreenWrapper>


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related: https://github.com/WordPress/gutenberg/pull/57578

## What?

Makes the pages list that uses dataviews the root for the "Pages" section:

https://github.com/WordPress/gutenberg/assets/583546/2ac382ff-95f7-4004-a7ff-d0aacc21e2e8

## Why?

This is the goal. Using in will make evident what's left.

## How?

- Update the paths to the proper places.
- Make the list layout the default for pages.

## Testing Instructions

- Enable the "admin views" experiment. Go to the site editor and verify that it works as expected.

## TODO

- Clear the dataviews params in the URL.

## Follow-ups / Related PRs

- Add details https://github.com/WordPress/gutenberg/pull/57578
- Add footer to the sidebar linking to 404 and search.

Questions to address in follow-ups:

- Where do we add the "Add page" trigger? In the sidebar (like the current design) or in the content frame (like we do for templates)? @jameskoster @SaxonF [Related conversation](https://github.com/WordPress/gutenberg/pull/56241#issuecomment-1816762258).

| Sidebar | Content frame |
| --- | --- |
| <img width="1507" alt="Captura de ecrã 2024-01-05, às 13 38 16" src="https://github.com/WordPress/gutenberg/assets/583546/33be9ed9-cc8a-469d-8e25-207fd05578c1"> | <img width="1507" alt="Captura de ecrã 2024-01-05, às 13 38 55" src="https://github.com/WordPress/gutenberg/assets/583546/27bd4c12-133c-4d5f-a266-795c358a6430"> | 

- What to do with the "special Front page"? Do we want to list in with any other page in the content frame?

<img width="311" alt="Captura de ecrã 2024-01-05, às 13 41 52" src="https://github.com/WordPress/gutenberg/assets/583546/b4a79ccf-dc92-498f-878d-044b61ecbc24">
