### PR TITLE
Font Library Modal: Reset the selected font when installing a new font

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -213,7 +213,7 @@ function FontLibraryProvider( { children } ) {
 				'settings.typography.fontFamilies',
 			] );
 			refreshLibrary();
-
+			setLibraryFontSelected( null );
 			return response;
 		} catch ( error ) {
 			return {
@@ -221,7 +221,6 @@ function FontLibraryProvider( { children } ) {
 			};
 		} finally {
 			setIsInstalling( false );
-			setLibraryFontSelected( null );
 		}
 	}
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -214,7 +214,7 @@ function FontLibraryProvider( { children } ) {
 			] );
 			refreshLibrary();
 			setIsInstalling( false );
-			handleSetLibraryFontSelected( null );
+			setLibraryFontSelected( null );
 
 			return response;
 		} catch ( error ) {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -213,7 +213,6 @@ function FontLibraryProvider( { children } ) {
 				'settings.typography.fontFamilies',
 			] );
 			refreshLibrary();
-			setLibraryFontSelected( null );
 			return response;
 		} catch ( error ) {
 			return {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -213,15 +213,15 @@ function FontLibraryProvider( { children } ) {
 				'settings.typography.fontFamilies',
 			] );
 			refreshLibrary();
-			setIsInstalling( false );
-			setLibraryFontSelected( null );
 
 			return response;
 		} catch ( error ) {
-			setIsInstalling( false );
 			return {
 				errors: [ error ],
 			};
+		} finally {
+			setIsInstalling( false );
+			setLibraryFontSelected( null );
 		}
 	}
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -214,6 +214,7 @@ function FontLibraryProvider( { children } ) {
 			] );
 			refreshLibrary();
 			setIsInstalling( false );
+			handleSetLibraryFontSelected( null );
 
 			return response;
 		} catch ( error ) {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -77,6 +77,7 @@ function InstalledFonts() {
 		!! libraryFontSelected && libraryFontSelected?.source !== 'theme';
 
 	useEffect( () => {
+		handleSelectFont( libraryFontSelected );
 		refreshLibrary();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a small PR to reset the selected font (`libraryFontSelected`) when installing a new font.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/WordPress/gutenberg/issues/54945.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a call to `setLibraryFontSelected` in `installFont` which sets the `libraryFontSelected` to `null`. 

This means that when navigating back to the installed fonts list in the Font Library modal, the initial list of fonts is shown rather than the previously selected font. This also means that the list is up to date, including the latest installed font. Previously, you had to navigate back to the list of installed fonts manually in order to reset the selected font.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the Font Library modal
2. In the Upload tab, add a single variant of a new font, and confirm the upload succeeded.
3. Click the Library tab, noting that you are viewing the full list of installed fonts.
4. Click into the font's variant detail list, noting the single variant that was added.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1645628/2e229558-4595-4a86-bf7d-32b63ddd1ef9

