### PR TITLE
Footnotes: fix wrong link when adding more than 9 footnotes

### DIFF
--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -75,6 +75,14 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 						html: replacement.innerHTML,
 					} );
 					countValue.text = String( index + 1 );
+					countValue.formats = Array.from(
+						{ length: countValue.text.length },
+						() => countValue.formats[ 0 ]
+					);
+					countValue.replacements = Array.from(
+						{ length: countValue.text.length },
+						() => countValue.replacements[ 0 ]
+					);
 					replacement.innerHTML = toHTMLString( {
 						value: countValue,
 					} );


### PR DESCRIPTION
Fixes #57321
Related to #54505

## What?

This PR fixes an issue where the link text is not applied correctly when the footnote number is 10 or higher.

| Before | After |
|--------|--------|
| Only 1 is linked. ![image](https://github.com/WordPress/gutenberg/assets/54422211/220aa567-e6f7-4591-ad23-9e40317e2d82) | The whole number is linked. ![image](https://github.com/WordPress/gutenberg/assets/54422211/bab88965-8f0e-47e8-8470-ee7f108f21e7) | 

## Why?

My understanding is that the newly added footnote will have the asterisk as their text. 

Then, `RichTextValue` object is generated using the code below.

https://github.com/WordPress/gutenberg/blob/3ddd0371318588c8821a947e661e7204d03a7f3b/packages/core-data/src/footnotes/index.js#L74-L76

Since the asterisk is a single character, the `RichTextValue` object will look like this:

```
{
    "formats": [
        [
            {
                "type": "core/link",
                // ...
            }
        ]
    ],
    "replacements": [
        null
    ],
    "text": "*"
}
```

The current implementation replaces the asterisk with the actual text _after_ generating the `RichTextValue` object, resulting in a mismatch between the length of the `text` and the length of `formats`/`replacements`:

```
{
    "formats": [
        [
            {
                "type": "core/link",
                // ...
            }
        ]
    ],
    "replacements": [
        null
    ],
    "text": "10"
}
```

## How?

I made sure to duplicate the `formats` and `replacements` elements by the length of the actual string.

Another approach is to replace the asterisk with the actual value when creating the `RichTextValue` object.

```javascript
// The innerHTML contains the count wrapped in a link.
const countValue = create( {
	html: replacement.innerHTML.replace(
		'*',
		String( index + 1 )
	),
} );
```

This approach is very simple, but I feel it's a bit unstable since it relies on HTML strings.

## Testing Instructions

When adding 10 or more footnotes, check that the numbers are linked correctly.

> [!NOTE]
> There seems to be a bug that immediately after adding a footnote, it remains an asterisk unless the block is selected. This issue was reported in #57598.

