### PR TITLE
(chore) Revert bump to the v17.5.1 (draft) due to bug in the release found by manual testing

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.3
  * Requires PHP: 7.0
- * Version: 17.5.1
+ * Version: 17.5.0
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg",
-	"version": "17.5.1",
+	"version": "17.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg",
-			"version": "17.5.1",
+			"version": "17.5.0",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "17.5.1",
+	"version": "17.5.0",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
## Why?

The fix https://github.com/WordPress/gutenberg/pull/58016 for https://github.com/WordPress/gutenberg/pull/57988, and the PR checks all passed (including all E2Es). 

I started a draft for the patch release, and I always smoke test the zip before publishing, just in case. While testing the zip, I discovered it caused a BSOD in the Site Editor (see screecast below) and confirmed it to be a core issue, as I could reproduce it in a vanilla `wp-env` instance. Therefore, I'm wiping out/reverting the draft for 17.5.1. We will rerelease the patch release once we figure out a fix for that issue.


https://github.com/WordPress/gutenberg/assets/81248/72dfa500-43ab-4042-8ed7-dfd312dbca27


## How?

1. Revert the commit that bumps the version in `trunk`.
2. Reset HEAD^ --hard in the `release/17.5` branch and force-pushing
3. Removing the `v17.5.1` draft release in Github (no need to delete the tag as it is only created when publishing).

## Next steps

* Figure out why https://github.com/WordPress/gutenberg/pull/58016 is causing the BSOD, fix it and include it and the fix in a new v17.5.1 patch release.

