### PR TITLE
DependencyExtractionWebpackPlugin: Add true shorthand for requestToExternalModule

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -267,13 +267,18 @@ module.exports = {
  *
  * @param {string} request Requested module
  *
- * @return {(string|undefined)} Script global
+ * @return {(string|true|undefined)} Module ID
  */
 function requestToExternalModule( request ) {
 	// Handle imports like `import myModule from 'my-module'`
 	if ( request === 'my-module' ) {
-		// Import should be ov the form `import { something } from "myModule";` in the final bundle.
+		// Import should be of the form `import { something } from "myModule";` in the final bundle.
 		return 'myModule';
+	}
+
+	// If the Module ID in source is the same as the external module, we can return `true`.
+	if ( request === 'external-module-id-no-change-required' ) {
+		return true;
 	}
 }
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -267,7 +267,7 @@ module.exports = {
  *
  * @param {string} request Requested module
  *
- * @return {(string|true|undefined)} Module ID
+ * @return {(string|boolean|undefined)} Module ID
  */
 function requestToExternalModule( request ) {
 	// Handle imports like `import myModule from 'my-module'`
@@ -277,9 +277,7 @@ function requestToExternalModule( request ) {
 	}
 
 	// If the Module ID in source is the same as the external module, we can return `true`.
-	if ( request === 'external-module-id-no-change-required' ) {
-		return true;
-	}
+	return request === 'external-module-id-no-change-required';
 }
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -82,6 +82,10 @@ class DependencyExtractionWebpackPlugin {
 				: defaultRequestToExternal( request );
 		}
 
+		if ( this.useModules && externalRequest === true ) {
+			externalRequest = request;
+		}
+
 		if ( externalRequest ) {
 			this.externalizedDeps.add( request );
 

--- a/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
+++ b/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
@@ -13,7 +13,9 @@ declare interface DependencyExtractionWebpackPluginOptions {
 	outputFormat?: 'php' | 'json';
 	outputFilename?: string | Function;
 	requestToExternal?: ( request: string ) => string | string[] | undefined;
-	requestToExternalModule?: ( request: string ) => string | true | undefined;
+	requestToExternalModule?: (
+		request: string
+	) => string | boolean | undefined;
 	requestToHandle?: ( request: string ) => string | undefined;
 	combinedOutputFile?: string | null;
 	combineAssets?: boolean;

--- a/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
+++ b/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
@@ -13,7 +13,7 @@ declare interface DependencyExtractionWebpackPluginOptions {
 	outputFormat?: 'php' | 'json';
 	outputFilename?: string | Function;
 	requestToExternal?: ( request: string ) => string | string[] | undefined;
-	requestToExternalModule?: ( request: string ) => string | undefined;
+	requestToExternalModule?: ( request: string ) => string | true | undefined;
 	requestToHandle?: ( request: string ) => string | undefined;
 	combinedOutputFile?: string | null;
 	combineAssets?: boolean;

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
@@ -12,9 +12,7 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( {
 			combineAssets: true,
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/webpack.config.js
@@ -7,9 +7,7 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
@@ -12,9 +12,7 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/has-extension-suffix/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/has-extension-suffix/webpack.config.js
@@ -10,9 +10,7 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/option-function-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/option-function-output-filename/webpack.config.js
@@ -10,9 +10,7 @@ module.exports = {
 				return `chunk--${ chunkData.chunk.name }--[name].asset.php`;
 			},
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/option-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/option-output-filename/webpack.config.js
@@ -8,9 +8,7 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( {
 			outputFilename: '[name]-foo.asset.php',
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
@@ -23,9 +23,7 @@ module.exports = {
 				if ( request === 'rxjs/operators' ) {
 					return request;
 				}
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 			requestToHandle( request ) {
 				if ( request === 'rxjs' || request === 'rxjs/operators' ) {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/runtime-chunk-single/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/runtime-chunk-single/webpack.config.js
@@ -11,9 +11,7 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/style-imports/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/style-imports/webpack.config.js
@@ -12,9 +12,7 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 		new MiniCSSExtractPlugin(),

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
@@ -7,9 +7,7 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
 				if ( request.startsWith( '@wordpress/' ) ) {
-					return request;
+					return true;
 				}
 			},
 		} ),

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
@@ -7,9 +7,7 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@wordpress/' ) ) {
-					return true;
-				}
+				return request.startsWith( '@wordpress/' );
 			},
 		} ),
 	],


### PR DESCRIPTION
## What?

The most common usage of the `requestToExternalModule` is to return the same requested module ID that was passed in. We add a simple of returning `true` to support this behavior without returning the original request.

## Why?

This makes the most common usage simpler. Instead of returning the string that was passed in, `true` can be returned.

See https://github.com/WordPress/gutenberg/pull/57199#discussion_r1442888318

## Testing Instructions

The default `requestToExternalModule` and some tests have been updated to use the `true` form. You can see that the none of the snapshots in tests require changes because this behavior works correctly.
