### PR TITLE
Fix comments block

### DIFF
--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -9,8 +9,8 @@ import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
  * @property {boolean|Array} allowedBlockTypes     Allowed block types
  * @property {boolean}       richEditingEnabled    Whether rich editing is enabled or not
  * @property {boolean}       codeEditingEnabled    Whether code editing is enabled or not
- * @property {boolean}       enableCustomFields    Whether the WordPress custom fields are enabled or not.
  * @property {boolean}       fontLibraryEnabled    Whether the font library is enabled or not.
+ * @property {boolean}       enableCustomFields    Whether the WordPress custom fields are enabled or not.
  *                                                 true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
  *                                                 false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
  *                                                 undefined = the current environment does not support Custom Fields, so the option toggle in Preferences -> Panels to enable the Custom Fields panel is not displayed.
@@ -27,7 +27,7 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 
 	richEditingEnabled: true,
 	codeEditingEnabled: true,
-	enableCustomFields: undefined,
 	fontLibraryEnabled: true,
+	enableCustomFields: undefined,
 	defaultRenderingMode: 'post-only',
 };


### PR DESCRIPTION
## What?
Fix comment block accidentally broken here: https://github.com/WordPress/gutenberg/pull/57818

Props  to @creativecoder for noticing this.