### PR TITLE
Set post editor sidebar tabs to manual activation

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -4,6 +4,7 @@
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { forwardRef } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
@@ -14,7 +15,7 @@ import { sidebars } from '../settings-sidebar';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
-const SettingsHeader = () => {
+const SettingsHeader = ( _, ref ) => {
 	const { documentLabel } = useSelect( ( select ) => {
 		const { getPostTypeLabel } = select( editorStore );
 
@@ -25,9 +26,19 @@ const SettingsHeader = () => {
 	}, [] );
 
 	return (
-		<Tabs.TabList>
-			<Tabs.Tab tabId={ sidebars.document }>{ documentLabel }</Tabs.Tab>
-			<Tabs.Tab tabId={ sidebars.block }>
+		<Tabs.TabList ref={ ref }>
+			<Tabs.Tab
+				tabId={ sidebars.document }
+				// Used for focus management in the SettingsSidebar component.
+				data-tab-id={ sidebars.document }
+			>
+				{ documentLabel }
+			</Tabs.Tab>
+			<Tabs.Tab
+				tabId={ sidebars.block }
+				// Used for focus management in the SettingsSidebar component.
+				data-tab-id={ sidebars.block }
+			>
 				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
 				{ __( 'Block' ) }
 			</Tabs.Tab>
@@ -35,4 +46,4 @@ const SettingsHeader = () => {
 	);
 };
 
-export default SettingsHeader;
+export default forwardRef( SettingsHeader );

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -157,6 +157,7 @@ const SettingsSidebar = () => {
 			// the selected tab to `null` avoids that.
 			selectedTabId={ isSettingsSidebarActive ? sidebarName : null }
 			onSelect={ onTabSelect }
+			selectOnMove={ false }
 		>
 			<SidebarContent
 				sidebarName={ sidebarName }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -64,7 +64,8 @@ const SidebarContent = ( {
 
 	// This effect addresses a race condition caused by tabbing from the last
 	// block in the editor into the settings sidebar. Without this effect, the
-	// selected tab and browser focus can become separated in an unexpected way.
+	// selected tab and browser focus can become separated in an unexpected way
+	// (e.g the "block" tab is focused, but the "post" tab is selected).
 	useEffect( () => {
 		const tabsElements = Array.from(
 			tabListRef.current?.querySelectorAll( '[role="tab"]' ) || []

--- a/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/keyboard-navigable-blocks.spec.js
@@ -75,7 +75,7 @@ test.describe( 'Order of block keyboard navigation', () => {
 		);
 
 		await page.keyboard.press( 'Tab' );
-		await KeyboardNavigableBlocks.expectLabelToHaveFocus( 'Block' );
+		await KeyboardNavigableBlocks.expectLabelToHaveFocus( 'Post' );
 	} );
 
 	test( 'allows tabbing in navigation mode if no block is selected (reverse)', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
This PR should wait for #57696 to be merged ✅

## What?
- Makes the **Document** and **Block** tab in the editor settings sidebar activate manually rather than automatically
- Adds a fix to address the tab flow issues discussed in #57696

## Why?
When #55360 was merged to implement the new `Tabs` component instead of the custom implementation in place previously, the activation method was changed. Previously, the `button` elements needed to be explicitly activated to select a tab. With that PR the activation became automatic whenever a tab was given focus.

In we noticed that automatic activation is more consistent with past behavior when migrating similar settings panels, and this change will bring them all in alignment (see #56959 and #57886)

Regarding tab flow: in the editor sidebars a race condition exists where if no tab is selected, and then the <kbd>Tab</kbd> key is used to cycle through all of the existing blocks, the next press of <kbd>Tab</kbd> will move focus to the settings sidebar.

When that happens, two events fire independently of each other in this order:
1. Focus moves from the final block to the currently active settings tab, which is **Block**
2. `interfaceStore` detects that focus is no longer on a block. The sidebar is automatically switched over the the **Post** tab.

The net result from a user perspective is that pressing <kbd>Tab</kbd> that last time focuses one tab wile selecting the other. This feels really confusing, so we're adding a check to prevent that from happening.

## How?
- Add the missing prop `selectOnMove` prop
- add a `useEffect` call that will checks to confirm that the currently selected tab matches the currently focused tab. if not, it updates browser focus so the user experience is <kbd>Tab</kbd>ing onto the tab that actually gets selected.

## Testing Instructions
1. Create a new post
4. Make sure the editor settings sidebar is active
5. Click on one of the tabs (**Post** or **Block**)
6. Use arrow keys to move between the two tabs
7. Confirm that the tab isn't automatically selected
8. Confirm that <kbd>Enter</kbd>/<kbd>Return</kbd>/<kbd>Space</kbd> selects the currently focused tab
9. Add a title and paragraph block with some text
10. Click below the block in the empty canvas
11. Press <kbd>Tab</kbd> to cycle through the title and the paragraph block, then once more to focus the sidebar
12. Confirm that when focus leaves the final block in the editor the **Post** tab is both selected and focused (this confirms that we've addressed the race condition described above).
