### PR TITLE
Move `createRoot()` to the `load` callback

### DIFF
--- a/docs/how-to-guides/data-basics/1-data-basics-setup.md
+++ b/docs/how-to-guides/data-basics/1-data-basics-setup.md
@@ -24,10 +24,10 @@ function MyFirstApp() {
 	return <span>Hello from JavaScript!</span>;
 }
 
-const root = createRoot( document.getElementById( 'my-first-gutenberg-app' ) );
 window.addEventListener(
 	'load',
 	function () {
+        const root = createRoot( document.getElementById( 'my-first-gutenberg-app' ) );
 		root.render(
 			<MyFirstApp />,
 		);


### PR DESCRIPTION
Getting the root element outside the `load` callback risks losing a race condition against the page load (and caused it not to work for me).

Moving the line into the callback ensures it's already loaded.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Simply making a change to a code example to ensure that we don't try and pass an element that hasn't yet loaded to `createRoot()`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As I was going through the documentation, I pasted the examples into my local environment but didn't see the expected output on the page. It looks like that was just because `getElementById()` wasn't finding the element.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I moved the line including `getElementById()` to inside the window's `load` event listener callback.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Follow the directions on the [Create your First App with Gutenberg Data > Setup](https://developer.wordpress.org/block-editor/how-to-guides/data-basics/1-data-basics-setup/) page.
2. At the [Testing if it worked](https://developer.wordpress.org/block-editor/how-to-guides/data-basics/1-data-basics-setup/#testing-if-it-worked) step, possibly see the page without the "Hello from JavaScript!" text.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
