### PR TITLE
Template/Page Editing UX: Try highlighting what's editable

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -902,6 +902,15 @@ A cloud of your most used tags. ([Source](https://github.com/WordPress/gutenberg
 -	**Supports:** align, spacing (margin, padding), typography (lineHeight), ~~html~~
 -	**Attributes:** largestFontSize, numberOfTags, showTagCounts, smallestFontSize, taxonomy
 
+## Template
+
+ ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/template))
+
+-	**Name:** core/template
+-	**Category:** theme
+-	**Supports:** ~~html~~, ~~inserter~~, ~~lock~~, ~~renaming~~, ~~reusable~~
+-	**Attributes:** ref
+
 ## Template Part
 
 Edit the different global regions of your site, like the header, footer, sidebar, or create your own. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/template-part))

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -26,7 +26,7 @@
 /* stylelint-disable */
 _::-webkit-full-page-media, _:future, :root .block-editor-block-list__layout::selection,
 _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-block-list__layout::selection {
-	background-color: transparent; 
+	background-color: transparent;
 }
 /* stylelint-enable */
 
@@ -181,6 +181,16 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	&.is-editing-disabled {
 		pointer-events: none;
 		user-select: none;
+
+		.block-editor-block-list__block:not(.is-editing-disabled) {
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+
+			// TODO: show pencil icon in top right
+
+			.block-editor-block-list__block:not(.is-editing-disabled) {
+				box-shadow: none;
+			}
+		}
 	}
 
 	.reusable-block-edit-panel * {

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -13,6 +13,7 @@ import {
 	store as blocksStore,
 	isReusableBlock,
 	isTemplatePart,
+	isTemplate,
 } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { copy } from '@wordpress/icons';
@@ -95,8 +96,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	} );
 
 	const isSingleBlock = blocks.length === 1;
