### PR TITLE
Show initial suggestions in rich text Link UI

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -85,7 +85,11 @@ const fetchLinkSuggestions = async (
 ) => {
 	const {
 		isInitialSuggestions = false,
-		initialSuggestionsSearchOptions = undefined,
+		initialSuggestionsSearchOptions = {
+			type: 'post',
+			subtype: 'page',
+			perPage: 20,
+		},
 	} = searchOptions;
 
 	const { disablePostFormats = false } = settings;

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -85,11 +85,7 @@ const fetchLinkSuggestions = async (
 ) => {
 	const {
 		isInitialSuggestions = false,
-		initialSuggestionsSearchOptions = {
-			type: 'post',
-			subtype: 'page',
-			perPage: 20,
-		},
+		initialSuggestionsSearchOptions = undefined,
 	} = searchOptions;
 
 	const { disablePostFormats = false } = settings;

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -271,6 +271,14 @@ function InlineLinkUI( {
 				createSuggestionButtonText={ createButtonText }
 				hasTextControl
 				settings={ LINK_SETTINGS }
+				suggestionsQuery={ {
+					// always show Pages as initial suggestions
+					initialSuggestionsSearchOptions: {
+						type: 'post',
+						subtype: 'page',
+						perPage: 20,
+					},
+				} }
 			/>
 		</Popover>
 	);

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -260,7 +260,6 @@ function InlineLinkUI( {
 			shift
 		>
 			<LinkControl
-				showInitialSuggestions={ true }
 				value={ linkValue }
 				onChange={ onChangeLink }
 				onRemove={ removeLink }
@@ -271,6 +270,7 @@ function InlineLinkUI( {
 				createSuggestionButtonText={ createButtonText }
 				hasTextControl
 				settings={ LINK_SETTINGS }
+				showInitialSuggestions={ true }
 				suggestionsQuery={ {
 					// always show Pages as initial suggestions
 					initialSuggestionsSearchOptions: {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -260,6 +260,7 @@ function InlineLinkUI( {
 			shift
 		>
 			<LinkControl
+				showInitialSuggestions={ true }
 				value={ linkValue }
 				onChange={ onChangeLink }
 				onRemove={ removeLink }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Upon opening the Link UI to create a new link in a rich text, the component will now display a set of initial suggestions. These are defaulted to pages.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of https://github.com/WordPress/gutenberg/issues/50884.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Set the defaults for all initial suggestions queries to be pages.

Enable the correct prop on the LinkConrol used in rich text links.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Type text
- Make a link on some of the text
- See the initial suggestions immediately appear. Should be max 20 of your latest Pages.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-11 at 11 34 57](https://github.com/WordPress/gutenberg/assets/1813435/bc30cb58-825f-4d34-a60c-55e1e59803f8)|![CleanShot 2024-01-11 at 11 34 27](https://github.com/WordPress/gutenberg/assets/1813435/71d3f44d-dfbf-490d-8780-59dacf54ae43)|

