### PR TITLE
[WIP] Block Styles: Leverage elements block support for block style variation element styling

### DIFF
--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -78,6 +78,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 
 	$settings['styles'] = array_merge( $global_styles, get_block_editor_theme_styles() );
 
+	$settings['__experimentalStyles']   = gutenberg_get_global_styles();
 	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
 	// These settings may need to be updated based on data coming from theme.json sources.
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3942,4 +3942,31 @@ class WP_Theme_JSON_Gutenberg {
 			),
 		);
 	}
+
+	/**
+	 * Retrieves the theme.json node for a specific block style variation.
+	 *
+	 * @param string $block_name     Name of the block type.
+	 * @param string $variation_name Slug for the block style variation.
+	 *
+	 * @return array Style object for the block style variation.
+	 */
+	public function get_block_style_variation( $block_name, $variation_name ) {
+		$path           = array( 'styles', 'blocks', $block_name, 'variations', $variation_name );
+		$variation_node = _wp_array_get( $this->theme_json, $path, null );
+
+		if ( ! $variation_node ) {
+			return null;
+		}
+
+		// TODO: When block style variations can be referenced e.g. from styles.blocks.variations.name
+		// the reference can be resolved here and merged with another values that have been explicitly
+		// set on the current variation node, such as when a user might customize a referenced variation.
+
+		if ( empty( $variation_node ) ) {
+			return null;
+		}
+
+		return $variation_node;
+	}
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1009,7 +1009,7 @@ class WP_Theme_JSON_Gutenberg {
 
 				if ( $duotone_support ) {
 					$root_selector    = wp_get_block_css_selector( $block_type );
-					$duotone_selector = WP_Theme_JSON_Gutenberg::scope_selector( $root_selector, $duotone_support );
+					$duotone_selector = static::scope_selector( $root_selector, $duotone_support );
 				}
 			}
 
