### PR TITLE
fix two typos in tutorial.md

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -327,7 +327,7 @@ Save the file and confirm that the block appears correctly in the Editor and on 
 
 ### Cleaning up
 
-When you use the `create-block` package to scaffold a block, it might include files that you don't need. In the case of this tutorial, the block doesn't use stylesheets or font end JavaScipt. Clean up the plugin's `src/` folder with the following actions.
+When you use the `create-block` package to scaffold a block, it might include files that you don't need. In the case of this tutorial, the block doesn't use stylesheets or front end JavaScript. Clean up the plugin's `src/` folder with the following actions.
 
 1. In the `edit.js` file, remove the lines that import `editor.scss`
 2. In the `index.js` file, remove the lines that import `style.scss`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
fixing two small typos

## Why?
to polish the beautiful tutorial (thank you!) a tiny bit

## How?
see diff

## Testing Instructions
./.

### Testing Instructions for Keyboard
./.

## Screenshots or screencast <!-- if applicable -->
