### PR TITLE
Block editor: don't register shortcuts for preview editors

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -70,6 +70,7 @@ export function BlockPreview( {
 		<ExperimentalBlockEditorProvider
 			value={ renderedBlocks }
 			settings={ settings }
+			inert={ true }
 		>
 			<AutoHeightBlockPreview
 				viewportWidth={ viewportWidth }

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -70,7 +70,6 @@ export function BlockPreview( {
 		<ExperimentalBlockEditorProvider
 			value={ renderedBlocks }
 			settings={ settings }
-			inert={ true }
 		>
 			<AutoHeightBlockPreview
 				viewportWidth={ viewportWidth }

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -19,7 +19,12 @@ import KeyboardShortcuts from '../keyboard-shortcuts';
 
 export const ExperimentalBlockEditorProvider = withRegistryProvider(
 	( props ) => {
-		const { children, settings, stripExperimentalSettings = false } = props;
+		const {
+			children,
+			settings,
+			stripExperimentalSettings = false,
+			inert,
+		} = props;
 
 		const { __experimentalUpdateSettings } = unlock(
 			useDispatch( blockEditorStore )
@@ -46,7 +51,7 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 
 		return (
 			<SlotFillProvider passthrough>
-				<KeyboardShortcuts.Register />
+				{ ! inert && <KeyboardShortcuts.Register /> }
 				<BlockRefsProvider>{ children }</BlockRefsProvider>
 			</SlotFillProvider>
 		);

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -19,12 +19,7 @@ import KeyboardShortcuts from '../keyboard-shortcuts';
 
 export const ExperimentalBlockEditorProvider = withRegistryProvider(
 	( props ) => {
-		const {
-			children,
-			settings,
-			stripExperimentalSettings = false,
-			inert,
-		} = props;
+		const { children, settings, stripExperimentalSettings = false } = props;
 
 		const { __experimentalUpdateSettings } = unlock(
 			useDispatch( blockEditorStore )
@@ -51,7 +46,9 @@ export const ExperimentalBlockEditorProvider = withRegistryProvider(
 
 		return (
 			<SlotFillProvider passthrough>
-				{ ! inert && <KeyboardShortcuts.Register /> }
+				{ ! settings.__unstableIsPreviewMode && (
+					<KeyboardShortcuts.Register />
+				) }
 				<BlockRefsProvider>{ children }</BlockRefsProvider>
 			</SlotFillProvider>
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We don't need shortcuts in previews and registering these takes time and causes store updates.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