@@ -3868,5 +3868,34 @@ class WP_Theme_JSON_Gutenberg {
 
 		$theme_json->theme_json['styles'] = self::convert_variables_to_value( $styles, $vars );
 		return $theme_json;
+	}
+
+	/**
+	 * Converts block styles registered through the `WP_Block_Styles_Registry`
+	 * with a style object, into theme.json format.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return array Styles configuration adhering to the theme.json schema.
+	 */
+	public static function get_from_block_styles_registry() {
+		$variations_data = array();
+		$registry        = WP_Block_Styles_Registry::get_instance();
+		$styles          = $registry->get_all_registered();
+
+		foreach ( $styles as $block_name => $variations ) {
+			foreach ( $variations as $variation_name => $variation ) {
+				if ( ! empty( $variation['style_data'] ) ) {
+					$variations_data[ $block_name ]['variations'][ $variation_name ] = $variation['style_data'];
+				}
+			}
+		}
+
+		return array(
+			'version' => static::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => $variations_data,
+			),
+		);
 	}
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -994,12 +994,33 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function get_blocks_metadata() {
 		// NOTE: the compat/6.1 version of this method in Gutenberg did not have these changes.
-		$registry = WP_Block_Type_Registry::get_instance();
-		$blocks   = $registry->get_all_registered();
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$blocks         = $registry->get_all_registered();
+		$style_registry = WP_Block_Styles_Registry::get_instance();
 
 		// Is there metadata for all currently registered blocks?
 		$blocks = array_diff_key( $blocks, static::$blocks_metadata );
 		if ( empty( $blocks ) ) {
+			// New block styles may have been registered within WP_Block_Styles_Registry.
+			// Update block metadata for any new block style variations.
+			$registered_styles = $style_registry->get_all_registered();
+			foreach ( static::$blocks_metadata as $block_name => $block_metadata ) {
+				if ( ! empty( $registered_styles[ $block_name ] ) ) {
+					$style_selectors = $block_metadata['styleVariations'] ?? array();
+
+					foreach ( $registered_styles[ $block_name ] as $block_style ) {
+						if ( ! isset( $style_selectors[ $block_style['name'] ] ) ) {
+							$style_selectors[ $block_style['name'] ] = static::append_to_selector(
+								'.is-style-' . $block_style['name'] . '.is-style-' . $block_style['name'],
+								$block_metadata['selector']
+							);
+						}
+					}
+
+					static::$blocks_metadata[ $block_name ]['styleVariations'] = $style_selectors;
+				}
+			}
+
 			return static::$blocks_metadata;
 		}
 
@@ -1032,12 +1053,21 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			// If the block has style variations, append their selectors to the block metadata.
+			$style_selectors = array();
 			if ( ! empty( $block_type->styles ) ) {
-				$style_selectors = array();
 				foreach ( $block_type->styles as $style ) {
 					// The style variation classname is duplicated in the selector to ensure that it overrides core block styles.
 					$style_selectors[ $style['name'] ] = static::append_to_selector( '.is-style-' . $style['name'] . '.is-style-' . $style['name'], static::$blocks_metadata[ $block_name ]['selector'] );
 				}
+			}
+
+			// Block style variations can be registered through the WP_Block_Styles_Registry as well as block.json.
+			$registered_styles = $style_registry->get_registered_styles_for_block( $block_name );
+			foreach ( $registered_styles as $style ) {
+				$style_selectors[ $style['name'] ] = static::append_to_selector( '.is-style-' . $style['name'] . '.is-style-' . $style['name'], static::$blocks_metadata[ $block_name ]['selector'] );
+			}
+
+			if ( ! empty( $style_selectors ) ) {
 				static::$blocks_metadata[ $block_name ]['styleVariations'] = $style_selectors;
 			}
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -841,8 +841,25 @@ class WP_Theme_JSON_Gutenberg {
 
 		$schema_styles_blocks   = array();
 		$schema_settings_blocks = array();
+
+		// Generate blocks schema without variations. They will be added later
+		// as each variation can support inner block styles which will need a
+		// schema for variation block styles that don't contain variations
+		// i.e. the variable block styles schema will be the same as the
+		// `$schema_styles_blocks` generated here.
 		foreach ( $valid_block_names as $block ) {
-			// Build the schema for each block style variation.
+			$schema_settings_blocks[ $block ]           = static::VALID_SETTINGS;
+			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
+			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
+		}
+
+		// Generate block style variations schema including nested block styles
+		// schema as generated above.
+		$block_style_variation_styles             = static::VALID_STYLES;
+		$block_style_variation_styles['blocks']   = $schema_styles_blocks;
+		$block_style_variation_styles['elements'] = $schema_styles_elements;
+
+		foreach ( $valid_block_names as $block ) {
 			$style_variation_names = array();
 			if (
 				! empty( $input['styles']['blocks'][ $block ]['variations'] ) &&
@@ -857,12 +874,9 @@ class WP_Theme_JSON_Gutenberg {
 
 			$schema_styles_variations = array();
 			if ( ! empty( $style_variation_names ) ) {
-				$schema_styles_variations = array_fill_keys( $style_variation_names, $styles_non_top_level );
+				$schema_styles_variations = array_fill_keys( $style_variation_names, $block_style_variation_styles );
 			}
 
-			$schema_settings_blocks[ $block ]             = static::VALID_SETTINGS;
-			$schema_styles_blocks[ $block ]               = $styles_non_top_level;
-			$schema_styles_blocks[ $block ]['elements']   = $schema_styles_elements;
 			$schema_styles_blocks[ $block ]['variations'] = $schema_styles_variations;
 		}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -217,19 +217,22 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * Returns the theme's data.
 	 *
 	 * Data from theme.json will be backfilled from existing
-	 * theme supports, if any. Note that if the same data
-	 * is present in theme.json and in theme supports,
-	 * the theme.json takes precedence.
+	 * theme supports and block style variations, if any.
+	 *
+	 * Note that if the same data is present in theme.json and in theme supports
+	 * or registered block styles, the theme.json takes precedence.
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Theme supports have been inlined and the `$theme_support_data` argument removed.
 	 * @since 6.0.0 Added an `$options` parameter to allow the theme data to be returned without theme supports.
+	 * @since 6.5.0 Theme data will now also include block style variations that were registered with a style object.
 	 *
 	 * @param array $deprecated Deprecated. Not used.
 	 * @param array $options {
 	 *     Options arguments.
 	 *
-	 *     @type bool $with_supports Whether to include theme supports in the data. Default true.
+	 *     @type bool $with_supports         Whether to include theme supports in the data. Default true.
+	 *     @type bool $with_style_variations Whether to include block style variations in the data. Default true.
 	 * }
 	 * @return WP_Theme_JSON Entity that holds theme data.
 	 */
@@ -238,7 +241,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			_deprecated_argument( __METHOD__, '5.9.0' );
 		}
 
-		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
+		$options = wp_parse_args(
+			$options,
+			array(
+				'with_supports'               => true,
+				'with_block_style_variations' => true,
+			)
+		);
 
 		if ( null === static::$theme || ! static::has_same_registered_blocks( 'theme' ) ) {
 			$wp_theme        = wp_get_theme();
@@ -286,74 +295,91 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		}
 
-		if ( ! $options['with_supports'] ) {
+		if ( ! $options['with_supports'] && ! $options['with_block_style_variations'] ) {
 			return static::$theme;
 		}
 
-		/*
-		 * We want the presets and settings declared in theme.json
-		 * to override the ones declared via theme supports.
-		 * So we take theme supports, transform it to theme.json shape
-		 * and merge the static::$theme upon that.
-		 */
-		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( get_classic_theme_supports_block_editor_settings() );
-		if ( ! wp_theme_has_theme_json() ) {
-			if ( ! isset( $theme_support_data['settings']['color'] ) ) {
-				$theme_support_data['settings']['color'] = array();
-			}
+		$theme_support_data = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(),
+		);
 
-			$default_palette = false;
-			if ( current_theme_supports( 'default-color-palette' ) ) {
-				$default_palette = true;
-			}
-			if ( ! isset( $theme_support_data['settings']['color']['palette'] ) ) {
-				// If the theme does not have any palette, we still want to show the core one.
-				$default_palette = true;
-			}
-			$theme_support_data['settings']['color']['defaultPalette'] = $default_palette;
+		if ( $options['with_supports'] ) {
+			/*
+			 * We want the presets and settings declared in theme.json
+			 * to override the ones declared via theme supports.
+			 * So we take theme supports, transform it to theme.json shape
+			 * and merge any block style variations from WP_Block_Styles_Registry
+			 * before merging the static::$theme upon that.
+			 */
+			$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( get_classic_theme_supports_block_editor_settings() );
+			if ( ! wp_theme_has_theme_json() ) {
+				if ( ! isset( $theme_support_data['settings']['color'] ) ) {
+					$theme_support_data['settings']['color'] = array();
+				}
 
-			$default_gradients = false;
-			if ( current_theme_supports( 'default-gradient-presets' ) ) {
-				$default_gradients = true;
-			}
-			if ( ! isset( $theme_support_data['settings']['color']['gradients'] ) ) {
-				// If the theme does not have any gradients, we still want to show the core ones.
-				$default_gradients = true;
-			}
-			$theme_support_data['settings']['color']['defaultGradients'] = $default_gradients;
+				$default_palette = false;
+				if ( current_theme_supports( 'default-color-palette' ) ) {
+					$default_palette = true;
+				}
+				if ( ! isset( $theme_support_data['settings']['color']['palette'] ) ) {
+					// If the theme does not have any palette, we still want to show the core one.
+					$default_palette = true;
+				}
+				$theme_support_data['settings']['color']['defaultPalette'] = $default_palette;
 
-			// Allow themes to enable all border settings via theme_support.
-			if ( current_theme_supports( 'border' ) ) {
-				$theme_support_data['settings']['border']['color']  = true;
-				$theme_support_data['settings']['border']['radius'] = true;
-				$theme_support_data['settings']['border']['style']  = true;
-				$theme_support_data['settings']['border']['width']  = true;
-			}
+				$default_gradients = false;
+				if ( current_theme_supports( 'default-gradient-presets' ) ) {
+					$default_gradients = true;
+				}
+				if ( ! isset( $theme_support_data['settings']['color']['gradients'] ) ) {
+					// If the theme does not have any gradients, we still want to show the core ones.
+					$default_gradients = true;
+				}
+				$theme_support_data['settings']['color']['defaultGradients'] = $default_gradients;
 
-			// Allow themes to enable link colors via theme_support.
-			if ( current_theme_supports( 'link-color' ) ) {
-				$theme_support_data['settings']['color']['link'] = true;
-			}
-			if ( current_theme_supports( 'experimental-link-color' ) ) {
-				_doing_it_wrong(
-					current_theme_supports( 'experimental-link-color' ),
-					__( '`experimental-link-color` is no longer supported. Use `link-color` instead.', 'gutenberg' ),
-					'6.3.0'
-				);
-			}
+				// Allow themes to enable all border settings via theme_support.
+				if ( current_theme_supports( 'border' ) ) {
+					$theme_support_data['settings']['border']['color']  = true;
+					$theme_support_data['settings']['border']['radius'] = true;
+					$theme_support_data['settings']['border']['style']  = true;
+					$theme_support_data['settings']['border']['width']  = true;
+				}
 
-			// BEGIN EXPERIMENTAL.
-			// Allow themes to enable appearance tools via theme_support.
-			// This feature was backported for WordPress 6.2 as of https://core.trac.wordpress.org/ticket/56487
-			// and then reverted as of https://core.trac.wordpress.org/ticket/57649
-			// Not to backport until the issues are resolved.
-			if ( current_theme_supports( 'appearance-tools' ) ) {
-				$theme_support_data['settings']['appearanceTools'] = true;
+				// Allow themes to enable link colors via theme_support.
+				if ( current_theme_supports( 'link-color' ) ) {
+					$theme_support_data['settings']['color']['link'] = true;
+				}
+				if ( current_theme_supports( 'experimental-link-color' ) ) {
+					_doing_it_wrong(
+						current_theme_supports( 'experimental-link-color' ),
+						__( '`experimental-link-color` is no longer supported. Use `link-color` instead.', 'gutenberg' ),
+						'6.3.0'
+					);
+				}
+
+				// BEGIN EXPERIMENTAL.
+				// Allow themes to enable appearance tools via theme_support.
+				// This feature was backported for WordPress 6.2 as of https://core.trac.wordpress.org/ticket/56487
+				// and then reverted as of https://core.trac.wordpress.org/ticket/57649
+				// Not to backport until the issues are resolved.
+				if ( current_theme_supports( 'appearance-tools' ) ) {
+					$theme_support_data['settings']['appearanceTools'] = true;
+				}
+				// END EXPERIMENTAL.
 			}
-			// END EXPERIMENTAL.
 		}
+
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
+
+		if ( $options['with_block_style_variations'] ) {
+			$block_style_variations_data = WP_Theme_JSON_Gutenberg::get_from_block_styles_registry();
+			$with_block_style_variations = new WP_Theme_JSON_Gutenberg( $block_style_variations_data );
+			$with_theme_supports->merge( $with_block_style_variations );
+		}
+
 		$with_theme_supports->merge( static::$theme );
+
 		return $with_theme_supports;
 	}
 

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Block functions specific for the Gutenberg editor plugin.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers a new block style for one or more block types.
+ *
+ * @since 6.5.0
+ *
+ * @param string|array $block_name       Block type name including namespace or array of namespaced block type names.
+ * @param array        $style_properties Array containing the properties of the style name, label,
+ *                                 style_handle (name of the stylesheet to be enqueued),
+ *                                 inline_style (string containing the CSS to be added),
+ *                                 style_data (theme.json-like object to generate CSS from).
+ * @return bool True if all block styles were registered with success and false otherwise.
+ */
+function gutenberg_register_block_style( $block_name, $style_properties ) {
+	if ( ! is_string( $block_name ) && ! is_array( $block_name ) ) {
+		_doing_it_wrong(
+			__METHOD__,
+			__( 'Block name must be a string or array.', 'gutenberg' ),
+			'5.3.0'
+		);
+
+		return false;
+	}
+
+	$block_names = is_string( $block_name ) ? array( $block_name ) : $block_name;
+	$result      = true;
+
+	foreach ( $block_names as $name ) {
+		if ( ! WP_Block_Styles_Registry::get_instance()->register( $name, $style_properties ) ) {
+			$result = false;
+		}
+	}
+
+	return $result;
+}

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -157,7 +157,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				'__experimentalStyles'                   => array(
 					'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
 					'type'        => 'object',
-					'context'     => array( 'mobile' ),
+					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor', 'mobile' ),
 				),
 
 				'__experimentalEnableQuoteBlockV2'       => array(

--- a/lib/load.php
+++ b/lib/load.php
@@ -101,6 +101,7 @@ require __DIR__ . '/compat/wordpress-6.4/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.4/kses.php';
 
 // WordPress 6.5 compat.
+require __DIR__ . '/compat/wordpress-6.5/blocks.php';
 require __DIR__ . '/compat/wordpress-6.5/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.5/class-wp-navigation-block-renderer.php';
 require __DIR__ . '/compat/wordpress-6.5/kses.php';

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -48,6 +48,25 @@ export const cleanEmptyObject = ( object ) => {
 		: Object.fromEntries( cleanedNestedObjects );
 };
 
+export const isObject = ( item ) =>
+	!! item && typeof item === 'object' && ! Array.isArray( item );
+
+export const deepMerge = ( target, source ) => {
+	if ( isObject( target ) && isObject( source ) ) {
+		for ( const key in source ) {
+			const getter = Object.getOwnPropertyDescriptor( source, key )?.get;
+			if ( typeof getter === 'function' ) {
+				Object.defineProperty( target, key, { get: getter } );
+			} else if ( isObject( source[ key ] ) ) {
+				if ( ! target[ key ] ) Object.assign( target, { [ key ]: {} } );
+				deepMerge( target[ key ], source[ key ] );
+			} else {
+				Object.assign( target, { [ key ]: source[ key ] } );
+			}
+		}
+	}
+};
+
 export function transformStyles(
 	activeSupports,
 	migrationPaths,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -25,6 +25,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalBlockDirectory',
 	'__experimentalDiscussionSettings',
 	'__experimentalFeatures',
+	'__experimentalStyles',
 	'__experimentalGlobalStylesBaseStyles',
 	'__experimentalPreferredStyleVariations',
 	'__unstableGalleryWithImageBlocks',

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2194,20 +2194,403 @@
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						},
 						"variations": {
-							"$ref": "#/definitions/stylesVariationPropertiesComplete"
+							"$ref": "#/definitions/stylesVariationsPropertiesComplete"
 						}
 					},
 					"additionalProperties": false
 				}
 			]
 		},
-		"stylesVariationPropertiesComplete": {
+		"stylesVariationsPropertiesComplete": {
 			"type": "object",
 			"patternProperties": {
 				"^[a-z][a-z0-9-]*$": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"$ref": "#/definitions/stylesVariationPropertiesComplete"
 				}
 			}
+		},
+		"stylesVariationPropertiesComplete": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"properties": {
+						"border": {},
+						"color": {},
+						"dimensions": {},
+						"spacing": {},
+						"typography": {},
+						"filter": {},
+						"shadow": {},
+						"outline": {},
+						"css": {},
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						"blocks": {
+							"$ref": "#/definitions/stylesVariationBlocksPropertiesComplete"
+						}
+					},
+					"additionalProperties": false
+				}
+			]
+		},
+		"stylesVariationBlocksPropertiesComplete": {
+			"type": "object",
+			"properties": {
+				"core/archives": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/audio": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/avatar": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/block": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/button": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/buttons": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/calendar": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/categories": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/code": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/column": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/columns": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-author-avatar": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-author-name": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-content": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-date": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-edit-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-reply-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-pagination": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-pagination-next": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-pagination-numbers": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-pagination-previous": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-title": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-template": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/cover": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/details": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/embed": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/file": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/freeform": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/gallery": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/group": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/heading": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/home-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/html": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/image": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/latest-comments": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/latest-posts": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/list": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/list-item": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/loginout": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/media-text": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/missing": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/more": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/navigation": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/navigation-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/navigation-submenu": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/nextpage": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/page-list": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/page-list-item": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/paragraph": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-author": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-author-biography": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-author-name": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-comment": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-comments-count": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-comments-form": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-comments-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-content": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-date": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-excerpt": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-featured-image": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-navigation-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-template": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-terms": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-time-to-read": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-title": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/preformatted": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/pullquote": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-no-results": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-pagination": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-pagination-next": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-pagination-numbers": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-pagination-previous": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-title": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/quote": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/read-more": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/rss": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/search": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/separator": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/shortcode": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/site-logo": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/site-tagline": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/site-title": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/social-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/social-links": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/spacer": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/table": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/table-of-contents": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/tag-cloud": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/template-part": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/term-description": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/text-columns": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/verse": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/video": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/widget-area": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/legacy-widget": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/widget-group": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				}
+			},
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				}
+			},
+			"additionalProperties": false
+		},
+		"stylesVariationBlockPropertiesComplete": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"properties": {
+						"border": {},
+						"color": {},
+						"dimensions": {},
+						"spacing": {},
+						"typography": {},
+						"filter": {},
+						"shadow": {},
+						"outline": {},
+						"css": {},
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						"blocks": {
+							"type": "object",
+							"allOf": [
+								{
+									"$ref": "#/definitions/stylesProperties"
+								},
+								{
+									"properties": {
+										"border": {},
+										"color": {},
+										"dimensions": {},
+										"spacing": {},
+										"typography": {},
+										"filter": {},
+										"shadow": {},
+										"outline": {},
+										"css": {},
+										"elements": {
+											"$ref": "#/definitions/stylesElementsPropertiesComplete"
+										}
+									},
+									"additionalProperties": false
+								}
+							]
+						}
+					},
+					"additionalProperties": false
+				}
+			]
 		}
 	},
 	"type": "object",


