### PR TITLE
Editor Canvas Container: render revisions and style book when blocks and settings available

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -32,6 +32,34 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 
 const PAGE_SIZE = 10;
 
+function RevisionsView( {
+	editorCanvasContainerView,
+	userConfig,
+	blocks,
+	onClose,
+} ) {
+	if ( editorCanvasContainerView === 'global-styles-revisions:style-book' ) {
+		return (
+			<StyleBook
+				userConfig={ userConfig }
+				isSelected={ () => {} }
+				onClose={ onClose }
+			/>
+		);
+	}
+
+	if ( editorCanvasContainerView === 'global-styles-revisions' ) {
+		return (
+			<Revisions
+				blocks={ blocks }
+				userConfig={ userConfig }
+				closeButtonLabel={ __( 'Close revisions' ) }
+			/>
+		);
+	}
+	return null;
+}
+
 function ScreenRevisions() {
 	const { goTo } = useNavigator();
 	const { user: currentEditorGlobalStyles, setUserConfig } =
@@ -160,25 +188,14 @@ function ScreenRevisions() {
 			{ ! hasRevisions && (
 				<Spinner className="edit-site-global-styles-screen-revisions__loading" />
 			) }
-			{ hasRevisions &&
-				( editorCanvasContainerView ===
-				'global-styles-revisions:style-book' ? (
-					<StyleBook
-						userConfig={ currentlySelectedRevision }
-						isSelected={ () => {} }
-						onClose={ () => {
-							setEditorCanvasContainerView(
-								'global-styles-revisions'
-							);
-						} }
-					/>
-				) : (
-					<Revisions
-						blocks={ blocks }
-						userConfig={ currentlySelectedRevision }
-						closeButtonLabel={ __( 'Close revisions' ) }
-					/>
-				) ) }
+			{ hasRevisions && (
+				<RevisionsView
+					editorCanvasContainerView={ editorCanvasContainerView }
+					userConfig={ currentlySelectedRevision }
+					blocks={ blocks }
+					onClose={ onCloseRevisions }
+				/>
+			) }
 			<RevisionsButtons
 				onChange={ selectRevision }
 				selectedRevisionId={ currentlySelectedRevisionId }

--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -11,7 +11,7 @@ import {
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useContext, useMemo } from '@wordpress/element';
+import { useContext, useMemo, useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,6 +45,9 @@ function Revisions( { userConfig, blocks } ) {
 		() => ( Array.isArray( blocks ) ? blocks : [ blocks ] ),
 		[ blocks ]
 	);
+	const [ isHide, setIsHide ] = useState( true );
+	const to = setTimeout( () => setIsHide( false ), 750 );
+	useEffect( () => () => clearTimeout( to ), [] );
 
 	const originalSettings = useSelect(
 		( select ) => select( blockEditorStore ).getSettings(),
@@ -63,7 +66,10 @@ function Revisions( { userConfig, blocks } ) {
 			: settings.styles;
 
 	const showCanvas =
-		!! editorStyles && !! originalSettings && !! renderedBlocksArray.length;
+		! isHide &&
+		!! editorStyles &&
+		!! originalSettings &&
+		!! renderedBlocksArray.length;
 
 	return (
 		<EditorCanvasContainer
@@ -85,14 +91,14 @@ function Revisions( { userConfig, blocks } ) {
 					}
 				</style>
 				<Disabled className="edit-site-revisions__example-preview__content">
-					{ showCanvas ? (
-						<ExperimentalBlockEditorProvider
-							value={ renderedBlocksArray }
-							settings={ settings }
-						>
+					<ExperimentalBlockEditorProvider
+						value={ renderedBlocksArray }
+						settings={ settings }
+					>
+						{ showCanvas ? (
 							<BlockList renderAppender={ false } />
-						</ExperimentalBlockEditorProvider>
-					) : null }
+						) : null }
+					</ExperimentalBlockEditorProvider>
 				</Disabled>
 			</Iframe>
 		</EditorCanvasContainer>

--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -11,7 +11,7 @@ import {
 	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useContext, useMemo, useState, useEffect } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,13 +41,10 @@ function Revisions( { userConfig, blocks } ) {
 		return {};
 	}, [ baseConfig, userConfig ] );
 
-	const renderedBlocksArray = useMemo(
+	const renderedBlocks = useMemo(
 		() => ( Array.isArray( blocks ) ? blocks : [ blocks ] ),
 		[ blocks ]
 	);
-	const [ isHide, setIsHide ] = useState( true );
-	const to = setTimeout( () => setIsHide( false ), 750 );
-	useEffect( () => () => clearTimeout( to ), [] );
 
 	const originalSettings = useSelect(
 		( select ) => select( blockEditorStore ).getSettings(),
@@ -66,10 +63,7 @@ function Revisions( { userConfig, blocks } ) {
 			: settings.styles;
 
 	const showCanvas =
-		! isHide &&
-		!! editorStyles &&
-		!! originalSettings &&
-		!! renderedBlocksArray.length;
+		!! editorStyles && !! originalSettings && !! renderedBlocks.length;
 
 	return (
 		<EditorCanvasContainer
@@ -92,7 +86,7 @@ function Revisions( { userConfig, blocks } ) {
 				</style>
 				<Disabled className="edit-site-revisions__example-preview__content">
 					<ExperimentalBlockEditorProvider
-						value={ renderedBlocksArray }
+						value={ renderedBlocks }
 						settings={ settings }
 					>
 						{ showCanvas ? (

--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -62,6 +62,9 @@ function Revisions( { userConfig, blocks } ) {
 			? globalStyles
 			: settings.styles;
 
+	const showCanvas =
+		!! editorStyles && !! originalSettings && !! renderedBlocksArray.length;
+
 	return (
 		<EditorCanvasContainer
 			title={ __( 'Revisions' ) }
@@ -82,12 +85,14 @@ function Revisions( { userConfig, blocks } ) {
 					}
 				</style>
 				<Disabled className="edit-site-revisions__example-preview__content">
-					<ExperimentalBlockEditorProvider
-						value={ renderedBlocksArray }
-						settings={ settings }
-					>
-						<BlockList renderAppender={ false } />
-					</ExperimentalBlockEditorProvider>
+					{ showCanvas ? (
+						<ExperimentalBlockEditorProvider
+							value={ renderedBlocksArray }
+							settings={ settings }
+						>
+							<BlockList renderAppender={ false } />
+						</ExperimentalBlockEditorProvider>
+					) : null }
 				</Disabled>
 			</Iframe>
 		</EditorCanvasContainer>

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -466,14 +466,14 @@ const Example = ( { id, title, blocks, isSelected, onClick } ) => {
 						aria-hidden
 					>
 						<Disabled className="edit-site-style-book__example-preview__content">
-							{ showCanvas ? (
-								<ExperimentalBlockEditorProvider
-									value={ renderedBlocks }
-									settings={ settings }
-								>
+							<ExperimentalBlockEditorProvider
+								value={ renderedBlocks }
+								settings={ settings }
+							>
+								{ showCanvas ? (
 									<BlockList renderAppender={ false } />
-								</ExperimentalBlockEditorProvider>
-							) : null }
+								) : null }
+							</ExperimentalBlockEditorProvider>
 						</Disabled>
 					</div>
 				</CompositeItem>

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -439,6 +439,8 @@ const Example = ( { id, title, blocks, isSelected, onClick } ) => {
 		[ blocks ]
 	);
 
+	const showCanvas = !! originalSettings && !! renderedBlocks.length;
+
 	return (
 		<div role="row">
 			<div role="gridcell">
@@ -464,12 +466,14 @@ const Example = ( { id, title, blocks, isSelected, onClick } ) => {
 						aria-hidden
 					>
 						<Disabled className="edit-site-style-book__example-preview__content">
-							<ExperimentalBlockEditorProvider
-								value={ renderedBlocks }
-								settings={ settings }
-							>
-								<BlockList renderAppender={ false } />
-							</ExperimentalBlockEditorProvider>
+							{ showCanvas ? (
+								<ExperimentalBlockEditorProvider
+									value={ renderedBlocks }
+									settings={ settings }
+								>
+									<BlockList renderAppender={ false } />
+								</ExperimentalBlockEditorProvider>
+							) : null }
 						</Disabled>
 					</div>
 				</CompositeItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and how?
This is a test to see if blocking rendering of the editor provider until after its dependencies are ready makes any noticeable difference to perceived smoothness of loading.

I don't think it does 🤷🏻 

At the very least, it adds a bit of a defensive layer and extracts `RevisionsView` into a component for near logic.


## Why?
See: https://github.com/WordPress/gutenberg/issues/53017



## Testing Instructions

Open the site editor and load the global styles revisions page.
Do the same for style book

A white "flash" is expected, but this PR attempt to reduce the block flash. Not even sure if it does anything 😄 