### PR TITLE
Site editor: avoid fetching themes on load

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -47,7 +47,7 @@ export default function SaveButton( {
 						)
 					) || isActivatingTheme,
 				isSaveViewOpen: isSaveViewOpened(),
-				// Do note call `getTheme` with null, it will cause a request to
+				// Do not call `getTheme` with null, it will cause a request to
 				// the server.
 				previewingThemeName: currentlyPreviewingThemeId
 					? select( coreStore ).getTheme( currentlyPreviewingThemeId )

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -34,9 +34,7 @@ export default function SaveButton( {
 			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 			const { isSaveViewOpened } = select( editSiteStore );
 			const isActivatingTheme = isResolving( 'activateTheme' );
-			const previewingTheme = select( coreStore ).getTheme(
-				currentlyPreviewingTheme()
-			);
+			const currentlyPreviewingThemeId = currentlyPreviewingTheme();
 
 			return {
 				isDirty: dirtyEntityRecords.length > 0,
@@ -49,7 +47,12 @@ export default function SaveButton( {
 						)
 					) || isActivatingTheme,
 				isSaveViewOpen: isSaveViewOpened(),
-				previewingThemeName: previewingTheme?.name?.rendered,
+				// Do note call `getTheme` with null, it will cause a request to
+				// the server.
+				previewingThemeName: currentlyPreviewingThemeId
+					? select( coreStore ).getTheme( currentlyPreviewingThemeId )
+							?.name?.rendered
+					: undefined,
 			};
 		}, [] );
 	const { setIsSaveViewOpened } = useDispatch( editSiteStore );

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -49,7 +49,7 @@ export default function SidebarNavigationScreen( {
 				dashboardLink: getSettings().__experimentalDashboardLink,
 				dashboardLinkText:
 					getSettings().__experimentalDashboardLinkText,
-				// Do note call `getTheme` with null, it will cause a request to
+				// Do not call `getTheme` with null, it will cause a request to
 				// the server.
 				previewingThemeName: currentlyPreviewingThemeId
 					? select( coreStore ).getTheme( currentlyPreviewingThemeId )

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -41,17 +41,26 @@ export default function SidebarNavigationScreen( {
 	description,
 	backPath: backPathProp,
 } ) {
-	const { dashboardLink, dashboardLinkText } = useSelect( ( select ) => {
-		const { getSettings } = unlock( select( editSiteStore ) );
-		return {
-			dashboardLink: getSettings().__experimentalDashboardLink,
-			dashboardLinkText: getSettings().__experimentalDashboardLinkText,
-		};
-	}, [] );
-	const { getTheme } = useSelect( coreStore );
+	const { dashboardLink, dashboardLinkText, previewingThemeName } = useSelect(
+		( select ) => {
+			const { getSettings } = unlock( select( editSiteStore ) );
+			const currentlyPreviewingThemeId = currentlyPreviewingTheme();
+			return {
+				dashboardLink: getSettings().__experimentalDashboardLink,
+				dashboardLinkText:
+					getSettings().__experimentalDashboardLinkText,
+				// Do note call `getTheme` with null, it will cause a request to
+				// the server.
+				previewingThemeName: currentlyPreviewingThemeId
+					? select( coreStore ).getTheme( currentlyPreviewingThemeId )
+							?.name?.rendered
+					: undefined,
+			};
+		},
+		[]
+	);
 	const location = useLocation();
 	const navigator = useNavigator();
-	const theme = getTheme( currentlyPreviewingTheme() );
 	const icon = isRTL() ? chevronRight : chevronLeft;
 
 	return (
@@ -108,7 +117,7 @@ export default function SidebarNavigationScreen( {
 							? title
 							: sprintf(
 									'Previewing %1$s: %2$s',
-									theme?.name?.rendered,
+									previewingThemeName,
 									title
 							  ) }
 					</Heading>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR prevents certain components in the site editor from triggering a server request to get all the themes. We shouldn't call `getTheme` with null.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We shouldn't be requesting all themes when the site editor loads.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
