### PR TITLE
Image Block: Change upload icon label

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -459,7 +459,7 @@ export default function Image( {
 						<ToolbarButton
 							onClick={ uploadExternal }
 							icon={ upload }
-							label={ __( 'Upload external image' ) }
+							label={ __( 'Upload image to media library' ) }
 						/>
 					</ToolbarGroup>
 				</BlockControls>

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -696,7 +696,9 @@ test.describe( 'Image', () => {
 		await expect( linkDom ).toHaveAttribute( 'href', url );
 	} );
 
-	test( 'should upload external image', async ( { editor } ) => {
+	test( 'should upload external image to media library', async ( {
+		editor,
+	} ) => {
 		await editor.insertBlock( {
 			name: 'core/image',
 			attributes: {
@@ -704,7 +706,7 @@ test.describe( 'Image', () => {
 			},
 		} );
 
-		await editor.clickBlockToolbarButton( 'Upload external image' );
+		await editor.clickBlockToolbarButton( 'Upload image to media library' );
 
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'


### PR DESCRIPTION
Fixes #56345

## What?

This PR updates the label of the external image upload icon in the block toolbar of the Image Block.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/8b52c052-87b4-412f-95f2-2347345ef992)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/cb01d0ec-6487-4664-883d-0bdf41eeed74)


## Why?

When you publish a post, the pre-publish check will ask you if you want to upload external images to the media library.

![image](https://github.com/WordPress/gutenberg/assets/54422211/bd0590d6-8d7c-48b8-8330-2f1ac3b53cc3)

This panel has a description so it's easy to understand what the "Upload" button actually does.

But the block toolbar has no such context, so users may be confused about _where_ to upload images.

## How?

Maybe it should be "Upload external image to media library" to provide full context. However, I excluded the word "external" because I don't want the tooltip text to be too long.

## Testing Instructions

- Insert a Image Block.
- Insert an image from URL.
- Focus the upload icon on the block toolbar.

