### PR TITLE
Tidy up block patterns selectors

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -15,7 +15,7 @@ import {
 	canInsertBlockType,
 	__experimentalGetAllowedPatterns,
 } from './selectors';
-import { getUserPatterns, checkAllowListRecursive } from './utils';
+import { getAllPatterns, checkAllowListRecursive } from './utils';
 
 /**
  * Returns true if the block interface is hidden, or false otherwise.
@@ -253,26 +253,20 @@ export const getInserterMediaCategories = createSelector(
  */
 export const hasAllowedPatterns = createSelector(
 	( state, rootClientId = null ) => {
-		const patterns = state.settings.__experimentalBlockPatterns;
-		const userPatterns = getUserPatterns( state );
+		const patterns = getAllPatterns( state );
 		const { allowedBlockTypes } = getSettings( state );
-		return [ ...userPatterns, ...patterns ].some(
-			( { name, inserter = true } ) => {
-				if ( ! inserter ) {
-					return false;
-				}
-				const { blocks } = __experimentalGetParsedPattern(
-					state,
-					name
-				);
-				return (
-					checkAllowListRecursive( blocks, allowedBlockTypes ) &&
-					blocks.every( ( { name: blockName } ) =>
-						canInsertBlockType( state, blockName, rootClientId )
-					)
-				);
+		return patterns.some( ( { name, inserter = true } ) => {
+			if ( ! inserter ) {
+				return false;
 			}
-		);
+			const { blocks } = __experimentalGetParsedPattern( state, name );
+			return (
+				checkAllowListRecursive( blocks, allowedBlockTypes ) &&
+				blocks.every( ( { name: blockName } ) =>
+					canInsertBlockType( state, blockName, rootClientId )
+				)
+			);
+		} );
 	},
 	( state, rootClientId ) => [
 		...__experimentalGetAllowedPatterns.getDependants(


### PR DESCRIPTION
When retrieving the block patterns we repeatedly do this:
```js
const patterns = getPatterns();
const userPatterns = getUserPatterns();
[ ...userPatterns, ...patterns ].filter( ... );
```
This PR extracts this into a new `getAllPatterns` selector, which is also memoized so it doesn't have to construct the merged array on each call.

Because this selector is memoized, we can use it when declaring selector dependencies. That's more straighforward than enumerating its low-level dependencies explicitly.



