### PR TITLE
Remove obsolete check from dataviews modal actions title

### DIFF
--- a/packages/dataviews/src/item-actions.js
+++ b/packages/dataviews/src/item-actions.js
@@ -59,10 +59,7 @@ function ActionWithModal( { action, item, ActionTrigger } ) {
 			<ActionTrigger { ...actionTriggerProps } />
 			{ isModalOpen && (
 				<Modal
-					title={
-						( ! hideModalHeader && action.modalHeader ) ||
-						action.label
-					}
+					title={ action.modalHeader || action.label }
 					__experimentalHideHeader={ !! hideModalHeader }
 					onRequestClose={ () => {
 						setIsModalOpen( false );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is just a minor code logic update. We check whether to show the header through `__experimentalHideHeader` prop, so the check in `title` doesn't make any difference. 


## Testing instructions
1. Actions with modals in DataViews should work as before.