### PR TITLE
Add BlockJsonDependenciesPlugin to modules build

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Add experimental support for `viewScriptModule` field in block.json for `build` and `start` scripts ([#57437](https://github.com/WordPress/gutenberg/pull/57437)).
 
+### Enhancements
+
+-   Ensure that watched module builds detect block.json changes ([#57927](https://github.com/WordPress/gutenberg/pull/57927)).
+
 ### Deprecations
 
 -   Experimental support for `viewModule` field in block.json is deprecated in favor of `viewScriptModule` ([#57437](https://github.com/WordPress/gutenberg/pull/57437)).


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a plugin that finds block.json files and adds them as
fileDependencies of the module build. This ensures that changes to
block.json files trigger updates to the module build.

See https://webpack.js.org/contribute/plugin-patterns/

> You may also feed new file paths into the watch graph to receive
> compilation triggers when those files change. Add valid file paths
> into the `compilation.fileDependencies` Set to add them to the
> watched files.


https://github.com/WordPress/gutenberg/assets/841763/c630b758-7dd6-46c0-9121-c8b6b49e255c



## Why?

@gziolo noticed that changes to block.json files wouldn't trigger changes to the module build (https://github.com/WordPress/gutenberg/pull/57461#discussion_r1454903155)



## Testing Instructions

To test this, you'll want to check this out and link it to a project that depends on @wordpress/scripts.

If you use `wp-scripts start`, changes to any `block.json` files in the project should trigger a rebuild. Changes to the `viewModule` field should change the compilation.