### PR TITLE
Font Library: add wp_get_font_dir() function.

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -135,7 +135,7 @@ class WP_Font_Family {
 	 */
 	private static function delete_asset( $src ) {
 		$filename  = basename( $src );
-		$file_path = path_join( WP_Font_Library::get_fonts_dir(), $filename );
+		$file_path = path_join( wp_font_dir()['path'], $filename );
 
 		wp_delete_file( $file_path );
 
@@ -162,7 +162,6 @@ class WP_Font_Family {
 		}
 		return true;
 	}
-
 
 	/**
 	 * Gets the overrides for the 'wp_handle_upload' function.
@@ -394,7 +393,7 @@ class WP_Font_Family {
 
 			// If the font face requires the use of the filesystem, create the fonts dir if it doesn't exist.
 			if ( ! empty( $font_face['downloadFromUrl'] ) && ! empty( $font_face['uploadedFile'] ) ) {
-				wp_mkdir_p( WP_Font_Library::get_fonts_dir() );
+				wp_mkdir_p( wp_font_dir()['path'] );
 			}
 
 			// If installing google fonts, download the font face assets.
@@ -599,9 +598,9 @@ class WP_Font_Family {
 	 */
 	public function install( $files = null ) {
 		add_filter( 'upload_mimes', array( 'WP_Font_Library', 'set_allowed_mime_types' ) );
-		add_filter( 'upload_dir', array( 'WP_Font_Library', 'fonts_dir' ) );
+		add_filter( 'upload_dir', 'wp_font_dir' );
 		$were_assets_written = $this->download_or_move_font_faces( $files );
-		remove_filter( 'upload_dir', array( 'WP_Font_Library', 'fonts_dir' ) );
+		remove_filter( 'upload_dir', 'wp_font_dir' );
 		remove_filter( 'upload_mimes', array( 'WP_Font_Library', 'set_allowed_mime_types' ) );
 
 		if ( ! $were_assets_written ) {

--- a/lib/experimental/fonts/font-library/class-wp-font-family.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family.php
@@ -135,7 +135,7 @@ class WP_Font_Family {
 	 */
 	private static function delete_asset( $src ) {
 		$filename  = basename( $src );
-		$file_path = path_join( wp_font_dir()['path'], $filename );
+		$file_path = path_join( wp_get_font_dir()['path'], $filename );
 
 		wp_delete_file( $file_path );
 
@@ -393,7 +393,7 @@ class WP_Font_Family {
 
 			// If the font face requires the use of the filesystem, create the fonts dir if it doesn't exist.
 			if ( ! empty( $font_face['downloadFromUrl'] ) && ! empty( $font_face['uploadedFile'] ) ) {
-				wp_mkdir_p( wp_font_dir()['path'] );
+				wp_mkdir_p( wp_get_font_dir()['path'] );
 			}
 
 			// If installing google fonts, download the font face assets.
@@ -598,9 +598,9 @@ class WP_Font_Family {
 	 */
 	public function install( $files = null ) {
 		add_filter( 'upload_mimes', array( 'WP_Font_Library', 'set_allowed_mime_types' ) );
-		add_filter( 'upload_dir', 'wp_font_dir' );
+		add_filter( 'upload_dir', 'wp_get_font_dir' );
 		$were_assets_written = $this->download_or_move_font_faces( $files );
-		remove_filter( 'upload_dir', 'wp_font_dir' );
+		remove_filter( 'upload_dir', 'wp_get_font_dir' );
 		remove_filter( 'upload_mimes', array( 'WP_Font_Library', 'set_allowed_mime_types' ) );
 
 		if ( ! $were_assets_written ) {

--- a/lib/experimental/fonts/font-library/class-wp-font-library.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-library.php
@@ -140,74 +140,7 @@ class WP_Font_Library {
 		return new WP_Error( 'font_collection_not_found', 'Font collection not found.' );
 	}
 
-	/**
-	 * Returns an array containing the current fonts upload directory's path and URL.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param array $defaults {
-	 *     Array of information about the upload directory.
-	 *
-	 *     @type string       $path    Base directory and subdirectory or full path to the fonts upload directory.
-	 *     @type string       $url     Base URL and subdirectory or absolute URL to the fonts upload directory.
-	 *     @type string       $subdir  Subdirectory
-	 *     @type string       $basedir Path without subdir.
-	 *     @type string       $baseurl URL path without subdir.
-	 *     @type string|false $error   False or error message.
-	 * }
-	 *
-	 * @return array $defaults {
-	 *     Array of information about the upload directory.
-	 *
-	 *     @type string       $path    Base directory and subdirectory or full path to the fonts upload directory.
-	 *     @type string       $url     Base URL and subdirectory or absolute URL to the fonts upload directory.
-	 *     @type string       $subdir  Subdirectory
-	 *     @type string       $basedir Path without subdir.
-	 *     @type string       $baseurl URL path without subdir.
-	 *     @type string|false $error   False or error message.
-	 * }
-	 */
-	public static function fonts_dir( $defaults = array() ) {
-		$site_path = self::get_multi_site_dir();
 
-		// Sets the defaults.
-		$defaults['path']    = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
-		$defaults['url']     = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
-		$defaults['subdir']  = '';
-		$defaults['basedir'] = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
-		$defaults['baseurl'] = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
-		$defaults['error']   = false;
-
-		// Filters the fonts directory data.
-		return apply_filters( 'fonts_dir', $defaults );
-	}
-
-	/**
-	 * Gets the Site dir for fonts, using the blog ID if multi-site, empty otherwise.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return string Site dir path.
-	 */
-	private static function get_multi_site_dir() {
-		$font_sub_dir = '';
-		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
-			$font_sub_dir = '/sites/' . get_current_blog_id();
-		}
-		return $font_sub_dir;
-	}
-
-	/**
-	 * Gets the upload directory for fonts.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return string Path of the upload directory for fonts.
-	 */
-	public static function get_fonts_dir() {
-		$fonts_dir_settings = self::fonts_dir();
-		return $fonts_dir_settings['path'];
-	}
 
 	/**
 	 * Sets the allowed mime types for fonts.

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -276,7 +276,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	 * @return bool Whether the font directory exists.
 	 */
 	private function has_upload_directory() {
-		$upload_dir = WP_Font_Library::get_fonts_dir();
+		$upload_dir = wp_font_dir()['path'];
 		return is_dir( $upload_dir );
 	}
 
@@ -290,7 +290,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	private function has_write_permission() {
 		// The update endpoints requires write access to the temp and the fonts directories.
 		$temp_dir   = get_temp_dir();
-		$upload_dir = WP_Font_Library::get_fonts_dir();
+		$upload_dir = wp_font_dir()['path'];
 		if ( ! is_writable( $temp_dir ) || ! wp_is_writable( $upload_dir ) ) {
 			return false;
 		}
@@ -353,7 +353,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 		}
 
 		if ( $this->needs_write_permission( $font_family_settings ) ) {
-			$upload_dir = WP_Font_Library::get_fonts_dir();
+			$upload_dir = wp_font_dir()['path'];
 			if ( ! $this->has_upload_directory() ) {
 				if ( ! wp_mkdir_p( $upload_dir ) ) {
 					$errors[] = new WP_Error(

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -276,7 +276,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	 * @return bool Whether the font directory exists.
 	 */
 	private function has_upload_directory() {
-		$upload_dir = wp_font_dir()['path'];
+		$upload_dir = wp_get_font_dir()['path'];
 		return is_dir( $upload_dir );
 	}
 
@@ -290,7 +290,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	private function has_write_permission() {
 		// The update endpoints requires write access to the temp and the fonts directories.
 		$temp_dir   = get_temp_dir();
-		$upload_dir = wp_font_dir()['path'];
+		$upload_dir = wp_get_font_dir()['path'];
 		if ( ! is_writable( $temp_dir ) || ! wp_is_writable( $upload_dir ) ) {
 			return false;
 		}
@@ -353,7 +353,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 		}
 
 		if ( $this->needs_write_permission( $font_family_settings ) ) {
-			$upload_dir = wp_font_dir()['path'];
+			$upload_dir = wp_get_font_dir()['path'];
 			if ( ! $this->has_upload_directory() ) {
 				if ( ! wp_mkdir_p( $upload_dir ) ) {
 					$errors[] = new WP_Error(

--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -82,3 +82,52 @@ $default_font_collection = array(
 );
 
 wp_register_font_collection( $default_font_collection );
+
+// @core-merge: This code should probably go into Core's src/wp-includes/functions.php.
+if ( ! function_exists( 'wp_font_dir' ) ) {
+	/**
+	 * Returns an array containing the current fonts upload directory's path and URL.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param array $defaults {
+	 *     Array of information about the upload directory.
+	 *
+	 *     @type string       $path    Base directory and subdirectory or full path to the fonts upload directory.
+	 *     @type string       $url     Base URL and subdirectory or absolute URL to the fonts upload directory.
+	 *     @type string       $subdir  Subdirectory
+	 *     @type string       $basedir Path without subdir.
+	 *     @type string       $baseurl URL path without subdir.
+	 *     @type string|false $error   False or error message.
+	 * }
+	 *
+	 * @return array $defaults {
+	 *     Array of information about the upload directory.
+	 *
+	 *     @type string       $path    Base directory and subdirectory or full path to the fonts upload directory.
+	 *     @type string       $url     Base URL and subdirectory or absolute URL to the fonts upload directory.
+	 *     @type string       $subdir  Subdirectory
+	 *     @type string       $basedir Path without subdir.
+	 *     @type string       $baseurl URL path without subdir.
+	 *     @type string|false $error   False or error message.
+	 * }
+	 */
+	function wp_font_dir( $defaults = array() ) {
+		// Multi site path
+		$site_path = '';
+		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
+			$site_path = '/sites/' . get_current_blog_id();
+		}
+
+		// Sets the defaults.
+		$defaults['path']    = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
+		$defaults['url']     = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
+		$defaults['subdir']  = '';
+		$defaults['basedir'] = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
+		$defaults['baseurl'] = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
+		$defaults['error']   = false;
+
+		// Filters the fonts directory data.
+		return apply_filters( 'font_dir', $defaults );
+	}
+}

--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -84,7 +84,7 @@ $default_font_collection = array(
 wp_register_font_collection( $default_font_collection );
 
 // @core-merge: This code should probably go into Core's src/wp-includes/functions.php.
-if ( ! function_exists( 'wp_font_dir' ) ) {
+if ( ! function_exists( 'wp_get_font_dir' ) ) {
 	/**
 	 * Returns an array containing the current fonts upload directory's path and URL.
 	 *
@@ -112,7 +112,7 @@ if ( ! function_exists( 'wp_font_dir' ) ) {
 	 *     @type string|false $error   False or error message.
 	 * }
 	 */
-	function wp_font_dir( $defaults = array() ) {
+	function wp_get_font_dir( $defaults = array() ) {
 		// Multi site path
 		$site_path = '';
 		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {

--- a/phpunit/tests/fonts/font-library/fontsDir.php
+++ b/phpunit/tests/fonts/font-library/fontsDir.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test WP_Font_Library::fonts_dir().
+ * Test wp_font_dir().
  *
  * @package WordPress
  * @subpackage Font Library
@@ -8,9 +8,9 @@
  * @group fonts
  * @group font-library
  *
- * @covers WP_Font_Library::fonts_dir
+ * @covers wp_font_dir
  */
-class Tests_Fonts_WpFontLibrary_FontsDir extends WP_Font_Library_UnitTestCase {
+class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 	private $dir_defaults;
 
 	public function __construct() {
@@ -26,8 +26,8 @@ class Tests_Fonts_WpFontLibrary_FontsDir extends WP_Font_Library_UnitTestCase {
 	}
 
 	public function test_fonts_dir() {
-		$fonts_dir = WP_Font_Library::fonts_dir();
-		$this->assertEquals( $fonts_dir, $this->dir_defaults );
+		$font_dir = wp_font_dir();
+		$this->assertEquals( $font_dir, $this->dir_defaults );
 	}
 
 	public function test_fonts_dir_with_filter() {
@@ -43,10 +43,10 @@ class Tests_Fonts_WpFontLibrary_FontsDir extends WP_Font_Library_UnitTestCase {
 		}
 
 		// Add the filter.
-		add_filter( 'fonts_dir', 'set_new_values' );
+		add_filter( 'font_dir', 'set_new_values' );
 
 		// Gets the fonts dir.
-		$fonts_dir = WP_Font_Library::fonts_dir();
+		$font_dir = wp_font_dir();
 
 		$expected = array(
 			'path'    => '/custom-path/fonts/my-custom-subdir',
@@ -57,14 +57,14 @@ class Tests_Fonts_WpFontLibrary_FontsDir extends WP_Font_Library_UnitTestCase {
 			'error'   => false,
 		);
 
-		$this->assertEquals( $fonts_dir, $expected, 'The fonts_dir() method should return the expected values.' );
+		$this->assertEquals( $font_dir, $expected, 'The wp_font_dir() method should return the expected values.' );
 
 		// Remove the filter.
-		remove_filter( 'fonts_dir', 'set_new_values' );
+		remove_filter( 'font_dir', 'set_new_values' );
 
 		// Gets the fonts dir.
-		$fonts_dir = WP_Font_Library::fonts_dir();
+		$font_dir = wp_font_dir();
 
-		$this->assertEquals( $fonts_dir, $this->dir_defaults, 'The fonts_dir() method should return the default values.' );
+		$this->assertEquals( $font_dir, $this->dir_defaults, 'The wp_font_dir() method should return the default values.' );
 	}
 }

--- a/phpunit/tests/fonts/font-library/fontsDir.php
+++ b/phpunit/tests/fonts/font-library/fontsDir.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test wp_font_dir().
+ * Test wp_get_font_dir().
  *
  * @package WordPress
  * @subpackage Font Library
@@ -8,7 +8,7 @@
  * @group fonts
  * @group font-library
  *
- * @covers wp_font_dir
+ * @covers wp_get_font_dir
  */
 class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 	private $dir_defaults;
@@ -26,7 +26,7 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 	}
 
 	public function test_fonts_dir() {
-		$font_dir = wp_font_dir();
+		$font_dir = wp_get_font_dir();
 		$this->assertEquals( $font_dir, $this->dir_defaults );
 	}
 
@@ -46,7 +46,7 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 		add_filter( 'font_dir', 'set_new_values' );
 
 		// Gets the fonts dir.
-		$font_dir = wp_font_dir();
+		$font_dir = wp_get_font_dir();
 
 		$expected = array(
 			'path'    => '/custom-path/fonts/my-custom-subdir',
@@ -57,14 +57,14 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 			'error'   => false,
 		);
 
-		$this->assertEquals( $font_dir, $expected, 'The wp_font_dir() method should return the expected values.' );
+		$this->assertEquals( $font_dir, $expected, 'The wp_get_font_dir() method should return the expected values.' );
 
 		// Remove the filter.
 		remove_filter( 'font_dir', 'set_new_values' );
 
 		// Gets the fonts dir.
-		$font_dir = wp_font_dir();
+		$font_dir = wp_get_font_dir();
 
-		$this->assertEquals( $font_dir, $this->dir_defaults, 'The wp_font_dir() method should return the default values.' );
+		$this->assertEquals( $font_dir, $this->dir_defaults, 'The wp_get_font_dir() method should return the default values.' );
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontFamily/base.php
+++ b/phpunit/tests/fonts/font-library/wpFontFamily/base.php
@@ -28,7 +28,7 @@ abstract class WP_Font_Family_UnitTestCase extends WP_UnitTestCase {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
-		static::$fonts_dir = wp_font_dir()['path'];
+		static::$fonts_dir = wp_get_font_dir()['path'];
 		wp_mkdir_p( static::$fonts_dir );
 	}
 

--- a/phpunit/tests/fonts/font-library/wpFontFamily/base.php
+++ b/phpunit/tests/fonts/font-library/wpFontFamily/base.php
@@ -28,7 +28,7 @@ abstract class WP_Font_Family_UnitTestCase extends WP_UnitTestCase {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
-		static::$fonts_dir = WP_Font_Library::get_fonts_dir();
+		static::$fonts_dir = wp_font_dir()['path'];
 		wp_mkdir_p( static::$fonts_dir );
 	}
 

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController/base.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController/base.php
@@ -18,7 +18,7 @@ abstract class WP_REST_Font_Families_Controller_UnitTestCase extends WP_UnitTest
 	public function set_up() {
 		parent::set_up();
 
-		static::$fonts_dir = wp_font_dir()['path'];
+		static::$fonts_dir = wp_get_font_dir()['path'];
 
 		// Create a user with administrator role.
 		$admin_id = $this->factory->user->create(

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController/base.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController/base.php
@@ -18,7 +18,7 @@ abstract class WP_REST_Font_Families_Controller_UnitTestCase extends WP_UnitTest
 	public function set_up() {
 		parent::set_up();
 
-		static::$fonts_dir = WP_Font_Library::get_fonts_dir();
+		static::$fonts_dir = wp_font_dir()['path'];
 
 		// Create a user with administrator role.
 		$admin_id = $this->factory->user->create(


### PR DESCRIPTION
## What?
Adds `wp_get_font_dir()` function.

## Why?
Emulates [wp_get_upload_dir()](https://developer.wordpress.org/reference/functions/wp_get_upload_dir/) but for the fonts directory.

## How?
Implementing wp_get_font_dir() function.

## Testing Instructions
Ways to test:
 
 1. Use the font library to install fonts.
 
 2. Run PHP unit tests.
 
3. Use the function in extension code (theme/plugin) as here:
```php
$fonts = wp_get_font_dir();
echo ( print_r($fonts) );
```

should print:

```
Array
(
    [path] => /var/www/html/wp1/wp-content/fonts
    [url] => http://localhost/wp1/wp-content/fonts
    [subdir] => 
    [basedir] => /var/www/html/wp1/wp-content/fonts
    [baseurl] => http://localhost/wp1/wp-content/fonts
    [error] => 
)
```
4. Modify the value using the filter:
```php
function custom_font_dir( $defaults ) {
		$defaults['path']    = '/custom/path/';
		$defaults['url']     = 'https://example.com/custom/url';
		$defaults['basedir'] = '/custom/path/';
		$defaults['baseurl'] = 'https://example.com/custom/url';
	return $defaults;
}

add_filter( 'font_dir', 'custom_font_dir' );

$fonts = wp_get_font_dir();
echo ( print_r($fonts) );
```
should print:
```
Array
(
    [path] => /custom/path/
    [url] => https://example.com/custom/url
    [subdir] => 
    [basedir] => /custom/path/
    [baseurl] => https://example.com/custom/url
    [error] => 
)
```
