### PR TITLE
Fix font asset download when font faces are installed

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -160,11 +160,10 @@ function FontCollection( { slug } ) {
 			if ( fontFamily?.fontFace ) {
 				await Promise.all(
 					fontFamily.fontFace.map( async ( fontFace ) => {
-						if ( fontFace.downloadFromUrl ) {
+						if ( fontFace.src ) {
 							fontFace.file = await downloadFontFaceAsset(
-								fontFace.downloadFromUrl
+								fontFace.src
 							);
-							delete fontFace.downloadFromUrl;
 						}
 					} )
 				);


### PR DESCRIPTION
## What?

When we switched to using the new font collection format in https://github.com/WordPress/gutenberg/pull/57884, I think we missed updating the client code to expect the fontFace asset in the `src` property, rather than `downloadFromUrl`.

This PR fixes that.

## Why?

To provide a font asset so it can be loaded from the site, rather that Google's CDN.


## Testing Instructions

- Install a font from the default collection
- See that the font asset is uploaded to wp-content/fonts
