### PR TITLE
Add effects/box shadow tools to block inspector

### DIFF
--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -53,9 +53,8 @@ function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 
 	$shadow_block_styles = array();
 
-	$preset_shadow                 = array_key_exists( 'shadow', $block_attributes ) ? "var:preset|shadow|{$block_attributes['shadow']}" : null;
-	$custom_shadow                 = isset( $block_attributes['style']['shadow'] ) ? $block_attributes['style']['shadow'] : null;
-	$shadow_block_styles['shadow'] = $preset_shadow ? $preset_shadow : $custom_shadow;
+	$custom_shadow                 = $block_attributes['style']['shadow'] ?? null;
+	$shadow_block_styles['shadow'] = $custom_shadow;
 
 	$attributes = array();
 	$styles     = gutenberg_style_engine_get_styles( $shadow_block_styles );

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -58,7 +58,7 @@ function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 	$shadow_block_styles['shadow'] = $preset_shadow ? $preset_shadow : $custom_shadow;
 
 	$attributes = array();
-	$styles     = gutenberg_style_engine_get_styles( $shadow_block_styles );
+	$styles     = gutenberg_style_engine_get_styles( $shadow_block_styles, array( 'convert_vars_to_classnames' => true ) );
 
 	if ( ! empty( $styles['css'] ) ) {
 		$attributes['style'] = $styles['css'];

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -58,7 +58,7 @@ function gutenberg_apply_shadow_support( $block_type, $block_attributes ) {
 	$shadow_block_styles['shadow'] = $preset_shadow ? $preset_shadow : $custom_shadow;
 
 	$attributes = array();
-	$styles     = gutenberg_style_engine_get_styles( $shadow_block_styles, array( 'convert_vars_to_classnames' => true ) );
+	$styles     = gutenberg_style_engine_get_styles( $shadow_block_styles );
 
 	if ( ! empty( $styles['css'] ) ) {
 		$attributes['style'] = $styles['css'];

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -186,7 +186,9 @@ class WP_Theme_JSON_Gutenberg {
 			'use_default_names' => false,
 			'value_key'         => 'shadow',
 			'css_vars'          => '--wp--preset--shadow--$slug',
-			'classes'           => array(),
+			'classes'           => array(
+				'.has-$slug-shadow' => 'box-shadow',
+			),
 			'properties'        => array( 'box-shadow' ),
 		),
 	);

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -186,9 +186,7 @@ class WP_Theme_JSON_Gutenberg {
 			'use_default_names' => false,
 			'value_key'         => 'shadow',
 			'css_vars'          => '--wp--preset--shadow--$slug',
-			'classes'           => array(
-				'.has-$slug-shadow' => 'box-shadow',
-			),
+			'classes'           => array(),
 			'properties'        => array( 'box-shadow' ),
 		),
 	);

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -140,10 +140,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 							group="border"
 							label={ __( 'Border' ) }
 						/>
-						<InspectorControls.Slot
-							group="effects"
-							label={ __( 'Effects' ) }
-						/>
 						<InspectorControls.Slot group="styles" />
 					</>
 				) }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -311,6 +311,10 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 						label={ __( 'Background' ) }
 					/>
 					<PositionControls />
+					<InspectorControls.Slot
+						group="effects"
+						label={ __( 'Effects' ) }
+					/>
 					<div>
 						<AdvancedControls />
 					</div>

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -140,6 +140,10 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 							group="border"
 							label={ __( 'Border' ) }
 						/>
+						<InspectorControls.Slot
+							group="effects"
+							label={ __( 'Effects' ) }
+						/>
 						<InspectorControls.Slot group="styles" />
 					</>
 				) }

--- a/packages/block-editor/src/components/global-styles/effects-panel.js
+++ b/packages/block-editor/src/components/global-styles/effects-panel.js
@@ -26,6 +26,7 @@ import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { mergeOrigins } from '../use-settings';
 import { getValueFromVariable, TOOLSPANEL_DROPDOWNMENU_PROPS } from './utils';
 import { setImmutably } from '../../utils/object';
 
