### PR TITLE
[RNMobile] Fix losing undo/redo history when using non-breaking space HTML entity

### DIFF
--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -52,10 +52,6 @@ import { getFormatColors } from './get-format-colors';
 import styles from './style.scss';
 import ToolbarButtonWithOptions from './toolbar-button-with-options';
 
-const unescapeSpaces = ( text ) => {
-	return text.replace( /&nbsp;|&#160;/gi, ' ' );
-};
-
 // The flattened color palettes array is memoized to ensure that the same array instance is
 // returned for the colors palettes. This value might be used as a prop, so having the same
 // instance will prevent unnecessary re-renders of the RichText component.
@@ -318,7 +314,7 @@ export class RichText extends Component {
 		}
 
 		const contentWithoutRootTag = this.removeRootTagsProducedByAztec(
-			unescapeSpaces( event.nativeEvent.text )
+			event.nativeEvent.text
 		);
 		// On iOS, onChange can be triggered after selection changes, even though there are no content changes.
 		if ( contentWithoutRootTag === this.value.toString() ) {
@@ -333,7 +329,7 @@ export class RichText extends Component {
 
 	onTextUpdate( event ) {
 		const contentWithoutRootTag = this.removeRootTagsProducedByAztec(
-			unescapeSpaces( event.nativeEvent.text )
+			event.nativeEvent.text
 		);
 
 		this.debounceCreateUndoLevel();
@@ -660,7 +656,7 @@ export class RichText extends Component {
 
 		// Check and dicsard stray event, where the text and selection is equal to the ones already cached.
 		const contentWithoutRootTag = this.removeRootTagsProducedByAztec(
-			unescapeSpaces( event.nativeEvent.text )
+			event.nativeEvent.text
 		);
 		if (
 			contentWithoutRootTag === this.value.toString() &&

--- a/packages/block-editor/src/components/rich-text/native/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/rich-text/native/test/__snapshots__/index.native.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<RichText/> Font Size renders component with style and font size 1`] = `
+exports[`<RichText/> when applying the font size renders component with style and font size 1`] = `
 "<!-- wp:paragraph {"style":{"color":{"text":"#fcb900"},"typography":{"fontSize":35.56}}} -->
 <p class="has-text-color" style="color:#fcb900;font-size:35.56px">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet ut nibh vitae ornare. Sed auctor nec augue at blandit.</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`<RichText/> Font Size should update the font size when style prop with font size property is provided 1`] = `
+exports[`<RichText/> when applying the font size should update the font size when style prop with font size property is provided 1`] = `
 <View
   style={
     [
@@ -42,7 +42,7 @@ exports[`<RichText/> Font Size should update the font size when style prop with 
 </View>
 `;
 
-exports[`<RichText/> Font Size should update the font size with decimals when style prop with font size property is provided 1`] = `
+exports[`<RichText/> when applying the font size should update the font size with decimals when style prop with font size property is provided 1`] = `
 <View
   style={
     [

--- a/packages/block-editor/src/components/rich-text/native/test/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/test/index.native.js
@@ -5,8 +5,9 @@ import { Dimensions } from 'react-native';
 import {
 	fireEvent,
 	getEditorHtml,
-	render,
 	initializeEditor,
+	render,
+	screen,
 } from 'test/helpers';
 
 /**
@@ -87,7 +88,7 @@ describe( '<RichText/>', () => {
 		it( 'should avoid updating attributes when values are equal', async () => {
 			const handleChange = jest.fn();
 			const defaultEmptyValue = new RichTextData();
-			const screen = render(
+			render(
 				<RichText
 					onChange={ handleChange }
 					value={ defaultEmptyValue }
@@ -259,7 +260,7 @@ describe( '<RichText/>', () => {
 			const fontSize = '10';
 			const style = { fontSize: '12' };
 			// Act.
-			const screen = render( <RichText fontSize={ fontSize } /> );
+			render( <RichText fontSize={ fontSize } /> );
 			screen.update( <RichText fontSize={ fontSize } style={ style } /> );
 			// Assert.
 			expect( screen.toJSON() ).toMatchSnapshot();
@@ -281,7 +282,7 @@ describe( '<RichText/>', () => {
 			const fontSize = '10';
 			const style = { fontSize: '12.56px' };
 			// Act.
-			const screen = render( <RichText fontSize={ fontSize } /> );
+			render( <RichText fontSize={ fontSize } /> );
 			screen.update( <RichText fontSize={ fontSize } style={ style } /> );
 			// Assert.
 			expect( screen.toJSON() ).toMatchSnapshot();

--- a/packages/block-editor/src/components/rich-text/native/test/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/test/index.native.js
@@ -88,7 +88,7 @@ describe( '<RichText/>', () => {
 		} );
 	} );
 
-	describe( 'Value changes', () => {
+	describe( 'when the value changes', () => {
 		it( 'should avoid updating attributes when values are equal', async () => {
 			const handleChange = jest.fn();
 			const defaultEmptyValue = RichTextData.empty();
@@ -145,7 +145,7 @@ describe( '<RichText/>', () => {
 		} );
 	} );
 
-	describe( 'Font Size', () => {
+	describe( 'when applying the font size', () => {
 		it( 'should display rich text at the DEFAULT font size.', () => {
 			// Arrange.
 			const expectedFontSize = 16;

--- a/packages/block-editor/src/components/rich-text/native/test/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/test/index.native.js
@@ -14,7 +14,11 @@ import {
  * WordPress dependencies
  */
 import { select } from '@wordpress/data';
-import { store as richTextStore, RichTextData } from '@wordpress/rich-text';
+import {
+	store as richTextStore,
+	RichTextData,
+	__unstableCreateElement,
+} from '@wordpress/rich-text';
 import { coreBlocks } from '@wordpress/block-library';
 import {
 	getBlockTypes,
@@ -101,6 +105,43 @@ describe( '<RichText/>', () => {
 			} );
 
 			expect( handleChange ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should preserve non-breaking space HTML entity', () => {
+			const onChange = jest.fn();
+			const onSelectionChange = jest.fn();
+			// The initial value is created using an HTML element to preserve
+			// the HTML entity.
+			const initialValue = RichTextData.fromHTMLElement(
+				__unstableCreateElement( document, '&nbsp;' )
+			);
+			render(
+				<RichText
+					onChange={ onChange }
+					onSelectionChange={ onSelectionChange }
+					value={ initialValue }
+					__unstableIsSelected
+				/>
+			);
+
+			// Trigger selection event with same text value as initial.
+			fireEvent(
+				screen.getByLabelText( /Text input/ ),
+				'onSelectionChange',
+				0,
+				0,
+				initialValue.toString(),
+				{
+					nativeEvent: {
+						eventCount: 0,
+						target: undefined,
+						text: initialValue.toString(),
+					},
+				}
+			);
+
+			expect( onChange ).not.toHaveBeenCalled();
+			expect( onSelectionChange ).toHaveBeenCalled();
 		} );
 	} );
 

--- a/packages/block-editor/src/components/rich-text/native/test/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/test/index.native.js
@@ -87,7 +87,7 @@ describe( '<RichText/>', () => {
 	describe( 'Value changes', () => {
 		it( 'should avoid updating attributes when values are equal', async () => {
 			const handleChange = jest.fn();
-			const defaultEmptyValue = new RichTextData();
+			const defaultEmptyValue = RichTextData.empty();
 			render(
 				<RichText
 					onChange={ handleChange }

--- a/packages/block-editor/src/components/rich-text/native/test/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/test/index.native.js
@@ -84,7 +84,7 @@ describe( '<RichText/>', () => {
 		} );
 	} );
 
-	describe( 'when changes arrive from Aztec', () => {
+	describe( 'Value changes', () => {
 		it( 'should avoid updating attributes when values are equal', async () => {
 			const handleChange = jest.fn();
 			const defaultEmptyValue = new RichTextData();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue related to losing undo/redo history.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes https://github.com/WordPress/gutenberg/issues/36527. Also fixes the case described in https://github.com/WordPress/gutenberg/issues/36527#issuecomment-1036288919.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In https://github.com/WordPress/gutenberg/pull/12249/commits/d2b241b16ac6b3f38f215b9958f2b37b01f74d4e we introduced a function to unescape the non-breaking space HTML entity from the `RichText` value upon different events like content and selection change. As observed in the web version of the editor, this HTML entity should be preserved as it's part of the content. Hence, this PR simply removes the `unescapeSpaces` function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Undo/redo history is preserved
1. Create a post and add the following HTML code:
```
<!-- wp:paragraph -->
<p>Block 1</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>&nbsp;</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Block 2</p>
<!-- /wp:paragraph -->
```
2. Save the post and re-open it.
3. Remove the first block, second block, and third block in this order.
4. Undo all the actions until all the blocks are recovered.
5. Redo all the actions and observe that not all blocks are removed.

### Non-breaking space HTML entity is preserved
1. Add the following HTML code _(extracted from https://automattic.com/how-we-work/)_ via the HTML mode in a post/page:
```
<!-- wp:paragraph -->
<p>We have a one-button deploy system for WordPress.com, and we push code to the site 60–80 times a day. WordPress.com is synced with the WordPress.org trunk pretty much every weekday.&nbsp;<strong>We’re strong believers in&nbsp;<a href="http://opensource.org/">Open Source</a></strong>, and we try to open source everything we can.</p>
<!-- /wp:paragraph -->
```
2. Switch back to Visual mode.
3. Save the post and re-open it.
4. Select the Paragraph block.
5. Observe that a new undo level is created.
6. Switch to HTML mode and observe that the `&nbsp;` entities are no longer included in the content.

### The [issue](https://github.com/WordPress/gutenberg/pull/12249#issuecomment-459570230) that originally triggered the changes can't be reproduced
1. Add a Paragraph block with the text "Hello World!".
2. Place the cursor at the end of the text.
3. Input two space characters (slowly so it doesn't trigger the automatic conversion to a '.')
4. Tap on the "B" (Bold) button on the format toolbar.
5. Observe that the Bold button stays toggled and that if you type more characters they aren't removed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

| App | Web |
|--------|--------|
| <video src=https://github.com/WordPress/gutenberg/assets/14905380/20db831f-a0fe-486a-af2e-722468a42531> | <video src=https://github.com/WordPress/gutenberg/assets/14905380/a1980953-cb77-4e2d-8229-8c2ad4069e75> |