### PR TITLE
Global Styles: Correctly decode border color values

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -85,8 +85,10 @@ export default function BorderPanel( {
 	defaultControls = DEFAULT_CONTROLS,
 } ) {
 	const colors = useColorsPerOrigin( settings );
-	const decodeValue = ( rawValue ) =>
-		getValueFromVariable( { settings }, '', rawValue );
+	const decodeValue = useCallback(
+		( rawValue ) => getValueFromVariable( { settings }, '', rawValue ),
+		[ settings ]
+	);
 	const encodeColorValue = ( colorValue ) => {
 		const allColors = colors.flatMap(
 			( { colors: originColors } ) => originColors
@@ -98,25 +100,13 @@ export default function BorderPanel( {
 			? 'var:preset|color|' + colorObject.slug
 			: colorValue;
 	};
-	const decodeColorValue = useCallback(
-		( colorValue ) => {
-			const allColors = colors.flatMap(
-				( { colors: originColors } ) => originColors
-			);
-			const colorObject = allColors.find(
-				( { slug } ) => colorValue === 'var:preset|color|' + slug
-			);
-			return colorObject ? colorObject.color : colorValue;
-		},
-		[ colors ]
-	);
 	const border = useMemo( () => {
 		if ( hasSplitBorders( inheritedValue?.border ) ) {
 			const borderValue = { ...inheritedValue?.border };
 			[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => {
 				borderValue[ side ] = {
 					...borderValue[ side ],
-					color: decodeColorValue( borderValue[ side ]?.color ),
+					color: decodeValue( borderValue[ side ]?.color ),
 				};
 			} );
 			return borderValue;
@@ -124,10 +114,10 @@ export default function BorderPanel( {
 		return {
 			...inheritedValue?.border,
 			color: inheritedValue?.border?.color
-				? decodeColorValue( inheritedValue?.border?.color )
+				? decodeValue( inheritedValue?.border?.color )
 				: undefined,
 		};
-	}, [ inheritedValue?.border, decodeColorValue ] );
+	}, [ inheritedValue?.border, decodeValue ] );
 	const setBorder = ( newBorder ) =>
 		onChange( { ...value, border: newBorder } );
 	const showBorderColor = useHasBorderColorControl( settings );


### PR DESCRIPTION
Fixes #52733

## What?
This PR fixes an issue where border color checkmarks are missing in the Global Styles.

https://github.com/WordPress/gutenberg/assets/54422211/c787b144-6708-43ec-bd43-175f0193a435

## Why?

With the current logic, the border color is decoded as follows:

- Pass the color value to the `decodeColorValue()` function
- In the `decodeColorValue()` function, find the color that matches the format `'var:preset|color|' + slug` among all colors.
- If there is a match, return the value of that color

However, when the Global Style is saved after the palette is selected, the color value is converted to a format called `var(--wp--preset--color--{slug})`.
This format no longer matches the `'var:preset|color|' + slug` format, so the color cannot be found and converted to the actual color value. As a result, the color popover recognizes it as a custom color and does not check the original palette.

## How?

Instead of the `decodeColorValue()` function, simply use the `decodeValue()` function.

My understanding is that when decoding a color, there is no need to consider whether the current color exists in color palettes. We should simply convert the color slug to the corresponding color value via `decodeValue()`.


## Testing Instructions

- Go to the Site Editor > Global Styles > Blocks > Button.
- In the Border panel, select a color palette.
- Save the Global styles.
- Reopen the border color palette.
- The expected palette should be selected.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/cc182c61-eddd-447a-96bd-c0d3dcd8e74c


