### PR TITLE
DataViews: add new page button in `Pages`

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalView as View,
 	__experimentalVStack as VStack,
+	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
@@ -42,6 +43,7 @@ import {
 	useEditPostAction,
 } from '../actions';
 import PostPreview from '../post-preview';
+import AddNewPageModal from '../add-new-page';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -323,6 +325,29 @@ export default function PagePages() {
 		[ view.type, setView ]
 	);
 
+	const [ showAddPageModal, setShowAddPageModal ] = useState( false );
+	const openModal = useCallback( () => {
+		if ( ! showAddPageModal ) {
+			setShowAddPageModal( true );
+		}
+	}, [ showAddPageModal ] );
+	const closeModal = useCallback( () => {
+		if ( showAddPageModal ) {
+			setShowAddPageModal( false );
+		}
+	}, [ showAddPageModal ] );
+	const handleNewPage = useCallback(
+		( { type, id } ) => {
+			history.push( {
+				postId: id,
+				postType: type,
+				canvas: 'edit',
+			} );
+			closeModal();
+		},
+		[ history ]
+	);
+
 	// TODO: we need to handle properly `data={ data || EMPTY_ARRAY }` for when `isLoading`.
 	return (
 		<>
@@ -333,6 +358,19 @@ export default function PagePages() {
 						: null
 				}
 				title={ __( 'Pages' ) }
+				actions={
+					<>
+						<Button variant="primary" onClick={ openModal }>
+							{ __( 'Add new page' ) }
+						</Button>
+						{ showAddPageModal && (
+							<AddNewPageModal
+								onSave={ handleNewPage }
+								onClose={ closeModal }
+							/>
+						) }
+					</>
+				}
 			>
 				<DataViews
 					paginationInfo={ paginationInfo }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/57578

## What?

Implements a new button for adding a page from Pages.

<img width="1512" alt="Captura de ecrã 2024-01-09, às 17 16 09" src="https://github.com/WordPress/gutenberg/assets/583546/463be8df-9208-4121-a39a-d93fb377a00f">


## Why?

We want to have parity with the existing Pages, which let users create a page from there.

## How?

Adds a new button in the content frame, like the one in Templates.

Alternatively, it could have been added in the sidebar as a `+` icon next to the title, like the existing Pages with the experiment disabled – though the button in the content frame is preferred as of [this conversation](https://github.com/WordPress/gutenberg/pull/57589#issuecomment-1878834946).

## Testing Instructions

- Enable the "admin views" experiment and visit "Pages".
- Try adding a new page.
