### PR TITLE
Update block variation transforms UI

### DIFF
--- a/packages/block-library/src/social-link/variations.js
+++ b/packages/block-library/src/social-link/variations.js
@@ -342,6 +342,7 @@ variations.forEach( ( variation ) => {
 	if ( variation.isActive ) return;
 	variation.isActive = ( blockAttributes, variationAttributes ) =>
 		blockAttributes.service === variationAttributes.service;
+	variation.scope = [ 'inserter', 'transform' ];
 } );
 
 export default variations;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/57253
Fixes: https://github.com/WordPress/gutenberg/issues/46726

This PR updates the block variation transforms UI in the block inspector controls. 

Currently on trunk we show a `ToggleGroupControl` when available variations are less than 5 and also have unique icons. The use of `ToggleGroupControl` [was added recently](https://href.li/?https://github.com/WordPress/gutenberg/pull/45654) and there was an issue at the logic too, as it would still show `buttons` if the variations were more than five.

In this PR:
1. I removed the `buttons` UI and always show a dropdown if we have more than five variations.
2. Removed the old dropdown used and used the new Dropdown component with radio inputs.
3. In order to demonstrate this and discuss on a scenario with lots of variations, I also added the `transform` scope to `Social Icon` block.

## Design

This will need design input as for start I implemented a design similar to the Page summary panel for the below reasons.

1. Icons are not displayed in the dropdown even if every variation has one. This is because some variations could have duplicate icons or no icons at all and additionally `DropdownMenuRadioItem` component would need to accommodate this, possible resulting in a lot of white space at the start of each option.
2. The BlockCard component above uses the active variation's title and icon so we definitely not want to duplicate both of them. Right now in this PR the `title` is duplicate and could be designed differently. In trunk when we are showing a dropdown, we only show a `Transform to variation` button.
3. This addition adds one more possible design challenge as we also show the variation transformations in BlockSwitcher. This can lead to a big dropdown there too(see the last part of the video in description). This could be handled differently as part of https://github.com/WordPress/gutenberg/issues/40208, either here or in a follow up.

So, despite the first design let's find what works best with @WordPress/gutenberg-design .




## Testing Instructions
1. In a page insert `Social Icons` and test the variation transformations.
2. Test existing variation transformations that work and are displayed like before(ex Group).


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/76a575dd-f022-4fd3-b7d6-34795abe205e