@@ -81,8 +82,22 @@ export default function EffectsPanel( {
 	// Shadow
 	const hasShadowEnabled = useHasShadowControl( settings );
 	const shadow = decodeValue( inheritedValue?.shadow );
+	const shadowPresets = settings?.shadow?.presets;
+	const mergedShadowPresets = shadowPresets
+		? mergeOrigins( shadowPresets )
+		: [];
 	const setShadow = ( newValue ) => {
-		onChange( setImmutably( value, [ 'shadow' ], newValue ) );
+		const slug = mergedShadowPresets?.find(
+			( { shadow: s } ) => s === newValue
+		)?.slug;
+
+		onChange(
+			setImmutably(
+				value,
+				[ 'shadow' ],
+				slug ? `var:preset|shadow|${ slug }` : newValue || undefined
+			)
+		);
 	};
 	const hasShadow = () => !! value?.shadow;
 	const resetShadow = () => setShadow( undefined );

--- a/packages/block-editor/src/components/global-styles/effects-panel.js
+++ b/packages/block-editor/src/components/global-styles/effects-panel.js
@@ -88,7 +88,7 @@ export default function EffectsPanel( {
 		: [];
 	const setShadow = ( newValue ) => {
 		const slug = mergedShadowPresets?.find(
-			( { shadow: s } ) => s === newValue
+			( { shadow: shadowName } ) => shadowName === newValue
 		)?.slug;
 
 		onChange(

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -46,6 +46,7 @@ const StylesTab = ( { blockName, clientId, hasBlockStyles } ) => {
 				label={ __( 'Dimensions' ) }
 			/>
 			<InspectorControls.Slot group="border" label={ __( 'Border' ) } />
+			<InspectorControls.Slot group="effects" label={ __( 'Effects' ) } />
 			<InspectorControls.Slot group="styles" />
 		</>
 	);

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -40,6 +40,7 @@ export default function useInspectorControlsTabs( blockName ) {
 		position: positionGroup,
 		styles: stylesGroup,
 		typography: typographyGroup,
+		effects: effectsGroup,
 	} = InspectorControlsGroups;
 
 	// List View Tab: If there are any fills for the list group add that tab.
@@ -55,6 +56,7 @@ export default function useInspectorControlsTabs( blockName ) {
 		...( useSlotFills( dimensionsGroup.Slot.__unstableName ) || [] ),
 		...( useSlotFills( stylesGroup.Slot.__unstableName ) || [] ),
 		...( useSlotFills( typographyGroup.Slot.__unstableName ) || [] ),
+		...( useSlotFills( effectsGroup.Slot.__unstableName ) || [] ),
 	];
 	const hasStyleFills = styleFills.length;
 

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -20,6 +20,7 @@ const InspectorControlsTypography = createSlotFill(
 );
 const InspectorControlsListView = createSlotFill( 'InspectorControlsListView' );
 const InspectorControlsStyles = createSlotFill( 'InspectorControlsStyles' );
+const InspectorControlsEffects = createSlotFill( 'InspectorControlsEffects' );
 
 const groups = {
 	default: InspectorControlsDefault,
@@ -28,6 +29,7 @@ const groups = {
 	border: InspectorControlsBorder,
 	color: InspectorControlsColor,
 	dimensions: InspectorControlsDimensions,
+	effects: InspectorControlsEffects,
 	filter: InspectorControlsFilter,
 	list: InspectorControlsListView,
 	position: InspectorControlsPosition,

--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -48,7 +48,7 @@ export function EffectsPanel( { clientId, setAttributes, settings } ) {
 	return (
 		<StylesEffectsPanel
 			as={ EffectsInspectorControl }
-			paneldId={ clientId }
+			panelId={ clientId }
 			settings={ settings }
 			value={ value }
 			onChange={ onChange }

--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -28,7 +28,6 @@ function EffectsInspectorControl( { children, resetAllFilter } ) {
 		</InspectorControls>
 	);
 }
-
 export function EffectsPanel( { clientId, setAttributes, settings } ) {
 	const isEnabled = useHasEffectsPanel( settings );
 	const blockAttributes = useSelect(
@@ -36,10 +35,17 @@ export function EffectsPanel( { clientId, setAttributes, settings } ) {
 		[ clientId ]
 	);
 	const shadow = blockAttributes?.style?.shadow;
-	const value = useMemo( () => attributesToStyle( shadow ), [ shadow ] );
+	const value = useMemo(
+		() => ( {
+			shadow,
+		} ),
+		[ shadow ]
+	);
 
-	const onChange = ( newShadow ) => {
-		setAttributes( styleToAttributes( newShadow, blockAttributes.style ) );
+	const onChange = ( newValue ) => {
+		setAttributes( {
+			style: { ...blockAttributes.style, shadow: newValue.shadow },
+		} );
 	};
 
 	if ( ! isEnabled ) {
@@ -55,24 +61,4 @@ export function EffectsPanel( { clientId, setAttributes, settings } ) {
 			onChange={ onChange }
 		/>
 	);
-}
-
-function styleToAttributes( newStyle, oldStyle ) {
-	const shadowValue = newStyle?.shadow;
-	const shadowSlug = shadowValue?.startsWith( 'var:preset|shadow|' )
-		? shadowValue.substring( 'var:preset|shadow|'.length )
-		: undefined;
-
-	return {
-		style: {
-			...oldStyle,
-			shadow: shadowSlug,
-		},
-	};
-}
-
-function attributesToStyle( shadow ) {
-	return {
-		shadow: shadow ? 'var:preset|shadow|' + shadow : undefined,
-	};
 }

--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -31,15 +31,16 @@ function EffectsInspectorControl( { children, resetAllFilter } ) {
 
 export function EffectsPanel( { clientId, setAttributes, settings } ) {
 	const isEnabled = useHasEffectsPanel( settings );
-	const onChange = ( newShadow ) => {
-		setAttributes( styleToAttributes( newShadow ) );
-	};
 	const blockAttributes = useSelect(
 		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
 		[ clientId ]
 	);
-	const shadow = blockAttributes?.shadow;
-	const value = useMemo( () => attributesToStyle( { shadow } ), [ shadow ] );
+	const shadow = blockAttributes?.style?.shadow;
+	const value = useMemo( () => attributesToStyle( shadow ), [ shadow ] );
+
+	const onChange = ( newShadow ) => {
+		setAttributes( styleToAttributes( newShadow, blockAttributes.style ) );
+	};
 
 	if ( ! isEnabled ) {
 		return null;
@@ -56,22 +57,22 @@ export function EffectsPanel( { clientId, setAttributes, settings } ) {
 	);
 }
 
-function styleToAttributes( style ) {
-	const shadowValue = style?.shadow;
+function styleToAttributes( newStyle, oldStyle ) {
+	const shadowValue = newStyle?.shadow;
 	const shadowSlug = shadowValue?.startsWith( 'var:preset|shadow|' )
 		? shadowValue.substring( 'var:preset|shadow|'.length )
 		: undefined;
 
 	return {
-		style: undefined, // TODO: check for style prop, and return it if it exists
-		shadow: shadowSlug,
+		style: {
+			...oldStyle,
+			shadow: shadowSlug,
+		},
 	};
 }
 
-function attributesToStyle( attributes ) {
+function attributesToStyle( shadow ) {
 	return {
-		shadow: attributes.shadow
-			? 'var:preset|shadow|' + attributes.shadow
-			: undefined,
+		shadow: shadow ? 'var:preset|shadow|' + shadow : undefined,
 	};
 }

--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -32,16 +32,14 @@ function EffectsInspectorControl( { children, resetAllFilter } ) {
 export function EffectsPanel( { clientId, setAttributes, settings } ) {
 	const isEnabled = useHasEffectsPanel( settings );
 	const onChange = ( newShadow ) => {
-		setAttributes( {
-			shadow: newShadow,
-		} );
+		setAttributes( styleToAttributes( newShadow ) );
 	};
 	const blockAttributes = useSelect(
 		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
 		[ clientId ]
 	);
 	const shadow = blockAttributes?.shadow;
-	const value = useMemo( () => ( { shadow } ), [ shadow ] );
+	const value = useMemo( () => attributesToStyle( { shadow } ), [ shadow ] );
 
 	if ( ! isEnabled ) {
 		return null;
@@ -56,4 +54,24 @@ export function EffectsPanel( { clientId, setAttributes, settings } ) {
 			onChange={ onChange }
 		/>
 	);
+}
+
+function styleToAttributes( style ) {
+	const shadowValue = style?.shadow;
+	const shadowSlug = shadowValue?.startsWith( 'var:preset|shadow|' )
+		? shadowValue.substring( 'var:preset|shadow|'.length )
+		: undefined;
+
+	return {
+		style: undefined, // TODO: check for style prop, and return it if it exists
+		shadow: shadowSlug,
+	};
+}
+
+function attributesToStyle( attributes ) {
+	return {
+		shadow: attributes.shadow
+			? 'var:preset|shadow|' + attributes.shadow
+			: undefined,
+	};
 }

--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -1,7 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { useMemo } from '@wordpress/element';
+import { hasBlockSupport } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
@@ -9,6 +11,7 @@ import StylesEffectsPanel, {
 	useHasEffectsPanel,
 } from '../components/global-styles/effects-panel';
 import { InspectorControls } from '../components';
+import { store as blockEditorStore } from '../store';
 
 export const EFFECTS_SUPPORT_KEYS = [ 'shadow' ];
 
@@ -18,36 +21,39 @@ export function hasEffectsSupport( blockName ) {
 	);
 }
 
-function EffectsInspectorControl( { children } ) {
-	return <InspectorControls group="effects">{ children }</InspectorControls>;
+function EffectsInspectorControl( { children, resetAllFilter } ) {
+	return (
+		<InspectorControls group="effects" resetAllFilter={ resetAllFilter }>
+			{ children }
+		</InspectorControls>
+	);
 }
 
-export function EffectsPanel( { clientId, name, setAttributes, settings } ) {
+export function EffectsPanel( { clientId, setAttributes, settings } ) {
 	const isEnabled = useHasEffectsPanel( settings );
-
 	const onChange = ( newShadow ) => {
 		setAttributes( {
 			shadow: newShadow,
 		} );
 	};
+	const blockAttributes = useSelect(
+		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
+		[ clientId ]
+	);
+	const shadow = blockAttributes?.shadow;
+	const value = useMemo( () => ( { shadow } ), [ shadow ] );
 
 	if ( ! isEnabled ) {
 		return null;
 	}
-
-	const defaultControls = getBlockSupport( name, [
-		'shadow',
-		'__experimentalDefaultControls',
-	] );
 
 	return (
 		<StylesEffectsPanel
 			as={ EffectsInspectorControl }
 			paneldId={ clientId }
 			settings={ settings }
-			value={ settings.shadow }
+			value={ value }
 			onChange={ onChange }
-			defaultControls={ defaultControls }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+import StylesEffectsPanel, {
+	useHasEffectsPanel,
+} from '../components/global-styles/effects-panel';
+import { InspectorControls } from '../components';
+
+export const EFFECTS_SUPPORT_KEYS = [ 'shadow' ];
+
+export function hasEffectsSupport( blockName ) {
+	return EFFECTS_SUPPORT_KEYS.some( ( key ) =>
+		hasBlockSupport( blockName, key )
+	);
+}
+
+function EffectsInspectorControl( { children } ) {
+	return <InspectorControls group="effects">{ children }</InspectorControls>;
+}
+
+export function EffectsPanel( { clientId, name, setAttributes, settings } ) {
+	const isEnabled = useHasEffectsPanel( settings );
+
+	const onChange = ( newShadow ) => {
+		setAttributes( {
+			shadow: newShadow,
+		} );
+	};
+
+	if ( ! isEnabled ) {
+		return null;
+	}
+
+	const defaultControls = getBlockSupport( name, [
+		'shadow',
+		'__experimentalDefaultControls',
+	] );
+
+	return (
+		<StylesEffectsPanel
+			as={ EffectsInspectorControl }
+			paneldId={ clientId }
+			settings={ settings }
+			value={ settings.shadow }
+			onChange={ onChange }
+			defaultControls={ defaultControls }
+		/>
+	);
+}

--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -12,7 +12,8 @@ import StylesEffectsPanel, {
 import { InspectorControls } from '../components';
 import { store as blockEditorStore } from '../store';
 
-export const EFFECTS_SUPPORT_KEYS = [ 'shadow' ];
+export const SHADOW_SUPPORT_KEY = 'shadow';
+export const EFFECTS_SUPPORT_KEYS = [ SHADOW_SUPPORT_KEY ];
 
 export function hasEffectsSupport( blockName ) {
 	return EFFECTS_SUPPORT_KEYS.some( ( key ) =>

--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -3,7 +3,6 @@
  */
 import { hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -35,12 +34,7 @@ export function EffectsPanel( { clientId, setAttributes, settings } ) {
 		[ clientId ]
 	);
 	const shadow = blockAttributes?.style?.shadow;
-	const value = useMemo(
-		() => ( {
-			shadow,
-		} ),
-		[ shadow ]
-	);
+	const value = { shadow };
 
 	const onChange = ( newValue ) => {
 		setAttributes( {

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -68,6 +68,7 @@ createBlockSaveFilter( [
 export { useCustomSides } from './dimensions';
 export { useLayoutClasses, useLayoutStyles } from './layout';
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
+export { getShadowClassesAndStyles, useShadowProps } from './use-shadow-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
 export { getSpacingClassesAndStyles } from './use-spacing-props';
 export { getTypographyClassesAndStyles } from './use-typography-props';

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -28,6 +28,7 @@ createBlockSaveFilter( [
 ] );
 
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
+export { getShadowClassesAndStyles, useShadowProps } from './use-shadow-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
 export { getSpacingClassesAndStyles } from './use-spacing-props';
 export { useCachedTruthy } from './use-cached-truthy';

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -27,6 +27,7 @@ import {
 	SPACING_SUPPORT_KEY,
 	DimensionsPanel,
 } from './dimensions';
+import { EFFECTS_SUPPORT_KEYS, EffectsPanel } from './effects';
 import {
 	shouldSkipSerialization,
 	useStyleOverride,
@@ -37,6 +38,7 @@ import { useBlockEditingMode } from '../components/block-editing-mode';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
+	...EFFECTS_SUPPORT_KEYS,
 	BORDER_SUPPORT_KEY,
 	COLOR_SUPPORT_KEY,
 	DIMENSIONS_SUPPORT_KEY,
@@ -336,6 +338,7 @@ function BlockStyleControls( {
 			<TypographyPanel { ...passedProps } />
 			<BorderPanel { ...passedProps } />
 			<DimensionsPanel { ...passedProps } />
+			<EffectsPanel { ...passedProps } />
 		</>
 	);
 }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -27,7 +27,11 @@ import {
 	SPACING_SUPPORT_KEY,
 	DimensionsPanel,
 } from './dimensions';
-import { EFFECTS_SUPPORT_KEYS, EffectsPanel } from './effects';
+import {
+	EFFECTS_SUPPORT_KEYS,
+	SHADOW_SUPPORT_KEY,
+	EffectsPanel,
+} from './effects';
 import {
 	shouldSkipSerialization,
 	useStyleOverride,
@@ -112,6 +116,7 @@ const skipSerializationPathsEdit = {
 	[ `${ SPACING_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
 		SPACING_SUPPORT_KEY,
 	],
+	[ `${ SHADOW_SUPPORT_KEY }` ]: [ SHADOW_SUPPORT_KEY ],
 };
 
 /**

--- a/packages/block-editor/src/hooks/supports.js
+++ b/packages/block-editor/src/hooks/supports.js
@@ -6,8 +6,6 @@ import { Platform } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { EFFECTS_SUPPORT_KEYS } from './effects';
-
 const ALIGN_SUPPORT_KEY = 'align';
 const ALIGN_WIDE_SUPPORT_KEY = 'alignWide';
 const BORDER_SUPPORT_KEY = '__experimentalBorder';
@@ -63,6 +61,7 @@ const TYPOGRAPHY_SUPPORT_KEYS = [
 	WRITING_MODE_SUPPORT_KEY,
 	LETTER_SPACING_SUPPORT_KEY,
 ];
+const EFFECTS_SUPPORT_KEYS = [ 'shadow' ];
 const SPACING_SUPPORT_KEY = 'spacing';
 const styleSupportKeys = [
 	...EFFECTS_SUPPORT_KEYS,

--- a/packages/block-editor/src/hooks/supports.js
+++ b/packages/block-editor/src/hooks/supports.js
@@ -3,9 +3,7 @@
  */
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { Platform } from '@wordpress/element';
-/**
- * Internal dependencies
- */
+
 const ALIGN_SUPPORT_KEY = 'align';
 const ALIGN_WIDE_SUPPORT_KEY = 'alignWide';
 const BORDER_SUPPORT_KEY = '__experimentalBorder';

--- a/packages/block-editor/src/hooks/supports.js
+++ b/packages/block-editor/src/hooks/supports.js
@@ -3,6 +3,10 @@
  */
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { Platform } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { EFFECTS_SUPPORT_KEYS } from './effects';
 
 const ALIGN_SUPPORT_KEY = 'align';
 const ALIGN_WIDE_SUPPORT_KEY = 'alignWide';
@@ -61,6 +65,7 @@ const TYPOGRAPHY_SUPPORT_KEYS = [
 ];
 const SPACING_SUPPORT_KEY = 'spacing';
 const styleSupportKeys = [
+	...EFFECTS_SUPPORT_KEYS,
 	...TYPOGRAPHY_SUPPORT_KEYS,
 	BORDER_SUPPORT_KEY,
 	COLOR_SUPPORT_KEY,

--- a/packages/block-editor/src/hooks/test/effects.js
+++ b/packages/block-editor/src/hooks/test/effects.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { hasEffectsSupport } from '../effects';
+
+describe( 'effects', () => {
+	describe( 'hasEffectsSupport', () => {
+		it( 'should return false if the block does not support effects', () => {
+			const settings = {
+				supports: {
+					shadow: false,
+				},
+			};
+
+			expect( hasEffectsSupport( settings ) ).toBe( false );
+		} );
+
+		it( 'should return true if the block supports effects', () => {
+			const settings = {
+				supports: {
+					shadow: true,
+				},
+			};
+
+			expect( hasEffectsSupport( settings ) ).toBe( true );
+		} );
+
+		it( 'should return true if the block supports effects and other features', () => {
+			const settings = {
+				supports: {
+					shadow: true,
+					align: true,
+				},
+			};
+
+			expect( hasEffectsSupport( settings ) ).toBe( true );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/use-shadow-props.js
+++ b/packages/block-editor/src/hooks/use-shadow-props.js
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import { getInlineStyles } from './style';
+
+// This utility is intended to assist where the serialization of the shadow
+// block support is being skipped for a block but the shadow related CSS classes
+// & styles still need to be generated so they can be applied to inner elements.
+
+/**
+ * Provides the CSS class names and inline styles for a block's shadow support
+ * attributes.
+ *
+ * @param {Object} attributes Block attributes.
+ * @return {Object} Shadow block support derived CSS classes & styles.
+ */
+export function getShadowClassesAndStyles( attributes ) {
+	const shadow = attributes.style?.shadow || '';
+
+	return {
+		className: undefined,
+		style: getInlineStyles( { shadow } ),
+	};
+}
+
+/**
+ * Derives the shadow related props for a block from its shadow block support
+ * attributes.
+ *
+ * @param {Object} attributes Block attributes.
+ *
+ * @return {Object} ClassName & style props from shadow block support.
+ */
+export function useShadowProps( attributes ) {
+	const shadowProps = getShadowClassesAndStyles( attributes );
+	return shadowProps;
+}

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -221,6 +221,7 @@ export function useBlockSettings( name, parentLayout ) {
 		isTextEnabled,
 		isHeadingEnabled,
 		isButtonEnabled,
+		shadow,
 	] = useSettings(
 		'background.backgroundImage',
 		'background.backgroundSize',
@@ -268,7 +269,8 @@ export function useBlockSettings( name, parentLayout ) {
 		'color.link',
 		'color.text',
 		'color.heading',
-		'color.button'
+		'color.button',
+		'shadow'
 	);
 
 	const rawSettings = useMemo( () => {
@@ -345,6 +347,7 @@ export function useBlockSettings( name, parentLayout ) {
 			},
 			layout,
 			parentLayout,
+			shadow,
 		};
 	}, [
 		backgroundImage,
@@ -395,6 +398,7 @@ export function useBlockSettings( name, parentLayout ) {
 		isTextEnabled,
 		isHeadingEnabled,
 		isButtonEnabled,
+		shadow,
 	] );
 
 	return useSettingsForBlockElement( rawSettings, name );

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -11,6 +11,8 @@ export {
 	useCustomSides as __experimentalUseCustomSides,
 	getSpacingClassesAndStyles as __experimentalGetSpacingClassesAndStyles,
 	getGapCSSValue as __experimentalGetGapCSSValue,
+	getShadowClassesAndStyles as __experimentalGetShadowClassesAndStyles,
+	useShadowProps as __experimentalUseShadowProps,
 	useCachedTruthy,
 } from './hooks';
 export * from './components';

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -32,6 +32,7 @@ import {
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalUseColorProps as useColorProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
+	__experimentalUseShadowProps as useShadowProps,
 	__experimentalLinkControl as LinkControl,
 	__experimentalGetElementClassName,
 	store as blockEditorStore,
@@ -184,6 +185,7 @@ function ButtonEdit( props ) {
 	const borderProps = useBorderProps( attributes );
 	const colorProps = useColorProps( attributes );
 	const spacingProps = useSpacingProps( attributes );
+	const shadowProps = useShadowProps( attributes );
 	const ref = useRef();
 	const richTextRef = useRef();
 	const blockProps = useBlockProps( {
@@ -266,6 +268,7 @@ function ButtonEdit( props ) {
 						...borderProps.style,
 						...colorProps.style,
 						...spacingProps.style,
+						...shadowProps.style,
 					} }
 					onSplit={ ( value ) =>
 						createBlock( 'core/button', {

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -12,6 +12,7 @@ import {
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
+	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
 
@@ -40,6 +41,7 @@ export default function save( { attributes, className } ) {
 	const borderProps = getBorderClassesAndStyles( attributes );
 	const colorProps = getColorClassesAndStyles( attributes );
 	const spacingProps = getSpacingClassesAndStyles( attributes );
+	const shadowProps = getShadowClassesAndStyles( attributes );
 	const buttonClasses = classnames(
 		'wp-block-button__link',
 		colorProps.className,
@@ -56,6 +58,7 @@ export default function save( { attributes, className } ) {
 		...borderProps.style,
 		...colorProps.style,
 		...spacingProps.style,
+		...shadowProps.style,
 	};
 
 	// The use of a `title` attribute here is soft-deprecated, but still applied

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `PaletteEdit` and `CircularOptionPicker`: improve unit tests ([#57809](https://github.com/WordPress/gutenberg/pull/57809)).
 -   `Tooltip`: no-op when nested inside other `Tooltip` components ([#57202](https://github.com/WordPress/gutenberg/pull/57202)).
 -   `Tooltip` and `Button`: tidy up unit tests ([#57975](https://github.com/WordPress/gutenberg/pull/57975)).
+-	`SlotFill`: fix typo in use-slot-fills return docs ([#57654](https://github.com/WordPress/gutenberg/pull/57654))
 
 ### Bug Fix
 

--- a/packages/components/src/slot-fill/bubbles-virtually/use-slot-fills.ts
+++ b/packages/components/src/slot-fill/bubbles-virtually/use-slot-fills.ts
@@ -19,6 +19,6 @@ export default function useSlotFills( name: SlotKey ) {
 	const fills = useSnapshot( registry.fills, { sync: true } );
 	// The important bit here is that this call ensures that the hook
 	// only causes a re-render if the "fills" of a given slot name
-	// change change, not any fills.
+	// change, not any fills.
 	return fills.get( name );
 }

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -182,6 +182,10 @@ final class WP_Style_Engine {
 				'css_vars'      => array(
 					'shadow' => '--wp--preset--shadow--$slug',
 				),
+				'classnames'    => array(
+					'has-shadow'       => true,
+					'has-$slug-shadow' => 'shadow',
+				),
 			),
 		),
 		'dimensions' => array(

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -182,10 +182,6 @@ final class WP_Style_Engine {
 				'css_vars'      => array(
 					'shadow' => '--wp--preset--shadow--$slug',
 				),
-				'classnames'    => array(
-					'has-shadow'       => true,
-					'has-$slug-shadow' => 'shadow',
-				),
 			),
 		),
 		'dimensions' => array(

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -543,6 +543,11 @@
 						}
 					}
 				},
+				"shadow": {
+					"type": "boolean",
+					"description": "Allow blocks to define a box shadow.",
+					"default": false
+				},
 				"typography": {
 					"type": "object",
 					"description": "This value signals that a block supports some of the CSS style properties related to typography. When it does, the block editor will show UI controls for the user to set their values if the theme declares support.\n\nWhen the block declares support for a specific typography property, its attributes definition is extended to include the style attribute.",


### PR DESCRIPTION
Introduces Shadow controls, within the Block Inspector's Effects panel, for blocks which have shadow support.

### To-do
- [x] Add Effects panel and Shadow controls for blocks that support shadows.
- [x] Implement shadow support on Button individual button blocks.

### Screenshot

<img width="573" alt="Screenshot 2024-01-11 at 17 50 01" src="https://github.com/WordPress/gutenberg/assets/1157901/548f18b4-40ee-40cd-ad6f-26e49ae3a697">

## Testing Instructions

### Scope

Changes in this PR includes shadow support only Button block. To test for more blocks, enable the support.

example: `packages/block-library/src/columns/block.json`
```
{
      "supports": {
		"shadow": true,
      }
}
```

### Test with presets

* Test shadow in global styles and block settings for button block, by choosing one of the preset shadows from UI.
* It should apply selected shadow to the button.
* Test by applying shadow from both global and button block settings. block settings should override global setting.

### Test with custom preset

Add a custom preset to your `theme.json`

```
{
        "settings": {
                 "shadow": {
			"presets": [
				{
					"name": "Custom shadow 1",
					"shadow": "0px 5px 5px 0px red",
					"slug": "custom-shadow-1"
				}
			]
		},
       .....
}
```

It should appear in the UI and should work similar to presets.

### Test with a direct shadow string.

Test by adding a shadow string directly to the button template as follows.

```
<!-- wp:buttons -->
<div class="wp-block-buttons">
<!-- wp:button {"style":{"shadow":"0px 5px 5px 0px green"}} -->
<div class="wp-block-button" style="box-shadow:0px 5px 5px 0px green"><a class="wp-block-button__link wp-element-button" style="box-shadow:0px 5px 5px 0px green">button</a></div>
<!-- /wp:button -->
</div>
<!-- /wp:buttons -->
```