### PR TITLE
Interactivity: Export `withScope()` and allow to use it with asynchronous operations.

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "test/with-scope",
+	"title": "E2E Interactivity tests - with scope",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScript": "with-scope-view",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/render.php
@@ -8,6 +8,7 @@
 gutenberg_enqueue_module( 'with-scope-view' );
 ?>
 
-<div data-wp-interactive='{ "namespace": "with-scope" }' data-wp-context='{"counter": 0}' data-wp-async-mock='callbacks.sampleAsyncFunction'>
-		<p data-wp-text="context.counter" data-testid="counter">0</p>
+<div data-wp-interactive='{ "namespace": "with-scope" }' data-wp-context='{"asyncCounter": 0, "syncCounter": 0}' data-wp-init--a='callbacks.asyncInit' data-wp-init--b='callbacks.syncInit'>
+		<p data-wp-text="context.asyncCounter" data-testid="asyncCounter">0</p>
+		<p data-wp-text="context.syncCounter" data-testid="syncCounter">0</p>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/render.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * HTML for testing the directive `data-wp-on`.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+
+gutenberg_enqueue_module( 'with-scope-view' );
+?>
+
+<div data-wp-interactive='{ "namespace": "with-scope" }' data-wp-context='{"counter": 0}' data-wp-async-mock='callbacks.sampleAsyncFunction'>
+		<p data-wp-text="context.counter" data-testid="counter">0</p>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/view.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext, directive, withScope } from '@wordpress/interactivity';
+
+
+directive( 'async-mock', ( { directives: { 'async-mock': asyncMock }, element, evaluate } ) => {
+	const entry = asyncMock.find( ( { suffix } ) => suffix === 'default' );
+	// Create an async directive function.
+	try {
+		element.textContent = 'running async directive...';
+		return withScope(evaluate( entry ));
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.log( 'error', e );
+	}
+} );
+
+
+store( 'with-scope', {
+	state: {
+		asyncText: 'hi async',
+	},
+	callbacks: {
+		keydownHandler: ( ) => {
+			const context = getContext();
+			context.counter += 1;
+		},
+		sampleAsyncFunction: async() => {
+            const context = getContext();
+            // simulate a delay with Promise and setTimeout
+            await new Promise(resolve => setTimeout(resolve, 1000));
+			context.counter += 1;
+        },
+	},
+} );

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/view.js
@@ -1,36 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext, directive, withScope } from '@wordpress/interactivity';
-
-
-directive( 'async-mock', ( { directives: { 'async-mock': asyncMock }, element, evaluate } ) => {
-	const entry = asyncMock.find( ( { suffix } ) => suffix === 'default' );
-	// Create an async directive function.
-	try {
-		element.textContent = 'running async directive...';
-		return withScope(evaluate( entry ));
-	} catch ( e ) {
-		// eslint-disable-next-line no-console
-		console.log( 'error', e );
-	}
-} );
-
+import { store, getContext, withScope } from '@wordpress/interactivity';
 
 store( 'with-scope', {
-	state: {
-		asyncText: 'hi async',
-	},
 	callbacks: {
-		keydownHandler: ( ) => {
-			const context = getContext();
-			context.counter += 1;
+		asyncInit: () => {
+			setTimeout( withScope(function*() {
+				yield new Promise(resolve => setTimeout(resolve, 1));
+				const context = getContext()
+				context.asyncCounter += 1;
+			}, 1 ));
 		},
-		sampleAsyncFunction: async() => {
-            const context = getContext();
-            // simulate a delay with Promise and setTimeout
-            await new Promise(resolve => setTimeout(resolve, 1000));
-			context.counter += 1;
-        },
+		syncInit: () => {
+			const context = getContext()
+			context.syncCounter += 1;
+		}
 	},
 } );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,12 +5,13 @@
 ### Enhancements
 
 -   Prevent the usage of Preact components in `wp-text`. ([#57879](https://github.com/WordPress/gutenberg/pull/57879))
--   Update `preact`, `@preact/signals` and `deepsignal` dependencies. ([57891](https://github.com/WordPress/gutenberg/pull/57891))
+-   Update `preact`, `@preact/signals` and `deepsignal` dependencies. ([#57891](https://github.com/WordPress/gutenberg/pull/57891))
+-   Export `withScope()` and allow to use it with asynchronous operations. ([#58013](https://github.com/WordPress/gutenberg/pull/58013))
 
 ### New Features
 
--   Add the `data-wp-run` directive along with the `useInit` and `useWatch` hooks. ([57805](https://github.com/WordPress/gutenberg/pull/57805))
--   Add `wp-data-on-window` and `wp-data-on-document` directives. ([57931](https://github.com/WordPress/gutenberg/pull/57931))
+-   Add the `data-wp-run` directive along with the `useInit` and `useWatch` hooks. ([#57805](https://github.com/WordPress/gutenberg/pull/57805))
+-   Add `wp-data-on-window` and `wp-data-on-document` directives. ([#57931](https://github.com/WordPress/gutenberg/pull/57931))
 
 ### Breaking Changes
 

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -132,6 +132,7 @@ export default () => {
 	// data-wp-init--[name]
 	directive( 'init', ( { directives: { init }, evaluate } ) => {
 		init.forEach( ( entry ) => {
+			// TODO: Replace with useEffect to prevent unneeded scopes.
 			useInit( () => evaluate( entry ) );
 		} );
 	} );

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -156,6 +156,8 @@ export const resetScope = () => {
 	scopeStack.pop();
 };
 
+export const getNamespace = () => namespaceStack.slice( -1 )[ 0 ];
+
 export const setNamespace = ( namespace: string ) => {
 	namespaceStack.push( namespace );
 };

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -5,7 +5,7 @@ import registerDirectives from './directives';
 import { init } from './router';
 
 export { store } from './store';
-export { directive, getContext, getElement } from './hooks';
+export { directive, getContext, getElement, getNamespace } from './hooks';
 export { navigate, prefetch } from './router';
 export {
 	withScope,

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -8,6 +8,7 @@ export { store } from './store';
 export { directive, getContext, getElement } from './hooks';
 export { navigate, prefetch } from './router';
 export {
+	withScope,
 	useWatch,
 	useInit,
 	useEffect,

--- a/packages/interactivity/src/utils.js
+++ b/packages/interactivity/src/utils.js
@@ -72,12 +72,9 @@ export function useSignalEffect( callback ) {
  * @return {Function} The wrapped function.
  */
 export const withScope = ( func ) => {
-	// Check if the property is a generator. If it is, we turn it into an
-	// asynchronous function where we restore the default namespace and scope
-	// each time it awaits/yields.
-	if ( func?.constructor?.name === 'GeneratorFunction' ) {
-		return async ( args ) => {
-			const scope = getScope();
+	if ( func?.constructor?.name === 'Promise' ) {
+		const scope = getScope();
+		return async ( ...args ) => {
 			const gen = func( ...args );
 			let value;
 			let it;
@@ -93,13 +90,11 @@ export const withScope = ( func ) => {
 				} catch ( e ) {
 					gen.throw( e );
 				}
-
 				if ( it.done ) break;
 			}
 			return value;
 		};
 	}
-	// We asume is a function.
 	const scope = getScope();
 	return ( ...args ) => {
 		setScope( scope );

--- a/test/e2e/specs/interactivity/with-scope.spec.ts
+++ b/test/e2e/specs/interactivity/with-scope.spec.ts
@@ -16,10 +16,12 @@ test.describe( 'withScope', () => {
 		await utils.deleteAllPosts();
 	} );
 
-	test( 'it should test', async ( { page } ) => {
-		const counter = page.getByTestId( 'counter' );
-		await expect( counter ).toHaveText( '0' );
-		await page.keyboard.press( 'ArrowDown' );
-		await expect( counter ).toHaveText( '1' );
+	test( 'directives using withScope should work with async and sync functions', async ( {
+		page,
+	} ) => {
+		const asyncCounter = page.getByTestId( 'asyncCounter' );
+		await expect( asyncCounter ).toHaveText( '1' );
+		const syncCounter = page.getByTestId( 'syncCounter' );
+		await expect( syncCounter ).toHaveText( '1' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/with-scope.spec.ts
+++ b/test/e2e/specs/interactivity/with-scope.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'withScope', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/with-scope' );
+	} );
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/with-scope' ) );
+	} );
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'it should test', async ( { page } ) => {
+		const counter = page.getByTestId( 'counter' );
+		await expect( counter ).toHaveText( '0' );
+		await page.keyboard.press( 'ArrowDown' );
+		await expect( counter ).toHaveText( '1' );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As discussed in: https://github.com/WordPress/gutenberg/discussions/57815
Export withScope, so the developer can access a context in a global event.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The best way to work with global events in the Interactivity API is using the directives `data-wp-on-window` or `data-wp-on-document`. But still, there can be scenarios where those are not sufficient.
https://github.com/WordPress/gutenberg/discussions/57815#discussioncomment-8113299

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Automated tests are included. But you can use any example available in the discussion:
https://github.com/WordPress/gutenberg/discussions/57815


