### PR TITLE
Block Hooks: Do not remove toggle if hooked block is present elsewhere

### DIFF
--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -96,13 +96,8 @@ function BlockHooksControlPure( { name, clientId } ) {
 					}
 
 					// If no hooked block was found in any of its designated locations,
-					// but it exists elsewhere in the block tree, we consider it manually inserted.
-					// In this case, we take note and will remove the corresponding toggle from the
-					// block inspector panel.
-					return {
-						...clientIds,
-						[ block.name ]: false,
-					};
+					// we set the toggle to disabled.
+					return clientIds;
 				},
 				{}
 			);
@@ -118,13 +113,7 @@ function BlockHooksControlPure( { name, clientId } ) {
 
 	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
 
-	// Remove toggle if block isn't present in the designated location but elsewhere in the block tree.
-	const hookedBlocksForCurrentBlockIfNotPresentElsewhere =
-		hookedBlocksForCurrentBlock?.filter(
-			( block ) => hookedBlockClientIds?.[ block.name ] !== false
-		);
-
-	if ( ! hookedBlocksForCurrentBlockIfNotPresentElsewhere.length ) {
+	if ( ! hookedBlocksForCurrentBlock.length ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -55,8 +55,7 @@ function BlockHooksControlPure( { name, clientId } ) {
 			const _hookedBlockClientIds = hookedBlocksForCurrentBlock.reduce(
 				( clientIds, block ) => {
 					// If the block doesn't exist anywhere in the block tree,
-					// we know that we have to display the toggle for it, and set
-					// it to disabled.
+					// we know that we have to set the toggle to disabled.
 					if ( getGlobalBlockCount( block.name ) === 0 ) {
 						return clientIds;
 					}


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/59955.

## What?
Don't remove hooked block toggle from "Plugins" panel if the hooked block is not in its expected location but elsewhere in the block tree.

## Why?
Previously, if a hooked block wasn't present in its expected location, but was found somewhere else, we would remove its toggle from the "Plugins" panel, as we'd assume that it was moved by the user to that other location (and that the user was thus familiar with the hooked block and did not need the extra visibility provided by the toggle).

However, this lead to confusion when there were multiple instances of the same anchor block: Once the user removed one of the hooked blocks, the toggle would vanish, as there were still all the other automatically inserted hooked blocks present.

This PR changes the behavior so that the toggle will always be visible.

## How?
By changing some logic.

## Testing Instructions

### To reproduce the issue (on `trunk`):

- Install and activate the [latest version of the Like Button plugin](https://github.com/ockham/like-button/releases/latest).
- Use a block theme like TT3 or TT4.
- In the Site Editor, edit the Single Posts template.
- Verify that the Like Button block is inserted both below the Post Content block, and as the Comment Template block's last child.
- Click on the Post Content block, and open the block inspector sidebar. Locate the 'Plugins' panel, and verify that the toggle is enabled. 
- Click on it to remove the block. _Note that this causes the toggle to disappear._ ❌ 

(Undo the change, and/or make sure not to save the template.)

### To verify the fix

On this branch, go through the above instructions again. Verify that the buggy behavior (marked ❌ ) has been fixed.

## Screenshots or screencast

| Before | After |
|-------|-------|
| ![toggle-fix-multiple-hooked-blocks](https://github.com/WordPress/gutenberg/assets/96308/3db1b5c7-ebb3-4224-a3c7-d87f661f41cc) | ![block-hooks-toggle-behavior-change](https://github.com/WordPress/gutenberg/assets/96308/da83f592-b4cd-4d09-bfd5-c02049113214) |