### PR TITLE
Update Table layout design details

### DIFF
--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -23,8 +23,8 @@ const Pagination = memo( function Pagination( {
 		totalPages !== 1 && (
 			<HStack
 				expanded={ false }
-				spacing={ 3 }
-				justify="space-between"
+				spacing={ 6 }
+				justify="end"
 				className="dataviews-pagination"
 			>
 				<HStack justify="flex-start" expanded={ false } spacing={ 2 }>

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -88,6 +88,11 @@
 		td:first-child,
 		th:first-child {
 			padding-left: $grid-unit-40;
+
+			.dataviews-table-header-button,
+			.dataviews-table-header {
+				margin-left: - #{$grid-unit-10};
+			}
 		}
 
 		td:last-child,
@@ -112,18 +117,27 @@
 		th {
 			position: sticky;
 			top: -1px;
-			background-color: lighten($gray-100, 4%);
+			background-color: $white;
 			box-shadow: inset 0 -#{$border-width} 0 $gray-100;
-			border-top: 1px solid $gray-100;
-			padding-top: $grid-unit-05;
-			padding-bottom: $grid-unit-05;
+			padding-top: $grid-unit-10;
+			padding-bottom: $grid-unit-10;
 			z-index: 1;
+			font-size: 11px;
+			text-transform: uppercase;
+			font-weight: 500;
+			padding-left: $grid-unit-05;
 		}
 	}
 
 	.dataviews-table-header-button {
-		padding: 0;
-		gap: $grid-unit-05;
+		padding: $grid-unit-05 $grid-unit-10;
+		font-size: 11px;
+		text-transform: uppercase;
+		font-weight: 500;
+		
+		&:not(:hover) {
+			color: $gray-900;
+		}
 
 		span {
 			speak: none;
@@ -132,6 +146,10 @@
 				display: none;
 			}
 		}
+	}
+
+	.dataviews-table-header {
+		padding-left: $grid-unit-05;
 	}
 }
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -134,7 +134,7 @@
 		font-size: 11px;
 		text-transform: uppercase;
 		font-weight: 500;
-		
+
 		&:not(:hover) {
 			color: $gray-900;
 		}

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -91,8 +91,8 @@ const HeaderMenu = forwardRef( function HeaderMenu(
 				<Button
 					size="compact"
 					className="dataviews-table-header-button"
-					style={ { padding: 0 } }
 					ref={ ref }
+					variant="tertiary"
 				>
 					{ field.header }
 					{ isSorted && (
@@ -409,7 +409,11 @@ function ViewTable( {
 							</th>
 						) ) }
 						{ !! actions?.length && (
-							<th data-field-id="actions">{ __( 'Actions' ) }</th>
+							<th data-field-id="actions">
+								<span className="dataviews-table-header">
+									{ __( 'Actions' ) }
+								</span>
+							</th>
 						) }
 					</tr>
 				</thead>

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -1,7 +1,8 @@
 .edit-site-page-pages__featured-image {
 	border-radius: $grid-unit-05;
-	width: $grid-unit-40;
-	height: $grid-unit-40;
+	width: $grid-unit-50;
+	height: $grid-unit-50;
+	display: block;
 }
 
 


### PR DESCRIPTION
## What?
Updates some design details of the data view Table layout, based on feedback from @pablohoneyhoney.

* Increase featured image in Pages table from 32px to 40px
* Remove grey background on table header row
* Adjust typography in table header cells and use `tertiary` button variants
* Pagination: move page selector closer to next/previous buttons

## Before
<img width="1309" alt="Screenshot 2024-01-08 at 13 48 15" src="https://github.com/WordPress/gutenberg/assets/846565/fb116894-c20a-42e0-b860-b0f7ed21b5e8">


## After
<img width="1309" alt="Screenshot 2024-01-08 at 13 48 02" src="https://github.com/WordPress/gutenberg/assets/846565/bd9cb4ac-9f0e-4341-9483-d624e114ae99">
