### PR TITLE
Design tools: add aria labels to the inputs of Height Control

### DIFF
--- a/packages/block-editor/src/components/height-control/index.js
+++ b/packages/block-editor/src/components/height-control/index.js
@@ -157,11 +157,14 @@ export default function HeightControl( {
 						onUnitChange={ handleUnitChange }
 						min={ 0 }
 						size={ '__unstable-large' }
+						aria-label={ __( 'Input custom height value' ) }
 					/>
 				</FlexItem>
 				<FlexItem isBlock>
 					<Spacer marginX={ 2 } marginBottom={ 0 }>
 						<RangeControl
+							label={ __( 'Adjust custom height value' ) }
+							hideLabelFromVision
 							value={ customRangeValue }
 							min={ 0 }
 							max={


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/57681

## What?
Adds labels to the controls in the `<HeightControl />` component.

This component comprises two input:

1. A custom height input field
2. A range control input field

When used as a minimum height control, the component's fieldset already has a legend of "Min. Height".

## Why?
To label these interactive controls.

## Testing Instructions
1. Select a block that provides a height control e.g. a Group block.
2. Locate the Min. Height control in the Settings Panel > Styles tab > Dimensions.
4. Inspect the source in the dev tools and check that the input elements are labeled (aria-label for both)

The range component will output a hidden `<label />` element as well. This is its default behaviour.

Output:

The custom input:

```html
<input autocomplete="off" inputmode="numeric" aria-label="Input custom height value" max="Infinity" min="0" step="1" class="components-input-control__input" id="inspector-input-control-4" type="number" value="">
```


The range control:

```html
<input class="components-range-control__slider" id="inspector-range-control-6" max="1000" min="0" step="1" aria-label="Adjust custom height value" aria-hidden="false" tabindex="0" type="range" value="0">
```
