### PR TITLE
Fix the iframe markup of the embed video in the Quick Start Guide

### DIFF
--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -2,7 +2,7 @@
 
 This guide is designed to demonstrate the basic principles of block development in WordPress using a hands-on approach. Following the steps below, you will create a custom block plugin that uses modern JavaScript (ESNext and JSX) in a matter of minutes. The example block displays the copyright symbol (©) and the current year, the perfect addition to any website's footer. You can see these steps in action through this short video demonstration.
 
-<div style="position:relative;overflow:hidden;padding-top:56.25%;"><iframe src="https://www.youtube.com/embed/nrut8SfXA44?si=YxvmHmAoYx-BDCog" title="WordPress Block Development: Quick Start Guide Video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="true" style="position:absolute;top:0;left:0;width:100%;max-width:960px;height:100%;max-height:540px;"></iframe></div>
+[youtube https://www.youtube.com/watch?v=nrut8SfXA44]
 
 ## Scaffold the block plugin
 

--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -2,7 +2,7 @@
 
 This guide is designed to demonstrate the basic principles of block development in WordPress using a hands-on approach. Following the steps below, you will create a custom block plugin that uses modern JavaScript (ESNext and JSX) in a matter of minutes. The example block displays the copyright symbol (©) and the current year, the perfect addition to any website's footer. You can see these steps in action through this short video demonstration.
 
-[youtube https://www.youtube.com/watch?v=nrut8SfXA44]
+<iframe width="960" height="540" src="https://www.youtube.com/embed/nrut8SfXA44?si=YxvmHmAoYx-BDCog" title="WordPress Block Development: Quick Start Guide Video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="true"></iframe>
 
 ## Scaffold the block plugin
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/WordPress/gutenberg/pull/57834. The implementation in that PR did not work since the `iframe` was stripped when the doc was published.

However, this can be solved by enabling some Jetpack functionality that @adamwoodnz discovered here: https://github.com/WordPress/gutenberg/pull/57834#issuecomment-1891219390

Therefore, this PR removed the unnecessary wrapper `div` and inline styles from the `iframe`.
