### PR TITLE
Interactivity API: add `wp-run` directive and `useInit` & `useWatch` hooks

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test/directive-run",
+	"title": "E2E Interactivity tests - directive run",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScript": "directive-run-view",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/render.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * HTML for testing the directive `data-wp-run`.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+
+gutenberg_enqueue_module( 'directive-run-view' );
+?>
+
+<div
+	data-wp-interactive='{ "namespace": "directive-run" }'
+	data-wp-navigation-id='test-directive-run'
+>
+	<div data-testid="hydrated" data-wp-text="state.isHydrated"></div>
+	<div data-testid="mounted" data-wp-text="state.isMounted"></div>
+	<div data-testid="renderCount" data-wp-text="state.renderCount"></div>
+	<div data-testid="navigated">no</div>
+
+	<div
+		data-wp-run--hydrated="callbacks.updateIsHydrated"
+		data-wp-run--renderCount="callbacks.updateRenderCount"
+		data-wp-text="state.clickCount"
+	></div>
+
+	<div data-wp-show-mock="state.isOpen">
+		<div
+			data-wp-run="callbacks.updateIsMounted"
+			data-wp-run--hooks="callbacks.runHooks"
+		></div>
+	</div>
+
+	<button data-testid="toggle" data-wp-on--click="actions.toggle">
+		Toggle
+	</button>
+
+	<button data-testid="increment" data-wp-on--click="actions.increment">
+		Increment
+	</button>
+
+	<button data-testid="navigate" data-wp-on--click="actions.navigate">
+		Navigate
+	</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/render.php
@@ -22,14 +22,9 @@ gutenberg_enqueue_module( 'directive-run-view' );
 		data-wp-run--renderCount="callbacks.updateRenderCount"
 		data-wp-text="state.clickCount"
 	></div>
+</div>
 
-	<div data-wp-show-mock="state.isOpen">
-		<div
-			data-wp-run="callbacks.updateIsMounted"
-			data-wp-run--hooks="callbacks.runHooks"
-		></div>
-	</div>
-
+<div data-wp-interactive='{ "namespace": "directive-run" }' >
 	<button data-testid="toggle" data-wp-on--click="actions.toggle">
 		Toggle
 	</button>
@@ -41,4 +36,19 @@ gutenberg_enqueue_module( 'directive-run-view' );
 	<button data-testid="navigate" data-wp-on--click="actions.navigate">
 		Navigate
 	</button>
+
+	<!-- Hook execution results are stored in this element as attributes. -->
+	<div
+		data-testid="wp-run hooks results"
+		data-wp-show-children="state.isOpen"
+		data-init=""
+		data-watch=""
+	>
+		<div
+			data-wp-run--mounted="callbacks.updateIsMounted"
+			data-wp-run--hooks="runs.useHooks"
+		>
+			Element with wp-run using hooks
+		</div>
+	</div>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/render.php
@@ -46,7 +46,7 @@ gutenberg_enqueue_module( 'directive-run-view' );
 	>
 		<div
 			data-wp-run--mounted="callbacks.updateIsMounted"
-			data-wp-run--hooks="runs.useHooks"
+			data-wp-run--hooks="callbacks.useHooks"
 		>
 			Element with wp-run using hooks
 		</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.js
