### PR TITLE
Update Templates table layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -90,7 +90,7 @@
 		@include break-huge() {
 			min-width: 200px;
 		}
-		
+
 		&[data-field-id="actions"] {
 			text-align: right;
 		}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -59,6 +59,10 @@
 	margin: $grid-unit-40 0 $grid-unit-20;
 }
 
+.dataviews-view-table-wrapper {
+	overflow-x: scroll;
+}
+
 .dataviews-view-table {
 	width: 100%;
 	text-indent: 0;
@@ -81,7 +85,12 @@
 	td,
 	th {
 		padding: $grid-unit-15;
-		min-width: 160px;
+		white-space: nowrap;
+
+		@include break-huge() {
+			min-width: 200px;
+		}
+		
 		&[data-field-id="actions"] {
 			text-align: right;
 		}
@@ -199,6 +208,10 @@
 
 	.dataviews-view-table-header {
 		padding-left: $grid-unit-05;
+	}
+
+	.dataviews-view-table__actions-column {
+		width: 1%;
 	}
 }
 

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -437,7 +437,7 @@ function ViewTable( {
 	);
 
 	return (
-		<div>
+		<div className="dataviews-view-table-wrapper">
 			<table
 				className="dataviews-view-table"
 				aria-busy={ isLoading }
@@ -506,7 +506,10 @@ function ViewTable( {
 							</th>
 						) ) }
 						{ !! actions?.length && (
-							<th data-field-id="actions">
+							<th
+								data-field-id="actions"
+								className="dataviews-view-table__actions-column"
+							>
 								<span className="dataviews-view-table-header">
 									{ __( 'Actions' ) }
 								</span>
@@ -581,7 +584,7 @@ function ViewTable( {
 									</td>
 								) ) }
 								{ !! actions?.length && (
-									<td>
+									<td className="dataviews-view-table__actions-column">
 										<ItemActions
 											item={ item }
 											actions={ actions }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -233,8 +233,8 @@ export default function DataviewsTemplates() {
 						)
 					);
 				},
-				maxWidth: 420,
-				minWidth: 360,
+				maxWidth: 400,
+				minWidth: 320,
 				enableSorting: false,
 			},
 			{

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -216,20 +216,26 @@ export default function DataviewsTemplates() {
 				id: 'description',
 				getValue: ( { item } ) => item.description,
 				render: ( { item } ) => {
-					return item.description
-						? decodeEntities( item.description )
-						: view.type === LAYOUT_TABLE && (
-								<>
-									<Text variant="muted" aria-hidden="true">
-										&#8212;
-									</Text>
-									<VisuallyHidden>
-										{ __( 'No description.' ) }
-									</VisuallyHidden>
-								</>
-						  );
+					return item.description ? (
+						<span className="page-templates-description">
+							{ decodeEntities( item.description ) }
+						</span>
+					) : (
+						view.type === LAYOUT_TABLE && (
+							<>
+								<Text variant="muted" aria-hidden="true">
+									&#8212;
+								</Text>
+								<VisuallyHidden>
+									{ __( 'No description.' ) }
+								</VisuallyHidden>
+							</>
+						)
+					);
 				},
-				maxWidth: 200,
+				maxWidth: 420,
+				minWidth: 360,
+				//width: '1%',
 				enableSorting: false,
 			},
 			{
@@ -242,6 +248,7 @@ export default function DataviewsTemplates() {
 				enableHiding: false,
 				type: ENUMERATION_TYPE,
 				elements: authors,
+				width: '1%',
 			},
 		],
 		[ authors, view.type ]

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -235,7 +235,6 @@ export default function DataviewsTemplates() {
 				},
 				maxWidth: 420,
 				minWidth: 360,
-				//width: '1%',
 				enableSorting: false,
 			},
 			{

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -11,3 +11,7 @@
 		}
 	}
 }
+
+.page-templates-description {
+	white-space: normal;
+}


### PR DESCRIPTION
## What?
Improve the overall layout of the Manage templates table.

## Why?
This is best described in video, here's the current templates table:

https://github.com/WordPress/gutenberg/assets/846565/85993f08-64a6-416e-bfa5-1d097fee616f

And here's this PR:


https://github.com/WordPress/gutenberg/assets/846565/fa668f2c-e074-46a3-af72-067961ca9e10

Changes / fixes include:

* Small-screen optimisations;
  * Only the table scrolls horizontally, not the entire view.
  * Author and Actions cells collapse down to 'hug' their contents and save space.
* Title and Description scale proportionately so that the description remains legible.


## How?
The `white-space: nowrap` + `width: 1%` trick is applied to table cells so that they 'hug' their contents. On larger screens a `min-width` is applied to stop columns appearing too dense on right-hand side of the table. 

A wrapper was added to the table markup (making use of an existing div) which is then used to facilitate horizontal scrolling.

## Testing Instructions
1. Enable data views experiment
2. Navigate to Appearance > Editor > Templates > Manage all templates
3. Observe the updated layout
4. Ensure the changes here do not adversely affect the other table layout at; Appearance > Editor > Pages

## Follow-ups
* Apply these same techniques to the Pages table.
* Explore making the title column (and potentially the actions column) sticky on small screens for better orientation.
