### PR TITLE
DataViews: add description to pages

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages-dataviews/index.js
@@ -76,7 +76,7 @@ export default function SidebarNavigationScreenPagesDataViews() {
 	return (
 		<SidebarNavigationScreen
 			title={ __( 'Pages' ) }
-			description={ __( 'Browse and edit pages on your site.' ) }
+			description={ __( 'Browse and manage pages.' ) }
 			content={ <DataViewsSidebarContent /> }
 			footer={
 				<VStack spacing={ 0 }>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages-dataviews/index.js
@@ -76,6 +76,7 @@ export default function SidebarNavigationScreenPagesDataViews() {
 	return (
 		<SidebarNavigationScreen
 			title={ __( 'Pages' ) }
+			description={ __( 'Browse and edit pages on your site.' ) }
 			content={ <DataViewsSidebarContent /> }
 			footer={
 				<VStack spacing={ 0 }>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -156,7 +156,7 @@ export default function SidebarNavigationScreenPages() {
 			) }
 			<SidebarNavigationScreen
 				title={ __( 'Pages' ) }
-				description={ __( 'Browse and edit pages on your site.' ) }
+				description={ __( 'Browse and manage pages.' ) }
 				actions={
 					<SidebarButton
 						icon={ plus }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/57578

## What?

- Updates the description for Pages:
  - Before: "Browse and edit pages of your site"
  - After: "Browse and manage pages"
- Add the same description to dataviews-powered Pages as well.

| | Before | After |
| --- | --- | --- |
| Pages (stable) | <img width="1507" alt="Captura de ecrã 2024-01-12, às 09 31 39" src="https://github.com/WordPress/gutenberg/assets/583546/3eeb6fa5-9766-4a6d-873f-acf3cae0a69e"> | <img width="1509" alt="Captura de ecrã 2024-01-15, às 12 33 48" src="https://github.com/WordPress/gutenberg/assets/583546/e0a14edf-6a0d-41f9-b826-39d818589cfe"> |
| Pages (dataviews) | <img width="1507" alt="Captura de ecrã 2024-01-12, às 09 45 29" src="https://github.com/WordPress/gutenberg/assets/583546/17aa4849-2a36-4177-a16b-0771669be2e5"> | <img width="1509" alt="Captura de ecrã 2024-01-15, às 12 33 33" src="https://github.com/WordPress/gutenberg/assets/583546/7e7677a0-443f-4dbc-80f9-c120df0d0899"> |


## Why?

All root pages have a description and the existing page we aim to replace also has one.

## How?

Adds the description to the sidebar component.

## Testing Instructions

- Enable the "new admin views" experiment and visit "Manage all pages".
- Verify the description is there.
