### PR TITLE
Data views table layout: Update cell vertical alignment

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -168,7 +168,16 @@
 			padding-left: $grid-unit-05;
 		}
 	}
-
+	tbody {
+		td {
+			vertical-align: top;
+		}
+		.dataviews-view-table__cell-content-wrapper {
+			min-height: $grid-unit-40;
+			display: flex;
+			align-items: center;
+		}
+	}
 	.dataviews-view-table-header-button {
 		padding: $grid-unit-05 $grid-unit-10;
 		font-size: 11px;

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -536,17 +536,21 @@ function ViewTable( {
 											minWidth: 20,
 										} }
 									>
-										<SingleSelectionCheckbox
-											id={ getItemId( item ) || index }
-											item={ item }
-											selection={ selection }
-											onSelectionChange={
-												onSelectionChange
-											}
-											getItemId={ getItemId }
-											data={ data }
-											primaryField={ primaryField }
-										/>
+										<span className="dataviews-view-table__cell-content-wrapper">
+											<SingleSelectionCheckbox
+												id={
+													getItemId( item ) || index
+												}
+												item={ item }
+												selection={ selection }
+												onSelectionChange={
+													onSelectionChange
+												}
+												getItemId={ getItemId }
+												data={ data }
+												primaryField={ primaryField }
+											/>
+										</span>
 									</td>
 								) }
 								{ visibleFields.map( ( field ) => (
@@ -560,9 +564,11 @@ function ViewTable( {
 												field.maxWidth || undefined,
 										} }
 									>
-										{ field.render( {
-											item,
-										} ) }
+										<span className="dataviews-view-table__cell-content-wrapper">
+											{ field.render( {
+												item,
+											} ) }
+										</span>
 									</td>
 								) ) }
 								{ !! actions?.length && (


### PR DESCRIPTION
## What?
Align contents of table cells `top` rather than `middle`.

## Why?
Top alignment works better when there are cells that grow in height, e.g. the "Description" field in the templates table.

## How?
1. Apply `vertical-align: top` to `.dataviews-view-table tbody td`.
2. Wrap cell content in a span with a `min-height` equal to the tallest element in each row (action buttons). This enables pseuso-middle-alignment when there are no cells that grow in height. 

## Testing Instructions
1. Enable the 'new admin views' experiment.
2. Browse the templates table and toggle the 'description' field.
3. Ensure the alignment is correct.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
| <img width="1306" alt="Screenshot 2024-01-12 at 13 23 32" src="https://github.com/WordPress/gutenberg/assets/846565/3bf5e175-f6ce-446b-80fc-facbd645b8bd"> |  <img width="1306" alt="Screenshot 2024-01-12 at 13 22 16" src="https://github.com/WordPress/gutenberg/assets/846565/4f310118-7fcd-4501-934f-19f9ae76dae6"> |

Note that the first 5 rows have the same appearance before and after, but in the rows with long descriptions cell contents are aligned with one another at the top of the row.
