### PR TITLE
Add image block support for pattern overrides

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -331,7 +331,11 @@ export default function Image( {
 	}, [ isSelected ] );
 
 	const canEditImage = id && naturalWidth && naturalHeight && imageEditing;
-	const allowCrop = ! multiImageSelection && canEditImage && ! isEditingImage;
+	const allowCrop =
+		! multiImageSelection &&
+		canEditImage &&
+		! isEditingImage &&
+		hasNonContentControls;
 
 	function switchToCover() {
 		replaceBlocks(

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -331,11 +331,7 @@ export default function Image( {
 	}, [ isSelected ] );
 
 	const canEditImage = id && naturalWidth && naturalHeight && imageEditing;
-	const allowCrop =
-		! multiImageSelection &&
-		canEditImage &&
-		! isEditingImage &&
-		hasNonContentControls;
+	const allowCrop = ! multiImageSelection && canEditImage && ! isEditingImage;
 
 	function switchToCover() {
 		replaceBlocks(

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -28,4 +28,9 @@ export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 		text: __( 'Text' ),
 		url: __( 'URL' ),
 	},
+	'core/image': {
+		url: __( 'URL' ),
+		title: __( 'Title' ),
+		alt: __( 'Alt Text' ),
+	},
 };


### PR DESCRIPTION
## What?
See #53705
Similar to #57789

Adds image block support for pattern overrides.

Initial support is for the image src (URL attribute), the title and the alt text.

Unfortunately there doesn't seem to be a way to edit the `title` in `contentOnly` mode, and the value set in the media library isn't used by the block. It could be a bug to fix, or alternatively it might not be worth supporting title initially. 🤔 

I also think support could expand to caption, href, rel and linkTarget, similar to what was discussed for the button block. This would be best achieved in a follow-up that covers adding support in the block bindings API.

## How?
Adds the configuration to support the image block.

## Testing Instructions
1. Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331 to create a pattern with overrides, but insert an image into the pattern
2. Insert some instances of the pattern and try changing the image.

## Screenshots or screencast <!-- if applicable -->
(sorry for the poorly cropped video!)

https://github.com/WordPress/gutenberg/assets/677833/360b83dd-a97a-49b4-ab90-0880cb1b22dd


