### PR TITLE
Formatting: add new rounding css number formatting function

### DIFF
--- a/lib/compat/wordpress-6.5/formatting.php
+++ b/lib/compat/wordpress-6.5/formatting.php
@@ -9,9 +9,11 @@
 
 /**
  * Given a numeric value, returns a rounded a valid CSS <number> as a string.
+ * Negative zero values, e.g., `-0.0`, will return "0".
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/number
  * Normalizes LM_NUMERIC locales with non-dot decimal point, e.g., "1,234.56" to "1234.56".
- * Negative zero values, e.g., `-0.0`, will return "0"
+ * The above is relevant to PHP < 8, whose float to string casting is locale-dependent.
+ * See https://php.watch/versions/8.0/float-to-string-locale-independent
  *
  * Usage:
  * Call just before constructing the final output of your CSS rules, and after any number-based calculation.

--- a/lib/compat/wordpress-6.5/formatting.php
+++ b/lib/compat/wordpress-6.5/formatting.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Extensions to the WordPress Formatting API.
+ * src/wp-includes/formatting.php
+ *
+ * @package gutenberg
+ */
+
+
+/**
+ * Given a numeric value, returns a rounded float as a string.
+ * Takes into account active LM_NUMERIC locales with non-dot decimal point (`localeconv()['decimal_point']`);
+ * Negative zero values, e.g., `-0.0`, will return "0"
+ *
+ * @param {int|string|float} $value          A CSS <number> data type.
+ *                                           See https://developer.mozilla.org/en-US/docs/Web/CSS/number
+ * @param  {int}             $decimal_places The number of decimal places to output. `0` === remove all decimals.
+ * @return {string?}         A rounded value with any decimal commas stripped.
+ *
+ */
+function wp_round_css_value( $value, $options ) {
+	if ( is_numeric( $value ) && is_float( floatval( $value ) ) ) {
+		$defaults = array(
+			'decimal_places'   => 3,
+		);
+
+		$options = wp_parse_args( $options, $defaults );
+
+		// Rounding.
+		$value = round( $value, $options['decimal_places'] );
+
+		/*
+		 * Save a negative sign for later.
+		 * When splitting int and float, we want to preserve the negativity of the int
+		 * for values such as `-0.2`. Coercing $value to int will return `0`.
+		 */
+		$negative_sign = $value < 0 ? '-' : '';
+
+		// Get the floating point remainder.
+		$decimal = fmod( $value, 1 );
+
+		// Turn the decimal fragment into a positve integer and remove any trailing zeros.
+		$decimal *= pow( 10, $options['decimal_places'] );
+		$decimal = abs( $decimal );
+		$decimal = rtrim( $decimal, '0' );
+
+		// Now get the whole, positive integer value (the left hand side of the float before the decimal).
+		$whole = (int) abs( $value );
+
+		return $decimal > 0 ? "{$negative_sign}{$whole}.{$decimal}" : "{$negative_sign}{$whole}";
+	}
+
+	return $value;
+}

--- a/lib/compat/wordpress-6.7/formatting.php
+++ b/lib/compat/wordpress-6.7/formatting.php
@@ -6,7 +6,6 @@
  * @package gutenberg
  */
 
