### PR TITLE
DataViews: Use i18n._x to clarify term "Duplicate"

### DIFF
--- a/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-pattern-actions.js
@@ -8,7 +8,7 @@ import { paramCase as kebabCase } from 'change-case';
  */
 import { getQueryArgs } from '@wordpress/url';
 import { downloadBlob } from '@wordpress/blob';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	TextControl,
@@ -251,9 +251,9 @@ export const resetAction = {
 
 export const duplicatePatternAction = {
 	id: 'duplicate-pattern',
-	label: __( 'Duplicate' ),
+	label: _x( 'Duplicate', 'action label' ),
 	isEligible: ( item ) => item.type !== TEMPLATE_PART_POST_TYPE,
-	modalHeader: __( 'Duplicate pattern' ),
+	modalHeader: _x( 'Duplicate pattern', 'action label' ),
 	RenderModal: ( { item, closeModal } ) => {
 		const { categoryId = PATTERN_DEFAULT_CATEGORY } = getQueryArgs(
 			window.location.href
@@ -276,7 +276,7 @@ export const duplicatePatternAction = {
 		return (
 			<CreatePatternModalContents
 				onClose={ closeModal }
-				confirmLabel={ __( 'Duplicate' ) }
+				confirmLabel={ _x( 'Duplicate', 'action label' ) }
 				{ ...duplicatedProps }
 			/>
 		);
@@ -285,9 +285,9 @@ export const duplicatePatternAction = {
 
 export const duplicateTemplatePartAction = {
 	id: 'duplicate-template-part',
-	label: __( 'Duplicate' ),
+	label: _x( 'Duplicate', 'action label' ),
 	isEligible: ( item ) => item.type === TEMPLATE_PART_POST_TYPE,
-	modalHeader: __( 'Duplicate template part' ),
+	modalHeader: _x( 'Duplicate template part', 'action label' ),
 	RenderModal: ( { item, closeModal } ) => {
 		const { createSuccessNotice } = useDispatch( noticesStore );
 		const { categoryId = PATTERN_DEFAULT_CATEGORY } = getQueryArgs(
@@ -322,7 +322,7 @@ export const duplicateTemplatePartAction = {
 				) }
 				onCreate={ onTemplatePartSuccess }
 				onError={ closeModal }
-				confirmLabel={ __( 'Duplicate' ) }
+				confirmLabel={ _x( 'Duplicate', 'action label' ) }
 			/>
 		);
 	},


### PR DESCRIPTION
## What?
Swap `__` for `_x` when generating certain UI strings in order to provide the context `action label` to translators.

## Why?
"Duplicate", "Duplicate pattern", "Duplicate template part": these labels all refer to actions, where "duplicate" is meant as a verb. For a translator, that context was not clear, as "duplicate" could have been understood to be an adjective.

## Testing Instructions
No changes should occur.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
