### PR TITLE
List View: Add keyboard clipboard events for cut, copy, paste

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -187,7 +187,7 @@ function ListViewBlock( {
 				selectBlock( undefined, focusClientId, null, null );
 			}
 
-			focusListItem( focusClientId, treeGridElementRef );
+			focusListItem( focusClientId, treeGridElementRef?.current );
 		},
 		[ selectBlock, treeGridElementRef ]
 	);

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -138,23 +138,6 @@ function ListViewComponent(
 
 	const [ expandedState, setExpandedState ] = useReducer( expanded, {} );
 
-	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone( {
-		dropZoneElement,
-		expandedState,
-		setExpandedState,
-	} );
-	const elementRef = useRef();
-
-	// Allow handling of copy, cut, and paste events.
-	const clipBoardRef = useClipboardHandler();
-
-	const treeGridRef = useMergeRefs( [
-		clipBoardRef,
-		elementRef,
-		dropZoneRef,
-		ref,
-	] );
-
 	const [ insertedBlock, setInsertedBlock ] = useState( null );
 
 	const { setSelectedTreeId } = useListViewExpandSelectedItem( {
@@ -176,11 +159,31 @@ function ListViewComponent(
 		},
 		[ setSelectedTreeId, updateBlockSelection, onSelect, getBlock ]
 	);
+
+	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone( {
+		dropZoneElement,
+		expandedState,
+		setExpandedState
+	} );
+	const elementRef = useRef();
+
+	// Allow handling of copy, cut, and paste events.
+	const clipBoardRef = useClipboardHandler( {
+		selectBlock: selectEditorBlock,
+	} );
+
+	const treeGridRef = useMergeRefs( [
+		clipBoardRef,
+		elementRef,
+		dropZoneRef,
+		ref,
+	] );
+
 	useEffect( () => {
 		// If a blocks are already selected when the list view is initially
 		// mounted, shift focus to the first selected block.
 		if ( selectedClientIds?.length ) {
-			focusListItem( selectedClientIds[ 0 ], elementRef );
+			focusListItem( selectedClientIds[ 0 ], elementRef?.current );
 		}
 		// Disable reason: Only focus on the selected item when the list view is mounted.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -42,6 +42,7 @@ import useListViewExpandSelectedItem from './use-list-view-expand-selected-item'
 import { store as blockEditorStore } from '../../store';
 import { BlockSettingsDropdown } from '../block-settings-menu/block-settings-dropdown';
 import { focusListItem } from './utils';
+import useClipboardHandler from '../writing-flow/use-clipboard-handler';
 
 const expanded = ( state, action ) => {
 	if ( Array.isArray( action.clientIds ) ) {
@@ -143,7 +144,16 @@ function ListViewComponent(
 		setExpandedState,
 	} );
 	const elementRef = useRef();
-	const treeGridRef = useMergeRefs( [ elementRef, dropZoneRef, ref ] );
+
+	// Allow handling of copy, cut, and paste events.
+	const clipBoardRef = useClipboardHandler();
+
+	const treeGridRef = useMergeRefs( [
+		clipBoardRef,
+		elementRef,
+		dropZoneRef,
+		ref,
+	] );
 
 	const [ insertedBlock, setInsertedBlock ] = useState( null );
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -163,7 +163,7 @@ function ListViewComponent(
 	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone( {
 		dropZoneElement,
 		expandedState,
-		setExpandedState
+		setExpandedState,
 	} );
 	const elementRef = useRef();
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -42,7 +42,7 @@ import useListViewExpandSelectedItem from './use-list-view-expand-selected-item'
 import { store as blockEditorStore } from '../../store';
 import { BlockSettingsDropdown } from '../block-settings-menu/block-settings-dropdown';
 import { focusListItem } from './utils';
-import useClipboardHandler from '../writing-flow/use-clipboard-handler';
+import useClipboardHandler from './use-clipboard-handler';
 
 const expanded = ( state, action ) => {
 	if ( Array.isArray( action.clientIds ) ) {

--- a/packages/block-editor/src/components/list-view/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/list-view/use-clipboard-handler.js
@@ -13,8 +13,7 @@ import { focusListItem } from './utils';
 import { getPasteBlocks, setClipboardBlocks } from '../writing-flow/utils';
 
 // This hook borrows from useClipboardHandler in ../writing-flow/use-clipboard-handler.js
-// and adds behaviour for the list view, while skipping partial selection. In the future,
-// consider refactoring the two hooks to share more code.
+// and adds behaviour for the list view, while skipping partial selection.
 export default function useClipboardHandler( { selectBlock } ) {
 	const {
 		getBlockOrder,

--- a/packages/block-editor/src/components/list-view/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/list-view/use-clipboard-handler.js
@@ -12,6 +12,9 @@ import { useNotifyCopy } from '../../utils/use-notify-copy';
 import { focusListItem } from './utils';
 import { getPasteBlocks, setClipboardBlocks } from '../writing-flow/utils';
 
+// This hook borrows from useClipboardHandler in ../writing-flow/use-clipboard-handler.js
+// and adds behaviour for the list view, while skipping partial selection. In the future,
+// consider refactoring the two hooks to share more code.
 export default function useClipboardHandler( { selectBlock } ) {
 	const {
 		getBlockOrder,

--- a/packages/block-editor/src/components/list-view/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/list-view/use-clipboard-handler.js
@@ -1,0 +1,232 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	serialize,
+	pasteHandler,
+	createBlock,
+	findTransform,
+	getBlockTransforms,
+} from '@wordpress/blocks';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useRefEffect } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { getPasteEventData } from '../../utils/pasting';
+import { store as blockEditorStore } from '../../store';
+import { useNotifyCopy } from '../../utils/use-notify-copy';
+
+export default function useClipboardHandler() {
+	const {
+		getBlockRootClientId,
+		getBlocksByClientId,
+		getSelectedBlockClientIds,
+		getSettings,
+		canInsertBlockType,
+		canRemoveBlocks,
+	} = useSelect( blockEditorStore );
+	const { flashBlock, removeBlocks, replaceBlocks, insertBlocks } =
+		useDispatch( blockEditorStore );
+	const notifyCopy = useNotifyCopy();
+
+	return useRefEffect( ( node ) => {
+		// Determine which blocks to update:
+		// If the current (focused) block is part of the block selection, use the whole selection.
+		// If the focused block is not part of the block selection, only update the focused block.
+		function getBlocksToUpdate( clientId ) {
+			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const isUpdatingSelectedBlocks =
+				selectedBlockClientIds.includes( clientId );
+			const firstBlockClientId = isUpdatingSelectedBlocks
+				? selectedBlockClientIds[ 0 ]
+				: clientId;
+			const firstBlockRootClientId =
+				getBlockRootClientId( firstBlockClientId );
+
+			const blocksToUpdate = isUpdatingSelectedBlocks
+				? selectedBlockClientIds
+				: [ clientId ];
+
+			return {
+				blocksToUpdate,
+				firstBlockClientId,
+				firstBlockRootClientId,
+				selectedBlockClientIds,
+			};
+		}
+
+		function handler( event ) {
+			if ( event.defaultPrevented ) {
+				// This was possibly already handled in rich-text/use-paste-handler.js.
+				return;
+			}
+
+			// Only handle events that occur within the list view.
+			if ( ! node.contains( event.target.ownerDocument.activeElement ) ) {
+				return;
+			}
+
+			// Retrieve the block clientId associated with the focused list view row.
+			// This enables applying copy / cut / paste behavior to the focused block,
+			// rather than just the blocks that are currently selected.
+			const listViewRow =
+				event.target.ownerDocument.activeElement?.closest(
+					'[role=row]'
+				);
+			const clientId = listViewRow?.dataset?.block;
+			if ( ! clientId ) {
+				return;
+			}
+
+			const {
+				blocksToUpdate: selectedBlockClientIds,
+				firstBlockRootClientId,
+			} = getBlocksToUpdate( clientId );
+
+			if ( selectedBlockClientIds.length === 0 ) {
+				return;
+			}
+
+			event.preventDefault();
+
+			if ( event.type === 'copy' || event.type === 'cut' ) {
+				if ( selectedBlockClientIds.length === 1 ) {
+					flashBlock( selectedBlockClientIds[ 0 ] );
+				}
+
+				notifyCopy( event.type, selectedBlockClientIds );
+				let blocks;
+				// Check if we have partial selection.
+				blocks = getBlocksByClientId( selectedBlockClientIds );
+
+				const wrapperBlockName = event.clipboardData.getData(
+					'__unstableWrapperBlockName'
+				);
+
+				if ( wrapperBlockName ) {
+					blocks = createBlock(
+						wrapperBlockName,
+						JSON.parse(
+							event.clipboardData.getData(
+								'__unstableWrapperBlockAttributes'
+							)
+						),
+						blocks
+					);
+				}
+
+				const serialized = serialize( blocks );
+
+				event.clipboardData.setData(
+					'text/plain',
+					toPlainText( serialized )
+				);
+				event.clipboardData.setData( 'text/html', serialized );
+			}
+
+			if ( event.type === 'cut' ) {
+				// Don't update the selection if the blocks cannot be deleted.
+				if (
+					! canRemoveBlocks(
+						selectedBlockClientIds,
+						firstBlockRootClientId
+					)
+				) {
+					return;
+				}
+				removeBlocks( selectedBlockClientIds );
+			} else if ( event.type === 'paste' ) {
+				const {
+					__experimentalCanUserUseUnfilteredHTML:
+						canUserUseUnfilteredHTML,
+				} = getSettings();
+				const { plainText, html, files } = getPasteEventData( event );
+				let blocks = [];
+
+				if ( files.length ) {
+					const fromTransforms = getBlockTransforms( 'from' );
+					blocks = files
+						.reduce( ( accumulator, file ) => {
+							const transformation = findTransform(
+								fromTransforms,
+								( transform ) =>
+									transform.type === 'files' &&
+									transform.isMatch( [ file ] )
+							);
+							if ( transformation ) {
+								accumulator.push(
+									transformation.transform( [ file ] )
+								);
+							}
+							return accumulator;
+						}, [] )
+						.flat();
+				} else {
+					blocks = pasteHandler( {
+						HTML: html,
+						plainText,
+						mode: 'BLOCKS',
+						canUserUseUnfilteredHTML,
+					} );
+				}
+
+				if ( selectedBlockClientIds.length === 1 ) {
+					const [ selectedBlockClientId ] = selectedBlockClientIds;
+
+					if (
+						blocks.every( ( block ) =>
+							canInsertBlockType(
+								block.name,
+								selectedBlockClientId
+							)
+						)
+					) {
+						insertBlocks(
+							blocks,
+							undefined,
+							selectedBlockClientId
+						);
+						return;
+					}
+				}
+
+				replaceBlocks(
+					selectedBlockClientIds,
+					blocks,
+					blocks.length - 1,
+					-1
+				);
+			}
+		}
+
+		node.ownerDocument.addEventListener( 'copy', handler );
+		node.ownerDocument.addEventListener( 'cut', handler );
+		node.ownerDocument.addEventListener( 'paste', handler );
+
+		return () => {
+			node.ownerDocument.removeEventListener( 'copy', handler );
+			node.ownerDocument.removeEventListener( 'cut', handler );
+			node.ownerDocument.removeEventListener( 'paste', handler );
+		};
+	}, [] );
+}
+
+/**
+ * Given a string of HTML representing serialized blocks, returns the plain
+ * text extracted after stripping the HTML of any tags and fixing line breaks.
+ *
+ * @param {string} html Serialized blocks.
+ * @return {string} The plain-text content with any html removed.
+ */
+function toPlainText( html ) {
+	// Manually handle BR tags as line breaks prior to `stripHTML` call
+	html = html.replace( /<br>/g, '\n' );
+
+	const plainText = stripHTML( html ).trim();
+
+	// Merge any consecutive line breaks
+	return plainText.replace( /\n\n+/g, '\n\n' );
+}

--- a/packages/block-editor/src/components/list-view/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/list-view/use-clipboard-handler.js
@@ -1,24 +1,16 @@
 /**
  * WordPress dependencies
  */
-import {
-	serialize,
-	pasteHandler,
-	createBlock,
-	findTransform,
-	getBlockTransforms,
-} from '@wordpress/blocks';
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { getPasteEventData } from '../../utils/pasting';
 import { store as blockEditorStore } from '../../store';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
 import { focusListItem } from './utils';
+import { getPasteBlocks, setClipboardBlocks } from '../writing-flow/utils';
 
 export default function useClipboardHandler( { selectBlock } ) {
 	const {
@@ -111,33 +103,8 @@ export default function useClipboardHandler( { selectBlock } ) {
 				}
 
 				notifyCopy( event.type, selectedBlockClientIds );
-				let blocks;
-				// Check if we have partial selection.
-				blocks = getBlocksByClientId( selectedBlockClientIds );
-
-				const wrapperBlockName = event.clipboardData.getData(
-					'__unstableWrapperBlockName'
-				);
-
-				if ( wrapperBlockName ) {
-					blocks = createBlock(
-						wrapperBlockName,
-						JSON.parse(
-							event.clipboardData.getData(
-								'__unstableWrapperBlockAttributes'
-							)
-						),
-						blocks
-					);
-				}
-
-				const serialized = serialize( blocks );
-
-				event.clipboardData.setData(
-					'text/plain',
-					toPlainText( serialized )
-				);
-				event.clipboardData.setData( 'text/html', serialized );
+				const blocks = getBlocksByClientId( selectedBlockClientIds );
+				setClipboardBlocks( event, blocks );
 			}
 
 			if ( event.type === 'cut' ) {
@@ -176,35 +143,10 @@ export default function useClipboardHandler( { selectBlock } ) {
 					__experimentalCanUserUseUnfilteredHTML:
 						canUserUseUnfilteredHTML,
 				} = getSettings();
-				const { plainText, html, files } = getPasteEventData( event );
-				let blocks = [];
-
-				if ( files.length ) {
-					const fromTransforms = getBlockTransforms( 'from' );
-					blocks = files
-						.reduce( ( accumulator, file ) => {
-							const transformation = findTransform(
-								fromTransforms,
-								( transform ) =>
-									transform.type === 'files' &&
-									transform.isMatch( [ file ] )
-							);
-							if ( transformation ) {
-								accumulator.push(
-									transformation.transform( [ file ] )
-								);
-							}
-							return accumulator;
-						}, [] )
-						.flat();
-				} else {
-					blocks = pasteHandler( {
-						HTML: html,
-						plainText,
-						mode: 'BLOCKS',
-						canUserUseUnfilteredHTML,
-					} );
-				}
+				const blocks = getPasteBlocks(
+					event,
+					canUserUseUnfilteredHTML
+				);
 
 				if ( selectedBlockClientIds.length === 1 ) {
 					const [ selectedBlockClientId ] = selectedBlockClientIds;
@@ -252,21 +194,4 @@ export default function useClipboardHandler( { selectBlock } ) {
 			node.ownerDocument.removeEventListener( 'paste', handler );
 		};
 	}, [] );
-}
-
-/**
- * Given a string of HTML representing serialized blocks, returns the plain
- * text extracted after stripping the HTML of any tags and fixing line breaks.
- *
- * @param {string} html Serialized blocks.
- * @return {string} The plain-text content with any html removed.
- */
-function toPlainText( html ) {
-	// Manually handle BR tags as line breaks prior to `stripHTML` call
-	html = html.replace( /<br>/g, '\n' );
-
-	const plainText = stripHTML( html ).trim();
-
-	// Merge any consecutive line breaks
-	return plainText.replace( /\n\n+/g, '\n\n' );
 }

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -63,12 +63,12 @@ export function getCommonDepthClientIds(
  *
  * @typedef {import('@wordpress/element').RefObject} RefObject
  *
- * @param {string}                 focusClientId      The client ID of the block to focus.
- * @param {RefObject<HTMLElement>} treeGridElementRef The container element to search within.
+ * @param {string}      focusClientId   The client ID of the block to focus.
+ * @param {HTMLElement} treeGridElement The container element to search within.
  */
-export function focusListItem( focusClientId, treeGridElementRef ) {
+export function focusListItem( focusClientId, treeGridElement ) {
 	const getFocusElement = () => {
-		const row = treeGridElementRef.current?.querySelector(
+		const row = treeGridElement?.querySelector(
 			`[role=row][data-block="${ focusClientId }"]`
 		);
 		if ( ! row ) return null;

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -63,8 +63,8 @@ export function getCommonDepthClientIds(
  *
  * @typedef {import('@wordpress/element').RefObject} RefObject
  *
- * @param {string}      focusClientId   The client ID of the block to focus.
- * @param {HTMLElement} treeGridElement The container element to search within.
+ * @param {string}       focusClientId   The client ID of the block to focus.
+ * @param {?HTMLElement} treeGridElement The container element to search within.
  */
 export function focusListItem( focusClientId, treeGridElement ) {
 	const getFocusElement = () => {

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -15,6 +15,13 @@ import {
  */
 import { getPasteEventData } from '../../utils/pasting';
 
+/**
+ * Sets the clipboard data for the provided blocks, with both HTML and plain
+ * text representations.
+ *
+ * @param {ClipboardEvent} event  Clipboard event.
+ * @param {WPBlock[]}      blocks Blocks to set as clipboard data.
+ */
 export function setClipboardBlocks( event, blocks ) {
 	let _blocks = blocks;
 	const wrapperBlockName = event.clipboardData.getData(
@@ -39,6 +46,13 @@ export function setClipboardBlocks( event, blocks ) {
 	event.clipboardData.setData( 'text/html', serialized );
 }
 
+/**
+ * Returns the blocks to be pasted from the clipboard event.
+ *
+ * @param {ClipboardEvent} event                    The clipboard event.
+ * @param {boolean}        canUserUseUnfilteredHTML Whether the user can or can't post unfiltered HTML.
+ * @return {Array|string} A list of blocks or a string, depending on `handlerMode`.
+ */
 export function getPasteBlocks( event, canUserUseUnfilteredHTML ) {
 	const { plainText, html, files } = getPasteEventData( event );
 	let blocks = [];

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import {
+	serialize,
+	createBlock,
+	pasteHandler,
+	findTransform,
+	getBlockTransforms,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { getPasteEventData } from '../../utils/pasting';
+
+export function setClipboardBlocks( event, blocks ) {
+	let _blocks = blocks;
+	const wrapperBlockName = event.clipboardData.getData(
+		'__unstableWrapperBlockName'
+	);
+
+	if ( wrapperBlockName ) {
+		_blocks = createBlock(
+			wrapperBlockName,
+			JSON.parse(
+				event.clipboardData.getData(
+					'__unstableWrapperBlockAttributes'
+				)
+			),
+			_blocks
+		);
+	}
+
+	const serialized = serialize( _blocks );
+
+	event.clipboardData.setData( 'text/plain', toPlainText( serialized ) );
+	event.clipboardData.setData( 'text/html', serialized );
+}
+
+export function getPasteBlocks( event, canUserUseUnfilteredHTML ) {
+	const { plainText, html, files } = getPasteEventData( event );
+	let blocks = [];
+
+	if ( files.length ) {
+		const fromTransforms = getBlockTransforms( 'from' );
+		blocks = files
+			.reduce( ( accumulator, file ) => {
+				const transformation = findTransform(
+					fromTransforms,
+					( transform ) =>
+						transform.type === 'files' &&
+						transform.isMatch( [ file ] )
+				);
+				if ( transformation ) {
+					accumulator.push( transformation.transform( [ file ] ) );
+				}
+				return accumulator;
+			}, [] )
+			.flat();
+	} else {
+		blocks = pasteHandler( {
+			HTML: html,
+			plainText,
+			mode: 'BLOCKS',
+			canUserUseUnfilteredHTML,
+		} );
+	}
+
+	return blocks;
+}
+
+/**
+ * Given a string of HTML representing serialized blocks, returns the plain
+ * text extracted after stripping the HTML of any tags and fixing line breaks.
+ *
+ * @param {string} html Serialized blocks.
+ * @return {string} The plain-text content with any html removed.
+ */
+function toPlainText( html ) {
+	// Manually handle BR tags as line breaks prior to `stripHTML` call
+	html = html.replace( /<br>/g, '\n' );
+
+	const plainText = stripHTML( html ).trim();
+
+	// Merge any consecutive line breaks
+	return plainText.replace( /\n\n+/g, '\n\n' );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/49563

Allow clipboard events within the list view to cut, copy, and paste blocks via keyboard shortcut.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When focus is within the list view, it can be very helpful to quickly copy blocks, or paste blocks over particular selected blocks. This PR allows that to happen.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Make a copy of the `useClipboardHandler` and attach it to the list view so that it can handle copying, cutting, and pasting both individual and multi-selections of blocks.

The copied `useClipboardHandler` differs from the one used in the editor canvas in some key ways:

* Acts on the currently focused list view item if the focused list view item is not part of the selected blocks — this is so that when navigating up and down the list view via keyboard, your actions are being applied to the thing you're working on, not the "block selection". If the focused block is part of a block selection, then we apply the action to the whole block selection, just as we do on `trunk` when pressing backspace to delete blocks.
* Intentionally does not handle or deal with partial selections as the list view only deals with whole blocks
* Keep focus within the list view after cutting or pasting list view items

<!--
## To-do

* [x] Create a separate `useClipboardHandler` for use in the list view that acts on the currently focused list view item when the currently focused block is not part of the selection.
* [x] When cutting, make sure block selection follows the logic used in the list view for deletions
* [x] When cutting and pasting, ensure focus remains within the list view
-->
<!--
* Possibly, move logic down to the block selection button, in order to ensure that we can handle the currently focused list item
* The clipboard logic most likely needs to follow the logic used elsewhere in the list view where we're applying the logic to the block that is currently _focused_ not just the block selection.
* If the currently focused block is part of the block selection, then we'd apply it to the whole selection.
* Another idea: we might be best served to make a copy of `useClipboardHandler` that lives in the list view. That way we can strip out the partial selection stuff that isn't needed, attach to the block level, and re-use the logic to figure out which blocks to apply things to. -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* In a post with a variety of blocks, open up the list view and click on a list view item a couple of times to ensure that focus is within the list view.
* Navigate up and down the list view and try CMD+C and CMD+X to copy and cut blocks, and CMD+V to paste blocks.
* Note that, following the logic used within the editor canvas, when pasting on to a container block, the copied blocks will be added as the last child. When pasting on to a non-container block, it will be replaced with the copied blocks

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/14988353/e61a6e26-df99-4dac-bc35-7f5b110353fe
