### PR TITLE
Performance: Measure typing with the top toolbar enabled

### DIFF
--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -27,6 +27,7 @@ export interface WPRawPerformanceResults {
 	firstBlock: number[];
 	type: number[];
 	typeWithoutInspector: number[];
+	typeWithTopToolbar: number[];
 	typeContainer: number[];
 	focus: number[];
 	inserterOpen: number[];
@@ -51,6 +52,7 @@ export interface WPPerformanceResults {
 	minType?: number;
 	maxType?: number;
 	typeWithoutInspector?: number;
+	typeWithTopToolbar?: number;
 	typeContainer?: number;
 	minTypeContainer?: number;
 	maxTypeContainer?: number;
@@ -97,6 +99,7 @@ export function curateResults(
 		minType: minimum( results.type ),
 		maxType: maximum( results.type ),
 		typeWithoutInspector: average( results.typeWithoutInspector ),
+		typeWithTopToolbar: average( results.typeWithTopToolbar ),
 		typeContainer: average( results.typeContainer ),
 		minTypeContainer: minimum( results.typeContainer ),
 		maxTypeContainer: maximum( results.typeContainer ),

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -23,6 +23,7 @@ const results = {
 	firstBlock: [],
 	type: [],
 	typeWithoutInspector: [],
+	typeWithTopToolbar: [],
 	typeContainer: [],
 	focus: [],
 	listViewOpen: [],
@@ -183,6 +184,39 @@ test.describe( 'Post Editor Performance', () => {
 
 			// Open the inspector again.
 			await editor.openDocumentSettingsSidebar();
+		} );
+	} );
+
+	test.describe( 'Typing (with top toolbar)', () => {
+		let draftId = null;
+
+		test( 'Setup the test post', async ( { admin, perfUtils, editor } ) => {
+			await admin.createNewPost();
+			await perfUtils.loadBlocksForLargePost();
+			await editor.insertBlock( { name: 'core/paragraph' } );
+			draftId = await perfUtils.saveDraft();
+		} );
+
+		test( 'Run the test', async ( {
+			admin,
+			perfUtils,
+			metrics,
+			editor,
+		} ) => {
+			await admin.editPost( draftId );
+			await perfUtils.disableAutosave();
+			// Enable fixed toolbar.
+			await editor.setIsFixedToolbar( true );
+			const canvas = await perfUtils.getCanvas();
+
+			const paragraph = canvas.getByRole( 'document', {
+				name: /Empty block/i,
+			} );
+
+			await type( paragraph, metrics, 'typeWithTopToolbar' );
+
+			// Disabled fixed toolbar. Default state.
+			await editor.setIsFixedToolbar( false );
 		} );
 	} );
 


### PR DESCRIPTION
## What?
PR adds typing perf metric when the top toolbar is enabled.

## Why?
Similar to #56753.

The difference in metrics gives us a good picture of how much of the performance issues are coming from the Block Toolbar.

## Testing Instructions
The perf tests should be green.
