### PR TITLE
Fix webpack not setting environment.module true

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -403,6 +403,10 @@ if ( hasExperimentalModulesFlag ) {
 			...baseConfig.output,
 			module: true,
 			chunkFormat: 'module',
+			environment: {
+				...baseConfig.output.environment,
+				module: true,
+			},
 			library: {
 				...baseConfig.output.library,
 				type: 'module',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Set `output.environment.modules = true` in the webpack modules config for wp-scripts. This aligns with the current interactivity webpack config:

https://github.com/WordPress/gutenberg/blob/6ef4629f77ab3da6502508b4c9539a3912300f0e/tools/webpack/interactivity.js#L26-L34

## Why?

Webpack (via wp-scripts) may refuse to output external modules unless we set `output.environment.modules = true`:

```
The target environment doesn't support EcmaScriptModule syntax so it's not possible to use external type 'module'
while analyzing module external module "@wordpress/interactivity" for concatenation
```

Noticed while working on https://github.com/WordPress/gutenberg/pull/57712

## Testing Instructions

You can test this on https://github.com/WordPress/gutenberg/pull/57712. This is currently committed there.

wp-scripts usage without `--experimental-modules` is unaffected.
