### PR TITLE
Font Library: disable font library UI using a PHP filter

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -185,15 +185,6 @@ if (
 	require __DIR__ . '/experimental/fonts/font-face/bc-layer/class-wp-web-fonts.php';
 } elseif ( ! class_exists( 'WP_Fonts' ) ) {
 
-	// Disables the Font Library.
-	// @core-merge: this should not go to core.
-	add_action(
-		'enqueue_block_editor_assets',
-		function () {
-			wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDisableFontLibrary = true', 'before' );
-		}
-	);
-
 	// Turns off Font Face hooks in Core.
 	// @since 6.4.0.
 	remove_action( 'wp_head', 'wp_print_font_faces', 50 );

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,6 +14,12 @@ import FontFamilies from './font-families';
 import ScreenHeader from './header';
 
 function ScreenTypography() {
+	const fontLibraryEnabled = useSelect(
+		( select ) =>
+			select( editorStore ).getEditorSettings().fontLibraryEnabled,
+		[]
+	);
+
 	return (
 		<>
 			<ScreenHeader
@@ -22,9 +30,7 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen-typography">
 				<VStack spacing={ 6 }>
-					{ ! window.__experimentalDisableFontLibrary && (
-						<FontFamilies />
-					) }
+					{ fontLibraryEnabled && <FontFamilies /> }
 					<TypographyElements />
 				</VStack>
 			</div>

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -10,6 +10,7 @@ import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
  * @property {boolean}       richEditingEnabled    Whether rich editing is enabled or not
  * @property {boolean}       codeEditingEnabled    Whether code editing is enabled or not
  * @property {boolean}       enableCustomFields    Whether the WordPress custom fields are enabled or not.
+ * @property {boolean}       fontLibraryEnabled    Whether the font library is enabled or not.
  *                                                 true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
  *                                                 false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
  *                                                 undefined = the current environment does not support Custom Fields, so the option toggle in Preferences -> Panels to enable the Custom Fields panel is not displayed.
@@ -27,5 +28,6 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	richEditingEnabled: true,
 	codeEditingEnabled: true,
 	enableCustomFields: undefined,
+	fontLibraryEnabled: true,
 	defaultRenderingMode: 'post-only',
 };


### PR DESCRIPTION
## What?
Adds the ability to disable the Font Library  UI using a PHP filter.

This PR just simplifies the work done by @jffng in this PR: https://github.com/WordPress/gutenberg/pull/57773/

## Why?
To make extenders able to disable the font library UI

## How?
Reading the editor settings from the data store.

## Testing Instructions
- Add this PHP somewhere to disable the font library UI and check that the font library is not available.

```php
function disable_font_library_ui( $editor_settings ) { 
	$editor_settings['fontLibraryEnabled'] = false;
    return $editor_settings; 
}

add_filter( "block_editor_settings_all", "disable_font_library_ui" );
```

May fi x:https://github.com/WordPress/gutenberg/issues/55275

