### PR TITLE
Reduce specificity of block style variation selectors.

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1021,8 +1021,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! empty( $block_type->styles ) ) {
 				$style_selectors = array();
 				foreach ( $block_type->styles as $style ) {
-					// The style variation classname is duplicated in the selector to ensure that it overrides core block styles.
-					$style_selectors[ $style['name'] ] = static::append_to_selector( '.is-style-' . $style['name'] . '.is-style-' . $style['name'], static::$blocks_metadata[ $block_name ]['selector'] );
+					$style_selectors[ $style['name'] ] = static::append_to_selector( '.is-style-' . $style['name'], static::$blocks_metadata[ $block_name ]['selector'] );
 				}
 				static::$blocks_metadata[ $block_name ]['styleVariations'] = $style_selectors;
 			}

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -98,19 +98,19 @@ $blocks-block__margin: 0.5em;
 	border-radius: 0 !important;
 }
 
-.wp-block-button.is-style-outline > .wp-block-button__link,
-.wp-block-button .wp-block-button__link.is-style-outline {
+.wp-block-button:where(.is-style-outline) > .wp-block-button__link,
+.wp-block-button .wp-block-button__link:where(.is-style-outline) {
 	border: 2px solid currentColor;
 	padding: 0.667em 1.333em;
 }
 
-.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-text-color),
-.wp-block-button .wp-block-button__link.is-style-outline:not(.has-text-color) {
+.wp-block-button:where(.is-style-outline) > .wp-block-button__link:not(.has-text-color),
+.wp-block-button .wp-block-button__link:where(.is-style-outline):not(.has-text-color) {
 	color: currentColor;
 }
 
-.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background),
-.wp-block-button .wp-block-button__link.is-style-outline:not(.has-background) {
+.wp-block-button:where(.is-style-outline) > .wp-block-button__link:not(.has-background),
+.wp-block-button .wp-block-button__link:where(.is-style-outline):not(.has-background) {
 	background-color: transparent;
 	// background-image is required to overwrite a gradient background
 	background-image: none;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #49835 (and tries to mitigate issues encountered in #56540)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add all blocks with style variations onto a post and set them to each of their variations. Save.
2. In global styles, try changing the styles of the variations - e.g. for Button Outline variation, try changing the background color.
3. Save and check that styles work as expected in editor and front end.

I've tested pretty extensively with all core block style variations and all still seems to work as expected. The only core styles that needed a slight specificity reduction were Button Outline ones.

I did encounter a bunch of existing bugs that are reproducible on trunk:

* Element styles (e.g. link and heading colors) aren't working within block style variations. This is a known issue, solved in #56540.

* I'm encountering problems with the Image Rounded variation: setting border-radius and duotone on the variation in global styles isn't working at all. It's broken on trunk too so not a problem specific to this PR.
 
* Duotone isn't working for the Site Logo Rounded variation either.

* Block spacing isn't working within the Quote Plain variation, or within the Social Icons variations. Again it's an issue on trunk: the styles aren't being output at all.

* Padding is being output for Table but seems to have no effect whatsoever.

* Letter case and spacing are output with correct specificity on Tag Cloud but changes don't show in the editor (front end looks fine)

These should probably be investigated separately.
