### PR TITLE
Patterns: Add black border back when editing synced pattern in the post editor

### DIFF
--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -1,6 +1,13 @@
 iframe[name="editor-canvas"] {
 	width: 100%;
 	height: 100%;
-	background-color: $white;
 	display: block;
+}
+
+iframe[name="editor-canvas"]:not(.has-history) {
+	background-color: $white;
+}
+
+iframe[name="editor-canvas"].has-history {
+	padding: $grid-unit-60 $grid-unit-60 0;
 }

--- a/packages/editor/src/components/editor-canvas/style.scss
+++ b/packages/editor/src/components/editor-canvas/style.scss
@@ -1,6 +1,0 @@
-.editor-canvas__iframe {
-	&.has-history {
-		padding: $grid-unit-60 $grid-unit-60 0;
-		background-color: $gray-900;
-	}
-}

--- a/packages/editor/src/components/editor-canvas/style.scss
+++ b/packages/editor/src/components/editor-canvas/style.scss
@@ -1,5 +1,6 @@
 .editor-canvas__iframe {
 	&.has-history {
 		padding: $grid-unit-60 $grid-unit-60 0;
+		background-color: $gray-900;
 	}
 }

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -29,4 +29,3 @@
 @import "./components/preview-dropdown/style.scss";
 @import "./components/table-of-contents/style.scss";
 @import "./components/template-validation-notice/style.scss";
-@import "./components/editor-canvas/style.scss";


### PR DESCRIPTION
## What?
Adds the black border back when editing a synced pattern in isolation in the post editor.

## Why?
The black background was originally just showing due to a bug which was fixed in #57330. Since this fixed the border is displaying as white.

## How?
Explicitly set the black border when the pattern is in the focused edit mode, which is identified if the `.has-history` class is set.

## Testing Instructions

- Add a synced pattern to a post in the post editor
- Select the pattern and click the `Edit original` in the toolbar
- Make sure a black border appears on the pattern edit screen

### Screenshots

Before:

https://github.com/WordPress/gutenberg/assets/3629020/e82a3383-e33b-457c-bf9d-be1d8e260150

After:

https://github.com/WordPress/gutenberg/assets/3629020/c4158bcf-8c6e-46f5-ba9b-c465c0211854





