### PR TITLE
DataViews: navigate through list items via arrow keys

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -288,23 +288,19 @@
 	margin: 0;
 	padding: $grid-unit-10;
 
-	li {
+	tr {
 		margin: 0;
-
-		.dataviews-view-list__item-wrapper {
-			position: relative;
-			padding-right: $grid-unit-30;
-			border-radius: $grid-unit-05;
-
-			&::after {
-				position: absolute;
-				content: "";
-				top: 100%;
-				left: $grid-unit-30;
-				right: $grid-unit-30;
-				background: $gray-100;
-				height: 1px;
-			}
+		position: relative;
+		padding-right: $grid-unit-30;
+		border-radius: $grid-unit-05;
+		&::after {
+			position: absolute;
+			content: "";
+			top: 100%;
+			left: $grid-unit-30;
+			right: $grid-unit-30;
+			background: $gray-100;
+			height: 1px;
 		}
 
 		&:not(.is-selected):hover {
@@ -317,21 +313,18 @@
 		}
 	}
 
-	li.is-selected,
-	li.is-selected:focus-within {
-		.dataviews-view-list__item-wrapper {
-			background-color: var(--wp-admin-theme-color);
+	tr.is-selected,
+	tr.is-selected:focus-within {
+		background-color: var(--wp-admin-theme-color);
+		color: $white;
+
+		.dataviews-view-list__primary-field,
+		.dataviews-view-list__fields,
+		.components-button {
 			color: $white;
-
-			.dataviews-view-list__primary-field,
-			.dataviews-view-list__fields,
-			.components-button {
-				color: $white;
-			}
-
-			&::after {
-				background: transparent;
-			}
+		}
+		&::after {
+			background: transparent;
 		}
 	}
 
@@ -415,15 +408,15 @@
 		opacity: 0;
 	}
 
-	li.is-selected,
-	li:hover,
-	li:focus-within {
+	tr.is-selected,
+	tr:hover,
+	tr:focus-within {
 		.dataviews-view-list__details-button {
 			opacity: 1;
 		}
 	}
 
-	li.is-selected {
+	tr.is-selected {
 		.dataviews-view-list__details-button {
 			&:focus {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) currentColor;

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -78,12 +78,9 @@ export default function ViewList( {
 						level={ 1 }
 						setSize={ 1 }
 						positionInSet={ index + 1 }
-						className={ classNames(
-							'dataviews-view-list__item-wrapper',
-							{
-								'is-selected': selection.includes( item.id ),
-							}
-						) }
+						className={ classNames( {
+							'is-selected': selection.includes( item.id ),
+						} ) }
 					>
 						<TreeGridCell>
 							{ () => (

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -10,6 +10,9 @@ import { useAsyncList } from '@wordpress/compose';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalTreeGrid as TreeGrid,
+	__experimentalTreeGridRow as TreeGridRow,
+	__experimentalTreeGridCell as TreeGridCell,
 	Button,
 } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
@@ -67,66 +70,90 @@ export default function ViewList( {
 	}
 
 	return (
-		<ul className="dataviews-view-list">
-			{ usedData.map( ( item ) => {
+		<TreeGrid className="dataviews-view-list">
+			{ usedData.map( ( item, index ) => {
 				return (
-					<li
+					<TreeGridRow
 						key={ getItemId( item ) }
-						className={ classNames( {
-							'is-selected': selection.includes( item.id ),
-						} ) }
+						level={ 1 }
+						setSize={ 1 }
+						positionInSet={ index + 1 }
+						className={ classNames(
+							'dataviews-view-list__item-wrapper',
+							{
+								'is-selected': selection.includes( item.id ),
+							}
+						) }
 					>
-						<HStack className="dataviews-view-list__item-wrapper">
-							<div
-								role="button"
-								tabIndex={ 0 }
-								aria-pressed={ selection.includes( item.id ) }
-								onKeyDown={ onEnter( item ) }
-								className="dataviews-view-list__item"
-								onClick={ () => onSelectionChange( [ item ] ) }
-							>
-								<HStack spacing={ 3 } justify="start">
-									<div className="dataviews-view-list__media-wrapper">
-										{ mediaField?.render( { item } ) || (
-											<div className="dataviews-view-list__media-placeholder"></div>
-										) }
-									</div>
-									<VStack spacing={ 1 }>
-										<span className="dataviews-view-list__primary-field">
-											{ primaryField?.render( { item } ) }
-										</span>
-										<div className="dataviews-view-list__fields">
-											{ visibleFields.map( ( field ) => {
-												return (
-													<span
-														key={ field.id }
-														className="dataviews-view-list__field"
-													>
-														{ field.render( {
-															item,
-														} ) }
-													</span>
-												);
-											} ) }
-										</div>
-									</VStack>
-								</HStack>
-							</div>
-							{ onDetailsChange && (
-								<Button
-									className="dataviews-view-list__details-button"
+						<TreeGridCell>
+							{ () => (
+								<div
+									role="button"
+									tabIndex={ 0 }
+									aria-pressed={ selection.includes(
+										item.id
+									) }
+									onKeyDown={ onEnter( item ) }
+									className="dataviews-view-list__item"
 									onClick={ () =>
-										onDetailsChange( [ item ] )
+										onSelectionChange( [ item ] )
 									}
-									icon={ info }
-									label={ __( 'View details' ) }
-									size="compact"
-								/>
+								>
+									<HStack spacing={ 3 } justify="start">
+										<div className="dataviews-view-list__media-wrapper">
+											{ mediaField?.render( {
+												item,
+											} ) || (
+												<div className="dataviews-view-list__media-placeholder"></div>
+											) }
+										</div>
+										<VStack spacing={ 1 }>
+											<span className="dataviews-view-list__primary-field">
+												{ primaryField?.render( {
+													item,
+												} ) }
+											</span>
+											<div className="dataviews-view-list__fields">
+												{ visibleFields.map(
+													( field ) => {
+														return (
+															<span
+																key={ field.id }
+																className="dataviews-view-list__field"
+															>
+																{ field.render(
+																	{
+																		item,
+																	}
+																) }
+															</span>
+														);
+													}
+												) }
+											</div>
+										</VStack>
+									</HStack>
+								</div>
 							) }
-						</HStack>
-					</li>
+						</TreeGridCell>
+						{ onDetailsChange && (
+							<TreeGridCell>
+								{ () => (
+									<Button
+										className="dataviews-view-list__details-button"
+										onClick={ () =>
+											onDetailsChange( [ item ] )
+										}
+										icon={ info }
+										label={ __( 'View details' ) }
+										size="compact"
+									/>
+								) }
+							</TreeGridCell>
+						) }
+					</TreeGridRow>
 				);
 			} ) }
-		</ul>
+		</TreeGrid>
 	);
 }

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -94,8 +94,10 @@ export default function ViewList( {
 									onClick={ () =>
 										onSelectionChange( [ item ] )
 									}
+									tabIndex={
+										tabIndex === undefined ? 0 : tabIndex
+									}
 									{ ...otherProps }
-									tabIndex={ tabIndex }
 								>
 									<HStack spacing={ 3 } justify="start">
 										<div className="dataviews-view-list__media-wrapper">

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -83,10 +83,9 @@ export default function ViewList( {
 						} ) }
 					>
 						<TreeGridCell>
-							{ () => (
+							{ ( { tabIndex, ...otherProps } ) => (
 								<div
 									role="button"
-									tabIndex={ 0 }
 									aria-pressed={ selection.includes(
 										item.id
 									) }
@@ -95,6 +94,8 @@ export default function ViewList( {
 									onClick={ () =>
 										onSelectionChange( [ item ] )
 									}
+									{ ...otherProps }
+									tabIndex={ tabIndex }
 								>
 									<HStack spacing={ 3 } justify="start">
 										<div className="dataviews-view-list__media-wrapper">
@@ -135,7 +136,7 @@ export default function ViewList( {
 						</TreeGridCell>
 						{ onDetailsChange && (
 							<TreeGridCell>
-								{ () => (
+								{ ( props ) => (
 									<Button
 										className="dataviews-view-list__details-button"
 										onClick={ () =>
@@ -144,6 +145,7 @@ export default function ViewList( {
 										icon={ info }
 										label={ __( 'View details' ) }
 										size="compact"
+										{ ...props }
 									/>
 								) }
 							</TreeGridCell>

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -33,6 +33,7 @@ function buildSelector( sequential ) {
 		sequential ? '[tabindex]:not([tabindex^="-"])' : '[tabindex]',
 		'a[href]',
 		'button:not([disabled])',
+		'[role="button"][tabindex]',
 		'input:not([type="hidden"]):not([disabled])',
 		'select:not([disabled])',
 		'textarea:not([disabled])',


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

**Work In Progress.**

## What?

Implements arrow key navigation for the list layout. The list of items behaves like a single stop.

## Why?

This provides a better keyboard navigation and follows [accessibility best practices](https://www.w3.org/WAI/ARIA/apg/patterns/treegrid/examples/treegrid-1/).

## How?

Substitutes the unordered `<ul>` list by a `<TreeGrid>`.

## Testing Instructions

- Enable the "new admin views" experiment in "Gutenberg > Experiments".
- Go to "Site Editor > Pages".
- Navigate with the keyboard through the list of items in the content frame.
