### PR TITLE
DataViews: Add `duplicate pattern` action in patterns page

### DIFF
--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -21,6 +21,7 @@ const {
 	DropdownMenuGroupV2: DropdownMenuGroup,
 	DropdownMenuItemV2: DropdownMenuItem,
 	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
+	kebabCase,
 } = unlock( componentsPrivateApis );
 
 function ButtonTrigger( { action, onClick } ) {
@@ -58,12 +59,17 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 			<ActionTrigger { ...actionTriggerProps } />
 			{ isModalOpen && (
 				<Modal
-					title={ ! hideModalHeader && action.label }
+					title={
+						( ! hideModalHeader && action.modalHeader ) ||
+						action.label
+					}
 					__experimentalHideHeader={ !! hideModalHeader }
 					onRequestClose={ () => {
 						setIsModalOpen( false );
 					} }
-					overlayClassName="dataviews-action-modal"
+					overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
+						action.id
+					) }` }
 				>
 					<RenderModal
 						item={ item }

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -54,6 +54,7 @@ import {
 	renameAction,
 	resetAction,
 	deleteAction,
+	duplicatePatternAction,
 } from './dataviews-pattern-actions';
 import usePatternSettings from './use-pattern-settings';
 import { unlock } from '../../lock-unlock';
@@ -314,7 +315,13 @@ export default function DataviewsPatterns() {
 	}, [ patterns, view, fields ] );
 
 	const actions = useMemo(
-		() => [ renameAction, exportJSONaction, resetAction, deleteAction ],
+		() => [
+			renameAction,
+			duplicatePatternAction,
+			exportJSONaction,
+			resetAction,
+			deleteAction,
+		],
 		[]
 	);
 	const onChangeView = useCallback(

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -255,3 +255,31 @@
 		z-index: 2;
 	}
 }
+
+// TODO: this is duplicated from `patterns-menu-items__convert-modal` styles,
+// except for the `z-index`. Need to check if this is still needed.
+.dataviews-action-modal__duplicate-pattern {
+	// Fix the modal width to prevent added categories from stretching the modal.
+	[role="dialog"] > [role="document"] {
+		width: 350px;
+	}
+
+	.patterns-menu-items__convert-modal-categories {
+		position: relative;
+	}
+
+	.components-form-token-field__suggestions-list:not(:empty) {
+		position: absolute;
+		border: $border-width solid var(--wp-admin-theme-color);
+		border-bottom-left-radius: $radius-block-ui;
+		border-bottom-right-radius: $radius-block-ui;
+		box-shadow: 0 0 0.5px 0.5px var(--wp-admin-theme-color);
+		box-sizing: border-box;
+		z-index: 1;
+		background-color: $white;
+		width: calc(100% + 2px); // Account for the border width of the token field.
+		left: -1px;
+		min-width: initial;
+		max-height: $grid-unit-60 * 2; // Adjust to not cover the save button, showing three items.
+	}
+}

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -28,11 +28,25 @@ import CategorySelector, { CATEGORY_SLUG } from './category-selector';
 import { unlock } from '../lock-unlock';
 
 export default function CreatePatternModal( {
+	className = 'patterns-menu-items__convert-modal',
+	modalTitle = __( 'Create pattern' ),
+	...restProps
+} ) {
+	return (
+		<Modal
+			title={ modalTitle }
+			onRequestClose={ restProps.onClose }
+			overlayClassName={ className }
+		>
+			<CreatePatternModalContents { ...restProps } />
+		</Modal>
+	);
+}
+
+export function CreatePatternModalContents( {
 	confirmLabel = __( 'Create' ),
 	defaultCategories = [],
-	className = 'patterns-menu-items__convert-modal',
 	content,
-	modalTitle = __( 'Create pattern' ),
 	onClose,
 	onError,
 	onSuccess,
@@ -148,78 +162,68 @@ export default function CreatePatternModal( {
 			return error.data.term_id;
 		}
 	}
-
 	return (
-		<Modal
-			title={ modalTitle }
-			onRequestClose={ () => {
-				onClose();
-				setTitle( '' );
+		<form
+			onSubmit={ ( event ) => {
+				event.preventDefault();
+				onCreate( title, syncType );
 			} }
-			overlayClassName={ className }
 		>
-			<form
-				onSubmit={ ( event ) => {
-					event.preventDefault();
-					onCreate( title, syncType );
-				} }
-			>
-				<VStack spacing="5">
-					<TextControl
-						label={ __( 'Name' ) }
-						value={ title }
-						onChange={ setTitle }
-						placeholder={ __( 'My pattern' ) }
-						className="patterns-create-modal__name-input"
-						__nextHasNoMarginBottom
+			<VStack spacing="5">
+				<TextControl
+					label={ __( 'Name' ) }
+					value={ title }
+					onChange={ setTitle }
+					placeholder={ __( 'My pattern' ) }
+					className="patterns-create-modal__name-input"
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+				<CategorySelector
+					categoryTerms={ categoryTerms }
+					onChange={ setCategoryTerms }
+					categoryMap={ categoryMap }
+				/>
+				<ToggleControl
+					label={ _x(
+						'Synced',
+						'Option that makes an individual pattern synchronized'
+					) }
+					help={ __(
+						'Sync this pattern across multiple locations.'
+					) }
+					checked={ syncType === PATTERN_SYNC_TYPES.full }
+					onChange={ () => {
+						setSyncType(
+							syncType === PATTERN_SYNC_TYPES.full
+								? PATTERN_SYNC_TYPES.unsynced
+								: PATTERN_SYNC_TYPES.full
+						);
+					} }
+				/>
+				<HStack justify="right">
+					<Button
 						__next40pxDefaultSize
-					/>
-					<CategorySelector
-						categoryTerms={ categoryTerms }
-						onChange={ setCategoryTerms }
-						categoryMap={ categoryMap }
-					/>
-					<ToggleControl
-						label={ _x(
-							'Synced',
-							'Option that makes an individual pattern synchronized'
-						) }
-						help={ __(
-							'Sync this pattern across multiple locations.'
-						) }
-						checked={ syncType === PATTERN_SYNC_TYPES.full }
-						onChange={ () => {
-							setSyncType(
-								syncType === PATTERN_SYNC_TYPES.full
-									? PATTERN_SYNC_TYPES.unsynced
-									: PATTERN_SYNC_TYPES.full
-							);
+						variant="tertiary"
+						onClick={ () => {
+							onClose();
+							setTitle( '' );
 						} }
-					/>
-					<HStack justify="right">
-						<Button
-							__next40pxDefaultSize
-							variant="tertiary"
-							onClick={ () => {
-								onClose();
-								setTitle( '' );
-							} }
-						>
-							{ __( 'Cancel' ) }
-						</Button>
+					>
+						{ __( 'Cancel' ) }
+					</Button>
 
-						<Button
-							__next40pxDefaultSize
-							variant="primary"
-							type="submit"
-							aria-disabled={ ! title || isSaving }
-							isBusy={ isSaving }
-						>
-							{ confirmLabel }
-						</Button>
-					</HStack>
-				</VStack>
-			</form>
-		</Modal>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						type="submit"
+						aria-disabled={ ! title || isSaving }
+						isBusy={ isSaving }
+					>
+						{ confirmLabel }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
 	);
 }

--- a/packages/patterns/src/components/duplicate-pattern-modal.js
+++ b/packages/patterns/src/components/duplicate-pattern-modal.js
@@ -29,11 +29,7 @@ function getTermLabels( pattern, categories ) {
 		.map( ( category ) => category.label );
 }
 
-export default function DuplicatePatternModal( {
-	pattern,
-	onClose,
-	onSuccess,
-} ) {
+export function useDuplicatePatternProps( { pattern, onSuccess } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const categories = useSelect( ( select ) => {
 		const { getUserPatternCategories, getBlockPatternCategories } =
@@ -44,12 +40,10 @@ export default function DuplicatePatternModal( {
 			user: getUserPatternCategories(),
 		};
 	} );
-
 	if ( ! pattern ) {
 		return null;
 	}
-
-	const duplicatedProps = {
+	return {
 		content: pattern.content,
 		defaultCategories: getTermLabels( pattern, categories ),
 		defaultSyncType:
@@ -63,31 +57,39 @@ export default function DuplicatePatternModal( {
 				? pattern.title
 				: pattern.title.raw
 		),
+		onSuccess: ( { pattern: newPattern } ) => {
+			createSuccessNotice(
+				sprintf(
+					// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
+					__( '"%s" duplicated.' ),
+					newPattern.title.raw
+				),
+				{
+					type: 'snackbar',
+					id: 'patterns-create',
+				}
+			);
+
+			onSuccess?.( { pattern: newPattern } );
+		},
 	};
+}
 
-	function handleOnSuccess( { pattern: newPattern } ) {
-		createSuccessNotice(
-			sprintf(
-				// translators: %s: The new pattern's title e.g. 'Call to action (copy)'.
-				__( '"%s" duplicated.' ),
-				newPattern.title.raw
-			),
-			{
-				type: 'snackbar',
-				id: 'patterns-create',
-			}
-		);
-
-		onSuccess?.( { pattern: newPattern } );
+export default function DuplicatePatternModal( {
+	pattern,
+	onClose,
+	onSuccess,
+} ) {
+	const duplicatedProps = useDuplicatePatternProps( { pattern, onSuccess } );
+	if ( ! pattern ) {
+		return null;
 	}
-
 	return (
 		<CreatePatternModal
 			modalTitle={ __( 'Duplicate pattern' ) }
 			confirmLabel={ __( 'Duplicate' ) }
 			onClose={ onClose }
 			onError={ onClose }
-			onSuccess={ handleOnSuccess }
 			{ ...duplicatedProps }
 		/>
 	);

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -2,8 +2,14 @@
  * Internal dependencies
  */
 import { lock } from './lock-unlock';
-import CreatePatternModal from './components/create-pattern-modal';
-import DuplicatePatternModal from './components/duplicate-pattern-modal';
+import {
+	default as CreatePatternModal,
+	CreatePatternModalContents,
+} from './components/create-pattern-modal';
+import {
+	default as DuplicatePatternModal,
+	useDuplicatePatternProps,
+} from './components/duplicate-pattern-modal';
 import RenamePatternModal from './components/rename-pattern-modal';
 import PatternsMenuItems from './components';
 import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
@@ -20,7 +26,9 @@ import {
 export const privateApis = {};
 lock( privateApis, {
 	CreatePatternModal,
+	CreatePatternModalContents,
 	DuplicatePatternModal,
+	useDuplicatePatternProps,
 	RenamePatternModal,
 	PatternsMenuItems,
 	RenamePatternCategoryModal,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds the `duplicate pattern` action in the patterns page. I haven't yet handled the duplication of template parts to reduce the scope.

Duplicating a pattern and creating a new one right now utilize many shared components like `DuplicatePatternModal` and `CreatePatternModal`. Since in DataViews' actions the modal is handled internally, I moved around some pieces of code and added some extra private APIs. Maybe simplifications could be made for components to do less - I think right now they are doing more than they should, but that's something to explore separately.

### Notes
I added some extra things in the DataViews actions:
1. Added `modalHeader` property to override if needed.
2. Added an extra default modal overlay css class based on the action's id for styling purposes



## Testing Instructions
1. Enable the admin views experiment and go to patterns page
3. Check the `Duplicate` action that works properly
4. Test the other places where `CreatePatternModal` and `DuplicatePatternModal` are used
5. Test that the old patterns page works as before, regarding the changes in the above components

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/b40707de-5913-41ca-940d-f5eab9436752


