### PR TITLE
Added Styling options for the Audio block

### DIFF
--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -42,6 +42,13 @@
 			"source": "attribute",
 			"selector": "audio",
 			"attribute": "preload"
+		},
+		"borderRadius": {
+			"type": "string",
+			"default": "0px",
+			"source": "attribute",
+			"selector": "audio",
+			"attribute": "borderRadius"
 		}
 	},
 	"supports": {
@@ -53,6 +60,28 @@
 			"__experimentalDefaultControls": {
 				"margin": false,
 				"padding": false
+			}
+		},
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalWritingMode": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
 			}
 		}
 	},

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -46,6 +46,10 @@
 		"borderRadius": {
 			"type": "string",
 			"default": "0px"
+		},
+		"captionContent": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -45,10 +45,7 @@
 		},
 		"borderRadius": {
 			"type": "string",
-			"default": "0px",
-			"source": "attribute",
-			"selector": "audio",
-			"attribute": "borderRadius"
+			"default": "0px"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -23,6 +23,7 @@ import {
 	MediaReplaceFlow,
 	useBlockProps,
 	store as blockEditorStore,
+	RichText
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -212,7 +213,9 @@ function AudioEdit( {
 						] }
 					/>
 				</PanelBody>
-				<PanelBody title="Block Settings" initialOpen={true}>
+			</InspectorControls>
+			<InspectorControls group="styles">
+				<PanelBody title="Styles" initialOpen={true}>
 					<Button
 						className='border-btn'
 						onClick={ () => borderStyleHandler("default") }
@@ -233,11 +236,21 @@ function AudioEdit( {
 					so the user clicking on it won't play the
 					file or change the position slider when the controls are enabled.
 				*/ }
-				Hello World
 				<Disabled isDisabled={ ! isSingleSelected }>
 					<audio controls="controls" src={ src } />
 				</Disabled>
 				{ isTemporaryAudio && <Spinner /> }
+				<RichText
+					{ ...blockProps }
+					tagName='p'
+					value={ attributes.captionContent }
+					allowedFormats={ [ 'core/bold', 'core/italic' ] }
+					onChange={ ( captionContent ) => setAttributes( { captionContent } ) }
+					placeholder={__( 'Enter the caption for the Audio' )}
+					style={{
+						padding:'0px'
+					}}
+				/>
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -13,6 +13,7 @@ import {
 	SelectControl,
 	Spinner,
 	ToggleControl,
+	Button
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -26,7 +27,7 @@ import {
 import { useEffect } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { audio as icon } from '@wordpress/icons';
+import { border, audio as icon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -125,6 +126,16 @@ function AudioEdit( {
 		className: classes,
 	} );
 
+	const borderStyleHandler = ( borderType ) => {
+		if( borderType === 'rounded' ){
+			setAttributes( { borderRadius: "10px" } );
+			console.log( attributes.borderRadius );
+			return;
+		}
+		setAttributes( { borderRadius: "0px" } );
+		console.log( attributes.borderRadius );
+	}
+
 	if ( ! src ) {
 		return (
 			<div { ...blockProps }>
@@ -192,6 +203,20 @@ function AudioEdit( {
 						] }
 					/>
 				</PanelBody>
+				<PanelBody title="Block Settings" initialOpen={true}>
+					<Button
+						className='border-btn'
+						onClick={ () => setAttributes({borderRadius:"0px"}) }
+					>
+						Default
+					</Button>
+					<Button
+						className='border-btn'
+						onClick={ ()=> setAttributes( {borderRadius: "10px"} ) }
+					>
+						Rounded
+					</Button>
+				</PanelBody>
 			</InspectorControls>
 			<figure { ...blockProps }>
 				{ /*
@@ -199,6 +224,7 @@ function AudioEdit( {
 					so the user clicking on it won't play the
 					file or change the position slider when the controls are enabled.
 				*/ }
+				Hello World
 				<Disabled isDisabled={ ! isSingleSelected }>
 					<audio controls="controls" src={ src } />
 				</Disabled>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -124,17 +124,26 @@ function AudioEdit( {
 
 	const blockProps = useBlockProps( {
 		className: classes,
+		style:{
+			borderRadius: attributes.borderRadius
+		}
 	} );
 
 	const borderStyleHandler = ( borderType ) => {
+		console.log( attributes.borderRadius );
 		if( borderType === 'rounded' ){
-			setAttributes( { borderRadius: "10px" } );
-			console.log( attributes.borderRadius );
+			setAttributes( { borderRadius: "15px" } );
 			return;
 		}
 		setAttributes( { borderRadius: "0px" } );
-		console.log( attributes.borderRadius );
 	}
+
+	useEffect(() => {
+		console.log(attributes.borderRadius);
+		 blockProps.style = {
+			borderRadius: attributes.borderRadius,
+		};
+	}, [attributes.borderRadius]);
 
 	if ( ! src ) {
 		return (
@@ -206,13 +215,13 @@ function AudioEdit( {
 				<PanelBody title="Block Settings" initialOpen={true}>
 					<Button
 						className='border-btn'
-						onClick={ () => setAttributes({borderRadius:"0px"}) }
+						onClick={ () => borderStyleHandler("default") }
 					>
 						Default
 					</Button>
 					<Button
 						className='border-btn'
-						onClick={ ()=> setAttributes( {borderRadius: "10px"} ) }
+						onClick={ ()=> borderStyleHandler("rounded") }
 					>
 						Rounded
 					</Button>

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -17,3 +17,17 @@
 		margin-left: -9px;
 	}
 }
+
+.border-btn {
+	width: 6rem;
+    background-color: #fff;
+    color: #000;
+    justify-content: center;
+    margin: 2px;
+	border: 1px solid #000
+}
+
+.border-btn:hover {
+	background-color: #000;
+    color: #fff;
+}

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -24,6 +24,10 @@ export default function save( { attributes } ) {
 					loop={ loop }
 					preload={ preload }
 				/>
+				<RichText.Content
+					tagName='p'
+					value={attributes.captionContent}
+				/>
 				{ ! RichText.isEmpty( caption ) && (
 					<RichText.Content
 						tagName="figcaption"

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -12,7 +12,11 @@ export default function save( { attributes } ) {
 
 	return (
 		src && (
-			<figure { ...useBlockProps.save() } style={{ borderRadius: "20px" }}>
+			<figure { ...useBlockProps.save({
+				style:{
+					borderRadius: attributes.borderRadius
+				}
+			}) }>
 				<audio
 					controls="controls"
 					src={ src }

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -12,7 +12,7 @@ export default function save( { attributes } ) {
 
 	return (
 		src && (
-			<figure { ...useBlockProps.save() }>
+			<figure { ...useBlockProps.save() } style={{ borderRadius: "20px" }}>
 				<audio
 					controls="controls"
 					src={ src }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR mainly focuses upon adding the styling options for the audio block which includes typography settings like core paragraph block and border-radius settings.

## Why?
As mentioned in the issue [#56837](https://github.com/WordPress/gutenberg/issues/56837), in the audio block there are no such flexibility in customizing the audio block. So in this PR, the main focus is to add more functionality in terms of styling of audio block. 
## How?
For adding more flexibility in terms of styling of the block, more block supports have been added in the `block.json` file as well as some extra settings options have been added for customizing the typography and border radius, text and background color etc.

## Testing Instructions
- Step by step instructions on how to test this PR. :-
    1. Open the Gutenberg editor.
    2. Add a audio block and upload any audio file.
    3. On the block settings, under the styles section, various customization options will appear like `typography`, `styles`, `colors` .

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/96969845/4974db2a-50ec-41ea-8862-476564ccefa5


<img width="1470" alt="image" src="https://github.com/WordPress/gutenberg/assets/96969845/33350d5e-37f0-47c5-a6f7-52c43df0cfcd">

