### PR TITLE
[RNMobile] Update Image component to avoid flicker when updating the URI

### DIFF
--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -255,12 +255,28 @@ const ImageComponent = ( {
 		shapeStyle,
 	];
 
+	// On iOS, add 1 to height to account for the 1px non-visible image
+	// that is used to determine when the network image has loaded
+	// We also must verify that it is not NaN, as it can be NaN when the image is loading.
+	// This is not necessary on Android as the non-visible image is not used.
+	let calculatedSelectedHeight;
+	if ( Platform.isIOS ) {
+		calculatedSelectedHeight =
+			containerSize && ! isNaN( containerSize.height )
+				? containerSize.height + 1
+				: 0;
+	} else {
+		calculatedSelectedHeight = containerSize?.height;
+	}
+
 	const imageSelectedStyles = [
 		usePreferredColorSchemeStyle(
 			styles.imageBorder,
 			styles.imageBorderDark
 		),
-		{ height: containerSize?.height },
+		{
+			height: calculatedSelectedHeight,
+		},
 	];
 
 	return (

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -85,28 +85,23 @@ const ImageComponent = ( {
 			} );
 
 			if ( url.startsWith( 'file:///' ) ) {
-				if ( ! isCurrent ) {
-					return;
-				}
-
-				if ( url !== localURL ) {
-					setNetworkImageLoaded( false );
-					setNetworkURL( false );
-				}
-
 				setLocalURL( url );
 			} else if ( url.startsWith( 'https://' ) ) {
 				if ( Platform.isIOS ) {
 					setNetworkURL( url );
 				} else if ( Platform.isAndroid ) {
-					const result = RNImage.prefetch( url );
-					if ( result ) {
-						if ( ! isCurrent ) {
-							return;
+					RNImage.prefetch( url ).then(
+						() => {
+							if ( ! isCurrent ) {
+								return;
+							}
+							setNetworkURL( url );
+							setNetworkImageLoaded( true );
+						},
+						() => {
+							// handle error
 						}
-						setNetworkURL( url );
-						setNetworkImageLoaded( true );
-					}
+					);
 				}
 			}
 		}

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -323,8 +323,7 @@ const ImageComponent = ( {
 										uri:
 											networkURL && networkImageLoaded
 												? networkURL
-												: ( localURL && localURL ) ||
-												  url,
+												: localURL || url,
 									} }
 									{ ...( ! focalPoint && {
 										resizeMethod: 'scale',

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -86,6 +86,8 @@ const ImageComponent = ( {
 
 			if ( url.startsWith( 'file:///' ) ) {
 				setLocalURL( url );
+				setNetworkURL( null );
+				setNetworkImageLoaded( false );
 			} else if ( url.startsWith( 'https://' ) ) {
 				if ( Platform.isIOS ) {
 					setNetworkURL( url );

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -85,6 +85,15 @@ const ImageComponent = ( {
 			} );
 
 			if ( url.startsWith( 'file:///' ) ) {
+				if ( ! isCurrent ) {
+					return;
+				}
+
+				if ( url !== localURL ) {
+					setNetworkImageLoaded( false );
+					setNetworkURL( false );
+				}
+
 				setLocalURL( url );
 			} else if ( url.startsWith( 'https://' ) ) {
 				if ( Platform.isIOS ) {
@@ -92,10 +101,11 @@ const ImageComponent = ( {
 				} else if ( Platform.isAndroid ) {
 					const result = RNImage.prefetch( url );
 					if ( result ) {
-						RNImage.prefetch( url ).then( () => {
-							setNetworkURL( url );
-							setNetworkImageLoaded( true );
-						} );
+						if ( ! isCurrent ) {
+							return;
+						}
+						setNetworkURL( url );
+						setNetworkImageLoaded( true );
 					}
 				}
 			}

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -305,6 +305,7 @@ const ImageComponent = ( {
 											resizeMethod: 'scale',
 										} ) }
 										resizeMode={ imageResizeMode }
+										testID={ `network-image-${ url }` }
 									/>
 								) }
 								{ ! networkImageLoaded && ! networkURL && (
@@ -334,6 +335,11 @@ const ImageComponent = ( {
 										resizeMethod: 'scale',
 									} ) }
 									resizeMode={ imageResizeMode }
+									testID={ `network-image-${
+										networkURL && networkImageLoaded
+											? networkURL
+											: localURL || url
+									}` }
 								/>
 								<Image
 									source={ { uri: networkURL } }

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -99,7 +99,11 @@ const ImageComponent = ( {
 							setNetworkImageLoaded( true );
 						},
 						() => {
-							// handle error
+							// This callback is called when the image fails to load,
+							// but these events are handled by `isUploadFailed`
+							// and `isUploadPaused` events instead.
+							//
+							// Ignoring the error event will persist the local image URI.
 						}
 					);
 				}

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -95,6 +95,7 @@ const ImageComponent = ( {
 							setLocalURL( url );
 						} );
 				} else {
+					setLocalURL( url );
 				}
 			}
 
@@ -213,12 +214,12 @@ const ImageComponent = ( {
 		focalPoint && styles.focalPointContainer,
 	];
 
-	const opacityValue = useRef( new Animated.Value( 0.3 ) ).current;
+	const opacityValue = useRef( new Animated.Value( 1 ) ).current;
 
 	useEffect( () => {
 		Animated.timing( opacityValue, {
 			toValue: isUploadInProgress ? 0.3 : 1,
-			duration: 200,
+			duration: 100,
 			useNativeDriver: true,
 		} ).start();
 	}, [ isUploadInProgress, opacityValue ] );
@@ -257,19 +258,6 @@ const ImageComponent = ( {
 		),
 		{ height: containerSize?.height },
 	];
-
-	const platformURI = Platform.isAndroid
-		? /* Android source prop */
-		  {
-				uri: networkURL || localURL || url,
-		  }
-		: /* iOS source prop */
-		  {
-				uri:
-					networkURL && networkImageLoaded
-						? networkURL
-						: ( localURL && localURL ) || url,
-		  };
 
 	return (
 		<View
@@ -310,22 +298,22 @@ const ImageComponent = ( {
 					<View style={ focalPoint && styles.focalPointContent }>
 						{ Platform.isAndroid && (
 							<>
-								{ networkImageLoaded && (
+								{ networkImageLoaded && networkURL && (
 									<Animated.Image
 										style={ imageStyles }
 										fadeDuration={ 0 }
-										source={ platformURI || localURL }
+										source={ { uri: networkURL } }
 										{ ...( ! focalPoint && {
 											resizeMethod: 'scale',
 										} ) }
 										resizeMode={ imageResizeMode }
 									/>
 								) }
-								{ ! networkImageLoaded && (
+								{ ! networkImageLoaded && ! networkURL && (
 									<Animated.Image
 										style={ imageStyles }
 										fadeDuration={ 0 }
-										source={ { uri: url } }
+										source={ { uri: localURL } }
 										{ ...( ! focalPoint && {
 											resizeMethod: 'scale',
 										} ) }
@@ -339,7 +327,11 @@ const ImageComponent = ( {
 								<Animated.Image
 									style={ imageStyles }
 									fadeDuration={ 0 }
-									source={ platformURI }
+									source={
+										networkURL && networkImageLoaded
+											? networkURL
+											: ( localURL && localURL ) || url
+									}
 									{ ...( ! focalPoint && {
 										resizeMethod: 'scale',
 									} ) }

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -280,12 +280,12 @@ const ImageComponent = ( {
 					<View style={ focalPoint && styles.focalPointContent }>
 						<Animated.Image
 							style={ imageStyles }
+							fadeDuration={ 0 }
 							source={ {
 								uri:
 									networkURL && networkImageLoaded
 										? networkURL
-										: ( localURL && localURL ) ||
-										  ( url && url ),
+										: ( localURL && localURL ) || url,
 							} }
 							{ ...( ! focalPoint && {
 								resizeMethod: 'scale',
@@ -294,7 +294,7 @@ const ImageComponent = ( {
 						/>
 						<Image
 							source={ networkURL }
-							style={ { height: 1, width: 1, opacity: 0 } }
+							style={ styles.nonVisibleImage }
 							onLoad={ () => {
 								setNetworkImageLoaded( true );
 							} }

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -84,22 +84,16 @@ const ImageComponent = ( {
 				}
 			} );
 
-			if ( Platform.isAndroid ) {
-				if ( url.startsWith( 'file:///' ) ) {
-					return setLocalURL( url );
-				} else if ( url.startsWith( 'https://' ) ) {
+			if ( url.startsWith( 'file:///' ) ) {
+				setLocalURL( url );
+			} else if ( url.startsWith( 'https://' ) ) {
+				if ( Platform.isAndroid ) {
 					RNImage.prefetch( url ).then( () => {
 						setNetworkURL( url );
 						setNetworkImageLoaded( true );
 					} );
-				}
-			}
-
-			if ( Platform.isIOS ) {
-				if ( url.startsWith( 'file:///' ) ) {
-					return setLocalURL( url );
-				} else if ( url.startsWith( 'https://' ) ) {
-					return setNetworkURL( url );
+				} else if ( Platform.isIOS ) {
+					setNetworkURL( url );
 				}
 			}
 		}
@@ -322,7 +316,6 @@ const ImageComponent = ( {
 							<>
 								<Animated.Image
 									style={ imageStyles }
-									fadeDuration={ 0 }
 									source={
 										networkURL && networkImageLoaded
 											? networkURL

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -87,13 +87,16 @@ const ImageComponent = ( {
 			if ( url.startsWith( 'file:///' ) ) {
 				setLocalURL( url );
 			} else if ( url.startsWith( 'https://' ) ) {
-				if ( Platform.isAndroid ) {
-					RNImage.prefetch( url ).then( () => {
-						setNetworkURL( url );
-						setNetworkImageLoaded( true );
-					} );
-				} else if ( Platform.isIOS ) {
+				if ( Platform.isIOS ) {
 					setNetworkURL( url );
+				} else if ( Platform.isAndroid ) {
+					const result = RNImage.prefetch( url );
+					if ( result ) {
+						RNImage.prefetch( url ).then( () => {
+							setNetworkURL( url );
+							setNetworkImageLoaded( true );
+						} );
+					}
 				}
 			}
 		}

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -316,18 +316,20 @@ const ImageComponent = ( {
 							<>
 								<Animated.Image
 									style={ imageStyles }
-									source={
-										networkURL && networkImageLoaded
-											? networkURL
-											: ( localURL && localURL ) || url
-									}
+									source={ {
+										uri:
+											networkURL && networkImageLoaded
+												? networkURL
+												: ( localURL && localURL ) ||
+												  url,
+									} }
 									{ ...( ! focalPoint && {
 										resizeMethod: 'scale',
 									} ) }
 									resizeMode={ imageResizeMode }
 								/>
 								<Image
-									source={ networkURL }
+									source={ { uri: networkURL } }
 									style={ styles.nonVisibleImage }
 									onLoad={ () => {
 										setNetworkImageLoaded( true );

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -85,17 +85,13 @@ const ImageComponent = ( {
 			} );
 
 			if ( Platform.isAndroid ) {
-				if ( url.startsWith( 'https://' ) ) {
-					RNImage.prefetch( url )
-						.then( () => {
-							setNetworkURL( url );
-							setNetworkImageLoaded( true );
-						} )
-						.catch( () => {
-							setLocalURL( url );
-						} );
-				} else {
-					setLocalURL( url );
+				if ( url.startsWith( 'file:///' ) ) {
+					return setLocalURL( url );
+				} else if ( url.startsWith( 'https://' ) ) {
+					RNImage.prefetch( url ).then( () => {
+						setNetworkURL( url );
+						setNetworkImageLoaded( true );
+					} );
 				}
 			}
 

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -171,3 +171,9 @@
 .wide {
 	width: 100%;
 }
+
+.nonVisibleImage {
+	height: 1;
+	width: 1;
+	opacity: 0;
+}

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -173,7 +173,7 @@
 }
 
 .nonVisibleImage {
-	height: 0;
-	width: 0;
+	height: 1;
+	width: 1;
 	opacity: 0;
 }

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -173,7 +173,7 @@
 }
 
 .nonVisibleImage {
-	height: 1;
-	width: 1;
+	height: 0;
+	width: 0;
 	opacity: 0;
 }

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -103,8 +103,10 @@ describe( 'Editor', () => {
 		await initializeEditor();
 
 		// Act
-		await act( () => mediaAppendCallback( MEDIA[ 0 ] ) );
-		await act( () => mediaAppendCallback( MEDIA[ 2 ] ) );
+		act( () => mediaAppendCallback( MEDIA[ 0 ] ) );
+		act( () => mediaAppendCallback( MEDIA[ 2 ] ) );
+		await screen.findByTestId( `network-image-${ MEDIA[ 0 ].serverUrl }` );
+		await screen.findByTestId( `network-image-${ MEDIA[ 2 ].serverUrl }` );
 
 		// Assert
 		expect( getEditorHtml() ).toMatchSnapshot();
@@ -122,10 +124,11 @@ describe( 'Editor', () => {
 		await initializeEditor();
 
 		// Act
-		await act( () => mediaAppendCallback( MEDIA[ 0 ] ) );
+		act( () => mediaAppendCallback( MEDIA[ 0 ] ) );
 		// Unsupported type (PDF file)
-		await act( () => mediaAppendCallback( MEDIA[ 1 ] ) );
-		await act( () => mediaAppendCallback( MEDIA[ 3 ] ) );
+		act( () => mediaAppendCallback( MEDIA[ 1 ] ) );
+		act( () => mediaAppendCallback( MEDIA[ 3 ] ) );
+		await screen.findByTestId( `network-image-${ MEDIA[ 0 ].serverUrl }` );
 
 		// Assert
 		expect( getEditorHtml() ).toMatchSnapshot();

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,6 +13,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [**] Image block media uploads display a custom error message when there is no internet connection [#56937]
 -   [*] Fix missing custom color indicator for custom gradients [#57605]
 -   [**] Display a notice when a network connection unavailable [#56934]
+-   [**] Prevent images from temporarily disappearing when uploading media [#57869]
 
 ## 1.110.0
 -   [*] [internal] Move InserterButton from components package to block-editor package [#56494]

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -284,6 +284,14 @@ jest.spyOn( Image, 'getSize' ).mockImplementation( ( url, success ) =>
 	success( 0, 0 )
 );
 
+jest.spyOn( Image, 'prefetch' ).mockImplementation(
+	( url, callback = () => {} ) => {
+		const mockRequestId = `mockRequestId-${ url }`;
+		callback( mockRequestId );
+		return Promise.resolve( true );
+	}
+);
+
 jest.mock( 'react-native/Libraries/Utilities/BackHandler', () => {
 	return jest.requireActual(
 		'react-native/Libraries/Utilities/__mocks__/BackHandler.js'


### PR DESCRIPTION
## What?
Fixes an issue where image uploads disappear or "blink" when transitioning from local to network states.

Related PRs:
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6550
* https://github.com/wordpress-mobile/WordPress-Android/pull/19963
* https://github.com/wordpress-mobile/WordPress-iOS/pull/22409

## Why?
Fixes:
* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6510
* https://github.com/wordpress-mobile/WordPress-iOS/issues/21358

Currently when uploading an Image, the Image itself "blinks" when transitioning its URI reference from a local on-device image to the uploaded, network-available image. This "blink" is possibly due to the time spent downloading the network-available resource itself, where the visual asset appears unavailable while the network image is downloading.

## How?
Adds more descriptive states when a `uri` is changed to await the full loading of a network-based image, before swapping out the URI from the local filestore-based image.

## Testing Instructions
1. Create a post and add an Image or Gallery block
2. Select "Choose from Device" from the media upload options and upload an image
3. When the image has been uploaded, observe that it does not blink or disappear when transitioning to full opacity

## Screenshots or screencast <!-- if applicable -->
Before | After
-|-
<img alt="A gif of an image blinking" src="https://github.com/WordPress/gutenberg/assets/643285/c77768d1-6e46-41b0-8ebe-64f74104bdb5" /> | <img alt="A gif of an image with a smooth transition" src="https://github.com/WordPress/gutenberg/assets/643285/d265fcca-63c1-4267-8956-f2013a4defd4" />


