### PR TITLE
Scripts: Use separate directories for module build output

### DIFF
--- a/packages/scripts/utils/block-json.js
+++ b/packages/scripts/utils/block-json.js
@@ -1,41 +1,32 @@
 const moduleFields = new Set( [ 'viewModule' ] );
 const scriptFields = new Set( [ 'viewScript', 'script', 'editorScript' ] );
+const styleFields = new Set( [ 'style', 'editorStyle' ] );
 
-/**
- * @param {Object} blockJson
- * @return {null|Record<string, unknown>} Fields
- */
-function getBlockJsonModuleFields( blockJson ) {
-	let result = null;
-	for ( const field of moduleFields ) {
-		if ( Object.hasOwn( blockJson, field ) ) {
-			if ( ! result ) {
-				result = {};
+function makeBlockJsonGetter( properties ) {
+	/**
+	 * @param {Object} blockJson
+	 * @return {null|Record<string, unknown>} Fields
+	 */
+	return ( blockJson ) => {
+		let result = null;
+		for ( const property of properties ) {
+			if ( Object.hasOwn( blockJson, property ) ) {
+				if ( ! result ) {
+					result = {};
+				}
+				result[ property ] = blockJson[ property ];
 			}
-			result[ field ] = blockJson[ field ];
 		}
-	}
-	return result;
+		return result;
+	};
 }
 
-/**
- * @param {Object} blockJson
- * @return {null|Record<string, unknown>} Fields
- */
-function getBlockJsonScriptFields( blockJson ) {
-	let result = null;
-	for ( const field of scriptFields ) {
-		if ( Object.hasOwn( blockJson, field ) ) {
-			if ( ! result ) {
-				result = {};
-			}
-			result[ field ] = blockJson[ field ];
-		}
-	}
-	return result;
-}
+const getBlockJsonModuleFields = makeBlockJsonGetter( moduleFields );
+const getBlockJsonScriptFields = makeBlockJsonGetter( scriptFields );
+const getBlockJsonStyleFields = makeBlockJsonGetter( styleFields );
 
 module.exports = {
 	getBlockJsonModuleFields,
 	getBlockJsonScriptFields,
+	getBlockJsonStyleFields,
 };


### PR DESCRIPTION
When we output for modules, we run 2 webpack compilations. There's a
chance that assets from the builds collide.

Using two different directories is cleaner.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

A `src` directory like this:

```
block.json  different-name-editor.css  different-name-view.css  index.tsx  render.php  shared.css  view.mts
```

Compiled with modules results in output like this:

```
build
├── block.json
├── module
│   ├── view.asset.php
│   └── view.js
├── render.php
├── script
│   ├── index.asset.php
│   └── index.js
└── style
    ├── index.css
    └── view.css

4 directories, 8 files
```

with a block.json updated to match:

```
{
  "$schema": "https://schemas.wp.org/trunk/block.json",
  "apiVersion": 3,
  "title": "Jon's cool counter",
  "name": "jon/the-block",
  "editorStyle": "file:./style/index.css",
  "editorScript": [
    "file:./script/index.js"
  ],
  "style": "file:./style/view.css",
  "viewModule": "file:./module/view.js",
  "render": "file:./render.php",
  "category": "text"
}
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
