### PR TITLE
Data view list layout: Fix thumbnail dimensions

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -299,11 +299,16 @@
 	}
 
 	.dataviews-view-list__media-wrapper {
-		min-width: $grid-unit-40;
+		width: $grid-unit-40;
 		height: $grid-unit-40;
 		border-radius: $grid-unit-05;
 		overflow: hidden;
 		position: relative;
+		flex-shrink: 0;
+
+		img {
+			width: inherit;
+		}
 
 		&::after {
 			content: "";

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -307,7 +307,9 @@
 		flex-shrink: 0;
 
 		img {
-			width: inherit;
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
 		}
 
 		&::after {


### PR DESCRIPTION
## What?
Ensure the dimensions of thumbnails in list view are square, and that the image fills the space regardless of aspect ratio.

## Why?
Otherwise text-alignment becomes ragged. 

## How?
Apply `width: 100%; height: 100%; object-fit: cover` to the image. This will ensure it fills the wrapper matching its dimensions, and that the image itself will fill the space visually.

| Before | After |
| --- | --- |
| <img width="357" alt="Screenshot 2024-01-11 at 17 25 50" src="https://github.com/WordPress/gutenberg/assets/846565/92509ead-4f4d-4af3-9bec-e2636f2c0a07"> | <img width="358" alt="Screenshot 2024-01-11 at 17 32 39" src="https://github.com/WordPress/gutenberg/assets/846565/d2ba5b71-e0d5-4d11-9173-40ac2fc5832b"> |

## Testing Instructions.
1. Add featured images to some pages.
2. Enable the data views experiment.
3. Navigate to Appearance > Editor > Pages and observe the thumbnails display nicely.
5. Update thumbnail dimensions in Settings > Media so that they are not square.
6. [Regenerate thumbnails](https://en-gb.wordpress.org/plugins/regenerate-thumbnails/).
7. Navigate to Appearance > Editor > Pages and observe the thumbnails display nicely.
