### PR TITLE
LinkControl: Remove unnecessary right padding of input fields

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-/**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
@@ -119,10 +115,6 @@ const LinkControlSearchInput = forwardRef(
 			}
 		};
 
-		const inputClasses = classnames( className, {
-			// 'has-no-label': ! hideLabelFromVision,
-		} );
-
 		return (
 			<div className="block-editor-link-control__search-input-container">
 				<URLInput
@@ -130,7 +122,7 @@ const LinkControlSearchInput = forwardRef(
 					__nextHasNoMarginBottom
 					label={ __( 'Link' ) }
 					hideLabelFromVision={ hideLabelFromVision }
-					className={ inputClasses }
+					className={ className }
 					value={ value }
 					onChange={ onInputChange }
 					placeholder={ placeholder ?? __( 'Search or type url' ) }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -51,13 +51,6 @@ $preview-image-height: 140px;
 	position: relative;
 }
 
-// If the input doesn't have a visible label then
-// we need to expand the input itself to occupy
-// the full available horizontal space.
-.block-editor-link-control__search-input.has-no-label .block-editor-url-input__input {
-	flex: 1;
-}
-
 .block-editor-link-control__field {
 	margin: $grid-unit-20; // allow margin collapse for vertical spacing.
 
@@ -77,6 +70,10 @@ $preview-image-height: 140px;
 		padding: $grid-unit-10 $button-size-next-default-40px $grid-unit-10 $grid-unit-20;
 		position: relative;
 		width: 100%;
+
+		.has-actions & {
+			padding-right: $grid-unit-20;
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up on #56685

## What?
This PR removes unnecessary right padding of input fields when there are "Action" buttons.

| Before | After |
|--------|--------|
|  ![image](https://github.com/WordPress/gutenberg/assets/54422211/d07a3a97-74f9-41c7-bc70-21ca77179d55)|  ![image](https://github.com/WordPress/gutenberg/assets/54422211/b58c987a-93e5-48ef-9863-1d4a75253c2f) | 

## Why?

In #56685, the padding on the right side was increased to prevent text from covering the submit button. However, once the URL is submitted, this submit button does not exist.

## How?

We can determine whether this submit button exists using the `showActions` variable, that is, the `has-actions` class. Use this class to override the right padding with the default value when there is no submit button.

## Testing Instructions

- Select the text and click the Link button on the block toolbar.
- Enter the link. The text should not cover the submit button.
- Press Enter and open the link again.
- Press the Edit button.
- There should be no extra padding on the right side of the two text fields.
