### PR TITLE
Font Library: Prefer downloading WOFF instead of TTF font files

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -84,7 +84,17 @@ class WP_Font_Collection {
 				return new WP_Error( 'font_collection_read_error', __( 'Invalid URL for Font Collection data.', 'gutenberg' ) );
 			}
 
-			$response = wp_remote_get( $this->config['src'] );
+			/**
+			 * The user-agent we want to use.
+			 *
+			 * The default user-agent is the only one compatible with woff (not woff2)
+			 * which also supports unicode ranges.
+			 *
+			 * To use woff2, change this to 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:73.0) Gecko/20100101 Firefox/73.0'.
+			 */
+			$user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8';
+
+			$response = wp_remote_get( $this->config['src'], array( 'user-agent' => $user_agent ) );
 			if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 				return new WP_Error( 'font_collection_read_error', __( 'Error fetching the Font Collection data from a URL.', 'gutenberg' ) );
 			}


### PR DESCRIPTION
## What?
[Issue reported on WP's Slack](https://wordpress.slack.com/archives/C015GUFFC00/p1704808470086589) by @luminuu:
> when using the Font Library in the Gutenberg plugin, the fonts downloaded are TTF files

## Why?
`.ttf` is an antiquated format, much larger in size than `.woff` or `.woff2` and also of lower quality, supporting far fewer features available in modern fonts.

## How?
Added a `user-agent` to our `wp_remote_get` call. Previously, there was no user-agent set so the default WP one was used. The user-agent selected here will download `.woff` files, so that we can still support some older browsers.
Looking at the [browser supports for woff2 on caniuse.com](https://caniuse.com/woff2) I think we can switch to `woff2` instead of `woff`, but I'm not 100% certain so I added a comment explaining _why_ this particular user-agent was selected, and which one to use if we want to use woff2.