### PR TITLE
Inserter: Try deferring search value instead of debouncing

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -13,11 +13,11 @@ import {
 	useMemo,
 	useImperativeHandle,
 	useRef,
+	useDeferredValue,
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useDebouncedInput } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -48,8 +48,10 @@ function InserterMenu(
 	},
 	ref
 ) {
-	const [ filterValue, setFilterValue, delayedFilterValue ] =
-		useDebouncedInput( __experimentalFilterValue );
+	const [ filterValue, setFilterValue ] = useState(
+		__experimentalFilterValue
+	);
+	const deferredFilterValue = useDeferredValue( filterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
 	const [ selectedPatternCategory, setSelectedPatternCategory ] =
 		useState( null );
@@ -200,12 +202,12 @@ function InserterMenu(
 
 	const showPatternPanel =
 		selectedTab === 'patterns' &&
-		! delayedFilterValue &&
+		! deferredFilterValue &&
 		selectedPatternCategory;
-	const showAsTabs = ! delayedFilterValue && ( showPatterns || showMedia );
+	const showAsTabs = ! deferredFilterValue && ( showPatterns || showMedia );
 	const showMediaPanel =
 		selectedTab === 'media' &&
-		! delayedFilterValue &&
+		! deferredFilterValue &&
 		selectedMediaCategory;
 
 	const handleSetSelectedTab = ( value ) => {
@@ -235,10 +237,10 @@ function InserterMenu(
 					placeholder={ __( 'Search' ) }
 					ref={ searchRef }
 				/>
-				{ !! delayedFilterValue && (
+				{ !! deferredFilterValue && (
 					<div className="block-editor-inserter__no-tab-container">
 						<InserterSearchResults
-							filterValue={ delayedFilterValue }
+							filterValue={ deferredFilterValue }
 							onSelect={ onSelect }
 							onHover={ onHover }
 							onHoverPattern={ onHoverPattern }
@@ -261,7 +263,7 @@ function InserterMenu(
 						tabsContents={ inserterTabsContents }
 					/>
 				) }
-				{ ! delayedFilterValue && ! showAsTabs && (
+				{ ! deferredFilterValue && ! showAsTabs && (
 					<div className="block-editor-inserter__no-tab-container">
 						{ blocksTab }
 					</div>


### PR DESCRIPTION
## What?
PR tries to replace `useDebouncedInput` with `useDeferredValue` for global inserter search.

## Why?
> Unlike debouncing or throttling, it doesn’t require choosing any fixed delay. [React Docs](https://react.dev/reference/react/useDeferredValue#how-is-deferring-a-value-different-from-debouncing-and-throttling)

## Testing Instructions
1. Open a post or page.
2. Open global inserter.
3. Type in the search field - `image` or `para`
4. Confirm the perceived performance of the search action is the same as before.
5. Confirm there is no regression in performance metrics for inserter search.

### Testing Instructions for Keyboard
Same