### PR TITLE
Block Bindings API: Add tests and fix newly discovered edge cases

### DIFF
--- a/lib/experimental/block-bindings/html-processing.php
+++ b/lib/experimental/block-bindings/html-processing.php
@@ -16,8 +16,8 @@ if ( ! function_exists( 'block_bindings_replace_html' ) ) {
 	 */
 	function block_bindings_replace_html( $block_content, $block_name, $block_attr, $source_value ) {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-		if ( null === $block_type ) {
-			return;
+		if ( null === $block_type || ! isset( $block_type->attributes[ $block_attr ] ) ) {
+			return $block_content;
 		}
 
 		// Depending on the attribute source, the processing will be different.

--- a/phpunit/experimental/WP_Block_Bindings_Test.php
+++ b/phpunit/experimental/WP_Block_Bindings_Test.php
@@ -58,7 +58,6 @@ class WP_Block_Bindings_Test extends WP_UnitTestCase {
 		$source_value      = 'Updated URL';
 
 		$result = $wp_block_bindings->replace_html( $block_content, $block_name, $block_attr, $source_value );
-		echo $result;
 		$this->assertStringContainsString( $source_value, $result );
 	}
 

--- a/phpunit/experimental/WP_Block_Bindings_Test.php
+++ b/phpunit/experimental/WP_Block_Bindings_Test.php
@@ -31,7 +31,7 @@ class WP_Block_Bindings_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	* Test replace_html method.
+	* Test replace_html method for content.
 	*/
 	public function test_replace_html_for_paragraph_content() {
 		$wp_block_bindings = new WP_Block_Bindings();
@@ -48,7 +48,7 @@ class WP_Block_Bindings_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	* Test replace_html method.
+	* Test replace_html method for attributes.
 	*/
 	public function test_replace_html_for_attribute() {
 		$wp_block_bindings = new WP_Block_Bindings();
@@ -61,7 +61,7 @@ class WP_Block_Bindings_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( $source_value, $result );
 	}
 
-	// Test cases for scenarios where block type is not registered, or attribute source is not 'html' or 'rich-text'.
+	// Test case for scenarios where block type is not registered.
 	public function test_replace_html_with_unregistered_block() {
 		$wp_block_bindings = new WP_Block_Bindings();
 
@@ -72,10 +72,10 @@ class WP_Block_Bindings_Test extends WP_UnitTestCase {
 
 		$result = $wp_block_bindings->replace_html( $block_content, $block_name, $block_attr, $source_value );
 
-		// Expect original content to be returned as block type is not registered.
 		$this->assertEquals( $block_content, $result );
 	}
 
+	// Test case for scenarios where block is registered but attribute does not exist on block type.
 	public function test_replace_html_with_registered_block_but_unsupported_source_type() {
 		$wp_block_bindings = new WP_Block_Bindings();
 
@@ -86,7 +86,6 @@ class WP_Block_Bindings_Test extends WP_UnitTestCase {
 
 		$result = $wp_block_bindings->replace_html( $block_content, $block_name, $block_attr, $source_value );
 
-		// Expect original content to be returned as the source type is not supported.
 		$this->assertEquals( $block_content, $result );
 	}
 }

--- a/phpunit/experimental/WP_Block_Bindings_Test.php
+++ b/phpunit/experimental/WP_Block_Bindings_Test.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Unit tests covering WP_Block_Bindings functionality.
+ *
+ * @package gutenberg
+ */
+
+class WP_Block_Bindings_Test extends WP_UnitTestCase {
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once __DIR__ . '/../../lib/experimental/block-bindings/index.php';
+	}
+
+	/**
+	* Test register_source method.
+	*/
+	public function test_register_source() {
+		$wp_block_bindings = new WP_Block_Bindings();
+
+		$source_name = 'test_source';
+		$label       = 'Test Source';
+		$apply       = function () { };
+
+		$wp_block_bindings->register_source( $source_name, $label, $apply );
+
+		$sources = $wp_block_bindings->get_sources();
+		$this->assertArrayHasKey( $source_name, $sources );
+		$this->assertEquals( $label, $sources[ $source_name ]['label'] );
+		$this->assertEquals( $apply, $sources[ $source_name ]['apply'] );
+	}
+
+	/**
+	* Test replace_html method.
+	*/
+	public function test_replace_html_for_paragraph_content() {
+		$wp_block_bindings = new WP_Block_Bindings();
+
+		$block_content = '<p>Hello World</p>';
+		$block_name    = 'core/paragraph';
+		$block_attr    = 'content';
+		$source_value  = 'Updated Content';
+
+		$result = $wp_block_bindings->replace_html( $block_content, $block_name, $block_attr, $source_value );
+
+		// Check if the block content was updated correctly.
+		$this->assertStringContainsString( $source_value, $result );
+	}
+
+	/**
+	* Test replace_html method.
+	*/
+	public function test_replace_html_for_attribute() {
+		$wp_block_bindings = new WP_Block_Bindings();
+		$block_content     = '<div><a url\="">Hello World</a></div>';
+		$block_name        = 'core/button';
+		$block_attr        = 'url';
+		$source_value      = 'Updated URL';
+
+		$result = $wp_block_bindings->replace_html( $block_content, $block_name, $block_attr, $source_value );
+		echo $result;
+		$this->assertStringContainsString( $source_value, $result );
+	}
+
+	// Test cases for scenarios where block type is not registered, or attribute source is not 'html' or 'rich-text'.
+	public function test_replace_html_with_unregistered_block() {
+		$wp_block_bindings = new WP_Block_Bindings();
+
+		$block_content = '<p>Hello World</p>';
+		$block_name    = 'NONEXISTENT';
+		$block_attr    = 'content';
+		$source_value  = 'Updated Content';
+
+		$result = $wp_block_bindings->replace_html( $block_content, $block_name, $block_attr, $source_value );
+
+		// Expect original content to be returned as block type is not registered.
+		$this->assertEquals( $block_content, $result );
+	}
+
+	public function test_replace_html_with_registered_block_but_unsupported_source_type() {
+		$wp_block_bindings = new WP_Block_Bindings();
+
+		$block_content = '<div>Hello World</div>';
+		$block_name    = 'core/paragraph';
+		$block_attr    = 'NONEXISTENT';
+		$source_value  = 'Updated Content';
+
+		$result = $wp_block_bindings->replace_html( $block_content, $block_name, $block_attr, $source_value );
+
+		// Expect original content to be returned as the source type is not supported.
+		$this->assertEquals( $block_content, $result );
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds tests for the Block Bindings API, first introduced in https://github.com/WordPress/gutenberg/pull/57249 and refactored in https://github.com/WordPress/gutenberg/pull/57742. It also fixes bugs that were discovered as a result of writing the tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In order to merge this functionality for WP 6.5, we need tests to ensure code quality into the future.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Run the tests locally using PHP Unit.
- Please check to see what other test cases we can add.