@@ -75,8 +75,6 @@ const { state } = store( 'directive-run', {
 		updateRenderCount() {
 			setTimeout( () => ( state.renderCount = state.renderCount + 1 ) );
 		},
-	},
-	runs: {
 		useHooks() {
 			// Runs only on first render.
 			useInit( () => {

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/view.js
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	store,
+	directive,
+	navigate
+} from '@wordpress/interactivity';
+
+// Fake `data-wp-show-mock` directive to test when things are removed from the
+// DOM.  Replace with `data-wp-show` when it's ready.
+directive(
+	'show-mock',
+	( { directives: { 'show-mock': showMock }, element, evaluate } ) => {
+		const entry = showMock.find( ( { suffix } ) => suffix === 'default' );
+		if ( ! evaluate( entry ) ) return null;
+		return element;
+	}
+);
+
+const html = `
+<div
+	data-wp-interactive='{ "namespace": "directive-run" }'
+	data-wp-navigation-id='test-directive-run'
+>
+	<div data-testid="hydrated" data-wp-text="state.isHydrated"></div>
+	<div data-testid="mounted" data-wp-text="state.isMounted"></div>
+	<div data-testid="renderCount" data-wp-text="state.renderCount"></div>
+	<div data-testid="navigated">yes</div>
+
+	<div
+		data-wp-run--hydrated="callbacks.updateIsHydrated"
+		data-wp-run--renderCount="callbacks.updateRenderCount"
+		data-wp-text="state.clickCount"
+	></div>
+</div>
+`;
+
+const { state } = store( 'directive-run', {
+	state: {
+		isOpen: false,
+		isHydrated: 'no',
+		isMounted: 'no',
+		renderCount: 0,
+		clickCount: 0
+	},
+	actions: {
+		toggle() {
+			state.isOpen = ! state.isOpen;
+		},
+		increment() {
+			state.clickCount = state.clickCount + 1;
+		},
+		navigate() {
+			navigate( window.location, {
+				force: true,
+				html,
+			} );
+		},
+	},
+	callbacks: {
+		updateIsHydrated() {
+			setTimeout( () => ( state.isHydrated = 'yes' ) );
+		},
+		updateIsMounted() {
+			setTimeout( () => ( state.isMounted = 'yes' ) );
+		},
+		updateRenderCount() {
+			setTimeout( () => ( state.renderCount = state.renderCount + 1 ) );
+		}
+	},
+} );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add the `data-wp-run` directive along with the `useInit` and `useWatch` hooks. ([57805](https://github.com/WordPress/gutenberg/pull/57805))
+
 ### Bug Fix
 
 -   Fix namespaces when there are nested interactive regions. ([#57029](https://github.com/WordPress/gutenberg/pull/57029))

--- a/packages/interactivity/docs/2-api-reference.md
+++ b/packages/interactivity/docs/2-api-reference.md
@@ -22,6 +22,7 @@ DOM elements are connected to data stored in the state and context through direc
     - [`wp-on`](#wp-on) ![](https://img.shields.io/badge/EVENT_HANDLERS-afd2e3.svg)
     - [`wp-watch`](#wp-watch) ![](https://img.shields.io/badge/SIDE_EFFECTS-afd2e3.svg)
     - [`wp-init`](#wp-init) ![](https://img.shields.io/badge/SIDE_EFFECTS-afd2e3.svg)
+    - [`wp-run`](#wp-run) ![](https://img.shields.io/badge/SIDE_EFFECTS-afd2e3.svg)
     - [`wp-key`](#wp-key) ![](https://img.shields.io/badge/TEMPLATING-afd2e3.svg)
   - [Values of directives are references to store properties](#values-of-directives-are-references-to-store-properties)
 - [The store](#the-store)
@@ -470,6 +471,57 @@ store( "myPlugin", {
 <br/>
 
 The `wp-init` can return a function. If it does, the returned function will run when the element is removed from the DOM.
+
+#### `wp-run` 
+
+It runs the passed callback **during node's render execution**.
+
+You can attach several `wp-run` to the same DOM element by using the syntax `data-wp-run--[unique-id]`. _The unique id doesn't need to be unique globally, it just needs to be different than the other unique ids of the `wp-run` directives of that DOM element._
+
+_Example of `data-wp-run` directive_ 
+
+```html
+<div data-wp-run="callbacks.logCounter">
+  <p>Hi!</>
+</div>
+```
+
+_Example of several `wp-run` directives on the same DOM element_
+
+```html
+<div 
+  data-wp-run--log="callbacks.logCounter" 
+  data-wp-run--custom="callbacks.customHooks"
+>
+  <p>Hi!</>
+</div>
+```
+
+<details>
+  <summary><em>See store used with the directive above</em></summary>
+
+```js
+store( "myPlugin", {
+  callbacks: {
+    logCounter: () => {
+      useInit(() => console.log( `Init at ` + new Date() ))
+      useWatch(() => {
+        const { counter } = getContext(); 
+        console.log("Counter is " + counter + " at " + new Date() );
+      })
+    },
+    customHooks: () => {
+      // You can call your own hooks here.
+      useCustomHook( /* ... */ );
+    }
+  },
+} );
+```
+
+</details>
+<br/>
+
+The `wp-run` directive executes its callback while the node is rendered. That means you can use and compose hooks inside the passed callback and create your own logic, providing more flexibility than previous directives.
 
 #### `wp-key` 
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -14,7 +14,7 @@ import { deepSignal, peek } from 'deepsignal';
  * Internal dependencies
  */
 import { createPortal } from './portals';
-import { useSignalEffect } from './utils';
+import { useWatch, useInit } from './utils';
 import { directive } from './hooks';
 import { SlotProvider, Slot, Fill } from './slots';
 import { navigate } from './router';
@@ -75,14 +75,14 @@ export default () => {
 	// data-wp-watch--[name]
 	directive( 'watch', ( { directives: { watch }, evaluate } ) => {
 		watch.forEach( ( entry ) => {
-			useSignalEffect( () => evaluate( entry ) );
+			useWatch( () => evaluate( entry ) );
 		} );
 	} );
 
 	// data-wp-init--[name]
 	directive( 'init', ( { directives: { init }, evaluate } ) => {
 		init.forEach( ( entry ) => {
-			useEffect( () => evaluate( entry ), [] );
+			useInit( () => evaluate( entry ) );
 		} );
 	} );
 
@@ -118,7 +118,7 @@ export default () => {
 							? `${ currentClass } ${ name }`
 							: name;
 
-					useEffect( () => {
+					useInit( () => {
 						// This seems necessary because Preact doesn't change the class
 						// names on the hydration, so we have to do it manually. It doesn't
 						// need deps because it only needs to do it the first time.
@@ -127,7 +127,7 @@ export default () => {
 						} else {
 							element.ref.current.classList.add( name );
 						}
-					}, [] );
+					} );
 				} );
 		}
 	);
@@ -182,7 +182,7 @@ export default () => {
 				if ( ! result ) delete element.props.style[ key ];
 				else element.props.style[ key ] = result;
 
-				useEffect( () => {
+				useInit( () => {
 					// This seems necessary because Preact doesn't change the styles on
 					// the hydration, so we have to do it manually. It doesn't need deps
 					// because it only needs to do it the first time.
@@ -191,7 +191,7 @@ export default () => {
 					} else {
 						element.ref.current.style[ key ] = result;
 					}
-				}, [] );
+				} );
 			} );
 	} );
 
@@ -217,7 +217,7 @@ export default () => {
 				// This seems necessary because Preact doesn't change the attributes
 				// on the hydration, so we have to do it manually. It doesn't need
 				// deps because it only needs to do it the first time.
-				useEffect( () => {
+				useInit( () => {
 					const el = element.ref.current;
 
 					// We set the value directly to the corresponding
@@ -260,7 +260,7 @@ export default () => {
 					} else {
 						el.removeAttribute( attribute );
 					}
-				}, [] );
+				} );
 			}
 		);
 	} );

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -390,4 +390,9 @@ export default () => {
 		),
 		{ priority: 4 }
 	);
+
+	// data-wp-run
+	directive( 'run', ( { directives: { run }, evaluate } ) => {
+		run.forEach( ( entry ) => evaluate( entry ) );
+	} );
 };

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -7,9 +7,17 @@ import { init } from './router';
 export { store } from './store';
 export { directive, getContext, getElement } from './hooks';
 export { navigate, prefetch } from './router';
-export { useWatch, useInit } from './utils';
+export {
+	useWatch,
+	useInit,
+	useEffect,
+	useLayoutEffect,
+	useCallback,
+	useMemo,
+} from './utils';
+
 export { h as createElement, cloneElement } from 'preact';
-export { useEffect, useLayoutEffect, useContext, useMemo } from 'preact/hooks';
+export { useContext } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';
 
 document.addEventListener( 'DOMContentLoaded', async () => {

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -17,7 +17,7 @@ export {
 } from './utils';
 
 export { h as createElement, cloneElement } from 'preact';
-export { useContext } from 'preact/hooks';
+export { useContext, useState, useRef } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';
 
 document.addEventListener( 'DOMContentLoaded', async () => {

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -9,7 +9,7 @@ export { directive, getContext, getElement } from './hooks';
 export { navigate, prefetch } from './router';
 export { useWatch, useInit } from './utils';
 export { h as createElement } from 'preact';
-export { useEffect, useContext, useMemo } from 'preact/hooks';
+export { useEffect, useLayoutEffect, useContext, useMemo } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';
 
 document.addEventListener( 'DOMContentLoaded', async () => {

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -7,6 +7,7 @@ import { init } from './router';
 export { store } from './store';
 export { directive, getContext, getElement } from './hooks';
 export { navigate, prefetch } from './router';
+export { useWatch, useInit } from './utils';
 export { h as createElement } from 'preact';
 export { useEffect, useContext, useMemo } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -8,7 +8,7 @@ export { store } from './store';
 export { directive, getContext, getElement } from './hooks';
 export { navigate, prefetch } from './router';
 export { useWatch, useInit } from './utils';
-export { h as createElement } from 'preact';
+export { h as createElement, cloneElement } from 'preact';
 export { useEffect, useLayoutEffect, useContext, useMemo } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';
 

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -37,7 +37,7 @@ function createFlusher( compute, notify ) {
 // Version of `useSignalEffect` with a `useEffect`-like execution. This hook
 // implementation comes from this PR, but we added short-cirtuiting to avoid
 // infinite loops: https://github.com/preactjs/signals/pull/290
-export function useSignalEffect( callback ) {
+export function useWatch( callback ) {
 	useEffect( () => {
 		let eff = null;
 		let isExecuting = false;
@@ -51,6 +51,11 @@ export function useSignalEffect( callback ) {
 		eff = createFlusher( callback, notify );
 		return eff.dispose;
 	}, [] );
+}
+
+// TODO: document this.
+export function useInit( callback ) {
+	useEffect( callback, [] );
 }
 
 // For wrapperless hydration.

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -70,9 +70,11 @@ const withScope = ( func ) => {
 	const scope = getScope();
 	return ( ...args ) => {
 		setScope( scope );
-		const output = func( ...args );
-		resetScope();
-		return output;
+		try {
+			return func( ...args );
+		} finally {
+			resetScope();
+		}
 	};
 };
 

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { useEffect } from 'preact/hooks';
+import {
+	useMemo as _useMemo,
+	useCallback as _useCallback,
+	useEffect as _useEffect,
+	useLayoutEffect as _useLayoutEffect,
+} from 'preact/hooks';
 import { effect } from '@preact/signals';
 
 /**
@@ -43,7 +48,7 @@ function createFlusher( compute, notify ) {
 // implementation comes from this PR, but we added short-cirtuiting to avoid
 // infinite loops: https://github.com/preactjs/signals/pull/290
 export function useSignalEffect( callback ) {
-	useEffect( () => {
+	_useEffect( () => {
 		let eff = null;
 		let isExecuting = false;
 		const notify = async () => {
@@ -102,7 +107,75 @@ export function useWatch( callback ) {
  * @param {Function} callback The hook callback.
  */
 export function useInit( callback ) {
-	useEffect( withScope( callback ), [] );
+	_useEffect( withScope( callback ), [] );
+}
+
+/**
+ * Accepts a function that contains imperative, possibly effectful code. The
+ * effects run after browser paint, without blocking it.
+ *
+ * This hook is equivalent to Preact's `useEffect` and makes the element's scope
+ * available so functions like `getElement()` and `getContext()` can be used
+ * inside the passed callback.
+ *
+ * @param {Function} callback Imperative function that can return a cleanup
+ *                            function.
+ * @param {any[]}    inputs   If present, effect will only activate if the
+ *                            values in the list change (using `===`).
+ */
+export function useEffect( callback, inputs ) {
+	_useEffect( withScope( callback ), inputs );
+}
+
+/**
+ * Accepts a function that contains imperative, possibly effectful code. Use
+ * this to read layout from the DOM and synchronously re-render.
+ *
+ * This hook is equivalent to Preact's `useLayoutEffect` and makes the element's
+ * scope available so functions like `getElement()` and `getContext()` can be
+ * used inside the passed callback.
+ *
+ * @param {Function} callback Imperative function that can return a cleanup
+ *                            function.
+ * @param {any[]}    inputs   If present, effect will only activate if the
+ *                            values in the list change (using `===`).
+ */
+export function useLayoutEffect( callback, inputs ) {
+	_useLayoutEffect( withScope( callback ), inputs );
+}
+
+/**
+ * Returns a memoized version of the callback that only changes if one of the
+ * inputs has changed (using `===`).
+ *
+ * This hook is equivalent to Preact's `useCallback` and makes the element's
+ * scope available so functions like `getElement()` and `getContext()` can be
+ * used inside the passed callback.
+ *
+ * @param {Function} callback Imperative function that can return a cleanup
+ *                            function.
+ * @param {any[]}    inputs   If present, effect will only activate if the
+ *                            values in the list change (using `===`).
+ */
+export function useCallback( callback, inputs ) {
+	_useCallback( withScope( callback ), inputs );
+}
+
+/**
+ * Pass a factory function and an array of inputs. `useMemo` will only recompute
+ * the memoized value when one of the inputs has changed.
+ *
+ * This hook is equivalent to Preact's `useMemo` and makes the element's scope
+ * available so functions like `getElement()` and `getContext()` can be used
+ * inside the passed factory function.
+ *
+ * @param {Function} factory Imperative function that can return a cleanup
+ *                           function.
+ * @param {any[]}    inputs  If present, effect will only activate if the
+ *                           values in the list change (using `===`).
+ */
+export function useMemo( factory, inputs ) {
+	_useMemo( withScope( factory ), inputs );
 }
 
 // For wrapperless hydration.

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -59,9 +59,9 @@ export function useSignalEffect( callback ) {
 }
 
 /**
- * Return the passed function wrapped with the current scope so it is accessible
- * whenever the function runs. This is primarily to make the scope accessible in
- * hook callbacks.
+ * Returns the passed function wrapped with the current scope so it is
+ * accessible whenever the function runs. This is primarily to make the scope
+ * available inside hook callbacks.
  *
  * @param {Function} func The passed function.
  * @return {Function} The wrapped function.
@@ -76,12 +76,29 @@ const withScope = ( func ) => {
 	};
 };
 
-// TODO: document this.
+/**
+ * Accepts a function that contains imperative code which runs whenever any of
+ * the accessed _reactive_ properties (e.g., values from the global state or the
+ * context) is modified.
+ *
+ * This hook makes the element's scope available so functions like
+ * `getElement()` and `getContext()` can be used inside the passed callback.
+ *
+ * @param {Function} callback The hook callback.
+ */
 export function useWatch( callback ) {
 	useSignalEffect( withScope( callback ) );
 }
 
-// TODO: document this.
+/**
+ * Accepts a function that contains imperative code which runs only after the
+ * element's first render, mainly useful for intialization logic.
+ *
+ * This hook makes the element's scope available so functions like
+ * `getElement()` and `getContext()` can be used inside the passed callback.
+ *
+ * @param {Function} callback The hook callback.
+ */
 export function useInit( callback ) {
 	useEffect( withScope( callback ), [] );
 }

--- a/test/e2e/specs/interactivity/directive-run.spec.ts
+++ b/test/e2e/specs/interactivity/directive-run.spec.ts
@@ -42,4 +42,20 @@ test.describe( 'data-wp-run', () => {
 		await expect( page.getByTestId( 'navigated' ) ).toHaveText( 'yes' );
 		await expect( page.getByTestId( 'renderCount' ) ).toHaveText( '4' );
 	} );
+
+	test( 'should allow executing hooks', async ( { page } ) => {
+		await page.getByTestId( 'toggle' ).click();
+		const results = page.getByTestId( 'wp-run hooks results' );
+		await expect( results ).toHaveAttribute( 'data-init', 'initialized' );
+
+		await expect( results ).toHaveAttribute( 'data-watch', '0' );
+		await page.getByTestId( 'increment' ).click();
+		await expect( results ).toHaveAttribute( 'data-watch', '1' );
+		await page.getByTestId( 'increment' ).click();
+		await expect( results ).toHaveAttribute( 'data-watch', '2' );
+
+		await page.getByTestId( 'toggle' ).click();
+		await expect( results ).toHaveAttribute( 'data-init', 'cleaned up' );
+		await expect( results ).toHaveAttribute( 'data-watch', 'cleaned up' );
+	} );
 } );

--- a/test/e2e/specs/interactivity/directive-run.spec.ts
+++ b/test/e2e/specs/interactivity/directive-run.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'data-wp-run', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/directive-run' );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/directive-run' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'should execute each element render', async ( { page } ) => {
+		await expect( page.getByTestId( 'hydrated' ) ).toHaveText( 'yes' );
+		await expect( page.getByTestId( 'renderCount' ) ).toHaveText( '1' );
+		await page.getByTestId( 'increment' ).click();
+		await expect( page.getByTestId( 'renderCount' ) ).toHaveText( '2' );
+		await page.getByTestId( 'increment' ).click();
+		await expect( page.getByTestId( 'renderCount' ) ).toHaveText( '3' );
+	} );
+
+	test( 'should execute when an element is mounted', async ( { page } ) => {
+		await expect( page.getByTestId( 'mounted' ) ).toHaveText( 'no' );
+		await page.getByTestId( 'toggle' ).click();
+		await expect( page.getByTestId( 'mounted' ) ).toHaveText( 'yes' );
+	} );
+
+	test( 'should work with client-side navigation', async ( { page } ) => {
+		await page.getByTestId( 'increment' ).click();
+		await page.getByTestId( 'increment' ).click();
+		await expect( page.getByTestId( 'navigated' ) ).toHaveText( 'no' );
+		await expect( page.getByTestId( 'renderCount' ) ).toHaveText( '3' );
+		await page.getByTestId( 'navigate' ).click();
+		await expect( page.getByTestId( 'navigated' ) ).toHaveText( 'yes' );
+		await expect( page.getByTestId( 'renderCount' ) ).toHaveText( '4' );
+	} );
+} );


### PR DESCRIPTION
Tracking issue: https://github.com/WordPress/gutenberg/issues/56803
Related discussion: https://github.com/WordPress/gutenberg/discussions/51863

Implements the `data-wp-run` directive to allow developers to define their custom logic to execute while rendering an element with directives. That logic can also include any hook to be executed.

Along with `data-wp-run`, the `useInit` and `useWatch` hooks are implemented.

## Why?

These features are required for the future public version of the Interactivity API. See the [tracking issue](https://github.com/WordPress/gutenberg/issues/56803) for details.

## How?

The `data-wp-run` directive was pretty straightforward to implement: it simply evaluates the passed callback.

Regarding the `useInit` and `useWatch`, I had to create a utility function to properly handle the element scope to make it available inside the callback logic.