### PR TITLE
Gallery Block: Remove duplicate return statement

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -42,9 +42,6 @@ function block_core_gallery_random_order( $parsed_block ) {
 	if ( 'core/gallery' === $parsed_block['blockName'] && ! empty( $parsed_block['attrs']['randomOrder'] ) ) {
 		shuffle( $parsed_block['innerBlocks'] );
 	}
-
-	return $parsed_block;
-
 	return $parsed_block;
 }
 


### PR DESCRIPTION
Follow-up on #57477

## What?

Remove duplicate return statement in the `render_block_data` filter.

## Why?

This was a simple mistake on my part 😅
