### PR TITLE
Interactivity API:  Render the root interactive blocks

### DIFF
--- a/lib/experimental/interactivity-api/class-wp-directive-processor.php
+++ b/lib/experimental/interactivity-api/class-wp-directive-processor.php
@@ -20,33 +20,26 @@ class WP_Directive_Processor extends Gutenberg_HTML_Tag_Processor_6_5 {
 	 *
 	 * @var string
 	 */
-	public static $root_block = null;
-
-	/**
-	 * Array containing the direct children of interactive blocks.
-	 *
-	 * @var array
-	 */
-	public static $children_of_interactive_block = array();
+	public static $interactive_root_block = null;
 
 	/**
 	 * Sets the current root block.
 	 *
 	 * @param array $block The block to add.
 	 */
-	public static function mark_root_block( $block ) {
+	public static function mark_interactive_root_block( $block ) {
 		if ( null !== $block['blockName'] ) {
-			self::$root_block = $block['blockName'] . md5( serialize( $block ) );
+			self::$interactive_root_block = $block['blockName'] . md5( serialize( $block ) );
 		} else {
-			self::$root_block = md5( serialize( $block ) );
+			self::$interactive_root_block = md5( serialize( $block ) );
 		}
 	}
 
 	/**
 	 * Resets the root block.
 	 */
-	public static function unmark_root_block() {
-		self::$root_block = null;
+	public static function unmark_interactive_root_block() {
+		self::$interactive_root_block = null;
 	}
 
 	/**
@@ -55,16 +48,16 @@ class WP_Directive_Processor extends Gutenberg_HTML_Tag_Processor_6_5 {
 	 * @param array $block The block to check.
 	 * @return bool True if block is a root block, false otherwise.
 	 */
-	public static function is_marked_as_root_block( $block ) {
-		// If self::$root_block is null, is impossible that any block has been marked as root.
-		if ( is_null( self::$root_block ) ) {
+	public static function is_marked_as_interactive_root_block( $block ) {
+		// If self::$interactive_root_block is null, is impossible that any block has been marked as root.
+		if ( is_null( self::$interactive_root_block ) ) {
 			return false;
 		}
 		// Blocks whose blockName is null are specifically intended to convey - "this is a freeform HTML block."
 		if ( null !== $block['blockName'] ) {
-			return str_contains( self::$root_block, $block['blockName'] ) && $block['blockName'] . md5( serialize( $block ) ) === self::$root_block;
+			return str_contains( self::$interactive_root_block, $block['blockName'] ) && $block['blockName'] . md5( serialize( $block ) ) === self::$interactive_root_block;
 		}
-		return md5( serialize( $block ) ) === self::$root_block;
+		return md5( serialize( $block ) ) === self::$interactive_root_block;
 	}
 
 	/**
@@ -72,28 +65,8 @@ class WP_Directive_Processor extends Gutenberg_HTML_Tag_Processor_6_5 {
 	 *
 	 * @return bool True if there is a root block, false otherwise.
 	 */
-	public static function has_root_block() {
-		return isset( self::$root_block );
-	}
-
-	/**
-	 * Stores a reference to a direct children of an interactive block to be able
-	 * to identify it later.
-	 *
-	 * @param array $block The block to add.
-	 */
-	public static function mark_children_of_interactive_block( $block ) {
-		self::$children_of_interactive_block[] = md5( serialize( $block ) );
-	}
-
-	/**
-	 * Checks if block is marked as children of an interactive block.
-	 *
-	 * @param array $block The block to check.
-	 * @return bool True if block is a children of an interactive block, false otherwise.
-	 */
-	public static function is_marked_as_children_of_interactive_block( $block ) {
-		return in_array( md5( serialize( $block ) ), self::$children_of_interactive_block, true );
+	public static function has_interactive_root_block() {
+		return isset( self::$interactive_root_block );
 	}
 
 	/**

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -18,10 +18,8 @@
  *
  * @return array The parsed block.
  */
-function gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block, $source_block, $parent_block ) {
-	$has_interactive_parent   = isset( $parent_block ) && isset( $parent_block->block_type->supports['interactivity'] ) && $parent_block->block_type->supports['interactivity'];
-	$has_interactive_ancestor = WP_Directive_Processor::has_root_block();
-	if ( ! $has_interactive_parent && ! $has_interactive_ancestor ) {
+function gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block ) {
+	if ( ! WP_Directive_Processor::has_root_block() ) {
 		$block_type     = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
 		$is_interactive = isset( $block_type->supports['interactivity'] ) && $block_type->supports['interactivity'];
 		if ( $is_interactive ) {
@@ -31,7 +29,7 @@ function gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block, $s
 
 	return $parsed_block;
 }
-add_filter( 'render_block_data', 'gutenberg_interactivity_mark_root_interactive_blocks', 10, 3 );
+add_filter( 'render_block_data', 'gutenberg_interactivity_mark_root_interactive_blocks', 10, 1 );
 
 /**
  * Processes the directives in the root blocks.

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -13,8 +13,6 @@
  * parent is null.
  *
  * @param array $parsed_block The parsed block.
- * @param array $source_block The source block.
- * @param WP_Block|null $parent_block The parent block.
  *
  * @return array The parsed block.
  */

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -19,8 +19,9 @@
  * @return array The parsed block.
  */
 function gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block, $source_block, $parent_block ) {
-	$has_interactive_parent = isset( $parent_block ) && isset( $parent_block->block_type->supports['interactivity'] ) && $parent_block->block_type->supports['interactivity'];
-	if ( ! $has_interactive_parent && ! WP_Directive_Processor::has_root_block() ) {
+	$has_interactive_direct_parent      = isset( $parent_block ) && isset( $parent_block->block_type->supports['interactivity'] ) && $parent_block->block_type->supports['interactivity'];
+	$has_interactive_other_level_parent = WP_Directive_Processor::has_root_block();
+	if ( ! $has_interactive_direct_parent && ! $has_interactive_other_level_parent ) {
 		$block_type     = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
 		$is_interactive = isset( $block_type->supports['interactivity'] ) && $block_type->supports['interactivity'];
 		if ( $is_interactive ) {

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -14,18 +14,23 @@
  *
  * @param array $parsed_block The parsed block.
  * @param array $source_block The source block.
- * @param array $parent_block The parent block.
+ * @param WP_Block|null $parent_block The parent block.
  *
  * @return array The parsed block.
  */
-function gutenberg_interactivity_mark_root_blocks( $parsed_block, $source_block, $parent_block ) {
-	if ( ! isset( $parent_block ) && ! WP_Directive_Processor::has_root_block() ) {
-		WP_Directive_Processor::mark_root_block( $parsed_block );
+function gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block, $source_block, $parent_block ) {
+	$has_interactive_parent = isset( $parent_block ) && isset( $parent_block->block_type->supports['interactivity'] ) && $parent_block->block_type->supports['interactivity'];
+	if ( ! $has_interactive_parent && ! WP_Directive_Processor::has_root_block() ) {
+		$block_type     = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
+		$is_interactive = isset( $block_type->supports['interactivity'] ) && $block_type->supports['interactivity'];
+		if ( $is_interactive ) {
+			WP_Directive_Processor::mark_root_block( $parsed_block );
+		}
 	}
 
 	return $parsed_block;
 }
-add_filter( 'render_block_data', 'gutenberg_interactivity_mark_root_blocks', 10, 3 );
+add_filter( 'render_block_data', 'gutenberg_interactivity_mark_root_interactive_blocks', 10, 3 );
 
 /**
  * Processes the directives in the root blocks.

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -19,9 +19,9 @@
  * @return array The parsed block.
  */
 function gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block, $source_block, $parent_block ) {
-	$has_interactive_direct_parent      = isset( $parent_block ) && isset( $parent_block->block_type->supports['interactivity'] ) && $parent_block->block_type->supports['interactivity'];
-	$has_interactive_other_level_parent = WP_Directive_Processor::has_root_block();
-	if ( ! $has_interactive_direct_parent && ! $has_interactive_other_level_parent ) {
+	$has_interactive_parent   = isset( $parent_block ) && isset( $parent_block->block_type->supports['interactivity'] ) && $parent_block->block_type->supports['interactivity'];
+	$has_interactive_ancestor = WP_Directive_Processor::has_root_block();
+	if ( ! $has_interactive_parent && ! $has_interactive_ancestor ) {
 		$block_type     = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
 		$is_interactive = isset( $block_type->supports['interactivity'] ) && $block_type->supports['interactivity'];
 		if ( $is_interactive ) {

--- a/lib/experimental/interactivity-api/directive-processing.php
+++ b/lib/experimental/interactivity-api/directive-processing.php
@@ -17,11 +17,11 @@
  * @return array The parsed block.
  */
 function gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block ) {
-	if ( ! WP_Directive_Processor::has_root_block() ) {
+	if ( ! WP_Directive_Processor::has_interactive_root_block() ) {
 		$block_type     = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
 		$is_interactive = isset( $block_type->supports['interactivity'] ) && $block_type->supports['interactivity'];
 		if ( $is_interactive ) {
-			WP_Directive_Processor::mark_root_block( $parsed_block );
+			WP_Directive_Processor::mark_interactive_root_block( $parsed_block );
 		}
 	}
 
@@ -38,145 +38,16 @@ add_filter( 'render_block_data', 'gutenberg_interactivity_mark_root_interactive_
  * @return string Filtered block content.
  */
 function gutenberg_process_directives_in_root_blocks( $block_content, $block ) {
-	if ( WP_Directive_Processor::is_marked_as_root_block( $block ) ) {
-		WP_Directive_Processor::unmark_root_block();
-
-		// Parse our own block delimiters for interactive and non-interactive blocks.
-		$parsed_blocks     = parse_blocks( $block_content );
-		$context           = new WP_Directive_Context();
-		$processed_content = '';
-		$namespace_stack   = array();
-
-		foreach ( $parsed_blocks as $parsed_block ) {
-			if ( 'core/interactivity-wrapper' === $parsed_block['blockName'] ) {
-				$processed_content .= gutenberg_process_interactive_block( $parsed_block, $context, $namespace_stack );
-			} elseif ( 'core/non-interactivity-wrapper' === $parsed_block['blockName'] ) {
-				$processed_content .= gutenberg_process_non_interactive_block( $parsed_block, $context, $namespace_stack );
-			} else {
-				$processed_content .= $parsed_block['innerHTML'];
-			}
-		}
-		return $processed_content;
+	if ( WP_Directive_Processor::is_marked_as_interactive_root_block( $block ) ) {
+		WP_Directive_Processor::unmark_interactive_root_block();
+		$context         = new WP_Directive_Context();
+		$namespace_stack = array();
+		return gutenberg_process_interactive_html( $block_content, $context, $namespace_stack );
 	}
 
 	return $block_content;
 }
-add_filter( 'render_block', 'gutenberg_process_directives_in_root_blocks', 20, 2 );
-
-/**
- * Marks the block as a children of an interactive block.
- *
- * @param array    $parsed_block The parsed block.
- * @param array    $source_block The source block.
- * @param WP_Block $parent_block The parent block.
- */
-function gutenberg_mark_chidren_of_interactive_block( $parsed_block, $source_block, $parent_block ) {
-	if (
-		isset( $parent_block ) &&
-		isset( $parent_block->block_type->supports['interactivity'] ) &&
-		$parent_block->block_type->supports['interactivity']
-	) {
-		WP_Directive_Processor::mark_children_of_interactive_block( $source_block );
-	}
-	return $parsed_block;
-}
-add_filter( 'render_block_data', 'gutenberg_mark_chidren_of_interactive_block', 100, 3 );
-
-/**
- * Adds a comment delimiter to mark if the block is interactive or not.
- *
- * @param string   $block_content The block content.
- * @param array    $block The full block, including name and attributes.
- * @param WP_Block $block_instance The block instance.
- */
-function gutenberg_mark_block_interactivity( $block_content, $block, $block_instance ) {
-	if (
-		isset( $block_instance->block_type->supports['interactivity'] ) &&
-		$block_instance->block_type->supports['interactivity']
-	) {
-		// Wraps the interactive block with a comment delimiter to be able to
-		// process it later.
-		return get_comment_delimited_block_content(
-			'core/interactivity-wrapper',
-			array(),
-			$block_content
-		);
-	} elseif ( WP_Directive_Processor::is_marked_as_children_of_interactive_block( $block ) ) {
-		// Wraps the non-interactive block with a comment delimiter to be able to
-		// skip it later.
-		return get_comment_delimited_block_content(
-			'core/non-interactivity-wrapper',
-			array(),
-			$block_content
-		);
-	}
-	return $block_content;
-}
-add_filter( 'render_block', 'gutenberg_mark_block_interactivity', 10, 3 );
-
-/**
- * Traverses the HTML of an interactive block, searching for Interactivity API
- * directives and processing them. For the inner blocks, it calls the
- * corresponding function depending on the wrapper type.
- *
- * @param array                $interactive_block The interactive block to process.
- * @param WP_Directive_Context $context The context to use when processing.
- * @param array                $namespace_stack Stack of namespackes passed by reference.
- *
- * @return string The processed HTML.
- */
-function gutenberg_process_interactive_block( $interactive_block, $context, &$namespace_stack ) {
-	$block_index              = 0;
-	$content                  = '';
-	$interactive_inner_blocks = array();
-
-	foreach ( $interactive_block['innerContent'] as $inner_content ) {
-		if ( is_string( $inner_content ) ) {
-			$content .= $inner_content;
-		} else {
-			// This is an inner block. It may be an interactive block or a
-			// non-interactive block.
-			$content                   .= '<wp-inner-blocks-' . $block_index . '></wp-inner-blocks-' . $block_index . '>';
-			$interactive_inner_blocks[] = $interactive_block['innerBlocks'][ $block_index++ ];
-		}
-	}
-
-	return gutenberg_process_interactive_html( $content, $context, $interactive_inner_blocks, $namespace_stack );
-}
-
-/**
- * Returns the HTML of a non-interactive block without processing the
- * directives. For the inner blocks, it calls the corresponding function
- * depending on the wrapper type.
- *
- * @param array                $non_interactive_block The non-interactive block to process.
- * @param WP_Directive_Context $context The context to use when processing.
- * @param array                $namespace_stack Stack of namespackes passed by reference.
- *
- * @return string The processed HTML.
- */
-function gutenberg_process_non_interactive_block( $non_interactive_block, $context, &$namespace_stack ) {
-	$block_index = 0;
-	$content     = '';
-	foreach ( $non_interactive_block['innerContent'] as $inner_content ) {
-		if ( is_string( $inner_content ) ) {
-			// This content belongs to a non interactive block and therefore it cannot
-			// contain directives. We add the HTML directly to the final output.
-			$content .= $inner_content;
-		} else {
-			// This is an inner block. It may be an interactive block or a
-			// non-interactive block.
-			$inner_block = $non_interactive_block['innerBlocks'][ $block_index++ ];
-
-			if ( 'core/interactivity-wrapper' === $inner_block['blockName'] ) {
-				$content .= gutenberg_process_interactive_block( $inner_block, $context, $namespace_stack );
-			} elseif ( 'core/non-interactivity-wrapper' === $inner_block['blockName'] ) {
-				$content .= gutenberg_process_non_interactive_block( $inner_block, $context, $namespace_stack );
-			}
-		}
-	}
-	return $content;
-}
+add_filter( 'render_block', 'gutenberg_process_directives_in_root_blocks', 10, 2 );
 
 /**
  * Processes interactive HTML by applying directives to the HTML tags.
@@ -193,7 +64,7 @@ function gutenberg_process_non_interactive_block( $non_interactive_block, $conte
  *
  * @return string The processed HTML.
  */
-function gutenberg_process_interactive_html( $html, $context, $inner_blocks = array(), &$namespace_stack = array() ) {
+function gutenberg_process_interactive_html( $html, $context, &$namespace_stack = array() ) {
 	static $directives = array(
 		'data-wp-interactive' => 'gutenberg_interactivity_process_wp_interactive',
 		'data-wp-context'     => 'gutenberg_interactivity_process_wp_context',
@@ -203,22 +74,12 @@ function gutenberg_process_interactive_html( $html, $context, $inner_blocks = ar
 		'data-wp-text'        => 'gutenberg_interactivity_process_wp_text',
 	);
 
-	$tags                   = new WP_Directive_Processor( $html );
-	$prefix                 = 'data-wp-';
-	$tag_stack              = array();
-	$inner_processed_blocks = array();
-	$inner_blocks_index     = 0;
+	$tags      = new WP_Directive_Processor( $html );
+	$prefix    = 'data-wp-';
+	$tag_stack = array();
 	while ( $tags->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 		$tag_name = $tags->get_tag();
 
-		// Processes the inner blocks.
-		if ( str_contains( $tag_name, 'WP-INNER-BLOCKS' ) && ! empty( $inner_blocks ) && ! $tags->is_tag_closer() ) {
-			if ( 'core/interactivity-wrapper' === $inner_blocks[ $inner_blocks_index ]['blockName'] ) {
-				$inner_processed_blocks[ strtolower( $tag_name ) ] = gutenberg_process_interactive_block( $inner_blocks[ $inner_blocks_index++ ], $context, $namespace_stack );
-			} elseif ( 'core/non-interactivity-wrapper' === $inner_blocks[ $inner_blocks_index ]['blockName'] ) {
-				$inner_processed_blocks[ strtolower( $tag_name ) ] = gutenberg_process_non_interactive_block( $inner_blocks[ $inner_blocks_index++ ], $context, $namespace_stack );
-			}
-		}
 		if ( $tags->is_tag_closer() ) {
 			if ( 0 === count( $tag_stack ) ) {
 				continue;
@@ -289,19 +150,7 @@ function gutenberg_process_interactive_html( $html, $context, $inner_blocks = ar
 		}
 	}
 
-	$processed_html = $tags->get_updated_html();
-
-	// Replaces the inner block tags with the content of each inner block
-	// processed.
-	if ( ! empty( $inner_processed_blocks ) ) {
-		foreach ( $inner_processed_blocks as $inner_block_tag => $inner_block_content ) {
-			if ( str_contains( $processed_html, $inner_block_tag ) ) {
-				$processed_html = str_replace( '<' . $inner_block_tag . '></' . $inner_block_tag . '>', $inner_block_content, $processed_html );
-			}
-		}
-	}
-
-	return $processed_html;
+	return $tags->get_updated_html();
 }
 
 /**

--- a/packages/e2e-tests/plugins/interactive-blocks.php
+++ b/packages/e2e-tests/plugins/interactive-blocks.php
@@ -40,7 +40,7 @@ add_action(
 		if ( 'true' === $_GET['disable_directives_ssr'] ) {
 			remove_filter(
 				'render_block_data',
-				'gutenberg_interactivity_mark_root_blocks'
+				'gutenberg_interactivity_mark_root_interactive_blocks'
 			);
 		}
 	}

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -105,18 +105,6 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 				),
 			)
 		);
-		register_block_type(
-			'test/non-interactive-root-block',
-			array(
-				'render_callback' => function ( $attributes, $content, $block ) {
-					$inner_blocks_html = '';
-					foreach ( $block->inner_blocks as $inner_block ) {
-						$inner_blocks_html .= $inner_block->render();
-					}
-					return '<div>' . $inner_blocks_html . '</div>';
-				},
-			)
-		);
 
 		WP_Interactivity_Initial_State::reset();
 	}
@@ -130,7 +118,6 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 		unregister_block_type( 'test/context-level-with-manual-inner-block-rendering' );
 		unregister_block_type( 'test/directives-ordering' );
 		unregister_block_type( 'test/directives' );
-		unregister_block_type( 'test/non-interactive-root-block' );
 		parent::tear_down();
 	}
 
@@ -138,7 +125,7 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 		$block_content =
 		'<!-- wp:test/context-level-1 /-->' .
 		'<!-- wp:test/context-level-2 /-->' .
-		'<!-- wp:test/non-interactive-root-block /-->';
+		'<!-- wp:paragraph --><p>Welcome</p><!-- /wp:paragraph -->';
 
 		$interactive_parsed_block = parse_blocks( $block_content )[0];
 

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -134,24 +134,24 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 		$non_interactive_root_block = parse_blocks( $block_content )[2];
 
 		// Test that root block is intially empty.
-		$this->assertEmpty( WP_Directive_Processor::$root_block );
+		$this->assertEmpty( WP_Directive_Processor::$interactive_root_block );
 
 		// Test that root block is not added if it is non interactive.
 		gutenberg_interactivity_mark_root_interactive_blocks( $non_interactive_root_block );
-		$this->assertEmpty( WP_Directive_Processor::$root_block );
+		$this->assertEmpty( WP_Directive_Processor::$interactive_root_block );
 
 		// Test that a non root block is added if it is interactive.
 		gutenberg_interactivity_mark_root_interactive_blocks( $interactive_parsed_block );
-		$this->assertNotEmpty( WP_Directive_Processor::$root_block );
+		$this->assertNotEmpty( WP_Directive_Processor::$interactive_root_block );
 
 		// Test that an interactive block is not added if it has in interactive ancestor.
-		$current_root_block = WP_Directive_Processor::$root_block;
+		$current_root_block = WP_Directive_Processor::$interactive_root_block;
 		gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block_second );
-		$this->assertSame( $current_root_block, WP_Directive_Processor::$root_block );
+		$this->assertSame( $current_root_block, WP_Directive_Processor::$interactive_root_block );
 
 		// Test that root block is removed after processing.
 		gutenberg_process_directives_in_root_blocks( $rendered_content, $interactive_parsed_block );
-		$this->assertEmpty( WP_Directive_Processor::$root_block );
+		$this->assertEmpty( WP_Directive_Processor::$interactive_root_block );
 	}
 
 	public function test_directive_processing_of_interactive_block() {
@@ -217,7 +217,7 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 	}
 
 	public function test_non_interactive_blocks_are_not_processed() {
-		$post_content    = '<!-- wp:test/context-level-1 --><!-- wp:test/non-interactive-with-directive /--><!-- /wp:test/context-level-1 -->';
+		$post_content    = '<!-- wp:test/non-interactive-with-directive /-->';
 		$rendered_blocks = do_blocks( $post_content );
 		$p               = new WP_HTML_Tag_Processor( $rendered_blocks );
 		$p->next_tag( array( 'class_name' => 'non-interactive-with-directive' ) );
@@ -226,7 +226,7 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 	}
 
 	public function test_non_interactive_blocks_with_manual_inner_block_rendering_are_not_processed() {
-		$post_content    = '<!-- wp:test/context-level-with-manual-inner-block-rendering --><!-- wp:test/non-interactive-with-directive /--><!-- /wp:test/context-level-with-manual-inner-block-rendering -->';
+		$post_content    = '<!-- wp:test/non-interactive-with-directive /-->';
 		$rendered_blocks = do_blocks( $post_content );
 		$p               = new WP_HTML_Tag_Processor( $rendered_blocks );
 		$p->next_tag( array( 'class_name' => 'non-interactive-with-directive' ) );

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -225,13 +225,13 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 		$this->assertSame( null, $value );
 	}
 
-	public function test_non_interactive_blocks_with_manual_inner_block_rendering_are_not_processed() {
-		$post_content    = '<!-- wp:test/non-interactive-with-directive /-->';
+	public function test_non_interactive_blocks_with_interactive_ancestor_are_processed() {
+		$post_content    = '<!-- wp:test/context-level-1 --><!-- wp:test/non-interactive-with-directive /--><!-- /wp:test/context-level-1 -->';
 		$rendered_blocks = do_blocks( $post_content );
 		$p               = new WP_HTML_Tag_Processor( $rendered_blocks );
 		$p->next_tag( array( 'class_name' => 'non-interactive-with-directive' ) );
 		$value = $p->get_attribute( 'value' );
-		$this->assertSame( null, $value );
+		$this->assertSame( 'level-1', $value );
 	}
 
 	public function test_directives_ordering() {

--- a/phpunit/experimental/interactivity-api/directive-processing-test.php
+++ b/phpunit/experimental/interactivity-api/directive-processing-test.php
@@ -137,41 +137,29 @@ class Tests_Process_Directives extends WP_UnitTestCase {
 	public function test_interactivity_process_directives_in_interactive_root_blocks() {
 		$block_content =
 		'<!-- wp:test/context-level-1 /-->' .
-		'<!-- wp:test/context-level-1 /-->' .
+		'<!-- wp:test/context-level-2 /-->' .
 		'<!-- wp:test/non-interactive-root-block /-->';
 
-		$interactive_parsed_block        = parse_blocks( $block_content )[0];
-		$interactive_source_block        = $interactive_parsed_block;
-		$interactive_parsed_block_object = new WP_Block( $interactive_parsed_block );
+		$interactive_parsed_block = parse_blocks( $block_content )[0];
 
-		$rendered_content                  = render_block( $interactive_parsed_block );
-		$parsed_block_second               = parse_blocks( $block_content )[1];
-		$non_interactive_root_block        = parse_blocks( $block_content )[2];
-		$non_interactive_root_block_object = new WP_Block( $non_interactive_root_block );
-		$interactive_parsed_block_object   = new WP_Block( $interactive_parsed_block );
+		$rendered_content           = render_block( $interactive_parsed_block );
+		$parsed_block_second        = parse_blocks( $block_content )[1];
+		$non_interactive_root_block = parse_blocks( $block_content )[2];
 
 		// Test that root block is intially empty.
 		$this->assertEmpty( WP_Directive_Processor::$root_block );
 
 		// Test that root block is not added if it is non interactive.
-		gutenberg_interactivity_mark_root_interactive_blocks( $non_interactive_root_block, $non_interactive_root_block, null );
+		gutenberg_interactivity_mark_root_interactive_blocks( $non_interactive_root_block );
 		$this->assertEmpty( WP_Directive_Processor::$root_block );
 
-		// Test that a root block is not added if its parent is interactive.
-		gutenberg_interactivity_mark_root_interactive_blocks( $interactive_parsed_block, $interactive_source_block, $interactive_parsed_block_object );
-		$this->assertEmpty( WP_Directive_Processor::$root_block );
-
-		// Test that a non root block is added if there is non interactive parent block.
-		gutenberg_interactivity_mark_root_interactive_blocks( $interactive_parsed_block, $interactive_source_block, $non_interactive_root_block_object );
+		// Test that a non root block is added if it is interactive.
+		gutenberg_interactivity_mark_root_interactive_blocks( $interactive_parsed_block );
 		$this->assertNotEmpty( WP_Directive_Processor::$root_block );
 
-		// Test that root block is added if there is no parent block.
-		gutenberg_interactivity_mark_root_interactive_blocks( $interactive_parsed_block, $interactive_source_block, null );
+		// Test that an interactive block is not added if it has in interactive ancestor.
 		$current_root_block = WP_Directive_Processor::$root_block;
-		$this->assertNotEmpty( $current_root_block );
-
-		// Test that a root block is not added if there is already a root block defined.
-		gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block_second, $interactive_source_block, null );
+		gutenberg_interactivity_mark_root_interactive_blocks( $parsed_block_second );
 		$this->assertSame( $current_root_block, WP_Directive_Processor::$root_block );
 
 		// Test that root block is removed after processing.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Identify and render/process only the root interactive blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We tested a skipping not interactive blocks for processing the HTML, but we found it too complex. The HTML API seems perfomant enough to try an approach of a single-pass processing the interactive islands of the page.

To be able to acommodate it, we need to work on a couple of steps:
 - Identify the root interactive blocks and their children (islands).
 - Skip interactive blocks that are children of another interactive (And will be processed in the final render step)
 - Refactor, clean and move to one `process_interactivity` function.
 
![Screenshot 2024-01-10 at 17 26 31](https://github.com/WordPress/gutenberg/assets/37012961/854ccf4b-3e39-480a-b933-67572d11bc9d)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR covers only the first two steps. Identifying and skipping interactive children.


