### PR TITLE
Data views: Update pagination spacing in List layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -301,6 +301,10 @@
 			}
 		}
 	}
+
+	& + .dataviews-pagination {
+		justify-content: space-between;
+	}
 }
 
 .dataviews-action-modal {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -337,7 +337,7 @@
 	& + .dataviews-pagination {
 		justify-content: space-between;
 	}
-	
+
 	.dataviews-view-list__details-button {
 		align-self: center;
 		opacity: 0;


### PR DESCRIPTION
Small follow-up to https://github.com/WordPress/gutenberg/pull/57644, where pagination spacing was updated to bring the page selector closer to the next/previous buttons. This works well in 'full-width' layouts like Grid / Table, but in the List layout it looks a little clumsy due to the narrower width. 

In this PR the page selector is aligned left in List layout which is more balanced while still being close to the next/previous buttons.

| Before | After |
| --- | --- |
| <img width="448" alt="Screenshot 2024-01-09 at 11 26 54" src="https://github.com/WordPress/gutenberg/assets/846565/751f65d1-36e8-4d9f-b184-3cab90a46a2e"> | <img width="474" alt="Screenshot 2024-01-09 at 11 27 13" src="https://github.com/WordPress/gutenberg/assets/846565/b6b84833-9aa1-4821-871e-f85f5c734b35"> |
