### PR TITLE
Global Styles: Allow font sizes to be overridden

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -104,7 +104,7 @@ function getUniqueFontSizesBySlug( settings ) {
 	const fontSizes = settings?.typography?.fontSizes;
 	const mergedFontSizes = fontSizes ? mergeOrigins( fontSizes ) : [];
 	const uniqueSizes = [];
-	for ( const currentSize of mergedFontSizes ) {
+	for ( const currentSize of mergedFontSizes.reverse() ) {
 		if ( ! uniqueSizes.some( ( { slug } ) => slug === currentSize.slug ) ) {
 			uniqueSizes.push( currentSize );
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Allow themes to override the default font sizes.

WIP

## Why?
When a theme provides custom font sizes that use the same slugs as the default, the theme ones should override the defaults.

## How?
The way that this works is not the right way to do it.

Font sizes get merged from "default" and "theme" into a "custom" attribute. This is then made unique in order, so I have reversed the order so that the theme settings win. I _think_ the way we should do this is to provide both "default" and "theme" to the control and allow it to do a merge based on the key rather than just the order.

## Testing Instructions
1. Add this to your theme.json:
```
                               {
                                       "name": "Override Small",
                                       "slug": "small",
                                       "size": "26px"
                               },
                               {
                                       "name": "Override Medium",
                                       "slug": "medium",
                                       "size": "40px"
                               },
                               {
                                       "name": "Override Large",
                                       "slug": "largel",
                                       "size": "72px"
                                }
```
2. Add a paragraph block and open the block inspector
3. Check the names of the font sizes in the typography controls
4. You should see the custom names when you hover the controls

## Screenshots or screencast <!-- if applicable -->
<img width="289" alt="Screenshot 2024-01-09 at 17 30 15" src="https://github.com/WordPress/gutenberg/assets/275961/b219a7e2-9d45-476a-8dbb-8418189f2770">
