### PR TITLE
CustomSelect: adjust `renderSelectedValue` to fix sizing

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Experimental
 
 -   `BoxControl`: Update design ([#56665](https://github.com/WordPress/gutenberg/pull/56665)).
+-   `CustomSelect`: adjust `renderSelectedValue` to fix sizing ([#57865](https://github.com/WordPress/gutenberg/pull/57865)).
 
 ## 25.15.0 (2024-01-10)
 

--- a/packages/components/src/custom-select-control-v2/index.tsx
+++ b/packages/components/src/custom-select-control-v2/index.tsx
@@ -49,7 +49,7 @@ export function CustomSelect( {
 	onChange,
 	size = 'default',
 	value,
-	renderSelectedValue = defaultRenderSelectedValue,
+	renderSelectedValue,
 	...props
 }: WordPressComponentProps< CustomSelectProps, 'button', false > ) {
 	const store = Ariakit.useSelectStore( {
@@ -59,6 +59,9 @@ export function CustomSelect( {
 	} );
 
 	const { value: currentValue } = store.useState();
+
+	const computedRenderSelectedValue =
+		renderSelectedValue ?? defaultRenderSelectedValue;
 
 	return (
 		<>
@@ -71,7 +74,7 @@ export function CustomSelect( {
 				hasCustomRenderProp={ !! renderSelectedValue }
 				store={ store }
 			>
-				{ renderSelectedValue( currentValue ) }
+				{ computedRenderSelectedValue( currentValue ) }
 				<Ariakit.SelectArrow />
 			</Styled.CustomSelectButton>
 			<Styled.CustomSelectPopover gutter={ 12 } store={ store } sameWidth>

--- a/packages/components/src/custom-select-control-v2/index.tsx
+++ b/packages/components/src/custom-select-control-v2/index.tsx
@@ -23,25 +23,6 @@ import type { WordPressComponentProps } from '../context';
 export const CustomSelectContext =
 	createContext< CustomSelectContextType >( undefined );
 
-function defaultRenderSelectedValue( value: CustomSelectProps[ 'value' ] ) {
-	const isValueEmpty = Array.isArray( value )
-		? value.length === 0
-		: value === undefined || value === null;
-
-	if ( isValueEmpty ) {
-		return __( 'Select an item' );
-	}
-
-	if ( Array.isArray( value ) ) {
-		return value.length === 1
-			? value[ 0 ]
-			: // translators: %s: number of items selected (it will always be 2 or more items)
-			  sprintf( __( '%s items selected' ), value.length );
-	}
-
-	return value;
-}
-
 export function CustomSelect( {
 	children,
 	defaultValue,
@@ -49,7 +30,7 @@ export function CustomSelect( {
 	onChange,
 	size = 'default',
 	value,
-	renderSelectedValue = defaultRenderSelectedValue,
+	renderSelectedValue,
 	...props
 }: WordPressComponentProps< CustomSelectProps, 'button', false > ) {
 	const store = Ariakit.useSelectStore( {
@@ -59,6 +40,25 @@ export function CustomSelect( {
 	} );
 
 	const { value: currentValue } = store.useState();
+
+	const defaultRenderSelectedValue = () => {
+		const isValueEmpty = Array.isArray( currentValue )
+			? currentValue.length === 0
+			: currentValue === undefined || currentValue === null;
+
+		if ( isValueEmpty ) {
+			return __( 'Select an item' );
+		}
+
+		if ( Array.isArray( currentValue ) ) {
+			return currentValue.length === 1
+				? currentValue[ 0 ]
+				: // translators: %s: number of items selected (it will always be 2 or more items)
+				  sprintf( __( '%s items selected' ), currentValue.length );
+		}
+
+		return currentValue;
+	};
 
 	return (
 		<>
@@ -71,7 +71,9 @@ export function CustomSelect( {
 				hasCustomRenderProp={ !! renderSelectedValue }
 				store={ store }
 			>
-				{ renderSelectedValue( currentValue ) }
+				{ renderSelectedValue
+					? renderSelectedValue( defaultRenderSelectedValue() )
+					: currentValue }
 				<Ariakit.SelectArrow />
 			</Styled.CustomSelectButton>
 			<Styled.CustomSelectPopover gutter={ 12 } store={ store } sameWidth>

--- a/packages/components/src/custom-select-control-v2/index.tsx
+++ b/packages/components/src/custom-select-control-v2/index.tsx
@@ -23,6 +23,25 @@ import type { WordPressComponentProps } from '../context';
 export const CustomSelectContext =
 	createContext< CustomSelectContextType >( undefined );
 
+function defaultRenderSelectedValue( value: CustomSelectProps[ 'value' ] ) {
+	const isValueEmpty = Array.isArray( value )
+		? value.length === 0
+		: value === undefined || value === null;
+
+	if ( isValueEmpty ) {
+		return __( 'Select an item' );
+	}
+
+	if ( Array.isArray( value ) ) {
+		return value.length === 1
+			? value[ 0 ]
+			: // translators: %s: number of items selected (it will always be 2 or more items)
+			  sprintf( __( '%s items selected' ), value.length );
+	}
+
+	return value;
+}
+
 export function CustomSelect( {
 	children,
 	defaultValue,
@@ -30,7 +49,7 @@ export function CustomSelect( {
 	onChange,
 	size = 'default',
 	value,
-	renderSelectedValue,
+	renderSelectedValue = defaultRenderSelectedValue,
 	...props
 }: WordPressComponentProps< CustomSelectProps, 'button', false > ) {
 	const store = Ariakit.useSelectStore( {
@@ -40,25 +59,6 @@ export function CustomSelect( {
 	} );
 
 	const { value: currentValue } = store.useState();
-
-	const defaultRenderSelectedValue = () => {
-		const isValueEmpty = Array.isArray( currentValue )
-			? currentValue.length === 0
-			: currentValue === undefined || currentValue === null;
-
-		if ( isValueEmpty ) {
-			return __( 'Select an item' );
-		}
-
-		if ( Array.isArray( currentValue ) ) {
-			return currentValue.length === 1
-				? currentValue[ 0 ]
-				: // translators: %s: number of items selected (it will always be 2 or more items)
-				  sprintf( __( '%s items selected' ), currentValue.length );
-		}
-
-		return currentValue;
-	};
 
 	return (
 		<>
@@ -71,9 +71,7 @@ export function CustomSelect( {
 				hasCustomRenderProp={ !! renderSelectedValue }
 				store={ store }
 			>
-				{ renderSelectedValue
-					? renderSelectedValue( defaultRenderSelectedValue() )
-					: currentValue }
+				{ renderSelectedValue( currentValue ) }
 				<Ariakit.SelectArrow />
 			</Styled.CustomSelectButton>
 			<Styled.CustomSelectPopover gutter={ 12 } store={ store } sameWidth>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When creating the component, [we introduced logic to have better default values](https://github.com/WordPress/gutenberg/pull/55790#discussion_r1403671214) for rendered select values. However, this affected the sizing styles, which relied on the boolean `hasCustomRenderProp` to check if `renderSelectedValue` is true or not. In trunk, `renderSelectedValue` will always return `true` so the styles aren't applying as expected. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To ensure the component size can be changed via the `size` prop. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

To fix this, we can remove `defaultRenderSelectedValue` as the default value for `renderSelectedValue` and instead invoke the function only when `renderSelectedValue` is `true`. 

If `renderSelectedValue` is `false`, the `currentValue` will be used, and if that is empty, Ariakit uses the first available value. 

## Testing Instructions
1. `npm run storybook:dev`
2. Go to `CustomSelectControl V2` story 
3. Ensure the styles for size `small` are applied to the 'Default' story (they won't apply to the other stories, where `hasCustomRenderProp` is `true`. 
