### PR TITLE
Fix formats not working in block bindings content

### DIFF
--- a/lib/experimental/block-bindings/class-wp-block-bindings.php
+++ b/lib/experimental/block-bindings/class-wp-block-bindings.php
@@ -101,7 +101,7 @@ class WP_Block_Bindings {
 						foreach ( $selector_attribute_names as $name ) {
 							$selector_attrs[ $name ] = $block_reader->get_attribute( $name );
 						}
-						$selector_markup = "<$selector>" . esc_html( $source_value ) . "</$selector>";
+						$selector_markup = "<$selector>" . wp_kses_post( $source_value ) . "</$selector>";
 						$amended_content = new WP_HTML_Tag_Processor( $selector_markup );
 						$amended_content->next_tag();
 						foreach ( $selector_attrs as $attribute_key => $attribute_value ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #58053

Currently formats are not working for block bindings content. This PR attempts to resolve the issue.

## How?
Currently `esc_html` is being used on any block content html. This PR switches to using `wp_kses_post` to allow a subset of safe html.

## Testing Instructions
Prerequisite: Enable the pattern overrides experiment from the gutenberg experiment page.

- Create a new post
- Insert a mixture of blocks that include paragraphs and optionally other blocks too
- Select the blocks, and 'Create a pattern' from the block options menu
- Give the pattern a name and make it 'synced'
- Click the 'Edit original' button on the toolbar
- Select a paragraph block in the pattern, and in the block settings sidebar expand the advanced section. Check the 'Allow instance overrides' option
- Use the 'Back' button in the header area of the editor to go back to the post
- Edit the paragraph and add formats
- View the post on the frontend

## Screenshots or screencast <!-- if applicable -->
#### Before

![Screenshot 2024-01-22 at 1 09 27 pm](https://github.com/WordPress/gutenberg/assets/677833/6c501be9-3797-4a79-8c18-89985dc208d2)

#### After

![Screenshot 2024-01-22 at 1 32 22 pm](https://github.com/WordPress/gutenberg/assets/677833/f2d755bd-48f9-43fd-9596-8b4080b9c35e)
