### PR TITLE
Add a control per block to reset pattern overrides

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -29,6 +29,7 @@ import {
 } from '@wordpress/block-editor';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { parse, cloneBlock } from '@wordpress/blocks';
+import { RichTextData } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -131,6 +132,16 @@ function applyInitialContentValuesToInnerBlocks(
 	} );
 }
 
+function isAttributeEqual( attribute1, attribute2 ) {
+	if (
+		attribute1 instanceof RichTextData &&
+		attribute2 instanceof RichTextData
+	) {
+		return attribute1.toString() === attribute2.toString();
+	}
+	return attribute1 === attribute2;
+}
+
 function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
 	/** @type {Record<string, { values: Record<string, unknown>}>} */
 	const content = {};
@@ -145,8 +156,10 @@ function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
 		const attributes = getOverridableAttributes( block );
 		for ( const attributeKey of attributes ) {
 			if (
-				block.attributes[ attributeKey ] !==
-				defaultValues[ blockId ][ attributeKey ]
+				! isAttributeEqual(
+					block.attributes[ attributeKey ],
+					defaultValues[ blockId ][ attributeKey ]
+				)
 			) {
 				content[ blockId ] ??= { values: {} };
 				content[ blockId ].values[ attributeKey ] =

--- a/packages/editor/src/hooks/pattern-partial-syncing.js
+++ b/packages/editor/src/hooks/pattern-partial-syncing.js
@@ -59,7 +59,7 @@ function ControlsWithStoreSubscription( props ) {
 	const hasPatternBindings =
 		!! bindings &&
 		Object.values( bindings ).some(
-			( binding ) => binding.source?.name === 'core/pattern-overrides'
+			( binding ) => binding.source === 'core/pattern-overrides'
 		);
 
 	const shouldShowPartialSyncingControls =

--- a/packages/editor/src/hooks/pattern-partial-syncing.js
+++ b/packages/editor/src/hooks/pattern-partial-syncing.js
@@ -15,6 +15,7 @@ import { unlock } from '../lock-unlock';
 
 const {
 	PartialSyncingControls,
+	ResetOverridesControl,
 	PATTERN_TYPES,
 	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
 } = unlock( patternsPrivateApis );
@@ -54,12 +55,30 @@ function ControlsWithStoreSubscription( props ) {
 			select( editorStore ).getCurrentPostType() === PATTERN_TYPES.user,
 		[]
 	);
+	const bindings = props.attributes.metadata?.bindings;
+	const hasPatternBindings =
+		!! bindings &&
+		Object.values( bindings ).some(
+			( binding ) => binding.source?.name === 'core/pattern-overrides'
+		);
+
+	const shouldShowPartialSyncingControls =
+		isEditingPattern && blockEditingMode === 'default';
+	const shouldShowResetOverridesControl =
+		! isEditingPattern &&
+		!! props.attributes.metadata?.id &&
+		blockEditingMode !== 'disabled' &&
+		hasPatternBindings;
 
 	return (
-		isEditingPattern &&
-		blockEditingMode === 'default' && (
-			<PartialSyncingControls { ...props } />
-		)
+		<>
+			{ shouldShowPartialSyncingControls && (
+				<PartialSyncingControls { ...props } />
+			) }
+			{ shouldShowResetOverridesControl && (
+				<ResetOverridesControl { ...props } />
+			) }
+		</>
 	);
 }
 

--- a/packages/patterns/src/components/reset-overrides-control.js
+++ b/packages/patterns/src/components/reset-overrides-control.js
@@ -36,7 +36,7 @@ export default function ResetOverridesControl( props ) {
 				getBlockParentsByBlockName( props.clientId, 'core/block' )
 			)[ 0 ];
 
-			if ( ! patternBlock?.attributes.overrides?.[ id ] ) {
+			if ( ! patternBlock?.attributes.content?.[ id ] ) {
 				return undefined;
 			}
 
@@ -60,7 +60,7 @@ export default function ResetOverridesControl( props ) {
 	};
 
 	return (
-		<BlockControls>
+		<BlockControls group="other">
 			<ToolbarGroup>
 				<ToolbarButton
 					onClick={ resetOverrides }

--- a/packages/patterns/src/components/reset-overrides-control.js
+++ b/packages/patterns/src/components/reset-overrides-control.js
@@ -67,7 +67,7 @@ export default function ResetOverridesControl( props ) {
 					disabled={ ! patternWithOverrides }
 					__experimentalIsFocusable
 				>
-					{ __( 'Reset to original' ) }
+					{ __( 'Reset' ) }
 				</ToolbarButton>
 			</ToolbarGroup>
 		</BlockControls>

--- a/packages/patterns/src/components/reset-overrides-control.js
+++ b/packages/patterns/src/components/reset-overrides-control.js
@@ -12,13 +12,16 @@ import { parse } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 function recursivelyFindBlockWithId( blocks, id ) {
-	return blocks.find( ( block ) => {
+	for ( const block of blocks ) {
 		if ( block.attributes.metadata?.id === id ) {
 			return block;
 		}
 
-		return recursivelyFindBlockWithId( block.innerBlocks, id );
-	} );
+		const found = recursivelyFindBlockWithId( block.innerBlocks, id );
+		if ( found ) {
+			return found;
+		}
+	}
 }
 
 export default function ResetOverridesControl( props ) {

--- a/packages/patterns/src/components/reset-overrides-control.js
+++ b/packages/patterns/src/components/reset-overrides-control.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	store as blockEditorStore,
+	BlockControls,
+} from '@wordpress/block-editor';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { useSelect, useRegistry } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { parse } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+function recursivelyFindBlockWithId( blocks, id ) {
+	return blocks.find( ( block ) => {
+		if ( block.attributes.metadata?.id === id ) {
+			return block;
+		}
+
+		return recursivelyFindBlockWithId( block.innerBlocks, id );
+	} );
+}
+
+export default function ResetOverridesControl( props ) {
+	const registry = useRegistry();
+	const id = props.attributes.metadata?.id;
+	const patternWithOverrides = useSelect(
+		( select ) => {
+			if ( ! id ) {
+				return undefined;
+			}
+
+			const { getBlockParentsByBlockName, getBlocksByClientId } =
+				select( blockEditorStore );
+			const patternBlock = getBlocksByClientId(
+				getBlockParentsByBlockName( props.clientId, 'core/block' )
+			)[ 0 ];
+
+			if ( ! patternBlock?.attributes.overrides?.[ id ] ) {
+				return undefined;
+			}
+
+			return patternBlock;
+		},
+		[ props.clientId, id ]
+	);
+
+	const resetOverrides = async () => {
+		const editedRecord = await registry
+			.resolveSelect( coreStore )
+			.getEditedEntityRecord(
+				'postType',
+				'wp_block',
+				patternWithOverrides.attributes.ref
+			);
+		const blocks = editedRecord.blocks ?? parse( editedRecord.content );
+		const block = recursivelyFindBlockWithId( blocks, id );
+
+		props.setAttributes( block.attributes );
+	};
+
+	return (
+		<BlockControls>
+			<ToolbarGroup>
+				<ToolbarButton
+					onClick={ resetOverrides }
+					disabled={ ! patternWithOverrides }
+					__experimentalIsFocusable
+				>
+					{ __( 'Reset to original' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
+		</BlockControls>
+	);
+}

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -14,6 +14,7 @@ import RenamePatternModal from './components/rename-pattern-modal';
 import PatternsMenuItems from './components';
 import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
 import PartialSyncingControls from './components/partial-syncing-controls';
+import ResetOverridesControl from './components/reset-overrides-control';
 import {
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
@@ -33,6 +34,7 @@ lock( privateApis, {
 	PatternsMenuItems,
 	RenamePatternCategoryModal,
 	PartialSyncingControls,
+	ResetOverridesControl,
 	PATTERN_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
 	PATTERN_USER_CATEGORY,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #53705 and https://github.com/WordPress/gutenberg/issues/57751. Continued from https://github.com/WordPress/gutenberg/pull/57845.

Add a control per block to reset pattern overrides.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As mentioned in https://github.com/WordPress/gutenberg/issues/57751.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a control and conditionally render it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331 to create a pattern with overrides and add it to a post.

1. Focus on one of the overridable blocks, and it should have a disabled control "Reset to original" in the toolbar.
2. Make some changes to the block, and the control should be enabled.
3. Clicking on it should reset only that block to the original state.
4. Undo/redo should work as expected.

## Screenshots or screencast <!-- if applicable -->
Block without overrides
![Block without overrides](https://github.com/WordPress/gutenberg/assets/7753001/e3a26f95-5ddc-4d3d-ab7d-e4ee8ca7a843)

Block with overrides
![Block with overrides](https://github.com/WordPress/gutenberg/assets/7753001/3a095f81-eb2e-4101-ac6a-a07020b3ab69)
