### PR TITLE
Support removing an attribute for Pattern Overrides

### DIFF
--- a/lib/block-supports/pattern.php
+++ b/lib/block-supports/pattern.php
@@ -21,7 +21,7 @@ if ( $gutenberg_experiments && array_key_exists( 'gutenberg-pattern-partial-sync
 			'core/paragraph' => array( 'content' ),
 			'core/heading'   => array( 'content' ),
 			'core/image'     => array( 'url', 'title', 'alt' ),
-			'core/button'    => array( 'url', 'text' ),
+			'core/button'    => array( 'url', 'text', 'linkTarget' ),
 		);
 		$pattern_support = array_key_exists( $block_type->name, $allowed_blocks );
 

--- a/lib/experimental/block-bindings/block-bindings.php
+++ b/lib/experimental/block-bindings/block-bindings.php
@@ -29,11 +29,11 @@ if ( ! function_exists( 'wp_block_bindings' ) ) {
  * @param string   $source_name The name of the source.
  * @param string   $label The label of the source.
  * @param callable $apply The callback executed when the source is processed during block rendering. The callable should have the following signature:
- *                        function (object $source_attrs, object $block_instance, string $attribute_name): string
+ *                        function (object $source_attrs, object $block_instance, string $attribute_name): WP_Binding_Patch
  *                        - object $source_attrs: Object containing source ID used to look up the override value, i.e. {"value": "{ID}"}.
  *                        - object $block_instance: The block instance.
  *                        - string $attribute_name: The name of an attribute used to retrieve an override value from the block context.
- *                        The callable should return a string that will be used to override the block's original value.
+ *                        The callable should return a patch that will be used to override the block's original value.
  * @return void
  */
 if ( ! function_exists( 'wp_block_bindings_register_source' ) ) {
@@ -56,14 +56,14 @@ if ( ! function_exists( 'wp_block_bindings_get_sources' ) ) {
 /**
  * Replaces the HTML content of a block based on the provided source value.
  *
- * @param string $block_content Block Content.
- * @param string $block_name The name of the block to process.
- * @param string $block_attr The attribute of the block we want to process.
- * @param string $source_value The value used to replace the HTML.
+ * @param string           $block_content Block Content.
+ * @param string           $block_name    The name of the block to process.
+ * @param string           $block_attr    The attribute of the block we want to process.
+ * @param WP_Binding_Patch $source_value  The patch used to apply to the HTML.
  * @return string The modified block content.
  */
 if ( ! function_exists( 'wp_block_bindings_replace_html' ) ) {
-	function wp_block_bindings_replace_html( $block_content, $block_name, $block_attr, $source_value ) {
-		return wp_block_bindings()->replace_html( $block_content, $block_name, $block_attr, $source_value );
+	function wp_block_bindings_replace_html( $block_content, $block_name, $block_attr, $source_patch ) {
+		return wp_block_bindings()->replace_html( $block_content, $block_name, $block_attr, $source_patch );
 	}
 }

--- a/lib/experimental/block-bindings/sources/pattern.php
+++ b/lib/experimental/block-bindings/sources/pattern.php
@@ -5,12 +5,23 @@
  * @package gutenberg
  */
 if ( function_exists( 'wp_block_bindings_register_source' ) ) {
+	function override_to_patch( $override ) {
+		switch ( $override[0] ) {
+			case 0: // remove
+				return new WP_Binding_Patch( WP_Binding_Patch_Operation::Remove );
+			case 1: // replace
+				return new WP_Binding_Patch( WP_Binding_Patch_Operation::Replace, $override[1] );
+		}
+		return null;
+	}
+
 	$pattern_source_callback = function ( $source_attrs, $block_instance, $attribute_name ) {
 		if ( ! _wp_array_get( $block_instance->attributes, array( 'metadata', 'id' ), false ) ) {
 			return null;
 		}
 		$block_id = $block_instance->attributes['metadata']['id'];
-		return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, $attribute_name ), null );
+		$attribute_override = _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, $attribute_name ), null );
+		return $attribute_override ? override_to_patch( $attribute_override ) : null;
 	};
 	wp_block_bindings_register_source(
 		'pattern_attributes',

--- a/lib/experimental/block-bindings/sources/post-meta.php
+++ b/lib/experimental/block-bindings/sources/post-meta.php
@@ -14,7 +14,8 @@ if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 			$post_id = get_the_ID();
 		}
 
-		return get_post_meta( $post_id, $source_attrs['value'], true );
+		$source_value = get_post_meta( $post_id, $source_attrs['value'], true );
+		return new WP_Binding_Patch( WP_Binding_Patch_Operation::Replace, $source_value );
 	};
 	wp_block_bindings_register_source(
 		'post_meta',

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -105,7 +105,7 @@ if ( $gutenberg_experiments && (
 				'core/paragraph' => array( 'content' ),
 				'core/heading'   => array( 'content' ),
 				'core/image'     => array( 'url', 'title', 'alt' ),
-				'core/button'    => array( 'url', 'text' ),
+				'core/button'    => array( 'url', 'text', 'linkTarget' ),
 			);
 
 			// If the block doesn't have the bindings property or isn't one of the allowed block types, return.
@@ -151,14 +151,14 @@ if ( $gutenberg_experiments && (
 				} else {
 					$source_args = $binding_source['source']['attributes'];
 				}
-				$source_value = $source_callback( $source_args, $block_instance, $binding_attribute );
+				$source_patch = $source_callback( $source_args, $block_instance, $binding_attribute );
 				// If the value is null, process next attribute.
-				if ( is_null( $source_value ) ) {
+				if ( is_null( $source_patch ) ) {
 					continue;
 				}
 
 				// Process the HTML based on the block and the attribute.
-				$modified_block_content = wp_block_bindings_replace_html( $modified_block_content, $block_instance->name, $binding_attribute, $source_value );
+				$modified_block_content = wp_block_bindings_replace_html( $modified_block_content, $block_instance->name, $binding_attribute, $source_patch );
 			}
 			return $modified_block_content;
 		}

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -27,6 +27,7 @@ export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 	'core/button': {
 		text: __( 'Text' ),
 		url: __( 'URL' ),
+		linkTarget: __( 'Link Target' ),
 	},
 	'core/image': {
 		url: __( 'URL' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #53705. An alternative to #57947.

This changes the overrides serialized data into a tuple with the following signature:

```ts
type Patch = [op: Operation, value?: any];

type Operation = 0 | 1; // 0: Remove, 1: Replace
```

This also opens up the possibility of having an `insert` patch that we can use for adding inner blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As opposed to #57947. This change is based on the assumption that sometimes some attributes have different meanings between having `NULL` as the value and not existing at all.

However, I don't find any existing use case for such an assumption. So, we might not need this after all.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Serialize the overrides data into a patch similar to the [JSON patch schema](https://jsonpatch.com/)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331 to create a pattern with overrides.

1. If you already have a button block with overrides then you'll need to re-toggle the "Allow instance overrides" setting in the source pattern to include the linkTarget attribute. (This could become a backward-compat concern that we'll need to deal with in a follow-up task.)
2. Add a link to the button block in the source pattern and check the "Open in new tab" checkbox.
3. Insert the pattern into a post. Uncheck the "Open in new tab" checkbox for the instance and save the post.
4. Visit the post in the frontend, clicking on the button should not open a new tab.

## Screenshots or screencast <!-- if applicable -->
TBD