### PR TITLE
DataViews: Backing template data view with session storage

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -35,6 +35,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  * Internal dependencies
  */
 import Page from '../page';
+import { useStateWithSessionStorage } from '../page/utils';
 import Link from '../routes/link';
 import AddNewTemplate from '../add-new-template';
 import { useAddedBy, AvatarImage } from '../list/added-by';
@@ -168,11 +169,17 @@ function TemplatePreview( { content, viewType } ) {
 
 export default function DataviewsTemplates() {
 	const [ templateId, setTemplateId ] = useState( null );
-	const [ view, setView ] = useState( DEFAULT_VIEW );
-	const { records: allTemplates, isResolving: isLoadingData } =
-		useEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
-			per_page: -1,
-		} );
+	const [ view, setView ] = useStateWithSessionStorage(
+		'page-templates-view-config',
+		DEFAULT_VIEW
+	);
+	const {
+		records: allTemplates,
+		hasResolved: hasLoadedData,
+		isResolving: isLoadingData,
+	} = useEntityRecords( 'postType', TEMPLATE_POST_TYPE, {
+		per_page: -1,
+	} );
 	const history = useHistory();
 
 	const onSelectionChange = useCallback(
@@ -334,6 +341,11 @@ export default function DataviewsTemplates() {
 
 	const onChangeView = useCallback(
 		( newView ) => {
+			// The data view consumer can send back a new view if
+			// it receives empty or incomplete data, so while we're
+			// waiting for that to load we'll ignore any updates.
+			if ( ! hasLoadedData || isLoadingData ) return;
+
 			if ( newView.type !== view.type ) {
 				newView = {
 					...newView,
@@ -345,7 +357,7 @@ export default function DataviewsTemplates() {
 
 			setView( newView );
 		},
-		[ view.type, setView ]
+		[ view.type, setView, hasLoadedData, isLoadingData ]
 	);
 
 	return (

--- a/packages/edit-site/src/components/page/utils.js
+++ b/packages/edit-site/src/components/page/utils.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+
+const createStoredStateProvider = ( store ) => ( key, initialValue ) => {
+	const getValue = useCallback( () => {
+		// Bail if we're not in a browser context.
+		if ( typeof window === 'undefined' ) return initialValue;
+
+		try {
+			const value = window[ store ].getItem( key );
+			return value ? JSON.parse( value ) : initialValue;
+		} catch ( error ) {
+			return initialValue;
+		}
+	}, [ key, initialValue ] );
+
+	const [ storedValue, setStoredValue ] = useState( getValue );
+
+	const setValue = useCallback(
+		( value ) => {
+			// Bail if we're not in a browser context.
+			if ( typeof window === 'undefined' ) return;
+
+			try {
+				const newValue =
+					value instanceof Function ? value( storedValue ) : value;
+				window[ store ].setItem( key, JSON.stringify( newValue ) );
+				setStoredValue( newValue );
+			} catch ( error ) {}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[ key ]
+	);
+	return [ storedValue, setValue ];
+};
+
+export const useStateWithLocalStorage =
+	createStoredStateProvider( 'localStorage' );
+export const useStateWithSessionStorage =
+	createStoredStateProvider( 'sessionStorage' );


### PR DESCRIPTION
## What?

This PR adds `sessionStorage`-backed persistence to `useState`, and uses this new functionality in Templates views, so that view configuration is kept for the duration of the session.

> [!NOTE]
> This has only been applied to Templates; Pages and Patterns remain unaffected. It would be relatively straightforward to change them though if this idea works.


## Why?

When a user reloads the page, or follows a link then comes back, the view is currently reset to defaults. This means that the user must potentially adjust the layout, adjust the filters, and find the relevant page, in order to get back to the previous view. This is bad for UX and accessibility.


## How?

A new `useStateWithSessionStorage` function has been created, that operates in the same way as `useState`, but additionally stores the data in `window.sessionStorage` where available. The initial value is loaded from session storage if possible, otherwise the initial data is used in the same way as `useState`.

## To do

- [ ] Reset filters when exiting the data view?


## Testing Instructions

1. With the `New admin views` Gutenberg experiment enabled, navigate to Appearance > Editor > Templates > Manage all templates
2. Change some aspect of the view (layout, filter, etc) and reload the page
3. Confirm that the view configuration remains as you left it
4. (Reduce page size and) navigate to another page
5. Go back to the admin index
6. Navigate to Appearance > Editor > Templates > Manage all templates again
7. Confirm that the view options persist, but that the current page is reset to 1
   * Note that filters remain persisted; this is potentially confusing, and we may want to reset those.

### Testing Instructions for Keyboard

There is no user-facing change in this PR that affects keyboard usage.


## Screencast

https://github.com/WordPress/gutenberg/assets/159848/18bfcba4-8e97-4f02-8846-1fade50e3890