### PR TITLE
Add token UI concept to Link UI

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -334,8 +334,6 @@ function LinkControl( {
 
 	const showActions = isEditingLink && hasLinkValue;
 
-	const showURLInput = hasLinkValue && ! value?.id;
-
 	// Only show text control once a URL value has been committed
 	// and it isn't just empty whitespace.
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
@@ -401,18 +399,6 @@ function LinkControl( {
 							'has-actions': showActions,
 						} ) }
 					>
-						{ showURLInput && (
-							<TextControl
-								__nextHasNoMarginBottom
-								className="block-editor-link-control__field block-editor-link-control__search-input"
-								label={ __( 'Link' ) }
-								value={ currentUrlInputValue }
-								onChange={ setInternalURLInputValue }
-								onKeyDown={ handleSubmitWithEnter }
-								size="__unstable-large"
-							/>
-						) }
-
 						{ showTextControl && (
 							<TextControl
 								__nextHasNoMarginBottom
@@ -426,45 +412,35 @@ function LinkControl( {
 							/>
 						) }
 
-						{ ! hasLinkValue && (
-							<>
-								<LinkControlSearchInput
-									currentLink={ value }
-									className="block-editor-link-control__field block-editor-link-control__search-input"
-									placeholder={ searchInputPlaceholder }
-									value={ currentUrlInputValue }
-									withCreateSuggestion={
-										withCreateSuggestion
-									}
-									onCreateSuggestion={ createPage }
-									onChange={ setInternalURLInputValue }
-									onSelect={ handleSelectSuggestion }
-									showInitialSuggestions={
-										showInitialSuggestions
-									}
-									allowDirectEntry={ ! noDirectEntry }
-									showSuggestions={ showSuggestions }
-									suggestionsQuery={ suggestionsQuery }
-									withURLSuggestion={ ! noURLSuggestion }
-									createSuggestionButtonText={
-										createSuggestionButtonText
-									}
-									hideLabelFromVision={ ! showTextControl }
+						<LinkControlSearchInput
+							currentLink={ value }
+							className="block-editor-link-control__field block-editor-link-control__search-input"
+							placeholder={ searchInputPlaceholder }
+							value={ currentUrlInputValue }
+							withCreateSuggestion={ withCreateSuggestion }
+							onCreateSuggestion={ createPage }
+							onChange={ setInternalURLInputValue }
+							onSelect={ handleSelectSuggestion }
+							showInitialSuggestions={ showInitialSuggestions }
+							allowDirectEntry={ ! noDirectEntry }
+							showSuggestions={ showSuggestions }
+							suggestionsQuery={ suggestionsQuery }
+							withURLSuggestion={ ! noURLSuggestion }
+							createSuggestionButtonText={
+								createSuggestionButtonText
+							}
+							hideLabelFromVision={ ! showTextControl }
+						/>
+						{ ! showActions && (
+							<div className="block-editor-link-control__search-enter">
+								<Button
+									onClick={ isDisabled ? noop : handleSubmit }
+									label={ __( 'Submit' ) }
+									icon={ keyboardReturn }
+									className="block-editor-link-control__search-submit"
+									aria-disabled={ isDisabled }
 								/>
-								{ ! showActions && (
-									<div className="block-editor-link-control__search-enter">
-										<Button
-											onClick={
-												isDisabled ? noop : handleSubmit
-											}
-											label={ __( 'Submit' ) }
-											icon={ keyboardReturn }
-											className="block-editor-link-control__search-submit"
-											aria-disabled={ isDisabled }
-										/>
-									</div>
-								) }
-							</>
+							</div>
 						) }
 					</div>
 					{ errorMessage && (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -334,6 +334,8 @@ function LinkControl( {
 
 	const showActions = isEditingLink && hasLinkValue;
 
+	const showURLInput = hasLinkValue && ! value?.id;
+
 	// Only show text control once a URL value has been committed
 	// and it isn't just empty whitespace.
 	// See https://github.com/WordPress/gutenberg/pull/33849/#issuecomment-932194927.
@@ -359,6 +361,7 @@ function LinkControl( {
 				<LinkPreview
 					key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
 					value={ value }
+					isEditing={ isEditing }
 					onEditClick={ () => setIsEditingLink( true ) }
 					hasRichPreviews={ hasRichPreviews }
 					hasUnlinkControl={ shownUnlinkControl }
@@ -398,6 +401,18 @@ function LinkControl( {
 							'has-actions': showActions,
 						} ) }
 					>
+						{ showURLInput && (
+							<TextControl
+								__nextHasNoMarginBottom
+								className="block-editor-link-control__field block-editor-link-control__search-input"
+								label={ __( 'Link' ) }
+								value={ currentUrlInputValue }
+								onChange={ setInternalURLInputValue }
+								onKeyDown={ handleSubmitWithEnter }
+								size="__unstable-large"
+							/>
+						) }
+
 						{ showTextControl && (
 							<TextControl
 								__nextHasNoMarginBottom

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -330,8 +330,7 @@ function LinkControl( {
 
 	const currentInputIsEmpty = ! currentUrlInputValue?.trim()?.length;
 
-	const shownUnlinkControl =
-		onRemove && value && ! isEditingLink && ! isCreatingPage;
+	const shownUnlinkControl = onRemove && value && ! isCreatingPage;
 
 	const showActions = isEditingLink && hasLinkValue;
 
@@ -356,6 +355,40 @@ function LinkControl( {
 				</div>
 			) }
 
+			{ hasLinkValue && ! isCreatingPage && (
+				<LinkPreview
+					key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
+					value={ value }
+					onEditClick={ () => setIsEditingLink( true ) }
+					hasRichPreviews={ hasRichPreviews }
+					hasUnlinkControl={ shownUnlinkControl }
+					additionalControls={ () => {
+						// Expose the "Opens in new tab" settings in the preview
+						// as it is the most common setting to change.
+						if (
+							! isEditing &&
+							settings?.find(
+								( setting ) => setting.id === 'opensInNewTab'
+							)
+						) {
+							return (
+								<LinkSettings
+									value={ internalControlValue }
+									settings={ settings?.filter(
+										( { id } ) => id === 'opensInNewTab'
+									) }
+									onChange={ onChange }
+								/>
+							);
+						}
+					} }
+					onRemove={ () => {
+						onRemove();
+						setIsEditingLink( true );
+					} }
+				/>
+			) }
+
 			{ isEditing && (
 				<>
 					<div
@@ -377,35 +410,46 @@ function LinkControl( {
 								size="__unstable-large"
 							/>
 						) }
-						<LinkControlSearchInput
-							currentLink={ value }
-							className="block-editor-link-control__field block-editor-link-control__search-input"
-							placeholder={ searchInputPlaceholder }
-							value={ currentUrlInputValue }
-							withCreateSuggestion={ withCreateSuggestion }
-							onCreateSuggestion={ createPage }
-							onChange={ setInternalURLInputValue }
-							onSelect={ handleSelectSuggestion }
-							showInitialSuggestions={ showInitialSuggestions }
-							allowDirectEntry={ ! noDirectEntry }
-							showSuggestions={ showSuggestions }
-							suggestionsQuery={ suggestionsQuery }
-							withURLSuggestion={ ! noURLSuggestion }
-							createSuggestionButtonText={
-								createSuggestionButtonText
-							}
-							hideLabelFromVision={ ! showTextControl }
-						/>
-						{ ! showActions && (
-							<div className="block-editor-link-control__search-enter">
-								<Button
-									onClick={ isDisabled ? noop : handleSubmit }
-									label={ __( 'Submit' ) }
-									icon={ keyboardReturn }
-									className="block-editor-link-control__search-submit"
-									aria-disabled={ isDisabled }
+
+						{ ! hasLinkValue && (
+							<>
+								<LinkControlSearchInput
+									currentLink={ value }
+									className="block-editor-link-control__field block-editor-link-control__search-input"
+									placeholder={ searchInputPlaceholder }
+									value={ currentUrlInputValue }
+									withCreateSuggestion={
+										withCreateSuggestion
+									}
+									onCreateSuggestion={ createPage }
+									onChange={ setInternalURLInputValue }
+									onSelect={ handleSelectSuggestion }
+									showInitialSuggestions={
+										showInitialSuggestions
+									}
+									allowDirectEntry={ ! noDirectEntry }
+									showSuggestions={ showSuggestions }
+									suggestionsQuery={ suggestionsQuery }
+									withURLSuggestion={ ! noURLSuggestion }
+									createSuggestionButtonText={
+										createSuggestionButtonText
+									}
+									hideLabelFromVision={ ! showTextControl }
 								/>
-							</div>
+								{ ! showActions && (
+									<div className="block-editor-link-control__search-enter">
+										<Button
+											onClick={
+												isDisabled ? noop : handleSubmit
+											}
+											label={ __( 'Submit' ) }
+											icon={ keyboardReturn }
+											className="block-editor-link-control__search-submit"
+											aria-disabled={ isDisabled }
+										/>
+									</div>
+								) }
+							</>
 						) }
 					</div>
 					{ errorMessage && (
@@ -418,39 +462,6 @@ function LinkControl( {
 						</Notice>
 					) }
 				</>
-			) }
-
-			{ value && ! isEditingLink && ! isCreatingPage && (
-				<LinkPreview
-					key={ value?.url } // force remount when URL changes to avoid race conditions for rich previews
-					value={ value }
-					onEditClick={ () => setIsEditingLink( true ) }
-					hasRichPreviews={ hasRichPreviews }
-					hasUnlinkControl={ shownUnlinkControl }
-					additionalControls={ () => {
-						// Expose the "Opens in new tab" settings in the preview
-						// as it is the most common setting to change.
-						if (
-							settings?.find(
-								( setting ) => setting.id === 'opensInNewTab'
-							)
-						) {
-							return (
-								<LinkSettings
-									value={ internalControlValue }
-									settings={ settings?.filter(
-										( { id } ) => id === 'opensInNewTab'
-									) }
-									onChange={ onChange }
-								/>
-							);
-						}
-					} }
-					onRemove={ () => {
-						onRemove();
-						setIsEditingLink( true );
-					} }
-				/>
 			) }
 
 			{ showSettings && (

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -31,6 +31,7 @@ export default function LinkPreview( {
 	hasUnlinkControl = false,
 	onRemove,
 	additionalControls,
+	isEditing,
 } ) {
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
@@ -120,7 +121,9 @@ export default function LinkPreview( {
 					className="block-editor-link-control__search-item-action"
 					onClick={ onEditClick }
 					size="compact"
+					disabled={ isEditing }
 				/>
+
 				{ hasUnlinkControl && (
 					<Button
 						icon={ linkOff }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -172,6 +172,7 @@ $block-editor-link-control-number-of-actions: 1;
 		width: 100%;
 		cursor: default;
 		padding: $grid-unit-20;
+		border-bottom: 1px solid $gray-200;
 	}
 
 	.block-editor-link-control__search-item-header {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a "token" preview of the currently selected link when the Link UI is in "edit" state. 

Part of https://github.com/WordPress/gutenberg/issues/50892

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a first step towards UX work on the Link UI to make clear when you have link to:

- a URL 
- a entity with WordPress (e.g. Post, Page...etc)

The key difference is that a URL is static and doesn't change underneath you where as an entity is dynamic and it's attributes may change.

For example, let's say you link to "My Sample Post" and the permalink for that is `/my-sample-post`. Next week you rename the Post to "My New Name Post" and also update the slug - the permalink is now `/my-new-name-post`. 

Unfortunately the link you made last week doesn't dynamically update and you have to go back and manually update it. 


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/9f32e096-2d7f-443a-829a-3472c8fbc930

