### PR TITLE
Font Families REST API endpoint: ensure unique font family slugs

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
@@ -381,20 +381,7 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 		$data['id']                 = $item->ID;
 		$data['theme_json_version'] = 2;
 		$data['parent']             = $item->post_parent;
-
-		$settings   = json_decode( $item->post_content, true );
-		$properties = $this->get_item_schema()['properties']['font_face_settings']['properties'];
-
-		// Provide required, empty settings if the post_content is not valid JSON.
-		if ( null === $settings ) {
-			$settings = array(
-				'fontFamily' => '',
-				'src'        => array(),
-			);
-		}
-
-		// Only return the properties defined in the schema.
-		$data['font_face_settings'] = array_intersect_key( $settings, $properties );
+		$data['font_face_settings'] = $this->get_settings_from_post( $item );
 
 		$response = rest_ensure_response( $data );
 		$links    = $this->prepare_links( $item );
@@ -747,5 +734,29 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 		}
 
 		return $new_path;
+	}
+
+	/**
+	 * Gets the font face's settings from the post.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_Post $post Font face post object.
+	 * @return array Font face settings array.
+	 */
+	protected function get_settings_from_post( $post ) {
+		$settings   = json_decode( $post->post_content, true );
+		$properties = $this->get_item_schema()['properties']['font_face_settings']['properties'];
+
+		// Provide required, empty settings if needed.
+		if ( null === $settings ) {
+			$settings = array(
+				'src' => array(),
+			);
+		}
+		$settings['fontFamily'] = $post->post_title ?? '';
+
+		// Only return the properties defined in the schema.
+		return array_intersect_key( $settings, $properties );
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -213,13 +213,13 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 		$settings = $request->get_param( 'font_family_settings' );
 
 		// Check that the font family slug is unique.
-			$existing_font_family = get_posts(
-				array(
-					'post_type'      => $this->post_type,
-					'posts_per_page' => 1,
-					'name'           => $settings['slug'],
-				)
-			);
+		$existing_font_family = get_posts(
+			array(
+				'post_type'      => $this->post_type,
+				'posts_per_page' => 1,
+				'name'           => $settings['slug'],
+			)
+		);
 		if ( ! empty( $existing_font_family ) ) {
 			return new WP_Error(
 				'rest_duplicate_font_family',
@@ -229,7 +229,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 			);
 		}
 
-			return parent::create_item( $request );
+		return parent::create_item( $request );
 	}
 
 	/**

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -193,6 +193,37 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Creates a single font family.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		$settings = $request->get_param( 'font_family_settings' );
+
+		// Check that the font family slug is unique.
+			$existing_font_family = get_posts(
+				array(
+					'post_type'      => $this->post_type,
+					'posts_per_page' => 1,
+					'name'           => $settings['slug'],
+				)
+			);
+		if ( ! empty( $existing_font_family ) ) {
+			return new WP_Error(
+				'rest_duplicate_font_family',
+				/* translators: %s: Font family slug. */
+				sprintf( __( 'A font family with slug "%s" already exists.', 'gutenberg' ), $settings['slug'] ),
+				array( 'status' => WP_Http::CONFLICT )
+			);
+		}
+
+			return parent::create_item( $request );
+	}
+
+	/**
 	 * Deletes a single font family.
 	 *
 	 * @since 6.5.0

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -216,7 +216,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 				'rest_duplicate_font_family',
 				/* translators: %s: Font family slug. */
 				sprintf( __( 'A font family with slug "%s" already exists.', 'gutenberg' ), $settings['slug'] ),
-				array( 'status' => WP_Http::CONFLICT )
+				array( 'status' => 400 )
 			);
 		}
 
@@ -380,6 +380,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 			'page'     => $params['page'],
 			'per_page' => $params['per_page'],
 			'search'   => $params['search'],
+			'slug'     => $params['slug'],
 		);
 	}
 

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -140,9 +140,18 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 		$schema   = $this->get_item_schema()['properties']['font_family_settings'];
 		$required = $schema['required'];
 
