### PR TITLE
Fix formatting issue due to incorrect link parsing in the Quick Start Guide

### DIFF
--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -41,7 +41,7 @@ When you are finished making changes, run the `npm run build` command. This opti
 
 You can use any local WordPress development environment to test your new block, but the scaffolded plugin includes configuration for `wp-env`. You must have [Docker](https://www.docker.com/products/docker-desktop) already installed and running on your machine, but if you do, run the `npx wp-env start` command. 
 
-Once the script finishes running, you can access the local environment at: `http://localhost:8888`. Log into the WordPress dashboard using username `admin` and password `password`. The plugin will already be installed and activated. Open the Editor or Site Editor, and insert the Copyright Date Block as you would any other block.
+Once the script finishes running, you can access the local environment at: <code>http://localhost:8888</code>. Log into the WordPress dashboard using username `admin` and password `password`. The plugin will already be installed and activated. Open the Editor or Site Editor, and insert the Copyright Date Block as you would any other block.
 
 Visit the [Getting started](https://developer.wordpress.org/block-editor/getting-started/devenv/get-started-with-wp-env/) guide to learn more about `wp-env`.
 


### PR DESCRIPTION
There is an issue in the Block Editor Handbook where links wrapped in backticks (\`) do not properly turn into code. This issue is [logged here](https://github.com/WordPress/wporg-developer/issues/466), but the temporary solution is to wrap the link in actual `<code>` markup. 

| Before | After |
|-|-|
|<img width="1022" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/20976da0-e300-4ee4-8f81-619240f8772b">|<img width="1032" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/e740194e-98e0-4d61-a03d-dcfa8a969f84">|
