### PR TITLE
Update pattern overrides to use a hard coded support array

### DIFF
--- a/lib/block-supports/pattern.php
+++ b/lib/block-supports/pattern.php
@@ -13,8 +13,17 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-partial-sync
 	 * @param WP_Block_Type $block_type Block Type.
 	 */
 	function gutenberg_register_pattern_support( $block_type ) {
-		global $block_bindings_allowed_blocks;
-		$pattern_support = array_key_exists( $block_type->name, $block_bindings_allowed_blocks );
+		// Note that this should be a duplicate or a subset of the $allowed_blocks
+		// defined in the `process_block_bindings` function.
+		// It should also match the client side config defined in
+		// `packages/patterns/src/constants.js`.
+		$allowed_blocks  = array(
+			'core/paragraph' => array( 'content' ),
+			'core/heading'   => array( 'content' ),
+			'core/image'     => array( 'url', 'title', 'alt' ),
+			'core/button'    => array( 'url', 'text' ),
+		);
+		$pattern_support = array_key_exists( $block_type->name, $allowed_blocks );
 
 		if ( $pattern_support ) {
 			if ( ! $block_type->uses_context ) {


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/53705.

In #57742, the public global `$block_bindings_allowed_blocks` variable will be removed in favour of private code.

This PR removes the pattern overrides dependency on that array, so that things don't break when #57742 is merged.

## How?
Duplicates the array. While this isn't great for maintenance, it should be fine while the list of supported blocks/attributes is small and unlikely to change much.

## Testing Instructions
Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331, and ensure overrides still work for headings, paragraphs and buttons