### PR TITLE
[Excerpt Block]: Character count instead of word count would make this block more useful and predictable for blog designs #53824

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -621,7 +621,7 @@ Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk
 -	**Name:** core/post-excerpt
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
+-	**Attributes:** countExcerptCharactersLength, excerptCharactersLength, excerptWordsLength, moreText, showMoreOnNewLine, textAlign
 
 ## Featured Image
 

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -17,9 +17,17 @@
 			"type": "boolean",
 			"default": true
 		},
-		"excerptLength": {
+		"excerptWordsLength": {
 			"type": "number",
 			"default": 55
+		},
+		"countExcerptCharactersLength": {
+			"type": "boolean",
+			"default": false
+		},
+		"excerptCharactersLength": {
+			"type": "number",
+			"default": 120
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -28,7 +28,7 @@ import { useCanEditEntity } from '../utils/hooks';
 const ELLIPSIS = '…';
 
 export default function PostExcerptEditor( {
-	attributes: { textAlign, moreText, showMoreOnNewLine, excerptLength },
+	attributes: { textAlign, moreText, showMoreOnNewLine, excerptWordsLength },
 	setAttributes,
 	isSelected,
 	context: { postId, postType, queryId },
@@ -153,7 +153,7 @@ export default function PostExcerptEditor( {
 	let trimmedExcerpt = '';
 	if ( wordCountType === 'words' ) {
 		trimmedExcerpt = rawOrRenderedExcerpt
-			.split( ' ', excerptLength )
+			.split( ' ', excerptWordsLength )
 			.join( ' ' );
 	} else if ( wordCountType === 'characters_excluding_spaces' ) {
 		/*
@@ -165,7 +165,7 @@ export default function PostExcerptEditor( {
 		 * so that the spaces are excluded from the word count.
 		 */
 		const excerptWithSpaces = rawOrRenderedExcerpt
-			.split( '', excerptLength )
+			.split( '', excerptWordsLength )
 			.join( '' );
 
 		const numberOfSpaces =
@@ -173,11 +173,11 @@ export default function PostExcerptEditor( {
 			excerptWithSpaces.replaceAll( ' ', '' ).length;
 
 		trimmedExcerpt = rawOrRenderedExcerpt
-			.split( '', excerptLength + numberOfSpaces )
+			.split( '', excerptWordsLength + numberOfSpaces )
 			.join( '' );
 	} else if ( wordCountType === 'characters_including_spaces' ) {
 		trimmedExcerpt = rawOrRenderedExcerpt
-			.split( '', excerptLength )
+			.split( '', excerptWordsLength )
 			.join( '' );
 	}
 
@@ -229,9 +229,9 @@ export default function PostExcerptEditor( {
 					/>
 					<RangeControl
 						label={ __( 'Max number of words' ) }
-						value={ excerptLength }
+						value={ excerptWordsLength }
 						onChange={ ( value ) => {
-							setAttributes( { excerptLength: value } );
+							setAttributes( { excerptWordsLength: value } );
 						} }
 						min="10"
 						max="100"

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -241,7 +241,7 @@ export default function PostExcerptEditor( {
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __( 'Count Excerpt Characters Length' ) }
+						label={ __( 'Set Character Length' ) }
 						checked={ countExcerptCharactersLength }
 						onChange={ ( newCountExcerptCharactersLength ) => {
 							setAttributes( {
@@ -262,7 +262,7 @@ export default function PostExcerptEditor( {
 								} );
 							} }
 							min="10"
-							max="600"
+							max="1000"
 						/>
 					) : (
 						<RangeControl

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -90,9 +90,10 @@ export default function PostExcerptEditor( {
 	 */
 	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
 
-	/** 
-	 * If the wordCountType is set to something else, Setting the Characters length won't be needed.
-	 * Making it false will help the words get rendered on Front-End as well.
+	/**
+	 * When wordCountType is not 'words', toggle button should
+	 * not be rendered. Hence, Making the countExcerptCharactersLength
+	 * false.
 	 */
 	if ( wordCountType !== 'words' ) {
 		setAttributes( { countExcerptCharactersLength: false } );

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -28,7 +28,14 @@ import { useCanEditEntity } from '../utils/hooks';
 const ELLIPSIS = '…';
 
 export default function PostExcerptEditor( {
-	attributes: { textAlign, moreText, showMoreOnNewLine, excerptWordsLength },
+	attributes: {
+		textAlign,
+		moreText,
+		showMoreOnNewLine,
+		excerptWordsLength,
+		countExcerptCharactersLength,
+		excerptCharactersLength,
+	},
 	setAttributes,
 	isSelected,
 	context: { postId, postType, queryId },
@@ -151,10 +158,15 @@ export default function PostExcerptEditor( {
 	).trim();
 
 	let trimmedExcerpt = '';
-	if ( wordCountType === 'words' ) {
+	if ( wordCountType === 'words' && ! countExcerptCharactersLength ) {
 		trimmedExcerpt = rawOrRenderedExcerpt
 			.split( ' ', excerptWordsLength )
 			.join( ' ' );
+	} else if ( wordCountType === 'words' && countExcerptCharactersLength ) {
+		trimmedExcerpt = rawOrRenderedExcerpt
+			.split( '', excerptCharactersLength )
+			.join( '' )
+			.trim();
 	} else if ( wordCountType === 'characters_excluding_spaces' ) {
 		/*
 		 * 1. Split the excerpt at the character limit,
@@ -227,15 +239,42 @@ export default function PostExcerptEditor( {
 							} )
 						}
 					/>
-					<RangeControl
-						label={ __( 'Max number of words' ) }
-						value={ excerptWordsLength }
-						onChange={ ( value ) => {
-							setAttributes( { excerptWordsLength: value } );
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Count Excerpt Characters Length' ) }
+						checked={ countExcerptCharactersLength }
+						onChange={ ( newCountExcerptCharactersLength ) => {
+							setAttributes( {
+								countExcerptCharactersLength:
+									newCountExcerptCharactersLength,
+							} );
 						} }
-						min="10"
-						max="100"
 					/>
+
+					{ wordCountType === 'words' &&
+					countExcerptCharactersLength ? (
+						<RangeControl
+							label={ __( 'Max number of Characters' ) }
+							value={ excerptCharactersLength }
+							onChange={ ( value ) => {
+								setAttributes( {
+									excerptCharactersLength: value,
+								} );
+							} }
+							min="10"
+							max="600"
+						/>
+					) : (
+						<RangeControl
+							label={ __( 'Max number of words' ) }
+							value={ excerptWordsLength }
+							onChange={ ( value ) => {
+								setAttributes( { excerptWordsLength: value } );
+							} }
+							min="10"
+							max="100"
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -90,6 +90,14 @@ export default function PostExcerptEditor( {
 	 */
 	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
 
+	/** 
+	 * If the wordCountType is set to something else, Setting the Characters length won't be needed.
+	 * Making it false will help the words get rendered on Front-End as well.
+	 */
+	if ( wordCountType !== 'words' ) {
+		setAttributes( { countExcerptCharactersLength: false } );
+	}
+
 	/**
 	 * When excerpt is editable, strip the html tags from
 	 * rendered excerpt. This will be used if the entity's
@@ -239,17 +247,19 @@ export default function PostExcerptEditor( {
 							} )
 						}
 					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Set Character Length' ) }
-						checked={ countExcerptCharactersLength }
-						onChange={ ( newCountExcerptCharactersLength ) => {
-							setAttributes( {
-								countExcerptCharactersLength:
-									newCountExcerptCharactersLength,
-							} );
-						} }
-					/>
+					{ wordCountType === 'words' && (
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Set Character Length' ) }
+							checked={ countExcerptCharactersLength }
+							onChange={ ( newCountExcerptCharactersLength ) => {
+								setAttributes( {
+									countExcerptCharactersLength:
+										newCountExcerptCharactersLength,
+								} );
+							} }
+						/>
+					) }
 
 					{ wordCountType === 'words' &&
 					countExcerptCharactersLength ? (

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -28,8 +28,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	$excerpt        = get_the_excerpt( $block->context['postId'] );
 	if ( isset( $excerpt_length ) && ! $attributes['countExcerptCharactersLength'] ) {
 		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
-	} else if ( isset( $excerpt_length ) && $attributes['countExcerptCharactersLength'] && strlen( $excerpt ) > $excerpt_length ) {
-		$excerpt = trim( substr( $excerpt, 0, $excerpt_length ) ) . '...' ;
+	} elseif ( isset( $excerpt_length ) && $attributes['countExcerptCharactersLength'] && strlen( $excerpt ) > $excerpt_length ) {
+		$excerpt = trim( substr( $excerpt, 0, $excerpt_length ) ) . '...';
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -24,10 +24,12 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	* Because the excerpt_length filter only applies to auto generated excerpts,
 	* wp_trim_words is used instead.
 	*/
-	$excerpt_length = $attributes['excerptLength'];
+	$excerpt_length = ( $attributes['countExcerptCharactersLength'] ) ? $attributes['excerptCharactersLength'] : $attributes['excerptWordsLength'];
 	$excerpt        = get_the_excerpt( $block->context['postId'] );
-	if ( isset( $excerpt_length ) ) {
+	if ( isset( $excerpt_length ) && ! $attributes['countExcerptCharactersLength'] ) {
 		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
+	} else if ( isset( $excerpt_length ) && $attributes['countExcerptCharactersLength'] && strlen( $excerpt ) > $excerpt_length ) {
+		$excerpt = trim( substr( $excerpt, 0, $excerpt_length ) ) . '...' ;
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR lets the User sets the maximum number of characters for the `post-excerpt` and also lets the user choose if they want to set the maximum characters or maximum words.

## Why?
According to an issue #53824 , there was no option of setting the maximum number of characters for the `post-excerpt`. This PR lets the user choose if they want to set the maximum number of characters and if yes they can set the maximum number of characters for the `post-excerpt`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Created a toggle control to choose if the user wants to set the maximum characters or not.
- Added attributes to store the user's choice and also the maximum number of characters for the `post-excerpt`
- Added checks to make sure that this toggle control would only be visible if the `wordCountType === 'words'`, for the other two options this feature is not required.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert an excerpt block.
3. Add some content to it, in the Inspector Control Settings for the block, you will find a toggle button labelled as "Set Character Length"
4. Selecting it, will let you set the max character length for `post-excerpt`, the range is from 10 to 1000.
5. Once done, you can click on publish/update and view the trimmed data both in the editor and Front-End.
6. You can always toggle back to setting the Maximum number of Words for `post-excerpt` using the same toggle button.
<!-- 3. etc. -->

<!-- ### Testing Instructions for Keyboard -->
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/93442804/9b2ce1e2-0970-42fc-8d64-57bb1db6b22e