### PR TITLE
Fix treegrid navigation in dataview list

### DIFF
--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -94,8 +94,10 @@ export default function ViewList( {
 									onClick={ () =>
 										onSelectionChange( [ item ] )
 									}
+									tabIndex={
+										tabIndex === undefined ? 0 : tabIndex
+									}
 									{ ...otherProps }
-									tabIndex={ tabIndex }
 								>
 									<HStack spacing={ 3 } justify="start">
 										<div className="dataviews-view-list__media-wrapper">

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -33,6 +33,7 @@ function buildSelector( sequential ) {
 		sequential ? '[tabindex]:not([tabindex^="-"])' : '[tabindex]',
 		'a[href]',
 		'button:not([disabled])',
+		'[role="button"][tabindex]',
 		'input:not([type="hidden"]):not([disabled])',
 		'select:not([disabled])',
 		'textarea:not([disabled])',


### PR DESCRIPTION
Note, this PR merges into the branch associated with #57895, and not trunk.

## What?
Attempt to solve the problem mentioned here - https://github.com/WordPress/gutenberg/pull/57895#discussion_r1453772521

## How?
Ensures any role=button elements with a tabindex can be selected by the focusable utility.

Also adds a tabindex to the element so that it can be selected when focus enters the tree grid for the first time. After this happens though it defers to treegrid for tabindex management.
