### PR TITLE
Update SearchControl consumers

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -108,10 +108,6 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__search {
 	padding: $grid-unit-20 $grid-unit-20 0 $grid-unit-20;
-
-	.components-search-control__icon {
-		right: $grid-unit-10 + ($grid-unit-60 - $icon-size) * 0.5;
-	}
 }
 
 .block-editor-inserter__tabs {
@@ -615,15 +611,9 @@ $block-inserter-tabs-height: 44px;
 	}
 
 	.block-editor-inserter__media-panel-search {
-		&.components-search-control {
-			input[type="search"].components-search-control__input {
-				background: $white;
-			}
-			button.components-button {
-				min-width: auto;
-				padding-left: $grid-unit-05 * 0.5;
-				padding-right: $grid-unit-05 * 0.5;
-			}
+		// TODO: Consider using the Theme component to automatically adapt to a gray background.
+		&:not(:focus-within) {
+			--wp-components-color-background: #{$white};
 		}
 	}
 }

--- a/packages/components/src/navigation/menu/menu-title-search.tsx
+++ b/packages/components/src/navigation/menu/menu-title-search.tsx
@@ -10,10 +10,11 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import withSpokenMessages from '../../higher-order/with-spoken-messages';
 import { useNavigationMenuContext } from './context';
 import { useNavigationContext } from '../context';
-import { MenuTitleSearchUI } from '../styles/navigation-styles';
 import { SEARCH_FOCUS_DELAY } from '../constants';
 
 import type { NavigationMenuTitleSearchProps } from '../types';
