### PR TITLE
Update/link control show preview of attachment in suggestion list

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -28,6 +28,7 @@ const ICONS_MAP = {
 
 function SearchItemIcon( { isURL, suggestion } ) {
 	let icon = null;
+	let imgSrc = null;
 
 	if ( isURL ) {
 		icon = globe;
@@ -40,7 +41,25 @@ function SearchItemIcon( { isURL, suggestion } ) {
 			if ( suggestion.isBlogHome ) {
 				icon = verse;
 			}
+		} else if (
+			suggestion.type === 'attachment' &&
+			suggestion.mimeType &&
+			suggestion.mimeType.startsWith( 'image/' )
+		) {
+			imgSrc = suggestion.url;
 		}
+	}
+
+	if ( imgSrc ) {
+		return (
+			<img
+				className="block-editor-link-control__search-item-img"
+				src={ imgSrc }
+				alt={ suggestion.title }
+				width={ 24 }
+				height={ 24 }
+			/>
+		);
 	}
 
 	if ( icon ) {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -220,6 +220,11 @@ $preview-image-height: 140px;
 		}
 	}
 
+	.block-editor-link-control__search-item-img {
+		aspect-ratio: 1/1;
+		margin-right: 8px;
+	}
+
 	&.is-error .block-editor-link-control__search-item-icon {
 		top: 0;
 		width: 32px;

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -31,11 +31,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * @typedef WPLinkSearchResult
  *
- * @property {number} id     Post or term id.
- * @property {string} url    Link url.
- * @property {string} title  Title of the link.
- * @property {string} type   The taxonomy or post type slug or type URL.
- * @property {WPKind} [kind] Link kind of post-type or taxonomy
+ * @property {number} id         Post or term id.
+ * @property {string} url        Link url.
+ * @property {string} title      Title of the link.
+ * @property {string} type       The taxonomy or post type slug or type URL.
+ * @property {WPKind} [kind]     Link kind of post-type or taxonomy
+ * @property {string} [mimeType] attachment mime type
  */
 
 /**
@@ -229,6 +230,7 @@ const fetchLinkSuggestions = async (
 						) || __( '(no title)' ),
 					type: result.subtype || result.type,
 					kind: result?.meta?.kind,
+					mimeType: result?.mime_type,
 				};
 			} );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is PR modifies LinkControl component to render preview of attachments instead of generic icon. But only if suggestion item type is attachment and mime type tells the component suggestion is indeed an image

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Closes #57776

Issue was brought up by the linked issue.
Not in any way major new feature but this PR adds nice cherry on top of the editor experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
First problem was to figure out to know when it is okay to render preview image and when not (media library can contain other files than images). This was achieved by tracking the code which does the REST API call and purges bloating data from return data. Here I added new field `mineType`. See diff on `__experimental-fetch-link-suggestions`

Now that there is clear way of knowing what kind of attachment it is `SearchItemIcon` component is able to switch icon to img tag. As a side note clarity img tag has width and height attribute(s) but the block-editor styles overwrite height attribute to auto. I left it there to be extra transparent that image is going use 1/1 aspect ratio

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Upload some test images (can be SVG also) media. Also add non-image files there (videos, pdf documents, go crazy here)
2. Open post or page and start playing around with LinkControl component. For example use "Buttons" block 
3. Make searches that return those files and observe that when attachment is indeed image then you see preview of image and if not you see good 'ol classic icon

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="412" alt="Screenshot 2024-01-13 at 11 26 37" src="https://github.com/WordPress/gutenberg/assets/62872075/d6998d48-324d-46d9-bd48-96a5f5c34426">

