### PR TITLE
Update the cherry pick script to work with the new version of gh

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -10,7 +10,7 @@ const LABEL = process.argv[ 2 ] || 'Backport to WP Beta/RC';
 const BRANCH = getCurrentBranch();
 const GITHUB_CLI_AVAILABLE = spawnSync( 'gh', [ 'auth', 'status' ] )
 	?.stdout?.toString()
-	.includes( '✓ Logged in to github.com as' );
+	.includes( '✓ Logged in to github.com' );
 
 const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
 
@@ -114,16 +114,23 @@ async function fetchPRs() {
 	const { items } = await GitHubFetch(
 		`/search/issues?q=is:pr state:closed sort:updated label:"${ LABEL }" repo:WordPress/gutenberg`
 	);
-	const PRs = items.map( ( { id, number, title, pull_request, closed_at } ) => ( {
-		id,
-		number,
-		title,
-		pull_request,
-	} ) )
+	const PRs = items
+		.map( ( { id, number, title, pull_request, closed_at } ) => ( {
+			id,
+			number,
+			title,
+			pull_request,
+		} ) )
 		.filter( ( { pull_request } ) => !! pull_request?.merged_at )
-		.sort( ( a, b ) => new Date(  a?.pull_request?.merged_at ) - new Date( b?.pull_request?.merged_at ) );
+		.sort(
+			( a, b ) =>
+				new Date( a?.pull_request?.merged_at ) -
+				new Date( b?.pull_request?.merged_at )
+		);
 
-	console.log( 'Found the following PRs to cherry-pick (sorted by closed date in ascending order): ' );
+	console.log(
+		'Found the following PRs to cherry-pick (sorted by closed date in ascending order): '
+	);
 	PRs.forEach( ( { number, title } ) =>
 		console.log( indent( `#${ number } – ${ title }` ) )
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The latest version of `gh` outputs this for `auth status`:

`Logged in to github.com account....` instead of `Logged in to github.com as`.

This changes the condition under which we check that someone is logged in to work with both versions.

## Testing Instructions
Update to the latest version of `gh`
Try running the script `npm run other:cherry-pick "Backport to Gutenberg RC"` but then cancel it before it runs.
On trunk you'll see an error that gh isn't installed. On this branch you should see a message telling you what will change.
