### PR TITLE
Add: End to end test to content locking stop editing as blocks behavior

### DIFF
--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -76,4 +76,56 @@ test.describe( 'Content-only lock', () => {
 			},
 		] );
 	} );
+
+	test( 'should be able to automatically stop temporarily modify as blocks when an outside block is selected', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Add content only locked block in the code editor
+		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group"><!-- wp:paragraph -->
+			<p>Locked block a</p>
+			<!-- /wp:paragraph -->
+			
+			<!-- wp:paragraph -->
+			<p>Locked block b</p>
+			<!-- /wp:paragraph --></div>
+			<!-- /wp:group -->
+			
+			<!-- wp:heading -->
+			<h2 class="wp-block-heading"><strong>outside block</strong></h2>
+			<!-- /wp:heading -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+		// Select the content locked block.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Group"i]' )
+			.click();
+		// Press modify to temporarily edit as blocks.
+		await editor.clickBlockOptionsMenuItem( 'Modify' );
+		// Selected a nest paragraph verify Block is not content locked
+		// Styles can be changed and nested blocks can be removed
+		await editor.canvas
+			.locator( 'role=document[name="Block: Paragraph"i]' )
+			.first()
+			.click();
+		await expect(
+			page.locator( '.color-block-support-panel' )
+		).toBeAttached();
+		await editor.clickBlockOptionsMenuItem( 'Delete' );
+		// Select an outside block
+		await editor.canvas
+			.locator( 'role=document[name="Block: Heading"i]' )
+			.click();
+		// Select a locked nested paragraph block again
+		await pageUtils.pressKeys( 'ArrowUp' );
+		// Block is content locked again simple styles like position can not be changed.
+		await expect(
+			page.locator( '.color-block-support-panel' )
+		).not.toBeAttached();
+	} );
 } );


### PR DESCRIPTION
Adds an end-to-end test to the regression fixed in https://github.com/WordPress/gutenberg/pull/57737.
Makes sure on content-locked blocks the temporary modification as normal blocks stops when the user selects an outside block.


## Testing Instructions
Verify the tests pass.

