### PR TITLE
Data: allow binding registry selector to multiple registries

### DIFF
--- a/packages/data/src/factory.js
+++ b/packages/data/src/factory.js
@@ -44,17 +44,16 @@ export function createRegistrySelector( registrySelector ) {
 	// and that has the same API as a regular selector. Binding it in such a way makes it
 	// possible to call the selector directly from another selector.
 	const wrappedSelector = ( ...args ) => {
+		let selector = selectorsByRegistry.get( wrappedSelector.registry );
 		// We want to make sure the cache persists even when new registry
 		// instances are created. For example patterns create their own editors
 		// with their own core/block-editor stores, so we should keep track of
 		// the cache for each registry instance.
-		if ( ! selectorsByRegistry.has( wrappedSelector.registry ) ) {
-			selectorsByRegistry.set(
-				wrappedSelector.registry,
-				registrySelector( wrappedSelector.registry.select )
-			);
+		if ( ! selector ) {
+			selector = registrySelector( wrappedSelector.registry.select );
+			selectorsByRegistry.set( wrappedSelector.registry, selector );
 		}
-		return selectorsByRegistry.get( wrappedSelector.registry )( ...args );
+		return selector( ...args );
 	};
 
 	/**

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -237,6 +237,11 @@ export default function createReduxStore( key, options ) {
 				const boundSelector = ( ...args ) => {
 					args = normalize( selector, args );
 					const state = store.__unstableOriginalGetState();
+					// Before calling the selector, switch to the correct
+					// registry.
+					if ( selector.isRegistrySelector ) {
+						selector.registry = registry;
+					}
 					return selector( state.root, ...args );
 				};
 

--- a/packages/data/src/test/registry-selectors.js
+++ b/packages/data/src/test/registry-selectors.js
@@ -78,8 +78,7 @@ describe( 'createRegistrySelector', () => {
 		expect( registry.select( uiStore ).getElementCount() ).toBe( 1 );
 	} );
 
-	// Even without createSelector, this fails in trunk.
-	it.skip( 'can bind one selector to multiple registries', () => {
+	it( 'can bind one selector to multiple registries (createRegistrySelector)', () => {
 		const registry1 = createRegistry();
 		const registry2 = createRegistry();
 
@@ -100,6 +99,26 @@ describe( 'createRegistrySelector', () => {
 
 		expect( registry1.select( uiStore ).getElementCount() ).toBe( 1 );
 		expect( registry2.select( uiStore ).getElementCount() ).toBe( 1 );
+	} );
+
+	it( 'can bind one selector to multiple registries (createRegistrySelector + createSelector)', () => {
+		const registry1 = createRegistry();
+		registry1.register( elementsStore );
+		registry1.register( uiStore );
+		registry1.dispatch( elementsStore ).add( 'Carbon' );
+
+		const registry2 = createRegistry();
+		registry2.register( elementsStore );
+		registry2.register( uiStore );
+		registry2.dispatch( elementsStore ).add( 'Helium' );
+
+		// Expects the `getFilteredElements` to be bound separately and independently to the two registries
+		expect( registry1.select( uiStore ).getFilteredElements() ).toEqual( [
+			'Carbon',
+		] );
+		expect( registry2.select( uiStore ).getFilteredElements() ).toEqual( [
+			'Helium',
+		] );
 	} );
 
 	it( 'can bind a memoized selector to a registry', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently it's not possible to bind a "registry selector" (created through `createRegistrySelector`) to multiple registries. This is because the selector is bound (registry property set) when a registry initialises, so on the next initialisation this `registry` property is overridden.

The easiest solution here is to "switch" registries before calling the selector.

Additionally a cache should be kept for each registry, which shouldn't invalidate when initialising or switching to other registries.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It currently prevents me from adding registry selectors to the block editor store, because it's possible to create multiple instances of these (separate editor instances in previews for example).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
