### PR TITLE
fix: Prevent text from being cut off in mobile OfflineStatus component

### DIFF
--- a/packages/editor/src/components/offline-status/index.native.js
+++ b/packages/editor/src/components/offline-status/index.native.js
@@ -90,10 +90,8 @@ const OfflineStatus = () => {
 			) }
 			style={ containerStyle }
 		>
-			<View style={ containerStyle }>
-				<Icon fill={ iconStyle.fill } icon={ offlineIcon } />
-				<Text style={ textStyle }>{ __( 'Working Offline' ) }</Text>
-			</View>
+			<Icon fill={ iconStyle.fill } icon={ offlineIcon } />
+			<Text style={ textStyle }>{ __( 'Working Offline' ) } </Text>
 		</View>
 	) : null;
 };


### PR DESCRIPTION
## What?
Resolves an Android issue where text was being cut off in the OfflineStatus component when bold text was being used.

Before | After
-|-
<img src="https://github.com/WordPress/gutenberg/assets/643285/dca3fcdb-6cc5-43f7-af00-a2c7f1d0845c" width="350" /> | <img src="https://github.com/WordPress/gutenberg/assets/643285/cd2c10af-f925-4d69-a29c-215f6fba1a0d" width="350" />
 

## Why?
This appears to be a legitimate bug in React Native:
- https://github.com/facebook/react-native/issues/21729
- https://github.com/react-native-community/discussions-and-proposals/issues/477

When a bold typeface style is used, the last node of the text appears to be removed.

When there are two or more words in one `<Text>` element, the last word is removed:
```
<Text>Working Offline</Text>
→ "Working "
```

When there is one word in a `<Text>` element, the last letter is removed:
```
<Text>Working</Text><Text>Offline</Text>
→ "Workin Offlin"
```

When there are two or more words in one `<Text>` element and a space is added, the space is removed:
```
<Text>Working Offline </Text>
→ "Working Offline"
```

## How?
This PR adds a space to the end of the <Text> element in OfflineStatus to workaround the issue. This space does not appear to impact the UI.

_Note:_ the space appears outside of the i18n string to avoid invoking the [i18n-no-flanking-whitespace](https://github.com/WordPress/gutenberg/blob/trunk/packages/eslint-plugin/docs/rules/i18n-no-flanking-whitespace.md) linter error. 

```
<Text style={ textStyle }>{ __( 'Working Offline' ) } </Text>
```

This PR also removes an extra `<View style={ containerStyle }></View>` that appears to be redundant from its parent.

## Testing Instructions
1. On an Android device, set the device to use a [bold font within Accessibility Settings](https://support.google.com/accessibility/android/answer/11183305?hl=en#zippy=%2Cuse-bold-fonts). 
2. Open a post in the Editor and turn off Network Connectivity via Airplane Mode.
3. Observe that the offline status indicator displays the text "Working Offline" next to a no-wifi icon, and that text is not cut off as in the "Before" screenshot above.

_Testing note:_ I was not able to consistently reproduce the original issue across various Android devices. I was not able to replicate the issue on a Samsung Galaxy FE20 or Google Pixel 6 Pro, but could consistently replicate it on a Pixel One.