### PR TITLE
Label the HeightControl.

### DIFF
--- a/packages/block-editor/src/components/height-control/index.js
+++ b/packages/block-editor/src/components/height-control/index.js
@@ -157,6 +157,8 @@ export default function HeightControl( {
 						onUnitChange={ handleUnitChange }
 						min={ 0 }
 						size={ '__unstable-large' }
+						label={ label }
+						hideLabelFromVision
 					/>
 				</FlexItem>
 				<FlexItem isBlock>
@@ -175,6 +177,8 @@ export default function HeightControl( {
 							withInputField={ false }
 							onChange={ handleSliderChange }
 							__nextHasNoMarginBottom
+							label={ label }
+							hideLabelFromVision
 						/>
 					</Spacer>
 				</FlexItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57681

## What?
<!-- In a few words, what is the PR actually doing? -->
The HeightControl controls are unlabeled. This PR just passed the omitted `label` prop, together with the `hideLabelFromVision` to visually hide the labels.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Unlabeled controls can't be used by assistive technology users (screen readers, speech recognition) even if there's some other `visual labeling` nearby.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Pass the omitted `label` prop to the HeightControl underlying components.
Adds the `hideLabelFromVision` prop to visually hide the label elements.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the reproduction steps from the issue.
- Observe the input and range controls are now labeled.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
