### PR TITLE
Interactivity API: Prevent the use of components in `wp-text`

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/render.php
@@ -34,4 +34,18 @@ gutenberg_enqueue_module( 'directive-text-view' );
 			Toggle Context Text
 		</button>
 	</div>
+	<div>
+		<span
+			data-wp-text="state.component"
+			data-testid="show state component"
+		></span>
+		<span
+			data-wp-text="state.number"
+			data-testid="show state number"
+		></span>
+		<span
+			data-wp-text="state.boolean"
+			data-testid="show state boolean"
+		></span>
+	</div>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/view.js
@@ -1,11 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext } from '@wordpress/interactivity';
+import { store, getContext, createElement } from '@wordpress/interactivity';
 
 const { state } = store( 'directive-context', {
 	state: {
 		text: 'Text 1',
+		component: () => (createElement( 'div', {}, state.text )),
+		number: 1,
+		boolean: true
 	},
 	actions: {
 		toggleStateText() {

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Allow only strings for `wp-text`. ([#57879](https://github.com/WordPress/gutenberg/pull/57879))
+- Prevent the usage of Preact components in `wp-text`. ([#57879](https://github.com/WordPress/gutenberg/pull/57879))
 
 ### New Features
 

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Allow only strings for `wp-text`. ([#57879](https://github.com/WordPress/gutenberg/pull/57879))
+
 ### New Features
 
 -   Add the `data-wp-run` directive along with the `useInit` and `useWatch` hooks. ([57805](https://github.com/WordPress/gutenberg/pull/57805))

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -331,11 +331,9 @@ export default () => {
 	directive( 'text', ( { directives: { text }, element, evaluate } ) => {
 		const entry = text.find( ( { suffix } ) => suffix === 'default' );
 		try {
-			if ( typeof evaluate( entry ) === 'object' ) {
-				element.props.children = null;
-				return;
-			}
-			element.props.children = evaluate( entry ).toString();
+			const result = evaluate( entry );
+			element.props.children =
+				typeof result === 'object' ? null : result.toString();
 		} catch ( e ) {
 			element.props.children = null;
 		}

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -330,7 +330,9 @@ export default () => {
 	// data-wp-text
 	directive( 'text', ( { directives: { text }, element, evaluate } ) => {
 		const entry = text.find( ( { suffix } ) => suffix === 'default' );
-		element.props.children = evaluate( entry );
+		const evaluatedEntry = evaluate( entry );
+		if ( typeof evaluatedEntry !== 'string' ) return null;
+		element.props.children = evaluatedEntry;
 	} );
 
 	// data-wp-slot

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -331,6 +331,10 @@ export default () => {
 	directive( 'text', ( { directives: { text }, element, evaluate } ) => {
 		const entry = text.find( ( { suffix } ) => suffix === 'default' );
 		try {
+			if ( typeof evaluate( entry ) === 'object' ) {
+				element.props.children = null;
+				return;
+			}
 			element.props.children = evaluate( entry ).toString();
 		} catch ( e ) {
 			element.props.children = null;

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -330,9 +330,11 @@ export default () => {
 	// data-wp-text
 	directive( 'text', ( { directives: { text }, element, evaluate } ) => {
 		const entry = text.find( ( { suffix } ) => suffix === 'default' );
-		const evaluatedEntry = evaluate( entry );
-		if ( typeof evaluatedEntry !== 'string' ) return null;
-		element.props.children = evaluatedEntry;
+		try {
+			element.props.children = evaluate( entry ).toString();
+		} catch ( e ) {
+			element.props.children = null;
+		}
 	} );
 
 	// data-wp-slot

--- a/test/e2e/specs/interactivity/directives-text.spec.ts
+++ b/test/e2e/specs/interactivity/directives-text.spec.ts
@@ -34,12 +34,12 @@ test.describe( 'data-wp-text', () => {
 		await expect( el ).toHaveText( 'Text 1' );
 	} );
 
-	test( 'work only with strings', async ( { page } ) => {
+	test( 'Transforms results into strings', async ( { page } ) => {
 		const elObject = page.getByTestId( 'show state component' );
 		await expect( elObject ).toBeHidden();
 		const elNumber = page.getByTestId( 'show state number' );
-		await expect( elNumber ).toBeHidden();
+		await expect( elNumber ).toHaveText( '1' );
 		const elBool = page.getByTestId( 'show state boolean' );
-		await expect( elBool ).toBeHidden();
+		await expect( elBool ).toHaveText( 'true' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/directives-text.spec.ts
+++ b/test/e2e/specs/interactivity/directives-text.spec.ts
@@ -33,4 +33,13 @@ test.describe( 'data-wp-text', () => {
 		await page.getByTestId( 'toggle context text' ).click();
 		await expect( el ).toHaveText( 'Text 1' );
 	} );
+
+	test( 'work only with strings', async ( { page } ) => {
+		const elObject = page.getByTestId( 'show state component' );
+		await expect( elObject ).toBeHidden();
+		const elNumber = page.getByTestId( 'show state number' );
+		await expect( elNumber ).toBeHidden();
+		const elBool = page.getByTestId( 'show state boolean' );
+		await expect( elBool ).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allow only returning types that have a `toString()` when using the wp-directive-text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To prevent screens showing undefineds and [Object Object] if the developer makes a type mistake.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Returning null if type is different from a string.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Automatic tests are included.

PD: Question from @DAreRodz: should we allow numbers?

CC: @luisherranz
