### PR TITLE
Update table header gap

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -85,6 +85,10 @@
 	tr {
 		border-bottom: 1px solid $gray-100;
 
+		.dataviews-view-table-header-button {
+			gap: $grid-unit-05;
+		}
+
 		td:first-child,
 		th:first-child {
 			padding-left: $grid-unit-40;


### PR DESCRIPTION
When tables are sorted an arrow is appended to the column header indicating the sort order. Currently there's no space between the label and the arrow which looks a little awkward:

<img width="151" alt="Screenshot 2024-01-09 at 11 32 43" src="https://github.com/WordPress/gutenberg/assets/846565/10ba69e9-e65d-4b9c-bb87-9accc46d7ee2">

This PR adds a small `gap` to address this issue:

<img width="116" alt="Screenshot 2024-01-09 at 11 33 36" src="https://github.com/WordPress/gutenberg/assets/846565/4513ddf0-deb6-4934-92b8-61c7093aab63">

To test:

* Enable the data views experiment
* View All templates (or All pages)
* Switch to Table layout
* Sort by title (or any other field)
* Observe a 4px gap between column header / arrow