### PR TITLE
Add Control to reverse the direction of flex

### DIFF
--- a/docs/explanations/architecture/styles.md
+++ b/docs/explanations/architecture/styles.md
@@ -543,6 +543,7 @@ The current semantic class names that can be output by the Layout block support 
 -   `is-content-justification-right`: When a block explicitly sets `justifyContent` to `right`.
 -   `is-content-justification-space-between`: When a block explicitly sets `justifyContent` to `space-between`.
 -   `is-nowrap`: When a block explicitly sets `flexWrap` to `nowrap`.
+-   `is-reversed`: When a block explicitly sets `flexDirectionOrder` to `reverse`.
 
 ### Opting out of generated layout styles
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -442,11 +442,25 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'declarations' => array( 'align-items' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ),
 				);
 			}
+
+			if ( ! empty( $layout['flexDirectionOrder'] ) && 'reverse' === $layout['flexDirectionOrder'] ) {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'flex-direction' => 'row-reverse' ),
+				);
+			}
 		} else {
-			$layout_styles[] = array(
-				'selector'     => $selector,
-				'declarations' => array( 'flex-direction' => 'column' ),
-			);
+			if ( ! empty( $layout['flexDirectionOrder'] ) && 'reverse' === $layout['flexDirectionOrder'] ) {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'flex-direction' => 'column-reverse' ),
+				);
+			} else {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'flex-direction' => 'column' ),
+				);
+			}
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
@@ -669,6 +683,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	if ( ! empty( $block['attrs']['layout']['flexWrap'] ) && 'nowrap' === $block['attrs']['layout']['flexWrap'] ) {
 		$class_names[] = 'is-nowrap';
+	}
+
+	if ( ! empty( $block['attrs']['layout']['flexDirectionOrder'] ) && 'reverse' === $block['attrs']['layout']['flexDirectionOrder'] ) {
+		$class_names[] = 'is-reversed';
 	}
 
 	// Get classname for layout type.

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -103,6 +103,13 @@ export function useLayoutClasses( blockAttributes = {}, blockName = '' ) {
 		layoutClassnames.push( 'is-nowrap' );
 	}
 
+	if (
+		usedLayout?.flexDirectionOrder &&
+		usedLayout.flexDirectionOrder === 'reverse'
+	) {
+		layoutClassnames.push( 'is-reversed' );
+	}
+
 	return layoutClassnames;
 }
 

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -87,6 +87,10 @@ export default {
 					</FlexItem>
 				</Flex>
 				<FlexWrapControl layout={ layout } onChange={ onChange } />
+				<FlexDirectionOrderControl
+					layout={ layout }
+					onChange={ onChange }
+				/>
 			</>
 		);
 	},
