### PR TITLE
Font Library: Add font collection JSON schema

### DIFF
--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -79,15 +79,19 @@ const keys = ( maybeObject ) => {
  *
  * @param {string} ref
  * @return {Object} definition
+ * @throws {Error} If the referenced definition is not found in 'themejson.definitions'.
  *
  * @example
  * getDefinition( '#/definitions/typographyProperties/properties/fontFamily' )
- * // returns themejson.definitions.typographyProperties.properties.fontFamily
+ *  // returns themejson.definitions.typographyProperties.properties.fontFamily
  *
  */
 const resolveDefintionRef = ( ref ) => {
 	const refParts = ref.split( '/' );
 	const definition = refParts[ refParts.length - 1 ];
+	if ( ! themejson.definitions[ definition ] ) {
+		throw new Error( `Can't resolve '${ ref }'. Definition not found` );
+	}
 	return themejson.definitions[ definition ];
 };
 

--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -134,7 +134,7 @@ const getSettingsPropertiesMarkup = ( struct ) => {
 		const def = 'default' in props[ key ] ? props[ key ].default : '';
 		const ps =
 			props[ key ].type === 'array'
-				? // ? keys( props[ key ].items.properties ).sort().join( ', ' )
+				?
 				  keys( getPropertiesFromArray( props[ key ].items ) )
 						.sort()
 						.join( ', ' )

--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -105,7 +105,7 @@ const resolveDefinitionRef = ( ref ) => {
 const getPropertiesFromArray = ( items ) => {
 	// if its a $ref resolve it
 	if ( items.$ref ) {
-		return resolveDefintionRef( items.$ref ).properties;
+		return resolveDefinitionRef( items.$ref ).properties;
 	}
 
 	// otherwise just return the properties

--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -86,7 +86,7 @@ const keys = ( maybeObject ) => {
  *  // returns themejson.definitions.typographyProperties.properties.fontFamily
  *
  */
-const resolveDefintionRef = ( ref ) => {
+const resolveDefinitionRef = ( ref ) => {
 	const refParts = ref.split( '/' );
 	const definition = refParts[ refParts.length - 1 ];
 	if ( ! themejson.definitions[ definition ] ) {

--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -84,7 +84,6 @@ const keys = ( maybeObject ) => {
  * @example
  * getDefinition( '#/definitions/typographyProperties/properties/fontFamily' )
  *  // returns themejson.definitions.typographyProperties.properties.fontFamily
- *
  */
 const resolveDefinitionRef = ( ref ) => {
 	const refParts = ref.split( '/' );
@@ -100,7 +99,6 @@ const resolveDefinitionRef = ( ref ) => {
  *
  * @param {Object} items
  * @return {Object} properties
- *
  */
 const getPropertiesFromArray = ( items ) => {
 	// if its a $ref resolve it
@@ -134,8 +132,7 @@ const getSettingsPropertiesMarkup = ( struct ) => {
 		const def = 'default' in props[ key ] ? props[ key ].default : '';
 		const ps =
 			props[ key ].type === 'array'
-				?
-				  keys( getPropertiesFromArray( props[ key ].items ) )
+				? keys( getPropertiesFromArray( props[ key ].items ) )
 						.sort()
 						.join( ', ' )
 				: '';

--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -75,6 +75,40 @@ const keys = ( maybeObject ) => {
 };
 
 /**
+ * Get definition from ref.
+ *
+ * @param {string} ref
+ * @return {Object} definition
+ *
+ * @example
+ * getDefinition( '#/definitions/typographyProperties/properties/fontFamily' )
+ * // returns themejson.definitions.typographyProperties.properties.fontFamily
+ *
+ */
+const resolveDefintionRef = ( ref ) => {
+	const refParts = ref.split( '/' );
+	const definition = refParts[ refParts.length - 1 ];
+	return themejson.definitions[ definition ];
+};
+
+/**
+ * Get properties from an array.
+ *
+ * @param {Object} items
+ * @return {Object} properties
+ *
+ */
+const getPropertiesFromArray = ( items ) => {
+	// if its a $ref resolve it
+	if ( items.$ref ) {
+		return resolveDefintionRef( items.$ref ).properties;
+	}
+
+	// otherwise just return the properties
+	return items.properties;
+};
+
+/**
  * Convert settings properties to markup.
  *
  * @param {Object} struct
@@ -96,7 +130,10 @@ const getSettingsPropertiesMarkup = ( struct ) => {
 		const def = 'default' in props[ key ] ? props[ key ].default : '';
 		const ps =
 			props[ key ].type === 'array'
-				? keys( props[ key ].items.properties ).sort().join( ', ' )
+				? // ? keys( props[ key ].items.properties ).sort().join( ', ' )
+				  keys( getPropertiesFromArray( props[ key ].items ) )
+						.sort()
+						.join( ', ' )
 				: '';
 		markup += `| ${ key } | ${ props[ key ].type } | ${ def } | ${ ps } |\n`;
 	} );

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,6 +1,6 @@
 # Schemas
 
-The collection of schemas used in WordPress, including the `theme.json` and `block.json` schemas.
+The collection of schemas used in WordPress, including the `theme.json`, `block.json` and `font-collection.json` schemas.
 
 JSON schemas are used by code editors to offer tooltips, autocomplete, and validation.
 
@@ -21,6 +21,14 @@ Or in your `theme.json`:
 ```json
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json"
+}
+```
+
+Or in your `font-collection.json`:
+
+```json
+{
+	"$schema": "https://schemas.wp.org/trunk/font-collection.json"
 }
 ```
 
@@ -56,8 +64,16 @@ To allow this you will need to:
 }
 ```
 
+-   update your font collections's `font-collection.json` to include:
+
+```json
+{
+	"$schema": "file://{{FULL_FILE_PATH}}/schemas/json/font-collection.json"
+}
+```
+
 Be sure to replace `{{FULL_FILE_PATH}}` with the full local path to your Gutenberg repo.
 
-With this in place you should now be able to edit either `schemas/json/theme .json` or `schemas/json/block.json` in order to see changes reflected in `theme.json` or `block.json` in your IDE.
+With this in place you should now be able to edit either `schemas/json/theme .json`, `schemas/json/block.json` or `schemas/json/font-collection.json` in order to see changes reflected in `theme.json`, `block.json` or `font-collection.json` in your IDE.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -1,0 +1,45 @@
+{
+	"title": "JSON schema for WordPress Font Collection",
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"type": "object",
+	"properties": {
+		"fontFamilies": {
+			"type": "array",
+			"description": "Array of font families ready to be installed",
+			"items": {
+				"type": "object",
+				"properties": {
+					"font_family_settings": {
+						"description": "Font family settings as in theme.json",
+						"allOf": [
+							{ "$ref": "./theme.json#/definitions/fontFamily" }
+						]
+					},
+					"categories": {
+						"type": "array",
+						"description": "Array of category slugs",
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			}
+		},
+		"categories": {
+			"type": "array",
+			"description": "Array of category objects",
+			"items": {
+				"type": "object",
+				"properties": {
+					"slug": {
+						"type": "string"
+					},
+					"title": {
+						"type": "string"
+					}
+				},
+				"required": [ "slug", "title" ]
+			}
+		}
+	}
+}

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -44,11 +44,11 @@
 					"slug": {
 						"type": "string"
 					},
-					"title": {
+					"name": {
 						"type": "string"
 					}
 				},
-				"required": [ "slug", "title" ]
+				"required": [ "slug", "name" ]
 			}
 		}
 	}

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -3,7 +3,16 @@
 	"$schema": "http://json-schema.org/draft-04/schema#",
 	"type": "object",
 	"properties": {
-		"fontFamilies": {
+		"$schema": {
+			"description": "JSON schema URI for font-collection.json.",
+			"type": "string"
+		},
+		"version": {
+			"description": "Version of font-collection.json schema to use.",
+			"type": "integer",
+			"enum": [ 1 ]
+		},
+		"font_families": {
 			"type": "array",
 			"description": "Array of font families ready to be installed",
 			"items": {
@@ -22,7 +31,8 @@
 							"type": "string"
 						}
 					}
-				}
+				},
+				"required": [ "font_family_settings" ]
 			}
 		},
 		"categories": {

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -1,5 +1,5 @@
 {
-	"title": "JSON schema for WordPress Font Collection",
+	"title": "JSON schema for WordPress Font Collections",
 	"$schema": "http://json-schema.org/draft-04/schema#",
 	"type": "object",
 	"properties": {

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -32,7 +32,8 @@
 						}
 					}
 				},
-				"required": [ "font_family_settings" ]
+				"required": [ "font_family_settings" ],
+				"additionalProperties": false
 			}
 		},
 		"categories": {
@@ -48,8 +49,11 @@
 						"type": "string"
 					}
 				},
-				"required": [ "slug", "name" ]
+				"required": [ "slug", "name" ],
+				"additionalProperties": false
 			}
 		}
-	}
+	},
+	"additionalProperties": false,
+	"required": [ "$schema", "version", "font_families" ]
 }

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -619,6 +619,7 @@
 		},
 		"fontFamily": {
 			"type": "object",
+			"description": "Font family preset",
 			"properties": {
 				"name": {
 					"description": "Name of the font family preset, translatable.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -609,132 +609,135 @@
 							"description": "Font family presets for the font family selector.\nGenerates a single custom property (`--wp--preset--font-family--{slug}`) per preset value.",
 							"type": "array",
 							"items": {
-								"type": "object",
-								"properties": {
-									"name": {
-										"description": "Name of the font family preset, translatable.",
-										"type": "string"
-									},
-									"slug": {
-										"description": "Kebab-case unique identifier for the font family preset.",
-										"type": "string"
-									},
-									"fontFamily": {
-										"description": "CSS font-family value.",
-										"type": "string"
-									},
-									"preview": {
-										"description": "URL to a preview image of the font family.",
-										"type": "string"
-									},
-									"fontFace": {
-										"description": "Array of font-face declarations.",
-										"type": "array",
-										"items": {
-											"type": "object",
-											"properties": {
-												"fontFamily": {
-													"description": "CSS font-family value.",
-													"type": "string",
-													"default": ""
-												},
-												"fontStyle": {
-													"description": "CSS font-style value.",
-													"type": "string",
-													"default": "normal"
-												},
-												"fontWeight": {
-													"description": "List of available font weights, separated by a space.",
-													"default": "400",
-													"oneOf": [
-														{
-															"type": "string"
-														},
-														{
-															"type": "integer"
-														}
-													]
-												},
-												"fontDisplay": {
-													"description": "CSS font-display value.",
-													"type": "string",
-													"default": "fallback",
-													"enum": [
-														"auto",
-														"block",
-														"fallback",
-														"swap",
-														"optional"
-													]
-												},
-												"src": {
-													"description": "Paths or URLs to the font files.",
-													"oneOf": [
-														{
-															"type": "string"
-														},
-														{
-															"type": "array",
-															"items": {
-																"type": "string"
-															}
-														}
-													],
-													"default": []
-												},
-												"fontStretch": {
-													"description": "CSS font-stretch value.",
-													"type": "string"
-												},
-												"ascentOverride": {
-													"description": "CSS ascent-override value.",
-													"type": "string"
-												},
-												"descentOverride": {
-													"description": "CSS descent-override value.",
-													"type": "string"
-												},
-												"fontVariant": {
-													"description": "CSS font-variant value.",
-													"type": "string"
-												},
-												"fontFeatureSettings": {
-													"description": "CSS font-feature-settings value.",
-													"type": "string"
-												},
-												"fontVariationSettings": {
-													"description": "CSS font-variation-settings value.",
-													"type": "string"
-												},
-												"lineGapOverride": {
-													"description": "CSS line-gap-override value.",
-													"type": "string"
-												},
-												"sizeAdjust": {
-													"description": "CSS size-adjust value.",
-													"type": "string"
-												},
-												"unicodeRange": {
-													"description": "CSS unicode-range value.",
-													"type": "string"
-												},
-												"preview": {
-													"description": "URL to a preview image of the font face.",
-													"type": "string"
-												}
-											},
-											"required": [ "fontFamily", "src" ],
-											"additionalProperties": false
-										}
-									}
-								},
-								"additionalProperties": false
+								"$ref": "#/definitions/fontFamily"
 							}
 						}
 					},
 					"additionalProperties": false
 				}
 			}
+		},
+		"fontFamily": {
+			"type": "object",
+			"properties": {
+				"name": {
+					"description": "Name of the font family preset, translatable.",
+					"type": "string"
+				},
+				"slug": {
+					"description": "Kebab-case unique identifier for the font family preset.",
+					"type": "string"
+				},
+				"fontFamily": {
+					"description": "CSS font-family value.",
+					"type": "string"
+				},
+				"preview": {
+					"description": "URL to a preview image of the font family.",
+					"type": "string"
+				},
+				"fontFace": {
+					"description": "Array of font-face declarations.",
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"fontFamily": {
+								"description": "CSS font-family value.",
+								"type": "string",
+								"default": ""
+							},
+							"fontStyle": {
+								"description": "CSS font-style value.",
+								"type": "string",
+								"default": "normal"
+							},
+							"fontWeight": {
+								"description": "List of available font weights, separated by a space.",
+								"default": "400",
+								"oneOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "integer"
+									}
+								]
+							},
+							"fontDisplay": {
+								"description": "CSS font-display value.",
+								"type": "string",
+								"default": "fallback",
+								"enum": [
+									"auto",
+									"block",
+									"fallback",
+									"swap",
+									"optional"
+								]
+							},
+							"src": {
+								"description": "Paths or URLs to the font files.",
+								"oneOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								],
+								"default": []
+							},
+							"fontStretch": {
+								"description": "CSS font-stretch value.",
+								"type": "string"
+							},
+							"ascentOverride": {
+								"description": "CSS ascent-override value.",
+								"type": "string"
+							},
+							"descentOverride": {
+								"description": "CSS descent-override value.",
+								"type": "string"
+							},
+							"fontVariant": {
+								"description": "CSS font-variant value.",
+								"type": "string"
+							},
+							"fontFeatureSettings": {
+								"description": "CSS font-feature-settings value.",
+								"type": "string"
+							},
+							"fontVariationSettings": {
+								"description": "CSS font-variation-settings value.",
+								"type": "string"
+							},
+							"lineGapOverride": {
+								"description": "CSS line-gap-override value.",
+								"type": "string"
+							},
+							"sizeAdjust": {
+								"description": "CSS size-adjust value.",
+								"type": "string"
+							},
+							"unicodeRange": {
+								"description": "CSS unicode-range value.",
+								"type": "string"
+							},
+							"preview": {
+								"description": "URL to a preview image of the font face.",
+								"type": "string"
+							}
+						},
+						"required": [ "fontFamily", "src" ],
+						"additionalProperties": false
+					}
+				}
+			},
+			"additionalProperties": false
 		},
 		"settingsPropertiesCustom": {
 			"type": "object",


### PR DESCRIPTION
## What?
- Font Library: Adds font collection JSON schema
- Makes fontFamily a schema definition and reference it from theme.json's 'fontFamilies'.
- Adds `gen-theme-reference.js` ability to resolve a definition by name.
- Updates README

## Why?
As a reference for the data JSON files for font collections.

## How?
Creating a new schema and reusing part of the existent theme.json schema

## Testing instructions
Create a file and reference the `font-collection.json` schema like this:

```
"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/1e4e1406d303b41e37b27e69cfbc654f42d6a589/schemas/json/font-collection.json",
```
If you use an editor like VS Code, you should have autocomplete and error detection working.

Disclaimer: Instead of this long URL, after merging into trunk, we will be able to use:
`https://schemas.wp.org/trunk/font-collection.json`

Full `font-collection.json`example:
```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/1e4e1406d303b41e37b27e69cfbc654f42d6a589/schemas/json/font-collection.json",
	"version": 1,
    "categories": [
        {
            "slug": "serif",
            "name": "Serif",
        }
    ],
    "font_families": [
        {
            "categories": [
                "serif"
            ],
            "font_family_settings":{
                "fontFamily": "Piazzolla, Times, Serif",
                "name": "Piazzolla",
                "slug": "piazzolla",
                "fontFace": [
                    {
                        "fontFamily": "Piazzolla",
                        "src": "http://example.com/fonts/piazzolla400.ttf",
                        "fontWeight": 400,
                        "fontStyle": "normal"
                    }
                ]
            }
        }
    ]
}
```



Closes: https://github.com/WordPress/gutenberg/issues/55266