### PR TITLE
Typography: replace non-dot decimal separator for float to string conversions

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -285,7 +285,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 
 	$acceptable_units_group = implode( '|', $options['acceptable_units'] );
 	// Matches integers and floats (including negative values) with optional decimal (dot or comma) and a unit value.
-	$pattern                = '/^(-?\d*[\.,]?\d+)(' . $acceptable_units_group . '){0,1}$/';
+	$pattern = '/^(-?\d*[\.,]?\d+)(' . $acceptable_units_group . '){0,1}$/';
 
 	preg_match( $pattern, $raw_value, $matches );
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -412,7 +412,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 	 * For floats coerced to strings, locales can use either a comma (,) or dot (.) as decimal separators.
 	 * Replace the locale separator with a dot for CSS rules to be valid.
 	 */
-	$linear_factor_scaled   = empty( $linear_factor_scaled ) || 1 === $linear_factor_scaled ? 1 : str_replace( ',', '.', round( $linear_factor_scaled, 3 )  );
+	$linear_factor_scaled   = empty( $linear_factor_scaled ) || 1 === $linear_factor_scaled ? 1 : str_replace( ',', '.', round( $linear_factor_scaled, 3 ) );
 	$fluid_target_font_size = $minimum_font_size_rem['combined'] . " + ((1vw - $view_port_width_offset) * $linear_factor_scaled)";
 
 	return "clamp($minimum_font_size_raw, $fluid_target_font_size, $maximum_font_size_raw)";

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -284,6 +284,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 	$options  = wp_parse_args( $options, $defaults );
 
 	$acceptable_units_group = implode( '|', $options['acceptable_units'] );
+	// Matches integers and floats (including negative values) with optional decimal (dot or comma) and a unit value.
 	$pattern                = '/^(-?\d*[\.,]?\d+)(' . $acceptable_units_group . '){0,1}$/';
 
 	preg_match( $pattern, $raw_value, $matches );
@@ -295,7 +296,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 
 	/*
 	 * For floats coerced to strings, locales can use either a comma (,) or dot (.) as decimal separators.
-	 * Replace the locale separator with a dot for CSS rules to be valid.
+	 * Use `str_replace` to replace any comma separators with a dot for CSS rules to be valid.
 	 */
 	$value = str_replace( ',', '.', $matches[1] );
 	// Converts units to pixel values by default.
@@ -403,15 +404,15 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 		return null;
 	}
 
-	// Build CSS rule.
-	// Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
-	$view_port_width_offset = gutenberg_get_typography_value_and_unit( ( $minimum_viewport_width['value'] / 100 ) . $font_size_unit )['combined'];
+	/*
+	 * Build CSS rule.
+	 * Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
+	 * For floats coerced to strings, locales can use either a comma (,) or dot (.) as decimal separators.
+	 * Use `str_replace` to replace any comma separators with a dot for CSS rules to be valid.
+	 */
+	$view_port_width_offset = str_replace( ',', '.', round( $minimum_viewport_width['value'] / 100, 3 ) ) . $font_size_unit;
 	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $maximum_viewport_width['value'] - $minimum_viewport_width['value'] ) );
 	$linear_factor_scaled   = $linear_factor * $scale_factor;
-	/*
-	 * For floats coerced to strings, locales can use either a comma (,) or dot (.) as decimal separators.
-	 * Replace the locale separator with a dot for CSS rules to be valid.
-	 */
 	$linear_factor_scaled   = empty( $linear_factor_scaled ) || 1 === $linear_factor_scaled ? 1 : str_replace( ',', '.', round( $linear_factor_scaled, 3 ) );
 	$fluid_target_font_size = $minimum_font_size_rem['combined'] . " + ((1vw - $view_port_width_offset) * $linear_factor_scaled)";
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -300,7 +300,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 	$raw_value         = is_string( $raw_value ) && ! $has_decimal_point ? str_replace( $local_info['decimal_point'], '.', $raw_value ) : $raw_value;
 
 	if ( ! $skip_unit_parsing ) {
-		$acceptable_units_group = $skip_unit_parsing ? "" : implode( '|', $options['acceptable_units'] );
+		$acceptable_units_group = $skip_unit_parsing ? '' : implode( '|', $options['acceptable_units'] );
 		$pattern                = '/^(\d*[\.]?\d+)(' . $acceptable_units_group . '){1,1}$/';
 
 		preg_match( $pattern, $raw_value, $matches );
@@ -427,9 +427,12 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 	$view_port_width_offset = gutenberg_get_typography_value_and_unit( ( $minimum_viewport_width['value'] / 100 ) . $font_size_unit )['combined'];
 	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $maximum_viewport_width['value'] - $minimum_viewport_width['value'] ) );
 	$linear_factor_scaled   = $linear_factor * $scale_factor;
