### PR TITLE
Site editor: reduce artificial loading delay from 1s to 100ms

### DIFF
--- a/packages/edit-site/src/components/layout/hooks.js
+++ b/packages/edit-site/src/components/layout/hooks.js
@@ -46,16 +46,17 @@ export function useIsSiteEditorLoading() {
 	useEffect( () => {
 		if ( inLoadingPause ) {
 			/*
-			 * We're using an arbitrary 1s timeout here to catch brief moments
-			 * without any resolving selectors that would result in displaying
-			 * brief flickers of loading state and loaded state.
+			 * We're using an arbitrary 100ms timeout here to catch brief
+			 * moments without any resolving selectors that would result in
+			 * displaying brief flickers of loading state and loaded state.
 			 *
 			 * It's worth experimenting with different values, since this also
-			 * adds 1s of artificial delay after loading has finished.
+			 * adds 100ms of artificial delay after loading has finished.
 			 */
+			const ARTIFICIAL_DELAY = 100;
 			const timeout = setTimeout( () => {
 				setLoaded( true );
-			}, 1000 );
+			}, ARTIFICIAL_DELAY );
 
 			return () => {
 				clearTimeout( timeout );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

1 second is way too much in my opinion to be artificially delaying loading of the site editor. Note that this is a delay that happens after all requests are resolved, so everyone is waiting 1 second longer than needed, making the site editor feel unnecessarily slow. 100ms should probably be enough the capture the brief moments between a request resolving and a request starting.

It's also unclear which pauses between which requests this is supposed to address. Where does the delay come from? Are all requests not started at the same time?

First introduced by #50222.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
