### PR TITLE
Stabilise view options button icon

### DIFF
--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -7,12 +7,13 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { memo } from '@wordpress/element';
+import { settings } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { unlock } from './lock-unlock';
-import { VIEW_LAYOUTS, LAYOUT_TABLE, SORTING_DIRECTIONS } from './constants';
+import { VIEW_LAYOUTS, SORTING_DIRECTIONS } from './constants';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -260,12 +261,7 @@ const ViewActions = memo( function ViewActions( {
 			trigger={
 				<Button
 					size="compact"
-					icon={
-						VIEW_LAYOUTS.find( ( v ) => v.type === view.type )
-							?.icon ||
-						VIEW_LAYOUTS.find( ( v ) => v.type === LAYOUT_TABLE )
-							.icon
-					}
+					icon={ settings }
 					label={ __( 'View options' ) }
 				/>
 			}


### PR DESCRIPTION
## What?
Update the view options button icon so that it remains static regardless of layout selection.

## Why?
See https://github.com/WordPress/gutenberg/issues/57822

## How?
Remove the logic used to determine which icon to use.

## Testing Instructions
1. Enable data views experiment.
2. Navigate to Appearance > Editor > Pages.
3. Switch between different layouts using the View Options menu in the top right.
4. Notice that the View Options button icon is always `settings` rather than switching based on layout type.

## Screenshots or screencast <!-- if applicable -->
<img width="501" alt="Screenshot 2024-01-18 at 12 33 15" src="https://github.com/WordPress/gutenberg/assets/846565/1dcc164a-8970-4978-b469-1234a2aa2497">

