### PR TITLE
Add taxonomy attribute to categories block #51388

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -79,7 +79,7 @@ Display a list of all categories. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, showEmpty, showHierarchy, showOnlyTopLevel, showPostCounts
+-	**Attributes:** displayAsDropdown, showEmpty, showHierarchy, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -26,6 +26,10 @@
 		"showEmpty": {
 			"type": "boolean",
 			"default": false
+		},
+		"taxonomy": {
+			"type": "string",
+			"default": "category"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -27,6 +27,7 @@ export default function CategoriesEdit( {
 		showPostCounts,
 		showOnlyTopLevel,
 		showEmpty,
+		taxonomy,
 	},
 	setAttributes,
 	className,
@@ -39,7 +40,7 @@ export default function CategoriesEdit( {
 
 	const { records: categories, isResolving } = useEntityRecords(
 		'taxonomy',
-		'category',
+		taxonomy,
 		query
 	);
 

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -23,7 +23,9 @@ function render_block_core_categories( $attributes ) {
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',
 		'hide_empty'   => empty( $attributes['showEmpty'] ),
+		'taxonomy'     => $attributes['taxonomy'],
 	);
+
 	if ( ! empty( $attributes['showOnlyTopLevel'] ) && $attributes['showOnlyTopLevel'] ) {
 		$args['parent'] = 0;
 	}

--- a/test/integration/fixtures/blocks/core__categories.json
+++ b/test/integration/fixtures/blocks/core__categories.json
@@ -7,7 +7,8 @@
 			"showHierarchy": false,
 			"showPostCounts": false,
 			"showOnlyTopLevel": false,
-			"showEmpty": false
+			"showEmpty": false,
+			"taxonomy": "category"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
FIx #51388

## Why?
Custom taxonomy list can be displayed by creating a variation of categories block.

## How?
By simply adding a taxonomy attribute we can leverage the `wp_dropdown_categories` to display any taxonomy.

## Testing Instructions
1. Register a custom taxonomy
2. Create a variation of block categories with taxonomy attribute equal to 'YOUR TAXONOMY'.
3. Insert somewhere to have a list of your taxonomy.

