### PR TITLE
Table: Remove unnecessary margin override in editor styles

### DIFF
--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -1,7 +1,4 @@
 .wp-block-table {
-	// Remove default <figure> style.
-	margin: 0;
-
 	.wp-block[data-align="left"] > &,
 	.wp-block[data-align="right"] > &,
 	.wp-block[data-align="center"] > & {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Remove the Table block's unnecessary `margin: 0;` rule in its editor styles. Since this doesn't affect the styles on the site frontend, this shouldn't be a breaking change.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The browser default `figure` element margins are already overridden via a lower specificity `:where()` rule here: https://github.com/WordPress/gutenberg/blob/9c5ce7eb6f5c76064209f741951917532cdd781d/packages/block-library/src/common.scss#L161

The higher specificity rule in `.wp-block-table` had the unintended effect of overriding the low specificity layout rules (see: https://github.com/WordPress/gutenberg/pull/47858 for when the layout rules were lowered in specificity). The result is that within the editor, the default layout block spacing is being overridden for the table block, when it shouldn't be.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the Table block's unnecessary `margin: 0;` rule in its editor styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Add a Table block to a post or page after another block.
* Prior to this PR, notice that the `margin: 0` rule prevents there being a space before the block within the editor, however on the site frontend that gap is present.
* With this PR applied, the editor should now match the site frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before (Editor) | After (Editor) |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/58b474a7-9210-4326-a904-6f0e3ad25ba2) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/dc73f695-8314-4c8d-81c3-84959470d683) |