### PR TITLE
Add a video demonstration to the Quick Start Guide

### DIFF
--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -2,6 +2,8 @@
 
 This guide is designed to demonstrate the basic principles of block development in WordPress using a hands-on approach. Following the steps below, you will create a custom block plugin that uses modern JavaScript (ESNext and JSX) in a matter of minutes. The example block displays the copyright symbol (©) and the current year, the perfect addition to any website's footer.
 
+[video width="960px" mp4="" poster="https://developer.wordpress.org/files/2024/01/quick-start-guide-video-thumbnail.png"][/video]
+
 ## Scaffold the block plugin
 
 Start by ensuring you have Node.js and `npm` installed on your computer. Review the [Node.js development environment](https://developer.wordpress.org/block-editor/getting-started/devenv/nodejs-development-environment/) guide if not.

--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -1,8 +1,8 @@
 # Quick Start Guide
 
-This guide is designed to demonstrate the basic principles of block development in WordPress using a hands-on approach. Following the steps below, you will create a custom block plugin that uses modern JavaScript (ESNext and JSX) in a matter of minutes. The example block displays the copyright symbol (©) and the current year, the perfect addition to any website's footer.
+This guide is designed to demonstrate the basic principles of block development in WordPress using a hands-on approach. Following the steps below, you will create a custom block plugin that uses modern JavaScript (ESNext and JSX) in a matter of minutes. The example block displays the copyright symbol (©) and the current year, the perfect addition to any website's footer. You can see these steps in action through this short video demonstration.
 
-[video width="960px" mp4="" poster="https://developer.wordpress.org/files/2024/01/quick-start-guide-video-thumbnail.png"][/video]
+<div style="position:relative;overflow:hidden;padding-top:56.25%;"><iframe src="https://www.youtube.com/embed/nrut8SfXA44?si=YxvmHmAoYx-BDCog" title="WordPress Block Development: Quick Start Guide Video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="true" style="position:absolute;top:0;left:0;width:100%;max-width:960px;height:100%;max-height:540px;"></iframe></div>
 
 ## Scaffold the block plugin
 


### PR DESCRIPTION
This PR adds a video demonstration that walks the viewer through the steps in the [Quick Start Guide](https://developer.wordpress.org/block-editor/getting-started/quick-start-guide/).

The implementation is not ideal, but it works. When docs are synced to [developer.wordpress.org/block-editor](https://developer.wordpress.org/block-editor), the content is wrapped in a Freeform block (Classic Editor). It's not actually converted into a block. This is something that we can explore improving in the future. 

Therefore, the YouTube video (hosted as an unlisted video on the [WordPress YT](https://www.youtube.com/@WordPress) channel) cannot use the Embed block and needs some additional markup to maintain its aspect ratio and be responsive. The finished product will look like this: 

<img width="1951" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/1b35f93e-6561-4e15-bb39-d24036e5e94d">

You can view the video directly here: https://www.youtube.com/watch?v=nrut8SfXA44
