### PR TITLE
Update Android publishing group id from org.wordpress-mobile to org.wordpress

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -36,7 +36,7 @@ plugins {
 // import the `readReactNativeVersion()` function
 apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
 
-group = 'org.wordpress-mobile.gutenberg-mobile'
+group = 'org.wordpress.gutenberg-mobile'
 
 // The sample build uses multiple directories to
 // keep boilerplate and common code separate from
@@ -119,7 +119,7 @@ project.afterEvaluate {
             ReactNativeAztecPublication(MavenPublication) {
                 artifact bundleReleaseAar
 
-                groupId 'org.wordpress-mobile.gutenberg-mobile'
+                groupId 'org.wordpress.gutenberg-mobile'
                 artifactId 'react-native-aztec'
                 // version is set by 'publish-to-s3' plugin
 

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -25,7 +25,7 @@ plugins {
 apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
 apply from: '../extractPackageVersion.gradle'
 
-group='org.wordpress-mobile.gutenberg-mobile'
+group='org.wordpress.gutenberg-mobile'
 
 def buildAssetsFolder = 'build/assets'
 
@@ -93,8 +93,8 @@ dependencies {
 
     // Published by `wordpress-mobile/react-native-libraries-publisher`
     // See the documentation for this value in `build.gradle.kts` of `wordpress-mobile/react-native-libraries-publisher`
-    def reactNativeLibrariesPublisherVersion = "v3"
-    def reactNativeLibrariesGroupId = "org.wordpress-mobile.react-native-libraries.$reactNativeLibrariesPublisherVersion"
+    def reactNativeLibrariesPublisherVersion = "v4"
+    def reactNativeLibrariesGroupId = "org.wordpress.react-native-libraries.$reactNativeLibrariesPublisherVersion"
     implementation "$reactNativeLibrariesGroupId:react-native-get-random-values:${extractPackageVersion(packageJson, 'react-native-get-random-values', 'dependencies')}"
     implementation "$reactNativeLibrariesGroupId:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
     implementation "$reactNativeLibrariesGroupId:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
@@ -110,7 +110,7 @@ dependencies {
     runtimeOnly "com.facebook.react:hermes-android:$rnVersion"
 
     if (willPublishReactNativeBridgeBinary) {
-        implementation "org.wordpress-mobile.gutenberg-mobile:react-native-aztec:$reactNativeAztecVersion"
+        implementation "org.wordpress.gutenberg-mobile:react-native-aztec:$reactNativeAztecVersion"
    } else {
         api project(':@wordpress_react-native-aztec')
    }
@@ -122,7 +122,7 @@ project.afterEvaluate {
             ReactNativeBridgePublication(MavenPublication) {
                 artifact bundleReleaseAar
 
-                groupId 'org.wordpress-mobile.gutenberg-mobile'
+                groupId 'org.wordpress.gutenberg-mobile'
                 artifactId 'react-native-gutenberg-bridge'
                 // version is set by 'publish-to-s3' plugin
 

--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
 dependencies {
     def packageJson = '../../package.json'
 
-    implementation "org.wordpress-mobile.gutenberg-mobile:react-native-bridge"
+    implementation "org.wordpress.gutenberg-mobile:react-native-bridge"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.android.material:material:1.9.0"
     // The version of react-native is set by the React Native Gradle Plugin
@@ -145,8 +145,8 @@ dependencies {
 
     // Published by `wordpress-mobile/react-native-libraries-publisher`
     // See the documentation for this value in `build.gradle.kts` of `wordpress-mobile/react-native-libraries-publisher`
-    def reactNativeLibrariesPublisherVersion = "v3"
-    def reactNativeLibrariesGroupId = "org.wordpress-mobile.react-native-libraries.$reactNativeLibrariesPublisherVersion"
+    def reactNativeLibrariesPublisherVersion = "v4"
+    def reactNativeLibrariesGroupId = "org.wordpress.react-native-libraries.$reactNativeLibrariesPublisherVersion"
     implementation "$reactNativeLibrariesGroupId:react-native-get-random-values:${extractPackageVersion(packageJson, 'react-native-get-random-values', 'dependencies')}"
     implementation "$reactNativeLibrariesGroupId:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
     implementation "$reactNativeLibrariesGroupId:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"

--- a/packages/react-native-editor/android/build.gradle
+++ b/packages/react-native-editor/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 34
         targetSdkVersion = 33
         supportLibVersion = '28.0.0'
-        
+
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"
     }
@@ -30,8 +30,7 @@ allprojects {
             content {
                 includeGroup "org.wordpress"
                 includeGroup "org.wordpress.aztec"
-                includeGroup "org.wordpress-mobile"
-                includeGroupByRegex "org.wordpress-mobile.react-native-libraries.*"
+                includeGroupByRegex "org.wordpress.react-native-libraries.*"
             }
         }
         maven { url 'https://www.jitpack.io' }


### PR DESCRIPTION
Out of abundance of caution, we are updating the group id that we use to publish the Android artifacts from `org.wordpress-mobile` to `org.wordpress` as we don't own the `wordpress-mobile.org` domain. This will also make it more consistent with every other WordPress Android artifact that's published to Automattic's S3 Maven.

The `react-native-libraries` change has been made here: https://github.com/wordpress-mobile/react-native-libraries-publisher/pull/32