### PR TITLE
Update Pages preview field display

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -387,6 +387,7 @@
 		overflow: hidden;
 		position: relative;
 		flex-shrink: 0;
+		background-color: $gray-100;
 
 		img {
 			width: 100%;

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -276,7 +276,7 @@
 		border-bottom: 1px solid $gray-200;
 		background-color: $gray-100;
 
-		> * {
+		img {
 			object-fit: cover;
 			width: 100%;
 			height: 100%;

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -214,16 +214,30 @@ export default function PagePages() {
 				getValue: ( { item } ) => item.featured_media,
 				render: ( { item } ) =>
 					!! item.featured_media ? (
-						<Media
-							className="edit-site-page-pages__featured-image"
-							id={ item.featured_media }
-							size={
-								view.type === LAYOUT_GRID
-									? [ 'large', 'full', 'medium', 'thumbnail' ]
-									: [ 'thumbnail', 'medium', 'large', 'full' ]
-							}
-						/>
-					) : null,
+						<span className="edit-site-page-pages__media-wrapper">
+							<Media
+								className="edit-site-page-pages__featured-image"
+								id={ item.featured_media }
+								size={
+									view.type === LAYOUT_GRID
+										? [
+												'large',
+												'full',
+												'medium',
+												'thumbnail',
+										  ]
+										: [
+												'thumbnail',
+												'medium',
+												'large',
+												'full',
+										  ]
+								}
+							/>
+						</span>
+					) : (
+						<span className="edit-site-page-pages__media-wrapper"></span>
+					),
 				enableSorting: false,
 			},
 			{

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -212,9 +212,15 @@ export default function PagePages() {
 				id: 'featured-image',
 				header: __( 'Featured Image' ),
 				getValue: ( { item } ) => item.featured_media,
-				render: ( { item } ) =>
-					!! item.featured_media ? (
-						<span className="edit-site-page-pages__media-wrapper">
+				render: ( { item } ) => (
+					<span
+						className={
+							view.type === LAYOUT_TABLE
+								? 'edit-site-page-pages__media-wrapper'
+								: ''
+						}
+					>
+						{ !! item.featured_media ? (
 							<Media
 								className="edit-site-page-pages__featured-image"
 								id={ item.featured_media }
@@ -234,10 +240,9 @@ export default function PagePages() {
 										  ]
 								}
 							/>
-						</span>
-					) : (
-						<span className="edit-site-page-pages__media-wrapper"></span>
-					),
+						) : null }
+					</span>
+				),
 				enableSorting: false,
 			},
 			{

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -1,28 +1,26 @@
-.dataviews-view-table {
-	.edit-site-page-pages__media-wrapper {
-		width: $grid-unit-50;
-		height: $grid-unit-50;
-		display: block;
-		border-radius: $grid-unit-05;
-		position: relative;
-		background-color: $gray-100;
-		overflow: hidden;
+.edit-site-page-pages__media-wrapper {
+	width: $grid-unit-50;
+	height: $grid-unit-50;
+	display: block;
+	border-radius: $grid-unit-05;
+	position: relative;
+	background-color: $gray-100;
+	overflow: hidden;
 
-		.edit-site-page-pages__featured-image {
-			height: 100%;
-			object-fit: cover;
-			width: 100%;
-		}
+	.edit-site-page-pages__featured-image {
+		height: 100%;
+		object-fit: cover;
+		width: 100%;
+	}
 
-		&::after {
-			border-radius: 4px;
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-			content: "";
-			height: 100%;
-			left: 0;
-			position: absolute;
-			top: 0;
-			width: 100%;
-		}
+	&::after {
+		border-radius: 4px;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+		content: "";
+		height: 100%;
+		left: 0;
+		position: absolute;
+		top: 0;
+		width: 100%;
 	}
 }

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -1,5 +1,28 @@
-.edit-site-page-pages__featured-image {
-	width: $grid-unit-50;
-	height: $grid-unit-50;
-	display: block;
+.dataviews-view-table {
+	.edit-site-page-pages__media-wrapper {
+		width: $grid-unit-50;
+		height: $grid-unit-50;
+		display: block;
+		border-radius: $grid-unit-05;
+		position: relative;
+		background-color: $gray-100;
+		overflow: hidden;
+
+		.edit-site-page-pages__featured-image {
+			height: 100%;
+			object-fit: cover;
+			width: 100%;
+		}
+
+		&::after {
+			border-radius: 4px;
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+			content: "";
+			height: 100%;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/57649.

## What?
Ensures the preview/media field display for pages is consistent across layouts. 

## Why?
Currently they are inconsistent:

| Table layout | List layout |
| --- | --- |
| <img width="489" alt="Screenshot 2024-01-17 at 13 48 44" src="https://github.com/WordPress/gutenberg/assets/846565/b86dedc2-b43d-40e2-b432-36cc42c84e01"> | <img width="353" alt="Screenshot 2024-01-17 at 13 48 37" src="https://github.com/WordPress/gutenberg/assets/846565/fe3c47c8-30e8-45e4-870e-10d68773f90b"> |


This PR fixes that inconsistency:

| Table layout | List layout |
| --- | --- |
| <img width="436" alt="Screenshot 2024-01-17 at 13 46 40" src="https://github.com/WordPress/gutenberg/assets/846565/a7f21529-a8ea-4498-887a-f6750b4dd03a"> | <img width="330" alt="Screenshot 2024-01-17 at 13 46 48" src="https://github.com/WordPress/gutenberg/assets/846565/0607e0bd-f317-4f95-9cec-d0a9e730350d"> |


## How?
The pages preview/media field output now includes a wrapper to which the required styles are attached.

## Note
The styles to achieve the consistent display are applied differently;

* They are applied globally in list layout, so that all preview/media files in all data views appear the same way
* They applied locally in the pages table layout

I don't know this this is ideal, it might be better to apply the table layout media styles globally, but I believe that's a larger change. 
