### PR TITLE
DataViews: Fix rounded corners of cards in grid layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -271,6 +271,7 @@
 		border: 1px solid $gray-200;
 		height: 100%;
 		justify-content: flex-start;
+		overflow: hidden;
 
 		.dataviews-view-grid__title-actions {
 			padding: 0 $grid-unit-05;


### PR DESCRIPTION
Follow up #57880

## What?

This PR ensures that the rounded corners of cards are displayed correctly in the data view as a grid layout.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/b0aad4bf-4c33-45ed-9968-192fc7ebd47f)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/7357286b-3d6d-4a50-89ba-edc9717fcb7c)

## Why?

This is because the background color of the content inside is protruding.

## How?

Simply applied `overflow: hidden`. Since the cards themselves are not focusable, the outline cutoff itself should not occur.

## Testing Instructions

- Enable "New admin views" on the Experiments page.
- Visit the Site Editor's Patterns page and switch to the grid layout.
- Check the corner of the card.
- Also check the grid layout on the All Templates page.