-	$linear_factor_scaled   = empty( $linear_factor_scaled ) || 1 === $linear_factor_scaled ? 1 : gutenberg_get_typography_value_and_unit( $linear_factor_scaled, array(
-		'skip_unit_parsing' => true,
-	) )['combined'];
+	$linear_factor_scaled   = empty( $linear_factor_scaled ) || 1 === $linear_factor_scaled ? 1 : gutenberg_get_typography_value_and_unit(
+		$linear_factor_scaled,
+		array(
+			'skip_unit_parsing' => true,
+		)
+	)['combined'];
 
 	$fluid_target_font_size = $minimum_font_size_rem['combined'] . " + ((1vw - $view_port_width_offset) * $linear_factor_scaled)";
 
@@ -570,10 +573,9 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		if ( ! empty( $minimum_font_size_limit ) && $calculated_minimum_font_size <= $minimum_font_size_limit['value'] ) {
 			$minimum_font_size_raw = $minimum_font_size_limit['combined'];
 		} else {
-			$minimum_font_size_calculated = gutenberg_get_typography_value_and_unit(
+			$minimum_font_size_raw = gutenberg_get_typography_value_and_unit(
 				$calculated_minimum_font_size . $preferred_size['unit']
-			);
-			$minimum_font_size_raw = $minimum_font_size_calculated['combined'];
+			)['combined'];
 		}
 	}
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -330,7 +330,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 */
 	public function test_gutenberg_get_typography_font_size_value_with_locale( $font_size, $should_use_fluid_typography, $expected_output ) {
 		$current_locale = setlocale( LC_NUMERIC, 0 );
-		setlocale( LC_NUMERIC,'de_DE.UTF-8' );
+		setlocale( LC_NUMERIC, 'de_DE.UTF-8' );
 		$actual = gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography );
 
 		$this->assertSame( $expected_output, $actual );
@@ -835,7 +835,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 */
 	public function test_valid_size_wp_get_typography_value_and_unit_with_locale( $raw_value, $expected, $options = array() ) {
 		$current_locale = setlocale( LC_NUMERIC, 0 );
-		setlocale( LC_NUMERIC,'de_DE.UTF-8' );
+		setlocale( LC_NUMERIC, 'de_DE.UTF-8' );
 		$this->assertEquals( $expected, gutenberg_get_typography_value_and_unit( $raw_value, $options ) );
 		setlocale( LC_NUMERIC, $current_locale );
 	}

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -894,8 +894,8 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'size: `"12px"`'                             => array(
 				'raw_value' => '12px',
 				'expected'  => array(
-					'value' => 12,
-					'unit'      => 'px',
+					'value'    => 12,
+					'unit'     => 'px',
 					'combined' => '12px',
 				),
 			),
@@ -934,7 +934,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'combined' => '7.358vh',
 				),
 				'options'   => array(
-					'acceptable_units' => array( 'vh' )
+					'acceptable_units' => array( 'vh' ),
 				),
 			),
 		);

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -329,12 +329,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
 	 */
 	public function test_gutenberg_get_typography_font_size_value_with_locale( $font_size, $should_use_fluid_typography, $expected_output ) {
-		$current_locale = setlocale(LC_NUMERIC, 0 );
-		setlocale(LC_NUMERIC,'de_DE.UTF-8' );
+		$current_locale = setlocale( LC_NUMERIC, 0 );
+		setlocale( LC_NUMERIC,'de_DE.UTF-8' );
 		$actual = gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography );
 
 		$this->assertSame( $expected_output, $actual );
