### PR TITLE
Add description to the save panel header when nothing is checked

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -218,9 +218,7 @@ export function EntitiesSavedStatesExtensible( {
 						? __(
 								'The following changes have been made to your site, templates, and content.'
 						  )
-						: __(
-								'No changes will be made to your site, templates, and content. Select the items you want to save.'
-						  ) }
+						: __( 'Select the items you want to save.' ) }
 				</p>
 			</div>
 

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -213,13 +213,15 @@ export function EntitiesSavedStatesExtensible( {
 					{ __( 'Are you ready to save?' ) }
 				</strong>
 				{ additionalPrompt }
-				{ isDirty && (
-					<p>
-						{ __(
-							'The following changes have been made to your site, templates, and content.'
-						) }
-					</p>
-				) }
+				<p>
+					{ isDirty
+						? __(
+								'The following changes have been made to your site, templates, and content.'
+						  )
+						: __(
+								'No changes will be made to your site, templates, and content. Select the items you want to save.'
+						  ) }
+				</p>
 			</div>
 
 			{ sortedPartitionedSavables.map( ( list ) => {


### PR DESCRIPTION
Fixes #52689

## What?

This PR adds a message to the save panel header when nothing is checked.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/4a865081-ef40-4039-ad74-85d321c3b7e0) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/3aa4eb45-7c05-4bb1-a2d1-32084bd14745) | 

## Why?

When no entity is checked, the save button is disabled. Some users may find it difficult to understand why they are disabled without an explanation.

## How?
Added description. Props to @benwormald who suggested this message in [this comment](https://github.com/WordPress/gutenberg/issues/52689#issuecomment-1691954756).

If you have a more appropriate message, I welcome your suggestions.

## Testing Instructions

- Open the Site Editor.
- Make changes to some entities (Site Logo, Site Title, Navigation).
- Click the Save button.
- Uncheck all entities.