### PR TITLE
Fix visual indication of switch to default template in the post editor

### DIFF
--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -594,12 +594,13 @@ export const getEditedPostTemplate = createRegistrySelector(
 		}
 
 		const post = select( editorStore ).getCurrentPost();
-		if ( post.link ) {
-			return select( coreStore ).__experimentalGetTemplateForLink(
-				post.link
-			);
-		}
-
-		return null;
+		const defaultTemplateId = select( coreStore ).getDefaultTemplateId( {
+			slug: `${ post.type }-${ post.slug }`,
+		} );
+		return select( coreStore ).getEditedEntityRecord(
+			'postType',
+			'wp_template',
+			defaultTemplateId
+		);
 	}
 );

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -594,8 +594,22 @@ export const getEditedPostTemplate = createRegistrySelector(
 		}
 
 		const post = select( editorStore ).getCurrentPost();
+		let slugToCheck;
+		// In `draft` status we might not have a slug available, so we use the `single`
+		// post type templates slug(ex page, single-post, single-product etc..).
+		// Pages do not need the `single` prefix in the slug to be prioritized
+		// through template hierarchy.
+		if ( post.slug ) {
+			slugToCheck =
+				post.type === 'page'
+					? `${ post.type }-${ post.slug }`
+					: `single-${ post.type }-${ post.slug }`;
+		} else {
+			slugToCheck =
+				post.type === 'page' ? 'page' : `single-${ post.type }`;
+		}
 		const defaultTemplateId = select( coreStore ).getDefaultTemplateId( {
-			slug: `${ post.type }-${ post.slug }`,
+			slug: slugToCheck,
 		} );
 		return select( coreStore ).getEditedEntityRecord(
 			'postType',

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -128,10 +128,25 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 						return currentTemplate.id;
 					}
 				}
-
 				// If no template is assigned, use the default template.
+				let slugToCheck;
+				// In `draft` status we might not have a slug available, so we use the `single`
+				// post type templates slug(ex page, single-post, single-product etc..).
+				// Pages do not need the `single` prefix in the slug to be prioritized
+				// through template hierarchy.
+				if ( editedEntity.slug ) {
+					slugToCheck =
+						postTypeToResolve === 'page'
+							? `${ postTypeToResolve }-${ editedEntity.slug }`
+							: `single-${ postTypeToResolve }-${ editedEntity.slug }`;
+				} else {
+					slugToCheck =
+						postTypeToResolve === 'page'
+							? 'page'
+							: `single-${ postTypeToResolve }`;
+				}
 				return getDefaultTemplateId( {
-					slug: `${ postTypeToResolve }-${ editedEntity?.slug }`,
+					slug: slugToCheck,
 				} );
 			}
 

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -70,6 +70,42 @@ test.describe( 'Post Editor Template mode', () => {
 		).toBeVisible();
 	} );
 
+	test( 'Swap templates and proper template resolution when switching to default template', async ( {
+		editor,
+		page,
+		requestUtils,
+		postEditorTemplateMode,
+	} ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await postEditorTemplateMode.createPostAndSaveDraft();
+		await page.reload();
+		await postEditorTemplateMode.disableTemplateWelcomeGuide();
+		await postEditorTemplateMode.openTemplatePopover();
+		// Swap to a custom template, save and reload.
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Swap template',
+			} )
+			.click();
+		await page
+			.getByRole( 'option', {
+				name: 'Custom',
+			} )
+			.click();
+		await editor.saveDraft();
+		await page.reload();
+		// Swap to the default template.
+		await postEditorTemplateMode.openTemplatePopover();
+		await page
+			.getByRole( 'menuitem', {
+				name: 'Use default template',
+			} )
+			.click();
+		await expect(
+			page.getByRole( 'button', { name: 'Template options' } )
+		).toHaveText( 'Single Entries' );
+	} );
+
 	test( 'Allow creating custom block templates in classic themes', async ( {
 		editor,
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/48577

When using the template switcher in the post editor sidebar to switch from a custom template back to the default one, there is no visual indication that the change was successful. Neither the template name in the sidebar or the layout actually changes.

## Why?
As @talldan mentions [here](https://github.com/WordPress/gutenberg/issues/48577#issuecomment-1459817254), internally we were using `__experimentalGetTemplateForLink` which doesn't take into account unsaved changes(in our case the `template` prop) which results in the wrong template resolution. The same problem was encountered in switching templates in site editor and has been resolved with this [PR](https://github.com/WordPress/gutenberg/pull/55883), that introduced the `getDefaultTemplateId` selector I'm using here.


## Testing Instructions
1. In a block theme with more than one post (single) template, create a post and set it to use a non-default template.
2. Save and reload the page.
3. Try switching the template back to the default.


## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/a929f645-6e35-4418-bc9c-4169789746bd