-	const isReusable = isSingleBlock && isReusableBlock( blocks[ 0 ] );
-	const isTemplate = isSingleBlock && isTemplatePart( blocks[ 0 ] );
+	const _isReusableBlock = isSingleBlock && isReusableBlock( blocks[ 0 ] );
+	const _isTemplatePart = isSingleBlock && isTemplatePart( blocks[ 0 ] );
+	const _isTemplate = isSingleBlock && isTemplate( blocks[ 0 ] );
 
 	function selectForMultipleBlocks( insertedBlocks ) {
 		if ( insertedBlocks.length > 1 ) {
@@ -134,7 +136,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	 * by allowing to exclude blocks from wildcard transformations.
 	 */
 	const hasPossibleBlockTransformations =
-		!! possibleBlockTransformations.length && canRemove && ! isTemplate;
+		!! possibleBlockTransformations.length &&
+		canRemove &&
+		! _isTemplatePart;
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;
@@ -155,7 +159,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					icon={
 						<>
 							<BlockIcon icon={ icon } showColors />
-							{ ( isReusable || isTemplate ) && (
+							{ ( _isReusableBlock ||
+								_isTemplatePart ||
+								_isTemplate ) && (
 								<span className="block-editor-block-switcher__toggle-text">
 									{ blockTitle }
 								</span>
@@ -201,7 +207,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 									className="block-editor-block-switcher__toggle"
 									showColors
 								/>
-								{ ( isReusable || isTemplate ) && (
+								{ ( _isReusableBlock ||
+									_isTemplatePart ||
+									_isTemplate ) && (
 									<span className="block-editor-block-switcher__toggle-text">
 										{ blockTitle }
 									</span>

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -15,6 +15,7 @@ import {
 	hasBlockSupport,
 	isReusableBlock,
 	isTemplatePart,
+	isTemplate,
 } from '@wordpress/blocks';
 import { ToolbarGroup } from '@wordpress/components';
 
@@ -135,7 +136,9 @@ export function PrivateBlockToolbar( {
 
 	const isMultiToolbar = blockClientIds.length > 1;
 	const isSynced =
-		isReusableBlock( blockType ) || isTemplatePart( blockType );
+		isReusableBlock( blockType ) ||
+		isTemplatePart( blockType ) ||
+		isTemplate( blockType );
 
 	// Shifts the toolbar to make room for the parent block selector.
 	const classes = classnames( 'block-editor-block-contextual-toolbar', {

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -115,6 +115,7 @@ import * as spacer from './spacer';
 import * as table from './table';
 import * as tableOfContents from './table-of-contents';
 import * as tagCloud from './tag-cloud';
+import * as template from './template';
 import * as templatePart from './template-part';
 import * as termDescription from './term-description';
 import * as textColumns from './text-columns';
@@ -190,6 +191,7 @@ const getAllBlocks = () => {
 		siteTitle,
 		siteTagline,
 		query,
+		template,
 		templatePart,
 		avatar,
 		postTitle,

--- a/packages/block-library/src/template/block.json
+++ b/packages/block-library/src/template/block.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/template",
+	"title": "Template",
+	"category": "theme",
+	"description": "",
+	"textdomain": "default",
+	"attributes": {
+		"ref": {
+			"type": "number"
+		}
+	},
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"renaming": false,
+		"inserter": false,
+		"lock": false
+	}
+}

--- a/packages/block-library/src/template/edit.js
+++ b/packages/block-library/src/template/edit.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	useBlockEditingMode,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useEntityBlockEditor } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+export default function TemplateEdit( { clientId, attributes: { ref } } ) {
+	useBlockEditingMode( 'default' );
+
+	const innerBlockClientIds = useSelect( ( select ) =>
+		select( blockEditorStore ).getBlockOrder( clientId )
+	);
+	const { setBlockEditingMode, unsetBlockEditingMode } =
+		useDispatch( blockEditorStore );
+	useEffect( () => {
+		innerBlockClientIds.forEach( ( id ) => {
+			setBlockEditingMode( id, 'disabled' );
+		} );
+		return () => innerBlockClientIds.forEach( unsetBlockEditingMode );
+	}, [
+		clientId,
+		innerBlockClientIds,
+		setBlockEditingMode,
+		unsetBlockEditingMode,
+	] );
+
+	const blockProps = useBlockProps();
+	const [ value, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		'wp_template',
+		{ id: ref }
+	);
+	const innerBlockProps = useInnerBlocksProps( blockProps, {
+		value,
+		onInput,
+		onChange,
+		allowedBlocks: [], // Prevent appender from showing.
+	} );
+
+	return <div { ...blockProps } { ...innerBlockProps } />;
+}

--- a/packages/block-library/src/template/index.js
+++ b/packages/block-library/src/template/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { capitalCase } from 'change-case';
+
+/**
+ * WordPress dependencies
+ */
+import { layout } from '@wordpress/icons';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { select } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon: layout,
+	__experimentalLabel( { ref } ) {
+		if ( ! ref ) return;
+		const entity = select( coreDataStore ).getEntityRecord(
+			'postType',
+			'wp_template',
+			ref
+		);
+		if ( ! entity ) return;
+		return (
+			decodeEntities( entity.title?.rendered ) ||
+			capitalCase( entity.slug )
+		);
+	},
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -336,6 +336,18 @@ _Returns_
 
 -   `boolean`: Whether the given block is a reusable block.
 
+### isTemplate
+
+Determines whether or not the given block is a template.
+
+_Parameters_
+
+-   _blockOrType_ `Object`: Block or Block Type to test.
+
+_Returns_
+
+-   `boolean`: Whether the given block is a template.
+
 ### isTemplatePart
 
 Determines whether or not the given block is a template part. This is a special block type that allows composing a page template out of reusable design elements.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -126,6 +126,7 @@ export {
 	hasBlockSupport,
 	getBlockVariations,
 	isReusableBlock,
+	isTemplate,
 	isTemplatePart,
 	getChildBlockNames,
 	hasChildBlocks,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -563,6 +563,17 @@ export function isReusableBlock( blockOrType ) {
 }
 
 /**
+ * Determines whether or not the given block is a template.
+ *
+ * @param {Object} blockOrType Block or Block Type to test.
+ *
+ * @return {boolean} Whether the given block is a template.
+ */
+export function isTemplate( blockOrType ) {
+	return blockOrType?.name === 'core/template';
+}
+
+/**
  * Determines whether or not the given block is a template part. This is a
  * special block type that allows composing a page template out of reusable
  * design elements.

--- a/packages/edit-site/src/hooks/index.js
+++ b/packages/edit-site/src/hooks/index.js
@@ -3,5 +3,6 @@
  */
 import './components';
 import './push-changes-to-global-styles';
+import './template-edit';
 import './template-part-edit';
 import './navigation-menu-edit';

--- a/packages/edit-site/src/hooks/template-edit.js
+++ b/packages/edit-site/src/hooks/template-edit.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarButton } from '@wordpress/components';
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { store as editorStore } from '@wordpress/editor';
+
+function EditTemplateMenuItem() {
+	const { setRenderingMode } = useDispatch( editorStore );
+	return (
+		<BlockControls group="other">
+			<ToolbarButton
+				onClick={ () => setRenderingMode( 'template-only' ) }
+			>
+				{ __( 'Edit template' ) }
+			</ToolbarButton>
+		</BlockControls>
+	);
+}
+
+export const withEditBlockControls = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const { name } = props;
+		return (
+			<>
+				<BlockEdit { ...props } />
+				{ name === 'core/template' && <EditTemplateMenuItem /> }
+			</>
+		);
+	},
+	'withEditBlockControls'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/edit-site/template-edit-button',
+	withEditBlockControls
+);

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -50,6 +50,11 @@ function useBlockEditorProps( post, template, mode ) {
 		useEntityBlockEditor( 'postType', template?.type, {
 			id: template?.id,
 		} );
+	const maybeTemplateBlocks = useMemo( () => {
+		if ( !! template && mode === 'template-locked' ) {
+			return [ createBlock( 'core/template', { ref: template.id } ) ];
+		}
+	}, [ template, mode ] );
 	const maybeNavigationBlocks = useMemo( () => {
 		if ( post.type === 'wp_navigation' ) {
 			return [
@@ -67,16 +72,23 @@ function useBlockEditorProps( post, template, mode ) {
 	// It is important that we don't create a new instance of blocks on every change
 	// We should only create a new instance if the blocks them selves change, not a dependency of them.
 	const blocks = useMemo( () => {
+		if ( maybeTemplateBlocks ) {
+			return maybeTemplateBlocks;
+		}
 		if ( maybeNavigationBlocks ) {
 			return maybeNavigationBlocks;
 		}
-
 		if ( rootLevelPost === 'template' ) {
 			return templateBlocks;
 		}
-
 		return postBlocks;
-	}, [ maybeNavigationBlocks, rootLevelPost, templateBlocks, postBlocks ] );
+	}, [
+		maybeTemplateBlocks,
+		maybeNavigationBlocks,
+		rootLevelPost,
+		templateBlocks,
+		postBlocks,
+	] );
 
 	// Handle fallback to postBlocks outside of the above useMemo, to ensure
 	// that constructed block templates that call `createBlock` are not generated


### PR DESCRIPTION
## What?
First attempt at implementing Part 1 of https://github.com/WordPress/gutenberg/issues/55025.

## Why?
See https://github.com/WordPress/gutenberg/issues/55025.

## How?
When editing a page in the site editor in `post-only` mode, we wrap everything with a new Template block. This is an internal (`supports.inserter: false`) block that is similar to Template Part and renders the specified template. By wrapping everything in a block, we can achieve the desired effect shown in Part 1 of https://github.com/WordPress/gutenberg/issues/55025 where clicking on a block that is part of the template results in a block toolbar appearing with an _Edit_ button.

## Testing Instructions
1. Go to Appearance → Editor → Pages and select a page to edit

## Screenshots or screencast 

https://github.com/WordPress/gutenberg/assets/612155/4bfb35f4-8acf-4921-80f5-89a0ef26ba16