### PR TITLE
Unify the Editor Mode Switcher, and enable it for template editing in the post editor

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -476,11 +476,11 @@ _Parameters_
 
 ### switchEditorMode
 
-Triggers an action used to switch editor mode.
+Sets the editor mode (for text editing or visual editing).
 
 _Parameters_
 
--   _mode_ `string`: The editor mode.
+-   _mode_ `'visual'|'text'`: The mode, either 'visual' or 'text'.
 
 ### toggleDistractionFree
 

--- a/docs/reference-guides/data/data-core-edit-site.md
+++ b/docs/reference-guides/data/data-core-edit-site.md
@@ -395,7 +395,11 @@ _Returns_
 
 ### switchEditorMode
 
-Undocumented declaration.
+Sets the editor mode (for text editing or visual editing).
+
+_Parameters_
+
+-   _mode_ `'visual'|'text'`: The mode, either 'visual' or 'text'.
 
 ### toggleDistractionFree
 

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -1,90 +1,37 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { editorPrivateApis, store as editorStore } from '@wordpress/editor';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import { store as editPostStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
 
-/**
- * Set of available mode options.
- *
- * @type {Array}
- */
-const MODES = [
-	{
-		value: 'visual',
-		label: __( 'Visual editor' ),
-	},
-	{
-		value: 'text',
-		label: __( 'Code editor' ),
-	},
-];
+const { DocumentTools: EditorModeSwitcher } = unlock( editorPrivateApis );
 
 function ModeSwitcher() {
-	const { shortcut, isRichEditingEnabled, isCodeEditingEnabled, mode } =
-		useSelect(
-			( select ) => ( {
-				shortcut: select(
-					keyboardShortcutsStore
-				).getShortcutRepresentation( 'core/edit-post/toggle-mode' ),
-				isRichEditingEnabled:
-					select( editorStore ).getEditorSettings()
-						.richEditingEnabled,
-				isCodeEditingEnabled:
-					select( editorStore ).getEditorSettings()
-						.codeEditingEnabled,
-				mode: select( editPostStore ).getEditorMode(),
-			} ),
-			[]
-		);
-	const { switchEditorMode } = useDispatch( editPostStore );
-
-	let selectedMode = mode;
-	if ( ! isRichEditingEnabled && mode === 'visual' ) {
-		selectedMode = 'text';
-	}
-	if ( ! isCodeEditingEnabled && mode === 'text' ) {
-		selectedMode = 'visual';
-	}
-
-	const choices = MODES.map( ( choice ) => {
-		if ( ! isCodeEditingEnabled && choice.value === 'text' ) {
-			choice = {
-				...choice,
-				disabled: true,
-			};
-		}
-		if ( ! isRichEditingEnabled && choice.value === 'visual' ) {
-			choice = {
-				...choice,
-				disabled: true,
-				info: __(
-					'You can enable the visual editor in your profile settings.'
-				),
-			};
-		}
-		if ( choice.value !== selectedMode && ! choice.disabled ) {
-			return { ...choice, shortcut };
-		}
-		return choice;
-	} );
+	const { shortcut, isRichEditingEnabled, isCodeEditingEnabled } = useSelect(
+		( select ) => ( {
+			shortcut: select(
+				keyboardShortcutsStore
+			).getShortcutRepresentation( 'core/edit-post/toggle-mode' ),
+			isRichEditingEnabled:
+				select( editorStore ).getEditorSettings().richEditingEnabled,
+			isCodeEditingEnabled:
+				select( editorStore ).getEditorSettings().codeEditingEnabled,
+		} ),
+		[]
+	);
 
 	return (
-		<MenuGroup label={ __( 'Editor' ) }>
-			<MenuItemsChoice
-				choices={ choices }
-				value={ selectedMode }
-				onSelect={ switchEditorMode }
-			/>
-		</MenuGroup>
+		<EditorModeSwitcher
+			shortcut={ shortcut }
+			isRichEditingEnabled={ isRichEditingEnabled }
+			isCodeEditingEnabled={ isCodeEditingEnabled }
+		/>
 	);
 }
 

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { editorPrivateApis, store as editorStore } from '@wordpress/editor';
+import {
+	privateApis as editorPrivateApis,
+	store as editorStore,
+} from '@wordpress/editor';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
@@ -10,7 +13,7 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
  */
 import { unlock } from '../../../lock-unlock';
 
-const { DocumentTools: EditorModeSwitcher } = unlock( editorPrivateApis );
+const { ModeSwitcher: EditorModeSwitcher } = unlock( editorPrivateApis );
 
 function ModeSwitcher() {
 	const { shortcut, isRichEditingEnabled, isCodeEditingEnabled } = useSelect(

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -5,9 +5,7 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { speak } from '@wordpress/a11y';
 import { store as noticesStore } from '@wordpress/notices';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import deprecated from '@wordpress/deprecated';
 import { addFilter } from '@wordpress/hooks';
@@ -188,33 +186,14 @@ export const toggleFeature =
 			.toggle( 'core/edit-post', feature );
 
 /**
- * Triggers an action used to switch editor mode.
+ * Sets the editor mode (for text editing or visual editing).
  *
- * @param {string} mode The editor mode.
+ * @param {'visual'|'text'} mode The mode, either 'visual' or 'text'.
  */
 export const switchEditorMode =
 	( mode ) =>
-	( { dispatch, registry } ) => {
-		registry.dispatch( preferencesStore ).set( 'core', 'editorMode', mode );
-
-		// Unselect blocks when we switch to the code editor.
-		if ( mode !== 'visual' ) {
-			registry.dispatch( blockEditorStore ).clearSelectedBlock();
-		}
-
-		if (
-			mode === 'text' &&
-			registry.select( preferencesStore ).get( 'core', 'distractionFree' )
-		) {
-			dispatch.toggleDistractionFree();
-		}
-
-		const message =
-			mode === 'visual'
-				? __( 'Visual editor selected' )
-				: __( 'Code editor selected' );
-		speak( message, 'assertive' );
-	};
+	( { registry } ) =>
+		registry.dispatch( editorStore ).setEditorMode( mode );
 
 /**
  * Triggers an action object used to toggle a plugin name flag.

--- a/packages/edit-site/src/components/header-edit-mode/mode-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/mode-switcher/index.js
@@ -13,12 +13,11 @@ import { unlock } from '../../../lock-unlock';
 const { DocumentTools: EditorModeSwitcher } = unlock( editorPrivateApis );
 
 function ModeSwitcher() {
-	const { shortcut } = useSelect(
-		( select ) => ( {
-			shortcut: select(
-				keyboardShortcutsStore
-			).getShortcutRepresentation( 'core/edit-site/toggle-mode' ),
-		} ),
+	const shortcut = useSelect(
+		( select ) =>
+			select( keyboardShortcutsStore ).getShortcutRepresentation(
+				'core/edit-site/toggle-mode'
+			),
 		[]
 	);
 

--- a/packages/edit-site/src/components/header-edit-mode/mode-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/mode-switcher/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { editorPrivateApis } from '@wordpress/editor';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
@@ -10,7 +10,7 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
  */
 import { unlock } from '../../../lock-unlock';
 
-const { DocumentTools: EditorModeSwitcher } = unlock( editorPrivateApis );
+const { ModeSwitcher: EditorModeSwitcher } = unlock( editorPrivateApis );
 
 function ModeSwitcher() {
 	const shortcut = useSelect(

--- a/packages/edit-site/src/components/header-edit-mode/mode-switcher/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/mode-switcher/index.js
@@ -1,60 +1,28 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { editorPrivateApis } from '@wordpress/editor';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
 
-/**
- * Set of available mode options.
- *
- * @type {Array}
- */
-const MODES = [
-	{
-		value: 'visual',
-		label: __( 'Visual editor' ),
-	},
-	{
-		value: 'text',
-		label: __( 'Code editor' ),
-	},
-];
+const { DocumentTools: EditorModeSwitcher } = unlock( editorPrivateApis );
 
 function ModeSwitcher() {
-	const { shortcut, mode } = useSelect(
+	const { shortcut } = useSelect(
 		( select ) => ( {
 			shortcut: select(
 				keyboardShortcutsStore
 			).getShortcutRepresentation( 'core/edit-site/toggle-mode' ),
-			mode: select( editSiteStore ).getEditorMode(),
 		} ),
 		[]
 	);
-	const { switchEditorMode } = useDispatch( editSiteStore );
 
-	const choices = MODES.map( ( choice ) => {
-		if ( choice.value !== mode ) {
-			return { ...choice, shortcut };
-		}
-		return choice;
-	} );
-
-	return (
-		<MenuGroup label={ __( 'Editor' ) }>
-			<MenuItemsChoice
-				choices={ choices }
-				value={ mode }
-				onSelect={ switchEditorMode }
-			/>
-		</MenuGroup>
-	);
+	return <EditorModeSwitcher shortcut={ shortcut } />;
 }
 
 export default ModeSwitcher;

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -11,7 +11,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
-import { speak } from '@wordpress/a11y';
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
@@ -500,30 +499,15 @@ export const closeGeneralSidebar =
 			.disableComplementaryArea( editSiteStoreName );
 	};
 
+/**
+ * Sets the editor mode (for text editing or visual editing).
+ *
+ * @param {'visual'|'text'} mode The mode, either 'visual' or 'text'.
+ */
 export const switchEditorMode =
 	( mode ) =>
-	( { dispatch, registry } ) => {
-		registry
-			.dispatch( 'core/preferences' )
-			.set( 'core', 'editorMode', mode );
-
-		// Unselect blocks when we switch to a non visual mode.
-		if ( mode !== 'visual' ) {
-			registry.dispatch( blockEditorStore ).clearSelectedBlock();
-		}
-
-		if ( mode === 'visual' ) {
-			speak( __( 'Visual editor selected' ), 'assertive' );
-		} else if ( mode === 'text' ) {
-			const isDistractionFree = registry
-				.select( preferencesStore )
-				.get( 'core', 'distractionFree' );
-			if ( isDistractionFree ) {
-				dispatch.toggleDistractionFree();
-			}
-			speak( __( 'Code editor selected' ), 'assertive' );
-		}
-	};
+	( { registry } ) =>
+		registry.dispatch( editorStore ).setEditorMode( mode );
 
 /**
  * Sets whether or not the editor allows only page content to be edited.

--- a/packages/editor/src/components/mode-switcher/index.js
+++ b/packages/editor/src/components/mode-switcher/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -33,7 +34,9 @@ function ModeSwitcher( {
 } ) {
 	const { mode } = useSelect(
 		( select ) => ( {
-			mode: select( editorStore ).getEditorMode(),
+			mode:
+				select( preferencesStore ).get( 'core', 'editorMode' ) ??
+				'visual',
 		} ),
 		[]
 	);

--- a/packages/editor/src/components/mode-switcher/index.js
+++ b/packages/editor/src/components/mode-switcher/index.js
@@ -10,6 +10,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Set of available mode options.
@@ -40,7 +41,7 @@ function ModeSwitcher( {
 		} ),
 		[]
 	);
-	const { switchEditorMode } = useDispatch( editorStore );
+	const { setEditorMode } = unlock( useDispatch( editorStore ) );
 
 	let selectedMode = mode;
 	if ( ! isRichEditingEnabled && mode === 'visual' ) {
@@ -77,7 +78,7 @@ function ModeSwitcher( {
 			<MenuItemsChoice
 				choices={ choices }
 				value={ mode }
-				onSelect={ switchEditorMode }
+				onSelect={ setEditorMode }
 			/>
 		</MenuGroup>
 	);

--- a/packages/editor/src/components/mode-switcher/index.js
+++ b/packages/editor/src/components/mode-switcher/index.js
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+/**
+ * Set of available mode options.
+ *
+ * @type {Array}
+ */
+const MODES = [
+	{
+		value: 'visual',
+		label: __( 'Visual editor' ),
+	},
+	{
+		value: 'text',
+		label: __( 'Code editor' ),
+	},
+];
+
+function ModeSwitcher( {
+	shortcut,
+	isCodeEditingEnabled = true,
+	isRichEditingEnabled = true,
+} ) {
+	const { mode } = useSelect(
+		( select ) => ( {
+			mode: select( editorStore ).getEditorMode(),
+		} ),
+		[]
+	);
+	const { switchEditorMode } = useDispatch( editorStore );
+
+	let selectedMode = mode;
+	if ( ! isRichEditingEnabled && mode === 'visual' ) {
+		selectedMode = 'text';
+	}
+	if ( ! isCodeEditingEnabled && mode === 'text' ) {
+		selectedMode = 'visual';
+	}
+
+	const choices = MODES.map( ( choice ) => {
+		if ( ! isCodeEditingEnabled && choice.value === 'text' ) {
+			choice = {
+				...choice,
+				disabled: true,
+			};
+		}
+		if ( ! isRichEditingEnabled && choice.value === 'visual' ) {
+			choice = {
+				...choice,
+				disabled: true,
+				info: __(
+					'You can enable the visual editor in your profile settings.'
+				),
+			};
+		}
+		if ( choice.value !== selectedMode && ! choice.disabled ) {
+			return { ...choice, shortcut };
+		}
+		return choice;
+	} );
+
+	return (
+		<MenuGroup label={ __( 'Editor' ) }>
+			<MenuItemsChoice
+				choices={ choices }
+				value={ mode }
+				onSelect={ switchEditorMode }
+			/>
+		</MenuGroup>
+	);
+}
+
+export default ModeSwitcher;

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -10,6 +10,7 @@ import useBlockEditorSettings from './components/provider/use-block-editor-setti
 import DocumentTools from './components/document-tools';
 import InserterSidebar from './components/inserter-sidebar';
 import ListViewSidebar from './components/list-view-sidebar';
+import ModeSwitcher from './components/mode-switcher';
 import PluginPostExcerpt from './components/post-excerpt/plugin';
 import PostPanelRow from './components/post-panel-row';
 import PostViewLink from './components/post-view-link';
@@ -25,6 +26,7 @@ lock( privateApis, {
 	EntitiesSavedStatesExtensible,
 	InserterSidebar,
 	ListViewSidebar,
+	ModeSwitcher,
 	PluginPostExcerpt,
 	PostPanelRow,
 	PostViewLink,

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -108,4 +110,34 @@ export const hideBlockTypes =
 		registry
 			.dispatch( preferencesStore )
 			.set( 'core', 'hiddenBlockTypes', [ ...mergedBlockNames ] );
+	};
+
+/**
+ * Sets the editor mode (for text editing or visual editing).
+ *
+ * @param {'visual'|'text'} mode The mode, either 'visual' or 'text'.
+ */
+export const setEditorMode =
+	( mode ) =>
+	( { dispatch, registry } ) => {
+		registry
+			.dispatch( 'core/preferences' )
+			.set( 'core', 'editorMode', mode );
+
+		// Unselect blocks when we switch to a non visual mode.
+		if ( mode !== 'visual' ) {
+			registry.dispatch( blockEditorStore ).clearSelectedBlock();
+		}
+
+		if ( mode === 'visual' ) {
+			speak( __( 'Visual editor selected' ), 'assertive' );
+		} else if ( mode === 'text' ) {
+			const isDistractionFree = registry
+				.select( preferencesStore )
+				.get( 'core', 'distractionFree' );
+			if ( isDistractionFree ) {
+				dispatch.toggleDistractionFree();
+			}
+			speak( __( 'Code editor selected' ), 'assertive' );
+		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to https://github.com/WordPress/gutenberg/pull/57700/files#r1446996419

One of the changes I made in https://github.com/WordPress/gutenberg/pull/57700 was to enable code editor mode when editing a template in the post editor.

As part of that I thought I'd tidy up some of the code, unifying it so that there's one mode switcher component.

On the way I noticed the `switchEditorMode` action works differently in the site editor compared to the post editor, and I'm not sure why. There is currently an issue in this PR where switch to the code editor causes a focus loss, so that may be why. It'll need to be fixed before this PR can be merged.

## Why?
There was both duplication and inconsistency before.

## How?
- Moves the `ModeSwitcher` component to the editor package (as a private API).
- Also adds a private `setEditorMode` action to the editor store that carries out a few steps (handles distraction free mode, makes a spoken announcement, clears the selected block).
- The edit-post and edit-site packages now use the above APIs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
