### PR TITLE
DependencyExtractionWebpackPlugin: Throw when using scripts from modules

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -73,10 +73,7 @@ class DependencyExtractionWebpackPlugin {
 		}
 
 		// Cascade to default if unhandled and enabled.
-		if (
-			typeof externalRequest === 'undefined' &&
-			this.options.useDefaults
-		) {
+		if ( ! externalRequest && this.options.useDefaults ) {
 			externalRequest = this.useModules
 				? defaultRequestToExternalModule( request )
 				: defaultRequestToExternal( request );
@@ -84,6 +81,10 @@ class DependencyExtractionWebpackPlugin {
 
 		if ( this.useModules && externalRequest === true ) {
 			externalRequest = request;
+		}
+
+		if ( externalRequest instanceof Error ) {
+			return callback( externalRequest );
 		}
 
 		if ( externalRequest ) {

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -62,36 +62,38 @@ class DependencyExtractionWebpackPlugin {
 	externalizeWpDeps( { request }, callback ) {
 		let externalRequest;
 
-		// Handle via options.requestToExternal(Module)  first.
-		if ( this.useModules ) {
-			if ( typeof this.options.requestToExternalModule === 'function' ) {
-				externalRequest =
-					this.options.requestToExternalModule( request );
+		try {
+			// Handle via options.requestToExternal(Module)  first.
+			if ( this.useModules ) {
+				if (
+					typeof this.options.requestToExternalModule === 'function'
+				) {
+					externalRequest =
+						this.options.requestToExternalModule( request );
 
-				// requestToExternalModule allows a boolean shorthand
-				if ( externalRequest === false ) {
-					externalRequest = undefined;
+					// requestToExternalModule allows a boolean shorthand
+					if ( externalRequest === false ) {
+						externalRequest = undefined;
+					}
+					if ( externalRequest === true ) {
+						externalRequest = request;
+					}
 				}
-				if ( externalRequest === true ) {
-					externalRequest = request;
-				}
+			} else if ( typeof this.options.requestToExternal === 'function' ) {
+				externalRequest = this.options.requestToExternal( request );
 			}
-		} else if ( typeof this.options.requestToExternal === 'function' ) {
-			externalRequest = this.options.requestToExternal( request );
-		}
 
-		// Cascade to default if unhandled and enabled.
-		if (
-			typeof externalRequest === 'undefined' &&
-			this.options.useDefaults
-		) {
-			externalRequest = this.useModules
-				? defaultRequestToExternalModule( request )
-				: defaultRequestToExternal( request );
-		}
-
-		if ( externalRequest instanceof Error ) {
-			return callback( externalRequest );
+			// Cascade to default if unhandled and enabled.
+			if (
+				typeof externalRequest === 'undefined' &&
+				this.options.useDefaults
+			) {
+				externalRequest = this.useModules
+					? defaultRequestToExternalModule( request )
+					: defaultRequestToExternal( request );
+			}
+		} catch ( err ) {
+			return callback( err );
 		}
 
 		if ( externalRequest ) {

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -67,20 +67,27 @@ class DependencyExtractionWebpackPlugin {
 			if ( typeof this.options.requestToExternalModule === 'function' ) {
 				externalRequest =
 					this.options.requestToExternalModule( request );
+
+				// requestToExternalModule allows a boolean shorthand
+				if ( externalRequest === false ) {
+					externalRequest = undefined;
+				}
+				if ( externalRequest === true ) {
+					externalRequest = request;
+				}
 			}
 		} else if ( typeof this.options.requestToExternal === 'function' ) {
 			externalRequest = this.options.requestToExternal( request );
 		}
 
 		// Cascade to default if unhandled and enabled.
-		if ( ! externalRequest && this.options.useDefaults ) {
+		if (
+			typeof externalRequest === 'undefined' &&
+			this.options.useDefaults
+		) {
 			externalRequest = this.useModules
 				? defaultRequestToExternalModule( request )
 				: defaultRequestToExternal( request );
-		}
-
-		if ( this.useModules && externalRequest === true ) {
-			externalRequest = request;
 		}
 
 		if ( externalRequest instanceof Error ) {

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -62,8 +62,11 @@ function defaultRequestToExternal( request ) {
  * Currently only @wordpress/interactivity
  *
  * @param {string} request Module request (the module name in `import from`) to be transformed
- * @return {string|undefined} The resulting external definition. Return `undefined`
- *   to ignore the request. Return `string` to map the request to an external. This may simply be returning the request, e.g. `@wordpress/interactivity` maps to the external `@wordpress/interactivity`.
+ * @return {string|boolean|Error|undefined} The resulting external definition.
+ *   - Return `undefined` to ignore the request (do not externalize).
+ *   - Return `true` to externalize the request with the same Module ID
+ *   - Return `string` to map the request to an external.
+ *   - Return `Error` to emit an error.
  */
 function defaultRequestToExternalModule( request ) {
 	if ( request === '@wordpress/interactivity' ) {
@@ -72,6 +75,14 @@ function defaultRequestToExternalModule( request ) {
 		// externalize this as a module (instead of our default `import()` external type)
 		// which forces @wordpress/interactivity imports to be hoisted to static imports.
 		return `module ${ request }`;
+	}
+
+	const isWordPressScript = Boolean( defaultRequestToExternal( request ) );
+
+	if ( isWordPressScript ) {
+		return new Error(
+			`Attempted to use WordPress script in a module: ${ request }`
+		);
 	}
 }
 

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -82,7 +82,7 @@ function defaultRequestToExternalModule( request ) {
 
 	if ( isWordPressScript ) {
 		throw new Error(
-			`Attempted to use WordPress script in a module: ${ request }`
+			`Attempted to use WordPress script in a module: ${ request }, which is not supported yet.`
 		);
 	}
 }

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -81,7 +81,7 @@ function defaultRequestToExternalModule( request ) {
 	const isWordPressScript = Boolean( defaultRequestToExternal( request ) );
 
 	if ( isWordPressScript ) {
-		return new Error(
+		throw new Error(
 			`Attempted to use WordPress script in a module: ${ request }`
 		);
 	}

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -61,10 +61,11 @@ function defaultRequestToExternal( request ) {
  *
  * Currently only @wordpress/interactivity
  *
+ * Do not use the boolean shorthand here, it's only handled for the `requestToExternalModule` option.
+ *
  * @param {string} request Module request (the module name in `import from`) to be transformed
- * @return {string|boolean|Error|undefined} The resulting external definition.
+ * @return {string|Error|undefined} The resulting external definition.
  *   - Return `undefined` to ignore the request (do not externalize).
- *   - Return `true` to externalize the request with the same Module ID
  *   - Return `string` to map the request to an external.
  *   - Return `Error` to emit an error.
  */

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -72,10 +72,10 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` sh
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`error\` should produce expected output 1`] = `
 "ERROR in ./index.js 5:0-23
-Module not found: Error: Attempted to use WordPress script in a module: jquery
+Module not found: Error: Attempted to use WordPress script in a module: jquery, which is not supported yet.
 
 ERROR in ./index.js 6:23-55
-Module not found: Error: Attempted to use WordPress script in a module: @wordpress/api-fetch
+Module not found: Error: Attempted to use WordPress script in a module: @wordpress/api-fetch, which is not supported yet.
 "
 `;
 

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.mjs' => array('dependencies' => array('@wordpress/blob'), 'version' => 'b2c5cea79a32b3d91bf8', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array('@wordpress/token-list'), 'version' => '5c4197fd48811f25807f', 'type' => 'module'));
+"<?php return array('fileA.mjs' => array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '4ab8cc4b6b7619053443', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array('@wordpress/token-list'), 'version' => '5c4197fd48811f25807f', 'type' => 'module'));
 "
 `;
 
@@ -16,6 +16,11 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` sh
     "externalType": "import",
     "request": "@wordpress/token-list",
     "userRequest": "@wordpress/token-list",
+  },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
   },
 ]
 `;
@@ -65,8 +70,17 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` sh
 ]
 `;
 
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`error\` should produce expected output 1`] = `
+"ERROR in ./index.js 5:0-23
+Module not found: Error: Attempted to use WordPress script in a module: jquery
+
+ERROR in ./index.js 6:23-55
+Module not found: Error: Attempted to use WordPress script in a module: @wordpress/api-fetch
+"
+`;
+
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '2925e30449840a5a80f8', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e325da3aa7dbb0c0c151', 'type' => 'module');
 "
 `;
 
@@ -77,11 +91,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-fil
     "request": "@wordpress/blob",
     "userRequest": "@wordpress/blob",
   },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
 ]
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '26d6da43027f3522b0ca', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '8308f1ac78c21f09c721', 'type' => 'module');
 "
 `;
 
@@ -91,6 +110,11 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffi
     "externalType": "import",
     "request": "@wordpress/blob",
     "userRequest": "@wordpress/blob",
+  },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
   },
 ]
 `;
@@ -130,7 +154,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should pr
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '2925e30449840a5a80f8', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e325da3aa7dbb0c0c151', 'type' => 'module');
 "
 `;
 
@@ -141,11 +165,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-out
     "request": "@wordpress/blob",
     "userRequest": "@wordpress/blob",
   },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
 ]
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '2925e30449840a5a80f8', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e325da3aa7dbb0c0c151', 'type' => 'module');
 "
 `;
 
@@ -156,12 +185,25 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filen
     "request": "@wordpress/blob",
     "userRequest": "@wordpress/blob",
   },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":[],"version":"34504aa793c63cd3d73a","type":"module"}"`;
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"4e62c01516f9dab8041f","type":"module"}"`;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
+]
+`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', '@wordpress/url', 'rxjs', 'rxjs/operators'), 'version' => '259fc706528651fc00c1', 'type' => 'module');
@@ -199,12 +241,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-singl
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => 'a0ec8ef279476bb51e19', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e14dfa7260edaee86a85', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '0bb8a9fae3dcfcc1ac38', 'type' => 'module');
+"<?php return array('dependencies' => array(), 'version' => 'e7402f5608a888d8fd66', 'type' => 'module');
 "
 `;
 
@@ -215,11 +257,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-singl
     "request": "@wordpress/blob",
     "userRequest": "@wordpress/blob",
   },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
 ]
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '38479966fb62d588f05e', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '22d18a3461df47fbaa79', 'type' => 'module');
 "
 `;
 
@@ -230,11 +277,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` sho
     "request": "@wordpress/blob",
     "userRequest": "@wordpress/blob",
   },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
 ]
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '2925e30449840a5a80f8', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e325da3aa7dbb0c0c151', 'type' => 'module');
 "
 `;
 
@@ -245,16 +297,26 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
     "request": "@wordpress/blob",
     "userRequest": "@wordpress/blob",
   },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
 ]
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'type' => 'dynamic')), 'version' => 'f0242eb6da78af6ca4b8', 'type' => 'module');
+"<?php return array('dependencies' => array('lodash', array('id' => '@wordpress/interactivity', 'type' => 'dynamic')), 'version' => 'fcc07ce68574cdc2a6a5', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
 [
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
   {
     "externalType": "module",
     "request": "@wordpress/interactivity",
@@ -264,7 +326,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interacti
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '52c1849898b74d94f025', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'f40de15d66b54da440d2', 'type' => 'module');
 "
 `;
 
