### PR TITLE
Workflow: Update to latest matching npm when publishing packages

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -342,6 +342,7 @@ jobs:
             - name: Publish packages to npm ("latest" dist-tag)
               run: |
                   cd main
+                  'npm install --global npm@"$(jq .engines.npm package.json)"'
                   npm ci
                   ./bin/plugin/cli.js npm-latest --semver minor --ci --repository-path ../publish
               env:

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -342,7 +342,7 @@ jobs:
             - name: Publish packages to npm ("latest" dist-tag)
               run: |
                   cd main
-                  'npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"'
+                  npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"
                   npm ci
                   ./bin/plugin/cli.js npm-latest --semver minor --ci --repository-path ../publish
               env:

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -342,7 +342,7 @@ jobs:
             - name: Publish packages to npm ("latest" dist-tag)
               run: |
                   cd main
-                  'npm install --global npm@"$(jq .engines.npm package.json)"'
+                  'npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"'
                   npm ci
                   ./bin/plugin/cli.js npm-latest --semver minor --ci --repository-path ../publish
               env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -85,7 +85,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'development' }}
               run: |
                   cd cli
-                  'npm install --global npm@"$(jq .engines.npm package.json)"'
+                  'npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"'
                   npm ci
                   ./bin/plugin/cli.js npm-next --ci --repository-path ../publish
               env:
@@ -95,7 +95,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'bugfix' }}
               run: |
                   cd cli
-                  'npm install --global npm@"$(jq .engines.npm package.json)"'
+                  'npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"'
                   npm ci
                   ./bin/plugin/cli.js npm-bugfix --ci --repository-path ../publish
               env:
@@ -105,7 +105,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
                   cd publish
-                  'npm install --global npm@"$(jq .engines.npm package.json)"'
+                  'npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"'
                   npm ci
                   npx lerna publish patch --dist-tag wp-${{ github.event.inputs.wp_version }} --no-private --yes --no-verify-access
               env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -85,7 +85,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'development' }}
               run: |
                   cd cli
-                  'npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"'
+                  npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"
                   npm ci
                   ./bin/plugin/cli.js npm-next --ci --repository-path ../publish
               env:
@@ -95,7 +95,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'bugfix' }}
               run: |
                   cd cli
-                  'npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"'
+                  npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"
                   npm ci
                   ./bin/plugin/cli.js npm-bugfix --ci --repository-path ../publish
               env:
@@ -105,7 +105,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
                   cd publish
-                  'npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"'
+                  npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"
                   npm ci
                   npx lerna publish patch --dist-tag wp-${{ github.event.inputs.wp_version }} --no-private --yes --no-verify-access
               env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -85,6 +85,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'development' }}
               run: |
                   cd cli
+                  'npm install --global npm@"$(jq .engines.npm package.json)"'
                   npm ci
                   ./bin/plugin/cli.js npm-next --ci --repository-path ../publish
               env:
@@ -94,6 +95,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'bugfix' }}
               run: |
                   cd cli
+                  'npm install --global npm@"$(jq .engines.npm package.json)"'
                   npm ci
                   ./bin/plugin/cli.js npm-bugfix --ci --repository-path ../publish
               env:
@@ -103,6 +105,7 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
                   cd publish
+                  'npm install --global npm@"$(jq .engines.npm package.json)"'
                   npm ci
                   npx lerna publish patch --dist-tag wp-${{ github.event.inputs.wp_version }} --no-private --yes --no-verify-access
               env:


### PR DESCRIPTION


## What?

Fix an error that prevented packages from being published by a stale npm version:

https://wordpress.slack.com/archives/C02QB2JS7/p1704969229967829

[See this action:](https://github.com/WordPress/gutenberg/actions/runs/7476385123/job/20347047179)

> ✖ node ./bin/check-latest-npm.js found some errors. Please fix them and try committing again.
> Latest npm check failed!
> Error: The local npm version does not match the expected latest version. Expected 10.2.5, found 10.2.3.

## Why?

The check-latest-version script runs on package changes but fails if we're not using the latest published npm version that satisfies our `engines.npm` field in package.json.

## How?

Install the latest satisfying npm version.

## Testing Instructions

I'm really not sure. You can test that the commands work by running them locally. **BEWARE:** running this would change the globally installed `npm` version.

```sh
npm install --global npm@"$(jq --raw-output --join-output .engines.npm package.json)"
```
