### PR TITLE
Template editing: Refactor the post editor template-only mode

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -79,7 +79,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			hasHistory: !! select( editorStore ).getEditorSettings().goBack,
 			isEditingTemplate:
-				select( editorStore ).getRenderingMode() === 'template-only',
+				select( editorStore ).getCurrentPostType() === 'wp_template',
 			isPublishSidebarOpened:
 				select( editPostStore ).isPublishSidebarOpened(),
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
@@ -159,7 +159,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 							isLargeViewport,
 					} ) }
 				>
-					{ ( isEditingTemplate || hasHistory ) && <DocumentBar /> }
+					{ hasHistory && <DocumentBar /> }
 				</div>
 			</motion.div>
 			<motion.div

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -45,7 +45,7 @@ function ModeSwitcher() {
 			isCodeEditingEnabled:
 				select( editorStore ).getEditorSettings().codeEditingEnabled,
 			isEditingTemplate:
-				select( editorStore ).getRenderingMode() === 'template-only',
+				select( editorStore ).getCurrentPostType() === 'wp_template',
 			mode: select( editPostStore ).getEditorMode(),
 		} ),
 		[]

--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -15,21 +15,18 @@ import { sidebars } from '../settings-sidebar';
 const { Tabs } = unlock( componentsPrivateApis );
 
 const SettingsHeader = () => {
-	const { documentLabel, isTemplateMode } = useSelect( ( select ) => {
-		const { getPostTypeLabel, getRenderingMode } = select( editorStore );
+	const { documentLabel } = useSelect( ( select ) => {
+		const { getPostTypeLabel } = select( editorStore );
 
 		return {
 			// translators: Default label for the Document sidebar tab, not selected.
 			documentLabel: getPostTypeLabel() || _x( 'Document', 'noun' ),
-			isTemplateMode: getRenderingMode() === 'template-only',
 		};
 	}, [] );
 
 	return (
 		<Tabs.TabList>
-			<Tabs.Tab tabId={ sidebars.document }>
-				{ isTemplateMode ? __( 'Template' ) : documentLabel }
-			</Tabs.Tab>
+			<Tabs.Tab tabId={ sidebars.document }>{ documentLabel }</Tabs.Tab>
 			<Tabs.Tab tabId={ sidebars.block }>
 				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
 				{ __( 'Block' ) }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -48,7 +48,7 @@ export const sidebars = {
 const SidebarContent = ( {
 	sidebarName,
 	keyboardShortcut,
-	isTemplateMode,
+	isEditingTemplate,
 } ) => {
 	// Because `PluginSidebarEditPost` renders a `ComplementaryArea`, we
 	// need to forward the `Tabs` context so it can be passed through the
@@ -77,7 +77,7 @@ const SidebarContent = ( {
 		>
 			<Tabs.Context.Provider value={ tabsContextValue }>
 				<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
-					{ ! isTemplateMode && (
+					{ ! isEditingTemplate && (
 						<>
 							<PostStatus />
 							<PluginDocumentSettingPanel.Slot />
@@ -90,7 +90,7 @@ const SidebarContent = ( {
 							<MetaBoxes location="side" />
 						</>
 					) }
-					{ isTemplateMode && <TemplateSummary /> }
+					{ isEditingTemplate && <TemplateSummary /> }
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
 					<BlockInspector />
@@ -105,7 +105,7 @@ const SettingsSidebar = () => {
 		sidebarName,
 		isSettingsSidebarActive,
 		keyboardShortcut,
-		isTemplateMode,
+		isEditingTemplate,
 	} = useSelect( ( select ) => {
 		// The settings sidebar is used by the edit-post/document and edit-post/block sidebars.
 		// sidebarName represents the sidebar that is active or that should be active when the SettingsSidebar toggle button is pressed.
@@ -132,8 +132,8 @@ const SettingsSidebar = () => {
 			sidebarName: sidebar,
 			isSettingsSidebarActive: isSettingsSidebar,
 			keyboardShortcut: shortcut,
-			isTemplateMode:
-				select( editorStore ).getRenderingMode() === 'template-only',
+			isEditingTemplate:
+				select( editorStore ).getCurrentPostType() === 'wp_template',
 		};
 	}, [] );
 
@@ -161,7 +161,7 @@ const SettingsSidebar = () => {
 			<SidebarContent
 				sidebarName={ sidebarName }
 				keyboardShortcut={ keyboardShortcut }
-				isTemplateMode={ isTemplateMode }
+				isEditingTemplate={ isEditingTemplate }
 			/>
 		</Tabs>
 	);

--- a/packages/edit-post/src/components/sidebar/template-summary/index.js
+++ b/packages/edit-post/src/components/sidebar/template-summary/index.js
@@ -4,16 +4,12 @@
 import { Icon, layout } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem, FlexBlock, PanelBody } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { store as editPostStore } from '../../../store';
+import { store as editorStore } from '@wordpress/editor';
 
 function TemplateSummary() {
 	const template = useSelect( ( select ) => {
-		const { getEditedPostTemplate } = select( editPostStore );
-		return getEditedPostTemplate();
+		const { getCurrentPost } = select( editorStore );
+		return getCurrentPost();
 	}, [] );
 
 	if ( ! template ) {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -30,15 +30,18 @@ export default function VisualEditor( { styles } ) {
 		renderingMode,
 		isBlockBasedTheme,
 		hasV3BlocksOnly,
+		isEditingTemplate,
 	} = useSelect( ( select ) => {
 		const { isFeatureActive } = select( editPostStore );
-		const { getEditorSettings, getRenderingMode } = select( editorStore );
+		const { getEditorSettings, getRenderingMode, getCurrentPostType } =
+			select( editorStore );
 		const { getBlockTypes } = select( blocksStore );
 		const editorSettings = getEditorSettings();
 
 		return {
 			isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 			renderingMode: getRenderingMode(),
+			isEditingTemplate: getCurrentPostType() === 'wp_template',
 			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
 			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
 				return type.apiVersion >= 3;
@@ -74,12 +77,12 @@ export default function VisualEditor( { styles } ) {
 	const isToBeIframed =
 		( ( hasV3BlocksOnly || ( isGutenbergPlugin && isBlockBasedTheme ) ) &&
 			! hasMetaBoxes ) ||
-		renderingMode === 'template-only';
+		isEditingTemplate;
 
 	return (
 		<div
 			className={ classnames( 'edit-post-visual-editor', {
-				'is-template-mode': renderingMode === 'template-only',
+				'is-template-mode': isEditingTemplate,
 				'has-inline-canvas': ! isToBeIframed,
 			} ) }
 		>

--- a/packages/edit-post/src/components/welcome-guide/index.js
+++ b/packages/edit-post/src/components/welcome-guide/index.js
@@ -12,17 +12,17 @@ import WelcomeGuideTemplate from './template';
 import { store as editPostStore } from '../../store';
 
 export default function WelcomeGuide() {
-	const { isActive, isTemplateMode } = useSelect( ( select ) => {
+	const { isActive, isEditingTemplate } = useSelect( ( select ) => {
 		const { isFeatureActive } = select( editPostStore );
-		const { getRenderingMode } = select( editorStore );
-		const _isTemplateMode = getRenderingMode() === 'template-only';
-		const feature = _isTemplateMode
+		const { getCurrentPostType } = select( editorStore );
+		const _isEditingTemplate = getCurrentPostType() === 'wp_template';
+		const feature = _isEditingTemplate
 			? 'welcomeGuideTemplate'
 			: 'welcomeGuide';
 
 		return {
 			isActive: isFeatureActive( feature ),
-			isTemplateMode: _isTemplateMode,
+			isEditingTemplate: _isEditingTemplate,
 		};
 	}, [] );
 
@@ -30,5 +30,9 @@ export default function WelcomeGuide() {
 		return null;
 	}
 
-	return isTemplateMode ? <WelcomeGuideTemplate /> : <WelcomeGuideDefault />;
+	return isEditingTemplate ? (
+		<WelcomeGuideTemplate />
+	) : (
+		<WelcomeGuideDefault />
+	);
 }

--- a/packages/edit-post/src/plugins/welcome-guide-menu-item/index.js
+++ b/packages/edit-post/src/plugins/welcome-guide-menu-item/index.js
@@ -7,16 +7,16 @@ import { __ } from '@wordpress/i18n';
 import { store as editorStore } from '@wordpress/editor';
 
 export default function WelcomeGuideMenuItem() {
-	const isTemplateMode = useSelect(
+	const isEditingTemplate = useSelect(
 		( select ) =>
-			select( editorStore ).getRenderingMode() === 'template-only',
+			select( editorStore ).getCurrentPostType() === 'wp_template',
 		[]
 	);
 
 	return (
 		<PreferenceToggleMenuItem
 			scope="core/edit-post"
-			name={ isTemplateMode ? 'welcomeGuideTemplate' : 'welcomeGuide' }
+			name={ isEditingTemplate ? 'welcomeGuideTemplate' : 'welcomeGuide' }
 			label={ __( 'Welcome Guide' ) }
 		/>
 	);

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -499,15 +499,6 @@ export function setIsEditingTemplate() {
 }
 
 /**
- * Switches to the template mode.
- */
-export const __unstableSwitchToTemplateMode =
-	() =>
-	( { registry } ) => {
-		registry.dispatch( editorStore ).setRenderingMode( 'template-only' );
-	};
-
-/**
  * Create a block based template.
  *
  * @deprecated

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -48,27 +48,15 @@ const icons = {
 };
 
 export default function DocumentBar() {
-	const {
-		isEditingTemplate,
-		templateId,
-		postType,
-		postId,
-		goBack,
-		getEditorSettings,
-	} = useSelect( ( select ) => {
+	const { postType, postId, goBack } = useSelect( ( select ) => {
 		const {
-			getRenderingMode,
-			getCurrentTemplateId,
 			getCurrentPostId,
 			getCurrentPostType,
 			getEditorSettings: getSettings,
 		} = select( editorStore );
-		const _templateId = getCurrentTemplateId();
 		const back = getSettings().goBack;
+
 		return {
-			isEditingTemplate:
-				!! _templateId && getRenderingMode() === 'template-only',
-			templateId: _templateId,
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
 			goBack: typeof back === 'function' ? back : undefined,
@@ -76,13 +64,7 @@ export default function DocumentBar() {
 		};
 	}, [] );
 
-	const { setRenderingMode } = useDispatch( editorStore );
-
 	const handleOnBack = () => {
-		if ( isEditingTemplate ) {
-			setRenderingMode( getEditorSettings().defaultRenderingMode );
-			return;
-		}
 		if ( goBack ) {
 			goBack();
 		}
@@ -90,9 +72,9 @@ export default function DocumentBar() {
 
 	return (
 		<BaseDocumentActions
-			postType={ isEditingTemplate ? 'wp_template' : postType }
-			postId={ isEditingTemplate ? templateId : postId }
-			onBack={ isEditingTemplate || goBack ? handleOnBack : undefined }
+			postType={ postType }
+			postId={ postId }
+			onBack={ goBack ? handleOnBack : undefined }
 		/>
 	);
 }

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -91,7 +91,7 @@ function EditorCanvas( {
 		wrapperBlockName,
 		wrapperUniqueId,
 		deviceType,
-		hasHistory,
+		showEditorPadding,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostId,
@@ -138,7 +138,7 @@ function EditorCanvas( {
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			deviceType: getDeviceType(),
-			hasHistory:
+			showEditorPadding:
 				!! editorSettings.goBack && postTypeSlug !== 'wp_template',
 		};
 	}, [] );
@@ -303,7 +303,7 @@ function EditorCanvas( {
 			height="100%"
 			iframeProps={ {
 				className: classnames( 'editor-canvas__iframe', {
-					'has-history': hasHistory,
+					'has-editor-padding': showEditorPadding,
 				} ),
 				...iframeProps,
 				style: {

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -138,7 +138,8 @@ function EditorCanvas( {
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			deviceType: getDeviceType(),
-			hasHistory: !! editorSettings.goBack,
+			hasHistory:
+				!! editorSettings.goBack && postTypeSlug !== 'wp_template',
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );

--- a/packages/editor/src/components/editor-canvas/style.scss
+++ b/packages/editor/src/components/editor-canvas/style.scss
@@ -1,5 +1,5 @@
 .editor-canvas__iframe {
-	&.has-history {
+	&.has-editor-padding {
 		padding: $grid-unit-60 $grid-unit-60 0;
 	}
 }

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -24,10 +24,13 @@ const POPOVER_PROPS = {
 };
 
 export default function BlockThemeControl( { id } ) {
-	const { isTemplateHidden } = useSelect( ( select ) => {
+	const { isTemplateHidden, getPostLinkProps } = useSelect( ( select ) => {
+		const { getEditorSettings } = select( editorStore );
 		const { getRenderingMode } = unlock( select( editorStore ) );
+
 		return {
 			isTemplateHidden: getRenderingMode() === 'post-only',
+			getPostLinkProps: getEditorSettings().getPostLinkProps,
 		};
 	}, [] );
 	const { editedRecord: template, hasResolved } = useEntityRecord(
@@ -35,9 +38,16 @@ export default function BlockThemeControl( { id } ) {
 		'wp_template',
 		id
 	);
-	const { getEditorSettings } = useSelect( editorStore );
+
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { setRenderingMode } = useDispatch( editorStore );
+	const editTemplate = getPostLinkProps
+		? getPostLinkProps( {
+				postId: template.wp_id,
+				postType: 'wp_template',
+				canvas: 'edit',
+		  } )
+		: {};
 
 	if ( ! hasResolved ) {
 		return null;
@@ -58,8 +68,8 @@ export default function BlockThemeControl( { id } ) {
 				<>
 					<MenuGroup>
 						<MenuItem
-							onClick={ () => {
-								setRenderingMode( 'template-only' );
+							onClick={ ( event ) => {
+								editTemplate.onClick( event );
 								onClose();
 								createSuccessNotice(
 									__(
@@ -67,16 +77,6 @@ export default function BlockThemeControl( { id } ) {
 									),
 									{
 										type: 'snackbar',
-										actions: [
-											{
-												label: __( 'Go back' ),
-												onClick: () =>
-													setRenderingMode(
-														getEditorSettings()
-															.defaultRenderingMode
-													),
-											},
-										],
 									}
 								);
 							} }


### PR DESCRIPTION
## What?
Refactors the post editor `template-only` mode to instead use the #57036 to pass a new entity into the editor provider.

## Why?
It was decided that passing a new entity into the editor provider was a better way of moving between different entities in the editor rather than adding multiple rendering modes for templates, patterns, navigation blocks, etc.

## How?


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
