### PR TITLE
Editor: Add the show most used blocks preference to the site editor

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -160,7 +160,6 @@ function Layout() {
 		isDistractionFree,
 		showBlockBreadcrumbs,
 		showMetaBoxes,
-		showMostUsedBlocks,
 		documentLabel,
 		hasHistory,
 	} = useSelect( ( select ) => {
@@ -193,8 +192,6 @@ function Layout() {
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
-			showMostUsedBlocks:
-				select( editPostStore ).isFeatureActive( 'mostUsedBlocks' ),
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
 			hasBlockSelected:
@@ -263,9 +260,7 @@ function Layout() {
 
 	const secondarySidebar = () => {
 		if ( mode === 'visual' && isInserterOpened ) {
-			return (
-				<InserterSidebar showMostUsedBlocks={ showMostUsedBlocks } />
-			);
+			return <InserterSidebar />;
 		}
 		if ( mode === 'visual' && isListViewOpened ) {
 			return <ListViewSidebar />;

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -263,6 +263,7 @@ export default function EditPostPreferencesModal() {
 					<>
 						<PreferencesModalSection title={ __( 'Inserter' ) }>
 							<EnableFeature
+								scope="core"
 								featureName="mostUsedBlocks"
 								help={ __(
 									'Adds a category with the most frequently used blocks in the inserter.'

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -202,6 +202,24 @@ export default function EditSitePreferencesModal() {
 				</>
 			),
 		},
+		{
+			name: 'blocks',
+			tabLabel: __( 'Blocks' ),
+			content: (
+				<>
+					<PreferencesModalSection title={ __( 'Inserter' ) }>
+						<EnableFeature
+							scope="core"
+							featureName="mostUsedBlocks"
+							help={ __(
+								'Adds a category with the most frequently used blocks in the inserter.'
+							) }
+							label={ __( 'Show most used blocks' ) }
+						/>
+					</PreferencesModalSection>
+				</>
+			),
+		},
 	];
 	if ( ! isModalActive ) {
 		return null;

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -18,11 +19,13 @@ import { useEffect, useRef } from '@wordpress/element';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 
-export default function InserterSidebar( { showMostUsedBlocks } ) {
-	const { insertionPoint } = useSelect( ( select ) => {
+export default function InserterSidebar() {
+	const { insertionPoint, showMostUsedBlocks } = useSelect( ( select ) => {
 		const { getInsertionPoint } = unlock( select( editorStore ) );
+		const { get } = select( preferencesStore );
 		return {
 			insertionPoint: getInsertionPoint(),
+			showMostUsedBlocks: get( 'core', 'mostUsedBlocks' ),
 		};
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( editorStore );

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/convert-editor-settings.js
@@ -11,6 +11,7 @@ export default function convertEditorSettings( data ) {
 		'focusMode',
 		'inactivePanels',
 		'keepCaretInsideBlock',
+		'mostUsedBlocks',
 		'openPanels',
 		'showBlockBreadcrumbs',
 		'showIconLabels',


### PR DESCRIPTION
Related #52632 
Similar to #57468 

## What?

This PR continues the work on the great unification between post and site editors. In this PR we're unifying the "Most used blocks" preference. If the user enables it in the post editor, the setting should be used in the site editor as well. Noting that the preference was not available in the site editor before, so this is a new feature added to the site editor.

## Testing instructions

- Enable "Most used blocks" preference in the post editor.
- Notice that it stays enabled when you open the site editor.