### PR TITLE
Styles revisions: remove body padding

### DIFF
--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -78,7 +78,7 @@ function Revisions( { userConfig, blocks } ) {
 					{
 						// Forming a "block formatting context" to prevent margin collapsing.
 						// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-						`.is-root-container { display: flow-root; } body { position: relative; padding: 32px; }`
+						`.is-root-container { display: flow-root; }`
 					}
 				</style>
 				<Disabled className="edit-site-revisions__example-preview__content">


### PR DESCRIPTION


## What?

Fixes https://github.com/WordPress/gutenberg/issues/57601

Remove the unnecessary padding from revision preview iframe body tags

## Why?
If there's a nested container with 100% width and a background color in the page, the extra padding will cause the body background color to show.


## Testing Instructions

1. In the site editor, give the site a background color of whatever
2. Now in the template, add a container block, ensuring it takes up 100% of the page width. Give that container block a background color.
3. Save the page to create a revision.
4. Now open the global styles revisions panel. Check that the body background color isn't peeking around the sides of your container.

Here's an example of a container with a background color:


```html
<!-- wp:group {"style":{"color":{"background":"#8827e3"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group has-background" style="background-color:#8827e3"><!-- wp:paragraph -->
<p>Hello!</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```


| Before  | After |
| ------------- | ------------- |
| <img width="500" alt="Screenshot 2024-01-11 at 2 00 30 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/d8810bef-d07f-4aa4-9b25-90376066cf2f">  | <img width="500" alt="Screenshot 2024-01-11 at 2 00 58 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/d5c331cb-bf17-4800-b3be-adfcd90d2aeb"> |

