### PR TITLE
Components: Tabs: Improve Controlled Mode Focus Handling

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 -   `Guide`, `Modal`: Restore accent color themability ([#58098](https://github.com/WordPress/gutenberg/pull/58098)).
 -   `DropdownMenuV2`: Restore accent color themability ([#58130](https://github.com/WordPress/gutenberg/pull/58130)).
+-   `Tabs`: improve controlled mode focus handling and keyboard navigation ([#57696](https://github.com/WordPress/gutenberg/pull/57696)).
 -   Expand theming support in the `COLORS` variable object ([#58097](https://github.com/WordPress/gutenberg/pull/58097)).
 
 ## 25.16.0 (2024-01-24)
@@ -45,7 +46,6 @@
 -   `BoxControl`: Update design ([#56665](https://github.com/WordPress/gutenberg/pull/56665)).
 -   `CustomSelect`: adjust `renderSelectedValue` to fix sizing ([#57865](https://github.com/WordPress/gutenberg/pull/57865)).
 -   `Theme`: Set `color` on wrapper div ([#58095](https://github.com/WordPress/gutenberg/pull/58095)).
--   `Tabs`: improve controlled mode focus handling and keyboard navigation ([#57696](https://github.com/WordPress/gutenberg/pull/57696)).
 
 ## 25.15.0 (2024-01-10)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -84,6 +84,7 @@
 -   `DropdownMenuV2`: remove temporary radix UI based implementation ([#55626](https://github.com/WordPress/gutenberg/pull/55626)).
 -   `Tabs`: do not render hidden content ([#57046](https://github.com/WordPress/gutenberg/pull/57046)).
 -   `Tabs`: improve hover and text alignment styles ([#57275](https://github.com/WordPress/gutenberg/pull/57275)).
+-   `Tabs`: improve controlled mode focus handling ([#57696](https://github.com/WordPress/gutenberg/pull/57696)).
 -   `Tabs`: make sure `Tab`s are associated to the right `TabPanel`s, regardless of the order they're rendered in ([#57033](https://github.com/WordPress/gutenberg/pull/57033)).
 
 ## 25.14.0 (2023-12-13)

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -45,6 +45,7 @@
 -   `BoxControl`: Update design ([#56665](https://github.com/WordPress/gutenberg/pull/56665)).
 -   `CustomSelect`: adjust `renderSelectedValue` to fix sizing ([#57865](https://github.com/WordPress/gutenberg/pull/57865)).
 -   `Theme`: Set `color` on wrapper div ([#58095](https://github.com/WordPress/gutenberg/pull/58095)).
+-   `Tabs`: improve controlled mode focus handling and keyboard navigation ([#57696](https://github.com/WordPress/gutenberg/pull/57696)).
 
 ## 25.15.0 (2024-01-10)
 
@@ -84,7 +85,6 @@
 -   `DropdownMenuV2`: remove temporary radix UI based implementation ([#55626](https://github.com/WordPress/gutenberg/pull/55626)).
 -   `Tabs`: do not render hidden content ([#57046](https://github.com/WordPress/gutenberg/pull/57046)).
 -   `Tabs`: improve hover and text alignment styles ([#57275](https://github.com/WordPress/gutenberg/pull/57275)).
--   `Tabs`: improve controlled mode focus handling ([#57696](https://github.com/WordPress/gutenberg/pull/57696)).
 -   `Tabs`: make sure `Tab`s are associated to the right `TabPanel`s, regardless of the order they're rendered in ([#57033](https://github.com/WordPress/gutenberg/pull/57033)).
 
 ## 25.14.0 (2023-12-13)

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -179,13 +179,6 @@ function Tabs( {
 			typeof previousSelectedId === 'string' &&
 			previousSelectedId === activeElement?.id;
 
-		// If the previously selected tab had focus when the selection changed,
-		// move focus to the newly selected tab.
-		if ( previousSelectedTabHadFocus && selectedId !== activeElement.id ) {
-			move( selectedId );
-			return;
-		}
-
 		// If a tab other than the one previously selected had focus when the
 		// selection changed, update the activeId to the currently focused tab.
 		// The activeId controls how arrow key navigation behaves. Keeping them

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -168,22 +168,20 @@ function Tabs( {
 		const currentItem = items.find( ( item ) => item.id === selectedId );
 		const activeElement = currentItem?.element?.ownerDocument.activeElement;
 
-		const tabsHasFocus =
-			activeElement &&
-			items.some( ( item ) => {
-				return activeElement === item.element;
-			} );
+		if (
+			! activeElement ||
+			! items.some( ( item ) => activeElement === item.element )
+		) {
+			return; // Return early if no tabs are focused.
+		}
+
 		const previousSelectedTabHadFocus =
 			typeof previousSelectedId === 'string' &&
 			previousSelectedId === activeElement?.id;
 
 		// If the previously selected tab had focus when the selection changed,
 		// move focus to the newly selected tab.
-		if (
-			tabsHasFocus &&
-			previousSelectedTabHadFocus &&
-			selectedId !== activeElement.id
-		) {
+		if ( previousSelectedTabHadFocus && selectedId !== activeElement.id ) {
 			move( selectedId );
 			return;
 		}
@@ -192,7 +190,7 @@ function Tabs( {
 		// selection changed, update the activeId to the currently focused tab.
 		// The activeId controls how arrow key navigation behaves. Keeping them
 		// in sync avoids confusion when navigating tabs with the keyboard.
-		if ( tabsHasFocus && ! previousSelectedTabHadFocus ) {
+		if ( ! previousSelectedTabHadFocus ) {
 			setActiveId( activeElement.id );
 		}
 	}, [

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -164,9 +164,8 @@ function Tabs( {
 			return;
 		}
 
-		const currentItem = items.find( ( item ) => item.id === selectedId );
 		const focusedElement =
-			currentItem?.element?.ownerDocument.activeElement;
+			items?.[ 0 ]?.element?.ownerDocument.activeElement;
 
 		if (
 			! focusedElement ||
@@ -182,7 +181,7 @@ function Tabs( {
 		if ( activeId !== focusedElement.id ) {
 			setActiveId( focusedElement.id );
 		}
-	}, [ activeId, isControlled, items, selectedId, setActiveId ] );
+	}, [ activeId, isControlled, items, setActiveId ] );
 
 	const contextValue = useMemo(
 		() => ( {

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -7,8 +7,13 @@ import * as Ariakit from '@ariakit/react';
 /**
  * WordPress dependencies
  */
-import { useInstanceId } from '@wordpress/compose';
-import { useLayoutEffect, useMemo, useRef } from '@wordpress/element';
+import { useInstanceId, usePrevious } from '@wordpress/compose';
+import {
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,7 +50,7 @@ function Tabs( {
 	const isControlled = selectedTabId !== undefined;
 
 	const { items, selectedId } = store.useState();
-	const { setSelectedId, move } = store;
+	const { setSelectedId, setActiveId, move } = store;
 
 	// Keep track of whether tabs have been populated. This is used to prevent
 	// certain effects from firing too early while tab data and relevant
@@ -154,26 +159,49 @@ function Tabs( {
 		setSelectedId,
 	] );
 
-	// In controlled mode, make sure browser focus follows the selected tab if
-	// the selection is changed while a tab is already being focused.
-	useLayoutEffect( () => {
-		if ( ! isControlled || ! selectOnMove ) {
+	const previousSelectedId = usePrevious( selectedId );
+
+	useEffect( () => {
+		if ( ! isControlled ) {
 			return;
 		}
 		const currentItem = items.find( ( item ) => item.id === selectedId );
 		const activeElement = currentItem?.element?.ownerDocument.activeElement;
-		const tabsHasFocus = items.some( ( item ) => {
-			return activeElement && activeElement === item.element;
-		} );
 
-		if (
+		const tabsHasFocus =
 			activeElement &&
+			items.some( ( item ) => {
+				return activeElement === item.element;
+			} );
+		const previousSelectedTabHadFocus =
+			previousSelectedId === activeElement?.id;
+
+		// If the previously selected tab had focus when the selection changed,
+		// move focus to the newly selected tab.
+		if (
 			tabsHasFocus &&
+			previousSelectedTabHadFocus &&
 			selectedId !== activeElement.id
 		) {
 			move( selectedId );
+			return;
 		}
-	}, [ isControlled, items, move, selectOnMove, selectedId ] );
+
+		// If a tab other than the one previously selected had focus when the
+		// selection changed, update the activeId to the currently focused tab.
+		// The activeId controls how arrow key navigation behaves. Keeping them
+		// in sync avoids confusion when navigating tabs with the keyboard.
+		if ( tabsHasFocus && ! previousSelectedTabHadFocus ) {
+			setActiveId( activeElement.id );
+		}
+	}, [
+		isControlled,
+		items,
+		move,
+		previousSelectedId,
+		selectedId,
+		setActiveId,
+	] );
 
 	const contextValue = useMemo(
 		() => ( {

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -174,6 +174,7 @@ function Tabs( {
 				return activeElement === item.element;
 			} );
 		const previousSelectedTabHadFocus =
+			typeof previousSelectedId === 'string' &&
 			previousSelectedId === activeElement?.id;
 
 		// If the previously selected tab had focus when the selection changed,

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -274,17 +274,29 @@ const ControlledModeTemplate: StoryFn< typeof Tabs > = ( props ) => {
 					<DropdownMenu
 						controls={ [
 							{
-								onClick: () => setSelectedTabId( 'tab1' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab1' ),
+										3000
+									),
 								title: 'Tab 1',
 								isActive: selectedTabId === 'tab1',
 							},
 							{
-								onClick: () => setSelectedTabId( 'tab2' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab2' ),
+										3000
+									),
 								title: 'Tab 2',
 								isActive: selectedTabId === 'tab2',
 							},
 							{
-								onClick: () => setSelectedTabId( 'tab3' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab3' ),
+										3000
+									),
 								title: 'Tab 3',
 								isActive: selectedTabId === 'tab3',
 							},
@@ -300,6 +312,7 @@ const ControlledModeTemplate: StoryFn< typeof Tabs > = ( props ) => {
 export const ControlledMode = ControlledModeTemplate.bind( {} );
 ControlledMode.args = {
 	selectedTabId: 'tab3',
+	selectOnMove: false,
 };
 
 const TabBecomesDisabledTemplate: StoryFn< typeof Tabs > = ( props ) => {

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -274,29 +274,17 @@ const ControlledModeTemplate: StoryFn< typeof Tabs > = ( props ) => {
 					<DropdownMenu
 						controls={ [
 							{
-								onClick: () =>
-									setTimeout(
-										() => setSelectedTabId( 'tab1' ),
-										3000
-									),
+								onClick: () => setSelectedTabId( 'tab1' ),
 								title: 'Tab 1',
 								isActive: selectedTabId === 'tab1',
 							},
 							{
-								onClick: () =>
-									setTimeout(
-										() => setSelectedTabId( 'tab2' ),
-										3000
-									),
+								onClick: () => setSelectedTabId( 'tab2' ),
 								title: 'Tab 2',
 								isActive: selectedTabId === 'tab2',
 							},
 							{
-								onClick: () =>
-									setTimeout(
-										() => setSelectedTabId( 'tab3' ),
-										3000
-									),
+								onClick: () => setSelectedTabId( 'tab3' ),
 								title: 'Tab 3',
 								isActive: selectedTabId === 'tab3',
 							},
@@ -312,7 +300,6 @@ const ControlledModeTemplate: StoryFn< typeof Tabs > = ( props ) => {
 export const ControlledMode = ControlledModeTemplate.bind( {} );
 ControlledMode.args = {
 	selectedTabId: 'tab3',
-	selectOnMove: false,
 };
 
 const TabBecomesDisabledTemplate: StoryFn< typeof Tabs > = ( props ) => {

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -28,11 +28,30 @@ export const TabList = forwardRef<
 		return null;
 	}
 	const { store } = context;
+
+	const { selectedId, activeId, selectOnMove } = store.useState();
+	const { setActiveId } = store;
+
+	const onBlur = () => {
+		if ( ! selectOnMove ) {
+			return;
+		}
+
+		// When automatic tab selection is on, make sure that the active tab is up
+		// to date with the selected tab when leaving the tablist. This makes sure
+		// that the selected tab will receive keyboard focus when tabbing back into
+		// the tablist.
+		if ( selectedId !== activeId ) {
+			setActiveId( selectedId );
+		}
+	};
+
 	return (
 		<Ariakit.TabList
 			ref={ ref }
 			store={ store }
 			render={ <TabListWrapper /> }
+			onBlur={ onBlur }
 			{ ...otherProps }
 		>
 			{ children }

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1172,6 +1172,66 @@ describe( 'Tabs', () => {
 				).not.toBeInTheDocument();
 			} );
 		} );
+		describe( 'When `selectedId` is changed by the controlling component', () => {
+			it( 'should automatically update focus if the selected tab already had focus', async () => {
+				const { rerender } = render(
+					<ControlledTabs
+						tabs={ TABS }
+						selectedTabId="beta"
+						selectOnMove={ false }
+					/>
+				);
+
+				// Tab key should focus the currently selected tab, which is Beta.
+				await press.Tab();
+				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
+				expect( await getSelectedTab() ).toHaveFocus();
+
+				rerender(
+					<ControlledTabs
+						tabs={ TABS }
+						selectedTabId="gamma"
+						selectOnMove={ false }
+					/>
+				);
+
+				// When the selected tab is changed, it should automatically receive focus.
+				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
+				expect( await getSelectedTab() ).toHaveFocus();
+			} );
+			it( 'should not automatically update focus if the selected tab was not already focused', async () => {
+				const { rerender } = render(
+					<ControlledTabs
+						tabs={ TABS }
+						selectedTabId="beta"
+						selectOnMove={ false }
+					/>
+				);
+
+				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
+
+				// Tab key should focus the currently selected tab, which is Beta.
+				await press.Tab();
+				expect( await getSelectedTab() ).toHaveFocus();
+				// Arrow left to focus Alpha, which is not the currently
+				// selected tab
+				await press.ArrowLeft();
+
+				rerender(
+					<ControlledTabs
+						tabs={ TABS }
+						selectedTabId="gamma"
+						selectOnMove={ false }
+					/>
+				);
+
+				// When the selected tab is changed, it should not automatically receive focus.
+				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
+				expect(
+					screen.getByRole( 'tab', { name: 'Alpha' } )
+				).toHaveFocus();
+			} );
+		} );
 
 		describe( 'When `selectOnMove` is `true`', () => {
 			it( 'should automatically select a newly focused tab', async () => {
@@ -1185,24 +1245,6 @@ describe( 'Tabs', () => {
 
 				// Arrow keys should select and move focus to the next tab.
 				await press.ArrowRight();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-				expect( await getSelectedTab() ).toHaveFocus();
-			} );
-			it( 'should automatically update focus when the selected tab is changed by the controlling component', async () => {
-				const { rerender } = render(
-					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
-				);
-
-				// Tab key should focus the currently selected tab, which is Beta.
-				await press.Tab();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-				expect( await getSelectedTab() ).toHaveFocus();
-
-				rerender(
-					<ControlledTabs tabs={ TABS } selectedTabId="gamma" />
-				);
-
-				// When the selected tab is changed, it should automatically receive focus.
 				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
 				expect( await getSelectedTab() ).toHaveFocus();
 			} );
@@ -1246,37 +1288,6 @@ describe( 'Tabs', () => {
 				// Pressing the enter/return should select the focused tab.
 				await press.Enter();
 				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			} );
-			it( 'should not automatically update focus when the selected tab is changed by the controlling component', async () => {
-				const { rerender } = render(
-					<ControlledTabs
-						tabs={ TABS }
-						selectedTabId="beta"
-						selectOnMove={ false }
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				// Tab key should focus the currently selected tab, which is Beta.
-				await press.Tab();
-				await waitFor( async () =>
-					expect( await getSelectedTab() ).toHaveFocus()
-				);
-
-				rerender(
-					<ControlledTabs
-						tabs={ TABS }
-						selectedTabId="gamma"
-						selectOnMove={ false }
-					/>
-				);
-
-				// When the selected tab is changed, it should not automatically receive focus.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-				expect(
-					screen.getByRole( 'tab', { name: 'Beta' } )
-				).toHaveFocus();
 			} );
 		} );
 	} );

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -14,7 +14,6 @@ import { useEffect, useState } from '@wordpress/element';
  */
 import Tabs from '..';
 import type { TabsProps } from '../types';
-import { act } from 'react-dom/test-utils';
 
 type Tab = {
 	tabId: string;
@@ -1174,79 +1173,32 @@ describe( 'Tabs', () => {
 			} );
 		} );
 		describe( 'When `selectedId` is changed by the controlling component', () => {
-			describe.each( [ true, false ] )(
-				'When `selectOnMove` is `%s`',
-				( selectOnMove ) => {
-					it( 'should move focus to the newly selected tab if the previously selected tab was focused', async () => {
-						const { rerender } = render(
-							<ControlledTabs
-								tabs={ TABS }
-								selectedTabId="beta"
-								selectOnMove={ selectOnMove }
-							/>
-						);
+			it( 'should continue to handle arrow key navigation properly', async () => {
+				const { rerender } = render(
+					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
+				);
 
-						// Tab key should focus the currently selected tab, which is Beta.
-						await press.Tab();
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Beta'
-						);
-						expect( await getSelectedTab() ).toHaveFocus();
+				// Tab key should focus the currently selected tab, which is Beta.
+				await press.Tab();
+				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
+				expect( await getSelectedTab() ).toHaveFocus();
 
-						rerender(
-							<ControlledTabs
-								tabs={ TABS }
-								selectedTabId="gamma"
-								selectOnMove={ selectOnMove }
-							/>
-						);
+				rerender(
+					<ControlledTabs tabs={ TABS } selectedTabId="gamma" />
+				);
 
-						// When the selected tab is changed, it should automatically receive focus.
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Gamma'
-						);
-						expect( await getSelectedTab() ).toHaveFocus();
-					} );
-					it( 'should not move focus to the newly selected tab if the previously selected tab was not focused', async () => {
-						const { rerender } = render(
-							<ControlledTabs
-								tabs={ TABS }
-								selectedTabId="beta"
-								selectOnMove={ selectOnMove }
-							/>
-						);
+				// When the selected tab is changed, it should not automatically receive focus.
+				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
+				expect(
+					screen.getByRole( 'tab', { name: 'Beta' } )
+				).toHaveFocus();
 
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Beta'
-						);
-
-						// Tab key should focus the currently selected tab, which is Beta.
-						await press.Tab();
-						expect( await getSelectedTab() ).toHaveFocus();
-						// Focus Alpha, which is not the currently selected tab
-						// (not the most elegant way, but it does the job).
-						act( () =>
-							screen.getByRole( 'tab', { name: 'Alpha' } ).focus()
-						);
-
-						rerender(
-							<ControlledTabs
-								tabs={ TABS }
-								selectedTabId="gamma"
-								selectOnMove={ selectOnMove }
-							/>
-						);
-
-						// When the selected tab is changed, it should not automatically receive focus.
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Gamma'
-						);
-						expect(
-							screen.getByRole( 'tab', { name: 'Alpha' } )
-						).toHaveFocus();
-					} );
-				}
-			);
+				// Arrow keys should move focus to the next tab, which is Gamma
+				await press.ArrowRight();
+				expect(
+					screen.getByRole( 'tab', { name: 'Gamma' } )
+				).toHaveFocus();
+			} );
 		} );
 
 		describe( 'When `selectOnMove` is `true`', () => {

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1173,32 +1173,109 @@ describe( 'Tabs', () => {
 			} );
 		} );
 		describe( 'When `selectedId` is changed by the controlling component', () => {
-			it( 'should continue to handle arrow key navigation properly', async () => {
-				const { rerender } = render(
-					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
-				);
+			describe.each( [ true, false ] )(
+				'and `selectOnMove` is %s',
+				( selectOnMove ) => {
+					it( 'should continue to handle arrow key navigation properly', async () => {
+						const { rerender } = render(
+							<ControlledTabs
+								tabs={ TABS }
+								selectedTabId="beta"
+								selectOnMove={ selectOnMove }
+							/>
+						);
 
-				// Tab key should focus the currently selected tab, which is Beta.
-				await press.Tab();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-				expect( await getSelectedTab() ).toHaveFocus();
+						// Tab key should focus the currently selected tab, which is Beta.
+						await press.Tab();
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Beta'
+						);
+						expect( await getSelectedTab() ).toHaveFocus();
 
-				rerender(
-					<ControlledTabs tabs={ TABS } selectedTabId="gamma" />
-				);
+						rerender(
+							<ControlledTabs
+								tabs={ TABS }
+								selectedTabId="gamma"
+								selectOnMove={ selectOnMove }
+							/>
+						);
 
-				// When the selected tab is changed, it should not automatically receive focus.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-				expect(
-					screen.getByRole( 'tab', { name: 'Beta' } )
-				).toHaveFocus();
+						// When the selected tab is changed, it should not automatically receive focus.
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Gamma'
+						);
+						expect(
+							screen.getByRole( 'tab', { name: 'Beta' } )
+						).toHaveFocus();
 
-				// Arrow keys should move focus to the next tab, which is Gamma
-				await press.ArrowRight();
-				expect(
-					screen.getByRole( 'tab', { name: 'Gamma' } )
-				).toHaveFocus();
-			} );
+						// Arrow keys should move focus to the next tab, which is Gamma
+						await press.ArrowRight();
+						expect(
+							screen.getByRole( 'tab', { name: 'Gamma' } )
+						).toHaveFocus();
+					} );
+
+					it( 'should focus the correct tab when tabbing out and back into the tablist', async () => {
+						const { rerender } = render(
+							<>
+								<button>Focus me</button>
+								<ControlledTabs
+									tabs={ TABS }
+									selectedTabId="beta"
+									selectOnMove={ selectOnMove }
+								/>
+							</>
+						);
+
+						// Tab key should focus the currently selected tab, which is Beta.
+						await press.Tab();
+						await press.Tab();
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Beta'
+						);
+						expect( await getSelectedTab() ).toHaveFocus();
+
+						rerender(
+							<>
+								<button>Focus me</button>
+								<ControlledTabs
+									tabs={ TABS }
+									selectedTabId="gamma"
+									selectOnMove={ selectOnMove }
+								/>
+							</>
+						);
+
+						// When the selected tab is changed, it should not automatically receive focus.
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Gamma'
+						);
+						expect(
+							screen.getByRole( 'tab', { name: 'Beta' } )
+						).toHaveFocus();
+
+						// Press shift+tab, move focus to the button before Tabs
+						await press.ShiftTab();
+						expect(
+							screen.getByRole( 'button', { name: 'Focus me' } )
+						).toHaveFocus();
+
+						// Press tab, move focus back to the tablist
+						await press.Tab();
+
+						const betaTab = screen.getByRole( 'tab', {
+							name: 'Beta',
+						} );
+						const gammaTab = screen.getByRole( 'tab', {
+							name: 'Gamma',
+						} );
+
+						expect(
+							selectOnMove ? gammaTab : betaTab
+						).toHaveFocus();
+					} );
+				}
+			);
 		} );
 
 		describe( 'When `selectOnMove` is `true`', () => {

--- a/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
@@ -75,7 +75,7 @@ test.describe( 'Order of block keyboard navigation', () => {
 		);
 
 		await page.keyboard.press( 'Tab' );
-		await KeyboardNavigableBlocks.expectLabelToHaveFocus( 'Post' );
+		await KeyboardNavigableBlocks.expectLabelToHaveFocus( 'Block' );
 	} );
 
 	test( 'allows tabbing in navigation mode if no block is selected (reverse)', async ( {


### PR DESCRIPTION
This PR is meant to initially serve as a proof of concept and place for discussion. I've included a possible path forward but I'm primarily interested in feedback on what the best path forward is. I put the changes together because I wanted to test their viability for own purposes, and figured I may as well include them in case a working example was helpful.

## What?

~Limit `controlled`-mode `Tabs` component focus updates related to selection changes to cases when the tab selected at the time of the change had focus.~

Remove the automatic focus syncing behavior while adding a new check to ensure arrow key navigation is preserved.

## Why?

Currently, the `Tabs` component is set to make sure that in controlled mode, if a tab has browser focus and the selected tab changes, the newly selected tab gets focus. This was first [discussed](https://github.com/WordPress/gutenberg/pull/55360#issuecomment-1828420884) when introducing the new `Tabs` component into the editor settings, and introduced in #56658. In that initial PR, we intentionally skip the focus updates when `selectOnMove` is `false`, to avoid moving focus on a user who is actively navigating across the available tabs.

In a [separate but similar PR](https://github.com/WordPress/gutenberg/pull/56959), we came to the conclusion that manual selection was a better option for the tabs in question. This means the update mentioned above will no longer apply, (`selectOnMove` will be `false`) and the selected tab can easily become out of sync with the currently focused tab.

I had two thoughts on how to address this:
- Completely remove the condition that `selectOnMove` be `true` for keeping focus and selection in sync
- Remove the `selectOnMove` condition, but limit the actual focus update to cases where the tab that was selected at that time of the change actually had focus.

~This PR experiments with the second option as a bit of a compromise. @andrewhayward's advice in the discussion linked above was to err on the side of not manipulating focus more than necessary. With the approach on this PR, if you've placed focus on the currently selected tab and the selection changes, focus will update you'll ultimately end up with focus still in alignment with the displayed content. On the other hand, if you've explicitly moved focus away from the selected tab the focus will not be changed. This way if you're actively navigating across tabs when a change happens, you're much less likely to find your focus bouncing around unexpectedly.~

Adjusting based on feedback (see comments below), this PR removes the previously introduced focus management. This means that if the currently selected tab is focused and that selection is changed by the controlling component, focus will not be moved to the newly selected tab.

Note: This also means that in the editor settings sidebars (both post and site editors) tabbing through the available blocks into the sidebar can cause the **Block** tab to be focused while the **Document** tab is actually selected. If necessary, we can look into adding a helper to the editor itself to avoid this situation. That way we address that use case without making the component itself overly opinionated.

## How?

~When deciding whether or not to update focus, we check the id of the previously selected tab. If that's the same tab that has focus (we haven't shifted focus yet, so it's still going to be wherever the user last placed it) we know the selected tab was focused before the change was made. In that case we shift the focus to the new tab.~

Regardless of any other factors, we no longer change browser focus.

We do, however, have to manage the component's internal focus. Ariakit tracks and manages focus internally via an `activeId` value. When the selected tab is changed, that `activeId` also changes to match the selection.

If DOM focus is on a different tab when this happens, the arrow keys will base their actions off of the new `activeId`, not the current DOM focus. This can lead to awkward navigation. To avoid that, when the selected tab is changed and focus was _not_ already on the focused tab, we update the `activeId` to once again match the currently select tab in the DOM. This ensures that arrow key behavior remains consistent.

## Testing Instructions
**In the editor:**

<details>
<summary>Apply the following testing diff</summary>

This adds `focusOnMove={false}` to this implementation, which I'll most likely be doing for real in a separate PR, but it's the most convenient place to test these changes.

```diff
diff --git a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
index 0cd69cb115..eac816b87c 100644
--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -157,6 +157,7 @@ const SettingsSidebar = () => {
 			// the selected tab to `null` avoids that.
 			selectedTabId={ isSettingsSidebarActive ? sidebarName : null }
 			onSelect={ onTabSelect }
+			selectOnMove={ false }
 		>
 			<SidebarContent
 				sidebarName={ sidebarName }

```

</details>

1. Create a new post and make sure the settings sidebar is open
2. Add a title and a paragraph block or two
3. Click below the blocks you've added on the empty area of the canvas
4. Press <kdb>Tab</kbd> to focus the title
5. Press <kdb>Tab</kbd> to focus the first block, repeat until focus reaches the last block. While a block is focused, the settings sidebar should automatically select the **Block** tab
6. Press <kdb>Tab</kbd> to move focus to the sidebar. This removes focus from a block, auto-selecting the **Post** tab
7. Confirm that when the **Post** tab is selected, browser focus does not automatically move to that tab.
8. Use the arrow keys to move between tabs, confirming they are not automatically selected.
9. Confirm that when you press an arrow key, focus moves as you'd expect it to on the first keystroke.

**In Storybook**

<details>
<summary>Apply the following test diff</summary>

This adds `selectOnMove={false}`  and a delay to the Controlled Mode story, so you can move focus to test the the effect of the tab changing on you.

```diff
diff --git a/packages/components/src/tabs/stories/index.story.tsx b/packages/components/src/tabs/stories/index.story.tsx
index 0e7ab725e3..5b8a966a35 100644
--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -273,17 +273,29 @@ const ControlledModeTemplate: StoryFn< typeof Tabs > = ( props ) => {
 					<DropdownMenu
 						controls={ [
 							{
-								onClick: () => setSelectedTabId( 'tab1' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab1' ),
+										3000
+									),
 								title: 'Tab 1',
 								isActive: selectedTabId === 'tab1',
 							},
 							{
-								onClick: () => setSelectedTabId( 'tab2' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab2' ),
+										3000
+									),
 								title: 'Tab 2',
 								isActive: selectedTabId === 'tab2',
 							},
 							{
-								onClick: () => setSelectedTabId( 'tab3' ),
+								onClick: () =>
+									setTimeout(
+										() => setSelectedTabId( 'tab3' ),
+										3000
+									),
 								title: 'Tab 3',
 								isActive: selectedTabId === 'tab3',
 							},
@@ -299,6 +311,7 @@ const ControlledModeTemplate: StoryFn< typeof Tabs > = ( props ) => {
 export const ControlledMode = ControlledModeTemplate.bind( {} );
 ControlledMode.args = {
 	selectedTabId: 'tab3',
+	selectOnMove: false,
 };
 
 const TabBecomesDisabledTemplate: StoryFn< typeof Tabs > = ( props ) => {

```

</details>

1. Launch Storybook and open the **Controlled Mode** story
2. Using the dropdown menu, select **Tab 1**
3. Before the three-second delay elapses, click on the canvas between the `Tabs` component and the dropdown menu. Then press <kdb>Tab</kbd> to focus the currently selected tab (**Tab 3**)
4. When the delay runs out the selected tab will change. Confirm that even though the selected tab changed, browser focus did not. You should still be focused on **Tab 3** but **Tab 1** should be selected and its contents visible.
5. Test the arrow keys and confirm they behave normally, moving left/right as expected.
6. Click or use the keyboard to select **Tab 1**
7. Use the dropdown again and select **Tab 3**
8. Before the delay expires, click on the canvas and press <kdb>Tab</kbd>, followed by <kdb>ArrowRight</kbd> so that **Tab 2** has focus
10. When the delay expires, confirm that **Tab 3** is selected, and its contents are displayed
11. Confirm that **Tab 2** still has browser focus.
12. Test arrow keys, confirming they move left or right as expected. Specifically, you're making sure they don't act like **Tab 3** got focus when it was selected.