### PR TITLE
Adding new `CompositeExperienceHelper` component

### DIFF
--- a/packages/components/src/composite/composite-experience-helper.tsx
+++ b/packages/components/src/composite/composite-experience-helper.tsx
@@ -1,0 +1,222 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createPortal,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import {
+	SVG,
+	Defs,
+	LinearGradient,
+	Stop,
+	G,
+	Path,
+	Rect,
+} from '@wordpress/primitives';
+import { __, isRTL } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import { View } from '../view';
+
+const DEFAULT_MESSAGE = __( 'Use arrow keys to navigate' );
+
+export interface Props extends React.ComponentProps< 'div' > {
+	audible?: boolean;
+	visible?: boolean;
+	message?: string;
+}
+
+interface RenderProps extends Props {
+	contentRef: React.RefObject< HTMLElement | undefined >;
+	helperIsActive: boolean;
+	helperIsVisible: boolean;
+}
+
+interface OverlayProps {
+	id: string;
+}
+
+const HelperOverlay = ( { id }: OverlayProps ) => {
+	const rtl = isRTL();
+	const gradientId = `${ id }-gradient`;
+	const shadowId = `${ id }-shadow`;
+
+	const style: React.CSSProperties = useMemo(
+		() => ( {
+			pointerEvents: 'none',
+			position: 'fixed',
+			bottom: '2em',
+			[ rtl ? 'right' : 'left' ]: '2em',
+		} ),
+		[ rtl ]
+	);
+
+	return useMemo(
+		() => (
+			<SVG
+				id={ id }
+				width="90"
+				height="60"
+				viewBox="0 0 90 60"
+				style={ style }
+			>
+				<Defs>
+					<LinearGradient
+						id={ gradientId }
+						x1="0"
+						x2="0"
+						y1="0"
+						y2="1"
+					>
+						<Stop offset="0%" stopColor="#FFF" />
+						<Stop offset="10%" stopColor="#AAA" />
+						<Stop offset="50%" stopColor="#CCC" />
+						<Stop offset="100%" stopColor="#FFF" />
+					</LinearGradient>
+					<filter id={ shadowId }>
+						<feDropShadow
+							dx="0"
+							dy="1"
+							stdDeviation="0.5"
+							floodColor="#FFF"
+						/>
+					</filter>
+				</Defs>
+				<G
+					stroke="#000"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				>
+					<G fill={ `url(#${ gradientId })` }>
+						<Rect
+							width="25"
+							height="25"
+							x="32.5"
+							y="2.5"
+							rx="5"
+							ry="5"
+						/>
+						<Rect
+							width="25"
+							height="25"
+							x="2.5"
+							y="32.5"
+							rx="5"
+							ry="5"
+						/>
+						<Rect
+							width="25"
+							height="25"
+							x="32.5"
+							y="32.5"
+							rx="5"
+							ry="5"
+						/>
+						<Rect
+							width="25"
+							height="25"
+							x="62.5"
+							y="32.5"
+							rx="5"
+							ry="5"
+						/>
+					</G>
+					<G fill="transparent" filter={ `url(#${ shadowId })` }>
+						<Path d="M41 16 l4 -4 4 4" />
+						<Path d="M16 41 l-4 4 4 4" />
+						<Path d="M41 44 l4 4 4 -4" />
+						<Path d="M74 41 l4 4 -4 4" />
+					</G>
+				</G>
+			</SVG>
+		),
+		[ style, id, gradientId, shadowId ]
+	);
+};
+
+export function useCompositeExperienceHelper( {
+	audible = true,
+	visible = true,
+	message = DEFAULT_MESSAGE,
+	...props
+}: Props ): RenderProps {
+	const [ helperIsActive, setHelperIsActive ] = useState( false );
+	const [ contentNode, setContentNode ] = useState<
+		HTMLElement | undefined
+	>();
+	const contentRef = useRef< HTMLElement | undefined >(
+		Object.create( null )
+	);
+	Object.defineProperty( contentRef, 'current', {
+		enumerable: true,
+		configurable: true,
+		get: () => contentNode,
+		set: setContentNode,
+	} );
+	const isMouseAction = useRef( false );
+
+	useEffect( () => {
+		if ( audible && helperIsActive ) {
+			speak( message );
+		}
+	}, [ audible, helperIsActive, message ] );
+
+	return {
+		...props,
+		onMouseDown: ( event ) => {
+			isMouseAction.current = true;
+			setHelperIsActive( false );
+			props.onMouseDown?.( event );
+		},
+		onMouseUp: ( event ) => {
+			isMouseAction.current = false;
+			props.onMouseUp?.( event );
+		},
+		onFocus: ( event ) => {
+			if ( ! isMouseAction.current ) {
+				setHelperIsActive( true );
+			}
+			props.onFocus?.( event );
+		},
+		onBlur: ( event ) => {
+			const { relatedTarget } = event;
+			if ( ! contentNode?.contains( relatedTarget ) ) {
+				setHelperIsActive( false );
+			}
+			props.onBlur?.( event );
+		},
+		contentRef,
+		helperIsActive,
+		helperIsVisible: helperIsActive && visible,
+	};
+}
+
+const CompositeExperienceHelper = ( props: Props ) => {
+	const overlayId = useId();
+	const { contentRef, helperIsActive, helperIsVisible, ...viewProps } =
+		useCompositeExperienceHelper( props );
+
+	return (
+		<>
+			<View { ...viewProps } ref={ contentRef } />
+			{ contentRef.current && helperIsVisible
+				? createPortal(
+						<HelperOverlay id={ overlayId } />,
+						contentRef.current.ownerDocument.body,
+						'composite-experience-helper-overlay'
+				  )
+				: null }
+		</>
+	);
+};
+
+export default CompositeExperienceHelper;

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryContext, StoryFn } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+import { isRTL } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Composite,
+	CompositeItem,
+	CompositeRow,
+	CompositeExperienceHelper,
+	useCompositeStore,
+} from '../v2';
+
+const meta: Meta< typeof CompositeExperienceHelper > = {
+	title: 'Components/Composite/CompositeExperienceHelper',
+	id: 'composite-experience-helper',
+	component: CompositeExperienceHelper,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			source: {
+				transform: ( _: unknown, context: StoryContext ) => {
+					const props = Object.entries( context.args )
+						.map(
+							( [ key, value ] ) =>
+								` ${ key }={ ${ JSON.stringify( value ) } }`
+						)
+						.join( '' );
+					return [
+						`<CompositeExperienceHelper${ props }>`,
+						'  <Composite store={ store }>',
+						'    ...',
+						'  </Composite>',
+						'</CompositeExperienceHelper>',
+					].join( '\n' );
+				},
+			},
+		},
+	},
+};
+export default meta;
+
+const Template: StoryFn< typeof CompositeExperienceHelper > = ( props ) => {
+	const store = useCompositeStore( { rtl: isRTL() } );
+
+	return (
+		<CompositeExperienceHelper { ...props }>
+			<Composite store={ store } role="grid">
+				<CompositeRow role="row">
+					<CompositeItem role="gridcell">A1</CompositeItem>
+					<CompositeItem role="gridcell">A2</CompositeItem>
+					<CompositeItem role="gridcell">A3</CompositeItem>
+				</CompositeRow>
+				<CompositeRow role="row">
+					<CompositeItem role="gridcell">B1</CompositeItem>
+					<CompositeItem role="gridcell">B2</CompositeItem>
+					<CompositeItem role="gridcell">B3</CompositeItem>
+				</CompositeRow>
+				<CompositeRow role="row">
+					<CompositeItem role="gridcell">C1</CompositeItem>
+					<CompositeItem role="gridcell">C2</CompositeItem>
+					<CompositeItem role="gridcell">C3</CompositeItem>
+				</CompositeRow>
+			</Composite>
+		</CompositeExperienceHelper>
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {};
+
+export const WithAudibleDisabled = Template.bind( {} );
+WithAudibleDisabled.args = { ...Default.args, audible: false };
+
+export const WithVisibleDisabled = Template.bind( {} );
+WithVisibleDisabled.args = { ...Default.args, visible: false };
+
+export const WithCustomMessage = Template.bind( {} );
+WithCustomMessage.args = { ...Default.args, message: 'An alternative prompt' };

--- a/packages/components/src/composite/v2.ts
+++ b/packages/components/src/composite/v2.ts
@@ -18,5 +18,7 @@ export {
 	useCompositeStore,
 } from '@ariakit/react';
 
+export { default as CompositeExperienceHelper } from './composite-experience-helper';
+
 /* eslint-disable-next-line no-restricted-imports */
 export type { CompositeStore } from '@ariakit/react';

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -8,6 +8,7 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
  */
 import {
 	Composite as CompositeV2,
+	CompositeExperienceHelper as CompositeExperienceHelperV2,
 	CompositeGroup as CompositeGroupV2,
 	CompositeItem as CompositeItemV2,
 	CompositeRow as CompositeRowV2,
@@ -36,6 +37,7 @@ import { lock } from './lock-unlock';
 export const privateApis = {};
 lock( privateApis, {
 	CompositeV2,
+	CompositeExperienceHelperV2,
 	CompositeGroupV2,
 	CompositeItemV2,
 	CompositeRowV2,


### PR DESCRIPTION
## What?

This PR adds a new component in the `Composite` family, to provide both a visual and an "audible" prompt (for assistive technology consumption), to indicate when an interactive UI element should be navigated with arrow keys rather than tabbing.

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/5998cbec-11c5-47b7-8699-c3eb20ad0c3d" alt="A sequence of user interactions, showing and hiding an arrow key graphic as the user tabs past an interactive control." width="600" />
</p>


## Why?

It can be unclear to the user when an interactive widget should be navigated with arrow keys, and it is left to trial and error to discover this. Equally, if an element has been removed from the tab order, it can be confusing as to how to reach it.


## How?

A new `CompositeExperienceHelper` component has been created, which handles focus events, rendering an arrow keypad graphic, and announcing the input mode. It can be used to wrap existing `Composite` consumers, and otherwise provide assistive functionality without further configuration.


## Further iteration...

### Collision detection

The arrow key graphic can potentially get in the way of other controls, as well as items with the current interaction context. It might be worth doing some work to minimise this disruption.

### New-user notification

For users completely new to keyboard navigation, we could show them some sort of popup the first time they come across this model, so that they can fully understand what it means in the future.


## Testing Instructions

In the new `Components / Composite / CompositeExperienceHelper` page in Storybook:

1. Clicking on any of the buttons in the example stories should not show any change in behaviour

### Testing Instructions for Keyboard

In the same Storybook page:

1. Navigating to the lead example story should:
   1. Show an "arrow key" graphic in the bottom left corner of the canvas
   2. Cause a screen reader announcement of "Use arrow keys to navigate" (politely, after other information is announced!)
2. Navigating to the 'With Audible Disabled' story should:
   1. Show an "arrow key" graphic in the bottom left corner of the canvas
   2. Not cause a screen reader announcement
3. Navigating to the 'With Visible Disabled' story should:
   1. Not show an "arrow key" graphic
   2. Cause a screen reader announcement of "Use arrow keys to navigate"
4. Navigating to the 'With Custom Message' story should:
   1. Show an "arrow key" graphic in the bottom left corner of the canvas
   2. Cause a screen reader announcement of "An alternative prompt"

Note that with `RTL` enabled, the "arrow key" graphic should, where appropriate, appear in the bottom _right_ corner of the canvas.

<p align="center">
  <img src="https://github.com/WordPress/gutenberg/assets/159848/97291ac6-f90d-4cfc-860c-cb6d788604fe" alt="In an RTL context, an interactive control has focus, and an arrow key graphic is below on the right-hand side." width="600" />
</p>


## Screenshots or screencast

https://github.com/WordPress/gutenberg/assets/159848/d50effec-7bcc-4a31-9d3b-9d11e63e7b61