@@ -354,32 +358,36 @@ function FlexLayoutJustifyContentControl( {
 }
 
 function FlexWrapControl( { layout, onChange } ) {
-	const { flexWrap = 'wrap', flexDirectionOrder = 'normal' } = layout;
+	const { flexWrap = 'wrap' } = layout;
 	return (
-		<>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Allow to wrap to multiple lines' ) }
-				onChange={ ( value ) => {
-					onChange( {
-						...layout,
-						flexWrap: value ? 'wrap' : 'nowrap',
-					} );
-				} }
-				checked={ flexWrap === 'wrap' }
-			/>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Reverse the order of elements' ) }
-				onChange={ ( value ) => {
-					onChange( {
-						...layout,
-						flexDirectionOrder: value ? 'reverse' : 'normal',
-					} );
-				} }
-				checked={ flexDirectionOrder === 'reverse' }
-			/>
-		</>
+		<ToggleControl
+			__nextHasNoMarginBottom
+			label={ __( 'Allow to wrap to multiple lines' ) }
+			onChange={ ( value ) => {
+				onChange( {
+					...layout,
+					flexWrap: value ? 'wrap' : 'nowrap',
+				} );
+			} }
+			checked={ flexWrap === 'wrap' }
+		/>
+	);
+}
+
+function FlexDirectionOrderControl( { layout, onChange } ) {
+	const { flexDirectionOrder = 'normal' } = layout;
+	return (
+		<ToggleControl
+			__nextHasNoMarginBottom
+			label={ __( 'Reverse the order of elements' ) }
+			onChange={ ( value ) => {
+				onChange( {
+					...layout,
+					flexDirectionOrder: value ? 'reverse' : 'normal',
+				} );
+			} }
+			checked={ flexDirectionOrder === 'reverse' }
+		/>
 	);
 }
 

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -370,7 +370,7 @@ function FlexWrapControl( { layout, onChange } ) {
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Reverse order of elements' ) }
+				label={ __( 'Reverse the order of elements' ) }
 				onChange={ ( value ) => {
 					onChange( {
 						...layout,

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -141,6 +141,7 @@ export default {
 			verticalAlignmentMap[ layout.verticalAlignment ];
 		const alignItems =
 			alignItemsMap[ layout.justifyContent ] || alignItemsMap.left;
+		const flexDirectionReversed = layout?.flexDirectionOrder === 'reverse';
 
 		let output = '';
 		const rules = [];
@@ -156,11 +157,18 @@ export default {
 			if ( justifyContent ) {
 				rules.push( `justify-content: ${ justifyContent }` );
 			}
+			if ( flexDirectionReversed ) {
+				rules.push( 'flex-direction: row-reverse' );
+			}
 		} else {
 			if ( verticalAlignment ) {
 				rules.push( `justify-content: ${ verticalAlignment }` );
 			}
-			rules.push( 'flex-direction: column' );
+			if ( flexDirectionReversed ) {
+				rules.push( 'flex-direction: column-reverse' );
+			} else {
+				rules.push( 'flex-direction: column' );
+			}
 			rules.push( `align-items: ${ alignItems }` );
 		}
 
@@ -346,19 +354,32 @@ function FlexLayoutJustifyContentControl( {
 }
 
 function FlexWrapControl( { layout, onChange } ) {
-	const { flexWrap = 'wrap' } = layout;
+	const { flexWrap = 'wrap', flexDirectionOrder = 'normal' } = layout;
 	return (
-		<ToggleControl
-			__nextHasNoMarginBottom
-			label={ __( 'Allow to wrap to multiple lines' ) }
-			onChange={ ( value ) => {
-				onChange( {
-					...layout,
-					flexWrap: value ? 'wrap' : 'nowrap',
-				} );
-			} }
-			checked={ flexWrap === 'wrap' }
-		/>
+		<>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Allow to wrap to multiple lines' ) }
+				onChange={ ( value ) => {
+					onChange( {
+						...layout,
+						flexWrap: value ? 'wrap' : 'nowrap',
+					} );
+				} }
+				checked={ flexWrap === 'wrap' }
+			/>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Reverse order of elements' ) }
+				onChange={ ( value ) => {
+					onChange( {
+						...layout,
+						flexDirectionOrder: value ? 'reverse' : 'normal',
+					} );
+				} }
+				checked={ flexDirectionOrder === 'reverse' }
+			/>
+		</>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- This adds a toggle control to `Row` and `Stack` block to reverse the direction of the elements.

## Why?
- This is an enhancement to support easily reversing of the content.
- Reference issue: https://github.com/WordPress/gutenberg/issues/41954

## How?
- This will add a ToggleControl in the Layout section to easily toggle between the normal and reversed direction of data in the blocks.

## Testing Instructions
- Open the Gutenberg Editor.
- Insert a Row/Stack block.
- A ToggleControl is added in the `Layout` section with the label `Reverse the order of elements`


## Screenshots or screencast
- <img width="1511" alt="image" src="https://github.com/WordPress/gutenberg/assets/19990999/d845ec40-af59-4f13-988b-322d8bb7d923">
- <img width="1512" alt="image" src="https://github.com/WordPress/gutenberg/assets/19990999/4b967d84-870d-4299-bb9c-b6a7a9985965">



