### PR TITLE
Components: Extend experimental v2 CustomSelectControl to allow custom popover props and hide label

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,7 @@
 -   `InputControl`, `NumberControl`, `UnitControl`, `SelectControl`, `TreeSelect`: Add `compact` size variant ([#57398](https://github.com/WordPress/gutenberg/pull/57398)).
 -   `ToggleGroupControl`: Update button size in large variant to be 32px ([#57338](https://github.com/WordPress/gutenberg/pull/57338)).
 -   `Tooltip`: improve unit tests ([#57345](https://github.com/WordPress/gutenberg/pull/57345)).
+-   `CustomSelectControl`: Update experimental Ariakit version to offer `popoverProps` and `hideLabelFromVision` props ([#57703](https://github.com/WordPress/gutenberg/pull/57703)).
 
 ### Experimental
 

--- a/packages/components/src/custom-select-control-v2/README.md
+++ b/packages/components/src/custom-select-control-v2/README.md
@@ -22,6 +22,13 @@ An optional default value for the control. If left `undefined`, the first non-di
 
 -   Required: no
 
+##### `hideLabelFromVision`: `boolean`
+
+If true, the label will only be visible to screen readers.
+
+-   Required: no
+-   Default: `false`
+
 ##### `label`: `string`
 
 Label for the control.
@@ -31,6 +38,12 @@ Label for the control.
 ##### `onChange`: `( newValue: string ) => void`
 
 A function that receives the new value of the input.
+
+-   Required: no
+
+##### `popoverProps`: `Object`
+
+Optional props passed to the Ariakit Select Popover.
 
 -   Required: no
 

--- a/packages/components/src/custom-select-control-v2/index.tsx
+++ b/packages/components/src/custom-select-control-v2/index.tsx
@@ -19,6 +19,7 @@ import type {
 	CustomSelectContext as CustomSelectContextType,
 } from './types';
 import type { WordPressComponentProps } from '../context';
+import { VisuallyHidden } from '../visually-hidden';
 
 export const CustomSelectContext =
 	createContext< CustomSelectContextType >( undefined );
@@ -45,11 +46,13 @@ function defaultRenderSelectedValue( value: CustomSelectProps[ 'value' ] ) {
 export function CustomSelect( {
 	children,
 	defaultValue,
+	hideLabelFromVision = false,
 	label,
 	onChange,
 	size = 'default',
 	value,
 	renderSelectedValue = defaultRenderSelectedValue,
+	popoverProps,
 	...props
 }: WordPressComponentProps< CustomSelectProps, 'button', false > ) {
 	const store = Ariakit.useSelectStore( {
@@ -59,12 +62,23 @@ export function CustomSelect( {
 	} );
 
 	const { value: currentValue } = store.useState();
+	const selectPopoverProps = {
+		gutter: 12,
+		sameWidth: true,
+		...popoverProps,
+		store,
+	};
 
 	return (
 		<>
-			<Styled.CustomSelectLabel store={ store }>
-				{ label }
-			</Styled.CustomSelectLabel>
+			{ hideLabelFromVision && (
+				<VisuallyHidden as="label">{ label }</VisuallyHidden>
+			) }
+			{ ! hideLabelFromVision && (
+				<Styled.CustomSelectLabel store={ store }>
+					{ label }
+				</Styled.CustomSelectLabel>
+			) }
 			<Styled.CustomSelectButton
 				{ ...props }
 				size={ size }
@@ -74,7 +88,7 @@ export function CustomSelect( {
 				{ renderSelectedValue( currentValue ) }
 				<Ariakit.SelectArrow />
 			</Styled.CustomSelectButton>
-			<Styled.CustomSelectPopover gutter={ 12 } store={ store } sameWidth>
+			<Styled.CustomSelectPopover { ...selectPopoverProps }>
 				<CustomSelectContext.Provider value={ { store } }>
 					{ children }
 				</CustomSelectContext.Provider>

--- a/packages/components/src/custom-select-control-v2/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control-v2/stories/index.story.tsx
@@ -115,6 +115,40 @@ MultiSelect.args = {
 	),
 };
 
+export const HiddenLabelSelect = Template.bind( {} );
+HiddenLabelSelect.args = {
+	hideLabelFromVision: true,
+	label: 'Label',
+	children: (
+		<>
+			<CustomSelectItem value="Small">
+				<span style={ { fontSize: '75%' } }>Small</span>
+			</CustomSelectItem>
+			<CustomSelectItem value="Something bigger">
+				<span style={ { fontSize: '200%' } }>Something bigger</span>
+			</CustomSelectItem>
+		</>
+	),
+};
+
+export const CustomPopoverSelect = Template.bind( {} );
+CustomPopoverSelect.args = {
+	popoverProps: {
+		sameWidth: false,
+	},
+	label: 'Label',
+	children: (
+		<>
+			<CustomSelectItem value="Small">
+				<span style={ { fontSize: '75%' } }>Small</span>
+			</CustomSelectItem>
+			<CustomSelectItem value="Something bigger">
+				<span style={ { fontSize: '200%' } }>Something bigger</span>
+			</CustomSelectItem>
+		</>
+	),
+};
+
 const renderControlledValue = ( gravatar: string | string[] ) => {
 	const avatar = `https://gravatar.com/avatar?d=${ gravatar }`;
 	return (

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -63,6 +63,8 @@ export const CustomSelectPopover = styled( Ariakit.SelectPopover )`
 	border-radius: ${ space( 0.5 ) };
 	background: ${ COLORS.white };
 	border: 1px solid ${ COLORS.gray[ 900 ] };
+	/* Force the passed wrapper props z-index otherwise it's overridden. */
+	z-index: ${ ( props ) => props.wrapperProps?.style?.zIndex };
 `;
 
 export const CustomSelectItem = styled( Ariakit.SelectItem )`

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -24,6 +24,12 @@ export type CustomSelectProps = {
 	 */
 	defaultValue?: string | string[];
 	/**
+	 * If true, the label will only be visible to screen readers.
+	 *
+	 * @default false
+	 */
+	hideLabelFromVision?: boolean;
+	/**
 	 * Label for the control.
 	 */
 	label: string;
@@ -31,6 +37,10 @@ export type CustomSelectProps = {
 	 * A function that receives the new value of the input.
 	 */
 	onChange?: ( newValue: string | string[] ) => void;
+	/**
+	 * Optional props passed to the Ariakit Select Popover.
+	 */
+	popoverProps?: Ariakit.SelectPopoverProps;
 	/**
 	 * Can be used to render select UI with custom styled values.
 	 */

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -14,6 +14,7 @@ import {
 	useCompositeStore as useCompositeStoreV2,
 } from './composite/v2';
 import { default as CustomSelectControl } from './custom-select-control';
+import { CustomSelect, CustomSelectItem } from './custom-select-control-v2';
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
 import { default as ProgressBar } from './progress-bar';
 import { createPrivateSlotFill } from './slot-fill';
@@ -41,6 +42,8 @@ lock( privateApis, {
 	CompositeRowV2,
 	useCompositeStoreV2,
 	CustomSelectControl,
+	CustomSelect,
+	CustomSelectItem,
 	__experimentalPopoverLegacyPositionToPlacement,
 	createPrivateSlotFill,
 	ComponentsContext,


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/57331
- https://github.com/WordPress/gutenberg/pull/56540

## What?

Adds two new props to the experimental v2 CustomSelectControl; `hideLabelFromVision` and `popoverProps`. The experimental control is also exported as a private API.

## Why?

The mockups for the updated block style variation controls require adding some things such as color indicators and custom styles to the proposed select's options. The experimental CustomSelectControl v2 is the best bet for achieving this design. 

To do that though, we need the ability to visually hide a label and customize the select's popover.

## How?

- Updates the component to wrap the control's label in `VisuallyHidden` if the new `hideLabelFromVision` prop is `true`
- Merges any new `popoverProps` value with the components existing values for `gutter`, `sameWidth` and `store` then passes those through to the underlying components
- Adds this experimental control to the components package's private apis so it can be leveraged in the block editor

## Testing Instructions

1. Fire up storybook and navigate to the `CustomSelectControl v2` page
2. Check that the control still behaves as before
3. Confirm the expected behaviour in the "Hidden Label Select" and "Custom Popover Select" stories
4. Optionally, check out [#57331](https://github.com/WordPress/gutenberg/pull/57331) from which these changes were extracted and follow its test instructions

## Screenshots or screencast <!-- if applicable -->

| Hide Label | Custom Popover |
|---|---|
| <img width="1030" alt="Screenshot 2024-01-10 at 3 06 51 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/c58017ce-b236-479b-8ca3-4bc9b6117cf9"> | <img width="1042" alt="Screenshot 2024-01-10 at 3 07 00 pm" src="https://github.com/WordPress/gutenberg/assets/60436221/18e4a06f-8339-478d-8c95-22dff9d88907"> |
