### PR TITLE
resolve dot issue of block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -259,4 +259,15 @@
 			margin-left: 6px;
 		}
 	}
+
+	// Reslve the block dot issue
+	.block-editor-block-popover {
+		.block-editor-block-contextual-toolbar {
+			.block-editor-block-parent-selector {
+				&:after {
+					content: "";
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Resolve the mentioned issue :- #57713


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Whenever we have choosen **Show button text labels** this from the Preference then in toolbar small dot appear at the end of toolbar.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Disable "Fixed toolbar" from the Options menu.
- From Preference in Accessibility make toggle true **Show button text labels**
- Insert a Group block.
- Add Paragraph block with in it.
- There should be a dot at the right end of the block toolbar.
