### PR TITLE
Remove "blocks" from copy and delete labels

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -41,9 +41,7 @@ const POPOVER_PROPS = {
 
 function CopyMenuItem( { blocks, onCopy, label } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
-	const copyMenuItemBlocksLabel =
-		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy' );
-	const copyMenuItemLabel = label ? label : copyMenuItemBlocksLabel;
+	const copyMenuItemLabel = label ? label : __( 'Copy' );
 	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
 }
 
@@ -201,9 +199,6 @@ export function BlockSettingsDropdown( {
 		hasSelectedBlocks,
 		getSelectedBlockClientIds,
 	] );
-
-	const removeBlockLabel =
-		count === 1 ? __( 'Delete' ) : __( 'Delete blocks' );
 
 	// This can occur when the selected block (the parent)
 	// displays child blocks within a List View.
@@ -411,7 +406,7 @@ export function BlockSettingsDropdown( {
 										) }
 										shortcut={ shortcuts.remove }
 									>
-										{ removeBlockLabel }
+										{ __( 'Delete' ) }
 									</MenuItem>
 								</MenuGroup>
 							) }

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -820,7 +820,7 @@ test.describe( 'List View', () => {
 			.click();
 		await page
 			.getByRole( 'menu', { name: 'Options for Heading' } )
-			.getByRole( 'menuitem', { name: 'Delete blocks' } )
+			.getByRole( 'menuitem', { name: 'Delete' } )
 			.click();
 		await expect
 			.poll(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Tiny PR to remove the change in label when selecting multiple blocks to copy or delete. It's distracting having the menu change based on the number of blocks selected, and we don't use this practice on all relevant options. 

## How?
Removes logic to determine if there are multiple blocks selected, reducing "Copy blocks" to "Copy" and "Delete blocks" to "Delete". 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert two paragraph blocks. 
3. Select one. 
4. Select the block options menu—either from the block toolbar, or in list view. 
5. See the options "Copy" and "Delete". 
6. Close and select both blocks. 
7. Select the block options menu again—either from the block toolbar, or in list view. 
8. See the options remain "Copy" and "Delete". 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-11 at 11 19 23](https://github.com/WordPress/gutenberg/assets/1813435/7b034623-92bd-468f-b89d-9465665a6b39)|![CleanShot 2024-01-11 at 11 19 49](https://github.com/WordPress/gutenberg/assets/1813435/6bee4daa-c919-4d82-9c4a-c727f03d05c3)|


