### PR TITLE
Only prioritise Quote transform where relevant

### DIFF
--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -37,7 +37,7 @@ function useGroupedTransforms( possibleBlockTransformations ) {
 		const priorityTextTranformsNames = Object.keys(
 			priorityContentTranformationBlocks
 		);
-		return possibleBlockTransformations.reduce(
+		const groupedPossibleTransforms = possibleBlockTransformations.reduce(
 			( accumulator, item ) => {
 				const { name } = item;
 				if ( priorityTextTranformsNames.includes( name ) ) {
@@ -49,6 +49,17 @@ function useGroupedTransforms( possibleBlockTransformations ) {
 			},
 			{ priorityTextTransformations: [], restTransformations: [] }
 		);
+		if (
+			groupedPossibleTransforms.priorityTextTransformations.length ===
+				1 &&
+			groupedPossibleTransforms.priorityTextTransformations[ 0 ].name ===
+				'core/quote'
+		) {
+			const singleQuote =
+				groupedPossibleTransforms.priorityTextTransformations.pop();
+			groupedPossibleTransforms.restTransformations.push( singleQuote );
+		}
+		return groupedPossibleTransforms;
 	}, [ possibleBlockTransformations ] );
 
 	// Order the priority text transformations.

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -49,6 +49,12 @@ function useGroupedTransforms( possibleBlockTransformations ) {
 			},
 			{ priorityTextTransformations: [], restTransformations: [] }
 		);
+		/**
+		 * If there is only one priority text transformation and it's a Quote,
+		 * is should move to the rest transformations. This is because Quote can
+		 * be a container for any block type, so in multi-block selection it will
+		 * always be suggested, even for non-text blocks.
+		 */
 		if (
 			groupedPossibleTransforms.priorityTextTransformations.length ===
 				1 &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Iterates on #40208.

#44072 hardcoded a list of "priority" transforms for text blocks, including Paragraph, Heading, List and Quote. The problem with including Quote in this list is that it's a generic container block, so any block or selection of blocks is allowed to transform into it. This results in Quote being unexpectedly singled out as a priority transform in situations where it doesn't make sense at all, such as when two Images are selected:

<img width="670" alt="Screenshot 2024-01-11 at 4 07 17 pm" src="https://github.com/WordPress/gutenberg/assets/8096000/6870c299-bdcb-425f-8ead-55ebbf9cecc6">


This PR fixes the issue by checking whether Quote is the only available priority transform, and assuming that's a reliable indicator of its irrelevance. This means Quote is no longer shown as a priority when any two text blocks (such as Verse and Code) are selected, but it is still shown for any single text block. I think this is a reasonable tradeoff to fix the currently very confusing experience.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a bunch of different blocks to the editor.
2. Try selecting each block, and selecting multiple blocks, and see what pops up in the list of transforms (in the block toolbar, click the block icon/name)
3. Two Image blocks, or any two non-text blocks, shouldn't show Quote as the priority option.
4. Two Paragraph or Heading blocks should still show Quote among the list of available options.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
