### PR TITLE
Add Template Modal: Update scroll related layout

### DIFF
--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -39,7 +39,8 @@
 
 	.edit-site-custom-template-modal__suggestions_list {
 		@include break-small() {
-			overflow: scroll;
+			max-height: $grid-unit-70 * 4; // Height of four buttons
+			overflow-y: auto;
 		}
 
 		&__list-item {


### PR DESCRIPTION
Related to #50595

## What?

This PR adjusts the layout in the Add Template Modal, especially regarding scrolling. This will change the layout to look like this:

### When there are many list items

| Before | After |
|--------|--------|
| An empty scroll bar is displayed even though the list cannot be scrolled (on Windows). If you scroll the modal content, the search control will disappear. | The modal's maximum height is limited to exactly 4 list items. The search control will maintain its position as you scroll. |
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/c756acec-2247-4f02-b3c2-a0b8a7d403a6) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/087e91b1-df03-47d8-949f-fc90097f09c5) | 

### When the number of list items is small

| Before | After |
|--------|--------|
| In Windows, empty horizontal and vertical scroll bars are displayed even though the list cannot be scrolled. | The scrollbar is not displayed. |
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/cf493693-a0f8-44fc-a891-052fbf179a84) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/f3b83154-f5be-4a47-bf32-bd0d7d68a24b) | 

## Why?

In #50595, the height of the suggestion list seems to have been [removed](https://github.com/WordPress/gutenberg/pull/50595/files#diff-70ab64cce594236859b34c50d62162dbd4ad7b844a0380d57a7ade2d90f11effL89). This makes `overflow:scroll` appear to no longer work.

Furthermore, in the case of `overflow:scroll`, horizontal and vertical scroll bars are always displayed on Windows.

## How?

I applied height again to the suggestion list. The button height is 56px unless the list item title is extremely long. I made the maximum height of the list to be exactly the same as these four buttons.

Furthermore, I limited the direction in which `overflow` is applied to vertical only, and changed `scroll` to `auto`. This will prevent unnecessary scroll bar from appearing on Windows OS.

## Testing Instructions

- For Mac OS, you may need to change the scrollbar settings to always display.
- Create multiple pages, categories, and tags in advance.
- Open the Add template modal in the Site Editor.
- Click one of the following:
  - Category Archives > Category
  - Tag Archives > Tag
  - Pages
- If the suggestion list is small, there should be no scrollbar.
- When the suggestion list is large, a scrollbar will appear, but the search control should maintain its position.

https://github.com/WordPress/gutenberg/assets/54422211/f61c0938-8abf-4da1-ac1b-28c9c8dd6dfb