### PR TITLE
Group GitHub Action Dependabot updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
       labels:
           - 'GitHub Actions'
           - '[Type] Build Tooling'
+      groups:
+        github-actions:
+          patterns:
+            - "*"
+            

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
           - 'GitHub Actions'
           - '[Type] Build Tooling'
       groups:
-        github-actions:
-          patterns:
-            - "*"
-            
+          github-actions:
+              patterns:
+                  - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,12 @@ updates:
           github-actions:
               patterns:
                   - '*'
+              exclude-patterns:
+                  - 'actions/setup-java'
+                  - 'gradle/*'
+                  - 'reactivecircus/*'
+          react-native:
+              patterns:
+                  - 'actions/setup-java'
+                  - 'gradle/*'
+                  - 'reactivecircus/*'


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This configures a `group` for GitHub Action updates proposed by Dependabot so that all updates are grouped in one pull request.

## Why?
This allows the repository to continue benefiting from automatic PRs for third-party actions while reducing the overall noise.