### PR DESCRIPTION
⚠️🚧  Do not merge! 🚧 ⚠️ 

This PR was an exploration into an alternative approach to solve the issues currently blocking https://github.com/WordPress/gutenberg/pull/56540

Related:
- https://github.com/WordPress/gutenberg/pull/56540

## What?

Alternate approach to https://github.com/WordPress/gutenberg/pull/56540.

## Why?

https://github.com/WordPress/gutenberg/pull/56540 is currently block by the fact that element styles for block style variations will take precedence over element styles applied directly to a child block instance. 

See https://github.com/WordPress/gutenberg/pull/56540#issuecomment-1882099850

## How?

- This PR trials merging a block style variation's element styles with those on a block instance to see if it is possible to avoid the specificity issues noted on the original PR and not need to bump the specificity of block instance element styles.

## Testing Instructions

1. Setup some custom block style variations with element styles. See [#56540](https://github.com/WordPress/gutenberg/pull/56540) for snippets to do this
2. Edit a post and add a group block containing some inner blocks that can contain links
3. Apply a block style variation to the parent group block
4. Try to override this by customizing element styles for links on the child blocks
5. Now switch the block style variation back and forth on the parent group block to trigger a known issue with this PR i.e. that the redefined element styles when switching block style variations will be defined after the child block element styles that haven't changed, and thus the block style variation element styles will be incorrectly applied.

## Known Issues

Changing block style variations on the parent will make it appear as though inner child block element styles have been lost. See test instructions for steps to replicate, in particular the step `#5`

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/60436221/eb44f688-6028-4f01-9785-aa2b25331f9e

