### PR TITLE
Fix parent selector button focus style and metrics

### DIFF
--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -35,10 +35,6 @@
 	}
 }
 
-.show-icon-labels .block-editor-block-toolbar .block-editor-block-switcher .components-button.has-icon::after {
-	font-size: 14px;
-}
-
 .components-button.block-editor-block-switcher__no-switcher-icon {
 	display: flex;
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -98,6 +98,10 @@
 
 	.block-editor-block-parent-selector {
 		position: relative;
+		// Must use the same negative margins of the .components-toolbar-group
+		// https://github.com/WordPress/gutenberg/blob/73a4716f429b5dce0190638049f5bd30f0b242f6/packages/block-editor/src/components/block-toolbar/style.scss#L32-L33
+		margin-top: -$border-width;
+		margin-bottom: -$border-width;
 
 		// Parent selector dot divider
 		&::after {
@@ -107,11 +111,6 @@
 			right: 0;
 			bottom: $grid-unit-20;
 		}
-	}
-
-	.block-editor-block-parent-selector__button {
-		position: relative;
-		top: -1px;
 	}
 }
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -242,15 +242,11 @@
 	.show-icon-labels & {
 
 		.block-editor-block-parent-selector {
-			position: static;
-			margin-top: -$border-width;
+			position: relative;
+			left: auto;
 			margin-left: -$border-width;
-			margin-bottom: -$border-width;
-
-			.block-editor-block-parent-selector__button {
-				position: static;
-			}
 		}
+
 		.block-editor-block-mover__move-button-container,
 		.block-editor-block-toolbar__block-controls .block-editor-block-mover {
 			border-left: 1px solid $gray-900;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -235,6 +235,11 @@
 			padding-right: 6px;
 			padding-left: 6px;
 			background-color: $white;
+
+			.show-icon-labels & {
+				padding-right: $grid-unit-15;
+				padding-left: $grid-unit-15;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57710

## What?
<!-- In a few words, what is the PR actually doing? -->
- When the 'Show button text labels' preference is enabled, the Parent selector button misses a focus style.
- Left and right padding is inconsistent compared to other buttons.
- Additionally, the Block switcher button font size is inconsistent, thus making text alignment uneven.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Focus indication is a prerequisite for keyboard accessibility as users need to understand where focus is in the first place.
- Visual glitches and inconsistencies contribute to make the UI be perceived as unpolished and confusing, thus iincreasing cognitive load.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- All the buttons need to be _positioned_ to allow the absolutely positioned CSS generated pseudo element responsible for the focus style to be shown correctly. This PR restores the `relative` positioning of the button that was set to `static` in https://github.com/WordPress/gutenberg/pull/56335
- Along with that, this PR aims to simplify the CSS for the button positioning. Basically, this button needs to behave like a toolbar group, which uses top and bottom negative margins.
- Also, fixes the left and right padding by using a more specific CSS selector.
- Lastly, restores the 'Block switcher' button font size to 12 pixels to make it consistent with the other buttons. The inconsistent 14 pixels size doesn't allow to correctly align the text of the buttons. Originally introduced in https://github.com/WordPress/gutenberg/pull/28691

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- test the following steps in all these 4 states of the editor:
  - Enable: Options > Preferences > Accessibility > 'Show button text labels'
    - Test with both Top toolbar disabled and enabled.
  - Enable: Options > Preferences > Accessibility > 'Show button text labels'
    - Test with both Top toolbar disabled and enabled.
- Add a Group block and add a few paragraphs within it.
- Select one of the paragraphs.
- Shift+Tab to move focus to the block toolbar.
- Observe the parent selector button shows a focus style.
- Observe the positioning of the button is correct.
- Observe the left and right padding are always consistent.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Example screenshots:

Before:

![before](https://github.com/WordPress/gutenberg/assets/1682452/3096072f-c3c2-41c2-ba4f-4c7032a2038a)


After:

![after](https://github.com/WordPress/gutenberg/assets/1682452/438ea616-6e8d-46d4-8b77-a05962f53335)

