### PR TITLE
Editor: Use hooks instead of HoCs for `EditorNotices`

### DIFF
--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -11,8 +11,11 @@ import { store as noticesStore } from '@wordpress/notices';
 import TemplateValidationNotice from '../template-validation-notice';
 
 export function EditorNotices() {
-	const notices = useSelect( ( select ) =>
-		select( noticesStore ).getNotices()
+	const { notices } = useSelect(
+		( select ) => ( {
+			notices: select( noticesStore ).getNotices(),
+		} ),
+		[]
 	);
 	const { removeNotice } = useDispatch( noticesStore );
 	const dismissibleNotices = notices.filter(

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { NoticeList } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -11,7 +10,11 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import TemplateValidationNotice from '../template-validation-notice';
 
-export function EditorNotices( { notices, onRemove } ) {
+export function EditorNotices() {
+	const notices = useSelect( ( select ) =>
+		select( noticesStore ).getNotices()
+	);
+	const { removeNotice } = useDispatch( noticesStore );
 	const dismissibleNotices = notices.filter(
 		( { isDismissible, type } ) => isDismissible && type === 'default'
 	);
@@ -28,7 +31,7 @@ export function EditorNotices( { notices, onRemove } ) {
 			<NoticeList
 				notices={ dismissibleNotices }
 				className="components-editor-notices__dismissible"
-				onRemove={ onRemove }
+				onRemove={ removeNotice }
 			>
 				<TemplateValidationNotice />
 			</NoticeList>
@@ -36,11 +39,4 @@ export function EditorNotices( { notices, onRemove } ) {
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => ( {
-		notices: select( noticesStore ).getNotices(),
-	} ) ),
-	withDispatch( ( dispatch ) => ( {
-		onRemove: dispatch( noticesStore ).removeNotice,
-	} ) ),
-] )( EditorNotices );
+export default EditorNotices;


### PR DESCRIPTION
## What?
This straightforward PR updates the `EditorNotices` component to use the `@wordpress/data` hooks instead of the HoCs.

## Why?
A micro-optimization to make the rendered component tree smaller. 

## How?
We're using the `useSelect` and `useDispatch` hooks instead of the `withSelect` and `withDispatch` hooks.

Because we're removing a `withSelect`, a `withDispatch` and a `compose` instance, this removes 3 levels of nesting.

## Testing Instructions
* Run `wp.data.dispatch( 'core/notices' ).createSuccessNotice('test!')` in your console and verify a dismissable notice properly appears.
* Run `wp.data.dispatch( 'core/notices' ).createSuccessNotice('test!', { isDismissible: false })` in your console and verify a non-dismissable notice properly appears.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->
None.