### PR TITLE
Pattern Overrides: Add `template-lock: all` to pattern inner blocks to prevent deletion/insertion

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -254,6 +254,7 @@ export default function ReusableBlockEdit( {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		templateLock: 'all',
 		layout,
 		renderAppender: innerBlocks?.length
 			? undefined


### PR DESCRIPTION
## What?
In #53705 there are two bugs mentioned:
> - New paragraph can be added by hitting enter at end of existing paragraph that has editable attributes, but the new paragraph can't be edited.
> -  A user can multi-select two non-adjacent paragraphs that have overrides and delete any 'locked' blocks between them.

## Why?
The bug happens because the inner block list is open to modifications.

#57036 used `blockEditingMode` to prevent edits to some inner blocks, but it only applies the changes to individual inner blocks and not the block list.

The conundrum is that `blockEditingMode` doesn't offer a way to disable the inner block list of a block while still keeping the rest of the block itself open to changes.

## How?
To fix this, this PR uses `templateLock`. A drawback is that the lock icon shows for blocks in List View:
![Screenshot 2024-01-09 at 3 04 08 pm](https://github.com/WordPress/gutenberg/assets/677833/760001e3-af33-4840-a46e-4f54000e4c31)

This is probably not a long term solution. It might be better to explore adding a new `blockEditingMode` called something like `disabledInnerBlocks`. Or more granular controls. That needs some further conversation.

## Testing Instructions
1. Follow the [testing instructions here to create a pattern with overrides](https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331). Make the pattern follow this structure - Paragraph, Image, Paragraph. Make the paragraphs allow content overrides.
2. Insert an instance of the pattern
3. Try multi-selecting the paragraphs and pressing backspace/delete. The blocks should not be deletable.
4. Try hitting enter from within a paragraph. A new paragraph should not be inserted (a line break will be inserted instead).

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/WordPress/gutenberg/assets/677833/f5e54f89-6662-4122-ab41-93a2870496ba

### After

https://github.com/WordPress/gutenberg/assets/677833/f1cb7600-078a-4a3e-8ca6-6e722e120120


