### PR TITLE
Remove `template-only` mode from editor and edit-post packages

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1404,13 +1404,12 @@ _Returns_
 Returns an action used to set the rendering mode of the post editor. We support multiple rendering modes:
 
 -   `all`: This is the default mode. It renders the post editor with all the features available. If a template is provided, it's preferred over the post.
--   `template-only`: This mode renders the editor with only the template blocks visible.
 -   `post-only`: This mode extracts the post blocks from the template and renders only those. The idea is to allow the user to edit the post/page in isolation without the wrapping template.
 -   `template-locked`: This mode renders both the template and the post blocks but the template blocks are locked and can't be edited. The post blocks are editable.
 
 _Parameters_
 
--   _mode_ `string`: Mode (one of 'template-only', 'post-only', 'template-locked' or 'all').
+-   _mode_ `string`: Mode (one of 'post-only', 'template-locked' or 'all').
 
 ### setTemplateValidity
 

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -4,10 +4,10 @@ iframe[name="editor-canvas"] {
 	display: block;
 }
 
-iframe[name="editor-canvas"]:not(.has-history) {
+iframe[name="editor-canvas"]:not(.has-editor-padding) {
 	background-color: $white;
 }
 
-iframe[name="editor-canvas"].has-history {
+iframe[name="editor-canvas"].has-editor-padding {
 	padding: $grid-unit-60 $grid-unit-60 0;
 }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -212,7 +212,6 @@ export default function ReusableBlockEdit( {
 		? getPostLinkProps( {
 				postId: ref,
 				postType: 'wp_block',
-				canvas: 'edit',
 		  } )
 		: {};
 

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -64,7 +64,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		hasBlockSelection,
 		hasActiveMetaboxes,
 		hasFixedToolbar,
-		isEditingTemplate,
 		isPublishSidebarOpened,
 		showIconLabels,
 		hasHistory,
@@ -78,8 +77,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				!! select( blockEditorStore ).getBlockSelectionStart(),
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			hasHistory: !! select( editorStore ).getEditorSettings().goBack,
-			isEditingTemplate:
-				select( editorStore ).getRenderingMode() === 'template-only',
 			isPublishSidebarOpened:
 				select( editPostStore ).isPublishSidebarOpened(),
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
@@ -150,7 +147,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				<div
 					className={ classnames( 'edit-post-header__center', {
 						'is-collapsed':
-							isEditingTemplate &&
+							hasHistory &&
 							hasBlockSelection &&
 							! isBlockToolsCollapsed &&
 							hasFixedToolbar &&

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -157,7 +157,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 							isLargeViewport,
 					} ) }
 				>
-					{ ( isEditingTemplate || hasHistory ) && <DocumentBar /> }
+					{ hasHistory && <DocumentBar /> }
 				</div>
 			</motion.div>
 			<motion.div

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -64,7 +64,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		hasBlockSelection,
 		hasActiveMetaboxes,
 		hasFixedToolbar,
-		isEditingTemplate,
 		isPublishSidebarOpened,
 		showIconLabels,
 		hasHistory,
@@ -78,8 +77,6 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				!! select( blockEditorStore ).getBlockSelectionStart(),
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			hasHistory: !! select( editorStore ).getEditorSettings().goBack,
-			isEditingTemplate:
-				select( editorStore ).getCurrentPostType() === 'wp_template',
 			isPublishSidebarOpened:
 				select( editPostStore ).isPublishSidebarOpened(),
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
@@ -150,7 +147,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				<div
 					className={ classnames( 'edit-post-header__center', {
 						'is-collapsed':
-							isEditingTemplate &&
+							hasHistory &&
 							hasBlockSelection &&
 							! isBlockToolsCollapsed &&
 							hasFixedToolbar &&

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -64,6 +64,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 		hasBlockSelection,
 		hasActiveMetaboxes,
 		hasFixedToolbar,
+		isEditingTemplate,
 		isPublishSidebarOpened,
 		showIconLabels,
 		hasHistory,
@@ -77,6 +78,8 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				!! select( blockEditorStore ).getBlockSelectionStart(),
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			hasHistory: !! select( editorStore ).getEditorSettings().goBack,
+			isEditingTemplate:
+				select( editorStore ).getCurrentPostType() === 'wp_template',
 			isPublishSidebarOpened:
 				select( editPostStore ).isPublishSidebarOpened(),
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
@@ -147,7 +150,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				<div
 					className={ classnames( 'edit-post-header__center', {
 						'is-collapsed':
-							hasHistory &&
+							isEditingTemplate &&
 							hasBlockSelection &&
 							! isBlockToolsCollapsed &&
 							hasFixedToolbar &&

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -29,32 +29,23 @@ const MODES = [
 ];
 
 function ModeSwitcher() {
-	const {
-		shortcut,
-		isRichEditingEnabled,
-		isCodeEditingEnabled,
-		isEditingTemplate,
-		mode,
-	} = useSelect(
-		( select ) => ( {
-			shortcut: select(
-				keyboardShortcutsStore
-			).getShortcutRepresentation( 'core/edit-post/toggle-mode' ),
-			isRichEditingEnabled:
-				select( editorStore ).getEditorSettings().richEditingEnabled,
-			isCodeEditingEnabled:
-				select( editorStore ).getEditorSettings().codeEditingEnabled,
-			isEditingTemplate:
-				select( editorStore ).getCurrentPostType() === 'wp_template',
-			mode: select( editPostStore ).getEditorMode(),
-		} ),
-		[]
-	);
+	const { shortcut, isRichEditingEnabled, isCodeEditingEnabled, mode } =
+		useSelect(
+			( select ) => ( {
+				shortcut: select(
+					keyboardShortcutsStore
+				).getShortcutRepresentation( 'core/edit-post/toggle-mode' ),
+				isRichEditingEnabled:
+					select( editorStore ).getEditorSettings()
+						.richEditingEnabled,
+				isCodeEditingEnabled:
+					select( editorStore ).getEditorSettings()
+						.codeEditingEnabled,
+				mode: select( editPostStore ).getEditorMode(),
+			} ),
+			[]
+		);
 	const { switchEditorMode } = useDispatch( editPostStore );
-
-	if ( isEditingTemplate ) {
-		return null;
-	}
 
 	let selectedMode = mode;
 	if ( ! isRichEditingEnabled && mode === 'visual' ) {

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -45,7 +45,7 @@ function ModeSwitcher() {
 			isCodeEditingEnabled:
 				select( editorStore ).getEditorSettings().codeEditingEnabled,
 			isEditingTemplate:
-				select( editorStore ).getRenderingMode() === 'template-only',
+				select( editorStore ).getCurrentPostType() === 'wp_template',
 			mode: select( editPostStore ).getEditorMode(),
 		} ),
 		[]

--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -15,21 +15,18 @@ import { sidebars } from '../settings-sidebar';
 const { Tabs } = unlock( componentsPrivateApis );
 
 const SettingsHeader = () => {
-	const { documentLabel, isTemplateMode } = useSelect( ( select ) => {
-		const { getPostTypeLabel, getRenderingMode } = select( editorStore );
+	const { documentLabel } = useSelect( ( select ) => {
+		const { getPostTypeLabel } = select( editorStore );
 
 		return {
 			// translators: Default label for the Document sidebar tab, not selected.
 			documentLabel: getPostTypeLabel() || _x( 'Document', 'noun' ),
-			isTemplateMode: getRenderingMode() === 'template-only',
 		};
 	}, [] );
 
 	return (
 		<Tabs.TabList>
-			<Tabs.Tab tabId={ sidebars.document }>
-				{ isTemplateMode ? __( 'Template' ) : documentLabel }
-			</Tabs.Tab>
+			<Tabs.Tab tabId={ sidebars.document }>{ documentLabel }</Tabs.Tab>
 			<Tabs.Tab tabId={ sidebars.block }>
 				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
 				{ __( 'Block' ) }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -48,7 +48,7 @@ export const sidebars = {
 const SidebarContent = ( {
 	sidebarName,
 	keyboardShortcut,
-	isTemplateMode,
+	isEditingTemplate,
 } ) => {
 	// Because `PluginSidebarEditPost` renders a `ComplementaryArea`, we
 	// need to forward the `Tabs` context so it can be passed through the
@@ -77,7 +77,7 @@ const SidebarContent = ( {
 		>
 			<Tabs.Context.Provider value={ tabsContextValue }>
 				<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
-					{ ! isTemplateMode && (
+					{ ! isEditingTemplate && (
 						<>
 							<PostStatus />
 							<PluginDocumentSettingPanel.Slot />
@@ -90,7 +90,7 @@ const SidebarContent = ( {
 							<MetaBoxes location="side" />
 						</>
 					) }
-					{ isTemplateMode && <TemplateSummary /> }
+					{ isEditingTemplate && <TemplateSummary /> }
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
 					<BlockInspector />
@@ -105,7 +105,7 @@ const SettingsSidebar = () => {
 		sidebarName,
 		isSettingsSidebarActive,
 		keyboardShortcut,
-		isTemplateMode,
+		isEditingTemplate,
 	} = useSelect( ( select ) => {
 		// The settings sidebar is used by the edit-post/document and edit-post/block sidebars.
 		// sidebarName represents the sidebar that is active or that should be active when the SettingsSidebar toggle button is pressed.
@@ -132,8 +132,8 @@ const SettingsSidebar = () => {
 			sidebarName: sidebar,
 			isSettingsSidebarActive: isSettingsSidebar,
 			keyboardShortcut: shortcut,
-			isTemplateMode:
-				select( editorStore ).getRenderingMode() === 'template-only',
+			isEditingTemplate:
+				select( editorStore ).getCurrentPostType() === 'wp_template',
 		};
 	}, [] );
 
@@ -161,7 +161,7 @@ const SettingsSidebar = () => {
 			<SidebarContent
 				sidebarName={ sidebarName }
 				keyboardShortcut={ keyboardShortcut }
-				isTemplateMode={ isTemplateMode }
+				isEditingTemplate={ isEditingTemplate }
 			/>
 		</Tabs>
 	);

--- a/packages/edit-post/src/components/sidebar/template-summary/index.js
+++ b/packages/edit-post/src/components/sidebar/template-summary/index.js
@@ -4,16 +4,12 @@
 import { Icon, layout } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem, FlexBlock, PanelBody } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { store as editPostStore } from '../../../store';
+import { store as editorStore } from '@wordpress/editor';
 
 function TemplateSummary() {
 	const template = useSelect( ( select ) => {
-		const { getEditedPostTemplate } = select( editPostStore );
-		return getEditedPostTemplate();
+		const { getCurrentPost } = select( editorStore );
+		return getCurrentPost();
 	}, [] );
 
 	if ( ! template ) {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -30,6 +30,7 @@ export default function VisualEditor( { styles } ) {
 		renderingMode,
 		isBlockBasedTheme,
 		hasV3BlocksOnly,
+		isEditingTemplate,
 	} = useSelect( ( select ) => {
 		const { isFeatureActive } = select( editPostStore );
 		const { getEditorSettings, getRenderingMode } = select( editorStore );
@@ -43,6 +44,8 @@ export default function VisualEditor( { styles } ) {
 			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
 				return type.apiVersion >= 3;
 			} ),
+			isEditingTemplate:
+				select( editorStore ).getCurrentPostType() === 'wp_template',
 		};
 	}, [] );
 	const hasMetaBoxes = useSelect(
@@ -74,12 +77,12 @@ export default function VisualEditor( { styles } ) {
 	const isToBeIframed =
 		( ( hasV3BlocksOnly || ( isGutenbergPlugin && isBlockBasedTheme ) ) &&
 			! hasMetaBoxes ) ||
-		renderingMode === 'template-only';
+		isEditingTemplate;
 
 	return (
 		<div
 			className={ classnames( 'edit-post-visual-editor', {
-				'is-template-mode': renderingMode === 'template-only',
+				'is-template-mode': isEditingTemplate,
 				'has-inline-canvas': ! isToBeIframed,
 			} ) }
 		>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -82,7 +82,6 @@ export default function VisualEditor( { styles } ) {
 	return (
 		<div
 			className={ classnames( 'edit-post-visual-editor', {
-				'is-template-mode': isEditingTemplate,
 				'has-inline-canvas': ! isToBeIframed,
 			} ) }
 		>

--- a/packages/edit-post/src/components/welcome-guide/index.js
+++ b/packages/edit-post/src/components/welcome-guide/index.js
@@ -12,17 +12,18 @@ import WelcomeGuideTemplate from './template';
 import { store as editPostStore } from '../../store';
 
 export default function WelcomeGuide() {
-	const { isActive, isTemplateMode } = useSelect( ( select ) => {
+	const { isActive, isEditingTemplate } = useSelect( ( select ) => {
 		const { isFeatureActive } = select( editPostStore );
-		const { getRenderingMode } = select( editorStore );
-		const _isTemplateMode = getRenderingMode() === 'template-only';
-		const feature = _isTemplateMode
+		const { getCurrentPostType } = select( editorStore );
+		const _isEditingTemplate = getCurrentPostType() === 'wp_template';
+
+		const feature = _isEditingTemplate
 			? 'welcomeGuideTemplate'
 			: 'welcomeGuide';
 
 		return {
 			isActive: isFeatureActive( feature ),
-			isTemplateMode: _isTemplateMode,
+			isEditingTemplate: _isEditingTemplate,
 		};
 	}, [] );
 
@@ -30,5 +31,9 @@ export default function WelcomeGuide() {
 		return null;
 	}
 
-	return isTemplateMode ? <WelcomeGuideTemplate /> : <WelcomeGuideDefault />;
+	return isEditingTemplate ? (
+		<WelcomeGuideTemplate />
+	) : (
+		<WelcomeGuideDefault />
+	);
 }

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -49,14 +49,13 @@ function Editor( {
 					canUser,
 				} = select( coreStore );
 				const { getEditorSettings } = select( editorStore );
-				const isTemplate = [
-					'wp_template',
-					'wp_template_part',
-				].includes( currentPost.postType );
+				const isTemplatePart = [ 'wp_template_part' ].includes(
+					currentPost.postType
+				);
 				// Ideally the initializeEditor function should be called using the ID of the REST endpoint.
 				// to avoid the special case.
 				let postObject;
-				if ( isTemplate ) {
+				if ( isTemplatePart ) {
 					const posts = getEntityRecords(
 						'postType',
 						currentPost.postType,
@@ -84,7 +83,10 @@ function Editor( {
 						'preferredStyleVariations'
 					),
 					template:
-						supportsTemplateMode && isViewable && canEditTemplate
+						supportsTemplateMode &&
+						isViewable &&
+						canEditTemplate &&
+						currentPost.postType !== 'wp_template'
 							? getEditedPostTemplate()
 							: null,
 					post: postObject,
@@ -94,12 +96,15 @@ function Editor( {
 		);
 
 	const { updatePreferredStyleVariations } = useDispatch( editPostStore );
+	const defaultRenderingMode =
+		currentPost.postType === 'wp_template' ? 'all' : 'post-only';
 
 	const editorSettings = useMemo( () => {
 		const result = {
 			...settings,
 			getPostLinkProps,
 			goBack,
+			defaultRenderingMode,
 			__experimentalPreferredStyleVariations: {
 				value: preferredStyleVariations,
 				onChange: updatePreferredStyleVariations,
@@ -114,6 +119,7 @@ function Editor( {
 		updatePreferredStyleVariations,
 		getPostLinkProps,
 		goBack,
+		defaultRenderingMode,
 	] );
 
 	if ( ! post ) {

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -42,35 +42,16 @@ function Editor( {
 			( select ) => {
 				const { isFeatureActive, getEditedPostTemplate } =
 					select( editPostStore );
-				const {
-					getEntityRecord,
-					getPostType,
-					getEntityRecords,
-					canUser,
-				} = select( coreStore );
+				const { getEntityRecord, getPostType, canUser } =
+					select( coreStore );
 				const { getEditorSettings } = select( editorStore );
-				const isTemplatePart = [ 'wp_template_part' ].includes(
-					currentPost.postType
+
+				const postObject = getEntityRecord(
+					'postType',
+					currentPost.postType,
+					currentPost.postId
 				);
-				// Ideally the initializeEditor function should be called using the ID of the REST endpoint.
-				// to avoid the special case.
-				let postObject;
-				if ( isTemplatePart ) {
-					const posts = getEntityRecords(
-						'postType',
-						currentPost.postType,
-						{
-							wp_id: currentPost.postId,
-						}
-					);
-					postObject = posts?.[ 0 ];
-				} else {
-					postObject = getEntityRecord(
-						'postType',
-						currentPost.postType,
-						currentPost.postId
-					);
-				}
+
 				const supportsTemplateMode =
 					getEditorSettings().supportsTemplateMode;
 				const isViewable =

--- a/packages/edit-post/src/hooks/use-post-history.js
+++ b/packages/edit-post/src/hooks/use-post-history.js
@@ -50,7 +50,7 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 		return {
 			href: newUrl,
 			onClick: ( event ) => {
-				event.preventDefault();
+				event?.preventDefault();
 				dispatch( {
 					type: 'push',
 					post: { postId: params.postId, postType: params.postType },

--- a/packages/edit-post/src/plugins/welcome-guide-menu-item/index.js
+++ b/packages/edit-post/src/plugins/welcome-guide-menu-item/index.js
@@ -7,16 +7,16 @@ import { __ } from '@wordpress/i18n';
 import { store as editorStore } from '@wordpress/editor';
 
 export default function WelcomeGuideMenuItem() {
-	const isTemplateMode = useSelect(
+	const isEditingTemplate = useSelect(
 		( select ) =>
-			select( editorStore ).getRenderingMode() === 'template-only',
+			select( editorStore ).getCurrentPostType() === 'wp_template',
 		[]
 	);
 
 	return (
 		<PreferenceToggleMenuItem
 			scope="core/edit-post"
-			name={ isTemplateMode ? 'welcomeGuideTemplate' : 'welcomeGuide' }
+			name={ isEditingTemplate ? 'welcomeGuideTemplate' : 'welcomeGuide' }
 			label={ __( 'Welcome Guide' ) }
 		/>
 	);

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -470,15 +470,6 @@ export function setIsEditingTemplate() {
 }
 
 /**
- * Switches to the template mode.
- */
-export const __unstableSwitchToTemplateMode =
-	() =>
-	( { registry } ) => {
-		registry.dispatch( editorStore ).setRenderingMode( 'template-only' );
-	};
-
-/**
  * Create a block based template.
  *
  * @deprecated

--- a/packages/edit-site/src/components/block-editor/back-button.js
+++ b/packages/edit-site/src/components/block-editor/back-button.js
@@ -24,11 +24,14 @@ function BackButton() {
 	const isTemplatePart = location.params.postType === TEMPLATE_PART_POST_TYPE;
 	const isNavigationMenu = location.params.postType === NAVIGATION_POST_TYPE;
 	const isPattern = location.params.postType === PATTERN_TYPES.user;
-	const previousTemplateId = location.state?.fromTemplateId;
 
-	const isFocusMode = isTemplatePart || isNavigationMenu || isPattern;
+	const isFocusMode =
+		location.params.focusMode ||
+		isTemplatePart ||
+		isNavigationMenu ||
+		isPattern;
 
-	if ( ! isFocusMode || ( ! previousTemplateId && ! isPattern ) ) {
+	if ( ! isFocusMode ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -22,22 +22,29 @@ import {
 	NAVIGATION_POST_TYPE,
 } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+const { useLocation } = unlock( routerPrivateApis );
 
 export default function SiteEditorCanvas() {
-	const { templateType, isFocusMode, isViewMode } = useSelect( ( select ) => {
-		const { getEditedPostType, getCanvasMode } = unlock(
-			select( editSiteStore )
-		);
+	const location = useLocation();
+	const { templateType, isFocusableEntity, isViewMode } = useSelect(
+		( select ) => {
+			const { getEditedPostType, getCanvasMode } = unlock(
+				select( editSiteStore )
+			);
 
-		const _templateType = getEditedPostType();
+			const _templateType = getEditedPostType();
 
-		return {
-			templateType: _templateType,
-			isFocusMode: FOCUSABLE_ENTITIES.includes( _templateType ),
-			isViewMode: getCanvasMode() === 'view',
-		};
-	}, [] );
-
+			return {
+				templateType: _templateType,
+				isFocusableEntity: FOCUSABLE_ENTITIES.includes( _templateType ),
+				isViewMode: getCanvasMode() === 'view',
+			};
+		},
+		[]
+	);
+	const isFocusMode = location.params.focusMode || isFocusableEntity;
 	const [ resizeObserver, sizes ] = useResizeObserver();
 
 	const settings = useSiteEditorSettings();

--- a/packages/edit-site/src/components/block-editor/use-post-link-props.js
+++ b/packages/edit-site/src/components/block-editor/use-post-link-props.js
@@ -17,7 +17,7 @@ export function usePostLinkProps() {
 	return ( params, state ) => {
 		return getPostLinkProps(
 			history,
-			{ ...params, focusMode: true },
+			{ ...params, focusMode: true, canvas: 'edit' },
 			state
 		);
 	};

--- a/packages/edit-site/src/components/block-editor/use-post-link-props.js
+++ b/packages/edit-site/src/components/block-editor/use-post-link-props.js
@@ -15,6 +15,10 @@ export function usePostLinkProps() {
 	const history = useHistory();
 
 	return ( params, state ) => {
-		return getPostLinkProps( history, params, state );
+		return getPostLinkProps(
+			history,
+			{ ...params, focusMode: true },
+			state
+		);
 	};
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -102,13 +102,13 @@ export default function Editor( { isLoading } ) {
 		contextPost,
 		editorMode,
 		canvasMode,
-		currentPostType,
 		blockEditorMode,
 		isRightSidebarOpen,
 		isInserterOpen,
 		isListViewOpen,
 		showIconLabels,
 		showBlockBreadcrumbs,
+		postTypeLabel,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const { getEditedPostContext, getEditorMode, getCanvasMode } = unlock(
@@ -117,7 +117,7 @@ export default function Editor( { isLoading } ) {
 		const { __unstableGetEditorMode } = select( blockEditorStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const { getEntityRecord } = select( coreDataStore );
-		const { getCurrentPostType, isInserterOpened, isListViewOpened } =
+		const { isInserterOpened, isListViewOpened, getPostTypeLabel } =
 			select( editorStore );
 		const _context = getEditedPostContext();
 
@@ -134,7 +134,6 @@ export default function Editor( { isLoading } ) {
 				: undefined,
 			editorMode: getEditorMode(),
 			canvasMode: getCanvasMode(),
-			currentPostType: getCurrentPostType(),
 			blockEditorMode: __unstableGetEditorMode(),
 			isInserterOpen: isInserterOpened(),
 			isListViewOpen: isListViewOpened(),
@@ -143,6 +142,7 @@ export default function Editor( { isLoading } ) {
 			),
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			showIconLabels: get( 'core', 'showIconLabels' ),
+			postTypeLabel: getPostTypeLabel(),
 		};
 	}, [] );
 
@@ -267,12 +267,7 @@ export default function Editor( { isLoading } ) {
 						footer={
 							shouldShowBlockBreadcrumbs && (
 								<BlockBreadcrumb
-									rootLabelText={
-										postWithTemplate &&
-										currentPostType !== 'wp_template'
-											? __( 'Page' )
-											: __( 'Template' )
-									}
+									rootLabelText={ postTypeLabel }
 								/>
 							)
 						}

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -102,7 +102,7 @@ export default function Editor( { isLoading } ) {
 		contextPost,
 		editorMode,
 		canvasMode,
-		renderingMode,
+		currentPostType,
 		blockEditorMode,
 		isRightSidebarOpen,
 		isInserterOpen,
@@ -117,7 +117,7 @@ export default function Editor( { isLoading } ) {
 		const { __unstableGetEditorMode } = select( blockEditorStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const { getEntityRecord } = select( coreDataStore );
-		const { getRenderingMode, isInserterOpened, isListViewOpened } =
+		const { getCurrentPostType, isInserterOpened, isListViewOpened } =
 			select( editorStore );
 		const _context = getEditedPostContext();
 
@@ -134,7 +134,7 @@ export default function Editor( { isLoading } ) {
 				: undefined,
 			editorMode: getEditorMode(),
 			canvasMode: getCanvasMode(),
-			renderingMode: getRenderingMode(),
+			currentPostType: getCurrentPostType(),
 			blockEditorMode: __unstableGetEditorMode(),
 			isInserterOpen: isInserterOpened(),
 			isListViewOpen: isListViewOpened(),
@@ -269,7 +269,7 @@ export default function Editor( { isLoading } ) {
 								<BlockBreadcrumb
 									rootLabelText={
 										postWithTemplate &&
-										renderingMode !== 'template-only'
+										currentPostType !== 'wp_template'
 											? __( 'Page' )
 											: __( 'Template' )
 									}

--- a/packages/edit-site/src/components/routes/link.js
+++ b/packages/edit-site/src/components/routes/link.js
@@ -22,7 +22,7 @@ export function getPostLinkProps(
 	shouldReplace = false
 ) {
 	function onClick( event ) {
-		event.preventDefault();
+		event?.preventDefault();
 
 		if ( shouldReplace ) {
 			history.replace( params, state );

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -8,7 +8,6 @@ import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -49,9 +48,7 @@ export function SidebarComplementaryAreaFills() {
 			hasBlockSelection:
 				!! select( blockEditorStore ).getBlockSelectionStart(),
 			supportsGlobalStyles: ! settings?.supportsTemplatePartsMode,
-			isEditingPage:
-				select( editSiteStore ).isPage() &&
-				select( editorStore ).getCurrentPostType() !== 'wp_template',
+			isEditingPage: select( editSiteStore ).isPage(),
 		};
 	}, [] );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -51,7 +51,7 @@ export function SidebarComplementaryAreaFills() {
 			supportsGlobalStyles: ! settings?.supportsTemplatePartsMode,
 			isEditingPage:
 				select( editSiteStore ).isPage() &&
-				select( editorStore ).getRenderingMode() !== 'template-only',
+				select( editorStore ).getCurrentPostType() !== 'wp_template',
 		};
 	}, [] );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
@@ -17,8 +17,6 @@ import { store as editorStore } from '@wordpress/editor';
  */
 import { STORE_NAME } from '../../../store/constants';
 import { SIDEBAR_BLOCK, SIDEBAR_TEMPLATE } from '../constants';
-// import { store as editSiteStore } from '../../../store';
-// import { POST_TYPE_LABELS, TEMPLATE_POST_TYPE } from '../../../utils/constants';
 
 const SettingsHeader = ( { sidebarName } ) => {
 	const postTypeLabel = useSelect(

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
@@ -17,23 +17,14 @@ import { store as editorStore } from '@wordpress/editor';
  */
 import { STORE_NAME } from '../../../store/constants';
 import { SIDEBAR_BLOCK, SIDEBAR_TEMPLATE } from '../constants';
-import { store as editSiteStore } from '../../../store';
-import { POST_TYPE_LABELS, TEMPLATE_POST_TYPE } from '../../../utils/constants';
+// import { store as editSiteStore } from '../../../store';
+// import { POST_TYPE_LABELS, TEMPLATE_POST_TYPE } from '../../../utils/constants';
 
 const SettingsHeader = ( { sidebarName } ) => {
-	const { isEditingPage, entityType } = useSelect( ( select ) => {
-		const { getEditedPostType, isPage } = select( editSiteStore );
-		const { getCurrentPostType } = select( editorStore );
-
-		return {
-			isEditingPage: isPage() && getCurrentPostType() !== 'wp_template',
-			entityType: getEditedPostType(),
-		};
-	} );
-
-	const entityLabel =
-		POST_TYPE_LABELS[ entityType ] ||
-		POST_TYPE_LABELS[ TEMPLATE_POST_TYPE ];
+	const postTypeLabel = useSelect(
+		( select ) => select( editorStore ).getPostTypeLabel(),
+		[]
+	);
 
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const openTemplateSettings = () =>
@@ -41,22 +32,11 @@ const SettingsHeader = ( { sidebarName } ) => {
 	const openBlockSettings = () =>
 		enableComplementaryArea( STORE_NAME, SIDEBAR_BLOCK );
 
-	let templateAriaLabel;
-	if ( isEditingPage ) {
-		templateAriaLabel =
-			sidebarName === SIDEBAR_TEMPLATE
-				? // translators: ARIA label for the Template sidebar tab, selected.
-				  __( 'Page (selected)' )
-				: // translators: ARIA label for the Template Settings Sidebar tab, not selected.
-				  __( 'Page' );
-	} else {
-		templateAriaLabel =
-			sidebarName === SIDEBAR_TEMPLATE
-				? // translators: ARIA label for the Template sidebar tab, selected.
-				  sprintf( __( '%s (selected)' ), entityLabel )
-				: // translators: ARIA label for the Template Settings Sidebar tab, not selected.
-				  entityLabel;
-	}
+	const documentAriaLabel =
+		sidebarName === SIDEBAR_TEMPLATE
+			? // translators: ARIA label for the Template sidebar tab, selected.
+			  sprintf( __( '%s (selected)' ), postTypeLabel )
+			: postTypeLabel;
 
 	/* Use a list so screen readers will announce how many tabs there are. */
 	return (
@@ -70,10 +50,10 @@ const SettingsHeader = ( { sidebarName } ) => {
 							'is-active': sidebarName === SIDEBAR_TEMPLATE,
 						}
 					) }
-					aria-label={ templateAriaLabel }
-					data-label={ isEditingPage ? __( 'Page' ) : entityLabel }
+					aria-label={ documentAriaLabel }
+					data-label={ postTypeLabel }
 				>
-					{ isEditingPage ? __( 'Page' ) : entityLabel }
+					{ postTypeLabel }
 				</Button>
 			</li>
 			<li>

--- a/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/settings-header/index.js
@@ -23,10 +23,10 @@ import { POST_TYPE_LABELS, TEMPLATE_POST_TYPE } from '../../../utils/constants';
 const SettingsHeader = ( { sidebarName } ) => {
 	const { isEditingPage, entityType } = useSelect( ( select ) => {
 		const { getEditedPostType, isPage } = select( editSiteStore );
-		const { getRenderingMode } = select( editorStore );
+		const { getCurrentPostType } = select( editorStore );
 
 		return {
-			isEditingPage: isPage() && getRenderingMode() !== 'template-only',
+			isEditingPage: isPage() && getCurrentPostType() !== 'wp_template',
 			entityType: getEditedPostType(),
 		};
 	} );

--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -25,12 +25,12 @@ export default function WelcomeGuideTemplate() {
 			'welcomeGuide'
 		);
 		const { isPage } = select( editSiteStore );
-		const { getRenderingMode } = select( editorStore );
+		const { getCurrentPostType } = select( editorStore );
 		return (
 			isTemplateActive &&
 			! isEditorActive &&
 			isPage() &&
-			getRenderingMode() === 'template-only'
+			getCurrentPostType() === 'wp_template'
 		);
 	}, [] );
 

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -43,17 +43,35 @@ const { useHistory } = unlock( routerPrivateApis );
 
 function usePageContentFocusCommands() {
 	const { record: template } = useEditedEntityRecord();
-	const { isPage, canvasMode, renderingMode } = useSelect( ( select ) => {
+	const {
+		isPage,
+		canvasMode,
+		getPostLinkProps,
+		templateId,
+		currentPostType,
+	} = useSelect( ( select ) => {
 		const { isPage: _isPage, getCanvasMode } = unlock(
 			select( editSiteStore )
 		);
-		const { getRenderingMode } = select( editorStore );
+		const { getCurrentPostType, getEditorSettings, getCurrentTemplateId } =
+			select( editorStore );
 		return {
 			isPage: _isPage(),
 			canvasMode: getCanvasMode(),
-			renderingMode: getRenderingMode(),
+			getPostLinkProps: getEditorSettings().getPostLinkProps,
+			templateId: getCurrentTemplateId(),
+			currentPostType: getCurrentPostType(),
 		};
 	}, [] );
+
+	const editTemplate = getPostLinkProps
+		? getPostLinkProps( {
+				postId: templateId,
+				postType: 'wp_template',
+				canvas: 'edit',
+		  } )
+		: {};
+
 	const { setRenderingMode } = useDispatch( editorStore );
 
 	if ( ! isPage || canvasMode !== 'edit' ) {
@@ -62,7 +80,7 @@ function usePageContentFocusCommands() {
 
 	const commands = [];
 
-	if ( renderingMode !== 'template-only' ) {
+	if ( currentPostType !== 'wp_template' ) {
 		commands.push( {
 			name: 'core/switch-to-template-focus',
 			/* translators: %1$s: template title */
@@ -72,7 +90,7 @@ function usePageContentFocusCommands() {
 			),
 			icon: layout,
 			callback: ( { close } ) => {
-				setRenderingMode( 'template-only' );
+				editTemplate.onClick();
 				close();
 			},
 		} );
@@ -129,7 +147,7 @@ function useManipulateDocumentCommands() {
 	const isEditingPage = useSelect(
 		( select ) =>
 			select( editSiteStore ).isPage() &&
-			select( editorStore ).getRenderingMode() !== 'template-only',
+			select( editorStore ).getCurrentPostType() !== 'wp_template',
 		[]
 	);
 

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -38,39 +38,33 @@ import { PREFERENCES_MODAL_NAME } from '../../components/preferences-modal';
 import { PATTERN_MODALS } from '../../components/pattern-modal';
 import { unlock } from '../../lock-unlock';
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+import { useLink } from '../../components/routes/link';
 
 const { useHistory } = unlock( routerPrivateApis );
 
 function usePageContentFocusCommands() {
 	const { record: template } = useEditedEntityRecord();
-	const {
-		isPage,
-		canvasMode,
-		getPostLinkProps,
-		templateId,
-		currentPostType,
-	} = useSelect( ( select ) => {
-		const { isPage: _isPage, getCanvasMode } = unlock(
-			select( editSiteStore )
-		);
-		const { getCurrentPostType, getEditorSettings, getCurrentTemplateId } =
-			select( editorStore );
-		return {
-			isPage: _isPage(),
-			canvasMode: getCanvasMode(),
-			getPostLinkProps: getEditorSettings().getPostLinkProps,
-			templateId: getCurrentTemplateId(),
-			currentPostType: getCurrentPostType(),
-		};
-	}, [] );
+	const { isPage, canvasMode, templateId, currentPostType } = useSelect(
+		( select ) => {
+			const { isPage: _isPage, getCanvasMode } = unlock(
+				select( editSiteStore )
+			);
+			const { getCurrentPostType, getCurrentTemplateId } =
+				select( editorStore );
+			return {
+				isPage: _isPage(),
+				canvasMode: getCanvasMode(),
+				templateId: getCurrentTemplateId(),
+				currentPostType: getCurrentPostType(),
+			};
+		},
+		[]
+	);
 
-	const editTemplate = getPostLinkProps
-		? getPostLinkProps( {
-				postId: templateId,
-				postType: 'wp_template',
-				canvas: 'edit',
-		  } )
-		: {};
+	const { onClick: editTemplate } = useLink( {
+		postType: 'wp_template',
+		postId: templateId,
+	} );
 
 	const { setRenderingMode } = useDispatch( editorStore );
 
@@ -90,7 +84,7 @@ function usePageContentFocusCommands() {
 			),
 			icon: layout,
 			callback: ( { close } ) => {
-				editTemplate.onClick();
+				editTemplate();
 				close();
 			},
 		} );

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -81,7 +81,6 @@ export default function DocumentBar() {
 	const handleOnBack = () => {
 		if ( isEditingTemplate ) {
 			setRenderingMode( getEditorSettings().defaultRenderingMode );
-			return;
 		}
 		if ( goBack ) {
 			goBack();

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -48,27 +48,14 @@ const icons = {
 };
 
 export default function DocumentBar() {
-	const {
-		isEditingTemplate,
-		templateId,
-		postType,
-		postId,
-		goBack,
-		getEditorSettings,
-	} = useSelect( ( select ) => {
+	const { postType, postId, goBack } = useSelect( ( select ) => {
 		const {
-			getRenderingMode,
-			getCurrentTemplateId,
 			getCurrentPostId,
 			getCurrentPostType,
 			getEditorSettings: getSettings,
 		} = select( editorStore );
-		const _templateId = getCurrentTemplateId();
 		const back = getSettings().goBack;
 		return {
-			isEditingTemplate:
-				!! _templateId && getRenderingMode() === 'template-only',
-			templateId: _templateId,
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
 			goBack: typeof back === 'function' ? back : undefined,
@@ -76,12 +63,7 @@ export default function DocumentBar() {
 		};
 	}, [] );
 
-	const { setRenderingMode } = useDispatch( editorStore );
-
 	const handleOnBack = () => {
-		if ( isEditingTemplate ) {
-			setRenderingMode( getEditorSettings().defaultRenderingMode );
-		}
 		if ( goBack ) {
 			goBack();
 		}
@@ -89,9 +71,9 @@ export default function DocumentBar() {
 
 	return (
 		<BaseDocumentActions
-			postType={ isEditingTemplate ? 'wp_template' : postType }
-			postId={ isEditingTemplate ? templateId : postId }
-			onBack={ isEditingTemplate || goBack ? handleOnBack : undefined }
+			postType={ postType }
+			postId={ postId }
+			onBack={ goBack ? handleOnBack : undefined }
 		/>
 	);
 }

--- a/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
@@ -46,7 +46,6 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 		? getPostLinkProps( {
 				postId: templateId,
 				postType: 'wp_template',
-				canvas: 'edit',
 		  } )
 		: {};
 	const { getNotices } = useSelect( noticesStore );

--- a/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
@@ -27,14 +27,31 @@ import { store as editorStore } from '../../store';
  *                                                                  editor iframe canvas.
  */
 export default function EditTemplateBlocksNotification( { contentRef } ) {
-	const renderingMode = useSelect(
-		( select ) => select( editorStore ).getRenderingMode(),
+	const { renderingMode, getPostLinkProps, templateId } = useSelect(
+		( select ) => {
+			const {
+				getRenderingMode,
+				getEditorSettings,
+				getCurrentTemplateId,
+			} = select( editorStore );
+			return {
+				renderingMode: getRenderingMode(),
+				getPostLinkProps: getEditorSettings().getPostLinkProps,
+				templateId: getCurrentTemplateId(),
+			};
+		},
 		[]
 	);
+	const editTemplate = getPostLinkProps
+		? getPostLinkProps( {
+				postId: templateId,
+				postType: 'wp_template',
+				canvas: 'edit',
+		  } )
+		: {};
 	const { getNotices } = useSelect( noticesStore );
 
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
-	const { setRenderingMode } = useDispatch( editorStore );
 
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
 
@@ -62,7 +79,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 					actions: [
 						{
 							label: __( 'Edit template' ),
-							onClick: () => setRenderingMode( 'template-only' ),
+							onClick: () => editTemplate.onClick(),
 						},
 					],
 				}
@@ -98,7 +115,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 			confirmButtonText={ __( 'Edit template' ) }
 			onConfirm={ () => {
 				setIsDialogOpen( false );
-				setRenderingMode( 'template-only' );
+				editTemplate.onClick();
 			} }
 			onCancel={ () => setIsDialogOpen( false ) }
 		>

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -138,8 +138,7 @@ function EditorCanvas( {
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			deviceType: getDeviceType(),
-			showEditorPadding:
-				!! editorSettings.goBack && postTypeSlug !== 'wp_template',
+			showEditorPadding: !! editorSettings.goBack,
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -91,7 +91,7 @@ function EditorCanvas( {
 		wrapperBlockName,
 		wrapperUniqueId,
 		deviceType,
-		hasHistory,
+		showEditorPadding,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostId,
@@ -138,7 +138,8 @@ function EditorCanvas( {
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			deviceType: getDeviceType(),
-			hasHistory: !! editorSettings.goBack,
+			showEditorPadding:
+				!! editorSettings.goBack && postTypeSlug !== 'wp_template',
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -302,7 +303,7 @@ function EditorCanvas( {
 			height="100%"
 			iframeProps={ {
 				className: classnames( 'editor-canvas__iframe', {
-					'has-history': hasHistory,
+					'has-editor-padding': showEditorPadding,
 				} ),
 				...iframeProps,
 				style: {

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -48,7 +48,6 @@ export default function BlockThemeControl( { id } ) {
 		? getPostLinkProps( {
 				postId: template.id,
 				postType: 'wp_template',
-				canvas: 'edit',
 		  } )
 		: {};
 

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -24,10 +24,13 @@ const POPOVER_PROPS = {
 };
 
 export default function BlockThemeControl( { id } ) {
-	const { isTemplateHidden } = useSelect( ( select ) => {
-		const { getRenderingMode } = unlock( select( editorStore ) );
+	const { isTemplateHidden, getPostLinkProps } = useSelect( ( select ) => {
+		const { getRenderingMode, getEditorSettings } = unlock(
+			select( editorStore )
+		);
 		return {
 			isTemplateHidden: getRenderingMode() === 'post-only',
+			getPostLinkProps: getEditorSettings().getPostLinkProps,
 		};
 	}, [] );
 	const { editedRecord: template, hasResolved } = useEntityRecord(
@@ -38,7 +41,13 @@ export default function BlockThemeControl( { id } ) {
 	const { getEditorSettings } = useSelect( editorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { setRenderingMode } = useDispatch( editorStore );
-
+	const editTemplate = getPostLinkProps
+		? getPostLinkProps( {
+				postId: template.wp_id,
+				postType: 'wp_template',
+				canvas: 'edit',
+		  } )
+		: {};
 	if ( ! hasResolved ) {
 		return null;
 	}
@@ -58,8 +67,9 @@ export default function BlockThemeControl( { id } ) {
 				<>
 					<MenuGroup>
 						<MenuItem
-							onClick={ () => {
+							onClick={ ( event ) => {
 								setRenderingMode( 'template-only' );
+								editTemplate.onClick( event );
 								onClose();
 								createSuccessNotice(
 									__(

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -24,15 +24,14 @@ const POPOVER_PROPS = {
 };
 
 export default function BlockThemeControl( { id } ) {
-	const { isTemplateHidden, getPostLinkProps, goBack } = useSelect(
+	const { isTemplateHidden, getPostLinkProps, getEditorSettings } = useSelect(
 		( select ) => {
-			const { getRenderingMode, getEditorSettings } = unlock(
-				select( editorStore )
-			);
+			const { getRenderingMode, getEditorSettings: _getEditorSettings } =
+				unlock( select( editorStore ) );
 			return {
 				isTemplateHidden: getRenderingMode() === 'post-only',
-				getPostLinkProps: getEditorSettings().getPostLinkProps,
-				goBack: getEditorSettings().goBack,
+				getPostLinkProps: _getEditorSettings().getPostLinkProps,
+				getEditorSettings: _getEditorSettings,
 			};
 		},
 		[]
@@ -83,7 +82,8 @@ export default function BlockThemeControl( { id } ) {
 										actions: [
 											{
 												label: __( 'Go back' ),
-												onClick: () => goBack(),
+												onClick: () =>
+													getEditorSettings().goBack(),
 											},
 										],
 									}

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -24,15 +24,19 @@ const POPOVER_PROPS = {
 };
 
 export default function BlockThemeControl( { id } ) {
-	const { isTemplateHidden, getPostLinkProps } = useSelect( ( select ) => {
-		const { getRenderingMode, getEditorSettings } = unlock(
-			select( editorStore )
-		);
-		return {
-			isTemplateHidden: getRenderingMode() === 'post-only',
-			getPostLinkProps: getEditorSettings().getPostLinkProps,
-		};
-	}, [] );
+	const { isTemplateHidden, getPostLinkProps, goBack } = useSelect(
+		( select ) => {
+			const { getRenderingMode, getEditorSettings } = unlock(
+				select( editorStore )
+			);
+			return {
+				isTemplateHidden: getRenderingMode() === 'post-only',
+				getPostLinkProps: getEditorSettings().getPostLinkProps,
+				goBack: getEditorSettings().goBack,
+			};
+		},
+		[]
+	);
 	const { editedRecord: template, hasResolved } = useEntityRecord(
 		'postType',
 		'wp_template',
@@ -47,6 +51,7 @@ export default function BlockThemeControl( { id } ) {
 				canvas: 'edit',
 		  } )
 		: {};
+
 	if ( ! hasResolved ) {
 		return null;
 	}
@@ -75,6 +80,12 @@ export default function BlockThemeControl( { id } ) {
 									),
 									{
 										type: 'snackbar',
+										actions: [
+											{
+												label: __( 'Go back' ),
+												onClick: () => goBack(),
+											},
+										],
 									}
 								);
 							} }

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -38,12 +38,11 @@ export default function BlockThemeControl( { id } ) {
 		'wp_template',
 		id
 	);
-	const { getEditorSettings } = useSelect( editorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { setRenderingMode } = useDispatch( editorStore );
 	const editTemplate = getPostLinkProps
 		? getPostLinkProps( {
-				postId: template.wp_id,
+				postId: template.id,
 				postType: 'wp_template',
 				canvas: 'edit',
 		  } )
@@ -77,16 +76,6 @@ export default function BlockThemeControl( { id } ) {
 									),
 									{
 										type: 'snackbar',
-										actions: [
-											{
-												label: __( 'Go back' ),
-												onClick: () =>
-													setRenderingMode(
-														getEditorSettings()
-															.defaultRenderingMode
-													),
-											},
-										],
 									}
 								);
 							} }

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -24,18 +24,19 @@ const POPOVER_PROPS = {
 };
 
 export default function BlockThemeControl( { id } ) {
-	const { isTemplateHidden, getPostLinkProps, getEditorSettings } = useSelect(
-		( select ) => {
+	const { isTemplateHidden, getPostLinkProps, getEditorSettings, hasGoBack } =
+		useSelect( ( select ) => {
 			const { getRenderingMode, getEditorSettings: _getEditorSettings } =
 				unlock( select( editorStore ) );
+			const editorSettings = _getEditorSettings();
 			return {
 				isTemplateHidden: getRenderingMode() === 'post-only',
-				getPostLinkProps: _getEditorSettings().getPostLinkProps,
+				getPostLinkProps: editorSettings.getPostLinkProps,
 				getEditorSettings: _getEditorSettings,
+				hasGoBack: editorSettings.hasOwnProperty( 'goBack' ),
 			};
-		},
-		[]
-	);
+		}, [] );
+
 	const { editedRecord: template, hasResolved } = useEntityRecord(
 		'postType',
 		'wp_template',
@@ -54,7 +55,14 @@ export default function BlockThemeControl( { id } ) {
 	if ( ! hasResolved ) {
 		return null;
 	}
-
+	const notificationAction = hasGoBack
+		? [
+				{
+					label: __( 'Go back' ),
+					onClick: () => getEditorSettings().goBack(),
+				},
+		  ]
+		: undefined;
 	return (
 		<DropdownMenu
 			popoverProps={ POPOVER_PROPS }
@@ -79,13 +87,7 @@ export default function BlockThemeControl( { id } ) {
 									),
 									{
 										type: 'snackbar',
-										actions: [
-											{
-												label: __( 'Go back' ),
-												onClick: () =>
-													getEditorSettings().goBack(),
-											},
-										],
+										actions: notificationAction,
 									}
 								);
 							} }

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -55,6 +55,8 @@ export default function BlockThemeControl( { id } ) {
 	if ( ! hasResolved ) {
 		return null;
 	}
+	// The site editor does not have a `goBack` setting as it uses its own routing
+	// and assigns its own backlink to focusMode pages.
 	const notificationAction = hasGoBack
 		? [
 				{

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -67,7 +67,6 @@ export default function BlockThemeControl( { id } ) {
 					<MenuGroup>
 						<MenuItem
 							onClick={ ( event ) => {
-								setRenderingMode( 'template-only' );
 								editTemplate.onClick( event );
 								onClose();
 								createSuccessNotice(

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -193,7 +193,7 @@ function PostTemplateDropdownContent( { onClose } ) {
 							);
 						} }
 					>
-						{ __( 'Edit templates' ) }
+						{ __( 'Edit template' ) }
 					</Button>
 				</p>
 			) }

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -106,7 +106,6 @@ function PostTemplateDropdownContent( { onClose } ) {
 			? getPostLinkProps( {
 					postId: currentTemplateId,
 					postType: 'wp_template',
-					canvas: 'edit',
 			  } )
 			: {};
 

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -63,12 +63,15 @@ function PostTemplateDropdownContent( { onClose } ) {
 		selectedTemplateSlug,
 		canCreate,
 		canEdit,
+		currentTemplateId,
+		getPostLinkProps,
 	} = useSelect(
 		( select ) => {
 			const { canUser, getEntityRecords } = select( coreStore );
 			const editorSettings = select( editorStore ).getEditorSettings();
 			const canCreateTemplates = canUser( 'create', 'templates' );
-
+			const _currentTemplateId =
+				select( editorStore ).getCurrentTemplateId();
 			return {
 				availableTemplates: editorSettings.availableTemplates,
 				fetchedTemplates: canCreateTemplates
@@ -88,11 +91,22 @@ function PostTemplateDropdownContent( { onClose } ) {
 					allowSwitchingTemplate &&
 					canCreateTemplates &&
 					editorSettings.supportsTemplateMode &&
-					!! select( editorStore ).getCurrentTemplateId(),
+					!! _currentTemplateId,
+				currentTemplateId: _currentTemplateId,
+				getPostLinkProps: editorSettings.getPostLinkProps,
 			};
 		},
 		[ allowSwitchingTemplate ]
 	);
+
+	const editTemplate =
+		getPostLinkProps && currentTemplateId
+			? getPostLinkProps( {
+					postId: currentTemplateId,
+					postType: 'wp_template',
+					canvas: 'edit',
+			  } )
+			: {};
 
 	const options = useMemo(
 		() =>
@@ -113,9 +127,7 @@ function PostTemplateDropdownContent( { onClose } ) {
 		options.find( ( option ) => ! option.value ); // The default option has '' value.
 
 	const { editPost } = useDispatch( editorStore );
-	const { getEditorSettings } = useSelect( editorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
-	const { setRenderingMode } = useDispatch( editorStore );
 	const [ isCreateModalOpen, setIsCreateModalOpen ] = useState( false );
 
 	return (
@@ -160,7 +172,7 @@ function PostTemplateDropdownContent( { onClose } ) {
 					<Button
 						variant="link"
 						onClick={ () => {
-							setRenderingMode( 'template-only' );
+							editTemplate.onClick();
 							onClose();
 							createSuccessNotice(
 								__(
@@ -168,21 +180,11 @@ function PostTemplateDropdownContent( { onClose } ) {
 								),
 								{
 									type: 'snackbar',
-									actions: [
-										{
-											label: __( 'Go back' ),
-											onClick: () =>
-												setRenderingMode(
-													getEditorSettings()
-														.defaultRenderingMode
-												),
-										},
-									],
 								}
 							);
 						} }
 					>
-						{ __( 'Edit template' ) }
+						{ __( 'Edit templatess' ) }
 					</Button>
 				</p>
 			) }

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -184,7 +184,7 @@ function PostTemplateDropdownContent( { onClose } ) {
 							);
 						} }
 					>
-						{ __( 'Edit templatess' ) }
+						{ __( 'Edit templates' ) }
 					</Button>
 				</p>
 			) }

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -65,6 +65,7 @@ function PostTemplateDropdownContent( { onClose } ) {
 		canEdit,
 		currentTemplateId,
 		getPostLinkProps,
+		getEditorSettings,
 	} = useSelect(
 		( select ) => {
 			const { canUser, getEntityRecords } = select( coreStore );
@@ -94,6 +95,7 @@ function PostTemplateDropdownContent( { onClose } ) {
 					!! _currentTemplateId,
 				currentTemplateId: _currentTemplateId,
 				getPostLinkProps: editorSettings.getPostLinkProps,
+				getEditorSettings: select( editorStore ).getEditorSettings,
 			};
 		},
 		[ allowSwitchingTemplate ]
@@ -180,6 +182,13 @@ function PostTemplateDropdownContent( { onClose } ) {
 								),
 								{
 									type: 'snackbar',
+									actions: [
+										{
+											label: __( 'Go back' ),
+											onClick: () =>
+												getEditorSettings().goBack(),
+										},
+									],
 								}
 							);
 						} }

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -101,7 +101,6 @@ export default function CreateNewTemplateModal( { onClose } ) {
 			? getPostLinkProps( {
 					postId: newTemplate.id,
 					postType: 'wp_template',
-					canvas: 'edit',
 			  } )
 			: {};
 		editTemplate.onClick();

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -94,7 +94,7 @@ export default function CreateNewTemplateModal( { onClose } ) {
 			slug: cleanForSlug( title || DEFAULT_TITLE ),
 			content: newTemplateContent,
 			title: title || DEFAULT_TITLE,
-		} ).then( () => {} );
+		} );
 
 		setIsBusy( false );
 		const editTemplate = getPostLinkProps

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -23,7 +23,7 @@ import { store as editorStore } from '../../store';
 const DEFAULT_TITLE = __( 'Custom Template' );
 
 export default function CreateNewTemplateModal( { onClose } ) {
-	const { defaultBlockTemplate, getPostLinkProps, getTemplateId } = useSelect(
+	const { defaultBlockTemplate, getPostLinkProps } = useSelect(
 		( select ) => {
 			const { getEditorSettings, getCurrentTemplateId } =
 				select( editorStore );
@@ -90,7 +90,7 @@ export default function CreateNewTemplateModal( { onClose } ) {
 				),
 			] );
 
-		await createTemplate( {
+		const newTemplate = await createTemplate( {
 			slug: cleanForSlug( title || DEFAULT_TITLE ),
 			content: newTemplateContent,
 			title: title || DEFAULT_TITLE,
@@ -99,7 +99,7 @@ export default function CreateNewTemplateModal( { onClose } ) {
 		setIsBusy( false );
 		const editTemplate = getPostLinkProps
 			? getPostLinkProps( {
-					postId: getTemplateId(),
+					postId: newTemplate.id,
 					postType: 'wp_template',
 					canvas: 'edit',
 			  } )

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -23,15 +23,19 @@ import { store as editorStore } from '../../store';
 const DEFAULT_TITLE = __( 'Custom Template' );
 
 export default function CreateNewTemplateModal( { onClose } ) {
-	const defaultBlockTemplate = useSelect(
-		( select ) =>
-			select( editorStore ).getEditorSettings().defaultBlockTemplate,
-		[]
+	const { defaultBlockTemplate, getPostLinkProps, getTemplateId } = useSelect(
+		( select ) => {
+			const { getEditorSettings, getCurrentTemplateId } =
+				select( editorStore );
+			return {
+				defaultBlockTemplate: getEditorSettings().defaultBlockTemplate,
+				getPostLinkProps: getEditorSettings().getPostLinkProps,
+				getTemplateId: getCurrentTemplateId,
+			};
+		}
 	);
 
-	const { createTemplate, setRenderingMode } = unlock(
-		useDispatch( editorStore )
-	);
+	const { createTemplate } = unlock( useDispatch( editorStore ) );
 
 	const [ title, setTitle ] = useState( '' );
 
@@ -90,11 +94,18 @@ export default function CreateNewTemplateModal( { onClose } ) {
 			slug: cleanForSlug( title || DEFAULT_TITLE ),
 			content: newTemplateContent,
 			title: title || DEFAULT_TITLE,
-		} );
+		} ).then( () => {} );
 
 		setIsBusy( false );
+		const editTemplate = getPostLinkProps
+			? getPostLinkProps( {
+					postId: getTemplateId(),
+					postType: 'wp_template',
+					canvas: 'edit',
+			  } )
+			: {};
+		editTemplate.onClick();
 		cancel();
-		setRenderingMode( 'template-only' );
 	};
 
 	return (

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -209,7 +209,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		// Sets the right rendering mode when loading the editor.
 		useEffect( () => {
 			setRenderingMode( settings.defaultRenderingMode ?? 'post-only' );
-		}, [ settings.defaultRenderingMode, setRenderingMode, post.type ] );
+		}, [ settings.defaultRenderingMode, setRenderingMode ] );
 
 		if ( ! isReady ) {
 			return null;

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -187,8 +187,6 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					}
 				);
 			}
-			// Not sure if the missing no dependencies here is deliberate or not so ignoring lint warning for now.
-			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [] );
 
 		// Synchronizes the active post with the state

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -113,8 +113,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {
 			const postContext =
-				rootLevelPost.type !== 'wp_template' ||
-				( shouldRenderTemplate && mode !== 'template-only' )
+				rootLevelPost.type !== 'wp_template'
 					? { postId: post.id, postType: post.type }
 					: {};
 
@@ -125,14 +124,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 						? rootLevelPost.slug
 						: undefined,
 			};
-		}, [
-			mode,
-			post.id,
-			post.type,
-			rootLevelPost.type,
-			rootLevelPost?.slug,
-			shouldRenderTemplate,
-		] );
+		}, [ post.id, post.type, rootLevelPost.type, rootLevelPost.slug ] );
 		const { editorSettings, selection, isReady } = useSelect(
 			( select ) => {
 				const {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -214,8 +214,12 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Sets the right rendering mode when loading the editor.
 		useEffect( () => {
-			setRenderingMode( settings.defaultRenderingMode ?? 'post-only' );
-		}, [ settings.defaultRenderingMode, setRenderingMode ] );
+			setRenderingMode(
+				settings.defaultRenderingMode ?? post.type === 'wp_template'
+					? 'template-only'
+					: 'post-only'
+			);
+		}, [ settings.defaultRenderingMode, setRenderingMode, post.type ] );
 
 		if ( ! isReady ) {
 			return null;

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -113,7 +113,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {
 			const postContext =
-				rootLevelPost.type !== 'wp_template'
+				rootLevelPost.type !== 'wp_template' || shouldRenderTemplate
 					? { postId: post.id, postType: post.type }
 					: {};
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -187,12 +187,14 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					}
 				);
 			}
+			// Not sure if the missing no dependencies here is deliberate or not so ignoring lint warning for now.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [] );
 
 		// Synchronizes the active post with the state
 		useEffect( () => {
 			setEditedPost( post.type, post.id );
-		}, [ post.type, post.id ] );
+		}, [ post.type, post.id, setEditedPost ] );
 
 		// Synchronize the editor settings as they change.
 		useEffect( () => {
@@ -208,7 +210,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		useEffect( () => {
 			setRenderingMode(
 				settings.defaultRenderingMode ?? post.type === 'wp_template'
-					? 'template-only'
+					? 'all'
 					: 'post-only'
 			);
 		}, [ settings.defaultRenderingMode, setRenderingMode, post.type ] );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -208,11 +208,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Sets the right rendering mode when loading the editor.
 		useEffect( () => {
-			setRenderingMode(
-				settings.defaultRenderingMode ?? post.type === 'wp_template'
-					? 'all'
-					: 'post-only'
-			);
+			setRenderingMode( settings.defaultRenderingMode ?? 'post-only' );
 		}, [ settings.defaultRenderingMode, setRenderingMode, post.type ] );
 
 		if ( ! isReady ) {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -313,8 +313,14 @@ export const trashPost =
 export const autosave =
 	( { local = false, ...options } = {} ) =>
 	async ( { select, dispatch } ) => {
+		const post = select.getCurrentPost();
+
+		// Currently template autosaving is not supported.
+		if ( post.type === 'wp_template' ) {
+			return;
+		}
+
 		if ( local ) {
-			const post = select.getCurrentPost();
 			const isPostNew = select.isEditedPostNew();
 			const title = select.getEditedPostAttribute( 'title' );
 			const content = select.getEditedPostAttribute( 'content' );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -576,11 +576,10 @@ export function updateEditorSettings( settings ) {
  * Returns an action used to set the rendering mode of the post editor. We support multiple rendering modes:
  *
  * -   `all`: This is the default mode. It renders the post editor with all the features available. If a template is provided, it's preferred over the post.
- * -   `template-only`: This mode renders the editor with only the template blocks visible.
  * -   `post-only`: This mode extracts the post blocks from the template and renders only those. The idea is to allow the user to edit the post/page in isolation without the wrapping template.
  * -   `template-locked`: This mode renders both the template and the post blocks but the template blocks are locked and can't be edited. The post blocks are editable.
  *
- * @param {string} mode Mode (one of 'template-only', 'post-only', 'template-locked' or 'all').
+ * @param {string} mode Mode (one of 'post-only', 'template-locked' or 'all').
  */
 export const setRenderingMode =
 	( mode ) =>

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -59,6 +59,7 @@ export const createTemplate =
 					],
 				}
 			);
+		return savedTemplate;
 	};
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -373,6 +373,12 @@ export const getAutosaveAttribute = createRegistrySelector(
 		}
 
 		const postType = getCurrentPostType( state );
+
+		// Currently template autosaving is not supported.
+		if ( postType === 'wp_template' ) {
+			return false;
+		}
+
 		const postId = getCurrentPostId( state );
 		const currentUserId = select( coreStore ).getCurrentUser()?.id;
 		const autosave = select( coreStore ).getAutosave(
@@ -592,6 +598,12 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 		}
 
 		const postType = getCurrentPostType( state );
+
+		// Currently template autosaving is not supported.
+		if ( postType === 'wp_template' ) {
+			return false;
+		}
+
 		const postId = getCurrentPostId( state );
 		const hasFetchedAutosave = select( coreStore ).hasFetchedAutosaves(
 			postType,

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -57,6 +57,7 @@ test.describe( 'Post Editor Template mode', () => {
 		);
 
 		// Save changes.
+		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Publish"i]' );
 		await page.click( 'role=button[name="Save"i]' );
 
@@ -249,6 +250,7 @@ class PostEditorTemplateMode {
 	}
 
 	async saveTemplateWithoutPublishing() {
+		await this.page.click( 'role=button[name="Back"i]' );
 		await this.page.click( 'role=button[name="Publish"i]' );
 		const editorPublishRegion = this.page.locator(
 			'role=region[name="Editor publish"i]'

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -143,11 +143,14 @@ test.describe( 'Pages', () => {
 
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Site title text' } )
+			.click( { force: true } );
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Site title text' } )
 			.fill( 'New Site Title' );
 
 		// Go back to page editing focus.
 		await page
-			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'region', { name: 'Editor content' } )
 			.getByRole( 'button', { name: 'Back' } )
 			.click();
 


### PR DESCRIPTION
## What?
Removes the `template-only` editor rendering mode.

## Why?
This mode was only added as a temporary measure to help with some of the work around integrating the site and post editors. With the work that was done in [57036](https://github.com/WordPress/gutenberg/pull/57036) this can now be removed as it is now possible to inject a new post into the editor provider, so the current post can be replaced with the template.

## How?
Uses the new `getPostLinkProps` editor setting to inject the template id and post type into the editor provider.

## Testing Instructions

- Add a new post and select the `Template - Edit Template` option in the right post panel
- Check that you navigate to the template and can edit it
- Use the back button in the top editor and make sure you go back to the post
- Check that when you click the post Save/Update button the template changes show as needing saving
- Also try the `Template - Create new template` option in right post panel and check it works
- Try the `Template - Edit template` option again and this time make sure the `Go back` option in the success snackbar works
- In the site editor open a page and repeat all of the above actions. The only difference will be that the `Go back` button will not appear in the notification, this is because the routing works differently in the site editor, and the top back link is more prominant

