### PR TITLE
Download then upload font face assets when installing from a collection

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -164,6 +164,9 @@ function FontCollection( { id } ) {
 		try {
 			for ( let i = 0; i < fontFamily.fontFace.length; i++ ) {
 				const fontFace = fontFamily.fontFace[ i ];
+				if ( ! fontFace.downloadFromUrl ) {
+					continue;
+				}
 				fontFace.file = await downloadFontFaceAsset(
 					fontFace.downloadFromUrl
 				);

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -158,15 +158,21 @@ function FontCollection( { id } ) {
 		const fontFamily = fontsToInstall[ 0 ];
 
 		try {
-			fontFamily?.fontFace?.forEach( async ( fontFace ) => {
-				if ( fontFace.downloadFromUrl ) {
-					fontFace.file = await downloadFontFaceAsset(
-						fontFace.downloadFromUrl
-					);
-					delete fontFace.downloadFromUrl;
-				}
-			} );
+			if ( fontFamily?.fontFace ) {
+				await Promise.all(
+					fontFamily.fontFace.map( async ( fontFace ) => {
+						if ( fontFace.downloadFromUrl ) {
+							fontFace.file = await downloadFontFaceAsset(
+								fontFace.downloadFromUrl
+							);
+							delete fontFace.downloadFromUrl;
+						}
+					} )
+				);
+			}
 		} catch ( error ) {
+			// If any of the fonts fail to download,
+			// show an error notice and stop the request from being sent.
 			setNotice( {
 				type: 'error',
 				message: __(

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -31,11 +31,7 @@ import { toggleFont } from './utils/toggleFont';
 import { getFontsOutline } from './utils/fonts-outline';
 import GoogleFontsConfirmDialog from './google-fonts-confirm-dialog';
 import { getNoticeFromInstallResponse } from './utils/get-notice-from-response';
-
-/**
- * Browser dependencies
- */
-const { File } = window;
+import { downloadFontFaceAsset } from './utils';
 
 const DEFAULT_CATEGORY = {
 	id: 'all',
@@ -162,16 +158,14 @@ function FontCollection( { id } ) {
 		const fontFamily = fontsToInstall[ 0 ];
 
 		try {
-			for ( let i = 0; i < fontFamily.fontFace.length; i++ ) {
-				const fontFace = fontFamily.fontFace[ i ];
-				if ( ! fontFace.downloadFromUrl ) {
-					continue;
+			fontFamily?.fontFace?.forEach( async ( fontFace ) => {
+				if ( fontFace.downloadFromUrl ) {
+					fontFace.file = await downloadFontFaceAsset(
+						fontFace.downloadFromUrl
+					);
+					delete fontFace.downloadFromUrl;
 				}
-				fontFace.file = await downloadFontFaceAsset(
-					fontFace.downloadFromUrl
-				);
-				delete fontFace.downloadFromUrl;
-			}
+			} );
 		} catch ( error ) {
 			setNotice( {
 				type: 'error',
@@ -186,20 +180,6 @@ function FontCollection( { id } ) {
 		const installNotice = getNoticeFromInstallResponse( response );
 		setNotice( installNotice );
 		resetFontsToInstall();
-	};
-
-	const downloadFontFaceAsset = async ( url ) => {
-		return fetch( new Request( url ) )
-			.then( ( response ) => {
-				return response.blob();
-			} )
-			.then( ( blob ) => {
-				const filename = url.split( '/' ).pop();
-				const file = new File( [ blob ], filename, {
-					type: blob.type,
-				} );
-				return file;
-			} );
 	};
 
 	return (

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -161,12 +161,22 @@ function FontCollection( { id } ) {
 	const handleInstall = async () => {
 		const fontFamily = fontsToInstall[ 0 ];
 
-		for ( let i = 0; i < fontFamily.fontFace.length; i++ ) {
-			const fontFace = fontFamily.fontFace[ i ];
-			fontFace.file = await downloadFontFaceAsset(
-				fontFace.downloadFromUrl
-			);
-			delete fontFace.downloadFromUrl;
+		try {
+			for ( let i = 0; i < fontFamily.fontFace.length; i++ ) {
+				const fontFace = fontFamily.fontFace[ i ];
+				fontFace.file = await downloadFontFaceAsset(
+					fontFace.downloadFromUrl
+				);
+				delete fontFace.downloadFromUrl;
+			}
+		} catch ( error ) {
+			setNotice( {
+				type: 'error',
+				message: __(
+					'Error installing the fonts, could not be downloaded.'
+				),
+			} );
+			return;
 		}
 
 		const response = await installFont( fontFamily );
@@ -178,11 +188,6 @@ function FontCollection( { id } ) {
 	const downloadFontFaceAsset = async ( url ) => {
 		return fetch( new Request( url ) )
 			.then( ( response ) => {
-				if ( ! response.ok ) {
-					throw new Error(
-						`HTTP error! Status: ${ response.status }`
-					);
-				}
 				return response.blob();
 			} )
 			.then( ( blob ) => {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -176,6 +176,11 @@ export function makeFormDataFromFontFamily( fontFamily ) {
 export async function downloadFontFaceAsset( url ) {
 	return fetch( new Request( url ) )
 		.then( ( response ) => {
+			if ( ! response.ok ) {
+				throw new Error(
+					`Error downloading font face asset from ${ url }. Server responded with status: ${ response.status }`
+				);
+			}
 			return response.blob();
 		} )
 		.then( ( blob ) => {
@@ -184,5 +189,13 @@ export async function downloadFontFaceAsset( url ) {
 				type: blob.type,
 			} );
 			return file;
+		} )
+		.catch( ( error ) => {
+			// eslint-disable-next-line no-console
+			console.error(
+				`Error downloading font face asset from ${ url }:`,
+				error
+			);
+			throw error;
 		} );
 }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -9,6 +9,11 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { FONT_WEIGHTS, FONT_STYLES } from './constants';
 import { unlock } from '../../../../lock-unlock';
 
+/**
+ * Browser dependencies
+ */
+const { File } = window;
+
 export function setUIValuesNeeded( font, extraValues = {} ) {
 	if ( ! font.name && ( font.fontFamily || font.slug ) ) {
 		font.name = font.fontFamily || font.slug;
@@ -163,4 +168,21 @@ export function makeFormDataFromFontFamily( fontFamily ) {
 
 	formData.append( 'font_family_settings', JSON.stringify( newFontFamily ) );
 	return formData;
+}
+
+/*
+ * Downloads a font face asset from a URL to the client and returns a File object.
+ */
+export async function downloadFontFaceAsset( url ) {
+	return fetch( new Request( url ) )
+		.then( ( response ) => {
+			return response.blob();
+		} )
+		.then( ( blob ) => {
+			const filename = url.split( '/' ).pop();
+			const file = new File( [ blob ], filename, {
+				type: blob.type,
+			} );
+			return file;
+		} );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This changes the way the client installs fonts from a remote location by first downloading then uploading.

## Why?
We eliminate the need to "sideload" a font from a remote location.

## How?
The client uses the same mechanisms to install a Font Face for 'remote' resources as it does for 'local' resources.  It first downloads ALL of the selected remote assets.  Once all of them are collected locally (via `fetch()`) they are sent to the font library API as multipart-data.

## Testing Instructions
Install and activate a font from the Default Font Collection (Google fonts)
Observe the traffic.  Note that the file is first downloaded and then attached to the request to install the font face.
Note that the font face works as expected with the UI (should seem unchanged).
