### PR TITLE
(edit-post)(preferences)(workaround) Keep `openPanels` and inactivePanels` preferences in the `core/edit-post` scope to satisfy existing consumers

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -54,7 +54,9 @@ export function initializeEditor(
 
 	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
 		fullscreenMode: true,
+		inactivePanels: [],
 		isPublishSidebarEnabled: true,
+		openPanels: [ 'post-status' ],
 		preferredStyleVariations: {},
 		themeStyles: true,
 		welcomeGuide: true,


### PR DESCRIPTION
## What?

Keep the `openPanels` and `inactivePanels` preferences in the `core/edit-post` scope - in addition to the `core` scope (to which they were moved in https://github.com/WordPress/gutenberg/pull/57529) to keep the old interface that some consumers expect.

## Why?

Consumers might still expect these preferences to be found in `core/edit-post` scope. If the setting is not found, it could cause an unhandled exception and break the functionality. This is the case with Yoast - it consumes the `openPanels` preference like this:

```js
select('core/preferences').get('core/edit-post', 'openPanels').includes('yoast-seo/document-panel');
```

Since `select('core/preferences').get('core/edit-post', 'openPanels')` returns `undefined` after the recent [changes](https://github.com/WordPress/gutenberg/pull/57529), the `.includes('yoast-seo/document-panel')` call leads to a `TypeError`, disrupting the code flow and causing issues with the Yoast metabox rendering (since nothing is guarding against that, i.e optional chaining). See the screenshot down below.

## How?

This workaround keeps the `openPanels` property in the object passed as an argument to the `dispatch( preferencesStore ).setDefaults( 'core/edit-post', ... )` call. @andrewserong also suggested defining the related `inactivePanels` property too.

This PR is meant to illustrate a temporary workaround that fixes the Yoast issue and also to trigger a discussion about a definitive solution. Some questions come to mind:

1. Was moving the preferences to another scope supposed to be a breaking change?
2. If not, how do we ensure these changes are abstracted from consumers? Is the way Yoast is accessing the preference wrong? What's the proper API to access those preferences?
3. Should we continue defining other properties moved to the `core` scope in `core/edit-post`? See [editorMode](https://github.com/WordPress/gutenberg/pull/57642/files#diff-4ad41ad30002069557c372462f6a35aa46c450d687fb16d741fd7101ed73509fR67) and [hiddenBlockTypes](https://github.com/WordPress/gutenberg/pull/57639/files#diff-4ad41ad30002069557c372462f6a35aa46c450d687fb16d741fd7101ed73509fR68).

## Testing Instructions

1. Spin up a WP site;
1. Build Gutenberg from `trunk` and build Gutenberg from it, install/sync this version to the site;
1. Install Yoast; the free version suffices;
1. Create a new post - you'll see the Yoast metabox is broken as described and shown in https://github.com/Automattic/wp-calypso/issues/86601;
1. Now build Gutenberg from this branch, resync/reinstall;
1. Refresh the post page and the Yoast metabox will render as expected.


## Screenshots or screencast 

| `trunk` | This branch |
|------------|-----------|
| ![Screenshot 2024-01-18 at 16 17 10](https://github.com/WordPress/gutenberg/assets/81248/5d2ee621-29dc-4cdc-a533-68cd36370163) | <img width="1020" alt="Screenshot 2024-01-18 at 17 46 57" src="https://github.com/WordPress/gutenberg/assets/81248/0ff2f079-8506-4477-bb73-0e807730ffbe"> |






