### PR TITLE
Interactivity API: Update `preact`, `@preact/signals` and `deepsignal` dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7317,21 +7317,6 @@
 				"url": "https://opencollective.com/popperjs"
 			}
 		},
-		"node_modules/@preact/signals": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.1.3.tgz",
-			"integrity": "sha512-N09DuAVvc90bBZVRwD+aFhtGyHAmJLhS3IFoawO/bYJRcil4k83nBOchpCEoS0s5+BXBpahgp0Mjf+IOqP57Og==",
-			"dependencies": {
-				"@preact/signals-core": "^1.2.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
-			},
-			"peerDependencies": {
-				"preact": "10.x"
-			}
-		},
 		"node_modules/@preact/signals-core": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.4.0.tgz",
@@ -24238,31 +24223,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/deepsignal": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.6.tgz",
-			"integrity": "sha512-yjd+vtiznL6YaMptOsKnEKkPr60OEApa+LRe+Qe6Ile/RfCOrELKk/YM3qVpXFZiyOI3Ng67GDEyjAlqVc697g==",
-			"peerDependencies": {
-				"@preact/signals": "^1.1.4",
-				"@preact/signals-core": "^1.3.1",
-				"@preact/signals-react": "^1.3.3",
-				"preact": "^10.16.0"
-			},
-			"peerDependenciesMeta": {
-				"@preact/signals": {
-					"optional": true
-				},
-				"@preact/signals-core": {
-					"optional": true
-				},
-				"@preact/signals-react": {
-					"optional": true
-				},
-				"preact": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/default-browser": {
@@ -43621,15 +43581,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/preact": {
-			"version": "10.13.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.13.2.tgz",
-			"integrity": "sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
-			}
-		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -55274,12 +55225,61 @@
 			"version": "3.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@preact/signals": "^1.1.3",
