### PR TITLE
Restore visual separator between mover buttons when show button label is on

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -232,15 +232,19 @@
 	}
 
 	@include break-small() {
-		// Specificity override for https://github.com/WordPress/gutenberg/blob/try/block-toolbar-labels/packages/block-editor/src/components/block-mover/style.scss#L69
-		.is-up-button.is-up-button.is-up-button {
-			margin-right: 0;
-			border-radius: 0;
-			order: 1;
-		}
+		.block-editor-block-mover__move-button-container {
+			position: relative;
 
-		.is-down-button.is-down-button.is-down-button {
-			order: 2;
+			&::before {
+				content: "";
+				display: block;
+				height: 1px;
+				width: 100%;
+				background: $gray-900;
+				position: absolute;
+				top: 50%;
+				transform: translateY(-50%);
+			}
 		}
 	}
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -203,6 +203,24 @@
 
 	.block-editor-block-mover .block-editor-block-mover__move-button-container {
 		width: auto;
+
+		@include break-small() {
+			position: relative;
+
+			&::before {
+				content: "";
+				display: block;
+				height: $border-width;
+				width: 100%;
+				background: $gray-900;
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				// With Top toolbar on, this separator has a smaller width. Translating both
+				// X and Y axis allows to make the separator alwasy centered regardless of its width.
+				transform: translate(-50%);
+			}
+		}
 	}
 
 	.block-editor-block-mover.is-horizontal {
@@ -229,26 +247,6 @@
 	.block-editor-block-mover .block-editor-block-mover__drag-handle.has-icon {
 		padding-left: $grid-unit-15;
 		padding-right: $grid-unit-15;
-	}
-
-	@include break-small() {
-		.block-editor-block-mover__move-button-container {
-			position: relative;
-
-			&::before {
-				content: "";
-				display: block;
-				height: $border-width;
-				width: 100%;
-				background: $gray-900;
-				position: absolute;
-				top: 50%;
-				left: 50%;
-				// With Top toolbar on, this separator has a smaller width. Translating both
-				// X and Y axis allows to make the separator alwasy centered regardless of its width.
-				transform: translate(-50%);
-			}
-		}
 	}
 
 	.block-editor-block-contextual-toolbar .block-editor-block-mover.is-horizontal .block-editor-block-mover-button.block-editor-block-mover-button {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -209,16 +209,16 @@
 
 			&::before {
 				content: "";
-				display: block;
 				height: $border-width;
 				width: 100%;
 				background: $gray-900;
 				position: absolute;
 				top: 50%;
 				left: 50%;
-				// With Top toolbar on, this separator has a smaller width. Translating both
-				// X and Y axis allows to make the separator alwasy centered regardless of its width.
-				transform: translate(-50%);
+				// With Top toolbar enabled, this separator has a smaller width. Translating the
+				// X axis allows to make the separator always centered regardless of its width.
+				transform: translate(-50%, 0);
+				margin-top: -$border-width * 0.5;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -238,12 +238,15 @@
 			&::before {
 				content: "";
 				display: block;
-				height: 1px;
+				height: $border-width;
 				width: 100%;
 				background: $gray-900;
 				position: absolute;
 				top: 50%;
-				transform: translateY(-50%);
+				left: 50%;
+				// With Top toolbar on, this separator has a smaller width. Translating both
+				// X and Y axis allows to make the separator alwasy centered regardless of its width.
+				transform: translate(-50%);
 			}
 		}
 	}

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -198,13 +198,23 @@
 	.edit-post-header__toolbar .block-editor-block-mover {
 		border-left: none;
 
+		// Modified group borders
 		&::before {
 			content: "";
 			width: $border-width;
-			margin-top: $grid-unit + $grid-unit-05;
-			margin-bottom: $grid-unit + $grid-unit-05;
+			margin-top: $grid-unit-15;
+			margin-bottom: $grid-unit-15;
 			background-color: $gray-300;
 			margin-left: $grid-unit;
+		}
+
+		// Modified block movers separator
+		.block-editor-block-mover__move-button-container {
+			&::before {
+				width: calc(100% - #{$grid-unit-30});
+				background: $gray-300;
+				left: calc(50% + 1px);
+			}
 		}
 	}
 }

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -69,7 +69,7 @@
 			margin-left: $grid-unit;
 		}
 
-		// Modified group borders
+		// Modified group borders.
 		.components-toolbar-group,
 		.components-toolbar {
 			border-right: none;
@@ -194,11 +194,10 @@
 }
 
 .show-icon-labels {
-
 	.edit-post-header__toolbar .block-editor-block-mover {
+		// Modified group borders.
 		border-left: none;
 
-		// Modified group borders
 		&::before {
 			content: "";
 			width: $border-width;
@@ -208,7 +207,7 @@
 			margin-left: $grid-unit;
 		}
 
-		// Modified block movers separator
+		// Modified block movers horizontal separator.
 		.block-editor-block-mover__move-button-container {
 			&::before {
 				width: calc(100% - #{$grid-unit-30});

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -143,9 +143,9 @@ $header-toolbar-min-width: 335px;
 	}
 
 	.block-editor-block-mover {
+		// Modified group borders.
 		border-left: none;
 
-		// Modified group borders
 		&::before {
 			content: "";
 			width: $border-width;
@@ -155,7 +155,7 @@ $header-toolbar-min-width: 335px;
 			margin-left: $grid-unit;
 		}
 
-		// Modified block movers separator
+		// Modified block movers horizontal separator.
 		.block-editor-block-mover__move-button-container {
 			&::before {
 				width: calc(100% - #{$grid-unit-30});
@@ -174,7 +174,7 @@ $header-toolbar-min-width: 335px;
 			border-bottom: 0;
 		}
 
-		// Modified group borders
+		// Modified group borders.
 		.components-toolbar-group,
 		.components-toolbar {
 			border-right: none;

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -145,13 +145,23 @@ $header-toolbar-min-width: 335px;
 	.block-editor-block-mover {
 		border-left: none;
 
+		// Modified group borders
 		&::before {
 			content: "";
 			width: $border-width;
-			margin-top: $grid-unit + $grid-unit-05;
-			margin-bottom: $grid-unit + $grid-unit-05;
+			margin-top: $grid-unit-15;
+			margin-bottom: $grid-unit-15;
 			background-color: $gray-300;
 			margin-left: $grid-unit;
+		}
+
+		// Modified block movers separator
+		.block-editor-block-mover__move-button-container {
+			&::before {
+				width: calc(100% - #{$grid-unit-30});
+				background: $gray-300;
+				left: calc(50% + 1px);
+			}
 		}
 	}
 }
@@ -172,8 +182,8 @@ $header-toolbar-min-width: 335px;
 			&::after {
 				content: "";
 				width: $border-width;
-				margin-top: $grid-unit + $grid-unit-05;
-				margin-bottom: $grid-unit + $grid-unit-05;
+				margin-top: $grid-unit-15;
+				margin-bottom: $grid-unit-15;
 				background-color: $gray-300;
 				margin-left: $grid-unit;
 			}

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -17,7 +17,7 @@
 			border-bottom: 0;
 		}
 
-		// Modified group borders
+		// Modified group borders.
 		.components-toolbar-group,
 		.components-toolbar {
 			border-right: none;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow-up to https://github.com/WordPress/gutenberg/pull/49556

Part of an effort to remove all the CSS order properties from the codebase.

## What?
<!-- In a few words, what is the PR actually doing? -->
While inspecting the CSS order properties, I noticed https://github.com/WordPress/gutenberg/pull/49556 removed the visual separator between the Move Up and Move Down block toolbar buttons when the 'Show button text labels' preference is enabled.

From an usability and accessibility perspective thatn's nod ideal as there is no visual separation between the buttons. It's not clear where the buttons boundary is and they just look like a single button with some multi line text within it, much like the other buttons in the toolbar.

Screenshot:

![before](https://github.com/WordPress/gutenberg/assets/1682452/4d0982b6-b4d8-42bf-8c25-c4a78e524b7a)



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There must be a clear separation between the two buttons.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Restores the visual separator making sure it doesn't alter the toolbar height.
- Removes no longer used CSS `order` properties.
- Removes other CSS leftovers.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the post editoror site editor > Options > Preferences > Accessibility tab
- Enable the 'Show button text labels' preference.
- Add a Group block with three paragrsphs inside of it.
- Select the second paragraph.
- Observe the mover buttons are visually separated bu the means of a horizontal line.
- Check the block toolbar height is 48 pixels, as expected.
- Check the parent selector button to select the Group block looks as expected (see glitches priginally fixed in https://github.com/WordPress/gutenberg/pull/49556)
- Enable the 'Top toolbar' from the Options menu.
- Observe the movers separator styls uses a lighter gray and some left / right spacing. See second screenshot.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Bock toolbar, zoomed in:

![after](https://github.com/WordPress/gutenberg/assets/1682452/f6fa9e9d-6d6d-4fe5-bc22-1ab13c588a85)


Top toolbar:

![Screenshot 2024-01-08 at 12 41 04](https://github.com/WordPress/gutenberg/assets/1682452/728bf895-839b-446d-8165-675306d4557c)


