### PR TITLE
Audio block: Add integration tests to cover enabling autoplay and loop setting in Audio block

### DIFF
--- a/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/edit.native.js.snap
@@ -532,3 +532,15 @@ exports[`Audio block renders placeholder without crashing 1`] = `
   </View>
 </View>
 `;
+
+exports[`Audio block should enable autoplay setting 1`] = `
+"<!-- wp:audio {"id":5} -->
+<figure class="wp-block-audio"><audio controls src="https://cldup.com/59IrU0WJtq.mp3" autoplay></audio></figure>
+<!-- /wp:audio -->"
+`;
+
+exports[`Audio block should enable loop setting 1`] = `
+"<!-- wp:audio {"id":5} -->
+<figure class="wp-block-audio"><audio controls src="https://cldup.com/59IrU0WJtq.mp3" loop></audio></figure>
+<!-- /wp:audio -->"
+`;

--- a/packages/block-library/src/audio/test/edit.native.js
+++ b/packages/block-library/src/audio/test/edit.native.js
@@ -5,7 +5,10 @@ import {
 	addBlock,
 	dismissModal,
 	fireEvent,
+	getBlock,
+	getEditorHtml,
 	initializeEditor,
+	openBlockSettings,
 	render,
 	screen,
 	setupCoreBlocks,
@@ -30,6 +33,10 @@ import { name } from '../index';
 jest.unmock( '@wordpress/react-native-aztec' );
 
 const MEDIA_UPLOAD_STATE_FAILED = 3;
+
+const AUDIO_BLOCK = `<!-- wp:audio {"id":5} -->
+<figure class="wp-block-audio"><audio controls src="https://cldup.com/59IrU0WJtq.mp3"></audio></figure>
+<!-- /wp:audio -->`;
 
 let uploadCallBack;
 subscribeMediaUpload.mockImplementation( ( callback ) => {
@@ -99,5 +106,27 @@ describe( 'Audio block', () => {
 		expect(
 			screen.getByText( 'Invalid URL. Audio file not found.' )
 		).toBeVisible();
+	} );
+
+	it( 'should enable autoplay setting', async () => {
+		await initializeEditor( { initialHtml: AUDIO_BLOCK } );
+
+		const audioBlock = getBlock( screen, 'Audio' );
+		fireEvent.press( audioBlock );
+		await openBlockSettings( screen );
+
+		fireEvent.press( screen.getByText( 'Autoplay' ) );
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'should enable loop setting', async () => {
+		await initializeEditor( { initialHtml: AUDIO_BLOCK } );
+
+		const audioBlock = getBlock( screen, 'Audio' );
+		fireEvent.press( audioBlock );
+		await openBlockSettings( screen );
+
+		fireEvent.press( screen.getByText( 'Loop' ) );
+		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add integration tests to cover the following cases:
* [TC008 - Autoplay setting](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc008)
* [TC009 - Loop setting](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc009)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This change is part of an ongoing effort to migrate manual tests to automated tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add integration tests for each case.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
* Check that all CI jobs pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A