### PR TITLE
[RNMobile] Video block: Fix logic for displaying empty state based on source presence

### DIFF
--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -212,7 +212,7 @@ class VideoEdit extends Component {
 	render() {
 		const { setAttributes, attributes, isSelected, wasBlockJustInserted } =
 			this.props;
-		const { id, src } = attributes;
+		const { id, src, guid } = attributes;
 		const { videoContainerHeight } = this.state;
 
 		const toolbarEditButton = (
@@ -236,7 +236,10 @@ class VideoEdit extends Component {
 			></MediaUpload>
 		);
 
-		if ( ! src ) {
+		// NOTE: `guid` is not part of the block's attribute definition. This case
+		// handled here is a temporary fix until a we find a better approach.
+		const isSourcePresent = src || ( guid && id );
+		if ( ! isSourcePresent ) {
 			return (
 				<View style={ { flex: 1 } }>
 					<MediaPlaceholder

--- a/packages/block-library/src/video/test/edit.native.js
+++ b/packages/block-library/src/video/test/edit.native.js
@@ -35,7 +35,7 @@ describe( 'Video block', () => {
 <!-- /wp:video -->
 		`,
 		} );
-		const addVideoButton = await screen.queryByText( 'Add video' );
+		const addVideoButton = screen.queryByText( 'Add video' );
 		expect( addVideoButton ).toBeVisible();
 	} );
 
@@ -47,7 +47,7 @@ describe( 'Video block', () => {
 <!-- /wp:video -->
 		`,
 		} );
-		const addVideoButton = await screen.queryByText( 'Add video' );
+		const addVideoButton = screen.queryByText( 'Add video' );
 		expect( addVideoButton ).toBeNull();
 	} );
 
@@ -61,7 +61,7 @@ https://videopress.com/<VIDEO_ID>
 <!-- /wp:video -->
 		`,
 		} );
-		const addVideoButton = await screen.queryByText( 'Add video' );
+		const addVideoButton = screen.queryByText( 'Add video' );
 		expect( addVideoButton ).toBeNull();
 	} );
 } );

--- a/packages/block-library/src/video/test/edit.native.js
+++ b/packages/block-library/src/video/test/edit.native.js
@@ -26,4 +26,42 @@ describe( 'Video block', () => {
 
 		expect( screen.getByText( 'Invalid URL.' ) ).toBeVisible();
 	} );
+
+	it( 'should render empty state when source is not present', async () => {
+		await initializeEditor( {
+			initialHtml: `
+<!-- wp:video -->
+<figure class="wp-block-video"></figure>
+<!-- /wp:video -->
+		`,
+		} );
+		const addVideoButton = await screen.queryByText( 'Add video' );
+		expect( addVideoButton ).toBeVisible();
+	} );
+
+	it( 'should not render empty state when video source is present', async () => {
+		await initializeEditor( {
+			initialHtml: `
+<!-- wp:video {"id":1234} -->
+<figure class="wp-block-video"><video controls src="https://VIDEO_URL.mp4"></video></figure>
+<!-- /wp:video -->
+		`,
+		} );
+		const addVideoButton = await screen.queryByText( 'Add video' );
+		expect( addVideoButton ).toBeNull();
+	} );
+
+	it( `should not render empty state when 'guid' and 'id' attributes are present`, async () => {
+		await initializeEditor( {
+			initialHtml: `
+<!-- wp:video {"guid":"ABCD1234","id":1234 -->
+<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">
+https://videopress.com/<VIDEO_ID>
+</div></figure>
+<!-- /wp:video -->
+		`,
+		} );
+		const addVideoButton = await screen.queryByText( 'Add video' );
+		expect( addVideoButton ).toBeNull();
+	} );
 } );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [**] Fix logic for displaying empty state based on source presence [#58015]
 
 ## 1.111.0
 -   [**] Image block media uploads display a custom error message when there is no internet connection [#56937]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,7 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
--   [**] Fix logic for displaying empty state based on source presence [#58015]
+-   [**] Video block: Fix logic for displaying empty state based on source presence [#58015]
 
 ## 1.111.0
 -   [**] Image block media uploads display a custom error message when there is no internet connection [#56937]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the condition in the Video Block that controls whether the empty state should be displayed. This PR follows the changes introduced in https://github.com/Automattic/jetpack/pull/24548 and https://github.com/WordPress/gutenberg/pull/49858. For the latter, seems it was the cause of the regression mentioned in https://github.com/WordPress/gutenberg/issues/30987#issuecomment-1898934138.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes https://github.com/WordPress/gutenberg/issues/30987.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the condition by including the case when `guid` attribute is present.

> [!WARNING]
> As mentioned in the inline comment, the `guid` attribute is not defined in the block's schema. However, we are using it here as a temporary workaround.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### 1 - Upload video
1. Open the app.
2. Create a post.
3. Add a Video block.
4. Upload a video from the device.
5. Once the upload finishes, observe that the video can be played.
    - If the site is private, there's a known issue on iOS (https://github.com/wordpress-mobile/gutenberg-mobile/issues/5497).

### 2 - Insert video from media library
1. Open the app.
2. Create a post.
3. Add a Video block.
4. Insert a video from the WordPress media library.
5. Observe that the video can be played.

### 3 - Save the post in the web version

> [!NOTE]
> These instructions are extracted from https://github.com/Automattic/jetpack/pull/24548.

##### WordPress.com site 

1. In the app:
    1. Create/edit a post.
    2. Add a video block.
    3. Insert a video.
    4. Save the post.
2. In the web:
    1. Open the post.
    2. Observe that the HTML code is different when switching to the Code editor.
    3. Save the post.
3. In the app again:
    1. Refresh the post list.
    2. Open the post.
    3. Confirm that the video block displays without error, as shown below. The video doesn't have a thumbnail and can't be played, but block settings can be modified.
    4. Preview the post to confirm the video is displayed.

<img src=https://user-images.githubusercontent.com/2998162/171063830-0a39c46e-01fd-4db5-8519-7f66d14cfad9.png width=150>

##### Self-hosted site without Jetpack

In addition to confirming that [the original bug](https://github.com/WordPress/gutenberg/issues/30987) is addressed, we should also confirm that there are no regressions to the way the video block appears for sites hosted outside of WordPress.com and without Jetpack.

1. In the app:
    1. Create/edit a post.
    2. Add a video block.
    5. Insert a video.
    6. Save the post.
2. In the web:
    1. Open the post.
    2. Observe that the HTML code remains the same.
    3. Add a block to modify the post (e.g. add a Paragraph block with text).
    4. Save the post.
3. In the app again:
    1. Refresh the post list.
    2. Open the post.
    3. Confirm that the video block displays as before, there should be no changes to its appearance within the app.

### 4 - Insert video via URL

> [!NOTE]
> These instructions are extracted from https://github.com/WordPress/gutenberg/pull/49858.

To test #42515: _Saving a Video block with a file URL displays placeholder text in the editor_ 

1. Create a new post in the native editor. 
1. Add a Video block. 
1. Tap _Insert from URL_. 
1. Set the URL to an MP4 file: `http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4`
1. Note the video preview displays a placeholder image for the video.
1. Tap the three-dot menu in the top-right of the editor. 
1. Tap _Save as Draft_.
1. After completing the network requests, observe that the first frame of the video remains as the placeholder image.

To test #42443: _Showing the play button after inserting URL that doesn't exist_

1. Create a new post in the native editor. 
1. Add a Video block. 
1. Tap _Insert from URL_. 
1. Insert a URL that doesn't exist or is invalid: `aaaaaa`
1. Observe that the MediaPlaceholder block remains prompting the user to "Add Video", and that an "Invalid URL" notification is presented to the user near the top of the screen.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A