### PR TITLE
Embed Block: Fix retry processing when embedding with trailing slash fails

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -127,16 +127,17 @@ const EmbedEdit = ( props ) => {
 	};
 
 	useEffect( () => {
-		if ( ! preview?.html || ! cannotEmbed || fetching ) {
+		if ( preview?.html || ! cannotEmbed || fetching ) {
 			return;
 		}
+
 		// At this stage, we're not fetching the preview and know it can't be embedded,
 		// so try removing any trailing slash, and resubmit.
 		const newURL = attributesUrl.replace( /\/$/, '' );
 		setURL( newURL );
 		setIsEditingURL( false );
 		setAttributes( { url: newURL } );
-	}, [ preview?.html, attributesUrl, cannotEmbed, fetching ] );
+	}, [ preview?.html, attributesUrl, cannotEmbed, fetching, setAttributes ] );
 
 	// Try a different provider in case the embed url is not supported.
 	useEffect( () => {

--- a/test/e2e/specs/editor/various/embedding.spec.js
+++ b/test/e2e/specs/editor/various/embedding.spec.js
@@ -122,7 +122,7 @@ test.describe( 'Embedding content', () => {
 		await expect(
 			currenEmbedBlock.getByRole( 'textbox', { name: 'Embed URL' } ),
 			'WordPress invalid content. Should render failed, edit state.'
-		).toHaveValue( 'https://wordpress.org/gutenberg/handbook/' );
+		).toHaveValue( 'https://wordpress.org/gutenberg/handbook' );
 
 		await embedUtils.insertEmbed( 'https://twitter.com/thatbunty' );
 		await expect(
@@ -189,7 +189,7 @@ test.describe( 'Embedding content', () => {
 	} );
 
 	// Reason: A possible regression of https://github.com/WordPress/gutenberg/pull/14705.
-	test.skip( 'should retry embeds that could not be embedded with trailing slashes, without the trailing slashes', async ( {
+	test( 'should retry embeds that could not be embedded with trailing slashes, without the trailing slashes', async ( {
 		editor,
 		embedUtils,
 	} ) => {


### PR DESCRIPTION
Fixes #58002

## What?

This PR fixes an issue where retrying when embedding a URL with a trailing slash fails, implemented in #14705, was not working.

## Why?

As far as I can tell, this regression occurred when class components were rewritten to function components in #22845.

https://github.com/WordPress/gutenberg/pull/22846/files?diff=unified&w=1#diff-ef12826bc6a57e80852c9800c4bb8db0157db2b1f1418686fc85088e5438bb78R106-R108

Originally, if a URL with a trailing slash could not be embedded, this block would remove the trailing slash and try to embed it again.

The current conditional statement performs the early return and skips retrying the embed if the preview HTML could NOT be retrieved. I think the expected behavior should be to skip retrying the embed if the preview HTML could be retrieved.

## How?

I reversed the conditional statement. Accordingly, I have re-enabled the skipped tests.

## Testing Instructions

- Insert an Embed Block.
- Enter `https://twitter.com/WordPress/` in the URL.
- The X account should now be successfully embedded.
- Click the "Edit URL" button.
- The trailing slash should have been removed (`https://twitter.com/WordPress`).
- Insert a Twitter block and repeat the steps above.
- Also try the new X URL(`https://x.com/WordPress/`). It will be translated to the `twitter.com` domain, which is the expected behavior in the current implementation.