### PR TITLE
DataViews: Add duplicate template pattern action

### DIFF
--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -39,11 +39,25 @@ import {
 } from '../../utils/template-part-create';
 
 export default function CreateTemplatePartModal( {
+	modalTitle = __( 'Create template part' ),
+	...restProps
+} ) {
+	return (
+		<Modal
+			title={ modalTitle }
+			onRequestClose={ restProps.closeModal }
+			overlayClassName="edit-site-create-template-part-modal"
+		>
+			<CreateTemplatePartModalContents { ...restProps } />
+		</Modal>
+	);
+}
+
+export function CreateTemplatePartModalContents( {
 	defaultArea = TEMPLATE_PART_AREA_DEFAULT_CATEGORY,
 	blocks = [],
 	confirmLabel = __( 'Create' ),
 	closeModal,
-	modalTitle = __( 'Create template part' ),
 	onCreate,
 	onError,
 	defaultTitle = '',
@@ -62,7 +76,6 @@ export default function CreateTemplatePartModal( {
 			select( editorStore ).__experimentalGetDefaultTemplatePartAreas(),
 		[]
 	);
-
 	async function createTemplatePart() {
 		if ( ! title || isSubmitting ) {
 			return;
@@ -105,91 +118,79 @@ export default function CreateTemplatePartModal( {
 			setIsSubmitting( false );
 		}
 	}
-
 	return (
-		<Modal
-			title={ modalTitle }
-			onRequestClose={ closeModal }
-			overlayClassName="edit-site-create-template-part-modal"
+		<form
+			onSubmit={ async ( event ) => {
+				event.preventDefault();
+				await createTemplatePart();
+			} }
 		>
-			<form
-				onSubmit={ async ( event ) => {
-					event.preventDefault();
-					await createTemplatePart();
-				} }
-			>
-				<VStack spacing="4">
-					<TextControl
-						__nextHasNoMarginBottom
-						label={ __( 'Name' ) }
-						value={ title }
-						onChange={ setTitle }
-						required
-					/>
-					<BaseControl
+			<VStack spacing="4">
+				<TextControl
+					__nextHasNoMarginBottom
+					label={ __( 'Name' ) }
+					value={ title }
+					onChange={ setTitle }
+					required
+				/>
+				<BaseControl
+					label={ __( 'Area' ) }
+					id={ `edit-site-create-template-part-modal__area-selection-${ instanceId }` }
+					className="edit-site-create-template-part-modal__area-base-control"
+				>
+					<RadioGroup
 						label={ __( 'Area' ) }
+						className="edit-site-create-template-part-modal__area-radio-group"
 						id={ `edit-site-create-template-part-modal__area-selection-${ instanceId }` }
-						className="edit-site-create-template-part-modal__area-base-control"
+						onChange={ setArea }
+						checked={ area }
 					>
-						<RadioGroup
-							label={ __( 'Area' ) }
-							className="edit-site-create-template-part-modal__area-radio-group"
-							id={ `edit-site-create-template-part-modal__area-selection-${ instanceId }` }
-							onChange={ setArea }
-							checked={ area }
-						>
-							{ templatePartAreas.map(
-								( {
-									icon,
-									label,
-									area: value,
-									description,
-								} ) => (
-									<Radio
-										key={ label }
-										value={ value }
-										className="edit-site-create-template-part-modal__area-radio"
-									>
-										<Flex align="start" justify="start">
-											<FlexItem>
-												<Icon icon={ icon } />
-											</FlexItem>
-											<FlexBlock className="edit-site-create-template-part-modal__option-label">
-												{ label }
-												<div>{ description }</div>
-											</FlexBlock>
+						{ templatePartAreas.map(
+							( { icon, label, area: value, description } ) => (
+								<Radio
+									key={ label }
+									value={ value }
+									className="edit-site-create-template-part-modal__area-radio"
+								>
+									<Flex align="start" justify="start">
+										<FlexItem>
+											<Icon icon={ icon } />
+										</FlexItem>
+										<FlexBlock className="edit-site-create-template-part-modal__option-label">
+											{ label }
+											<div>{ description }</div>
+										</FlexBlock>
 
-											<FlexItem className="edit-site-create-template-part-modal__checkbox">
-												{ area === value && (
-													<Icon icon={ check } />
-												) }
-											</FlexItem>
-										</Flex>
-									</Radio>
-								)
-							) }
-						</RadioGroup>
-					</BaseControl>
-					<HStack justify="right">
-						<Button
-							variant="tertiary"
-							onClick={ () => {
-								closeModal();
-							} }
-						>
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button
-							variant="primary"
-							type="submit"
-							aria-disabled={ ! title || isSubmitting }
-							isBusy={ isSubmitting }
-						>
-							{ confirmLabel }
-						</Button>
-					</HStack>
-				</VStack>
-			</form>
-		</Modal>
+										<FlexItem className="edit-site-create-template-part-modal__checkbox">
+											{ area === value && (
+												<Icon icon={ check } />
+											) }
+										</FlexItem>
+									</Flex>
+								</Radio>
+							)
+						) }
+					</RadioGroup>
+				</BaseControl>
+				<HStack justify="right">
+					<Button
+						variant="tertiary"
+						onClick={ () => {
+							closeModal();
+						} }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						type="submit"
+						aria-disabled={ ! title || isSubmitting }
+						isBusy={ isSubmitting }
+					>
+						{ confirmLabel }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
 	);
 }

--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -35,6 +35,7 @@ import {
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_DEFAULT_CATEGORY,
 } from '../../utils/constants';
+import { CreateTemplatePartModalContents } from '../create-template-part-modal';
 
 const { useHistory } = unlock( routerPrivateApis );
 const { CreatePatternModalContents, useDuplicatePatternProps } =
@@ -277,6 +278,51 @@ export const duplicatePatternAction = {
 				onClose={ closeModal }
 				confirmLabel={ __( 'Duplicate' ) }
 				{ ...duplicatedProps }
+			/>
+		);
+	},
+};
+
+export const duplicateTemplatePartAction = {
+	id: 'duplicate-template-part',
+	label: __( 'Duplicate' ),
+	isEligible: ( item ) => item.type === TEMPLATE_PART_POST_TYPE,
+	modalHeader: __( 'Duplicate template part' ),
+	RenderModal: ( { item, closeModal } ) => {
+		const { createSuccessNotice } = useDispatch( noticesStore );
+		const { categoryId = PATTERN_DEFAULT_CATEGORY } = getQueryArgs(
+			window.location.href
+		);
+		const history = useHistory();
+		async function onTemplatePartSuccess( templatePart ) {
+			createSuccessNotice(
+				sprintf(
+					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
+					__( '"%s" duplicated.' ),
+					item.title
+				),
+				{ type: 'snackbar', id: 'edit-site-patterns-success' }
+			);
+			history.push( {
+				postType: TEMPLATE_PART_POST_TYPE,
+				postId: templatePart?.id,
+				categoryType: TEMPLATE_PART_POST_TYPE,
+				categoryId,
+			} );
+			closeModal();
+		}
+		return (
+			<CreateTemplatePartModalContents
+				blocks={ item.blocks }
+				defaultArea={ item.templatePart.area }
+				defaultTitle={ sprintf(
+					/* translators: %s: Existing template part title */
+					__( '%s (Copy)' ),
+					item.title
+				) }
+				onCreate={ onTemplatePartSuccess }
+				onError={ closeModal }
+				confirmLabel={ __( 'Duplicate' ) }
 			/>
 		);
 	},

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -55,6 +55,7 @@ import {
 	resetAction,
 	deleteAction,
 	duplicatePatternAction,
+	duplicateTemplatePartAction,
 } from './dataviews-pattern-actions';
 import usePatternSettings from './use-pattern-settings';
 import { unlock } from '../../lock-unlock';
@@ -318,6 +319,7 @@ export default function DataviewsPatterns() {
 		() => [
 			renameAction,
 			duplicatePatternAction,
+			duplicateTemplatePartAction,
 			exportJSONaction,
 			resetAction,
 			deleteAction,

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -225,7 +225,7 @@
 }
 
 /**
- * DataViews patterns styles
+ * DataViews patterns styles.
  * TODO: when this becomes stable, consolidate styles with the above.
  */
 .edit-site-page-patterns-dataviews {
@@ -256,8 +256,6 @@
 	}
 }
 
-// TODO: this is duplicated from `patterns-menu-items__convert-modal` styles,
-// except for the `z-index`. Need to check if this is still needed.
 .dataviews-action-modal__duplicate-pattern {
 	// Fix the modal width to prevent added categories from stretching the modal.
 	[role="dialog"] > [role="document"] {
@@ -281,5 +279,13 @@
 		left: -1px;
 		min-width: initial;
 		max-height: $grid-unit-60 * 2; // Adjust to not cover the save button, showing three items.
+	}
+}
+
+.dataviews-action-modal__duplicate-template-part {
+	.components-modal__frame {
+		@include break-small {
+			max-width: 500px;
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds the duplicate template action in the patterns page

## Testing Instructions
1. Enable the admin views experiment and go to patterns page
2. Check the Duplicate action that works properly for template parts
3. Test the other places where `CreateTemplatePartModal` is used
4. Test that the old patterns page works as before, regarding the changes in the above components

