### PR TITLE
Template part block: avoid parsing ALL patterns on mount

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -29,6 +29,43 @@ import {
 	useTemplatePartArea,
 } from './utils/hooks';
 
+function ReplaceButton( {
+	isEntityAvailable,
+	area,
+	clientId,
+	templatePartId,
+	isTemplatePartSelectionOpen,
+	setIsTemplatePartSelectionOpen,
+} ) {
+	const { templateParts } = useAlternativeTemplateParts(
+		area,
+		templatePartId
+	);
+	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
+
+	const hasReplacements = !! templateParts.length || !! blockPatterns.length;
+	const canReplace =
+		isEntityAvailable &&
+		hasReplacements &&
+		( area === 'header' || area === 'footer' );
+
+	if ( ! canReplace ) {
+		return null;
+	}
+
+	return (
+		<MenuItem
+			onClick={ () => {
+				setIsTemplatePartSelectionOpen( true );
+			} }
+			aria-expanded={ isTemplatePartSelectionOpen }
+			aria-haspopup="dialog"
+		>
+			{ __( 'Replace' ) }
+		</MenuItem>
+	);
+}
+
 export default function TemplatePartEdit( {
 	attributes,
 	setAttributes,
@@ -81,22 +118,12 @@ export default function TemplatePartEdit( {
 		},
 		[ templatePartId, attributes.area, clientId ]
 	);
-	const { templateParts } = useAlternativeTemplateParts(
-		area,
-		templatePartId
-	);
-	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
-	const hasReplacements = !! templateParts.length || !! blockPatterns.length;
+
 	const areaObject = useTemplatePartArea( area );
 	const blockProps = useBlockProps();
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
 	const TagName = tagName || areaObject.tagName;
-
-	const canReplace =
-		isEntityAvailable &&
-		hasReplacements &&
-		( area === 'header' || area === 'footer' );
 
 	// We don't want to render a missing state if we have any inner blocks.
 	// A new template part is automatically created if we have any inner blocks but no entity.
@@ -153,36 +180,33 @@ export default function TemplatePartEdit( {
 						/>
 					</TagName>
 				) }
-				{ canReplace && (
-					<BlockSettingsMenuControls>
-						{ ( { selectedClientIds } ) => {
-							// Only enable for single selection that matches the current block.
-							// Ensures menu item doesn't render multiple times.
-							if (
-								! (
-									selectedClientIds.length === 1 &&
-									clientId === selectedClientIds[ 0 ]
-								)
-							) {
-								return null;
-							}
+				<BlockSettingsMenuControls>
+					{ ( { selectedClientIds } ) => {
+						// Only enable for single selection that matches the current block.
+						// Ensures menu item doesn't render multiple times.
+						if (
+							! (
+								selectedClientIds.length === 1 &&
+								clientId === selectedClientIds[ 0 ]
+							)
+						) {
+							return null;
+						}
 
-							return (
-								<MenuItem
-									onClick={ () => {
-										setIsTemplatePartSelectionOpen( true );
-									} }
-									aria-expanded={
-										isTemplatePartSelectionOpen
-									}
-									aria-haspopup="dialog"
-								>
-									{ __( 'Replace' ) }
-								</MenuItem>
-							);
-						} }
-					</BlockSettingsMenuControls>
-				) }
+						return (
+							<ReplaceButton
+								{ ...{
+									isEntityAvailable,
+									area,
+									clientId,
+									templatePartId,
+									isTemplatePartSelectionOpen,
+									setIsTemplatePartSelectionOpen,
+								} }
+							/>
+						);
+					} }
+				</BlockSettingsMenuControls>
 				{ isEntityAvailable && (
 					<TemplatePartInnerBlocks
 						tagName={ TagName }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently the site editor seems to trigger parsing all the patterns on load. This is happening because the template part blocks is selecting `getPatternsByBlockTypes` in the edit function.

Observations:

* It's needed just to check the length... so a lot is happening just for a check.
* This is for a menu item that's not even rendered unless you open the options...
* It seems unexpected that `getPatternsByBlockTypes` is parsing ALL the patterns. Ideally one first gets the subset, then parse the patterns.

The solution I went for here is to avoid calling the expensive selector until that menu item is rendered, since this also reduces the number of subscriptions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is on load

<img width="958" alt="Screenshot 2024-01-15 at 21 47 37" src="https://github.com/WordPress/gutenberg/assets/4710635/56f530b1-2c30-45ec-877d-26f589605055">

This is the template library (grid). All the red stuff is gone now.

![image](https://github.com/WordPress/gutenberg/assets/4710635/621d98ab-3434-4c6b-be79-06d95f942afa)



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
