### PR TITLE
Experiment: Interactivity API workers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -203,6 +203,7 @@
 				"lerna": "7.1.4",
 				"lint-staged": "10.0.1",
 				"make-dir": "3.0.0",
+				"md5": "^2.2.1",
 				"metro-react-native-babel-preset": "0.73.10",
 				"metro-react-native-babel-transformer": "0.73.10",
 				"mkdirp": "3.0.1",
@@ -21521,6 +21522,14 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/check-node-version": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.1.0.tgz",
@@ -23603,6 +23612,14 @@
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			}
+		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/crypto-browserify": {
@@ -36978,6 +36995,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
 			}
 		},
 		"node_modules/md5.js": {
@@ -55275,6 +55302,7 @@
 			"dependencies": {
 				"@preact/signals": "^1.1.3",
 				"deepsignal": "^1.3.6",
+				"md5": "^2.2.1",
 				"preact": "^10.13.2"
 			},
 			"engines": {
@@ -70088,6 +70116,7 @@
 			"requires": {
 				"@preact/signals": "^1.1.3",
 				"deepsignal": "^1.3.6",
+				"md5": "^2.2.1",
 				"preact": "^10.13.2"
 			}
 		},
@@ -73380,6 +73409,11 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+		},
 		"check-node-version": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.1.0.tgz",
@@ -75015,6 +75049,11 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
 		},
 		"crypto-browserify": {
 			"version": "3.12.0",
@@ -85162,6 +85201,16 @@
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
 			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
 			"dev": true
+		},
+		"md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"requires": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
 		},
 		"md5.js": {
 			"version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
 		"lerna": "7.1.4",
 		"lint-staged": "10.0.1",
 		"make-dir": "3.0.0",
+		"md5": "^2.2.1",
 		"metro-react-native-babel-preset": "0.73.10",
 		"metro-react-native-babel-transformer": "0.73.10",
 		"mkdirp": "3.0.1",

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@preact/signals": "^1.1.3",
 		"deepsignal": "^1.3.6",
+		"md5": "^2.2.1",
 		"preact": "^10.13.2"
 	},
 	"publishConfig": {

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -5,6 +5,7 @@ import registerDirectives from './directives';
 import { init } from './router';
 
 export { store } from './store';
+export { registerWorker, getWorker } from './worker';
 export { directive, getContext, getElement } from './hooks';
 export { navigate, prefetch } from './router';
 export { h as createElement } from 'preact';

--- a/packages/interactivity/src/worker.js
+++ b/packages/interactivity/src/worker.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import md5 from 'md5';
+
+const workerProxies = {};
+
+const pendingPromises = {};
+
+export function registerWorker( handle, scriptUrl, callbacks ) {
+	if ( workerProxies[ handle ] ) {
+		window.console.error(
+			`Worker with handle ${ handle } is already registered.`
+		);
+		return;
+	}
+
+	const worker = new Worker( scriptUrl, { type: 'module' } );
+
+	workerProxies[ handle ] = {};
+	callbacks.forEach( ( callback ) => {
+		workerProxies[ handle ][ callback ] = createCallbackHandler(
+			worker,
+			callback
+		);
+	} );
+
+	worker.onmessage = ( event ) => {
+		if ( ! event.data || ! event.data.hash || ! event.data.result ) {
+			return;
+		}
+
+		const { result, hash } = event.data;
+
+		if ( ! pendingPromises[ hash ] ) {
+			window.console.error(
+				`Worker callback with hash ${ hash } does not exist or was already resolved.`
+			);
+			return;
+		}
+
+		const resolve = pendingPromises[ hash ];
+		delete pendingPromises[ hash ];
+
+		resolve( result );
+	};
+
+	return workerProxies[ handle ];
+}
+
+export function getWorker( handle ) {
+	if ( ! workerProxies[ handle ] ) {
+		window.console.error(
+			`Worker with handle ${ handle } is not registered.`
+		);
+		return null;
+	}
+
+	return workerProxies[ handle ];
+}
+
+function createCallbackHandler( worker, callback ) {
+	return ( ...args ) => {
+		const hash = createPromiseHash( callback, args );
+
+		const promise = new Promise( ( resolve ) => {
+			pendingPromises[ hash ] = resolve;
+		} );
+		worker.postMessage( { callback, args, hash } );
+		return promise;
+	};
+}
+
+function createPromiseHash( callback, args ) {
+	const initial = `${ callback }::${ md5( JSON.stringify( args ) ) }`;
+	if ( ! pendingPromises[ initial ] ) {
+		return initial;
+	}
+
+	let i = 2;
+	while ( pendingPromises[ `${ initial }::${ i }` ] ) {
+		i++;
+	}
+
+	return `${ initial }::${ i }`;
+}


### PR DESCRIPTION
This is an extremely early exploration of how web workers could be used as part of the Interactivity API.

This PR is not functional and doesn't even compile, partly owed by my lack of familiarity with latest Gutenberg JS practices 😆 
Anyway, the point of this is mostly to consider the idea further. An eventual solution would probably be better implemented by other people. :)

## Why?
Using expensive logic should avoid using the main thread. The idea is that e.g. Interactivity API `actions` or `callbacks` could make use of workers for certain more expensive pieces of logic.

## How?
The idea is the following:
* Plugins can register a worker module script (for now implemented only in JS, but could be made available via PHP modules API and then "translated" into JS).
* These workers would contain "callback" functions that are then exposed on a "proxy" object in the main thread.
* Any Interactivity API `actions` or `callbacks` (or any code whatsoever) could call the worker callbacks on that proxy, which would return promises. Those promises are resolved when the worker indicates completion of the callback.
    * The "proxy" object is currently a manually coded list of functions, which is not great. I'm confident there are more elegant ways to solve this.
* So far the PR only includes a proof of concept of how the main thread part (i.e. the actual Interactivity API integration) would work. There would need to be a worker-specific Interactivity API script (currently not implemented) that the worker scripts from plugins would import to provide the worker-side critical infrastructure.