### PR TITLE
Font Library: Update uninstall/delete on client side

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -263,6 +263,8 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 		foreach ( $this->get_font_face_ids( $font_family_id ) as $font_face_id ) {
 			wp_delete_post( $font_face_id, true );
 		}
+
+		return $deleted;
 	}
 
 	/**

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -303,12 +303,14 @@ function FontLibraryProvider( { children } ) {
 				fontFamilyToUninstall.slug
 			);
 
-			// Uninstall the font (remove the font files from the server and the posts from the database).
+			// Uninstall the font family.
+			// (Removes the font files from the server and the posts from the database).
 			const uninstalledFontFamily = await fetchUninstallFontFamily(
 				fontFamilyToUninstallData.id
 			);
 
-			// Deactivate the font family (remove the font family from the global styles).
+			// Deactivate the font family if delete request is successful
+			// (Removes the font family from the global styles).
 			if ( uninstalledFontFamily.deleted ) {
 				deactivateFontFamily( fontFamilyToUninstall );
 				// Save the global styles to the database.

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -70,12 +70,15 @@ function FontLibraryProvider( { children } ) {
 	} );
 
 	const libraryFonts =
-		( libraryPosts || [] ).map( ( post ) => {
-			post.font_family_settings.fontFace =
-				post?._embedded?.font_faces.map(
-					( face ) => face.font_face_settings
-				) || [];
-			return post.font_family_settings;
+		( libraryPosts || [] ).map( ( fontFamilyPost ) => {
+			return {
+				id: fontFamilyPost.id,
+				...fontFamilyPost.font_family_settings,
+				fontFace:
+					fontFamilyPost?._embedded?.font_faces.map(
+						( face ) => face.font_face_settings
+					) || [],
+			};
 		} ) || [];
 
 	// Global Styles (settings) font families
@@ -298,15 +301,10 @@ function FontLibraryProvider( { children } ) {
 
 	async function uninstallFont( fontFamilyToUninstall ) {
 		try {
-			// Get the font family data by slug.
-			const fontFamilyToUninstallData = await fetchGetFontFamilyBySlug(
-				fontFamilyToUninstall.slug
-			);
-
 			// Uninstall the font family.
 			// (Removes the font files from the server and the posts from the database).
 			const uninstalledFontFamily = await fetchUninstallFontFamily(
-				fontFamilyToUninstallData.id
+				fontFamilyToUninstall.id
 			);
 
 			// Deactivate the font family if delete request is successful

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -299,7 +299,7 @@ function FontLibraryProvider( { children } ) {
 		}
 	}
 
-	async function uninstallFont( fontFamilyToUninstall ) {
+	async function uninstallFontFamily( fontFamilyToUninstall ) {
 		try {
 			// Uninstall the font family.
 			// (Removes the font files from the server and the posts from the database).
@@ -441,7 +441,7 @@ function FontLibraryProvider( { children } ) {
 				getFontFacesActivated,
 				loadFontFaceAsset,
 				installFont,
-				uninstallFont,
+				uninstallFontFamily,
 				toggleActivateFont,
 				getAvailableFontsOutline,
 				modalTabOpen,

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -326,10 +326,11 @@ function FontLibraryProvider( { children } ) {
 			return uninstalledFontFamily;
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
-			console.error( error );
-			return {
-				errors: [ error ],
-			};
+			console.error(
+				`There was an error uninstalling the font family:`,
+				error
+			);
+			throw error;
 		}
 	}
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -62,7 +62,7 @@ function InstalledFonts() {
 			setNotice( {
 				type: 'error',
 				message:
-					__( 'There was an error uninstalling the font family.' ) +
+					__( 'There was an error uninstalling the font family. ' ) +
 					error.message,
 			} );
 		}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -52,17 +52,17 @@ function InstalledFonts() {
 			await uninstallFont( libraryFontSelected );
 			setNotice( {
 				type: 'success',
-				message: __( 'Fonts were uninstalled successfully.' ),
+				message: __( 'Font family uninstalled successfully.' ),
 			} );
 
-			// If the font was succesfully uninstalled it is unselected
+			// If the font was succesfully uninstalled it is unselected.
 			handleUnselectFont();
 			setIsConfirmDeleteOpen( false );
 		} catch ( error ) {
 			setNotice( {
 				type: 'error',
 				message:
-					__( 'There was an error uninstalling the fonts.' ) +
+					__( 'There was an error uninstalling the font family.' ) +
 					error.message,
 			} );
 		}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -32,7 +32,7 @@ function InstalledFonts() {
 		baseThemeFonts,
 		handleSetLibraryFontSelected,
 		refreshLibrary,
-		uninstallFont,
+		uninstallFontFamily,
 		isResolvingLibrary,
 	} = useContext( FontLibraryContext );
 	const [ isConfirmDeleteOpen, setIsConfirmDeleteOpen ] = useState( false );
@@ -49,7 +49,7 @@ function InstalledFonts() {
 
 	const handleConfirmUninstall = async () => {
 		try {
-			await uninstallFont( libraryFontSelected );
+			await uninstallFontFamily( libraryFontSelected );
 			setNotice( {
 				type: 'success',
 				message: __( 'Font family uninstalled successfully.' ),

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -48,15 +48,24 @@ function InstalledFonts() {
 	const [ notice, setNotice ] = useState( null );
 
 	const handleConfirmUninstall = async () => {
-		const response = await uninstallFont( libraryFontSelected );
-		// TODO: Refactor uninstall notices
-		// const uninstallNotice = getNoticeFromUninstallResponse( response );
-		// setNotice( uninstallNotice );
-		// If the font was succesfully uninstalled it is unselected
-		if ( ! response?.errors?.length ) {
+		try {
+			await uninstallFont( libraryFontSelected );
+			setNotice( {
+				type: 'success',
+				message: __( 'Fonts were uninstalled successfully.' ),
+			} );
+
+			// If the font was succesfully uninstalled it is unselected
 			handleUnselectFont();
+			setIsConfirmDeleteOpen( false );
+		} catch ( error ) {
+			setNotice( {
+				type: 'error',
+				message:
+					__( 'There was an error uninstalling the fonts.' ) +
+					error.message,
+			} );
 		}
-		setIsConfirmDeleteOpen( false );
 	};
 
 	const handleUninstallClick = async () => {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/resolvers.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/resolvers.js
@@ -57,14 +57,10 @@ export async function fetchGetFontFamilyBySlug( slug ) {
 	} );
 }
 
-export async function fetchUninstallFonts( fonts ) {
-	const data = {
-		font_families: fonts,
-	};
+export async function fetchUninstallFontFamily( fontFamilyId ) {
 	const config = {
-		path: '/wp/v2/font-families',
+		path: `/wp/v2/font-families/${ fontFamilyId }?force=true`,
 		method: 'DELETE',
-		data,
 	};
 	return apiFetch( config );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Implements the new deletion endpoint on the client side for the Font Library.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Install a font family via the Font Library modal.
2. Open the font family in the modal.
3. Click the 'Delete' button in the bottom left of the modal.
4. The font family and all its font faces should be uninstalled and deleted.
