### PR TITLE
Image block: Move UI for lightbox from sidebar to the content toolbar alongside link settings

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	.block-editor-link-control {
-		width: 300px; // Hardcoded width avoids resizing of control when switching between preview/edit.
+		width: 200px; // Hardcoded width avoids resizing of control when switching between preview/edit.
 
 		.block-editor-url-input {
 			padding: 0; // Cancel unnecessary default 1px padding in this case.

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -6,15 +6,19 @@ import { useRef, useState } from '@wordpress/element';
 import {
 	ToolbarButton,
 	Button,
-	NavigableMenu,
 	MenuItem,
 	ToggleControl,
 	TextControl,
-	SVG,
-	Path,
+	MenuGroup,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { link as linkIcon, close } from '@wordpress/icons';
+import {
+	link as linkIcon,
+	image,
+	page,
+	fullscreen,
+	linkOff,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -26,37 +30,6 @@ const LINK_DESTINATION_CUSTOM = 'custom';
 const LINK_DESTINATION_MEDIA = 'media';
 const LINK_DESTINATION_ATTACHMENT = 'attachment';
 const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
-
-const icon = (
-	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-		<Path d="M0,0h24v24H0V0z" fill="none" />
-		<Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" />
-		<Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" />
-	</SVG>
-);
-
-const expandIcon = (
-	<SVG
-		data-name="Layer 1"
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 11 11"
-	>
-		<Path d="M2,0C.9,0,0,.9,0,2v2h1.5v-2c0-.28.22-.5.5-.5h2V0h-2ZM4,9.5h-2c-.28,0-.5-.22-.5-.5v-2H0v2c0,1.1.9,2,2,2h2v-1.5ZM7,11v-1.5h2c.28,0,.5-.22.5-.5v-2h1.5v2c0,1.1-.9,2-2,2h-2ZM9,0c1.1,0,2,.9,2,2v2h-1.5v-2c0-.28-.22-.5-.5-.5h-2V0h2Z" />
-	</SVG>
-);
-
-const unlinkIcon = (
-	<SVG
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 24 24"
-		width="24"
-		height="24"
-		aria-hidden="true"
-		focusable="false"
-	>
-		<Path d="M17.031 4.703 15.576 4l-1.56 3H14v.03l-2.324 4.47H9.5V13h1.396l-1.502 2.889h-.95a3.694 3.694 0 0 1 0-7.389H10V7H8.444a5.194 5.194 0 1 0 0 10.389h.17L7.5 19.53l1.416.719L15.049 8.5h.507a3.694 3.694 0 0 1 0 7.39H14v1.5h1.556a5.194 5.194 0 0 0 .273-10.383l1.202-2.304Z"></Path>
-	</SVG>
-);
 
 const ImageURLInputUI = ( {
 	linkDestination,
@@ -178,15 +151,16 @@ const ImageURLInputUI = ( {
 			linkDestination: LINK_DESTINATION_NONE,
 			href: '',
 		} );
+		setIsOpen( false );
 	};
 
 	const getLinkDestinations = () => {
 		const linkDestinations = [
 			{
 				linkDestination: LINK_DESTINATION_MEDIA,
-				title: __( 'Link to media file' ),
+				title: __( 'Link to image file' ),
 				url: mediaType === 'image' ? mediaUrl : undefined,
-				icon,
+				icon: image,
 			},
 		];
 		if ( mediaType === 'image' && mediaLink ) {
@@ -194,12 +168,7 @@ const ImageURLInputUI = ( {
 				linkDestination: LINK_DESTINATION_ATTACHMENT,
 				title: __( 'Link to attachment page' ),
 				url: mediaType === 'image' ? mediaLink : undefined,
-				icon: (
-					<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-						<Path d="M0 0h24v24H0V0z" fill="none" />
-						<Path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6z" />
-					</SVG>
-				),
+				icon: page,
 			} );
 		}
 		return linkDestinations;
@@ -252,7 +221,7 @@ const ImageURLInputUI = ( {
 			/>
 			<TextControl
 				__nextHasNoMarginBottom
-				label={ __( 'Link CSS Class' ) }
+				label={ __( 'Link CSS class' ) }
 				value={ linkClass || '' }
 				onChange={ onSetLinkClass }
 			/>
@@ -273,7 +242,7 @@ const ImageURLInputUI = ( {
 			<ToolbarButton
 				icon={ linkIcon }
 				className="components-toolbar__control"
-				label={ url ? __( 'Edit link' ) : __( 'Insert link' ) }
+				label={ url ? __( 'Edit link' ) : __( 'Add link' ) }
 				aria-expanded={ isOpen }
 				onClick={ openLinkUI }
 				ref={ setPopoverAnchor }
@@ -287,7 +256,7 @@ const ImageURLInputUI = ( {
 					renderSettings={ () => advancedOptions }
 					additionalControls={
 						showLinkEditor && (
-							<NavigableMenu>
+							<MenuGroup>
 								{ getLinkDestinations().map( ( link ) => (
 									<MenuItem
 										key={ link.linkDestination }
@@ -306,7 +275,10 @@ const ImageURLInputUI = ( {
 									<MenuItem
 										key="expand-on-click"
 										className="block-editor-url-popover__expand-on-click"
-										icon={ expandIcon }
+										icon={ fullscreen }
+										info={ __(
+											'Scale the image with a lightbox effect.'
+										) }
 										iconPosition="left"
 										onClick={ () => {
 											setUrlInput( null );
@@ -319,15 +291,10 @@ const ImageURLInputUI = ( {
 											stopEditLink();
 										} }
 									>
-										<p>{ __( 'Expand on click' ) }</p>
-										<p className="expand-on-click__description">
-											{ __(
-												'Scales the image with a lightbox effect'
-											) }
-										</p>
+										{ __( 'Expand on click' ) }
 									</MenuItem>
 								) }
-							</NavigableMenu>
+							</MenuGroup>
 						)
 					}
 				>
@@ -351,9 +318,10 @@ const ImageURLInputUI = ( {
 								urlLabel={ urlLabel }
 							/>
 							<Button
-								icon={ close }
+								icon={ linkOff }
 								label={ __( 'Remove link' ) }
 								onClick={ onLinkRemove }
+								size="compact"
 							/>
 						</>
 					) }
@@ -363,7 +331,7 @@ const ImageURLInputUI = ( {
 								className="block-editor-url-popover__expand-on-click block-editor-url-popover__expand-on-click__unlink"
 								url={ url }
 							>
-								{ expandIcon }
+								{ fullscreen }
 								<div className="expand-on-click__unlink-textbox">
 									<p>{ __( 'Expand on click' ) }</p>
 									<p className="expand-on-click__description">
@@ -373,11 +341,12 @@ const ImageURLInputUI = ( {
 									</p>
 								</div>
 								<Button
-									icon={ unlinkIcon }
+									icon={ linkOff }
 									label={ __( 'Remove link' ) }
 									onClick={ () => {
 										onSetLightbox( false );
 									} }
+									size="compact"
 								/>
 							</div>
 						</>

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -342,7 +342,7 @@ const ImageURLInputUI = ( {
 							<Button
 								icon={ linkOff }
 								className="remove-link"
-								label={ __( 'Remove link' ) }
+								label={ __( 'Disable expand on click' ) }
 								onClick={ () => {
 									onSetLightbox( false );
 								} }

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -151,7 +151,6 @@ const ImageURLInputUI = ( {
 			linkDestination: LINK_DESTINATION_NONE,
 			href: '',
 		} );
-		setIsOpen( false );
 	};
 
 	const getLinkDestinations = () => {

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -328,30 +328,28 @@ const ImageURLInputUI = ( {
 						</>
 					) }
 					{ ! url && ! isEditingLink && lightboxEnabled && (
-						<>
-							<div
-								className="block-editor-url-popover__expand-on-click block-editor-url-popover__expand-on-click__unlink"
-								url={ url }
-							>
+						<div className="block-editor-url-popover__expand-on-click">
+							<div className="fullscreen-icon">
 								{ fullscreen }
-								<div className="expand-on-click__unlink-textbox">
-									<p>{ __( 'Expand on click' ) }</p>
-									<p className="expand-on-click__description">
-										{ __(
-											'Scales the image with a lightbox effect'
-										) }
-									</p>
-								</div>
-								<Button
-									icon={ linkOff }
-									label={ __( 'Remove link' ) }
-									onClick={ () => {
-										onSetLightbox( false );
-									} }
-									size="compact"
-								/>
 							</div>
-						</>
+							<div className="text">
+								<p>{ __( 'Expand on click' ) }</p>
+								<p className="description">
+									{ __(
+										'Scales the image with a lightbox effect'
+									) }
+								</p>
+							</div>
+							<Button
+								icon={ linkOff }
+								className="remove-link"
+								label={ __( 'Remove link' ) }
+								onClick={ () => {
+									onSetLightbox( false );
+								} }
+								size="compact"
+							/>
+						</div>
 					) }
 				</URLPopover>
 			) }

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -253,7 +253,9 @@ const ImageURLInputUI = ( {
 					anchor={ popoverAnchor }
 					onFocusOutside={ onFocusOutside() }
 					onClose={ closeLinkUI }
-					renderSettings={ () => advancedOptions }
+					renderSettings={
+						! lightboxEnabled ? () => advancedOptions : null
+					}
 					additionalControls={
 						showLinkEditor && (
 							<MenuGroup>

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -70,6 +70,7 @@ const ImageURLInputUI = ( {
 	rel,
 	showLightboxSetting,
 	lightboxEnabled,
+	onSetLightbox,
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	// Use internal state instead of a ref to make sure that the component
@@ -310,11 +311,11 @@ const ImageURLInputUI = ( {
 										onClick={ () => {
 											setUrlInput( null );
 											onChangeUrl( {
-												lightbox: { enabled: true },
 												linkDestination:
 													LINK_DESTINATION_NONE,
 												href: '',
 											} );
+											onSetLightbox( true );
 											stopEditLink();
 										} }
 									>
@@ -375,9 +376,7 @@ const ImageURLInputUI = ( {
 									icon={ unlinkIcon }
 									label={ __( 'Remove link' ) }
 									onClick={ () => {
-										onChangeUrl( {
-											lightbox: { enabled: false },
-										} );
+										onSetLightbox( false );
 									} }
 								/>
 							</div>

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -37,16 +37,11 @@ const icon = (
 
 const expandIcon = (
 	<SVG
+		data-name="Layer 1"
 		xmlns="http://www.w3.org/2000/svg"
-		width="12"
-		height="12"
-		fill="none"
-		viewBox="0 0 12 12"
+		viewBox="0 0 11 11"
 	>
-		<Path
-			fill="#000"
-			d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z"
-		/>
+		<Path d="M2,0C.9,0,0,.9,0,2v2h1.5v-2c0-.28.22-.5.5-.5h2V0h-2ZM4,9.5h-2c-.28,0-.5-.22-.5-.5v-2H0v2c0,1.1.9,2,2,2h2v-1.5ZM7,11v-1.5h2c.28,0,.5-.22.5-.5v-2h1.5v2c0,1.1-.9,2-2,2h-2ZM9,0c1.1,0,2,.9,2,2v2h-1.5v-2c0-.28-.22-.5-.5-.5h-2V0h2Z" />
 	</SVG>
 );
 
@@ -307,6 +302,7 @@ const ImageURLInputUI = ( {
 								) ) }
 								<MenuItem
 									key="expand-on-click"
+									className="block-editor-url-popover__expand-on-click"
 									icon={ expandIcon }
 									iconPosition="left"
 									onClick={ () => {
@@ -320,7 +316,12 @@ const ImageURLInputUI = ( {
 										stopEditLink();
 									} }
 								>
-									{ __( 'Expand on click' ) }
+									<p>{ __( 'Expand on click' ) }</p>
+									<p className="expand-on-click__description">
+										{ __(
+											'Scales the image with a lightbox effect'
+										) }
+									</p>
 								</MenuItem>
 							</NavigableMenu>
 						)
@@ -355,13 +356,13 @@ const ImageURLInputUI = ( {
 					{ ! url && ! isEditingLink && lightboxEnabled && (
 						<>
 							<div
-								className="block-editor-url-popover__expand-on-click"
+								className="block-editor-url-popover__expand-on-click block-editor-url-popover__expand-on-click__unlink"
 								url={ url }
 							>
 								{ expandIcon }
-								<div>
+								<div className="expand-on-click__unlink-textbox">
 									<p>{ __( 'Expand on click' ) }</p>
-									<p>
+									<p className="expand-on-click__description">
 										{ __(
 											'Scales the image with a lightbox effect'
 										) }

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -68,6 +68,7 @@ const ImageURLInputUI = ( {
 	linkTarget,
 	linkClass,
 	rel,
+	showLightboxSetting,
 	lightboxEnabled,
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -300,29 +301,31 @@ const ImageURLInputUI = ( {
 										{ link.title }
 									</MenuItem>
 								) ) }
-								<MenuItem
-									key="expand-on-click"
-									className="block-editor-url-popover__expand-on-click"
-									icon={ expandIcon }
-									iconPosition="left"
-									onClick={ () => {
-										setUrlInput( null );
-										onChangeUrl( {
-											lightbox: { enabled: true },
-											linkDestination:
-												LINK_DESTINATION_NONE,
-											href: '',
-										} );
-										stopEditLink();
-									} }
-								>
-									<p>{ __( 'Expand on click' ) }</p>
-									<p className="expand-on-click__description">
-										{ __(
-											'Scales the image with a lightbox effect'
-										) }
-									</p>
-								</MenuItem>
+								{ showLightboxSetting && (
+									<MenuItem
+										key="expand-on-click"
+										className="block-editor-url-popover__expand-on-click"
+										icon={ expandIcon }
+										iconPosition="left"
+										onClick={ () => {
+											setUrlInput( null );
+											onChangeUrl( {
+												lightbox: { enabled: true },
+												linkDestination:
+													LINK_DESTINATION_NONE,
+												href: '',
+											} );
+											stopEditLink();
+										} }
+									>
+										<p>{ __( 'Expand on click' ) }</p>
+										<p className="expand-on-click__description">
+											{ __(
+												'Scales the image with a lightbox effect'
+											) }
+										</p>
+									</MenuItem>
+								) }
 							</NavigableMenu>
 						)
 					}

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -70,6 +70,7 @@ function URLPopover( {
 			focusOnMount={ focusOnMount }
 			placement={ computedPlacement }
 			shift
+			variant="toolbar"
 			{ ...popoverProps }
 		>
 			<div className="block-editor-url-popover__input-container">
@@ -82,6 +83,7 @@ function URLPopover( {
 							label={ __( 'Link settings' ) }
 							onClick={ toggleSettingsVisibility }
 							aria-expanded={ isSettingsExpanded }
+							size="compact"
 						/>
 					) }
 				</div>

--- a/packages/block-editor/src/components/url-popover/link-editor.js
+++ b/packages/block-editor/src/components/url-popover/link-editor.js
@@ -40,6 +40,7 @@ export default function LinkEditor( {
 				icon={ keyboardReturn }
 				label={ __( 'Apply' ) }
 				type="submit"
+				size="compact"
 			/>
 		</form>
 	);

--- a/packages/block-editor/src/components/url-popover/link-viewer.js
+++ b/packages/block-editor/src/components/url-popover/link-viewer.js
@@ -41,6 +41,7 @@ export default function LinkViewer( {
 					icon={ edit }
 					label={ __( 'Edit' ) }
 					onClick={ onEditLinkClick }
+					size="compact"
 				/>
 			) }
 		</div>

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -1,54 +1,38 @@
 .block-editor-url-popover__additional-controls {
-	border-top: $border-width solid $gray-300;
-	margin: 10px 0 15px;
+	border-top: $border-width solid $gray-900;
+	padding: $grid-unit-10 $grid-unit-10;
 }
 
-.block-editor-url-popover__additional-controls > div[role="menu"] .components-button:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) > svg {
-	box-shadow: none;
-}
-
-.block-editor-url-popover__additional-controls div[role="menu"] > .components-button {
-	padding-left: $grid-unit-15;
-	margin: 5px 0;
+.block-editor-url-popover__input-container {
+	padding: $grid-unit-10;
+	padding-left: $grid-unit-20;
 }
 
 .block-editor-url-popover__row {
 	display: flex;
+	gap: $grid-unit-05;
 }
 
 // Any children of the popover-row that are not the settings-toggle
 // should take up as much space as possible.
 .block-editor-url-popover__row > :not(.block-editor-url-popover__settings-toggle) {
 	flex-grow: 1;
+	gap: $grid-unit-05;
 }
 
-// Mimic toolbar component styles for the icons in this popover.
-.block-editor-url-popover .components-button.has-icon {
-	padding: 3px;
+.block-editor-url-popover__additional-controls .components-button.has-icon {
+	padding-left: $grid-unit-10;
+	padding-right: $grid-unit-10;
+	height: auto;
+	text-align: left;
 
 	> svg {
-		padding: 5px;
-		border-radius: $radius-block-ui;
-		height: 30px;
-		width: 30px;
-	}
-
-	&:not(:disabled):focus {
-		box-shadow: none;
-
-		> svg {
-			@include block-toolbar-button-style__focus();
-		}
+		margin-right: $grid-unit-10;
 	}
 }
 
 .block-editor-url-popover__settings-toggle {
 	flex-shrink: 0;
-
-	// Add a left divider to the toggle button.
-	border-radius: 0;
-	border-left: $border-width solid $gray-300;
-	margin-left: 1px;
 
 	&[aria-expanded="true"] .dashicon {
 		transform: rotate(180deg);
@@ -58,7 +42,7 @@
 .block-editor-url-popover__settings {
 	display: block;
 	padding: $grid-unit-20;
-	border-top: $border-width solid $gray-300;
+	border-top: $border-width solid $gray-900;
 }
 
 .block-editor-url-popover__link-editor,
@@ -67,49 +51,49 @@
 }
 
 .block-editor-url-popover__link-viewer-url {
-	margin: $grid-unit-10 - $border-width;
+	display: flex;
+	align-items: center;
 	flex-grow: 1;
 	flex-shrink: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	min-width: 150px;
-	max-width: 500px;
+	margin-right: $grid-unit-10;
 
 	&.has-invalid-link {
 		color: $alert-red;
 	}
 }
 
-.block-editor-url-popover__expand-on-click {
-	display: flex;
-	align-items: center;
-	flex-grow: 1;
-	flex-shrink: 1;
-	max-width: 500px;
-	min-width: 150px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	text-align: left;
+// .block-editor-url-popover__expand-on-click {
+// 	display: flex;
+// 	align-items: center;
+// 	flex-grow: 1;
+// 	flex-shrink: 1;
+// 	max-width: $modal-min-width;
+// 	min-width: 150px;
+// 	overflow: hidden;
+// 	text-overflow: ellipsis;
+// 	white-space: nowrap;
+// 	text-align: left;
 
-	.components-menu-item__item {
-		display: block;
-	}
+// 	// .components-menu-item__item {
+// 	// 	display: block;
+// 	// }
 
-	.expand-on-click__description {
-		color: #7b7b7b;
-	}
+// 	.expand-on-click__description {
+// 		color: #7b7b7b;
+// 	}
 
-	p {
-		margin: 0;
-	}
-}
+// 	p {
+// 		margin: 0;
+// 	}
+// }
 
-.expand-on-click__unlink-textbox {
-	min-width: 300px;
-}
+// .expand-on-click__unlink-textbox {
+// 	min-width: 300px;
+// }
 
-.block-editor-url-popover__expand-on-click__unlink {
-	padding: 10px;
-}
+// .block-editor-url-popover__expand-on-click__unlink {
+// 	padding: 10px;
+// }

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -65,35 +65,36 @@
 	}
 }
 
-// .block-editor-url-popover__expand-on-click {
-// 	display: flex;
-// 	align-items: center;
-// 	flex-grow: 1;
-// 	flex-shrink: 1;
-// 	max-width: $modal-min-width;
-// 	min-width: 150px;
-// 	overflow: hidden;
-// 	text-overflow: ellipsis;
-// 	white-space: nowrap;
-// 	text-align: left;
+.block-editor-url-popover__expand-on-click {
+	display: flex;
+	align-items: center;
+	min-width: $modal-min-width;
+	overflow: hidden;
+	white-space: nowrap;
 
-// 	// .components-menu-item__item {
-// 	// 	display: block;
-// 	// }
+	.fullscreen-icon {
+		padding-right: $grid-unit-05;
 
-// 	.expand-on-click__description {
-// 		color: #7b7b7b;
-// 	}
+		> svg {
+			width: $icon-size;
+			height: $icon-size;
+		}
+	}
 
-// 	p {
-// 		margin: 0;
-// 	}
-// }
+	.text {
+		flex-grow: 1;
 
-// .expand-on-click__unlink-textbox {
-// 	min-width: 300px;
-// }
+		p {
+			margin: 0;
+		}
+	}
 
-// .block-editor-url-popover__expand-on-click__unlink {
-// 	padding: 10px;
-// }
+	.description {
+		color: $gray-600;
+	}
+
+	.remove-link {
+		margin-right: $grid-unit-10;
+	}
+
+}

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -1,5 +1,6 @@
 .block-editor-url-popover__additional-controls {
 	border-top: $border-width solid $gray-300;
+	margin: 10px 0 15px;
 }
 
 .block-editor-url-popover__additional-controls > div[role="menu"] .components-button:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) > svg {
@@ -8,6 +9,7 @@
 
 .block-editor-url-popover__additional-controls div[role="menu"] > .components-button {
 	padding-left: $grid-unit-15;
+	margin: 5px 0;
 }
 
 .block-editor-url-popover__row {
@@ -84,14 +86,30 @@
 	align-items: center;
 	flex-grow: 1;
 	flex-shrink: 1;
-	margin: 7px;
 	max-width: 500px;
 	min-width: 150px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	text-align: left;
+
+	.components-menu-item__item {
+		display: block;
+	}
+
+	.expand-on-click__description {
+		color: #7b7b7b;
+	}
 
 	p {
-		margin: 0 0 0 7px;
+		margin: 0;
 	}
+}
+
+.expand-on-click__unlink-textbox {
+	min-width: 300px;
+}
+
+.block-editor-url-popover__expand-on-click__unlink {
+	padding: 10px;
 }

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -78,3 +78,20 @@
 		color: $alert-red;
 	}
 }
+
+.block-editor-url-popover__expand-on-click {
+	display: flex;
+	align-items: center;
+	flex-grow: 1;
+	flex-shrink: 1;
+	margin: 7px;
+	max-width: 500px;
+	min-width: 150px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+
+	p {
+		margin: 0 0 0 7px;
+	}
+}

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -254,6 +254,22 @@ export default function Image( {
 		setAttributes( props );
 	}
 
+	function onSetLightbox( enable ) {
+		if ( enable && ! lightboxSetting?.enabled ) {
+			setAttributes( {
+				lightbox: { enabled: true },
+			} );
+		} else if ( ! enable && lightboxSetting?.enabled ) {
+			setAttributes( {
+				lightbox: { enabled: false },
+			} );
+		} else {
+			setAttributes( {
+				lightbox: undefined,
+			} );
+		}
+	}
+
 	function onSetTitle( value ) {
 		// This is the HTML title attribute, separate from the media object
 		// title.
@@ -437,6 +453,7 @@ export default function Image( {
 						rel={ rel }
 						showLightboxSetting={ showLightboxSetting }
 						lightboxEnabled={ lightboxChecked }
+						onSetLightbox={ onSetLightbox }
 					/>
 				) }
 				{ allowCrop && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -439,6 +439,7 @@ export default function Image( {
 						linkTarget={ linkTarget }
 						linkClass={ linkClass }
 						rel={ rel }
+						lightboxEnabled={ lightbox?.enabled }
 					/>
 				) }
 				{ allowCrop && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -7,7 +7,6 @@ import {
 	ResizableBox,
 	Spinner,
 	TextareaControl,
-	ToggleControl,
 	TextControl,
 	ToolbarButton,
 	ToolbarGroup,
@@ -328,14 +327,11 @@ export default function Image( {
 
 	const [ lightboxSetting ] = useSettings( 'lightbox' );
 
-	const showLightboxToggle =
+	const showLightboxSetting =
 		!! lightbox || lightboxSetting?.allowEditing === true;
 
 	const lightboxChecked =
 		!! lightbox?.enabled || ( ! lightbox && !! lightboxSetting?.enabled );
-
-	const lightboxToggleDisabled =
-		linkDestination && linkDestination !== 'none';
 
 	const dimensionsControl = (
 		<DimensionsTool
@@ -439,6 +435,7 @@ export default function Image( {
 						linkTarget={ linkTarget }
 						linkClass={ linkClass }
 						rel={ rel }
+						showLightboxSetting={ showLightboxSetting }
 						lightboxEnabled={ lightboxChecked }
 					/>
 				) }
@@ -533,34 +530,6 @@ export default function Image( {
 							onChange={ updateImage }
 							options={ imageSizeOptions }
 						/>
-					) }
-					{ showLightboxToggle && (
-						<ToolsPanelItem
-							hasValue={ () => !! lightbox }
-							label={ __( 'Expand on click' ) }
-							onDeselect={ () => {
-								setAttributes( { lightbox: undefined } );
-							} }
-							isShownByDefault={ true }
-						>
-							<ToggleControl
-								label={ __( 'Expand on click' ) }
-								checked={ lightboxChecked }
-								onChange={ ( newValue ) => {
-									setAttributes( {
-										lightbox: { enabled: newValue },
-									} );
-								} }
-								disabled={ lightboxToggleDisabled }
-								help={
-									lightboxToggleDisabled
-										? __(
-												'“Expand on click” scales the image up, and can’t be combined with a link.'
-										  )
-										: ''
-								}
-							/>
-						</ToolsPanelItem>
 					) }
 				</ToolsPanel>
 			</InspectorControls>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -439,7 +439,7 @@ export default function Image( {
 						linkTarget={ linkTarget }
 						linkClass={ linkClass }
 						rel={ rel }
-						lightboxEnabled={ lightbox?.enabled }
+						lightboxEnabled={ lightboxChecked }
 					/>
 				) }
 				{ allowCrop && (

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -670,10 +670,7 @@ test.describe( 'Image', () => {
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
 		);
 
-		await page
-			.getByLabel( 'Block tools' )
-			.getByLabel( 'Insert link' )
-			.click();
+		await page.getByLabel( 'Block tools' ).getByLabel( 'Add link' ).click();
 
 		// This form lacks distinguishing qualities other than the
 		// class name, so we use page.locator() instead of page.getByRole()


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR moves the UI for the image lightbox from the sidebar's block settings to the context toolbar so that it can exist alongside the rest of the link logic.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/54916
Right now the UX for the lightbox is divorced from the rest of the handling for links.
This consolidates it and makes it more intuitive.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In the `image-url-input-ui` component, this PR adds the logic, markup, and styles for the new design and `Expand on click` toolbar item. Also, in `image.js`, I modified the logic for reading from or overriding the lightbox setting from the global styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Post Editor

#### With global styles `expand on click` setting _enabled_
1. In the global styles for the image block, ensure that `Expand on click` is enabled
2. Add an image to a post
3. Click the image and view the link settings; see that the `Expand on click` option is active
4. Publish and view the post; ensure the lightbox works as expected
6. In the post editor, click the image, open the link settings, and remove `Expand on click`
7. Check the post code source and see that `"lightbox":{"enabled":false}` has been added in the block delimiter
8. Save and view the post; ensure the lightbox is now disabled
9. In the post editor, reenable `Expand on click`
10. Check the code source again and verify `"lightbox":{"enabled":false}` has been removed

#### With global styles `expand on click` setting _disabled_
(same as above, but in reverse)
1. In the global styles for the image block, ensure that `Expand on click` is disabled
2. Add an image to a post
3. Click the image and view the link settings; see that the `Expand on click` option is deactivated
4. Publish and view the post; ensure the lightbox does not open
6. In the post editor, click the image, open the link settings, and enable `Expand on click`
7. Check the post code source and see that `"lightbox":{"enabled":true}` has been added in the block delimiter
8. Save and view the post; ensure the lightbox is now enabled
9. In the post editor, redeactivate `Expand on click`
10. Check the code source again and verify that the `"lightbox":{"enabled":true}` has been removed

### Site editor

For the site editor, please test the same as above. In addition, verify that toggling the global styles `Expand on ciick` setting also toggles the link UI for the image.

![toggle-lightbox-global-styles](https://github.com/WordPress/gutenberg/assets/5360536/440067ae-2f33-4832-ba46-52c8673e1148)

_Also_, check that adding and removing `Link to image file`, `Link to attachment page`, and custom links still works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
This uses existing UI and should work as expected with standard keyboard navigation.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/5360536/4f408215-c156-4547-a22f-da1e7fd54fdb
