### PR TITLE
Remove unused argument from sprintf in pagination.js

### DIFF
--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -31,10 +31,7 @@ const Pagination = memo( function Pagination( {
 					{ createInterpolateElement(
 						sprintf(
 							// translators: %s: Total number of pages.
-							_x(
-								'Page <CurrenPageControl /> of %s',
-								'paging'
-							),
+							_x( 'Page <CurrenPageControl /> of %s', 'paging' ),
 							totalPages
 						),
 						{

--- a/packages/dataviews/src/pagination.js
+++ b/packages/dataviews/src/pagination.js
@@ -30,12 +30,11 @@ const Pagination = memo( function Pagination( {
 				<HStack justify="flex-start" expanded={ false } spacing={ 2 }>
 					{ createInterpolateElement(
 						sprintf(
-							// translators: %1$s: Current page number, %2$s: Total number of pages.
+							// translators: %s: Total number of pages.
 							_x(
-								'Page <CurrenPageControl /> of %2$s',
+								'Page <CurrenPageControl /> of %s',
 								'paging'
 							),
-							view.page,
 							totalPages
 						),
 						{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Currently, there is only %2$s and no %1$s in the format string `Page <CurrenPageControl /> of %2$s`

```
sprintf(
    // translators: %1$s: Current page number, %2$s: Total number of pages.
    _x(
        'Page <CurrenPageControl /> of %2$s',
        'paging'
    ),
    view.page,
    totalPages
),
```

It makes for confusing output on the GlotPress screen.

![unused-arg-sprintf](https://github.com/WordPress/gutenberg/assets/8876600/b66d5124-0eb7-49da-8700-b1aa270cc41c)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
