### PR TITLE
Interactivity API: Fix data-wp-on-document flaky test

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/render.php
@@ -8,10 +8,21 @@
 gutenberg_enqueue_module( 'directive-on-document-view' );
 ?>
 
-<div data-wp-interactive='{ "namespace": "directive-on-document" }' data-wp-context='{"isVisible":true}'>
-	<button data-wp-on--click="actions.visibilityHandler" data-testid="visibility">Switch visibility</button>
-	<div data-wp-show-mock="context.isVisible">
-		<div data-wp-on-document--keydown="callbacks.keydownHandler">
+<div data-wp-interactive='{ "namespace": "directive-on-document" }'>
+	<button 
+		data-testid="visibility"
+		data-wp-on--click="actions.visibilityHandler"
+	>
+		Switch visibility
+	</button>
+
+	<div data-wp-text="state.isEventAttached" data-testid="isEventAttached">no</div>
+
+	<div data-wp-show-mock="state.isVisible">
+		<div
+			data-wp-on-document--keydown="callbacks.keydownHandler"
+			data-wp-init="callbacks.init"
+		>
 			<p data-wp-text="state.counter" data-testid="counter">0</p>
 		</div>
 	</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store, directive, getContext } from '@wordpress/interactivity';
+import { store, directive } from '@wordpress/interactivity';
 
 // Mock `data-wp-show` directive to test when things are removed from the
 // DOM.  Replace with `data-wp-show` when it's ready.
@@ -19,16 +19,21 @@ directive(
 const { state } = store( 'directive-on-document', {
 	state: {
 		counter: 0,
+		isVisible: true,
+		isEventAttached: 'no',
 	},
 	callbacks: {
-		keydownHandler: ( ) => {
+		keydownHandler() {
 			state.counter += 1;
+		},
+		init() {
+			state.isEventAttached = 'yes';
 		},
 	},
 	actions: {
 		visibilityHandler: () => {
-			const context = getContext();
-			context.isVisible = ! context.isVisible;
+			state.isEventAttached = 'no';
+			state.isVisible = ! state.isVisible;
 		},
 	}
 } );

--- a/test/e2e/specs/interactivity/directive-on-document.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-document.spec.ts
@@ -42,6 +42,8 @@ test.describe( 'data-wp-on-document', () => {
 		await visibilityButton.click();
 		await expect( counter ).toHaveText( '1' );
 		await page.keyboard.press( 'ArrowDown' );
-		await expect( counter ).toHaveText( '2' );
+		// Force a new locator to prevent flaky tests.
+		const updatedCounter = page.getByTestId( 'counter' );
+		await expect( updatedCounter ).toHaveText( '2' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/directive-on-document.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-document.spec.ts
@@ -41,9 +41,12 @@ test.describe( 'data-wp-on-document', () => {
 		// Add the element back.
 		await visibilityButton.click();
 		await expect( counter ).toHaveText( '1' );
+		// Wait for the JS to reattach the event listener.
+		// https://github.com/WordPress/gutenberg/pull/58008
+		await page.evaluate(
+			() => new Promise( ( resolve ) => requestAnimationFrame( resolve ) )
+		);
 		await page.keyboard.press( 'ArrowDown' );
-		// Force a new locator to prevent flaky tests.
-		const updatedCounter = page.getByTestId( 'counter' );
-		await expect( updatedCounter ).toHaveText( '2' );
+		await expect( counter ).toHaveText( '2' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/directive-on-document.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-document.spec.ts
@@ -30,22 +30,28 @@ test.describe( 'data-wp-on-document', () => {
 		page,
 	} ) => {
 		const counter = page.getByTestId( 'counter' );
+		const isEventAttached = page.getByTestId( 'isEventAttached' );
 		const visibilityButton = page.getByTestId( 'visibility' );
+
 		await expect( counter ).toHaveText( '0' );
+		await expect( isEventAttached ).toHaveText( 'yes' );
 		await page.keyboard.press( 'ArrowDown' );
 		await expect( counter ).toHaveText( '1' );
+
 		// Remove the element.
 		await visibilityButton.click();
 		// This keyboard press should not increase the counter.
 		await page.keyboard.press( 'ArrowDown' );
+
 		// Add the element back.
 		await visibilityButton.click();
 		await expect( counter ).toHaveText( '1' );
-		// Wait for the JS to reattach the event listener.
-		// https://github.com/WordPress/gutenberg/pull/58008
-		await page.evaluate(
-			() => new Promise( ( resolve ) => requestAnimationFrame( resolve ) )
-		);
+		await expect( counter ).toHaveText( '1' );
+
+		// Wait until the effects run again.
+		await expect( isEventAttached ).toHaveText( 'yes' );
+
+		// Check that the event listener is attached again.
 		await page.keyboard.press( 'ArrowDown' );
 		await expect( counter ).toHaveText( '2' );
 	} );

--- a/test/e2e/specs/interactivity/directive-on-window.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-window.spec.ts
@@ -39,11 +39,6 @@ test.describe( 'data-wp-on-window', () => {
 		// Add the element back.
 		await visibilityButton.click();
 		await expect( counter ).toHaveText( '1' );
-		// Wait for the JS to reattach the event listener.
-		// https://github.com/WordPress/gutenberg/pull/58008
-		await page.evaluate(
-			() => new Promise( ( resolve ) => requestAnimationFrame( resolve ) )
-		);
 		await page.setViewportSize( { width: 200, height: 600 } );
 		await expect( counter ).toHaveText( '2' );
 	} );

--- a/test/e2e/specs/interactivity/directive-on-window.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-window.spec.ts
@@ -39,6 +39,11 @@ test.describe( 'data-wp-on-window', () => {
 		// Add the element back.
 		await visibilityButton.click();
 		await expect( counter ).toHaveText( '1' );
+		// Wait for the JS to reattach the event listener.
+		// https://github.com/WordPress/gutenberg/pull/58008
+		await page.evaluate(
+			() => new Promise( ( resolve ) => requestAnimationFrame( resolve ) )
+		);
 		await page.setViewportSize( { width: 200, height: 600 } );
 		await expect( counter ).toHaveText( '2' );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #57983.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Nobody wants flaky tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Defining a new location in playwright should wait for the locator to appear. (Which happens on the previously visibility button click.)