-		// Allow setting individual properties if we are updating an existing font family.
 		if ( isset( $request['id'] ) ) {
+			// Allow sending individual properties if we are updating an existing font family.
 			unset( $schema['required'] );
+
+			// But don't allow updating the slug, since it is used as a unique identifier.
+			if ( isset( $settings['slug'] ) ) {
+				return new WP_Error(
+					'rest_invalid_param',
+					__( 'font_family_settings[slug] cannot be updated.', 'gutenberg' ),
+					array( 'status' => 400 )
+				);
+			}
 		}
 
 		// Check that the font face settings match the theme.json schema.

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -200,8 +200,8 @@ class WP_REST_Font_Faces_Controller_Test extends WP_Test_REST_Controller_Testcas
 		);
 
 		$empty_settings = array(
-			'fontFamily' => '',
 			'src'        => array(),
+			'fontFamily' => '',
 		);
 
 		wp_set_current_user( self::$admin_id );

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -272,7 +272,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 	 * @covers WP_REST_Font_Faces_Controller::create_item
 	 */
 	public function test_create_item() {
-		$settings = array_merge( self::$default_settings, array( 'slug' => 'test_create_item' ) );
+		$settings = array_merge( self::$default_settings, array( 'slug' => 'open-sans-2' ) );
 
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
@@ -295,7 +295,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 	 * @covers WP_REST_Font_Faces_Controller::validate_create_font_face_request
 	 */
 	public function test_create_item_default_theme_json_version() {
-		$settings = array_merge( self::$default_settings, array( 'slug' => 'test_create_item_theme_json' ) );
+		$settings = array_merge( self::$default_settings, array( 'slug' => 'open-sans-2' ) );
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
 		$request->set_param( 'font_family_settings', wp_json_encode( $settings ) );
@@ -356,7 +356,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 	public function data_create_item_with_default_preview() {
 		$default_settings = array(
 			'name'       => 'Open Sans',
-			'slug'       => 'create_item_with_default_preview',
+			'slug'       => 'open-sans-2',
 			'fontFamily' => '"Open Sans", sans-serif',
 		);
 		return array(
@@ -454,7 +454,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 	 * @covers WP_REST_Font_Faces_Controller::create_item
 	 */
 	public function test_create_item_no_permission() {
-		$settings = array_merge( self::$default_settings, array( 'slug' => 'test_create_item_no_permissions' ) );
+		$settings = array_merge( self::$default_settings, array( 'slug' => 'open-sans-2' ) );
 		wp_set_current_user( 0 );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
 		$request->set_param( 'font_family_settings', wp_json_encode( $settings ) );
@@ -490,7 +490,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 			'preview'    => 'https://s.w.org/images/fonts/16.9/previews/open-sans/open-sans-400-normal.svg',
 		);
 
-		$font_family_id = self::create_font_family_post( array( 'slug' => 'open-sans-update' ) );
+		$font_family_id = self::create_font_family_post( array( 'slug' => 'open-sans-2' ) );
 		$request        = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . $font_family_id );
 		$request->set_param(
 			'font_family_settings',
@@ -504,7 +504,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 
 		$expected_settings = array(
 			'name'       => $settings['name'],
-			'slug'       => 'open-sans-update',
+			'slug'       => 'open-sans-2',
 			'fontFamily' => $settings['fontFamily'],
 			'preview'    => $settings['preview'],
 		);

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -148,6 +148,23 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 	/**
 	 * @covers WP_REST_Font_Faces_Controller::get_items
 	 */
+	public function test_get_items_by_slug() {
+		$font_family = get_post( self::$font_family_id2 );
+
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/font-families' );
+		$request->set_param( 'slug', $font_family->post_name );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 1, $data );
+		$this->assertSame( $font_family->ID, $data[0]['id'] );
+	}
+
+	/**
+	 * @covers WP_REST_Font_Faces_Controller::get_items
+	 */
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-families' );
@@ -421,7 +438,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_duplicate_font_family', $response, 409 );
+		$this->assertErrorResponse( 'rest_duplicate_font_family', $response, 400 );
 		$expected_message = 'A font family with slug "helvetica" already exists.';
 		$message          = $response->as_error()->get_error_messages()[0];
 		$this->assertSame( $expected_message, $message );

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -88,7 +88,12 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 					'post_status'  => 'publish',
 					'post_title'   => $settings['name'],
 					'post_name'    => $settings['slug'],
-					'post_content' => wp_json_encode( $settings ),
+					'post_content' => wp_json_encode(
+						array(
+							'fontFamily' => $settings['fontFamily'],
+							'preview'    => $settings['preview'],
+						)
+					),
 				)
 			)
 		);
@@ -221,7 +226,8 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 
 		$empty_settings = array(
 			'name'       => '',
-			'slug'       => '',
+			// Slug will default to the post id.
+			'slug'       => (string) $font_family_id,
 			'fontFamily' => '',
 			'preview'    => '',
 		);
@@ -484,7 +490,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 			'preview'    => 'https://s.w.org/images/fonts/16.9/previews/open-sans/open-sans-400-normal.svg',
 		);
 
-		$font_family_id = self::create_font_family_post();
+		$font_family_id = self::create_font_family_post( array( 'slug' => 'open-sans-update' ) );
 		$request        = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . $font_family_id );
 		$request->set_param(
 			'font_family_settings',
@@ -498,7 +504,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 
 		$expected_settings = array(
 			'name'       => $settings['name'],
-			'slug'       => 'open-sans',
+			'slug'       => 'open-sans-update',
 			'fontFamily' => $settings['fontFamily'],
 			'preview'    => $settings['preview'],
 		);
@@ -768,7 +774,14 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 		$this->assertSame( $font_face_ids, $data['font_faces'] );
 
 		$this->assertArrayHasKey( 'font_family_settings', $data );
-		$this->assertSame( $post->post_content, wp_json_encode( $data['font_family_settings'] ) );
+		$settings          = $data['font_family_settings'];
+		$expected_settings = array(
+			'name'       => $post->post_title,
+			'slug'       => $post->post_name,
+			'fontFamily' => $settings['fontFamily'],
+			'preview'    => $settings['preview'],
+		);
+		$this->assertSame( $expected_settings, $settings );
 
 		$this->assertNotEmpty( $links );
 		$this->assertSame( rest_url( 'wp/v2/font-families/' . $post->ID ), $links['self'][0]['href'] );


### PR DESCRIPTION
## What?

Better slug handling for `wp/v2/font-families` and `wp/v2/font-families/<id>` endpoints

- Ensure a unique slug when creating a new font family
- Disallow changing the slug for existing font families
- Allow querying for a font family by slug using `wp/v2/font-families?slug=`
- Removed duplicate data storage so that settings stored outside of post_content are removed before JSON encoding (e.g. font family slug is stored as `post_name`, so the slug is not duplicated in the json encoded post_content)

## Why?

Slugs are a secondary unique identifier for font families, so should be unique. Part of https://github.com/WordPress/gutenberg/issues/55278.


## Testing Instructions

- Check that you cannot creating a font family (`POST wp/v2/font-families`) providing `font_family_settings[slug]` that is already in use.
- Check that you cannot update (`POST wp/v2/font-families/<id>`) the slug for an existing font family
- Check that you can query for font families by slug (`wp/v2/font-families?slug=`)
