### PR TITLE
Image Block: Make block name affect list view

### DIFF
--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -29,6 +29,12 @@ export const settings = {
 		},
 	},
 	__experimentalLabel( attributes, { context } ) {
+		const customName = attributes?.metadata?.name;
+
+		if ( context === 'list-view' && customName ) {
+			return customName;
+		}
+
 		if ( context === 'accessibility' ) {
 			const { caption, alt, url } = attributes;
 


### PR DESCRIPTION
Part of #57954

## What?

This PR fixes an issue where the block name is not reflected in the list view for the Image block.

### Before

![before](https://github.com/WordPress/gutenberg/assets/54422211/909f1b81-b70e-4f01-9a90-f0a254f95c2c)

### After

![after](https://github.com/WordPress/gutenberg/assets/54422211/60aaddc9-9196-4ccc-94b1-72797fa16383)

## Why?

If that block has opted into `__experimentLabel`, the list view will display the default block name unless we explicitly return `metadata.name` when the context is `list-view`.

For a more detailed analysis, please refer to #57954.

## Testing Instructions

- Insert an Image block.
- Fill the block name field with some text.
- Open the List View.
- You should see that text instead of the default block name.
