### PR TITLE
Block Hooks: Fix toggle

### DIFF
--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -83,7 +83,7 @@ function BlockHooksControlPure( { name, clientId } ) {
 					}
 
 					const hookedBlock = candidates?.find(
-						( candidate ) => name === candidate.name
+						( candidate ) => candidate.name === block.name
 					);
 
 					// If the block exists in the designated location, we consider it hooked


### PR DESCRIPTION
## What?
Fix the Block Hooks toggle (broken by https://github.com/WordPress/gutenberg/pull/56862#discussion_r1457264271).

## Why?
After #56862, the Block Hooks toggle stopped working properly:

If you had one instance of a hooked block that was inserted `before` of `after` its anchor block in your template, it became impossible to use the toggle to remove the block -- it would just stay enabled. (You could only delete the block manually.)

If you had additional instances of hooked blocks, the behavior would be even weirder: Even if you deleted the hooked block, the toggle would stay enabled.

## How?

By fixing a check that was using the wrong variable to compare to.

## Testing Instructions

### To reproduce the issue (on `trunk`):

- Install and activate the [latest version of the Like Button plugin](https://github.com/ockham/like-button/releases/latest).
- Use a block theme like TT3 or TT4.
- In the Site Editor, edit the Single Posts template.
- Verify that the Like Button block is inserted both below the Post Content block, and as the Comment Template block's last child.
- Click on the Post Content block, and open the block inspector sidebar. Locate the 'Plugins' panel, and verify that the toggle is enabled. Try clicking on it to disable it, and verify that that doesn't work; it just stays enabled ❌ 
- Manually delete the Like Button block below the Post Content block.
- Select the Post Content block again, and verify that the Like Button toggle is disabled.
- Click on it to re-enable it; this will re-insert the Like Button.
- Try once again to disable the toggle; like before, it won't work ❌ 

Now manually delete the other Like Button (in the Comments Template block) to test the scenario with only one hooked block.

- Then, go back to the Post Content block, and try using the toggle again. Still won't work ❌ 
- Delete the Like Button block below the Post Content block.
- Select the Post Content block again. Note that this time, the Like Button toggle is still enabled ❌ 

### To verify the fix

On this branch, go through the above instructions again. Verify that the buggy behavior (marked ❌ ) has been fixed.

_Note that importantly, some of the "fixed" behavior is still counter-intuitive: If both instances of the Like Button block (i.e. below Post Content and in Comment Template) were present in the first place, disabling the Like Button toggle for the Post Content will **cause the toggle to disappear altogether. This is currently expected behavior;** it will be fixed separately by https://github.com/WordPress/gutenberg/pull/57928._

## Screenshots or screencast
| | Before | After |
|-|-------|-------|
| Multiple hooked blocks | ![toggle-bug-multiple-hooked-blocks](https://github.com/WordPress/gutenberg/assets/96308/d9d66831-ccd9-462b-98b2-0fa4f3b79291) | ![toggle-fix-multiple-hooked-blocks](https://github.com/WordPress/gutenberg/assets/96308/3db1b5c7-ebb3-4224-a3c7-d87f661f41cc) |
| One hooked block | ![toggle-bug-one-hooked-block](https://github.com/WordPress/gutenberg/assets/96308/538d74ba-5eb2-4dda-a92f-30d3602258c4) | ![toggle-fix-one-hooked-block](https://github.com/WordPress/gutenberg/assets/96308/ae20d903-ffdf-425f-99b8-e868a4bacac4) | 
