### PR TITLE
Add links to additional local dev tools in Block Development Environment readme

### DIFF
--- a/docs/getting-started/devenv/README.md
+++ b/docs/getting-started/devenv/README.md
@@ -48,3 +48,10 @@ Refer to the [Get started with `wp-env`](/docs/getting-started/devenv/get-starte
 <div class="callout callout-info">
     Throughout the Handbook, you may also see references to <code><a href="https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now">wp-now</a></code>. This is a lightweight tool powered by <a hre="https://developer.wordpress.org/playground/">WordPress Playground</a> that streamlines setting up a simple local WordPress environment. While still experimental, this tool is great for quickly testing WordPress releases, plugins, and themes. 
 </div>
+
+This list is not exhaustive, but here are several additional options to choose from if you prefer not to use `wp-env`:
+
+- [Local](https://localwp.com/)
+- [XAMPP](https://www.apachefriends.org/)
+- [MAMP](https://www.mamp.info/en/mamp/mac/)
+- [Varying Vagrant Vagrants](https://varyingvagrantvagrants.org/) (VVV)


### PR DESCRIPTION
While `wp-env` is the recommended tool in the Block Editor Handbook for [local WordPress development environments](https://developer.wordpress.org/block-editor/getting-started/devenv/#local-wordpress-environment), there are many other popular tools in the community, and there are developers who do not want to have to install Docker. This Twitter [discussion](https://twitter.com/igorbenic/status/1744388352537682398?s=46&t=tLqu-4WGyvBs1cDTKpVGSg) is one example. 

In the Themes Handbook, we are [noting a number of additional tools](https://developer.wordpress.org/themes/getting-started/tools-and-setup/#setting-up-a-local-development-environment). Therefore, the purpose of this PR is to add a list of additional resources, while maintaining `wp-env` as the recommended tool. This allows developers to choose the tool that works best for them while clarifying that you do not have to use `wp-env` if you prefer not to. We are also improving parity between the Themes Handbook and the Block Editor Handbook.
