### PR TITLE
Editor styles: cache transform

### DIFF
--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -5,6 +5,52 @@ import postcss, { CssSyntaxError } from 'postcss';
 import wrap from 'postcss-prefixwrap';
 import rebaseUrl from 'postcss-urlrebase';
 
+const transformStylesCache = new WeakMap();
+
+function transformStyle(
+	{ css, ignoredSelectors = [], baseURL },
+	wrapperSelector = ''
+) {
+	// When there is no wrapper selector or base URL, there is no need
+	// to transform the CSS. This is most cases because in the default
+	// iframed editor, no wrapping is needed, and not many styles
+	// provide a base URL.
+	if ( ! wrapperSelector && ! baseURL ) {
+		return css;
+	}
+
+	try {
+		return postcss(
+			[
+				wrapperSelector &&
+					wrap( wrapperSelector, {
+						ignoredSelectors: [
+							...ignoredSelectors,
+							wrapperSelector,
+						],
+					} ),
+				baseURL && rebaseUrl( { rootUrl: baseURL } ),
+			].filter( Boolean )
+		).process( css, {} ).css; // use sync PostCSS API
+	} catch ( error ) {
+		if ( error instanceof CssSyntaxError ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'wp.blockEditor.transformStyles Failed to transform CSS.',
+				error.message + '\n' + error.showSourceCode( false )
+			);
+		} else {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'wp.blockEditor.transformStyles Failed to transform CSS.',
+				error
+			);
+		}
+
+		return null;
+	}
+}
+
 /**
  * Applies a series of CSS rule transforms to wrap selectors inside a given class and/or rewrite URLs depending on the parameters passed.
  *
@@ -18,45 +64,14 @@ import rebaseUrl from 'postcss-urlrebase';
  * @return {Array} converted rules.
  */
 const transformStyles = ( styles, wrapperSelector = '' ) => {
-	return styles.map( ( { css, ignoredSelectors = [], baseURL } ) => {
-		// When there is no wrapper selector or base URL, there is no need
-		// to transform the CSS. This is most cases because in the default
-		// iframed editor, no wrapping is needed, and not many styles
-		// provide a base URL.
-		if ( ! wrapperSelector && ! baseURL ) {
-			return css;
+	return styles.map( ( style ) => {
+		if ( transformStylesCache.has( style ) ) {
+			return transformStylesCache.get( style );
 		}
 
-		try {
-			return postcss(
-				[
-					wrapperSelector &&
-						wrap( wrapperSelector, {
-							ignoredSelectors: [
-								...ignoredSelectors,
-								wrapperSelector,
-							],
-						} ),
-					baseURL && rebaseUrl( { rootUrl: baseURL } ),
-				].filter( Boolean )
-			).process( css, {} ).css; // use sync PostCSS API
-		} catch ( error ) {
-			if ( error instanceof CssSyntaxError ) {
-				// eslint-disable-next-line no-console
-				console.warn(
-					'wp.blockEditor.transformStyles Failed to transform CSS.',
-					error.message + '\n' + error.showSourceCode( false )
-				);
-			} else {
-				// eslint-disable-next-line no-console
-				console.warn(
-					'wp.blockEditor.transformStyles Failed to transform CSS.',
-					error
-				);
-			}
-
-			return null;
-		}
+		const transformedStyle = transformStyle( style, wrapperSelector );
+		transformStylesCache.set( style, transformedStyle );
+		return transformedStyle;
 	} );
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Editor styles settings remain constant for all previews, so we should cache the transforms so the work is not repeated for each preview.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

1st run: -5% (load patterns)
2nd run -5.6%

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
