### PR TITLE
Update style revision top toolbar text

### DIFF
--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -35,7 +35,7 @@ function getEditorCanvasContainerTitle( view ) {
 			return __( 'Style Book' );
 		case 'global-styles-revisions':
 		case 'global-styles-revisions:style-book':
-			return __( 'Styles Revisions' );
+			return __( 'Style Revisions' );
 		default:
 			return '';
 	}

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -35,7 +35,7 @@ function getEditorCanvasContainerTitle( view ) {
 			return __( 'Style Book' );
 		case 'global-styles-revisions':
 		case 'global-styles-revisions:style-book':
-			return __( 'Global styles revisions' );
+			return __( 'Styles Revisions' );
 		default:
 			return '';
 	}

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -14,7 +14,7 @@ test.use( {
 	},
 } );
 
-test.describe( 'Global styles revisions', () => {
+test.describe( 'Style Revisions', () => {
 	let stylesPostId;
 	test.beforeAll( async ( { requestUtils } ) => {
 		await Promise.all( [


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/51202 by updating just the copy from "Global styles revisions" to "Style Revisions", matching what we show with "Style Book". 

## Why?
The current copy references the code project name (Global styles) and is likely to cause confusion.

## How?

Updates the copy. 
