### PR TITLE
Fix Widgets page Undo and Redo accessibility and keyboard interaction

### DIFF
--- a/packages/edit-widgets/src/components/header/document-tools/index.js
+++ b/packages/edit-widgets/src/components/header/document-tools/index.js
@@ -105,8 +105,8 @@ function DocumentTools() {
 			/>
 			{ isMediumViewport && (
 				<>
-					<UndoButton />
-					<RedoButton />
+					<ToolbarItem as={ UndoButton } />
+					<ToolbarItem as={ RedoButton } />
 					<ToolbarItem
 						as={ Button }
 						className="edit-widgets-header-toolbar__list-view-toggle"

--- a/packages/edit-widgets/src/components/header/document-tools/index.js
+++ b/packages/edit-widgets/src/components/header/document-tools/index.js
@@ -83,6 +83,7 @@ function DocumentTools() {
 			className="edit-widgets-header-toolbar"
 			aria-label={ __( 'Document tools' ) }
 			shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
+			variant="unstyled"
 		>
 			<ToolbarItem
 				ref={ inserterButton }

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -45,7 +45,6 @@
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 2;
-	overflow-x: hidden;
 	padding-left: $grid-unit-20;
 }
 
@@ -67,7 +66,7 @@
 }
 
 .edit-widgets-header-toolbar {
-	border: none;
+	gap: $grid-unit-10;
 
 	// The Toolbar component adds different styles to buttons, so we reset them
 	// here to the original button styles

--- a/packages/edit-widgets/src/components/header/undo-redo/redo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/redo.js
@@ -2,13 +2,14 @@
  * WordPress dependencies
  */
 import { __, isRTL } from '@wordpress/i18n';
-import { ToolbarButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
+import { forwardRef } from '@wordpress/element';
 
-export default function RedoButton() {
+function RedoButton( props, ref ) {
 	const shortcut = isAppleOS()
 		? displayShortcut.primaryShift( 'z' )
 		: displayShortcut.primary( 'y' );
@@ -19,7 +20,9 @@ export default function RedoButton() {
 	);
 	const { redo } = useDispatch( coreStore );
 	return (
-		<ToolbarButton
+		<Button
+			{ ...props }
+			ref={ ref }
 			icon={ ! isRTL() ? redoIcon : undoIcon }
 			label={ __( 'Redo' ) }
 			shortcut={ shortcut }
@@ -31,3 +34,5 @@ export default function RedoButton() {
 		/>
 	);
 }
+
+export default forwardRef( RedoButton );

--- a/packages/edit-widgets/src/components/header/undo-redo/undo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/undo.js
@@ -2,20 +2,23 @@
  * WordPress dependencies
  */
 import { __, isRTL } from '@wordpress/i18n';
-import { ToolbarButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
+import { forwardRef } from '@wordpress/element';
 
-export default function UndoButton() {
+function UndoButton( props, ref ) {
 	const hasUndo = useSelect(
 		( select ) => select( coreStore ).hasUndo(),
 		[]
 	);
 	const { undo } = useDispatch( coreStore );
 	return (
-		<ToolbarButton
+		<Button
+			{ ...props }
+			ref={ ref }
 			icon={ ! isRTL() ? undoIcon : redoIcon }
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }
@@ -27,3 +30,5 @@ export default function UndoButton() {
 		/>
 	);
 }
+
+export default forwardRef( UndoButton );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57647

## What?
<!-- In a few words, what is the PR actually doing? -->
- Makes the Undo and Redo buttons always focusable also when there's no history steps.
- Fixes arrow keys navigation in the toolbar
- Fixes focus style and spacing between the toolbar buttons.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- These buttons use both disabled and aria-disabled, which is clearly wrong and makes the button not focusable when there's no history steps.
- The buttons should always be focusable to make arrow kesy navigation work as expected, like in the Post editor and Site editor.
- The focus style must always be visible.
- Spacing and styling of the whole toolbar should be consistent with the similar toolbars in the other editors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It appears that the Undo and Redo buttons need to use `forwardRef` to correctly handle the aria-disabled attribute instead of `disabled`. Also, arrow keys navigation needs to dynamically set `tabindex="-1"` on all the toolbar buttons except the one that is currently focused. This doesn't seem to work correctly without `forwardRef`.

I guess something needs to be passed to the underlying Button element but honestly I don't understand why `forwardRef` is necessary. I would appreciate someone more familiar with this to have a look.
This PR basically mimics the editor package [EditorHistoryUndo](https://github.com/WordPress/gutenberg/blob/24919010c859892e02c02ceeebb7d801b4625726/packages/editor/src/components/editor-history/undo.js) and [EditorHistoryRedo](https://github.com/WordPress/gutenberg/blob/24919010c859892e02c02ceeebb7d801b4625726/packages/editor/src/components/editor-history/redo.js) implementation but it's not clear at all to me why `forwardRef` is needed.

**More importantly**: I would expect that when using `ToolbarItem`, `ToolbarButton`, or `ToolbarDropdownMenu`  in a `NavigableToolbar` the toolbar works as expected out of the box, handling `aria-disabled` nad arrow keys navigation out of the box. This doesn't seem to be the case and it makes using these components pretty confusing. It's not clear at all how to use them and have the expected behavior working correctly.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Set Twenty Twenty-One as your active theme.
- Go to Appearance > Widgets.
- Use the Tab key to navigate the Widgets editor documents tools toolbar (the one with the inserter, undo and redo, and list view).
- Observe the toolbar provides only one Tab stop.
- Navigate the other toolbar buttons with left and arrow keys.
- Observe the Undo and Redo buttons receive focus even when there's no history steps.
- Make some edits to a widget (or add one and edit it).
- Use the Undo and Redo buttons and check they work as expected.
- Observe the spacing netween the toolbar buttons is now consistent with the one in the other editors.
- Observe the focus style on the buttons is fully visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
