### PR TITLE
Fluid typography: do not calculate fluid font size when min and max viewport widths are equal

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -407,8 +407,10 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 		return null;
 	}
 
-	// Build CSS rule.
-	// Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
+	/*
+	 * Build CSS rule.
+	 * Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
+	 */
 	$view_port_width_offset = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
 	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $linear_factor_denominator ) );
 	$linear_factor_scaled   = round( $linear_factor * $scale_factor, 3 );

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -401,10 +401,16 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 		return null;
 	}
 
+	// Calculates the linear factor denominator. If it's 0, we cannot calculate a fluid value.
+	$linear_factor_denominator = $maximum_viewport_width['value'] - $minimum_viewport_width['value'];
+	if ( empty( $linear_factor_denominator ) ) {
+		return null;
+	}
+
 	// Build CSS rule.
 	// Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
 	$view_port_width_offset = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
-	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $maximum_viewport_width['value'] - $minimum_viewport_width['value'] ) );
+	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $linear_factor_denominator ) );
 	$linear_factor_scaled   = round( $linear_factor * $scale_factor, 3 );
 	$linear_factor_scaled   = empty( $linear_factor_scaled ) ? 1 : $linear_factor_scaled;
 	$fluid_target_font_size = implode( '', $minimum_font_size_rem ) . " + ((1vw - $view_port_width_offset) * $linear_factor_scaled)";

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -181,6 +181,13 @@ export function getComputedFluidTypographyValue( {
 		return null;
 	}
 
+	// Calculates the linear factor denominator. If it's 0, we cannot calculate a fluid value.
+	const linearDenominator =
+		maximumViewportWidthParsed.value - minimumViewportWidthParsed.value;
+	if ( ! linearDenominator ) {
+		return null;
+	}
+
 	// Build CSS rule.
 	// Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
 	const minViewportWidthOffsetValue = roundToPrecision(
@@ -193,8 +200,7 @@ export function getComputedFluidTypographyValue( {
 	const linearFactor =
 		100 *
 		( ( maximumFontSizeParsed.value - minimumFontSizeParsed.value ) /
-			( maximumViewportWidthParsed.value -
-				minimumViewportWidthParsed.value ) );
+			linearDenominator );
 	const linearFactorScaled = roundToPrecision(
 		( linearFactor || 1 ) * scaleFactor,
 		3

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -64,6 +64,15 @@ describe( 'getComputedFluidTypographyValue()', () => {
 		);
 	} );
 
+	it( 'should return `null` when maximum and minimum viewport width are equal', () => {
+		const fluidTypographyValues = getComputedFluidTypographyValue( {
+			fontSize: '30px',
+			minimumViewportWidth: '500px',
+			maximumViewportWidth: '500px',
+		} );
+		expect( fluidTypographyValues ).toBeNull();
+	} );
+
 	it( 'should return a fluid font size when given a scale factor', () => {
 		const fluidTypographyValues = getComputedFluidTypographyValue( {
 			fontSize: '30px',

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -933,6 +933,16 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => 'clamp(50px, 3.125rem + ((1vw - 3.2px) * 7.353), 100px)',
 			),
+			'returns `null` when maximum and minimum viewport width are equal' => array(
+				'args'            => array(
+					'minimum_viewport_width' => '800px',
+					'maximum_viewport_width' => '800px',
+					'minimum_font_size'      => '50px',
+					'maximum_font_size'      => '100px',
+					'scale_factor'           => 1,
+				),
+				'expected_output' => null,
+			),
 			'returns `null` when `maximum_viewport_width` is an unsupported unit' => array(
 				'args'            => array(
 					'minimum_viewport_width' => '320px',


### PR DESCRIPTION
## What?
When the same value is provided for min and max viewport widths in the fluid typography config, return early.

Kudos to @josephscott for catching this.

Core patch:

- https://github.com/WordPress/wordpress-develop/pull/5875

## Why?

To avoid dividing by zero values. PHP will throw an error and, besides, the fluid typography clamp rule needs valid max and min viewport constraints.

Alternatives to this approach:

1. We could provide a fallback from the [default values](https://github.com/WordPress/gutenberg/blob/29cf213ee3a6a5ef39e768ec6de3e20873355d15/lib/block-supports/typography.php#L474-L474) in `gutenberg_get_typography_font_size_value()`, e.g., `1600 - 320`.

## Testing Instructions



The error is triggered when the min and max viewport widths are equal.

Here is some test theme.json

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"typography": {
			"fluid": {
				"minFontSize": "16px",
				"maxViewportWidth": "1640px",
				"minViewportWidth": "1640px"
			},
			"fontSizes": [
				{
					"name": "heading",
					"slug": "heading",
					"size": "20px"
				}
			]
		}
	},
}
```


Check that font-sizes are not fluid.

> [!IMPORTANT]
> In the Editor things will be appear broken because, via `wp-admin/edit-form-blocks.php` Core is running theme.json through the Theme_Json class, which will call Core `wp_` typography functions.

Here's the expected error:

<details>

<summary>PHP error in the editor</summary>

```
Fatal error: Uncaught DivisionByZeroError: Division by zero in /var/www/html/wp-includes/block-supports/typography.php:476 Stack trace: #0 /var/www/html/wp-includes/block-supports/typography.php(628): wp_get_computed_fluid_typography_value(Array) #1 /var/www/html/wp-includes/class-wp-theme-json.php(1732): wp_get_typography_font_size_value(Array) #2 /var/www/html/wp-includes/class-wp-theme-json.php(1812): WP_Theme_JSON::get_settings_values_by_slug(Array, Array, Array) #3 /var/www/html/wp-includes/class-wp-theme-json.php(1549): WP_Theme_JSON::compute_preset_vars(Array, Array) #4 /var/www/html/wp-includes/class-wp-theme-json.php(1087): WP_Theme_JSON->get_css_variables(Array, Array) #5 /var/www/html/wp-includes/global-styles-and-settings.php(206): WP_Theme_JSON->get_stylesheet(Array, Array) #6 /var/www/html/wp-includes/block-editor.php(511): wp_get_global_stylesheet(Array) #7 /var/www/html/wp-admin/edit-form-blocks.php(284): get_block_editor_settings(Array, Object(WP_Block_Editor_Context)) #8 /var/www/html/wp-admin/post.php(187): require('/var/www/html/w...') #9 {main} thrown in /var/www/html/wp-includes/block-supports/typography.php on line 476

```

</details>

There's a [Core patch](https://github.com/WordPress/wordpress-develop/pull/5875) you can run to get everything working.

E.g., if using `wp-env` use a `.wp-env.override.json` override file to point to the WordPress source 

```json
{
	"core": "../wordpress-develop/src",
	"plugins": [ "." ]
}
```


