### PR TITLE
DataViews: set primary field styles

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -71,6 +71,11 @@
 		text-decoration: none;
 		color: $gray-900;
 		font-weight: 500;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+		display: block;
+		width: 100%;
 	}
 	th {
 		text-align: left;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -168,16 +168,6 @@
 			padding-left: $grid-unit-05;
 		}
 	}
-	tbody {
-		td {
-			vertical-align: top;
-		}
-		.dataviews-view-table__cell-content-wrapper {
-			min-height: $grid-unit-40;
-			display: flex;
-			align-items: center;
-		}
-	}
 	.dataviews-view-table-header-button {
 		padding: $grid-unit-05 $grid-unit-10;
 		font-size: 11px;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -213,6 +213,11 @@
 	overflow: hidden;
 	display: block;
 	width: 100%;
+
+	a {
+		text-decoration: none;
+		color: inherit;
+	}
 }
 
 .dataviews-view-grid {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -202,6 +202,19 @@
 	}
 }
 
+.dataviews-view-list__primary-field,
+.dataviews-view-grid__primary-field,
+.dataviews-view-table__primary-field {
+	font-size: $default-font-size;
+	font-weight: 500;
+	color: $gray-900;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
+	display: block;
+	width: 100%;
+}
+
 .dataviews-view-grid {
 	margin-bottom: $grid-unit-30;
 	grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
@@ -213,26 +226,6 @@
 
 	@include break-huge() {
 		grid-template-columns: repeat(4, minmax(0, 1fr)) !important; // Todo: eliminate !important dependency
-	}
-
-	.dataviews-view-grid__card {
-		.dataviews-view-grid__primary-field {
-			.dataviews-view-grid__title-field {
-				white-space: nowrap;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				display: block;
-				font-size: $default-font-size;
-				width: 100%;
-			}
-
-			.dataviews-view-grid__title-field a,
-			button.dataviews-view-grid__title-field {
-				font-weight: 500;
-				color: $gray-900;
-				text-decoration: none;
-			}
-		}
 	}
 
 	.dataviews-view-grid__media {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -222,7 +222,7 @@
 	button.components-button.is-link {
 		text-decoration: none;
 		color: inherit;
-		font-weight: 500;
+		font-weight: inherit;
 	}
 }
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -223,6 +223,21 @@
 		text-decoration: none;
 		color: inherit;
 		font-weight: inherit;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+		display: block;
+		width: 100%;
+	}
+}
+
+.dataviews-view-grid__primary-field {
+	a {
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+		display: block;
+		width: 100%;
 	}
 }
 

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -218,6 +218,12 @@
 		text-decoration: none;
 		color: inherit;
 	}
