### PR TITLE
DataViews: add footer to Pages sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages-dataviews/index.js
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalTruncate as Truncate,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { layout } from '@wordpress/icons';
+import { useMemo } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useLink } from '../routes/link';
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+import SidebarNavigationItem from '../sidebar-navigation-item';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+
+const PageItem = ( { postType = 'page', postId, ...props } ) => {
+	const linkInfo = useLink(
+		{
+			postType,
+			postId,
+		},
+		{
+			backPath: '/page',
+		}
+	);
+	return <SidebarNavigationItem { ...linkInfo } { ...props } />;
+};
+
+export default function SidebarNavigationScreenPagesDataViews() {
+	const { records: templateRecords } = useEntityRecords(
+		'postType',
+		TEMPLATE_POST_TYPE,
+		{
+			per_page: -1,
+		}
+	);
+	const templates = useMemo(
+		() =>
+			templateRecords?.filter( ( { slug } ) =>
+				[ '404', 'search' ].includes( slug )
+			),
+		[ templateRecords ]
+	);
+
+	return (
+		<SidebarNavigationScreen
+			title={ __( 'Pages' ) }
+			content={ <DataViewsSidebarContent /> }
+			footer={
+				<VStack spacing={ 0 }>
+					{ templates?.map( ( item ) => (
+						<PageItem
+							postType={ TEMPLATE_POST_TYPE }
+							postId={ item.id }
+							key={ item.id }
+							icon={ layout }
+							withChevron
+						>
+							<Truncate numberOfLines={ 1 }>
+								{ decodeEntities(
+									item.title?.rendered || __( '(no title)' )
+								) }
+							</Truncate>
+						</PageItem>
+					) ) }
+				</VStack>
+			}
+		/>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -7,7 +7,6 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { memo, useRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
@@ -32,9 +31,8 @@ import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen
 import SaveHub from '../save-hub';
 import { unlock } from '../../lock-unlock';
 import SidebarNavigationScreenPages from '../sidebar-navigation-screen-pages';
+import SidebarNavigationScreenPagesDataViews from '../sidebar-navigation-screen-pages-dataviews';
 import SidebarNavigationScreenPage from '../sidebar-navigation-screen-page';
-import SidebarNavigationScreen from '../sidebar-navigation-screen';
-import DataViewsSidebarContent from '../sidebar-dataviews';
 
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -69,10 +67,7 @@ function SidebarScreens() {
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page">
 				{ window?.__experimentalAdminViews ? (
-					<SidebarNavigationScreen
-						title={ __( 'Pages' ) }
-						content={ <DataViewsSidebarContent /> }
-					/>
+					<SidebarNavigationScreenPagesDataViews />
 				) : (
 					<SidebarNavigationScreenPages />
 				) }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/57578

## What?

Adds a footer to the sidebar of `Pages` containing the `404` and `Search` templates.

<img width="1512" alt="Captura de ecrã 2024-01-09, às 18 25 23" src="https://github.com/WordPress/gutenberg/assets/583546/47ad6751-1301-4ca0-a8e3-e4021817e48e">

## Why?

To achieve feature parity with the existing `Pages` root.

## How?

Creates a new `SidebarNavigationScreenPagesDataViews` that adds the footer.

## Testing Instructions

- Enable the "view admin" experiment and visit "Pages".
- Verify the footer is present and works as expected.