-				"deepsignal": "^1.3.6",
-				"preact": "^10.13.2"
+				"@preact/signals": "^1.2.2",
+				"deepsignal": "^1.4.0",
+				"preact": "^10.19.3"
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"packages/interactivity/node_modules/@preact/signals": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.2.tgz",
+			"integrity": "sha512-ColCqdo4cRP18bAuIR4Oik5rDpiyFtPIJIygaYPMEAwTnl4buWkBOflGBSzhYyPyJfKpkwlekrvK+1pzQ2ldWw==",
+			"dependencies": {
+				"@preact/signals-core": "^1.4.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact": "10.x"
+			}
+		},
+		"packages/interactivity/node_modules/deepsignal": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.4.0.tgz",
+			"integrity": "sha512-x0XUMT48s+xQRLc2fPFfxnYLCJ46vffw47OQ5NcHFzacOjfW5eA0NrEmI0bhQHL6MgUHkBVT4TIiWTVwzTEwpg==",
+			"peerDependencies": {
+				"@preact/signals": "^1.1.4",
+				"@preact/signals-core": "^1.5.1",
+				"@preact/signals-react": "^1.3.8 || ^2.0.0",
+				"preact": "^10.16.0"
+			},
+			"peerDependenciesMeta": {
+				"@preact/signals": {
+					"optional": true
+				},
+				"@preact/signals-core": {
+					"optional": true
+				},
+				"@preact/signals-react": {
+					"optional": true
+				},
+				"preact": {
+					"optional": true
+				}
+			}
+		},
+		"packages/interactivity/node_modules/preact": {
+			"version": "10.19.3",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+			"integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
 			}
 		},
 		"packages/interface": {
@@ -61424,14 +61424,6 @@
 			"version": "2.11.7",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
 			"integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
-		},
-		"@preact/signals": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.1.3.tgz",
-			"integrity": "sha512-N09DuAVvc90bBZVRwD+aFhtGyHAmJLhS3IFoawO/bYJRcil4k83nBOchpCEoS0s5+BXBpahgp0Mjf+IOqP57Og==",
-			"requires": {
-				"@preact/signals-core": "^1.2.3"
-			}
 		},
 		"@preact/signals-core": {
 			"version": "1.4.0",
@@ -70102,9 +70094,29 @@
 		"@wordpress/interactivity": {
 			"version": "file:packages/interactivity",
 			"requires": {
-				"@preact/signals": "^1.1.3",
-				"deepsignal": "^1.3.6",
-				"preact": "^10.13.2"
+				"@preact/signals": "^1.2.2",
+				"deepsignal": "^1.4.0",
+				"preact": "^10.19.3"
+			},
+			"dependencies": {
+				"@preact/signals": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.2.tgz",
+					"integrity": "sha512-ColCqdo4cRP18bAuIR4Oik5rDpiyFtPIJIygaYPMEAwTnl4buWkBOflGBSzhYyPyJfKpkwlekrvK+1pzQ2ldWw==",
+					"requires": {
+						"@preact/signals-core": "^1.4.0"
+					}
+				},
+				"deepsignal": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.4.0.tgz",
+					"integrity": "sha512-x0XUMT48s+xQRLc2fPFfxnYLCJ46vffw47OQ5NcHFzacOjfW5eA0NrEmI0bhQHL6MgUHkBVT4TIiWTVwzTEwpg=="
+				},
+				"preact": {
+					"version": "10.19.3",
+					"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+					"integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ=="
+				}
 			}
 		},
 		"@wordpress/interface": {
@@ -75508,11 +75520,6 @@
 			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
 			"integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
 			"dev": true
-		},
-		"deepsignal": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.6.tgz",
-			"integrity": "sha512-yjd+vtiznL6YaMptOsKnEKkPr60OEApa+LRe+Qe6Ile/RfCOrELKk/YM3qVpXFZiyOI3Ng67GDEyjAlqVc697g=="
 		},
 		"default-browser": {
 			"version": "4.0.0",
@@ -90300,11 +90307,6 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-		},
-		"preact": {
-			"version": "10.13.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.13.2.tgz",
-			"integrity": "sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw=="
 		},
 		"prebuild-install": {
 			"version": "7.1.1",

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Add the `data-wp-run` directive along with the `useInit` and `useWatch` hooks. ([57805](https://github.com/WordPress/gutenberg/pull/57805))
 
+### Enhancements
+
+-  Update `preact`, `@preact/signals` and `deepsignal` dependencies. ([57891](https://github.com/WordPress/gutenberg/pull/57891))
+
 ### Breaking Changes
 
 -   Remove `data-wp-slot` and `data-wp-fill`. ([#57854](https://github.com/WordPress/gutenberg/pull/57854))

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -26,9 +26,9 @@
 	"react-native": "src/index",
 	"types": "build-types",
 	"dependencies": {
-		"@preact/signals": "^1.1.3",
-		"deepsignal": "^1.3.6",
-		"preact": "^10.13.2"
+		"@preact/signals": "^1.2.2",
+		"deepsignal": "^1.4.0",
+		"preact": "^10.19.3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useContext, useMemo, useRef, useLayoutEffect } from 'preact/hooks';
+import { useContext, useMemo, useRef } from 'preact/hooks';
 import { deepSignal, peek } from 'deepsignal';
 
 /**
@@ -194,17 +194,6 @@ export default () => {
 				const attribute = entry.suffix;
 				const result = evaluate( entry );
 				element.props[ attribute ] = result;
-				// Preact doesn't handle the `role` attribute properly, as it doesn't remove it when `null`.
-				// We need this workaround until the following issue is solved:
-				// https://github.com/preactjs/preact/issues/4136
-				useLayoutEffect( () => {
-					if (
-						attribute === 'role' &&
-						( result === null || result === undefined )
-					) {
-						element.ref.current.removeAttribute( attribute );
-					}
-				}, [ attribute, result ] );
 
 				// This seems necessary because Preact doesn't change the attributes
 				// on the hydration, so we have to do it manually. It doesn't need
@@ -228,7 +217,6 @@ export default () => {
 						attribute !== 'download' &&
 						attribute !== 'rowSpan' &&
 						attribute !== 'colSpan' &&
-						attribute !== 'role' &&
 						attribute in el
 					) {
 						try {

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -217,6 +217,7 @@ export default () => {
 						attribute !== 'download' &&
 						attribute !== 'rowSpan' &&
 						attribute !== 'colSpan' &&
+						attribute !== 'role' &&
 						attribute in el
 					) {
 						try {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Upgrade Preact, Preact Signals and Deepsignal dependencies in Interactivity API.
Reverts #54608, as Preact now removes the role attribute if its value is null.

https://github.com/preactjs/preact/issues/4136 has been closed in 10.18.0

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Being updated is important, and even more if those updates allows the project to have less JS code.
