### PR TITLE
Group templates in sidebar list

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -30,20 +31,11 @@ const TemplateItem = ( { postType, postId, ...props } ) => {
 
 export default function SidebarNavigationScreenTemplates() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-
 	const { records: templates, isResolving: isLoading } = useEntityRecords(
 		'postType',
 		TEMPLATE_POST_TYPE,
-		{
-			per_page: -1,
-		}
+		{ per_page: -1 }
 	);
-
-	const sortedTemplates = templates ? [ ...templates ] : [];
-	sortedTemplates.sort( ( a, b ) =>
-		a.title.rendered.localeCompare( b.title.rendered )
-	);
-
 	const browseAllLink = useLink( { path: '/wp_template/all' } );
 	const canCreate = ! isMobileViewport;
 	return (
@@ -66,24 +58,7 @@ export default function SidebarNavigationScreenTemplates() {
 				<>
 					{ isLoading && __( 'Loading templates…' ) }
 					{ ! isLoading && (
-						<ItemGroup>
-							{ ! templates?.length && (
-								<Item>{ __( 'No templates found' ) }</Item>
-							) }
-							{ sortedTemplates.map( ( template ) => (
-								<TemplateItem
-									postType={ TEMPLATE_POST_TYPE }
-									postId={ template.id }
-									key={ template.id }
-									withChevron
-								>
-									{ decodeEntities(
-										template.title?.rendered ||
-											template.slug
-									) }
-								</TemplateItem>
-							) ) }
-						</ItemGroup>
+						<SidebarTemplatesList templates={ templates } />
 					) }
 				</>
 			}
@@ -95,5 +70,88 @@ export default function SidebarNavigationScreenTemplates() {
 				)
 			}
 		/>
+	);
+}
+
+function TemplatesGroup( { title, templates } ) {
+	return (
+		<ItemGroup>
+			{ !! title && (
+				<Item className="edit-site-sidebar-navigation-screen-templates__templates-group-title">
+					{ title }
+				</Item>
+			) }
+			{ templates.map( ( template ) => (
+				<TemplateItem
+					postType={ TEMPLATE_POST_TYPE }
+					postId={ template.id }
+					key={ template.id }
+					withChevron
+				>
+					{ decodeEntities(
+						template.title?.rendered || template.slug
+					) }
+				</TemplateItem>
+			) ) }
+		</ItemGroup>
+	);
+}
+function SidebarTemplatesList( { templates } ) {
+	if ( ! templates?.length ) {
+		return (
+			<ItemGroup>
+				<Item>{ __( 'No templates found' ) }</Item>
+			</ItemGroup>
+		);
+	}
+	const sortedTemplates = templates ? [ ...templates ] : [];
+	sortedTemplates.sort( ( a, b ) =>
+		a.title.rendered.localeCompare( b.title.rendered )
+	);
+	const { themeTemplates, customTemplates, ...pluginTemplates } =
+		sortedTemplates.reduce(
+			( accumulator, template ) => {
+				const {
+					original_source: originalSource,
+					author_text: authorText,
+				} = template;
+				if ( originalSource === 'plugin' ) {
+					if ( ! accumulator[ authorText ] ) {
+						accumulator[ authorText ] = [];
+					}
+					accumulator[ authorText ].push( template );
+				} else if ( template.is_custom ) {
+					accumulator.customTemplates.push( template );
+				} else {
+					accumulator.themeTemplates.push( template );
+				}
+				return accumulator;
+			},
+			{ themeTemplates: [], customTemplates: [] }
+		);
+	return (
+		<VStack spacing={ 3 }>
+			{ !! themeTemplates.length && (
+				<TemplatesGroup templates={ themeTemplates } />
+			) }
+			{ !! customTemplates.length && (
+				<TemplatesGroup
+					title={ __( 'Custom' ) }
+					templates={ customTemplates }
+				/>
+			) }
+			{ !! Object.keys( pluginTemplates ).length &&
+				Object.entries( pluginTemplates ).map(
+					( [ plugin, _pluginTemplates ] ) => {
+						return (
+							<TemplatesGroup
+								key={ plugin }
+								title={ plugin }
+								templates={ _pluginTemplates }
+							/>
+						);
+					}
+				) }
+		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/index.js
@@ -108,7 +108,7 @@ function SidebarTemplatesList( { templates } ) {
 	sortedTemplates.sort( ( a, b ) =>
 		a.title.rendered.localeCompare( b.title.rendered )
 	);
-	const { themeTemplates, customTemplates, ...pluginTemplates } =
+	const { hierarchyTemplates, customTemplates, ...plugins } =
 		sortedTemplates.reduce(
 			( accumulator, template ) => {
 				const {
@@ -123,16 +123,16 @@ function SidebarTemplatesList( { templates } ) {
 				} else if ( template.is_custom ) {
 					accumulator.customTemplates.push( template );
 				} else {
-					accumulator.themeTemplates.push( template );
+					accumulator.hierarchyTemplates.push( template );
 				}
 				return accumulator;
 			},
-			{ themeTemplates: [], customTemplates: [] }
+			{ hierarchyTemplates: [], customTemplates: [] }
 		);
 	return (
 		<VStack spacing={ 3 }>
-			{ !! themeTemplates.length && (
-				<TemplatesGroup templates={ themeTemplates } />
+			{ !! hierarchyTemplates.length && (
+				<TemplatesGroup templates={ hierarchyTemplates } />
 			) }
 			{ !! customTemplates.length && (
 				<TemplatesGroup
@@ -140,18 +140,17 @@ function SidebarTemplatesList( { templates } ) {
 					templates={ customTemplates }
 				/>
 			) }
-			{ !! Object.keys( pluginTemplates ).length &&
-				Object.entries( pluginTemplates ).map(
-					( [ plugin, _pluginTemplates ] ) => {
-						return (
-							<TemplatesGroup
-								key={ plugin }
-								title={ plugin }
-								templates={ _pluginTemplates }
-							/>
-						);
-					}
-				) }
+			{ Object.entries( plugins ).map(
+				( [ plugin, pluginTemplates ] ) => {
+					return (
+						<TemplatesGroup
+							key={ plugin }
+							title={ plugin }
+							templates={ pluginTemplates }
+						/>
+					);
+				}
+			) }
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
@@ -1,0 +1,9 @@
+.edit-site-sidebar-navigation-screen-templates__templates-group-title.components-item {
+	text-transform: uppercase;
+	color: $gray-600;
+	// 6px right padding to align with + button
+	padding: $grid-unit-10 6px $grid-unit-10 $grid-unit-20;
+	border: none;
+	min-height: $grid-unit-50;
+	border-radius: $radius-block-ui;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates/style.scss
@@ -1,9 +1,9 @@
 .edit-site-sidebar-navigation-screen-templates__templates-group-title.components-item {
 	text-transform: uppercase;
-	color: $gray-600;
+	color: $gray-200;
 	// 6px right padding to align with + button
-	padding: $grid-unit-10 6px $grid-unit-10 $grid-unit-20;
-	border: none;
-	min-height: $grid-unit-50;
-	border-radius: $radius-block-ui;
+	padding: $grid-unit-30 6px $grid-unit-20 $grid-unit-20;
+	border-top: 1px solid $gray-800;
+	font-size: 11px;
+	font-weight: 500;
 }

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -34,6 +34,7 @@
 @import "./components/sidebar-navigation-screen-details-footer/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-page/style.scss";
+@import "./components/sidebar-navigation-screen-templates/style.scss";
 @import "components/sidebar-navigation-screen-details-panel/style.scss";
 @import "./components/sidebar-navigation-screen-pattern/style.scss";
 @import "./components/sidebar-navigation-screen-patterns/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/48651

This PR separates the custom templates and the templates added by plugins. Currently the check for plugin templates is based on the `original_source` property(internally checks if there is file and if the `origin` has value `plugin`), but it's very possible other plugins add templates differently.

I'm not very familiar of all the ways plugins add templates, but in general this can also affect the `author` filter in templates list. So if this doesn't work well, we'll probably need to see if we can have an API for that - although it seems convoluted at first sight since there are also filters in place for changing/overriding templates.


## Testing Instructions
1. In site editor click the `Templates` in navigation sidebar and observe the grouping.
2. Try different plugins that add templates.


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/51f3aafa-2101-4250-b063-0c433e531718


