### PR TITLE
Add a control to reset pattern overrides

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -208,15 +208,18 @@ export default function ReusableBlockEdit( {
 		[ innerBlocks, setBlockEditingMode ]
 	);
 
-	// Apply the initial overrides from the pattern block to the inner blocks.
-	useEffect( () => {
-		const initialBlocks =
+	const initialBlocks = useMemo(
+		() =>
 			// Clone the blocks to generate new client IDs.
 			editedRecord.blocks?.map( ( block ) => cloneBlock( block ) ) ??
 			( editedRecord.content && typeof editedRecord.content !== 'function'
 				? parse( editedRecord.content )
-				: [] );
+				: [] ),
+		[ editedRecord.blocks, editedRecord.content ]
+	);
 
+	// Apply the initial overrides from the pattern block to the inner blocks.
+	useEffect( () => {
 		defaultValuesRef.current = {};
 		const editingMode = getBlockEditingMode( patternClientId );
 		// Replace the contents of the blocks with the overrides.
@@ -237,7 +240,7 @@ export default function ReusableBlockEdit( {
 	}, [
 		__unstableMarkNextChangeAsNotPersistent,
 		patternClientId,
-		editedRecord,
+		initialBlocks,
 		replaceInnerBlocks,
 		registry,
 		getBlockEditingMode,
@@ -293,6 +296,10 @@ export default function ReusableBlockEdit( {
 		editOriginalProps.onClick( event );
 	};
 
+	const resetOverrides = () => {
+		replaceInnerBlocks( patternClientId, initialBlocks );
+	};
+
 	let children = null;
 
 	if ( hasAlreadyRendered ) {
@@ -333,6 +340,15 @@ export default function ReusableBlockEdit( {
 					</ToolbarGroup>
 				</BlockControls>
 			) }
+			{ overrides ? (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton onClick={ resetOverrides }>
+							{ __( 'Reset overrides' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				</BlockControls>
+			) : null }
 			{ children === null ? (
 				<div { ...innerBlocksProps } />
 			) : (

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -297,7 +297,9 @@ export default function ReusableBlockEdit( {
 	};
 
 	const resetOverrides = () => {
-		replaceInnerBlocks( patternClientId, initialBlocks );
+		if ( overrides ) {
+			replaceInnerBlocks( patternClientId, initialBlocks );
+		}
 	};
 
 	let children = null;
@@ -340,15 +342,18 @@ export default function ReusableBlockEdit( {
 					</ToolbarGroup>
 				</BlockControls>
 			) }
-			{ overrides ? (
-				<BlockControls>
-					<ToolbarGroup>
-						<ToolbarButton onClick={ resetOverrides }>
-							{ __( 'Reset overrides' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-			) : null }
+
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						onClick={ resetOverrides }
+						aria-disabled={ overrides ? 'true' : 'false' }
+					>
+						{ __( 'Reset to original' ) }
+					</ToolbarButton>
+				</ToolbarGroup>
+			</BlockControls>
+
 			{ children === null ? (
 				<div { ...innerBlocksProps } />
 			) : (

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -147,6 +147,13 @@ function setBlockEditMode( setEditMode, blocks, mode ) {
 	} );
 }
 
+function getHasOverridableBlocks( blocks ) {
+	return blocks.some( ( block ) => {
+		if ( isPartiallySynced( block ) ) return true;
+		return getHasOverridableBlocks( block.innerBlocks );
+	} );
+}
+
 export default function ReusableBlockEdit( {
 	name,
 	attributes: { ref, overrides },
@@ -206,6 +213,11 @@ export default function ReusableBlockEdit( {
 	useEffect(
 		() => setBlockEditMode( setBlockEditingMode, innerBlocks ),
 		[ innerBlocks, setBlockEditingMode ]
+	);
+
+	const hasOverridableBlocks = useMemo(
+		() => getHasOverridableBlocks( innerBlocks ),
+		[ innerBlocks ]
 	);
 
 	const initialBlocks = useMemo(
@@ -343,16 +355,18 @@ export default function ReusableBlockEdit( {
 				</BlockControls>
 			) }
 
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton
-						onClick={ resetOverrides }
-						aria-disabled={ overrides ? 'true' : 'false' }
-					>
-						{ __( 'Reset to original' ) }
-					</ToolbarButton>
-				</ToolbarGroup>
-			</BlockControls>
+			{ hasOverridableBlocks && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							onClick={ resetOverrides }
+							aria-disabled={ overrides ? 'false' : 'true' }
+						>
+							{ __( 'Reset to original' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
 
 			{ children === null ? (
 				<div { ...innerBlocksProps } />

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -360,7 +360,8 @@ export default function ReusableBlockEdit( {
 					<ToolbarGroup>
 						<ToolbarButton
 							onClick={ resetOverrides }
-							aria-disabled={ overrides ? 'false' : 'true' }
+							disabled={ ! overrides }
+							__experimentalIsFocusable
 						>
 							{ __( 'Reset to original' ) }
 						</ToolbarButton>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #53705. Close https://github.com/WordPress/gutenberg/issues/57751.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/57751.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a block control to reset the pattern overrides.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331 to create a pattern with overrides and add it to a post.

1. Focus on the pattern, and the block toolbar should have "Reset overrides."
2. Clicking on the control should reset the overrides.
3. Undo/redo should work as expected.
4. Patterns without overrides should not have the control.

## Screenshots or screencast <!-- if applicable -->
For patterns that can be overridden but no overrides.
![For patterns that can be overridden but no overrides.](https://github.com/WordPress/gutenberg/assets/7753001/1601f94c-12b1-46d3-b5c9-5abe566b85d9)

For patterns that can be overridden and with overrides.
![For patterns that can be overridden and with overrides.](https://github.com/WordPress/gutenberg/assets/7753001/e35ea221-ac28-43ad-954a-d0600523412c)

For patterns that cannot be overridden.
![For patterns that cannot be overridden.](https://github.com/WordPress/gutenberg/assets/7753001/2906f7ef-fd71-4268-9c36-60eefdb6a49f)

