### PR TITLE
Patterns: Refactor the findOrCreate term method 

### DIFF
--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -77,24 +77,29 @@ export function CreatePatternModalContents( {
 	const categoryMap = useMemo( () => {
 		// Merge the user and core pattern categories and remove any duplicates.
 		const uniqueCategories = new Map();
-		[ ...userPatternCategories, ...corePatternCategories ].forEach(
-			( category ) => {
-				if (
-					! uniqueCategories.has( category.label ) &&
-					// There are two core categories with `Post` label so explicitly remove the one with
-					// the `query` slug to avoid any confusion.
-					category.name !== 'query'
-				) {
-					// We need to store the name separately as this is used as the slug in the
-					// taxonomy and may vary from the label.
-					uniqueCategories.set( category.label, {
-						label: category.label,
-						value: category.label,
-						name: category.name,
-					} );
-				}
+		userPatternCategories.forEach( ( category ) => {
+			uniqueCategories.set( category.label.toLowerCase(), {
+				label: category.label,
+				name: category.name,
+				id: category.id,
+				type: 'user',
+			} );
+		} );
+
+		corePatternCategories.forEach( ( category ) => {
+			if (
+				! uniqueCategories.has( category.label ) &&
+				// There are two core categories with `Post` label so explicitly remove the one with
+				// the `query` slug to avoid any confusion.
+				category.name !== 'query'
+			) {
+				uniqueCategories.set( category.label.toLowerCase(), {
+					label: category.label,
+					name: category.name,
+					type: 'core',
+				} );
 			}
-		);
+		} );
 		return uniqueCategories;
 	}, [ userPatternCategories, corePatternCategories ] );
 
@@ -140,9 +145,13 @@ export function CreatePatternModalContents( {
 	 */
 	async function findOrCreateTerm( term ) {
 		try {
-			// We need to match any existing term to the correct slug to prevent duplicates, eg.
-			// the core `Headers` category uses the singular `header` as the slug.
-			const existingTerm = categoryMap.get( term );
+			const existingTerm = categoryMap.get( term.toLowerCase() );
+			if ( existingTerm && existingTerm.type === 'user' ) {
+				return existingTerm.id;
+			}
+			// If we have an existing core category we need to match the new user category to the
+			// correct slug rather than autogenerating it to prevent duplicates, eg. the core `Headers`
+			// category uses the singular `header` as the slug.
 			const termData = existingTerm
 				? { name: existingTerm.label, slug: existingTerm.name }
 				: { name: term };
@@ -155,11 +164,7 @@ export function CreatePatternModalContents( {
 			invalidateResolution( 'getUserPatternCategories' );
 			return newTerm.id;
 		} catch ( error ) {
-			if ( error.code !== 'term_exists' ) {
-				throw error;
-			}
-
-			return error.data.term_id;
+			throw error;
 		}
 	}
 	return (

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -88,7 +88,7 @@ export function CreatePatternModalContents( {
 
 		corePatternCategories.forEach( ( category ) => {
 			if (
-				! uniqueCategories.has( category.label ) &&
+				! uniqueCategories.has( category.label.toLowerCase() ) &&
 				// There are two core categories with `Post` label so explicitly remove the one with
 				// the `query` slug to avoid any confusion.
 				category.name !== 'query'

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -82,7 +82,6 @@ export function CreatePatternModalContents( {
 				label: category.label,
 				name: category.name,
 				id: category.id,
-				type: 'user',
 			} );
 		} );
 
@@ -96,7 +95,6 @@ export function CreatePatternModalContents( {
 				uniqueCategories.set( category.label.toLowerCase(), {
 					label: category.label,
 					name: category.name,
-					type: 'core',
 				} );
 			}
 		} );
@@ -146,7 +144,7 @@ export function CreatePatternModalContents( {
 	async function findOrCreateTerm( term ) {
 		try {
 			const existingTerm = categoryMap.get( term.toLowerCase() );
-			if ( existingTerm && existingTerm.type === 'user' ) {
+			if ( existingTerm && existingTerm.id ) {
 				return existingTerm.id;
 			}
 			// If we have an existing core category we need to match the new user category to the

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -162,7 +162,11 @@ export function CreatePatternModalContents( {
 			invalidateResolution( 'getUserPatternCategories' );
 			return newTerm.id;
 		} catch ( error ) {
-			throw error;
+			if ( error.code !== 'term_exists' ) {
+				throw error;
+			}
+
+			return error.data.term_id;
 		}
 	}
 	return (


### PR DESCRIPTION
## What?
Refactors the findOrCreate term method to not call the API if the user category already exists, and fixes a bug that allowed different cased labels that could then not be selected.

## Why?

- There is no point in calling the API if we already have the category and the id
- The ability to save different cased versions of a category, but then not select them while an edge case has the potential for confusion

## How?

- Changed the way the categoryMap is generated to allow identifying of existing user categories and just return the id if exists rather than relying on failed API call to return the existing id as happens in the flat term selector component
- Lower case the categoryMap key to prevent duplicate terms with different casing being added

## Testing Instructions
- Remove all the user pattern categories from a site
- Add a pattern and assign a brand new category that doesn't already exist as a core category, eg. `Horses`
-  Check that the `/v2/wp_pattern_category` endpoint was called and the category was added successfully 
- Add a new pattern and assign the same `Horses` category and check that `/v2/wp_pattern_category` was not called and the category was successfully assigned to the pattern
- Add a new pattern and select the core pattern category `Headers`
- Check that a user category of `Headers` was added with slug of `header`
- In a site with no user categories add a new pattern and assign the category `banners` with lower case `b` and check that the category is added as `Banners` to match the existing core category


