### PR TITLE
DataViews: show loading / no result message for the list layout

### DIFF
--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -20,6 +20,7 @@ export default function ViewList( {
 	view,
 	fields,
 	data,
+	isLoading,
 	getItemId,
 	onSelectionChange,
 	onDetailsChange,
@@ -48,6 +49,22 @@ export default function ViewList( {
 			onSelectionChange( [ item ] );
 		}
 	};
+
+	const hasData = usedData?.length;
+	if ( ! hasData ) {
+		return (
+			<div
+				className={ classNames( {
+					'dataviews-loading': isLoading,
+					'dataviews-no-results': ! hasData && ! isLoading,
+				} ) }
+			>
+				{ ! hasData && (
+					<p>{ isLoading ? __( 'Loading…' ) : __( 'No results' ) }</p>
+				) }
+			</div>
+		);
+	}
 
 	return (
 		<ul className="dataviews-view-list">


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Adds a "Loading..." or "No results" message to the list layout.

| | Before | After |
| --- | --- | --- |
| Loading | <img width="655" alt="Captura de ecrã 2024-01-11, às 15 44 15" src="https://github.com/WordPress/gutenberg/assets/583546/9d680a5f-902c-40a3-bc90-3ecbbb395f3b"> | <img width="657" alt="Captura de ecrã 2024-01-11, às 15 42 42" src="https://github.com/WordPress/gutenberg/assets/583546/59f09524-46a4-431e-b229-ec53b507b4c6"> |
| No results | <img width="657" alt="Captura de ecrã 2024-01-11, às 15 43 07" src="https://github.com/WordPress/gutenberg/assets/583546/651e6889-d926-4a06-921b-3e7cb96868b3"> | <img width="659" alt="Captura de ecrã 2024-01-11, às 15 41 55" src="https://github.com/WordPress/gutenberg/assets/583546/3e5a2d20-5ff7-4045-925a-8c46176be0e6"> |

## Why?

To provide users with current information about what's happening.

## How?

Adds a notice.

## Testing Instructions

- Enable the "admin views" experiment and visit "Manage all pages".
- While it is loading you should see the "Loading..." indicator. Throtle your CPU down or just hardcode a `isLoading: true` somewhere to see it in action, if it happen too fast.
- Use the filters so the list no longer has any item. Verify the "No results" message is shown.

