### PR TITLE
Automate creation of Issue for major release PHP synchronisation

### DIFF
--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -426,7 +426,7 @@ function formatPRLine( { pullRequest: pr, isBeforeLastRCDate } ) {
 	return `- [ ] ${ pr.url } - @${
 		pr.creator
 	} | Trac ticket | Core backport PR ${
-		isBeforeLastRCDate && '(⚠️ Check for existing backport in Trac)'
+		isBeforeLastRCDate ? '(⚠️ Check for existing backport in Trac)' : ''
 	}\n`;
 }
 

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -24,6 +24,8 @@ const IGNORED_PATHS = [
 	'packages/block-library', // this is handled automatically.
 ];
 
+const MAX_NESTING_LEVEL = 3;
+
 const DEBUG = !! getArg( 'debug' );
 
 const __filename = fileURLToPath( import.meta.url );
@@ -118,7 +120,7 @@ async function main() {
 
 	const processResult = pipe(
 		processCommits,
-		removeNesting,
+		reduceNesting,
 		dedupePRsPerLevel,
 		removeEmptyLevels,
 		sortLevels
@@ -266,14 +268,14 @@ function dedupePRsPerLevel( data ) {
 	return processLevel( data );
 }
 
-function removeNesting( data, maxLevel = 3 ) {
+function reduceNesting( data ) {
 	function processLevel( levelData, level = 1 ) {
 		const processedData = {};
 
 		for ( const [ key, value ] of Object.entries( levelData ) ) {
 			if ( Array.isArray( value ) ) {
 				processedData[ key ] = value;
-			} else if ( level < maxLevel ) {
+			} else if ( level < MAX_NESTING_LEVEL ) {
 				processedData[ key ] = processLevel( value, level + 1 );
 			} else {
 				processedData[ key ] = flattenData( value );

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -19,8 +19,9 @@ const OWNER = 'wordpress';
 const REPO = 'gutenberg';
 
 const IGNORED_PATHS = [
-	'lib/experiments-page.php',
-	'packages/e2e-tests/plugins',
+	'lib/load.php', // plugin specific code.
+	'lib/experiments-page.php', // experiments are plugin specific.
+	'packages/e2e-tests/plugins', // PHP files related to e2e tests only.
 	'packages/block-library', // this is handled automatically.
 ];
 

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -155,12 +155,19 @@ async function octokitRequest( method = '', params = {}, settings = {} ) {
 
 	const requestType = settings?.paginate ? 'paginate' : 'request';
 
-	const result = await octokit[ requestType ]( method, params );
+	try {
+		const result = await octokit[ requestType ]( method, params );
 
-	if ( requestType === 'paginate' ) {
-		return result;
+		if ( requestType === 'paginate' ) {
+			return result;
+		}
+		return result.data;
+	} catch ( error ) {
+		console.error(
+			`Error making request to ${ method }: ${ error.message }`
+		);
+		process.exit( 1 );
 	}
-	return result.data;
 }
 
 async function getAllCommitsFromPaths( since, paths ) {

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -67,7 +67,7 @@ async function main() {
 		}
 	} else {
 		console.error(
-			`Error. The --since argument is required (e.g. YYYY-MM-DD). This should be the date of the previous release's final RC.`
+			`Error. The --since argument is required (e.g. YYYY-MM-DD). This should be the date of the final Gutenberg release that was included in the last stable WP Core release (see https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/).`
 		);
 		process.exit( 1 );
 	}

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -158,12 +158,12 @@ async function main() {
 
 			// This is temporarily required because PRs merged between Beta 1 (since)
 			// and the final RC may have already been manually backported to Core.
-			// This is however no reliable way to identify these PRs as the `Cackport to WP beta/RC`
+			// This is however no reliable way to identify these PRs as the `Backport to WP beta/RC`
 			// label is manually removed once the PR has been backported.
-			// In future releases we will instead retain the label and add a **new** label
-			// to indicate the PR has been backported to Core.
+			// In future releases we will add a **new** label `Backported`
+			// to indicate the PR was backported to Core.
 			// As a result, in the future we will be able to exclude any PRs that have
-			// the `Backport to WP beta/RC` label.
+			// already been backported using the `Backported` label.
 			if ( isAfter( lastRcDate, commitData.commit.committer.date ) ) {
 				commitData.isBeforeLastRCDate = true;
 			}

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -425,6 +425,7 @@ async function getCommit( octokit, sha ) {
 	return commit;
 }
 
+// eslint-disable-next-line no-unused-vars
 async function getPullRequestDataForCommit( octokit, commitSha ) {
 	const { data: pullRequests } = await octokit.request(
 		'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -76,7 +76,7 @@ async function main() {
 	const paths = [ '/lib', '/packages/block-library', '/phpunit' ];
 
 	console.log( `• Fetching all commits made to ${ REPO } since: ${ since }` );
-	let commits = await getAllCommitsFromPaths( since, paths );
+	let commits = await fetchAllCommitsFromPaths( since, paths );
 
 	// Remove identical commits based on sha
 	commits = commits.reduce( ( acc, current ) => {
@@ -95,7 +95,7 @@ async function main() {
 	);
 	const commitsWithCommitData = await Promise.all(
 		commits.map( async ( commit ) => {
-			const commitData = await getCommit( commit.sha );
+			const commitData = await fetchCommit( commit.sha );
 
 			// Our Issue links to the PRs associated with the commits so we must
 			// provide this data. We could also get the PR data from the commit data,
@@ -170,11 +170,11 @@ async function octokitRequest( method = '', params = {}, settings = {} ) {
 	}
 }
 
-async function getAllCommitsFromPaths( since, paths ) {
+async function fetchAllCommitsFromPaths( since, paths ) {
 	let commits = [];
 
 	for ( const path of paths ) {
-		const pathCommits = await getAllCommits( since, path );
+		const pathCommits = await fetchAllCommits( since, path );
 		commits = [ ...commits, ...pathCommits ];
 	}
 
@@ -425,7 +425,7 @@ function generateIssueContent( result, level = 1 ) {
 	return issueContent;
 }
 
-async function getAllCommits( since, path ) {
+async function fetchAllCommits( since, path ) {
 	return await octokitPaginate( 'GET /repos/{owner}/{repo}/commits', {
 		since,
 		per_page: 30,
@@ -433,7 +433,7 @@ async function getAllCommits( since, path ) {
 	} );
 }
 
-async function getCommit( sha ) {
+async function fetchCommit( sha ) {
 	return octokitRequest( 'GET /repos/{owner}/{repo}/commits/{sha}', {
 		sha,
 	} );

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -329,12 +329,11 @@ function processCommits( commits ) {
 
 			let current = result;
 
-			// If the file is under 'phpunit', add it directly to the 'phpunit' key
-			// this is it's helpful to have a full list of commits that modify tests.
+			// If the file is under 'phpunit', always add it to the 'phpunit' key
+			// as it's helpful to have a full list of commits that modify tests.
 			if ( parts.includes( 'phpunit' ) ) {
 				current.phpunit = current.phpunit || [];
 				current.phpunit = [ ...current.phpunit, commit ];
-				return;
 			}
 
 			for ( let i = 0; i < parts.length; i++ ) {

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -21,6 +21,7 @@ const REPO = 'gutenberg';
 const IGNORED_PATHS = [
 	'lib/experiments-page.php',
 	'packages/e2e-tests/plugins',
+	'packages/block-library', // this is handled automatically.
 ];
 
 const DEBUG = !! getArg( 'debug' );
@@ -73,7 +74,7 @@ async function main() {
 	// These should be paths where we expect to find PHP files that
 	// will require syncing to WordPress Core. This list should be
 	// extremely selective.
-	const paths = [ '/lib', '/packages/block-library', '/phpunit' ];
+	const paths = [ '/lib', '/phpunit' ];
 
 	console.log( `• Fetching all commits made to ${ REPO } since: ${ since }` );
 	let commits = await fetchAllCommitsFromPaths( since, paths );

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -339,11 +339,6 @@ function processCommits( commits ) {
 			for ( let i = 0; i < parts.length; i++ ) {
 				const part = parts[ i ];
 
-				// Skip 'src' part under 'block-library'
-				if ( part === 'src' && parts[ i - 1 ] === 'block-library' ) {
-					continue;
-				}
-
 				if ( i === parts.length - 1 ) {
 					current[ part ] = current[ part ] || [];
 					current[ part ] = [ ...current[ part ], commit ];

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -1,0 +1,455 @@
+/**
+ * External dependencies
+ */
+
+import Octokit from '@octokit/rest';
+import fs from 'fs';
+
+import { fileURLToPath } from 'url';
+import nodePath, { dirname } from 'path';
+
+function getArg( argName ) {
+	const arg = process.argv.find( ( arg ) =>
+		arg.startsWith( `--${ argName }=` )
+	);
+	return arg ? arg.split( '=' )[ 1 ] : null;
+}
+
+const OWNER = 'wordpress';
+const REPO = 'gutenberg';
+
+const IGNORED_PATHS = [
+	'lib/experiments-page.php',
+	'packages/e2e-tests/plugins',
+];
+
+const DEBUG = false;
+
+const __filename = fileURLToPath( import.meta.url );
+const __dirname = dirname( __filename );
+
+async function main() {
+	const authToken = getArg( 'token' );
+	if ( ! authToken ) {
+		console.error( 'Aborted. The --token argument is required.' );
+		process.exit( 1 );
+	}
+
+	const since = getArg( 'since' );
+	if ( ! since ) {
+		console.error( 'Aborted. The --since argument is required.' );
+		process.exit( 1 );
+	}
+
+	console.log( 'Welcome to the PHP Sync Issue Generator!' );
+	const octokit = new Octokit( {
+		auth: authToken,
+	} );
+
+	console.log( '--------------------------------' );
+	console.log( '• Running script...' );
+
+	// These should be paths where we expect to find PHP files that
+	// will require syncing to WordPress Core. This list should be
+	// extremely selective.
+	const paths = [ '/lib', '/packages/block-library', '/phpunit' ];
+
+	console.log( `• Fetching all commits made to ${ REPO } since: ${ since }` );
+	let commits = await getAllCommitsFromPaths(
+		octokit,
+		OWNER,
+		REPO,
+		since,
+		paths
+	);
+
+	// Remove identical commits based on sha
+	commits = commits.reduce( ( acc, current ) => {
+		const x = acc.find( ( item ) => item.sha === current.sha );
+		if ( ! x ) {
+			return acc.concat( [ current ] );
+		}
+		return acc;
+	}, [] );
+
+	// Fetch the full commit data for each of the commits.
+	// This is because the /commits endpoint does not include the
+	// information about the `files` modified in the commit.
+	console.log(
+		`• Fetching full commit data for ${ commits.length } commits`
+	);
+	const commitsWithCommitData = await Promise.all(
+		commits.map( async ( commit ) => {
+			const commitData = await getCommit( octokit, commit.sha );
+
+			// Our Issue links to the PRs associated with the commits so we must
+			// provide this data. We could also get the PR data from the commit data,
+			// using getPullRequestDataForCommit, but that requires yet another
+			// network request. Therefore we optimise for trying to build
+			// the PR URL from the commit data we have available.
+			const pullRequest = {
+				url: buildPRURL( commit ),
+				creator: commit?.author?.login || 'unknown',
+			};
+
+			if ( pullRequest ) {
+				commitData.pullRequest = pullRequest;
+			}
+
+			return commitData;
+		} )
+	);
+
+	const processResult = pipe(
+		processCommits,
+		removeNesting,
+		removeSinglePRLevels,
+		dedupePRsPerLevel,
+		removeEmptyLevels,
+		sortLevels
+	);
+
+	console.log( `• Processing ${ commitsWithCommitData.length } commits` );
+	const result = processResult( commitsWithCommitData );
+
+	console.log( `• Generating Issue content` );
+	const content = generateIssueContent( result );
+
+	// Write the Markdown content to a file
+	fs.writeFileSync( nodePath.join( __dirname, 'issueContent.md' ), content );
+}
+
+async function getAllCommitsFromPaths( octokit, owner, repo, since, paths ) {
+	let commits = [];
+
+	for ( const path of paths ) {
+		const pathCommits = await getAllCommits(
+			octokit,
+			owner,
+			repo,
+			since,
+			path
+		);
+		commits = [ ...commits, ...pathCommits ];
+	}
+
+	return commits;
+}
+
+function buildPRURL( commit ) {
+	const prIdMatch = commit.commit.message.match( /\(#(\d+)\)/ );
+	const prId = prIdMatch ? prIdMatch[ 1 ] : null;
+	return prId
+		? `https://github.com/WordPress/gutenberg/pull/${ prId }`
+		: `[Commit](${ commit.html_url })`;
+}
+
+function sortLevels( data ) {
+	function processLevel( levelData ) {
+		const processedData = {};
+
+		// Separate directories and files
+		const directories = {};
+		const files = {};
+
+		for ( const [ key, value ] of Object.entries( levelData ) ) {
+			if ( key.endsWith( '.php' ) ) {
+				files[ key ] = Array.isArray( value )
+					? value
+					: processLevel( value );
+			} else {
+				directories[ key ] = Array.isArray( value )
+					? value
+					: processLevel( value );
+			}
+		}
+
+		// Combine directories and files
+		Object.assign( processedData, directories, files );
+
+		return processedData;
+	}
+
+	return processLevel( data );
+}
+
+function removeEmptyLevels( data ) {
+	function processLevel( levelData ) {
+		const processedData = {};
+
+		for ( const [ key, value ] of Object.entries( levelData ) ) {
+			if ( Array.isArray( value ) ) {
+				if ( value.length > 0 ) {
+					processedData[ key ] = value;
+				}
+			} else {
+				const processedLevel = processLevel( value );
+				if ( Object.keys( processedLevel ).length > 0 ) {
+					processedData[ key ] = processedLevel;
+				}
+			}
+		}
+
+		return processedData;
+	}
+
+	return processLevel( data );
+}
+
+function dedupePRsPerLevel( data ) {
+	function processLevel( levelData ) {
+		const processedData = {};
+		const prSet = new Set();
+
+		for ( const [ key, value ] of Object.entries( levelData ) ) {
+			if ( Array.isArray( value ) ) {
+				processedData[ key ] = value.filter( ( commit ) => {
+					if ( ! prSet.has( commit.pullRequest.url ) ) {
+						prSet.add( commit.pullRequest.url );
+						return true;
+					}
+					return false;
+				} );
+			} else {
+				processedData[ key ] = processLevel( value );
+			}
+		}
+
+		return processedData;
+	}
+
+	return processLevel( data );
+}
+
+function removeSinglePRLevels( data ) {
+	function processLevel( levelData, parentData = null, parentKey = null ) {
+		const processedData = {};
+
+		for ( const [ key, value ] of Object.entries( levelData ) ) {
+			if ( Array.isArray( value ) ) {
+				if ( value.length === 1 && parentData && parentKey ) {
+					if ( ! Array.isArray( parentData[ parentKey ] ) ) {
+						parentData[ parentKey ] = [];
+					}
+					parentData[ parentKey ] = [
+						...parentData[ parentKey ],
+						...value,
+					];
+				} else {
+					processedData[ key ] = value;
+				}
+			} else {
+				processedData[ key ] = processLevel(
+					value,
+					processedData,
+					key
+				);
+			}
+		}
+
+		return processedData;
+	}
+
+	return processLevel( data );
+}
+
+function removeNesting( data, maxLevel = 3 ) {
+	function processLevel( levelData, level = 1 ) {
+		const processedData = {};
+
+		for ( const [ key, value ] of Object.entries( levelData ) ) {
+			if ( Array.isArray( value ) ) {
+				processedData[ key ] = value;
+			} else if ( level < maxLevel ) {
+				processedData[ key ] = processLevel( value, level + 1 );
+			} else {
+				processedData[ key ] = flattenData( value );
+			}
+		}
+
+		return processedData;
+	}
+
+	function flattenData( nestedData ) {
+		let flatData = [];
+
+		for ( const value of Object.values( nestedData ) ) {
+			if ( Array.isArray( value ) ) {
+				flatData = [ ...flatData, ...value ];
+			} else {
+				flatData = [ ...flatData, ...flattenData( value ) ];
+			}
+		}
+
+		return flatData;
+	}
+
+	return processLevel( data );
+}
+
+function processCommits( commits ) {
+	const result = {};
+
+	commits.forEach( ( commit ) => {
+		// Skip commits without an associated pull request
+		if ( ! commit.pullRequest ) {
+			return;
+		}
+		commit.files.forEach( ( file ) => {
+			// Skip files that are not PHP files.
+			if ( ! file.filename.endsWith( '.php' ) ) {
+				return;
+			}
+
+			// Skip files within specific packages.
+			if (
+				IGNORED_PATHS.some(
+					( path ) =>
+						file.filename.startsWith( path ) ||
+						file.filename === path
+				)
+			) {
+				return;
+			}
+
+			const parts = file.filename.split( '/' );
+			let current = result;
+
+			// If the file is under 'phpunit', add it directly to the 'phpunit' key
+			// this is it's helpful to have a full list of commits that modify tests.
+			if ( parts.includes( 'phpunit' ) ) {
+				current.phpunit = current.phpunit || [];
+				current.phpunit = [ ...current.phpunit, commit ];
+				return;
+			}
+
+			for ( let i = 0; i < parts.length; i++ ) {
+				const part = parts[ i ];
+
+				// Skip 'src' part under 'block-library'
+				if ( part === 'src' && parts[ i - 1 ] === 'block-library' ) {
+					continue;
+				}
+
+				if ( i === parts.length - 1 ) {
+					current[ part ] = current[ part ] || [];
+					current[ part ] = [ ...current[ part ], commit ];
+				} else {
+					current[ part ] = current[ part ] || {};
+					current = current[ part ];
+				}
+			}
+		} );
+	} );
+
+	return result;
+}
+
+function formatPRLine( pr ) {
+	return `- [ ] ${ pr.url } - @/${ pr.creator } | Trac ticket | Core backport PR\n`;
+}
+
+function formatHeading( level, key ) {
+	const emoji = key.endsWith( '.php' ) ? '📄' : '📁';
+	return `${ '#'.repeat( level ) } ${ emoji } ${ key }\n\n`;
+}
+
+function generateIssueContent( result, level = 1 ) {
+	let issueContent = '';
+	let isFirstSection = true;
+
+	for ( const [ key, value ] of Object.entries( result ) ) {
+		// Add horizontal rule divider between sections, but not before the first section
+		if ( level <= 2 && ! isFirstSection ) {
+			issueContent += '\n---\n';
+		}
+
+		issueContent += formatHeading( level, key );
+
+		if ( Array.isArray( value ) ) {
+			value.forEach( ( commit ) => {
+				issueContent += formatPRLine( commit.pullRequest );
+			} );
+		} else {
+			issueContent += generateIssueContent( value, level + 1 );
+		}
+
+		isFirstSection = false;
+	}
+
+	return issueContent;
+}
+
+async function getAllCommits( octokit, owner, repo, since, path ) {
+	let commits = [];
+	if ( DEBUG ) {
+		// just fetch the first 30 results using octokit.request
+		const { data } = await octokit.request(
+			'GET /repos/{owner}/{repo}/commits',
+			{
+				owner,
+				repo,
+				since,
+				per_page: 30,
+				path,
+			}
+		);
+
+		commits = data;
+	} else {
+		// The paginate method will fetch all pages of results from the API.
+		// We limit the total results because we only fetch commits
+		// since a certain date (via the "since" param).
+		commits = await octokit.paginate( 'GET /repos/{owner}/{repo}/commits', {
+			owner,
+			repo,
+			since,
+			per_page: 100,
+			path,
+		} );
+	}
+
+	return commits;
+}
+
+async function getCommit( octokit, sha ) {
+	const { data: commit } = await octokit.request(
+		'GET /repos/{owner}/{repo}/commits/{sha}',
+		{
+			owner: OWNER,
+			repo: REPO,
+			sha,
+		}
+	);
+
+	return commit;
+}
+
+async function getPullRequestDataForCommit( octokit, commitSha ) {
+	const { data: pullRequests } = await octokit.request(
+		'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
+		{
+			owner: OWNER,
+			repo: REPO,
+			commit_sha: commitSha,
+		}
+	);
+
+	// If a related Pull Request is found, return its URL and creator
+	if ( pullRequests.length > 0 ) {
+		const pullRequest = pullRequests[ 0 ];
+		return {
+			url: pullRequest.html_url,
+			creator: pullRequest.user.login,
+		};
+	}
+
+	return null;
+}
+
+const pipe =
+	( ...fns ) =>
+	( x ) =>
+		fns.reduce( ( v, f ) => f( v ), x );
+
+main();

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -426,7 +426,7 @@ function formatPRLine( { pullRequest: pr, isBeforeLastRCDate } ) {
 	return `- [ ] ${ pr.url } - @${
 		pr.creator
 	} | Trac ticket | Core backport PR ${
-		isBeforeLastRCDate ? '(⚠️ Check for existing backport in Trac)' : ''
+		isBeforeLastRCDate ? '(⚠️ Check for existing WP Core backport)' : ''
 	}\n`;
 }
 

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -31,13 +31,17 @@ const __dirname = dirname( __filename );
 async function main() {
 	const authToken = getArg( 'token' );
 	if ( ! authToken ) {
-		console.error( 'Aborted. The --token argument is required.' );
+		console.error(
+			'Aborted. The --token argument is required. See: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token'
+		);
 		process.exit( 1 );
 	}
 
 	const since = getArg( 'since' );
 	if ( ! since ) {
-		console.error( 'Aborted. The --since argument is required.' );
+		console.error(
+			'Aborted. The --since argument is required (e.g. 2023-11-01).'
+		);
 		process.exit( 1 );
 	}
 

--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -371,7 +371,7 @@ function processCommits( commits ) {
 }
 
 function formatPRLine( pr ) {
-	return `- [ ] ${ pr.url } - @/${ pr.creator } | Trac ticket | Core backport PR\n`;
+	return `- [ ] ${ pr.url } - @${ pr.creator } | Trac ticket | Core backport PR\n`;
 }
 
 function formatHeading( level, key ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Automates the creation of the contents for the Issue that tracks PHP changes ([example](https://github.com/WordPress/gutenberg/issues/54177)) that may need to be synchronised to WP Core for a major release.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For a major release, the Editor Tech Lead needs to create an Issue like [this one](https://github.com/WordPress/gutenberg/issues/54177) which details all the PHP changes that may need backport to Core.

This requires manually going through all the key directories in the project that may contain PHP changes and then checking all the PRs that have been merged since the final RC of the _previous_ release. If any PRs contain PHP changes then the PR needs to be added to the Issue in a very specific format. 

It also requires organising headings for each seciton and doing a lot of manual formatting.

All this is:

- laborious - I'm told it typically requires a full day or more to complete
- prone to error - it's easy to make a typo or miss a change

This is why I think it's wide open for automation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR has a script which can be run locally which will

- get all commits to `trunk` in a number of key directories (including `/lib`, `/block-library` and `/phpunit`) since a date you provide.
- get the details for each of the commits including the files that were changed
- put the commit under the correct heading based on which files were changed
- dedupe the result set
- output the markdown required to create the Issue

I've made some subjective choices about how things are group and displayed:

- ~PRs may be listed only once in the Issue - the exception is PRs which modify PHP Unit tests as I wanted to display a full list of changes that affect the `/phpunit` directory.~ Actually PRs are allowed more than once as long as it's across different sections
- No more than 3 level of nesting - anything beyond that gets very visually messy. I've grouped PRs that would appear under those subheadings under the third level of nesting.
- Certain directories are excluded including `e2e-tests` and `experiments-page.php` which are never synchronised - please feel free to suggest additions to that list.
- I've elected to avoid the additional network requests required to fetch the details of the PRs associated with each commit. Instead I've used regex to attempt to build the PR URL from the commit message. This isn't 100% reliable but it works in the majority of cases and we have a reasonable fallback in place.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Get [GH Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
- Run `node bin/generate-php-sync-issue.mjs --token={YOUR_TOKEN_HERE} --since=2023-11-01`
- Open `issueContent.md` and copy all contents.
- Go to https://github.com/WordPress/gutenberg/issues/new/ and paste contents.
- `Preview` the Issue - **DO NOT SUBMIT IT!**
- Take any given PR in the Issue and check that the files it modified match up with where it is listed in the Issue.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->



## Screenshots or screencast <!-- if applicable -->
