### PR TITLE
Remove the 👋 emoji from the Block Editor Handbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Block Editor Handbook
 
-👋 Welcome to the Block Editor Handbook.
+Welcome to the Block Editor Handbook.
 
 The [**Block Editor**](https://wordpress.org/gutenberg/) is a modern and up-to-date paradigm for WordPress site building and publishing. It uses a modular system of **Blocks** to compose and format content and is designed to create rich and flexible layouts for websites and digital products.
 


### PR DESCRIPTION
While emojis are fun, I do not think this specific emoji is needed, and it's also negatively impacting the Open Graph Meta for the page, see https://github.com/WordPress/wporg-developer/pull/478. 

| Before | After |
|-|-|
|<img width="919" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/354eced2-60f6-41b2-88bc-25bcd906b70b">| <img width="930" alt="image" src="https://github.com/WordPress/gutenberg/assets/4832319/5561c7f0-b16b-48e8-b0a5-7fb6fa700da6">|