### PR TITLE
Fix misplaced ReactRefreshWebpackPlugin

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -380,6 +380,8 @@ const scriptConfig = {
 		process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
 		// MiniCSSExtractPlugin to extract the CSS thats gets imported into JavaScript.
 		new MiniCSSExtractPlugin( { filename: '[name].css' } ),
+		// React Fast Refresh.
+		hasReactFastRefresh && new ReactRefreshWebpackPlugin(),
 		// WP_NO_EXTERNALS global variable controls whether scripts' assets get
 		// generated, and the default externals set.
 		! process.env.WP_NO_EXTERNALS &&
@@ -423,8 +425,6 @@ if ( hasExperimentalModulesFlag ) {
 			process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
 			// MiniCSSExtractPlugin to extract the CSS thats gets imported into JavaScript.
 			new MiniCSSExtractPlugin( { filename: '[name].css' } ),
-			// React Fast Refresh.
-			hasReactFastRefresh && new ReactRefreshWebpackPlugin(),
 			// WP_NO_EXTERNALS global variable controls whether scripts' assets get
 			// generated, and the default externals set.
 			! process.env.WP_NO_EXTERNALS &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Restore ReatRefreshWebpackPlugin to @wordpress/scripts webpack config.

See https://github.com/WordPress/gutenberg/pull/57461/files#r1449177817

I haven't included a changelog entry because the package hasn't been published yet.

## Why?

#57461 accidentally moved the plugin to the modules config. It should have remained in the scripts webpack config and not been included in the modules config.

## Testing Instructions

Code review is sufficient.
