### PR TITLE
Font Library: Remove 'version' property from font collection schema

### DIFF
--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -7,11 +7,6 @@
 			"description": "JSON schema URI for font-collection.json.",
 			"type": "string"
 		},
-		"version": {
-			"description": "Version of font-collection.json schema to use.",
-			"type": "integer",
-			"enum": [ 1 ]
-		},
 		"font_families": {
 			"type": "array",
 			"description": "Array of font families ready to be installed",
@@ -55,5 +50,5 @@
 		}
 	},
 	"additionalProperties": false,
-	"required": [ "$schema", "version", "font_families" ]
+	"required": [ "$schema", "font_families" ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove 'version' property from `font-collection.json` schema.

## Why?
We won't be using that information and it can be confusing if it stays in the schema.

## How?
removing the property from the schema file.