### PR TITLE
Remove right negative margin from pinned items

### DIFF
--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -27,7 +27,4 @@
 
 	// Gap between pinned items.
 	gap: $grid-unit-10;
-
-	// Account for larger grid from parent container gap.
-	margin-right: -$grid-unit-05;
 }


### PR DESCRIPTION
## What?

This PR removes the negative margin on the right from pinned items in the header. This should ensure that all icons have the same gap of 8px.

## Why?

This style was added in #40411 to fix gaps, but now it seems unnecessary.

## Testing Instructions

Try a scenario like the one below.

- Site Editor, Post Editor, Widget Editor
- "Show button text labels" enabled/disabled
- Mobile layout
- Custom Pinned Item

To test Custom Pinner Item, run the code below in your browser console.

Post Editor:

```javascript
wp.plugins.registerPlugin( 'my-plugin', {
	render: function () {
		return wp.element.createElement(
			wp.editPost.PluginSidebar,
			{
				name: 'my-plugin',
				icon: 'admin-post',
				title: 'My plugin',
			},
			'Meta field'
		);
	},
} );
```

Site Editor:

```javascript
wp.plugins.registerPlugin( 'my-plugin', {
	render: function () {
		return wp.element.createElement(
			wp.editSite.PluginSidebar,
			{
				name: 'my-plugin',
				icon: 'admin-post',
				title: 'My plugin',
			},
			'Meta field'
		);
	},
} );
```

## Screenshots or screencast <!-- if applicable -->

| State | Before | After |
|--------|--------|--------|
| Default | ![before](https://github.com/WordPress/gutenberg/assets/54422211/f2d2d1b6-a9a4-4f25-9e68-0b61a9cae2f1) | ![after](https://github.com/WordPress/gutenberg/assets/54422211/69d526b0-68f3-441a-988d-f18972af1f58) |
| Focused | ![before-focused](https://github.com/WordPress/gutenberg/assets/54422211/1808476c-bfce-4052-b68d-43e35ac382b9) | ![after-focused](https://github.com/WordPress/gutenberg/assets/54422211/49951752-037c-402f-9b1c-3b3dac631131) |
| Show Text | ![before-text](https://github.com/WordPress/gutenberg/assets/54422211/177e485c-f5b5-4d9c-ade8-a3672cfecd6c) | ![after-text](https://github.com/WordPress/gutenberg/assets/54422211/b71a8eac-4ab2-408e-a500-ca73f0f7ded4) |
| Show Text (Focused) | ![before-text-focused](https://github.com/WordPress/gutenberg/assets/54422211/795e1394-eb76-4892-8cda-f3707f6045a5) | ![after-text-focused](https://github.com/WordPress/gutenberg/assets/54422211/a02835ad-e3c0-4110-9e09-9ed82ebb2824) |
| Custom Pinned Item | ![before-plugin-sidebar](https://github.com/WordPress/gutenberg/assets/54422211/7791515a-9054-4d28-95e7-b2ea0653710a) | ![after-plugin-sidebar](https://github.com/WordPress/gutenberg/assets/54422211/e196fb0c-0f68-45ab-bdeb-2ce491685396) | 