### PR TITLE
Update versions-in-wordpress.md

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 16.2-16.7          | 6.4.2             |
 | 16.2-16.7          | 6.4.1             |
 | 16.2-16.7          | 6.4               |
 | 15.2-16.1          | 6.3.1             |


### PR DESCRIPTION
## What?
Fixed #57910

update the versions on WordPress to latests. 

## Why?
completeness and consistencies sake. 

## How?
added a line to the overview table. 

no testing, documentation only 