### PR TITLE
DataViews: make list layout the default for templates with the experiment enabled

### DIFF
--- a/packages/edit-site/src/components/page-main/index.js
+++ b/packages/edit-site/src/components/page-main/index.js
@@ -20,7 +20,10 @@ export default function PageMain() {
 		params: { path },
 	} = useLocation();
 
-	if ( path === '/wp_template/all' ) {
+	if (
+		path === '/wp_template/all' ||
+		( path === '/wp_template' && window?.__experimentalAdminViews )
+	) {
 		return <PageTemplates />;
 	} else if ( path === '/wp_template_part/all' ) {
 		return <PageTemplateParts />;

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -170,6 +170,18 @@ export default function DataviewsTemplates() {
 		[ setTemplateId ]
 	);
 
+	const onDetailsChange = useCallback(
+		( items ) => {
+			if ( items?.length === 1 ) {
+				history.push( {
+					postId: items[ 0 ].id,
+					postType: TEMPLATE_POST_TYPE,
+				} );
+			}
+		},
+		[ history ]
+	);
+
 	const authors = useMemo( () => {
 		if ( ! allTemplates ) {
 			return EMPTY_ARRAY;
@@ -363,6 +375,7 @@ export default function DataviewsTemplates() {
 					view={ view }
 					onChangeView={ onChangeView }
 					onSelectionChange={ onSelectionChange }
+					onDetailsChange={ onDetailsChange }
 					deferredRendering={
 						! view.hiddenFields?.includes( 'preview' )
 					}

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -77,7 +77,7 @@ const defaultConfigPerViewType = {
 };
 
 const DEFAULT_VIEW = {
-	type: LAYOUT_TABLE,
+	type: LAYOUT_LIST,
 	search: '',
 	page: 1,
 	perPage: 20,

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -76,7 +76,11 @@ function SidebarScreens() {
 				<SidebarNavigationScreenPage />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/:postType(wp_template)">
-				<SidebarNavigationScreenTemplates />
+				{ window?.__experimentalAdminViews ? (
+					<SidebarNavigationScreenTemplatesBrowse />
+				) : (
+					<SidebarNavigationScreenTemplates />
+				) }
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/patterns">
 				<SidebarNavigationScreenPatterns />

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -16,6 +16,7 @@ export default function getIsListPage(
 	return (
 		[ '/wp_template/all', '/wp_template_part/all' ].includes( path ) ||
 		( path === '/page' && window?.__experimentalAdminViews ) ||
+		( path === '/wp_template' && window?.__experimentalAdminViews ) ||
 		( path === '/patterns' &&
 			// Don't treat "/patterns" without categoryType and categoryId as a
 			// list page in mobile because the sidebar covers the whole page.

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -18,7 +18,11 @@ test.describe( 'Templates', () => {
 		] );
 	} );
 	test( 'Sorting', async ( { admin, page } ) => {
-		await admin.visitSiteEditor( { path: '/wp_template/all' } );
+		await admin.visitSiteEditor( { path: '/wp_template' } );
+		// Switch to table layout.
+		await page.getByLabel( 'View options' ).click();
+		await page.getByRole( 'menuitem', { name: 'Layout' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
 		// Descending by title.
 		await page
 			.getByRole( 'button', { name: 'Template', exact: true } )
@@ -48,7 +52,13 @@ test.describe( 'Templates', () => {
 			title: 'Date Archives',
 			content: 'hi',
 		} );
-		await admin.visitSiteEditor( { path: '/wp_template/all' } );
+		await admin.visitSiteEditor( { path: '/wp_template' } );
+
+		// Switch to table layout.
+		await page.getByLabel( 'View options' ).click();
+		await page.getByRole( 'menuitem', { name: 'Layout' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+
 		// Global search.
 		await page.getByRole( 'searchbox', { name: 'Filter list' } ).click();
 		await page.keyboard.type( 'tag' );
@@ -84,7 +94,13 @@ test.describe( 'Templates', () => {
 		await expect( titles ).toHaveCount( 2 );
 	} );
 	test( 'Field visibility', async ( { admin, page } ) => {
-		await admin.visitSiteEditor( { path: '/wp_template/all' } );
+		await admin.visitSiteEditor( { path: '/wp_template' } );
+
+		// Switch to table layout.
+		await page.getByLabel( 'View options' ).click();
+		await page.getByRole( 'menuitem', { name: 'Layout' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+
 		await page.getByRole( 'button', { name: 'Description' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Hide' } ).click();
 		await expect(


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

This PR makes the dataviews powered-page the default for the Templates page root.

Before:

https://github.com/WordPress/gutenberg/assets/583546/2200a7c5-cfef-4859-b18c-256647dccca5 

After:

https://github.com/WordPress/gutenberg/assets/583546/ca029093-413f-4c86-8a27-12a4e727cb93

## Why?

It's the target flow we want.

## How?

- Adds the details button to the list layout. https://github.com/WordPress/gutenberg/pull/57933/commits/324bbfaaa57ba4fed6e8e06f5e407c10cce513c3
- Makes the list layout the default for the dataviews-powered page. https://github.com/WordPress/gutenberg/pull/57933/commits/2c02f24f90039bbf73e0170c49cf58fb14fa8eb9
- Updates the root Templates to load the dataviews-powered page.
  - Sidebar https://github.com/WordPress/gutenberg/pull/57933/commits/2847652fcc99bb4bc75b1daa96cb929ad5e37f2d
  - Content https://github.com/WordPress/gutenberg/pull/57933/commits/ac0930dd93361b5488b4363309eeada13b50e82c
- Update e2e tests https://github.com/WordPress/gutenberg/pull/57933/commits/84053ab0d5977d1389197e1ae77721357315ae1b

## Testing Instructions

- Enable the "new admin views" experiment and visit "Site Editor > Templates". Verify the dataviews-powered page is displayed.
- Disable the "new admin views" experiment and visit "Site Editor > Templates". Verify the existing page is displayed.
