### PR TITLE
Font Faces endpoint: prevent creating font faces with duplicate settings

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
@@ -91,7 +91,7 @@ class WP_Font_Family_Utils {
 				function ( $family ) {
 					$trimmed = trim( $family );
 					if ( ! empty( $trimmed ) && strpos( $trimmed, ' ' ) !== false && strpos( $trimmed, "'" ) === false && strpos( $trimmed, '"' ) === false ) {
-							return "'" . $trimmed . "'";
+							return '"' . $trimmed . '"';
 					}
 					return $trimmed;
 				},
@@ -106,5 +106,63 @@ class WP_Font_Family_Utils {
 		}
 
 		return $font_family;
+	}
+
+	/**
+	 * Generates a slug from font face properties.
+	 *
+	 * Used for comparison with other font faces in the same family.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param array $settings Font face settings.
+	 * @return string Font face slug.
+	 */
+	public static function get_font_face_slug( $settings ) {
+		$settings = wp_parse_args(
+			$settings,
+			array(
+				'fontFamily'  => '',
+				'fontStyle'   => 'normal',
+				'fontWeight'  => '400',
+				'fontStretch' => 'normal',
+			)
+		);
+
+		// Convert all values to lowercase for comparison.
+		$font_family  = mb_strtolower( $settings['fontFamily'] );
+		$font_style   = strtolower( $settings['fontStyle'] );
+		$font_weight  = strtolower( $settings['fontWeight'] );
+		$font_stretch = strtolower( $settings['fontStretch'] );
+
+		// Convert weight keywords to numeric strings.
+		$font_weight = str_replace( 'normal', '400', $font_weight );
+		$font_weight = str_replace( 'bold', '700', $font_weight );
+
+		// Convert stretch keywords to numeric strings.
+		$font_stretch_map = array(
+			'ultra-condensed' => '50%',
+			'extra-condensed' => '62.5%',
+			'condensed'       => '75%',
+			'semi-condensed'  => '87.5%',
+			'normal'          => '100%',
+			'semi-expanded'   => '112.5%',
+			'expanded'        => '125%',
+			'extra-expanded'  => '150%',
+			'untra-expanded'  => '200%',
+		);
+		$font_stretch     = str_replace( array_keys( $font_stretch_map ), array_values( $font_stretch_map ), $font_stretch );
+
+		$slug_elements = array( $font_family, $font_style, $font_weight, $font_stretch );
+
+		// Remove quotes to normalize font-family names, and ';' to use as a separator.
+		$slug_elements = array_map(
+			function ( $elem ) {
+				return trim( str_replace( array( '"', "'", ';' ), '', $elem ) );
+			},
+			$slug_elements
+		);
+
+		return join( ';', $slug_elements );
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
@@ -175,8 +175,10 @@ class WP_Font_Family_Utils {
 				// Remove quotes to normalize font-family names, and ';' to use as a separator.
 				$elem = trim( str_replace( array( '"', "'", ';' ), '', $elem ) );
 
-				// Normalize comma separated lists by removing spaces in between items,
-				// but keep spaces within items (e.g. "Open Sans" and "OpenSans" are different fonts).
+				// Normalize comma separated lists by removing whitespace in between items,
+				// but keep whitespace within items (e.g. "Open Sans" and "OpenSans" are different fonts).
+				// CSS spec for whitespace includes: U+000A LINE FEED, U+0009 CHARACTER TABULATION, or U+0020 SPACE,
+				// which by default are all matched by \s in PHP.
 				return preg_replace( '/,\s+/', ',', $elem );
 			},
 			$slug_elements

--- a/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
@@ -122,18 +122,20 @@ class WP_Font_Family_Utils {
 		$settings = wp_parse_args(
 			$settings,
 			array(
-				'fontFamily'  => '',
-				'fontStyle'   => 'normal',
-				'fontWeight'  => '400',
-				'fontStretch' => 'normal',
+				'fontFamily'   => '',
+				'fontStyle'    => 'normal',
+				'fontWeight'   => '400',
+				'fontStretch'  => 'normal',
+				'unicodeRange' => 'U+0-10FFFF',
 			)
 		);
 
 		// Convert all values to lowercase for comparison.
-		$font_family  = mb_strtolower( $settings['fontFamily'] );
-		$font_style   = strtolower( $settings['fontStyle'] );
-		$font_weight  = strtolower( $settings['fontWeight'] );
-		$font_stretch = strtolower( $settings['fontStretch'] );
+		$font_family   = mb_strtolower( $settings['fontFamily'] );
+		$font_style    = strtolower( $settings['fontStyle'] );
+		$font_weight   = strtolower( $settings['fontWeight'] );
+		$font_stretch  = strtolower( $settings['fontStretch'] );
+		$unicode_range = strtoupper( $settings['unicodeRange'] );
 
 		// Convert weight keywords to numeric strings.
 		$font_weight = str_replace( 'normal', '400', $font_weight );
@@ -153,7 +155,7 @@ class WP_Font_Family_Utils {
 		);
 		$font_stretch     = str_replace( array_keys( $font_stretch_map ), array_values( $font_stretch_map ), $font_stretch );
 
-		$slug_elements = array( $font_family, $font_style, $font_weight, $font_stretch );
+		$slug_elements = array( $font_family, $font_style, $font_weight, $font_stretch, $unicode_range );
 
 		// Remove quotes to normalize font-family names, and ';' to use as a separator.
 		$slug_elements = array_map(

--- a/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-family-utils.php
@@ -113,7 +113,8 @@ class WP_Font_Family_Utils {
 	 *
 	 * Used for comparison with other font faces in the same family, to prevent duplicates
 	 * that would both match according the CSS font matching spec. Uses only simple case-insensitive
-	 * matching for unicodeRange, so does not handle overlapping ranges.
+	 * matching for fontFamily and unicodeRange, so does not handle overlapping font-family lists or
+	 * unicode ranges.
 	 *
 	 * @since 6.5.0
 	 *

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
@@ -663,7 +663,10 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 
 		// Settings have already been decoded by ::sanitize_font_face_settings().
 		$settings = $request->get_param( 'font_face_settings' );
-		$title    = WP_Font_Family_Utils::get_font_face_slug( $settings );
+
+		// Store this "slug" as the post_title rather than post_name, since it uses the fontFamily setting,
+		// which may contain multibyte characters.
+		$title = WP_Font_Family_Utils::get_font_face_slug( $settings );
 
 		$prepared_post->post_type    = $this->post_type;
 		$prepared_post->post_parent  = $request['font_family_id'];

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
@@ -295,6 +295,22 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 		$settings    = $request->get_param( 'font_face_settings' );
 		$file_params = $request->get_file_params();
 
+		// Check that the necessary font face properties are unique.
+		$existing_font_face = get_posts(
+			array(
+				'post_type'      => $this->post_type,
+				'posts_per_page' => 1,
+				'title'          => WP_Font_Family_Utils::get_font_face_slug( $settings ),
+			)
+		);
+		if ( ! empty( $existing_font_face ) ) {
+			return new WP_Error(
+				'rest_duplicate_font_face',
+				__( 'A font face matching those settings already exists.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		// Move the uploaded font asset from the temp folder to the fonts directory.
 		if ( ! function_exists( 'wp_handle_upload' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -647,12 +663,13 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 
 		// Settings have already been decoded by ::sanitize_font_face_settings().
 		$settings = $request->get_param( 'font_face_settings' );
+		$title    = WP_Font_Family_Utils::get_font_face_slug( $settings );
 
 		$prepared_post->post_type    = $this->post_type;
 		$prepared_post->post_parent  = $request['font_family_id'];
 		$prepared_post->post_status  = 'publish';
-		$prepared_post->post_title   = $settings['fontFamily'];
-		$prepared_post->post_name    = sanitize_title( $settings['fontFamily'] );
+		$prepared_post->post_title   = $title;
+		$prepared_post->post_name    = sanitize_title( $title );
 		$prepared_post->post_content = wp_json_encode( $settings );
 
 		return $prepared_post;
@@ -751,10 +768,10 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 		// Provide required, empty settings if needed.
 		if ( null === $settings ) {
 			$settings = array(
-				'src' => array(),
+				'fontFamily' => '',
+				'src'        => array(),
 			);
 		}
-		$settings['fontFamily'] = $post->post_title ?? '';
 
 		// Only return the properties defined in the schema.
 		return array_intersect_key( $settings, $properties );

--- a/phpunit/tests/fonts/font-library/wpFontFamilyUtils/formatFontFamily.php
+++ b/phpunit/tests/fonts/font-library/wpFontFamilyUtils/formatFontFamily.php
@@ -36,11 +36,11 @@ class Tests_Fonts_WpFontsFamilyUtils_FormatFontFamily extends WP_UnitTestCase {
 		return array(
 			'data_families_with_spaces_and_numbers' => array(
 				'font_family' => 'Rock 3D , Open Sans,serif',
-				'expected'    => "'Rock 3D', 'Open Sans', serif",
+				'expected'    => '"Rock 3D", "Open Sans", serif',
 			),
 			'data_single_font_family'               => array(
 				'font_family' => 'Rock 3D',
-				'expected'    => "'Rock 3D'",
+				'expected'    => '"Rock 3D"',
 			),
 			'data_no_spaces'                        => array(
 				'font_family' => 'Rock3D',
@@ -48,7 +48,7 @@ class Tests_Fonts_WpFontsFamilyUtils_FormatFontFamily extends WP_UnitTestCase {
 			),
 			'data_many_spaces_and_existing_quotes'  => array(
 				'font_family' => 'Rock 3D serif, serif,sans-serif, "Open Sans"',
-				'expected'    => "'Rock 3D serif', serif, sans-serif, \"Open Sans\"",
+				'expected'    => '"Rock 3D serif", serif, sans-serif, "Open Sans"',
 			),
 			'data_empty_family'                     => array(
 				'font_family' => ' ',

--- a/phpunit/tests/fonts/font-library/wpFontFamilyUtils/getFontFaceSlug.php
+++ b/phpunit/tests/fonts/font-library/wpFontFamilyUtils/getFontFaceSlug.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Test WP_Font_Family_Utils::get_font_face_slug().
+ *
+ * @package WordPress
+ * @subpackage Font Library
+ * *
+ * @covers WP_Font_Family_Utils::get_font_face_slug
+ */
+class Tests_Fonts_WpFontsFamilyUtils_GetFontFamilySlug extends WP_UnitTestCase {
+	/**
+	 * @dataProvider data_get_font_face_slug_normalizes_values
+	 */
+	public function test_get_font_face_slug_normalizes_values( $settings, $expected_slug ) {
+		$slug = WP_Font_Family_Utils::get_font_face_slug( $settings );
+
+		$this->assertSame( $expected_slug, $slug );
+	}
+
+	public function data_get_font_face_slug_normalizes_values() {
+		return array(
+			'Sets defaults'                           => array(
+				'settings'      => array(
+					'fontFamily' => 'Open Sans',
+				),
+				'expected_slug' => 'open sans;normal;400;100%;U+0-10FFFF',
+			),
+			'Converts normal weight to 400'           => array(
+				'settings'      => array(
+					'fontFamily' => 'Open Sans',
+					'fontWeight' => 'normal',
+				),
+				'expected_slug' => 'open sans;normal;400;100%;U+0-10FFFF',
+			),
+			'Converts bold weight to 700'             => array(
+				'settings'      => array(
+					'fontFamily' => 'Open Sans',
+					'fontWeight' => 'bold',
+				),
+				'expected_slug' => 'open sans;normal;700;100%;U+0-10FFFF',
+			),
+			'Converts normal font-stretch to 100%'    => array(
+				'settings'      => array(
+					'fontFamily'  => 'Open Sans',
+					'fontStretch' => 'normal',
+				),
+				'expected_slug' => 'open sans;normal;400;100%;U+0-10FFFF',
+			),
+			'Removes double quotes from fontFamilies' => array(
+				'settings'      => array(
+					'fontFamily' => '"Open Sans"',
+				),
+				'expected_slug' => 'open sans;normal;400;100%;U+0-10FFFF',
+			),
+			'Removes single quotes from fontFamilies' => array(
+				'settings'      => array(
+					'fontFamily' => "'Open Sans'",
+				),
+				'expected_slug' => 'open sans;normal;400;100%;U+0-10FFFF',
+			),
+			'Removes spaces between comma separated font families' => array(
+				'settings'      => array(
+					'fontFamily' => 'Open Sans, serif',
+				),
+				'expected_slug' => 'open sans,serif;normal;400;100%;U+0-10FFFF',
+			),
+			'Removes tabs between comma separated font families' => array(
+				'settings'      => array(
+					'fontFamily' => "Open Sans,\tserif",
+				),
+				'expected_slug' => 'open sans,serif;normal;400;100%;U+0-10FFFF',
+			),
+			'Removes new lines between comma separated font families' => array(
+				'settings'      => array(
+					'fontFamily' => "Open Sans,\nserif",
+				),
+				'expected_slug' => 'open sans,serif;normal;400;100%;U+0-10FFFF',
+			),
+		);
+	}
+}

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -548,7 +548,7 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 		/**
 	 * @dataProvider data_update_item_santize_font_family
 	 *
-	 * @covers WP_REST_Font_Families_Controller::update_item
+	 * @covers WP_REST_Font_Families_Controller::sanitize_font_face_settings
 	 */
 	public function test_update_item_santize_font_family( $font_family_setting, $expected ) {
 		wp_set_current_user( self::$admin_id );
@@ -567,9 +567,9 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 
 	public function data_update_item_santize_font_family() {
 		return array(
-			array( 'Libre Barcode 128 Text', "'Libre Barcode 128 Text'" ),
-			array( 'B612 Mono', "'B612 Mono'" ),
-			array( 'Open Sans, Noto Sans, sans-serif', "'Open Sans', 'Noto Sans', sans-serif" ),
+			array( 'Libre Barcode 128 Text', '"Libre Barcode 128 Text"' ),
+			array( 'B612 Mono', '"B612 Mono"' ),
+			array( 'Open Sans, Noto Sans, sans-serif', '"Open Sans", "Noto Sans", sans-serif' ),
 		);
 	}
 

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -767,6 +767,8 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 				'fields'      => 'ids',
 				'post_parent' => $post_id,
 				'post_type'   => 'wp_font_face',
+				'order'       => 'ASC',
+				'orderby'     => 'ID',
 			)
 		);
 		$this->assertArrayHasKey( 'font_faces', $data );

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -770,7 +770,10 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 			)
 		);
 		$this->assertArrayHasKey( 'font_faces', $data );
-		$this->assertSame( $font_face_ids, $data['font_faces'] );
+
+		foreach ( $font_face_ids as $font_face_id ) {
+			$this->assertContains( $font_face_id, $data['font_faces'] );
+		}
 
 		$this->assertArrayHasKey( 'font_family_settings', $data );
 		$settings          = $data['font_family_settings'];


### PR DESCRIPTION
## What?

Return an error when trying to create a Font Face with settings that match an existing one.

According to [the css spec](https://drafts.csswg.org/css-fonts/#font-style-matching), these properties are used to match a @font-face declaration when loading fonts, and so are used here to determine duplication: fontFamily, fontStyle, fontWeight, fontStretch, and unicodeRange.

## Why?

Part of https://github.com/WordPress/gutenberg/issues/55278

## How?

When a new wp_font_face is created, a slug is generated from the font face settings and stored in the `post_title` field, which is then used to check for duplicates.

## Testing Instructions

- Create a font family using the `POST wp/v2/font-families/<id>/font-faces`
- Try to create another font family with the same settings, including fontFamily, fontStyle, fontWeight, fontStretch, and unicodeRange, you should get an error.