+
+	button.components-button.is-link {
+		text-decoration: none;
+		color: inherit;
+		font-weight: 500;
+	}
 }
 
 .dataviews-view-grid {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -290,6 +290,7 @@
 		&:not(.is-selected):hover {
 			color: var(--wp-admin-theme-color);
 
+			.dataviews-view-list__primary-field,
 			.dataviews-view-list__fields {
 				color: var(--wp-admin-theme-color);
 			}
@@ -302,6 +303,7 @@
 			background-color: var(--wp-admin-theme-color);
 			color: $white;
 
+			.dataviews-view-list__primary-field,
 			.dataviews-view-list__fields,
 			.components-button {
 				color: $white;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -71,11 +71,6 @@
 		text-decoration: none;
 		color: $gray-900;
 		font-weight: 500;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		overflow: hidden;
-		display: block;
-		width: 100%;
 	}
 	th {
 		text-align: left;
@@ -222,22 +217,17 @@
 	a {
 		text-decoration: none;
 		color: inherit;
-	}
-
-	button.components-button.is-link {
-		text-decoration: none;
-		color: inherit;
-		font-weight: inherit;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
 		display: block;
 		width: 100%;
 	}
-}
 
-.dataviews-view-grid__primary-field {
-	a {
+	button.components-button.is-link {
+		text-decoration: none;
+		color: inherit;
+		font-weight: inherit;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -244,10 +244,6 @@
 		}
 	}
 
-	.dataviews-view-grid__primary-field {
-		min-height: $grid-unit-30;
-	}
-
 	.dataviews-view-grid__fields {
 		position: relative;
 		font-size: 12px;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -168,6 +168,16 @@
 			padding-left: $grid-unit-05;
 		}
 	}
+	tbody {
+		td {
+			vertical-align: top;
+		}
+		.dataviews-view-table__cell-content-wrapper {
+			min-height: $grid-unit-40;
+			display: flex;
+			align-items: center;
+		}
+	}
 	.dataviews-view-table-header-button {
 		padding: $grid-unit-05 $grid-unit-10;
 		font-size: 11px;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -222,6 +222,10 @@
 		overflow: hidden;
 		display: block;
 		width: 100%;
+
+		&:hover {
+			color: $gray-900;
+		}
 	}
 
 	button.components-button.is-link {

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	FlexBlock,
 	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -54,9 +53,9 @@ export default function ViewGrid( {
 						{ mediaField?.render( { item } ) }
 					</div>
 					<HStack justify="space-between">
-						<FlexBlock className="dataviews-view-grid__primary-field">
+						<HStack className="dataviews-view-grid__primary-field">
 							{ primaryField?.render( { item } ) }
-						</FlexBlock>
+						</HStack>
 						<ItemActions
 							item={ item }
 							actions={ actions }

--- a/packages/dataviews/src/view-grid.js
+++ b/packages/dataviews/src/view-grid.js
@@ -53,11 +53,8 @@ export default function ViewGrid( {
 					<div className="dataviews-view-grid__media">
 						{ mediaField?.render( { item } ) }
 					</div>
-					<HStack
-						className="dataviews-view-grid__primary-field"
-						justify="space-between"
-					>
-						<FlexBlock>
+					<HStack justify="space-between">
+						<FlexBlock className="dataviews-view-grid__primary-field">
 							{ primaryField?.render( { item } ) }
 						</FlexBlock>
 						<ItemActions

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -92,7 +92,9 @@ export default function ViewList( {
 										) }
 									</div>
 									<VStack spacing={ 1 }>
-										{ primaryField?.render( { item } ) }
+										<span className="dataviews-view-list__primary-field">
+											{ primaryField?.render( { item } ) }
+										</span>
 										<div className="dataviews-view-list__fields">
 											{ visibleFields.map( ( field ) => {
 												return (

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -564,7 +564,16 @@ function ViewTable( {
 												field.maxWidth || undefined,
 										} }
 									>
-										<span className="dataviews-view-table__cell-content-wrapper">
+										<span
+											className={ classnames(
+												'dataviews-view-table__cell-content-wrapper',
+												{
+													'dataviews-view-table__primary-field':
+														primaryField?.id ===
+														field.id,
+												}
+											) }
+										>
 											{ field.render( {
 												item,
 											} ) }

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -536,21 +536,17 @@ function ViewTable( {
 											minWidth: 20,
 										} }
 									>
-										<span className="dataviews-view-table__cell-content-wrapper">
-											<SingleSelectionCheckbox
-												id={
-													getItemId( item ) || index
-												}
-												item={ item }
-												selection={ selection }
-												onSelectionChange={
-													onSelectionChange
-												}
-												getItemId={ getItemId }
-												data={ data }
-												primaryField={ primaryField }
-											/>
-										</span>
+										<SingleSelectionCheckbox
+											id={ getItemId( item ) || index }
+											item={ item }
+											selection={ selection }
+											onSelectionChange={
+												onSelectionChange
+											}
+											getItemId={ getItemId }
+											data={ data }
+											primaryField={ primaryField }
+										/>
 									</td>
 								) }
 								{ visibleFields.map( ( field ) => (
@@ -565,14 +561,11 @@ function ViewTable( {
 										} }
 									>
 										<span
-											className={ classnames(
-												'dataviews-view-table__cell-content-wrapper',
-												{
-													'dataviews-view-table__primary-field':
-														primaryField?.id ===
-														field.id,
-												}
-											) }
+											className={ classnames( {
+												'dataviews-view-table__primary-field':
+													primaryField?.id ===
+													field.id,
+											} ) }
 										>
 											{ field.render( {
 												item,

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -536,17 +536,21 @@ function ViewTable( {
 											minWidth: 20,
 										} }
 									>
-										<SingleSelectionCheckbox
-											id={ getItemId( item ) || index }
-											item={ item }
-											selection={ selection }
-											onSelectionChange={
-												onSelectionChange
-											}
-											getItemId={ getItemId }
-											data={ data }
-											primaryField={ primaryField }
-										/>
+										<span className="dataviews-view-table__cell-content-wrapper">
+											<SingleSelectionCheckbox
+												id={
+													getItemId( item ) || index
+												}
+												item={ item }
+												selection={ selection }
+												onSelectionChange={
+													onSelectionChange
+												}
+												getItemId={ getItemId }
+												data={ data }
+												primaryField={ primaryField }
+											/>
+										</span>
 									</td>
 								) }
 								{ visibleFields.map( ( field ) => (
@@ -561,11 +565,14 @@ function ViewTable( {
 										} }
 									>
 										<span
-											className={ classnames( {
-												'dataviews-view-table__primary-field':
-													primaryField?.id ===
-													field.id,
-											} ) }
+											className={ classnames(
+												'dataviews-view-table__cell-content-wrapper',
+												{
+													'dataviews-view-table__primary-field':
+														primaryField?.id ===
+														field.id,
+												}
+											) }
 										>
 											{ field.render( {
 												item,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalView as View,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -224,29 +220,22 @@ export default function PagePages() {
 				id: 'title',
 				getValue: ( { item } ) => item.title?.rendered,
 				render: ( { item } ) => {
-					return (
-						<VStack spacing={ 1 }>
-							<View as="span">
-								{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
-									view.type
-								) ? (
-									<Link
-										params={ {
-											postId: item.id,
-											postType: item.type,
-											canvas: 'edit',
-										} }
-									>
-										{ decodeEntities(
-											item.title?.rendered
-										) || __( '(no title)' ) }
-									</Link>
-								) : (
-									decodeEntities( item.title?.rendered ) ||
-									__( '(no title)' )
-								) }
-							</View>
-						</VStack>
+					return [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
+						view.type
+					) ? (
+						<Link
+							params={ {
+								postId: item.id,
+								postType: item.type,
+								canvas: 'edit',
+							} }
+						>
+							{ decodeEntities( item.title?.rendered ) ||
+								__( '(no title)' ) }
+						</Link>
+					) : (
+						decodeEntities( item.title?.rendered ) ||
+							__( '(no title)' )
 					);
 				},
 				maxWidth: 400,

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -78,10 +78,21 @@ function useView( type ) {
 	const { editEntityRecord } = useDispatch( coreStore );
 
 	const customView = useMemo( () => {
-		return (
-			editedViewRecord?.content && JSON.parse( editedViewRecord?.content )
-		);
+		const storedView =
+			editedViewRecord?.content &&
+			JSON.parse( editedViewRecord?.content );
+		if ( ! storedView ) {
+			return storedView;
+		}
+
+		return {
+			...storedView,
+			layout: {
+				...( DEFAULT_CONFIG_PER_VIEW_TYPE[ storedView?.type ] || {} ),
+			},
+		};
 	}, [ editedViewRecord?.content ] );
+
 	const setCustomView = useCallback(
 		( viewToSet ) => {
 			editEntityRecord(

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -226,10 +226,7 @@ export default function PagePages() {
 				render: ( { item } ) => {
 					return (
 						<VStack spacing={ 1 }>
-							<View
-								as="span"
-								className="dataviews-view-grid__title-field"
-							>
+							<View as="span">
 								{ [ LAYOUT_TABLE, LAYOUT_GRID ].includes(
 									view.type
 								) ? (

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -4,7 +4,6 @@
 import {
 	__experimentalHStack as HStack,
 	Button,
-	__experimentalHeading as Heading,
 	Tooltip,
 	Flex,
 } from '@wordpress/components';
@@ -201,17 +200,15 @@ function Title( { item, categoryId } ) {
 				{ item.type === PATTERN_TYPES.theme ? (
 					item.title
 				) : (
-					<Heading level={ 5 }>
-						<Button
-							variant="link"
-							onClick={ onClick }
-							// Required for the grid's roving tab index system.
-							// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
-							tabIndex="-1"
-						>
-							{ item.title || item.name }
-						</Button>
-					</Heading>
+					<Button
+						variant="link"
+						onClick={ onClick }
+						// Required for the grid's roving tab index system.
+						// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
+						tabIndex="-1"
+					>
+						{ item.title || item.name }
+					</Button>
 				) }
 			</Flex>
 		</HStack>

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -199,9 +199,7 @@ function Title( { item, categoryId } ) {
 			) }
 			<Flex as="span" gap={ 0 } justify="left">
 				{ item.type === PATTERN_TYPES.theme ? (
-					<span className="dataviews-view-grid__title-field">
-						{ item.title }
-					</span>
+					<span>{ item.title }</span>
 				) : (
 					<Heading level={ 5 }>
 						<Button
@@ -210,7 +208,6 @@ function Title( { item, categoryId } ) {
 							// Required for the grid's roving tab index system.
 							// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
 							tabIndex="-1"
-							className="dataviews-view-grid__title-field"
 						>
 							{ item.title || item.name }
 						</Button>

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -199,7 +199,7 @@ function Title( { item, categoryId } ) {
 			) }
 			<Flex as="span" gap={ 0 } justify="left">
 				{ item.type === PATTERN_TYPES.theme ? (
-					<span>{ item.title }</span>
+					item.title
 				) : (
 					<Heading level={ 5 }>
 						<Button

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -196,7 +196,12 @@ function Title( { item, categoryId } ) {
 					/>
 				</Tooltip>
 			) }
-			<Flex as="span" gap={ 0 } justify="left">
+			<Flex
+				as="div"
+				gap={ 0 }
+				justify="left"
+				className="edit-site-patterns__pattern-title"
+			>
 				{ item.type === PATTERN_TYPES.theme ? (
 					item.title
 				) : (

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -254,6 +254,15 @@
 		top: 0;
 		z-index: 2;
 	}
+
+	.edit-site-patterns__pattern-title {
+		display: block;
+		width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		color: inherit;
+	}
 }
 
 .dataviews-action-modal__duplicate-pattern {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -105,7 +105,7 @@ function TemplateTitle( { item, viewType } ) {
 
 	return (
 		<VStack spacing={ 1 }>
-			<View as="span" className="dataviews-view-grid__title-field">
+			<View as="span">
 				<Link
 					params={ {
 						postId: item.id,

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -8,10 +8,8 @@ import removeAccents from 'remove-accents';
  */
 import {
 	Icon,
-	__experimentalView as View,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	VisuallyHidden,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -96,28 +94,19 @@ function normalizeSearchInput( input = '' ) {
 
 function TemplateTitle( { item, viewType } ) {
 	if ( viewType === LAYOUT_LIST ) {
-		return (
-			<>
-				{ decodeEntities( item.title?.rendered ) || __( '(no title)' ) }
-			</>
-		);
+		return decodeEntities( item.title?.rendered ) || __( '(no title)' );
 	}
 
 	return (
-		<VStack spacing={ 1 }>
-			<View as="span">
-				<Link
-					params={ {
-						postId: item.id,
-						postType: item.type,
-						canvas: 'edit',
-					} }
-				>
-					{ decodeEntities( item.title?.rendered ) ||
-						__( '(no title)' ) }
-				</Link>
-			</View>
-		</VStack>
+		<Link
+			params={ {
+				postId: item.id,
+				postType: item.type,
+				canvas: 'edit',
+			} }
+		>
+			{ decodeEntities( item.title?.rendered ) || __( '(no title)' ) }
+		</Link>
 	);
 }
 

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -15,7 +15,9 @@ import {
 } from '../../utils/constants';
 
 export const DEFAULT_CONFIG_PER_VIEW_TYPE = {
-	[ LAYOUT_TABLE ]: {},
+	[ LAYOUT_TABLE ]: {
+		primaryField: 'title',
+	},
 	[ LAYOUT_GRID ]: {
 		mediaField: 'featured-image',
 		primaryField: 'title',


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Makes the styles for the primary field (title) equal for all views.

| | Before | After |
| --- | --- | --- |
| Patterns. From theme | <img width="1509" alt="Captura de ecrã 2024-01-15, às 12 15 01" src="https://github.com/WordPress/gutenberg/assets/583546/1123b28a-cc40-485c-a527-3cc1982b9dc9"> | <img width="1507" alt="Captura de ecrã 2024-01-16, às 13 10 48" src="https://github.com/WordPress/gutenberg/assets/583546/2f8fe0c2-d0ac-4b17-93e0-1a68c6d15dc1"> |
| Patterns. From user |  <img width="1507" alt="Captura de ecrã 2024-01-15, às 18 49 21" src="https://github.com/WordPress/gutenberg/assets/583546/e600246d-873f-4705-848a-e7b1440cccd5"> | <img width="1507" alt="Captura de ecrã 2024-01-16, às 13 10 56" src="https://github.com/WordPress/gutenberg/assets/583546/8eb347bc-3ea1-48bd-b51f-c19dbcd1b248"> |
| Templates as table | <img width="1506" alt="Captura de ecrã 2024-01-15, às 16 19 51" src="https://github.com/WordPress/gutenberg/assets/583546/9fa4828f-840d-4021-8f96-428d3580245a"> | <img width="1507" alt="Captura de ecrã 2024-01-16, às 13 11 09" src="https://github.com/WordPress/gutenberg/assets/583546/4eef87c2-e2e1-4b01-8430-6fb680d771ad"> |
| Templates as list | <img width="1509" alt="Captura de ecrã 2024-01-15, às 12 15 31" src="https://github.com/WordPress/gutenberg/assets/583546/39fdeffd-d945-4d36-a29e-b867a6c2e3ca"> | <img width="1507" alt="Captura de ecrã 2024-01-16, às 13 11 26" src="https://github.com/WordPress/gutenberg/assets/583546/69a683ba-2617-4b0c-9954-f75f92c657fd"> |
| Templates as grid | <img width="1509" alt="Captura de ecrã 2024-01-15, às 12 15 24" src="https://github.com/WordPress/gutenberg/assets/583546/46bbdb4d-e003-42a3-ac97-827c7a2bf4c6"> | <img width="1507" alt="Captura de ecrã 2024-01-16, às 13 11 17" src="https://github.com/WordPress/gutenberg/assets/583546/5e1d04a9-4bbe-4105-af6e-3e3e8b575728"> |
| Pages as list | <img width="1509" alt="Captura de ecrã 2024-01-15, às 12 15 40" src="https://github.com/WordPress/gutenberg/assets/583546/761e2859-0417-41f6-8b4c-885a3d60571c"> | <img width="1507" alt="Captura de ecrã 2024-01-16, às 13 11 45" src="https://github.com/WordPress/gutenberg/assets/583546/9c890312-dd6a-4724-add9-8c56fb541e46"> |
| Pages as table | <img width="1509" alt="Captura de ecrã 2024-01-15, às 12 15 54" src="https://github.com/WordPress/gutenberg/assets/583546/def62b08-6a96-486e-a4e7-bb8c381d994f"> | <img width="1507" alt="Captura de ecrã 2024-01-16, às 13 11 53" src="https://github.com/WordPress/gutenberg/assets/583546/13213541-0947-4894-98b1-eec7f522a14c"> |
| Pages as grid | <img width="1509" alt="Captura de ecrã 2024-01-15, às 12 15 47" src="https://github.com/WordPress/gutenberg/assets/583546/3d7c6df3-a479-497f-be23-af9f2d6770dd"> | <img width="1507" alt="Captura de ecrã 2024-01-16, às 13 12 02" src="https://github.com/WordPress/gutenberg/assets/583546/d217a260-de31-45cf-b7b4-af70a4af8022"> | 


## Why?

We want to make it coherent, style wise:

- font size 13px
- font weight 500
- color gray-900
- truncated

## How?

- Removes the use of `dataviews-view-grid__title-field` class in consumer code (Pages, Templates, Patterns pages) to style the title. Consumers should not use dataviews defined classes.
- DataViews provides the styles for the primary field by making sure all layouts attach a specific class. Consumers don't have to provide the styles on their own.

## Testing Instructions

- Enable the "new admin views" experiment and visit Pages, Patterns, and Templates > Manage all templates.
- Verify the styles for the primary field in each layout (it's `title` for all of them).

## TODO

- [x] Truncation for Grid does not work.
- [x] Truncation in tables does not work.
- [x] Vertical alignment for Patterns from users & Grid for Templates and Pages. [f6c407b](https://github.com/WordPress/gutenberg/pull/57846/commits/f6c407b3e4b804aeae3d4e3e7c3783523848b376)
- [x] In List layout, when hovering an item the title should be blue (matching the other fields), currently it remains dark gray. [7f7d2b3](https://github.com/WordPress/gutenberg/pull/57846/commits/7f7d2b314b6719a66197bcd3192f0482d2a3bca8)