-
 /**
  * Given a numeric value, returns a rounded a valid CSS <number> as a string.
  * Negative zero values, e.g., `-0.0`, will return "0".

--- a/lib/load.php
+++ b/lib/load.php
@@ -125,6 +125,7 @@ require __DIR__ . '/compat/wordpress-6.5/compat.php';
 require __DIR__ . '/compat/wordpress-6.5/blocks.php';
 require __DIR__ . '/compat/wordpress-6.5/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.5/kses.php';
+require __DIR__ . '/compat/wordpress-6.5/formatting.php';
 require __DIR__ . '/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php';
 require __DIR__ . '/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api-directives-processor.php';
 require __DIR__ . '/compat/wordpress-6.5/interactivity-api/interactivity-api.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -125,7 +125,6 @@ require __DIR__ . '/compat/wordpress-6.5/compat.php';
 require __DIR__ . '/compat/wordpress-6.5/blocks.php';
 require __DIR__ . '/compat/wordpress-6.5/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.5/kses.php';
-require __DIR__ . '/compat/wordpress-6.5/formatting.php';
 require __DIR__ . '/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php';
 require __DIR__ . '/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api-directives-processor.php';
 require __DIR__ . '/compat/wordpress-6.5/interactivity-api/interactivity-api.php';
@@ -152,6 +151,9 @@ require __DIR__ . '/compat/wordpress-6.6/block-bindings/pattern-overrides.php';
 require __DIR__ . '/compat/wordpress-6.6/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.6/option.php';
 require __DIR__ . '/compat/wordpress-6.6/post.php';
+
+// WordPress 6.7 compat.
+require __DIR__ . '/compat/wordpress-6.7/formatting.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/phpunit/formatting-test.php
+++ b/phpunit/formatting-test.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Test formatting functions.
+ *
+ * @package Gutenberg
+ */
+
+class Gutenberg_Formatting_Test extends WP_UnitTestCase {
+	/**
+	 * Tests CSS number output.
+	 *
+	 * @covers ::gutenberg_round_css_value
+	 *
+	 * @dataProvider data_gutenberg_round_css_value
+	 *
+	 * @param int|string|float $value           A CSS <number> data type.
+	 * @param array            $options         {
+	 *     Optional. An array of options. Default empty array.
+	 * }
+	 * @param string           $expected_output Expected value of style property from gutenberg_apply_typography_support().
+	 */
+	public function test_gutenberg_round_css_value( $value, $options, $expected_output ) {
+		$actual = gutenberg_round_css_value( $value, $options );
+		$this->assertSame( $expected_output, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_gutenberg_round_css_value() {
+		return array(
+			'returns from integer'                       => array(
+				'value'           => 50,
+				'options'         => array(),
+				'expected_output' => '50',
+			),
+			'returns from (str) integer'                 => array(
+				'value'           => '100',
+				'options'         => array(),
+				'expected_output' => '100',
+			),
+			'returns from float'                         => array(
+				'value'           => 1.222,
+				'options'         => array(),
+				'expected_output' => '1.222',
+			),
+			'returns from (str) float'                   => array(
+				'value'           => '1.222',
+				'options'         => array(),
+				'expected_output' => '1.222',
+			),
+			'rounding does not affect integers'          => array(
+				'value'           => 199333,
+				'options'         => array(),
+				'expected_output' => '199333',
+			),
+			'rounds float with default decimal places'   => array(
+				'value'           => 55.87466666,
+				'options'         => array(),
+				'expected_output' => '55.875',
+			),
+			'rounds (str) float with default decimal places' => array(
+				'value'           => '55.87466666',
+				'options'         => array(),
+				'expected_output' => '55.875',
+			),
+			'returns from exponent'                      => array(
+				'value'           => 10e3,
+				'options'         => array(),
+				'expected_output' => '10000',
+			),
+			'returns from float with no leading 0'       => array(
+				'value'           => .9,
+				'options'         => array(),
+				'expected_output' => '0.9',
+			),
+			'returns from (str) float with no leading 0' => array(
+				'value'           => '.9',
+				'options'         => array(),
+				'expected_output' => '0.9',
+			),
+			'returns negative int'                       => array(
+				'value'           => '-234',
+				'options'         => array(),
+				'expected_output' => '-234',
+			),
+			'returns negative float'                     => array(
+				'value'           => -1100.87688,
+				'options'         => array(),
+				'expected_output' => '-1100.877',
+			),
+			'returns from negative exponent'             => array(
+				'value'           => -3.4e-2,
+				'options'         => array(),
+				'expected_output' => '-0.034',
+			),
+			'returns from negative float < 0'            => array(
+				'value'           => -0.5,
+				'options'         => array(),
+				'expected_output' => '-0.5',
+			),
+			'returns zero from 0.0'                      => array(
+				'value'           => 0.0,
+				'options'         => array(),
+				'expected_output' => '0',
+			),
+			'returns zero from +0.0'                     => array(
+				'value'           => +0.0,
+				'options'         => array(),
+				'expected_output' => '0',
+			),
+			'returns zero from -0.0'                     => array(
+				'value'           => -0.0,
+				'options'         => array(),
+				'expected_output' => '0',
+			),
+			'returns with resolved negative/positive signs' => array(
+				'value'           => +-12.2,
+				'options'         => array(),
+				'expected_output' => '-12.2',
+			),
+			'ignores (str) negative/positive signs'      => array(
+				'value'           => '+-12.2',
+				'options'         => array(),
+				'expected_output' => '+-12.2',
+			),
+			'ignores values with invalid, localized large numbers' => array(
+				'value'           => '1.222,22',
+				'options'         => array(),
+				'expected_output' => '1.222,22',
+			),
+			'ignores non-numeric array'                  => array(
+				'value'           => array(),
+				'options'         => array(),
+				'expected_output' => array(),
+			),
+			'ignores non-numeric null'                   => array(
+				'value'           => null,
+				'options'         => array(),
+				'expected_output' => null,
+			),
+			'ignores values invalid, localized floats'   => array(
+				'value'           => '1,99999999',
+				'options'         => array(),
+				'expected_output' => '1,99999999',
+			),
+			'ignores values with a-z characters'         => array(
+				'value'           => 'abc',
+				'options'         => array(),
+				'expected_output' => 'abc',
+			),
+			'ignores CSS values + units'                 => array(
+				'value'           => '20.9999999vh',
+				'options'         => array(),
+				'expected_output' => '20.9999999vh',
+			),
+			'ignores double dot decimals'                => array(
+				'value'           => '12.1.1',
+				'options'         => array(),
+				'expected_output' => '12.1.1',
+			),
+			'ignores shorthand CSS values'               => array(
+				'value'           => '12px 24px 12px 12px',
+				'options'         => array(),
+				'expected_output' => '12px 24px 12px 12px',
+			),
+			'ignores clamp CSS formula'                  => array(
+				'value'           => 'clamp(15px, 0.9375rem + ((1vw - 7.68px) * 5.409), 60px)',
+				'options'         => array(),
+				'expected_output' => 'clamp(15px, 0.9375rem + ((1vw - 7.68px) * 5.409), 60px)',
+			),
+			'rounds correctly with 0 decimals'           => array(
+				'value'           => 100.123456,
+				'options'         => array(
+					'decimal_places' => 0,
+				),
+				'expected_output' => '100',
+			),
+			'rounds correctly with custom decimals'      => array(
+				'value'           => 100.987654345,
+				'options'         => array(
+					'decimal_places' => 7,
+				),
+				'expected_output' => '100.9876543',
+			),
+			'rounds negative floats correctly with custom decimals' => array(
+				'value'           => -555.5555555555555555,
+				'options'         => array(
+					'decimal_places' => 9,
+				),
+				'expected_output' => '-555.555555556',
+			),
+		);
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Partly resolves https://github.com/WordPress/gutenberg/issues/57607

If this PR is merged, it can be used in a refactor of:

- https://github.com/WordPress/gutenberg/pull/57634 

This time, create a function that can be used to create rounded CSS number strings from anywhere!.

It also outputs valid CSS values where locales use commas as decimal separators.

## Why?
In PHP version < 8, PHP uses the current locale for float to string conversions.

That means `1.333 + "px"`, for example, will be converted to `1,333px` for some locales, e.g., `pl_PL`, `fr_FR` etc

PHP 8 does not do this.

See: https://php.watch/versions/8.0/float-to-string-locale-independent

This is so we can output valid CSS values where locales use commas as decimal separators.


## Questions

Is there enough test coverage? Do the PHP comments make sense? Can the function be improved give its stated purpose?

## Testing Instructions

### Unit

`npm run test:unit:php:base -- --filter Gutenberg_Formatting_Test`


### Manual

To test manually, we need to set up a server with < PHP 8 and also with a non-en LC_NUMERIC locale.

See the below diff on the changes to wp-env/docker and also setting the local via `setlocale`.

Finally, use the new function `gutenberg_round_css_value` when outputting fluid font sizes.

<details>

<summary>Example test environment</summary>

```diff
diff --git a/.wp-env.json b/.wp-env.json
index 05ea05b280..dc209b8df0 100644
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,6 +2,7 @@
 	"$schema": "./schemas/json/wp-env.json",
 	"core": "WordPress/WordPress",
 	"plugins": [ "." ],
+	"phpVersion": "7.4",
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {
diff --git a/lib/block-supports/typography.php b/lib/block-supports/typography.php
index fa2a7b81e9..296cc07d21 100644
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -340,7 +340,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 	}
 
 	return array(
-		'value' => round( $value, 3 ),
+		'value' => gutenberg_round_css_value( $value, 3 ),
 		'unit'  => $unit,
 	);
 }
@@ -428,9 +428,9 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 	 * Build CSS rule.
 	 * Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
 	 */
-	$view_port_width_offset = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
+	$view_port_width_offset = gutenberg_round_css_value( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
 	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $linear_factor_denominator ) );
-	$linear_factor_scaled   = round( $linear_factor * $scale_factor, 3 );
+	$linear_factor_scaled   = gutenberg_round_css_value( $linear_factor * $scale_factor, 3 );
 	$linear_factor_scaled   = empty( $linear_factor_scaled ) ? 1 : $linear_factor_scaled;
 	$fluid_target_font_size = implode( '', $minimum_font_size_rem ) . " + ((1vw - $view_port_width_offset) * $linear_factor_scaled)";
 
diff --git a/lib/compat/wordpress-6.7/formatting.php b/lib/compat/wordpress-6.7/formatting.php
index 4ef4bdd44d..ced5c00be0 100644
--- a/lib/compat/wordpress-6.7/formatting.php
+++ b/lib/compat/wordpress-6.7/formatting.php
@@ -5,6 +5,7 @@
  *
  * @package gutenberg
  */
+setlocale( LC_ALL, 'de_DE.UTF-8' );
 
 /**
  * Given a numeric value, returns a rounded a valid CSS <number> as a string.
diff --git a/packages/env/lib/init-config.js b/packages/env/lib/init-config.js
index 318bcae151..a78fa7f30d 100644
--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -207,6 +207,16 @@ RUN apt-get -qy install git
 # Set up sudo so they can have root access.
 RUN apt-get -qy install sudo
 RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers`;
+			const locale = 'de_DE.UTF-8';
+			dockerFileContent += `
+# Install locales
+RUN apt-get update && apt-get install -y locales locales-all
+RUN locale-gen ${ locale }
+ENV LANG ${ locale }
+ENV LANGUAGE ${ locale }
+ENV LC_ALL ${ locale }
+RUN update-locale LANG=${ locale }
+`;
 			break;
 		}
 		case 'cli': {


```

</details>


I'm using TT4 to test. Once you apply the changes in the example diff,  run the following commands:

```bash
npm run wp-env destroy
# Hit `y` to destroy your local docker containers
npm run wp-env start 
```

With the environment set up, the fluid font sizes should contain expected decimal values:


```css
    --wp--preset--font-size--large: clamp(1.39rem, 1.39rem + ((1vw - 0.2rem) * 0.767), 1.85rem);
    --wp--preset--font-size--x-large: clamp(1.85rem, 1.85rem + ((1vw - 0.2rem) * 1.083), 2.5rem);
    --wp--preset--font-size--xx-large: clamp(2.5rem, 2.5rem + ((1vw - 0.2rem) * 1.283), 3.27rem);
```

#### Before

```css
    --wp--preset--font-size--large: clamp(1.39rem, 1,39rem + ((1vw - 0,2rem) * 0, 767), 1.85rem);
    --wp--preset--font-size--x-large: clamp(1.85rem, 1,85rem + ((1vw - 0,2rem) * 1, 083), 2.5rem);
    --wp--preset--font-size--xx-large: clamp(2.5rem, 2,5rem + ((1vw - 0,2rem) * 1, 283), 3.27rem);
```


