### PR TITLE
Update: Break Long Strings to Preserve Layout

### DIFF
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -32,7 +32,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"className": true,
+		"className": false,
 		"color": {
 			"gradients": true,
 			"link": true,

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -32,7 +32,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"className": false,
+		"className": true,
 		"color": {
 			"gradients": true,
 			"link": true,

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -55,7 +55,7 @@ p.has-text-align-left[style*="writing-mode:vertical-lr"] {
 	rotate: 180deg;
 }
 
-.wp-block-paragraph {
+p {
 	// Break long strings of text without spaces so they don't overflow the block.
 	overflow-wrap: break-word;
 }

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -54,3 +54,8 @@ p.has-text-align-right[style*="writing-mode:vertical-rl"],
 p.has-text-align-left[style*="writing-mode:vertical-lr"] {
 	rotate: 180deg;
 }
+
+.wp-block-paragraph {
+	// Break long strings of text without spaces so they don't overflow the block.
+	overflow-wrap: break-word;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
1. Add `overflow-wrap: break-word` to the paragraph block.

## Why?
1. Break long text strings without spaces so they don't overflow the block.
2. A continuous long text breaks the layout on the site's front end.

## How?
1. Adding `overflow-wrap` style similar to the style in the editor layout to paragraph block on frontend
3. Issue addressed: https://github.com/WordPress/gutenberg/issues/52871

## Testing Instructions
1. Open the Gutenberg editor.
2. Type a long continuous text with no spaces in between.
4. Publish the post
5. View the post frontend

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="580" alt="Screenshot 2024-01-15 at 5 06 37 AM" src="https://github.com/WordPress/gutenberg/assets/77241728/1724444e-28ab-4b96-9974-96eece82a6a8">

### After
<img width="683" alt="Screenshot 2024-01-15 at 5 05 38 AM" src="https://github.com/WordPress/gutenberg/assets/77241728/413f53a8-aae1-471a-b2d0-1725a0df3c05">