-		setlocale(LC_NUMERIC, $current_locale );
+		setlocale( LC_NUMERIC, $current_locale );
 	}
 
 	/**
@@ -834,10 +834,10 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 * @param array $options Options to pass to function.
 	 */
 	public function test_valid_size_wp_get_typography_value_and_unit_with_locale( $raw_value, $expected, $options = array() ) {
-		$current_locale = setlocale(LC_NUMERIC, 0 );
-		setlocale(LC_NUMERIC,'de_DE.UTF-8' );
+		$current_locale = setlocale( LC_NUMERIC, 0 );
+		setlocale( LC_NUMERIC,'de_DE.UTF-8' );
 		$this->assertEquals( $expected, gutenberg_get_typography_value_and_unit( $raw_value, $options ) );
-		setlocale(LC_NUMERIC, $current_locale );
+		setlocale( LC_NUMERIC, $current_locale );
 	}
 
 	/**
@@ -862,65 +862,65 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'size: `"10"`'                               => array(
 				'raw_value' => '10',
 				'expected'  => array(
-					'value' => 10,
-					'unit'  => 'px',
-					'combined'  => '10px',
+					'value'    => 10,
+					'unit'     => 'px',
+					'combined' => '10px',
 				),
 			),
 			'size: `11`'                                 => array(
 				'raw_value' => 11,
 				'expected'  => array(
-					'value' => 11,
-					'unit'  => 'px',
-					'combined'  => '11px',
+					'value'    => 11,
+					'unit'     => 'px',
+					'combined' => '11px',
 				),
 			),
 			'size: `11.234`'                             => array(
 				'raw_value' => '11.234',
 				'expected'  => array(
-					'value' => 11.234,
-					'unit'  => 'px',
-					'combined'  => '11.234px',
+					'value'    => 11.234,
+					'unit'     => 'px',
+					'combined' => '11.234px',
 				),
 			),
 			'size: `"12rem"`'                            => array(
 				'raw_value' => '12rem',
 				'expected'  => array(
-					'value' => 12,
-					'unit'  => 'rem',
-					'combined'  => '12rem',
+					'value'    => 12,
+					'unit'     => 'rem',
+					'combined' => '12rem',
 				),
 			),
 			'size: `"12px"`'                             => array(
 				'raw_value' => '12px',
 				'expected'  => array(
 					'value' => 12,
-					'unit'  => 'px',
-					'combined'  => '12px',
+					'unit'      => 'px',
+					'combined' => '12px',
 				),
 			),
 			'size: `"12em"`'                             => array(
 				'raw_value' => '12em',
 				'expected'  => array(
-					'value' => 12,
-					'unit'  => 'em',
-					'combined'  => '12em',
+					'value'    => 12,
+					'unit'     => 'em',
+					'combined' => '12em',
 				),
 			),
 			'size: `"12.74em"`'                          => array(
 				'raw_value' => '12.74em',
 				'expected'  => array(
-					'value' => 12.74,
-					'unit'  => 'em',
-					'combined'  => '12.74em',
+					'value'    => 12.74,
+					'unit'     => 'em',
+					'combined' => '12.74em',
 				),
 			),
 			'size: `"33.3333"`'                          => array(
 				'raw_value' => 33.3333,
 				'expected'  => array(
-					'value' => 33.333,
-					'unit'  => '',
-					'combined'  => '33.333',
+					'value'    => 33.333,
+					'unit'     => '',
+					'combined' => '33.333',
 				),
 				'options'   => array(
 					'skip_unit_parsing' => true,
@@ -929,12 +929,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'size: `"7.353vh"`'                          => array(
 				'raw_value' => '7.357777vh',
 				'expected'  => array(
-					'value' => 7.358,
-					'unit'  => 'vh',
-					'combined'  => '7.358vh',
+					'value'    => 7.358,
+					'unit'     => 'vh',
+					'combined' => '7.358vh',
 				),
 				'options'   => array(
-					'acceptable_units'  => array( 'vh' )
+					'acceptable_units' => array( 'vh' )
 				),
 			),
 		);

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -309,35 +309,6 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests generating font size values, including fluid formulae, from fontSizes preset using a locale
-	 * that uses a comma as a decimal separator.
-	 *
-	 * @covers ::wp_get_typography_font_size_value
-	 * @covers ::wp_get_typography_value_and_unit
-	 * @covers ::wp_get_computed_fluid_typography_value
-	 *
-	 * @dataProvider data_generate_font_size_preset_fixtures
-	 *
-	 * @param array  $font_size                     {
-	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
-	 *
-	 *     @type string $name Name of the font size preset.
-	 *     @type string $slug Kebab-case unique identifier for the font size preset.
-	 *     @type string $size CSS font-size value, including units where applicable.
-	 * }
-	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
-	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
-	 */
-	public function test_gutenberg_get_typography_font_size_value_with_locale( $font_size, $should_use_fluid_typography, $expected_output ) {
-		$current_locale = setlocale( LC_NUMERIC, 0 );
-		setlocale( LC_NUMERIC, 'de_DE.UTF-8' );
-		$actual = gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography );
-
-		$this->assertSame( $expected_output, $actual );
-		setlocale( LC_NUMERIC, $current_locale );
-	}
-
-	/**
 	 * Data provider for test_wp_get_typography_font_size_value.
 	 *
 	 * @return array
@@ -823,24 +794,6 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that valid font size values are parsed with a locale that uses a comma as a decimal separator.
-	 *
-	 * @covers ::gutenberg_get_typography_value_and_unit
-	 *
-	 * @dataProvider data_valid_size_wp_get_typography_value_and_unit
-	 *
-	 * @param mixed $raw_value Raw size value to test.
-	 * @param mixed $expected  An expected return value.
-	 * @param array $options Options to pass to function.
-	 */
-	public function test_valid_size_wp_get_typography_value_and_unit_with_locale( $raw_value, $expected, $options = array() ) {
-		$current_locale = setlocale( LC_NUMERIC, 0 );
-		setlocale( LC_NUMERIC, 'de_DE.UTF-8' );
-		$this->assertEquals( $expected, gutenberg_get_typography_value_and_unit( $raw_value, $options ) );
-		setlocale( LC_NUMERIC, $current_locale );
-	}
-
-	/**
 	 * Data provider.
 	 *
 	 * @return array
@@ -923,7 +876,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'combined' => '33.333',
 				),
 				'options'   => array(
-					'skip_unit_parsing' => true,
+					'parse_units' => false,
 				),
 			),
 			'size: `"7.353vh"`'                          => array(
@@ -935,6 +888,22 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				),
 				'options'   => array(
 					'acceptable_units' => array( 'vh' ),
+				),
+			),
+			'size: `"12,1238rem"`'                       => array(
+				'raw_value' => '12,1238rem',
+				'expected'  => array(
+					'value'    => 12.124,
+					'unit'     => 'rem',
+					'combined' => '12.124rem',
+				),
+			),
+			'size: `"1,7879"`'                           => array(
+				'raw_value' => '1,7879',
+				'expected'  => array(
+					'value'    => 1.788,
+					'unit'     => 'px',
+					'combined' => '1.788px',
 				),
 			),
 		);

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -868,17 +868,6 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'combined' => '12.74em',
 				),
 			),
-			'size: `"33.3333"`'                          => array(
-				'raw_value' => 33.3333,
-				'expected'  => array(
-					'value'    => 33.333,
-					'unit'     => '',
-					'combined' => '33.333',
-				),
-				'options'   => array(
-					'parse_units' => false,
-				),
-			),
 			'size: `"7.353vh"`'                          => array(
 				'raw_value' => '7.357777vh',
 				'expected'  => array(
@@ -904,6 +893,14 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'value'    => 1.788,
 					'unit'     => 'px',
 					'combined' => '1.788px',
+				),
+			),
+			'size: `-10.2rem`'                           => array(
+				'raw_value' => '-10.2rem',
+				'expected'  => array(
+					'value'    => -10.2,
+					'unit'     => 'rem',
+					'combined' => '-10.2rem',
 				),
 			),
 		);


### PR DESCRIPTION
Resolves: 

- https://github.com/WordPress/gutenberg/issues/57607

## What?

When coercing a float to a string, replace commas with dots.

This is so we can output valid CSS values where locales use commas as decimal separators.


## Why?
In PHP version < 8, PHP uses the current locale for float to string conversions.

That means `1.333 + "px"`, for example, will be converted to `1,333px`.

PHP 8 does not do this.

See: https://php.watch/versions/8.0/float-to-string-locale-independent

## How?
String replace before turning floats to strings or trying to use stringified floats for any other business.


E.g., 

`str_replace( ',', '.', '$some_number )`

## Testing Instructions

To test, we need to be running a PHP version of < 8, e.g., 7.4.

If you're not and you're using `wp-env`, you can update the `.wp-env.json` file and set the `phpVersion` value.

Another dependency is `locale`, which needs to be installed on the server.

Here's a diff that does all that:

<details>

<summary>wp-env override and locale</summary>

```diff
diff --git a/.wp-env.json b/.wp-env.json
index 79810b194b..a1d3716f4c 100644
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,6 @@
 {
 	"core": "WordPress/WordPress",
+	"phpVersion": "7.4",
 	"plugins": [ "." ],
 	"themes": [ "./test/emptytheme" ],
 	"env": {
diff --git a/packages/env/lib/init-config.js b/packages/env/lib/init-config.js
index 318bcae151..eb9962b0de 100644
--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -207,6 +207,17 @@ RUN apt-get -qy install git
 # Set up sudo so they can have root access.
 RUN apt-get -qy install sudo
 RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
+
+			const locale = 'de_DE.UTF-8';
+			dockerFileContent += `
+# Install locales
+RUN apt-get update && apt-get install -y locales locales-all
+RUN locale-gen ${ locale }
+ENV LANG ${ locale }
+ENV LANGUAGE ${ locale }
+ENV LC_ALL ${ locale }
+RUN update-locale LANG=${ locale }
+`;
 			break;
 		}
 		case 'cli': {

```

</details>

If you don't mind losing your docker containers, once that patch is applied, run the following commands:

```bash
npm run wp-env destroy
# Hit `y` to destroy your local docker containers
npm run wp-env start 
```

Then, somewhere at the top of the typography.php file (not inside a function), add the following line:

`setlocale( LC_ALL, 'de_DE.UTF-8' );`

This sets the locale to German, which uses commas as decimal separators, e.g., `1,33`.

Finally, ensure that tests pass and that fluid typography works on the frontend as expected.
