### PR TITLE
Fix Navigation block submenu spacing styles overridden by List block styles

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -22,10 +22,12 @@ $navigation-icon-size: 24px;
 	}
 
 	ul,
-	ul li {
+	ul li,
+	ul.has-background {
 		list-style: none;
 
 		// Overrides generic ".entry-content li" styles on the front end.
+		// Also overrides List block "ul.has-background" styles on the front end.
 		padding: 0;
 	}
 


### PR DESCRIPTION
Addresses #57620

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Find expanded details in #57620.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses Navigation block submenu spacing styles getting overridden by List block when Submenu overlay background color is set at the front end.

## Testing Instructions

1. Go to the block editor screen on any page.
2. Add a Navigation block, along with a submenu and dropdown items.
3. Set the Submenu overlay Background, Text color in the Navigation block (Take a look at the screenshots below for ref.)
4. Make sure to add/have a List block somewhere in that page.
5. Save/publish and visit live preview.
6. Hover/click over the submenu dropdown shouldn't have additional spacing as seen in #57620.