@@ -274,6 +336,11 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\`
     "externalType": "import",
     "request": "@wordpress/blob",
     "userRequest": "@wordpress/blob",
+  },
+  {
+    "externalType": "import",
+    "request": "lodash",
+    "userRequest": "lodash",
   },
 ]
 `;
@@ -361,6 +428,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`dynamic-import\` sh
     "userRequest": "@wordpress/blob",
   },
 ]
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`error\` should produce expected output 1`] = `
+"ERROR in main
+Module not found: Error: Ensure error in script build.
+"
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -72,6 +72,16 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 					} )
 				);
 
+				/* eslint-disable jest/no-conditional-expect */
+				if ( configCase.includes( 'error' ) ) {
+					expect( stats.hasErrors() ).toBe( true );
+					expect(
+						stats.toString( { errors: true, all: false } )
+					).toMatchSnapshot();
+					return;
+				}
+				/* eslint-enable jest/no-conditional-expect */
+
 				if ( stats.hasErrors() ) {
 					throw new Error(
 						stats.toString( { errors: true, all: false } )

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
@@ -12,7 +12,9 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( {
 			combineAssets: true,
 			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
+				return (
+					request.startsWith( '@wordpress/' ) || request === 'lodash'
+				);
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/error/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/error/index.js
@@ -1,0 +1,10 @@
+/* eslint-disable eslint-comments/disable-enable-pair */
+/* eslint-disable eslint-comments/no-unlimited-disable */
+/* eslint-disable */
+
+import $ from 'jquery';
+const apiFetch = await import( '@wordpress/api-fetch' );
+
+$( () => {
+	apiFetch( { path: '/' } );
+} );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/error/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/error/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( {
 			// eslint-disable-next-line no-unused-vars
 			requestToExternal( request ) {
-				return new Error( 'Ensure error in script build.' );
+				throw new Error( 'Ensure error in script build.' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/error/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/error/webpack.config.js
@@ -6,11 +6,9 @@ const DependencyExtractionWebpackPlugin = require( '../../..' );
 module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
-			outputFilename: '[name]-foo.asset.php',
-			requestToExternalModule( request ) {
-				return (
-					request.startsWith( '@wordpress/' ) || request === 'lodash'
-				);
+			// eslint-disable-next-line no-unused-vars
+			requestToExternal( request ) {
+				return new Error( 'Ensure error in script build.' );
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
@@ -12,7 +12,9 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
+				return (
+					request.startsWith( '@wordpress/' ) || request === 'lodash'
+				);
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/has-extension-suffix/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/has-extension-suffix/webpack.config.js
@@ -10,7 +10,9 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
+				return (
+					request.startsWith( '@wordpress/' ) || request === 'lodash'
+				);
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/option-function-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/option-function-output-filename/webpack.config.js
@@ -10,7 +10,9 @@ module.exports = {
 				return `chunk--${ chunkData.chunk.name }--[name].asset.php`;
 			},
 			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
+				return (
+					request.startsWith( '@wordpress/' ) || request === 'lodash'
+				);
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/output-format-json/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/output-format-json/webpack.config.js
@@ -5,6 +5,11 @@ const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
 	plugins: [
-		new DependencyExtractionWebpackPlugin( { outputFormat: 'json' } ),
+		new DependencyExtractionWebpackPlugin( {
+			outputFormat: 'json',
+			requestToExternalModule( request ) {
+				return request === 'lodash';
+			},
+		} ),
 	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/runtime-chunk-single/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/runtime-chunk-single/webpack.config.js
@@ -11,7 +11,9 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
+				return (
+					request.startsWith( '@wordpress/' ) || request === 'lodash'
+				);
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/style-imports/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/style-imports/webpack.config.js
@@ -12,7 +12,9 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
+				return (
+					request.startsWith( '@wordpress/' ) || request === 'lodash'
+				);
 			},
 		} ),
 		new MiniCSSExtractPlugin(),

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-interactivity/webpack.config.js
@@ -4,5 +4,11 @@
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
-	plugins: [ new DependencyExtractionWebpackPlugin() ],
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				return request === 'lodash';
+			},
+		} ),
+	],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
+				return (
+					request.startsWith( '@wordpress/' ) || request === 'lodash'
+				);
 			},
 		} ),
 	],

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
 	plugins: [
 		new DependencyExtractionWebpackPlugin( {
 			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
+				return (
+					request.startsWith( '@wordpress/' ) || request === 'lodash'
+				);
 			},
 		} ),
 	],


### PR DESCRIPTION
## What?

Throw errors when using WordPress script dependencies in a module build.

Part of #57492 

### Concerns

I'm requesting review but I have some concerns. This was discussed as part of #57492 and it seems important to address what we expect to be a common error. I do have concerns about this approach.

Scripts are not _currently_ supported, but we hope to support scripts soon. Is this a good solution? Should there be an option? When and how will we remove the error throwing from this plugin?

## Why?

WordPress Script dependencies are not currently available as dependencies of WordPress Modules. Using e.g. `lodash` or `@wordpress/api-fetch` in a module build would result in bundling that dependency. For a package like `lodash` that's undesirable but should work. However, many `@wordpress/*` packages are not intended to be bundle or duplicated and will not work as expected.

It's likely an error to use WordPress Scripts inside modules at this time.

## How?

If the dependency extraction plugin detects a Script dependency inside a Module build, it will throw an error.

## Testing Instructions

This is tested on CI.

You can try linking and using the plugin in a local build. If script dependencies are found it should error and not complete the build:

```
assets by status 6 KiB [cached] 2 assets
Entrypoint main = main.js main.asset.php
runtime modules 2.05 KiB 1 module
./src/index.js 408 bytes [built] [code generated]
external "alternate-module-name" 42 bytes [built] [code generated]
external "@wordpress/interactivity" 42 bytes [built] [code generated]

ERROR in ./src/index.js 1:0-23
Module not found: Error: Attempted to use WordPress script in a module: lodash

ERROR in ./src/index.js 2:0-38
Module not found: Error: Attempted to use WordPress script in a module: @wordpress/api-fetch

webpack 5.89.0 compiled with 2 errors in 39 ms
```
