### PR TITLE
Font Library: Use data or src file to define font collection data

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -51,7 +51,7 @@ class WP_Font_Collection {
 			throw new Exception( 'Font Collection config name is required as a non-empty string.' );
 		}
 
-		if ( ( empty( $config['src'] ) || ! is_string( $config['src'] ) ) && ( empty( $config['data'] )  ) ) {
+		if ( ( empty( $config['src'] ) || ! is_string( $config['src'] ) ) && ( empty( $config['data'] ) ) ) {
 			throw new Exception( 'Font Collection config "src" option OR "data" option is required.' );
 		}
 
@@ -79,7 +79,7 @@ class WP_Font_Collection {
 	 */
 	public function get_data() {
 
-		if ( ! empty( $this->config[ 'data' ] ) ) {
+		if ( ! empty( $this->config['data'] ) ) {
 			return $this->get_config();
 		}
 

--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -35,7 +35,7 @@ class WP_Font_Collection {
 	 * @since 6.5.0
 	 *
 	 * @param array $config Font collection config options.
-	 *                      See {@see wp_register_font_collection()} for the supported fields.
+	 *  See {@see wp_register_font_collection()} for the supported fields.
 	 * @throws Exception If the required parameters are missing.
 	 */
 	public function __construct( $config ) {
@@ -63,24 +63,57 @@ class WP_Font_Collection {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @return array An array containing the font collection config.
+	 * @return array {
+	 *     An array of font collection config.
+	 *
+	 *     @type string $id          The font collection's unique ID.
+	 *     @type string $name        The font collection's name.
+	 *     @type string $description The font collection's description.
+	 * }
 	 */
 	public function get_config() {
-		return $this->config;
+		return array(
+			'id'          => $this->config['id'],
+			'name'        => $this->config['name'],
+			'description' => $this->config['description'] ?? '',
+		);
 	}
 
 	/**
-	 * Gets the font collection data.
+	 * Gets the font collection config and data.
+	 *
+	 * This function returns an array containing the font collection's unique ID,
+	 * name, and its data as a PHP array.
 	 *
 	 * @since 6.5.0
 	 *
-	 * @return array|WP_Error An array containing the list of font families in theme.json format on success,
+	 * @return array {
+	 *     An array of font collection config and data.
+	 *
+	 *     @type string $id          The font collection's unique ID.
+	 *     @type string $name        The font collection's name.
+	 *     @type string $description The font collection's description.
+	 *     @type array  $data        The font collection's data as a PHP array.
+	 * }
+	 */
+	public function get_config_and_data() {
+		$config_and_data         = $this->get_config();
+		$config_and_data['data'] = $this->load_data();
+		return $config_and_data;
+	}
+
+	/**
+	 * Loads the font collection data.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return array|WP_Error An array containing the list of font families in font-collection.json format on success,
 	 *                        else an instance of WP_Error on failure.
 	 */
-	public function get_data() {
+	public function load_data() {
 
 		if ( ! empty( $this->config['data'] ) ) {
-			return $this->get_config();
+			return $this->config['data'];
 		}
 
 		// If the src is a URL, fetch the data from the URL.
@@ -109,9 +142,6 @@ class WP_Font_Collection {
 			}
 		}
 
-		$collection_data         = $this->get_config();
-		$collection_data['data'] = $data;
-		unset( $collection_data['src'] );
-		return $collection_data;
+		return $data;
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -51,8 +51,8 @@ class WP_Font_Collection {
 			throw new Exception( 'Font Collection config name is required as a non-empty string.' );
 		}
 
-		if ( empty( $config['src'] ) || ! is_string( $config['src'] ) ) {
-			throw new Exception( 'Font Collection config "src" option is required as a non-empty string.' );
+		if ( ( empty( $config['src'] ) || ! is_string( $config['src'] ) ) && ( empty( $config['data'] )  ) ) {
+			throw new Exception( 'Font Collection config "src" option OR "data" option is required.' );
 		}
 
 		$this->config = $config;
@@ -78,6 +78,11 @@ class WP_Font_Collection {
 	 *                        else an instance of WP_Error on failure.
 	 */
 	public function get_data() {
+
+		if ( ! empty( $this->config[ 'data' ] ) ) {
+			return $this->get_config();
+		}
+
 		// If the src is a URL, fetch the data from the URL.
 		if ( str_contains( $this->config['src'], 'http' ) && str_contains( $this->config['src'], '://' ) ) {
 			if ( ! wp_http_validate_url( $this->config['src'] ) ) {

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-collections-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-collections-controller.php
@@ -77,13 +77,16 @@ class WP_REST_Font_Collections_Controller extends WP_REST_Controller {
 			$collection->add_data( array( 'status' => 404 ) );
 			return $collection;
 		}
-		$collection_with_data = $collection->get_data();
+		$config_and_data = $collection->get_config_and_data();
+		$collection_data = $config_and_data['data'];
+
 		// If there was an error getting the collection data, return the error.
-		if ( is_wp_error( $collection_with_data ) ) {
-			$collection_with_data->add_data( array( 'status' => 500 ) );
-			return $collection_with_data;
+		if ( is_wp_error( $collection_data ) ) {
+			$collection_data->add_data( array( 'status' => 500 ) );
+			return $collection_data;
 		}
-		return new WP_REST_Response( $collection_with_data );
+
+		return new WP_REST_Response( $config_and_data );
 	}
 
 	/**

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-collections-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-collections-controller.php
@@ -96,7 +96,7 @@ class WP_REST_Font_Collections_Controller extends WP_REST_Controller {
 	public function get_font_collections() {
 		$collections = array();
 		foreach ( WP_Font_Library::get_font_collections() as $collection ) {
-			$collections[] = $collection->get_config();
+			$collections[] = $collection->get_config_and_data();
 		}
 
 		return new WP_REST_Response( $collections, 200 );

--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -50,7 +50,8 @@ if ( ! function_exists( 'wp_register_font_collection' ) ) {
 	 *     Font collection associative array of configuration options.
 	 *
 	 *     @type string $id             The font collection's unique ID.
-	 *     @type string $src The font collection's data JSON file.
+	 *     @type string $src            The font collection's data as a JSON file path.
+	 *     @type array  $data           The font collection's data as a PHP array.
 	 * }
 	 * @return WP_Font_Collection|WP_Error A font collection is it was registered
 	 *                                     successfully, else WP_Error.

--- a/phpunit/tests/fonts/font-library/wpFontCollection/__construct.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/__construct.php
@@ -84,7 +84,7 @@ class Tests_Fonts_WpFontCollection_Construct extends WP_UnitTestCase {
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 				),
-				'Font Collection config "src" option is required as a non-empty string.',
+				'Font Collection config "src" option OR "data" option is required.',
 			),
 
 		);

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getConfig.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getConfig.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test WP_Font_Collection::get_data().
+ * Test WP_Font_Collection::get_config().
  *
  * @package WordPress
  * @subpackage Font Library
@@ -8,53 +8,18 @@
  * @group fonts
  * @group font-library
  *
- * @covers WP_Font_Collection::get_data
+ * @covers WP_Font_Collection::get_config
  */
-class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
-
-	public function set_up() {
-		parent::set_up();
-
-		// Mock the wp_remote_request() function.
-		add_filter( 'pre_http_request', array( $this, 'mock_request' ), 10, 3 );
-	}
-
-	public function tear_down() {
-		// Remove the mock to not affect other tests.
-		remove_filter( 'pre_http_request', array( $this, 'mock_request' ) );
-
-		parent::tear_down();
-	}
-
-	public function mock_request( $preempt, $args, $url ) {
-		// if the URL is not the URL you want to mock, return false.
-		if ( 'https://localhost/fonts/mock-font-collection.json' !== $url ) {
-			return false;
-		}
-
-		// Mock the response body.
-		$mock_collection_data = array(
-			'fontFamilies' => 'mock',
-			'categories'   => 'mock',
-		);
-
-		return array(
-			'body'     => json_encode( $mock_collection_data ),
-			'response' => array(
-				'code' => 200,
-			),
-		);
-	}
-
+class Tests_Fonts_WpFontCollection_GetConfig extends WP_UnitTestCase {
 	/**
-	 * @dataProvider data_should_get_data
+	 * @dataProvider data_should_get_config
 	 *
 	 * @param array $config Font collection config options.
 	 * @param array $expected_data Expected data.
 	 */
-	public function test_should_get_data( $config, $expected_data ) {
+	public function test_should_get_config( $config, $expected_data ) {
 		$collection = new WP_Font_Collection( $config );
-		$this->assertSame( $expected_data, $collection->get_data() );
+		$this->assertSame( $expected_data, $collection->get_config() );
 	}
 
 	/**
@@ -62,7 +27,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_should_get_data() {
+	public function data_should_get_config() {
 		$mock_file = wp_tempnam( 'my-collection-data-' );
 		file_put_contents( $mock_file, '{"this is mock data":true}' );
 
@@ -78,7 +43,6 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 					'id'          => 'my-collection',
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
-					'data'        => array( 'this is mock data' => true ),
 				),
 			),
 			'with a url'  => array(
@@ -92,10 +56,6 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 					'id'          => 'my-collection-with-url',
 					'name'        => 'My Collection with URL',
 					'description' => 'My collection description',
-					'data'        => array(
-						'fontFamilies' => 'mock',
-						'categories'   => 'mock',
-					),
 				),
 			),
 			'with data'   => array(
@@ -109,7 +69,6 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 					'id'          => 'my-collection',
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
-					'data'        => array( 'this is mock data' => true ),
 				),
 			),
 		);

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getConfigAndData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getConfigAndData.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Test WP_Font_Collection::get_config_and_data().
+ *
+ * @package WordPress
+ * @subpackage Font Library
+ *
+ * @group fonts
+ * @group font-library
+ *
+ * @covers WP_Font_Collection::get_config_and_data
+ */
+class Tests_Fonts_WpFontCollection_GetConfigAndData extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		// Mock the wp_remote_request() function.
+		add_filter( 'pre_http_request', array( $this, 'mock_request' ), 10, 3 );
+	}
+
+	public function tear_down() {
+		// Remove the mock to not affect other tests.
+		remove_filter( 'pre_http_request', array( $this, 'mock_request' ) );
+
+		parent::tear_down();
+	}
+
+	public function mock_request( $preempt, $args, $url ) {
+		// if the URL is not the URL you want to mock, return false.
+		if ( 'https://localhost/fonts/mock-font-collection.json' !== $url ) {
+			return false;
+		}
+
+		// Mock the response body.
+		$mock_collection_data = array(
+			'fontFamilies' => 'mock',
+			'categories'   => 'mock',
+		);
+
+		return array(
+			'body'     => json_encode( $mock_collection_data ),
+			'response' => array(
+				'code' => 200,
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_should_get_config_and_data
+	 *
+	 * @param array $config Font collection config options.
+	 * @param array $expected_data Expected data.
+	 */
+	public function test_should_get_config_and_data( $config, $expected_data ) {
+		$collection = new WP_Font_Collection( $config );
+		$this->assertSame( $expected_data, $collection->get_config_and_data() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_get_config_and_data() {
+		$mock_file = wp_tempnam( 'my-collection-data-' );
+		file_put_contents( $mock_file, '{"this is mock data":true}' );
+
+		return array(
+			'with a file' => array(
+				'config'        => array(
+					'id'          => 'my-collection',
+					'name'        => 'My Collection',
+					'description' => 'My collection description',
+					'src'         => $mock_file,
+				),
+				'expected_data' => array(
+					'id'          => 'my-collection',
+					'name'        => 'My Collection',
+					'description' => 'My collection description',
+					'data'        => array( 'this is mock data' => true ),
+				),
+			),
+			'with a url'  => array(
+				'config'        => array(
+					'id'          => 'my-collection-with-url',
+					'name'        => 'My Collection with URL',
+					'description' => 'My collection description',
+					'src'         => 'https://localhost/fonts/mock-font-collection.json',
+				),
+				'expected_data' => array(
+					'id'          => 'my-collection-with-url',
+					'name'        => 'My Collection with URL',
+					'description' => 'My collection description',
+					'data'        => array(
+						'fontFamilies' => 'mock',
+						'categories'   => 'mock',
+					),
+				),
+			),
+			'with data'   => array(
+				'config'        => array(
+					'id'          => 'my-collection',
+					'name'        => 'My Collection',
+					'description' => 'My collection description',
+					'data'        => array( 'this is mock data' => true ),
+				),
+				'expected_data' => array(
+					'id'          => 'my-collection',
+					'name'        => 'My Collection',
+					'description' => 'My collection description',
+					'data'        => array( 'this is mock data' => true ),
+				),
+			),
+		);
+	}
+}

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -98,7 +98,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 					),
 				),
 			),
-			'with data' => array(
+			'with data'   => array(
 				'config'        => array(
 					'id'          => 'my-collection',
 					'name'        => 'My Collection',

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -98,6 +98,20 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 					),
 				),
 			),
+			'with data' => array(
+				'config'        => array(
+					'id'          => 'my-collection',
+					'name'        => 'My Collection',
+					'description' => 'My collection description',
+					'data'        => array( 'this is mock data' => true ),
+				),
+				'expected_data' => array(
+					'id'          => 'my-collection',
+					'name'        => 'My Collection',
+					'description' => 'My collection description',
+					'data'        => array( 'this is mock data' => true ),
+				),
+			),
 		);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This allows a Font Collection to be set by passing Font Collection data instead of a src .json file.

## Why?
So that collection details can by dynamically generated. 

## How?
Internally the details of the Font Collection are kept in a `data` property.  They are stored there once the `.json` file referenced in `src` are fetched.  This change just allows that `data` property to be passed instead of a `src` value.

## Testing Instructions
Unit tests are provided that demonstrates that the data passed in is the data that comes out.  I'm not sure what other testing scenarios to suggest.
