### PR TITLE
Support `linkTarget` of `core/button` for Pattern Overrides

### DIFF
--- a/lib/block-supports/pattern.php
+++ b/lib/block-supports/pattern.php
@@ -21,7 +21,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-partial-sync
 			'core/paragraph' => array( 'content' ),
 			'core/heading'   => array( 'content' ),
 			'core/image'     => array( 'url', 'title', 'alt' ),
-			'core/button'    => array( 'url', 'text' ),
+			'core/button'    => array( 'url', 'text', 'linkTarget' ),
 		);
 		$pattern_support = array_key_exists( $block_type->name, $allowed_blocks );
 

--- a/lib/experimental/block-bindings/class-wp-block-bindings.php
+++ b/lib/experimental/block-bindings/class-wp-block-bindings.php
@@ -16,6 +16,10 @@ if ( class_exists( 'WP_Block_Bindings' ) ) {
  * Core class used to define supported blocks, register sources, and populate HTML with content from those sources.
  */
 class WP_Block_Bindings {
+	/**
+	 * A singleton flag to represent skipping processing the attribute.
+	 */
+	const SKIP = array();
 
 	/**
 	 * Holds the registered block bindings sources, keyed by source identifier.

--- a/lib/experimental/block-bindings/sources/pattern.php
+++ b/lib/experimental/block-bindings/sources/pattern.php
@@ -7,10 +7,10 @@
 if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 	$pattern_source_callback = function ( $source_attrs, $block_instance, $attribute_name ) {
 		if ( ! _wp_array_get( $block_instance->attributes, array( 'metadata', 'id' ), false ) ) {
-			return null;
+			return WP_Block_Bindings::SKIP;
 		}
 		$block_id = $block_instance->attributes['metadata']['id'];
-		return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, $attribute_name ), null );
+		return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, $attribute_name ), WP_Block_Bindings::SKIP );
 	};
 	wp_block_bindings_register_source(
 		'pattern_attributes',

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -105,7 +105,7 @@ if ( $gutenberg_experiments && (
 				'core/paragraph' => array( 'content' ),
 				'core/heading'   => array( 'content' ),
 				'core/image'     => array( 'url', 'title', 'alt' ),
-				'core/button'    => array( 'url', 'text' ),
+				'core/button'    => array( 'url', 'text', 'linkTarget' ),
 			);
 
 			// If the block doesn't have the bindings property or isn't one of the allowed block types, return.
@@ -153,7 +153,7 @@ if ( $gutenberg_experiments && (
 				}
 				$source_value = $source_callback( $source_args, $block_instance, $binding_attribute );
 				// If the value is null, process next attribute.
-				if ( is_null( $source_value ) ) {
+				if ( WP_Block_Bindings::SKIP === $source_value ) {
 					continue;
 				}
 

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -104,9 +104,14 @@ function applyInitialOverrides( blocks, overrides = {}, defaultValues ) {
 			defaultValues[ blockId ] ??= {};
 			defaultValues[ blockId ][ attributeKey ] =
 				block.attributes[ attributeKey ];
-			if ( overrides[ blockId ]?.[ attributeKey ] !== undefined ) {
+			if (
+				overrides[ blockId ] &&
+				Object.hasOwn( overrides[ blockId ], attributeKey )
+			) {
 				newAttributes[ attributeKey ] =
-					overrides[ blockId ][ attributeKey ];
+					overrides[ blockId ][ attributeKey ] === undefined
+						? null
+						: overrides[ blockId ][ attributeKey ];
 			}
 		}
 		return {
@@ -134,10 +139,10 @@ function getOverridesFromBlocks( blocks, defaultValues ) {
 				defaultValues[ blockId ][ attributeKey ]
 			) {
 				overrides[ blockId ] ??= {};
-				// TODO: We need a way to represent `undefined` in the serialized overrides.
-				// Also see: https://github.com/WordPress/gutenberg/pull/57249#discussion_r1452987871
 				overrides[ blockId ][ attributeKey ] =
-					block.attributes[ attributeKey ];
+					block.attributes[ attributeKey ] === undefined
+						? null
+						: block.attributes[ attributeKey ];
 			}
 		}
 	}

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -27,6 +27,7 @@ export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 	'core/button': {
 		text: __( 'Text' ),
 		url: __( 'URL' ),
+		linkTarget: __( 'Link Target' ),
 	},
 	'core/image': {
 		url: __( 'URL' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #53705.

Support the `linkTarget` attribute of the button block for Pattern Overrides. Currently, the attribute relies on `undefined` to represent "no target". We need a way to represent `undefined` values for attributes to be able to override the pattern.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because you can edit link target when editing the URL of the button block but it was never saved to the pattern instance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use a special flag `WP_Block_Bindings::SKIP` on the server side to represent skipping the processing of the attribute instead of using `null`. This also means we're treating `undefined`(unset) and `null` as the same value for attributes. This might not always be true for third-party blocks though. If this doesn't work then we'll look for other alternatives.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331 to create a pattern with overrides.

1. If you already have a button block with overrides then you'll need to re-toggle the "Allow instance overrides" setting in the source pattern to include the `linkTarget` attribute. (This could become a backward-compat concern that we'll need to deal with in a follow-up task.)
2. Add a link to the button block in the source pattern and check the "Open in new tab" checkbox.
3. Insert the pattern into a post. Uncheck the "Open in new tab" checkbox for the instance and save the post.
4. Visit the post in the frontend, clicking on the button should not open a new tab.

## Screenshots or screencast <!-- if applicable -->
TBD
