### PR TITLE
Editor: Use hooks instead of HoCs in 'PostVisibilityCheck'

### DIFF
--- a/packages/editor/src/components/post-visibility/check.js
+++ b/packages/editor/src/components/post-visibility/check.js
@@ -1,26 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-export function PostVisibilityCheck( { hasPublishAction, render } ) {
-	const canEdit = hasPublishAction;
+export default function PostVisibilityCheck( { render } ) {
+	const canEdit = useSelect( ( select ) => {
+		return (
+			select( editorStore ).getCurrentPost()._links?.[
+				'wp:action-publish'
+			] ?? false
+		);
+	} );
+
 	return render( { canEdit } );
 }
-
-export default compose( [
-	withSelect( ( select ) => {
-		const { getCurrentPost, getCurrentPostType } = select( editorStore );
-		return {
-			hasPublishAction:
-				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,
-			postType: getCurrentPostType(),
-		};
-	} ),
-] )( PostVisibilityCheck );

--- a/packages/editor/src/components/post-visibility/test/check.js
+++ b/packages/editor/src/components/post-visibility/test/check.js
@@ -4,31 +4,42 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+
+/**
  * Internal dependencies
  */
-import { PostVisibilityCheck } from '../check';
+import PostVisibilityCheck from '../check';
+
+function setupMockSelect( hasPublishAction ) {
+	useSelect.mockImplementation( ( mapSelect ) => {
+		return mapSelect( () => ( {
+			getCurrentPost: () => ( {
+				_links: {
+					'wp:action-publish': hasPublishAction,
+				},
+			} ),
+		} ) );
+	} );
+}
 
 describe( 'PostVisibilityCheck', () => {
 	const renderProp = ( { canEdit } ) => ( canEdit ? 'yes' : 'no' );
 
 	it( "should not render the edit link if the user doesn't have the right capability", () => {
-		render(
-			<PostVisibilityCheck
-				hasPublishAction={ false }
-				render={ renderProp }
-			/>
-		);
+		setupMockSelect( false );
+		render( <PostVisibilityCheck render={ renderProp } /> );
 		expect( screen.queryByText( 'yes' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'no' ) ).toBeVisible();
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		render(
-			<PostVisibilityCheck
-				hasPublishAction={ true }
-				render={ renderProp }
-			/>
-		);
+		setupMockSelect( true );
+		render( <PostVisibilityCheck render={ renderProp } /> );
 		expect( screen.queryByText( 'no' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'yes' ) ).toBeVisible();
 	} );


### PR DESCRIPTION
## What?
PR updates the `PostVisibilityCheck` component to use data hooks instead of HoCs

## Why?
A micro-optimization makes the rendered component tree smaller.

This is similar to #53330.

## Testing Instructions
1. Open a post or page.
2. Confirm post "Visibility" actions work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-01-10 at 11 11 35](https://github.com/WordPress/gutenberg/assets/240569/6f715118-711c-4ee5-af2e-f0f827756c2b)