+import SearchControl from '../../search-control';
+import { MenuTitleSearchControlWrapper } from '../styles/navigation-styles';
 
 function MenuTitleSearch( {
 	debouncedSpeak,
@@ -80,9 +81,9 @@ function MenuTitleSearch( {
 	).trim();
 
 	return (
-		<div className="components-navigation__menu-title-search">
-			<MenuTitleSearchUI
-				autoComplete="off"
+		<MenuTitleSearchControlWrapper>
+			<SearchControl
+				__nextHasNoMarginBottom
 				className="components-navigation__menu-search-input"
 				id={ inputId }
 				onChange={ ( value ) => onSearch?.( value ) }
@@ -90,10 +91,9 @@ function MenuTitleSearch( {
 				placeholder={ placeholder }
 				onClose={ onClose }
 				ref={ inputRef }
-				type="search"
 				value={ search }
 			/>
-		</div>
+		</MenuTitleSearchControlWrapper>
 	);
 }
 

--- a/packages/components/src/navigation/styles/navigation-styles.tsx
+++ b/packages/components/src/navigation/styles/navigation-styles.tsx
@@ -17,7 +17,6 @@ import { Text } from '../../text';
 import { Heading } from '../../heading';
 import { reduceMotion, rtl } from '../../utils';
 import { space } from '../../utils/space';
-import SearchControl from '../../search-control';
 
 export const NavigationUI = styled.div`
 	width: 100%;
@@ -69,6 +68,11 @@ export const MenuTitleUI = styled.div`
 	width: 100%;
 `;
 
+export const MenuTitleSearchControlWrapper = styled.div`
+	margin: 11px 0; // non-ideal hardcoding to maintain same height as Heading, could be improved
+	padding: 1px; // so the focus border doesn't get cut off by the overflow hidden on MenuTitleUI
+`;
+
 export const MenuTitleActionsUI = styled.span`
 	height: ${ space( 6 ) }; // 24px, same height as the buttons inside
 
@@ -88,32 +92,6 @@ export const MenuTitleActionsUI = styled.span`
 			opacity: 1;
 			color: inherit;
 		}
-	}
-`;
-
-export const MenuTitleSearchUI = styled( SearchControl )`
-	input[type='search'].components-search-control__input {
-		margin: 0;
-		background: #303030;
-		color: #fff;
-
-		&:focus {
-			background: #434343;
-			color: #fff;
-		}
-
-		&::placeholder {
-			color: rgba( 255, 255, 255, 0.6 );
-		}
-	}
-
-	svg {
-		fill: white;
-	}
-
-	.components-button.has-icon {
-		padding: 0;
-		min-width: auto;
 	}
 `;
 

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -134,6 +134,7 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 			{ showSearchControl && (
 				<SearchControl
 					__nextHasNoMarginBottom
+					className="edit-site-custom-template-modal__search"
 					onChange={ setSearch }
 					value={ search }
 					label={ labels.search_items }

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -134,7 +134,6 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 			{ showSearchControl && (
 				<SearchControl
 					__nextHasNoMarginBottom
-					className="edit-site-custom-template-modal__search"
 					onChange={ setSearch }
 					value={ search }
 					label={ labels.search_items }

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -21,16 +21,6 @@
 		}
 	}
 
-	.edit-site-custom-template-modal__search {
-		&:not(:focus-within) {
-			--wp-components-color-background: #{$white};
-
-			.components-input-control__backdrop {
-				border-color: $gray-300;
-			}
-		}
-	}
-
 	@include break-medium() {
 		width: 456px;
 	}

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -21,14 +21,12 @@
 		}
 	}
 
-	.components-search-control {
-		input[type="search"].components-search-control__input {
-			background: $white;
-			border: 1px solid $gray-300;
+	.edit-site-custom-template-modal__search {
+		&:not(:focus-within) {
+			--wp-components-color-background: #{$white};
 
-			&:focus {
-				border-color: var(--wp-admin-theme-color);
-				box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+			.components-input-control__backdrop {
+				border-color: $gray-300;
 			}
 		}
 	}

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -31,17 +31,12 @@
 		flex-grow: 1;
 	}
 
-	// The increased specificity here is to overcome component styles
-	// without relying on internal component class names.
+	// TODO: Consider using the Theme component to automatically adapt to a dark background.
 	.edit-site-patterns__search {
-		input[type="search"] {
-			height: $button-size-next-default-40px;
-			background: $gray-800;
-			color: $gray-200;
+		--wp-components-color-foreground: #{$gray-200};
 
-			&:focus {
-				background: $gray-800;
-			}
+		.components-input-control__container {
+			background: $gray-800;
 		}
 
 		svg {


### PR DESCRIPTION
Stacked on #56524

## What?

Adjusts the styling of consumers who had style overrides on SearchControl.

## Why?

The SearchControl refresh in #56524 changes some styling.

## How?

Remove outdated style overrides, and adds style adjustments where necessary.

## Testing Instructions / Screenshots

### `Navigation` component

See the Navigation ▸ Search story in Storybook (`?path=/story/components-experimental-navigation--search`). (This component is not used in the Gutenberg app and will likely be deprecated soon.)

### Block inserter / Media inserter

| Before | After |
|--------|-------|
|<img src="https://github.com/WordPress/gutenberg/assets/555336/6303f416-b0e7-4f5c-8c94-d032bf150366" alt="Old search control in block inserter" width="400">|<img src="https://github.com/WordPress/gutenberg/assets/555336/33acf714-646f-45c1-a00c-0f731883ed53" alt="New search control in block inserter" width="400">|

### ~Patterns (Data views disabled)~

`/wp-admin/site-editor.php?path=%2Fpatterns`

This view seems to have been retired already, since it isn't accessible anymore even when the "New admin views" experimental flag is disabled.

| Before | After |
|--------|-------|
|<img src="https://github.com/WordPress/gutenberg/assets/555336/30d7cacf-359c-4a6f-92ff-f3dfe82f2314" alt="Old search control in All patterns" width="400">|<img src="https://github.com/WordPress/gutenberg/assets/555336/30d7cacf-359c-4a6f-92ff-f3dfe82f2314" alt="New search control in All patterns" width="400">|

### New Template Modal

<details><summary>Apply this patch to always show search control</summary>
<p>

```diff
diff --git a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
index 7e53bd7377..bba9b2ba56 100644
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -131,7 +131,7 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 	}
 	return (
 		<>
-			{ showSearchControl && (
+			{ true && (
 				<SearchControl
 					__nextHasNoMarginBottom
 					className="edit-site-custom-template-modal__search"

```

</p>
</details> 

`/wp-admin/site-editor.php?path=%2Fwp_template%2Fall` ▸ "Add New Template" button ▸ Pages

| Before | After |
|--------|-------|
|<img src="https://github.com/WordPress/gutenberg/assets/555336/672ab3a3-b5f5-4060-a357-14f42ef067a5" alt="Old search control in new template modal" width="400">|<img src="https://github.com/WordPress/gutenberg/assets/555336/7b27d574-c4c9-452a-9e6b-70b10c1c8598" alt="New search control in new template modal" width="400">|
