### PR TITLE
Site Editor: Fix All Templates page layout when New admin views is disabled

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -64,12 +64,15 @@ export default function useLayoutAreas() {
 		return {
 			areas: {
 				content: <PageTemplates />,
-				preview: isListLayout && (
+				preview: window.__experimentalAdminViews && isListLayout && (
 					<Editor isLoading={ isSiteEditorLoading } />
 				),
 			},
 			widths: {
-				content: isListLayout ? 380 : undefined,
+				content:
+					window.__experimentalAdminViews && isListLayout
+						? 380
+						: undefined,
 			},
 		};
 	}


### PR DESCRIPTION
## What?
This PR fixes an issue where the canvas is displayed on the All Templates page and the data view is a list layout when the experimental flag "New admin views" is **disabled**.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/dd8df8ea-9411-404d-a2b9-9e9199fec3ee) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/db163d37-d7d4-45a1-97f8-6677e5462179) | 

## Why?

In #57109, the All templates page now uses the data view even if the experimental flag is disabled. However, After #57938, when the experimental flag is disabled, the data view is now displayed as a list layout and unintentionally displays the preview area.

If the experimental flag is disabled, you will not be able to switch to the table layout. It's the intended behavior that the data view is visible, but I think it should be a table layout and the canvas should not be displayed.

## How?

Added a conditional statement to determine whether the experimental flag is enabled in template routing.

> [!NOTE]
> While working on this PR, I noticed that the sticky header on All Templates page and All Template Parts page were not working. If this is not the intended behavior, I think it needs to be fixed.

## Testing Instructions

- **Disable** the "New admin views" experiment.
- Visit "Site Editor > Templates > All Templates". Verify the data view as a table layout is displayed and the preview is not displayed.
- **Enable** the "New admin views" experiment.
- Visit "Site Editor > Templates". Verify the data view as a list layout is displayed and the preview is displayed.