### PR TITLE
DataViews: use table layout for templates when experiment disabled

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -77,7 +77,7 @@ const defaultConfigPerViewType = {
 };
 
 const DEFAULT_VIEW = {
-	type: LAYOUT_LIST,
+	type: window?.__experimentalAdminViews ? LAYOUT_LIST : LAYOUT_TABLE,
 	search: '',
 	page: 1,
 	perPage: 20,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/57933

## What?

When the "new admin views" experiment is disabled, the "Site Editor > Templates > Manage all templates" should display the table layout.

## Why?

The table layout is stable, but the list is not yet.

## How?

Uses table or list as default, depending on whether the experiment is enabled or not.

## Testing Instructions

- Enable the "new admin views" experiment and go to "Site Editor > Templates". Verify the list layout is in use.
- Disable the "new admin views" experiment and go to "Site Editor > Templates > Manage all templates". Verify the table layout is in use.
