### PR TITLE
Bring back the chevron

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -119,9 +119,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 							className={ classnames(
 								'selected-block-tools-wrapper',
 								{
-									'is-collapsed':
-										isEditingTemplate &&
-										isBlockToolsCollapsed,
+									'is-collapsed': isBlockToolsCollapsed,
 								}
 							) }
 						>
@@ -131,7 +129,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 							ref={ blockToolbarRef }
 							name="block-toolbar"
 						/>
-						{ isEditingTemplate && hasBlockSelection && (
+						{ hasBlockSelection && (
 							<Button
 								className="edit-post-header__block-tools-toggle"
 								icon={ isBlockToolsCollapsed ? next : previous }


### PR DESCRIPTION
This PR adds back the collapse chevron in the editor header as requested by @jasmussen [here](https://github.com/WordPress/gutenberg/issues/55025#issuecomment-1884355446) and [here](https://github.com/WordPress/gutenberg/pull/56335#discussion_r1433754297).

The purpose of this small update is to have a unified experience between post and site editing experiences.