### PR TITLE
Lazy parse patterns

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2244,6 +2244,8 @@ export const __experimentalUserPatternCategories = createSelector(
 	( state ) => [ state.settings.__experimentalUserPatternCategories ]
 );
 
+const parsedPatternCache = new WeakMap();
+
 export const __experimentalGetParsedPattern = createSelector(
 	( state, patternName ) => {
 		const patterns = state.settings.__experimentalBlockPatterns;
@@ -2256,20 +2258,18 @@ export const __experimentalGetParsedPattern = createSelector(
 			return null;
 		}
 
-		const parsedPattern = {
+		return {
 			...pattern,
 			// Only parse the content if needed (if the blocks property is
 			// accessed), and cache the result.
 			get blocks() {
-				const parsedContent = parse( pattern.content, {
+				const blocks = parse( pattern.content, {
 					__unstableSkipMigrationLogs: true,
 				} );
-				parsedPattern.blocks = parsedContent;
-				return parsedContent;
+				parsedPatternCache.set( pattern, blocks );
+				return blocks;
 			},
 		};
-
-		return parsedPattern;
 	},
 	( state ) => [
 		state.settings.__experimentalBlockPatterns,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2255,12 +2255,21 @@ export const __experimentalGetParsedPattern = createSelector(
 		if ( ! pattern ) {
 			return null;
 		}
-		return {
+
+		const parsedPattern = {
 			...pattern,
-			blocks: parse( pattern.content, {
-				__unstableSkipMigrationLogs: true,
-			} ),
+			// Only parse the content if needed (if the blocks property is
+			// accessed), and cache the result.
+			get blocks() {
+				const parsedContent = parse( pattern.content, {
+					__unstableSkipMigrationLogs: true,
+				} );
+				parsedPattern.blocks = parsedContent;
+				return parsedContent;
+			},
 		};
+
+		return parsedPattern;
 	},
 	( state ) => [
 		state.settings.__experimentalBlockPatterns,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently patterns are parsed, regardless of whether it's needed. In many cases a set or subset of patterns are requested without the need for its content. We can "lazy" parse the content by converting the property to a getter, and cache the result for subsequent access.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
