### PR TITLE
Block Bindings: Refactor block bindings editor implementation

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -812,6 +812,18 @@ _Properties_
 
 Ensures that the text selection keeps the same vertical distance from the viewport during keyboard events within this component. The vertical distance can vary. It is the last clicked or scrolled to position.
 
+### updateBlockBindingsAttribute
+
+Helper to update the bindings attribute used by the Block Bindings API.
+
+_Parameters_
+
+-   _blockAttributes_ `Object`: - The original block attributes.
+-   _setAttributes_ `Function`: - setAttributes function to modify the bindings property.
+-   _attributeName_ `string`: - The attribute in the bindings object to update.
+-   _sourceName_ `string`: - The source name added to the bindings property.
+-   _sourceAttributes_ `string`: - The source attributes added to the bindings property.
+
 ### URLInput
 
 _Related_

--- a/packages/block-editor/src/hooks/bindings.js
+++ b/packages/block-editor/src/hooks/bindings.js
@@ -6,15 +6,16 @@ import {
 	Button,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { useContext } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { plugins as pluginsIcon } from '@wordpress/icons';
-
 /**
  * Internal dependencies
  */
 import { BlockControls } from '../components';
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
+import BlockContext from '../components/block-context';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -31,15 +32,19 @@ const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 
 function BlockBindingsUI( props ) {
 	const { name: blockName, clientId } = props;
-	const { attributes, sources } = useSelect( ( select ) => {
-		return {
-			attributes:
-				select( blockEditorStore ).getBlockAttributes( clientId ),
-			sources: unlock(
-				select( blockEditorStore )
-			).getAllBlockBindingsSources(),
-		};
-	}, [] );
+	const { attributes, sources } = useSelect(
+		( select ) => {
+			return {
+				attributes:
+					select( blockEditorStore ).getBlockAttributes( clientId ),
+				sources: unlock(
+					select( blockEditorStore )
+				).getAllBlockBindingsSources(),
+			};
+		},
+		[ clientId ]
+	);
+	const blockContext = useContext( BlockContext );
 	if ( ! ( blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) ) {
 		return null;
 	}
@@ -94,6 +99,7 @@ function BlockBindingsUI( props ) {
 												>
 													{ source.component(
 														props,
+														blockContext,
 														attribute
 													) }
 												</DropdownMenu>

--- a/packages/block-editor/src/hooks/bindings.js
+++ b/packages/block-editor/src/hooks/bindings.js
@@ -40,6 +40,9 @@ function BlockBindingsUI( props ) {
 			).getAllBlockBindingsSources(),
 		};
 	}, [] );
+	if ( ! ( blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/packages/block-editor/src/hooks/bindings.js
+++ b/packages/block-editor/src/hooks/bindings.js
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import {
+	Button,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { plugins as pluginsIcon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { BlockControls } from '../components';
+import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
+
+const {
+	DropdownMenuV2: DropdownMenu,
+	DropdownMenuItemV2: DropdownMenuItem,
+	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
+} = unlock( componentsPrivateApis );
+
+const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
+	'core/paragraph': [ 'content' ],
+	'core/heading': [ 'content' ],
+	'core/image': [ 'url', 'title' ],
+	'core/button': [ 'url', 'text' ],
+};
+
+function BlockBindingsUI( { name: blockName, clientId } ) {
+	const { attributes, sources } = useSelect( ( select ) => {
+		return {
+			attributes:
+				select( blockEditorStore ).getBlockAttributes( clientId ),
+			sources: unlock(
+				select( blockEditorStore )
+			).getAllBlockBindingsSources(),
+		};
+	}, [] );
+
+	return (
+		<>
+			<BlockControls group="other">
+				<DropdownMenu
+					onOpenChange={ function noRefCheck() {} }
+					trigger={
+						<Button __next40pxDefaultSize icon={ pluginsIcon } />
+					}
+				>
+					{ /* Iterate over block attributes */ }
+					{ BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].map(
+						( attribute ) => {
+							return (
+								<DropdownMenu
+									trigger={
+										<DropdownMenuItem>
+											<DropdownMenuItemLabel>
+												{ attribute }
+											</DropdownMenuItemLabel>
+										</DropdownMenuItem>
+									}
+									key={ attribute }
+								>
+									{ /* Iterate over sources */ }
+									{ Object.entries( sources ).map(
+										( [ sourceName, source ] ) => {
+											return (
+												<DropdownMenu
+													trigger={
+														<DropdownMenuItem>
+															<DropdownMenuItemLabel
+																className={
+																	attributes
+																		.metadata
+																		?.bindings?.[
+																		attribute
+																	]?.source
+																		?.name ===
+																		sourceName &&
+																	'is-source-bound'
+																}
+															>
+																{ source.label }
+															</DropdownMenuItemLabel>
+														</DropdownMenuItem>
+													}
+													key={ sourceName }
+												>
+													{ source.component() }
+												</DropdownMenu>
+											);
+										}
+									) }
+								</DropdownMenu>
+							);
+						}
+					) }
+				</DropdownMenu>
+			</BlockControls>
+		</>
+	);
+}
+
+export default {
+	edit: BlockBindingsUI,
+	hasSupport() {
+		return true;
+	},
+};

--- a/packages/block-editor/src/hooks/bindings.js
+++ b/packages/block-editor/src/hooks/bindings.js
@@ -29,7 +29,8 @@ const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 	'core/button': [ 'url', 'text' ],
 };
 
-function BlockBindingsUI( { name: blockName, clientId } ) {
+function BlockBindingsUI( props ) {
+	const { name: blockName, clientId } = props;
 	const { attributes, sources } = useSelect( ( select ) => {
 		return {
 			attributes:
@@ -88,7 +89,10 @@ function BlockBindingsUI( { name: blockName, clientId } ) {
 													}
 													key={ sourceName }
 												>
-													{ source.component() }
+													{ source.component(
+														props,
+														attribute
+													) }
 												</DropdownMenu>
 											);
 										}
@@ -105,6 +109,7 @@ function BlockBindingsUI( { name: blockName, clientId } ) {
 
 export default {
 	edit: BlockBindingsUI,
+	attributeKeys: [ 'metadata' ],
 	hasSupport() {
 		return true;
 	},

--- a/packages/block-editor/src/hooks/bindings.js
+++ b/packages/block-editor/src/hooks/bindings.js
@@ -6,6 +6,7 @@ import {
 	Button,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { addFilter } from '@wordpress/hooks';
 import { plugins as pluginsIcon } from '@wordpress/icons';
 
 /**
@@ -108,3 +109,25 @@ export default {
 		return true;
 	},
 };
+
+if ( window.__experimentalBlockBindings ) {
+	addFilter(
+		'blocks.registerBlockType',
+		'core/block-bindings-ui',
+		( settings, name ) => {
+			if ( ! ( name in BLOCK_BINDINGS_ALLOWED_BLOCKS ) ) {
+				return settings;
+			}
+			const contextItems = [ 'postId', 'postType', 'queryId' ];
+			const usesContextArray = settings.usesContext;
+			const oldUsesContextArray = new Set( usesContextArray );
+			contextItems.forEach( ( item ) => {
+				if ( ! oldUsesContextArray.has( item ) ) {
+					usesContextArray.push( item );
+				}
+			} );
+			settings.usesContext = usesContextArray;
+			return settings;
+		}
+	);
+}

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -11,6 +11,7 @@ import align from './align';
 import './lock';
 import anchor from './anchor';
 import ariaLabel from './aria-label';
+import bindings from './bindings';
 import customClassName from './custom-class-name';
 import './generated-class-name';
 import style from './style';
@@ -32,6 +33,7 @@ createBlockEditFilter(
 	[
 		align,
 		anchor,
+		bindings,
 		customClassName,
 		style,
 		duotone,

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -28,6 +28,7 @@ import contentLockUI from './content-lock-ui';
 import './metadata';
 import blockHooks from './block-hooks';
 import blockRenaming from './block-renaming';
+import './use-bindings-attributes';
 
 createBlockEditFilter(
 	[

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -1,0 +1,101 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useRegistry, useSelect } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../store';
+import { useBlockEditContext } from '../components/block-edit/context';
+import { unlock } from '../lock-unlock';
+
+/** @typedef {import('@wordpress/compose').WPHigherOrderComponent} WPHigherOrderComponent */
+/** @typedef {import('@wordpress/blocks').WPBlockSettings} WPBlockSettings */
+
+/**
+ * Given a binding of block attributes, returns a higher order component that
+ * overrides its `attributes` and `setAttributes` props to sync any changes needed.
+ *
+ * @return {WPHigherOrderComponent} Higher-order component.
+ */
+const createEditFunctionWithBindingsAttribute = () =>
+	createHigherOrderComponent(
+		( BlockEdit ) => ( props ) => {
+			const { clientId } = useBlockEditContext();
+
+			const {
+				getBlockBindingsSource,
+				getBlockAttributes,
+				updateBlockAttributes,
+			} = useSelect( ( select ) => {
+				return {
+					getBlockBindingsSource: unlock( select( blockEditorStore ) )
+						.getBlockBindingsSource,
+					getBlockAttributes:
+						select( blockEditorStore ).getBlockAttributes,
+					updateBlockAttributes:
+						select( blockEditorStore ).updateBlockAttributes,
+				};
+			}, [] );
+
+			const updatedAttributes = getBlockAttributes( clientId );
+			if ( updatedAttributes?.metadata?.bindings ) {
+				Object.entries( updatedAttributes.metadata.bindings ).forEach(
+					( [ attributeName, settings ] ) => {
+						const source = getBlockBindingsSource(
+							settings.source.name
+						);
+
+						if ( source ) {
+							// Second argument (`setValue`) will be used to update the value in the future.
+							const [ value ] = source.useSource(
+								props,
+								settings.source.attributes
+							);
+							updatedAttributes[ attributeName ] = value;
+						}
+					}
+				);
+			}
+
+			const registry = useRegistry();
+
+			return (
+				<>
+					<BlockEdit
+						key="edit"
+						attributes={ updatedAttributes }
+						setAttributes={ ( newAttributes, blockId ) =>
+							registry.batch( () =>
+								updateBlockAttributes( blockId, newAttributes )
+							)
+						}
+						{ ...props }
+					/>
+				</>
+			);
+		},
+		'useBoundAttributes'
+	);
+
+/**
+ * Filters a registered block's settings to enhance a block's `edit` component
+ * to upgrade bound attributes.
+ *
+ * @param {WPBlockSettings} settings Registered block settings.
+ *
+ * @return {WPBlockSettings} Filtered block settings.
+ */
+function shimAttributeSource( settings ) {
+	settings.edit = createEditFunctionWithBindingsAttribute()( settings.edit );
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/editor/custom-sources-backwards-compatibility/shim-attribute-source',
+	shimAttributeSource
+);

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -20,6 +20,14 @@ import { unlock } from '../lock-unlock';
  *
  * @return {WPHigherOrderComponent} Higher-order component.
  */
+
+const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
+	'core/paragraph': [ 'content' ],
+	'core/heading': [ 'content' ],
+	'core/image': [ 'url', 'title' ],
+	'core/button': [ 'url', 'text' ],
+};
+
 const createEditFunctionWithBindingsAttribute = () =>
 	createHigherOrderComponent(
 		( BlockEdit ) => ( props ) => {
@@ -49,12 +57,23 @@ const createEditFunctionWithBindingsAttribute = () =>
 						);
 
 						if ( source ) {
-							// Second argument (`setValue`) will be used to update the value in the future.
-							const [ value ] = source.useSource(
+							// Second argument (`updateMetaValue`) will be used to update the value in the future.
+							const {
+								placeholder,
+								useValue: [ metaValue = null ] = [],
+							} = source.useSource(
 								props,
 								settings.source.attributes
 							);
-							updatedAttributes[ attributeName ] = value;
+
+							if ( placeholder ) {
+								updatedAttributes.placeholder = placeholder;
+								updatedAttributes[ attributeName ] = null;
+							}
+
+							if ( metaValue ) {
+								updatedAttributes[ attributeName ] = metaValue;
+							}
 						}
 					}
 				);
@@ -89,6 +108,9 @@ const createEditFunctionWithBindingsAttribute = () =>
  * @return {WPBlockSettings} Filtered block settings.
  */
 function shimAttributeSource( settings ) {
+	if ( ! ( settings.name in BLOCK_BINDINGS_ALLOWED_BLOCKS ) ) {
+		return settings;
+	}
 	settings.edit = createEditFunctionWithBindingsAttribute()( settings.edit );
 
 	return settings;

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -449,7 +449,6 @@ export function createBlockEditFilter( features ) {
 							name={ props.name }
 							isSelected={ props.isSelected }
 							clientId={ props.clientId }
-							context={ props.context }
 							setAttributes={ props.setAttributes }
 							__unstableParentLayout={
 								props.__unstableParentLayout

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -449,6 +449,7 @@ export function createBlockEditFilter( features ) {
 							name={ props.name }
 							isSelected={ props.isSelected }
 							clientId={ props.clientId }
+							context={ props.context }
 							setAttributes={ props.setAttributes }
 							__unstableParentLayout={
 								props.__unstableParentLayout

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -240,6 +240,16 @@ export function clearBlockRemovalPrompt() {
 	};
 }
 
+export function registerBlockBindingsSource( source ) {
+	return {
+		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
+		sourceName: source.name,
+		sourceLabel: source.label,
+		sourceComponent: source.component,
+		useSource: source.useSource,
+	};
+}
+
 /**
  * Returns an action object used to set up any rules that a block editor may
  * provide in order to prevent a user from accidentally removing certain

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -170,6 +170,14 @@ export function getStyleOverrides( state ) {
 	return state.styleOverrides;
 }
 
+export function getAllBlockBindingsSources( state ) {
+	return state.blockBindingsSources;
+}
+
+export function getBlockBindingsSource( state, sourceName ) {
+	return state?.blockBindingsSources?.[ sourceName ];
+}
+
 /** @typedef {import('./actions').InserterMediaCategory} InserterMediaCategory */
 /**
  * Returns the registered inserter media categories through the public API.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1513,6 +1513,21 @@ function removalPromptData( state = false, action ) {
 	return state;
 }
 
+function blockBindingsSources( state = {}, action ) {
+	if ( action.type === 'REGISTER_BLOCK_BINDINGS_SOURCE' ) {
+		return {
+			...state,
+			[ action.sourceName ]: {
+				label: action.sourceLabel,
+				component: action.sourceComponent,
+				useSource: action.useSource,
+			},
+		};
+	}
+
+	return state;
+}
+
 /**
  * Reducer returning any rules that a block editor may provide in order to
  * prevent a user from accidentally removing certain blocks. These rules are
@@ -2044,6 +2059,7 @@ const combinedReducers = combineReducers( {
 	blockEditingModes,
 	styleOverrides,
 	removalPromptData,
+	blockBindingsSources,
 	blockRemovalRules,
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,

--- a/packages/block-editor/src/utils/index.js
+++ b/packages/block-editor/src/utils/index.js
@@ -1,3 +1,4 @@
 export { default as transformStyles } from './transform-styles';
 export * from './block-variation-transforms';
 export { default as getPxFromCssUnit } from './get-px-from-css-unit';
+export * from './update-bindings-attribute';

--- a/packages/block-editor/src/utils/update-bindings-attribute.js
+++ b/packages/block-editor/src/utils/update-bindings-attribute.js
@@ -1,0 +1,50 @@
+/**
+ * Helper to update the bindings attribute used by the Block Bindings API.
+ *
+ * @param {Object}   blockAttributes  - The original block attributes.
+ * @param {Function} setAttributes    - setAttributes function to modify the bindings property.
+ * @param {string}   attributeName    - The attribute in the bindings object to update.
+ * @param {string}   sourceName       - The source name added to the bindings property.
+ * @param {string}   sourceAttributes - The source attributes added to the bindings property.
+ */
+export const updateBlockBindingsAttribute = (
+	blockAttributes,
+	setAttributes,
+	attributeName,
+	sourceName,
+	sourceAttributes
+) => {
+	// TODO: Review if we can create a React Hook for this.
+
+	let updatedBindings = {};
+	// // If no sourceName is provided, remove the attribute from the bindings.
+	if ( sourceName === null ) {
+		if ( ! blockAttributes?.metadata.bindings ) {
+			return blockAttributes?.metadata;
+		}
+
+		updatedBindings = {
+			...blockAttributes?.metadata?.bindings,
+			[ attributeName ]: undefined,
+		};
+		if ( Object.keys( updatedBindings ).length === 1 ) {
+			updatedBindings = undefined;
+		}
+	} else {
+		updatedBindings = {
+			...blockAttributes?.metadata?.bindings,
+			[ attributeName ]: {
+				source: { name: sourceName, attributes: sourceAttributes },
+			},
+		};
+	}
+
+	setAttributes( {
+		metadata: {
+			...blockAttributes.metadata,
+			bindings: updatedBindings,
+		},
+	} );
+
+	return blockAttributes.metadata;
+};

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -27,7 +27,7 @@
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",
-		"{src,build,build-module}/{index.js,store/index.js,hooks/**}"
+		"{src,build,build-module}/{index.js,store/index.js,hooks/**,bindings/**}"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",

--- a/packages/editor/src/bindings/index.js
+++ b/packages/editor/src/bindings/index.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { dispatch } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import postMeta from './post-meta';
+
+const { registerBlockBindingsSource } = unlock( dispatch( blockEditorStore ) );
+registerBlockBindingsSource( postMeta );

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -4,12 +4,23 @@
 import { updateBlockBindingsAttribute } from '@wordpress/block-editor';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
 import { store as editorStore } from '../store';
+
+const { getCurrentPostId, getCurrentPostType } = select( editorStore );
+const { getEntityRecord, getEntityRecords } = select( coreStore );
+
+// Prettify the name until the label is available in the REST API endpoint.
+const keyToLabel = ( key ) => {
+	return key
+		.split( '_' )
+		.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+		.join( ' ' );
+};
 
 function PostMetaComponent( props, blockContext, selectedAttribute ) {
 	const {
@@ -18,31 +29,90 @@ function PostMetaComponent( props, blockContext, selectedAttribute ) {
 		DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
 	} = unlock( componentsPrivateApis );
 	const { metadata, setAttributes } = props;
-	// TODO: Expose the post meta in the `types` REST API endpoint and use that.
-	const data = useSelect(
-		( select ) => {
-			const postId = blockContext.postId
-				? blockContext.postId
-				: select( editorStore ).getCurrentPostId();
-			const postType = blockContext.postType
-				? blockContext.postType
-				: select( editorStore ).getCurrentPostType();
-			const { getEntityRecord } = select( coreStore );
-			return getEntityRecord( 'postType', postType, postId );
-		},
-		[ blockContext.postId, blockContext.postType ]
-	);
-	if ( ! data || ! data.meta ) {
-		return null;
+
+	// Get list of post_meta fields depending on the context.
+	const postId = blockContext.postId
+		? blockContext.postId
+		: getCurrentPostId();
+	const postType = blockContext.postType
+		? blockContext.postType
+		: getCurrentPostType();
+
+	let data = {};
+	if ( postType === 'wp_template' ) {
+		const { slug: templateSlug } = getEntityRecord(
+			'postType',
+			'wp_template',
+			postId
+		);
+
+		// Get the post type from the template slug.
+
+		// Match "page-{slug}".
+		const pagePattern = /^page(?:-(.+))?$/;
+		// Match "single-{postType}-{slug}".
+		const postPattern = /^single-([^-]+)(?:-(.+))?$/;
+		// Match "wp-custom-template-{slug}".
+		const customTemplatePattern = /^wp-custom-template-(.+)$/;
+		// If it doesn't match any of the accepted patterns, return.
+		if (
+			! templateSlug !== 'index' &&
+			! templateSlug !== 'page' &&
+			! pagePattern.test( templateSlug ) &&
+			! postPattern.test( templateSlug ) &&
+			! customTemplatePattern.test( templateSlug )
+		) {
+			data = null;
+		}
+
+		let records = [];
+		// If it is an index or a generic page template, return any page.
+		if ( templateSlug === 'index' || templateSlug === 'page' ) {
+			records = getEntityRecords( 'postType', 'page', {
+				per_page: 1,
+			} );
+		}
+
+		// If it is specific page template, return that one.
+		if ( pagePattern.test( templateSlug ) ) {
+			records = getEntityRecords( 'postType', 'page', {
+				slug: templateSlug.match( pagePattern )[ 1 ],
+			} );
+		}
+
+		// If it is post/cpt template.
+		if ( postPattern.test( templateSlug ) ) {
+			const [ , entityPostType, entitySlug ] =
+				templateSlug.match( postPattern );
+
+			// If it is a specific post.
+			if ( entitySlug ) {
+				records = getEntityRecords( 'postType', entityPostType, {
+					slug: entitySlug,
+				} );
+			} else {
+				// If it is a generic template, return any post.
+				records = getEntityRecords( 'postType', entityPostType, {
+					per_page: 1,
+				} );
+			}
+		}
+
+		// If it is a custom template, get the fields from any page.
+		if ( customTemplatePattern.test( templateSlug ) || ! records ) {
+			records = getEntityRecords( 'postType', 'page', {
+				per_page: 1,
+			} );
+		}
+
+		data = records?.[ 0 ];
+	} else {
+		data = getEntityRecord( 'postType', postType, postId );
 	}
 
-	// Prettify the name until the label is available in the REST API endpoint.
-	const keyToLabel = ( key ) => {
-		return key
-			.split( '_' )
-			.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
-			.join( ' ' );
-	};
+	if ( ! data || ! data?.meta ) {
+		return null;
+	}
 
 	return (
 		<DropdownMenuGroup>
@@ -85,16 +155,23 @@ export default {
 	useSource( props, sourceAttributes ) {
 		const { context } = props;
 		const { value: metaKey } = sourceAttributes;
+		const postType = context.postType
+			? context.postType
+			: getCurrentPostType();
 		const [ meta, setMeta ] = useEntityProp(
 			'postType',
 			context.postType,
 			'meta',
 			context.postId
 		);
+
+		if ( postType === 'wp_template' ) {
+			return { placeholder: keyToLabel( metaKey ) };
+		}
 		const metaValue = meta[ metaKey ];
 		const updateMetaValue = ( newValue ) => {
 			setMeta( { ...meta, [ metaKey ]: newValue } );
 		};
-		return [ metaValue, updateMetaValue ];
+		return { useValue: [ metaValue, updateMetaValue ] };
 	},
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { updateBlockBindingsAttribute } from '@wordpress/block-editor';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+import { store as editorStore } from '../store';
+
+function PostMetaComponent( props, selectedAttribute ) {
+	const {
+		DropdownMenuGroupV2: DropdownMenuGroup,
+		DropdownMenuItemLabelV2: DropdownMenuItemLabel,
+		DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
+	} = unlock( componentsPrivateApis );
+	const { context, metadata, setAttributes } = props;
+	// TODO: Expose the post meta in the `types` REST API endpoint and use that.
+	const data = useSelect(
+		( select ) => {
+			const postId = context.postId
+				? context.postId
+				: select( editorStore ).getCurrentPostId();
+			const postType = context.postType
+				? context.postType
+				: select( editorStore ).getCurrentPostType();
+			const { getEntityRecord } = select( coreStore );
+			return getEntityRecord( 'postType', postType, postId );
+		},
+		[ context.postId, context.postType ]
+	);
+	if ( ! data || ! data.meta ) {
+		return null;
+	}
+
+	// Prettify the name until the label is available in the REST API endpoint.
+	const keyToLabel = ( key ) => {
+		return key
+			.split( '_' )
+			.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+			.join( ' ' );
+	};
+
+	return (
+		<DropdownMenuGroup>
+			{ Object.keys( data.meta ).map( ( key ) => {
+				return (
+					<DropdownMenuCheckboxItem
+						key={ key }
+						name={ 'bindings-attribute' }
+						value={ key }
+						checked={
+							metadata?.bindings?.[ selectedAttribute ]?.source
+								?.name === 'post_meta' &&
+							metadata?.bindings?.[ selectedAttribute ]?.source
+								?.attributes?.value === key
+						}
+						onClick={ async () => {
+							updateBlockBindingsAttribute(
+								{ metadata },
+								setAttributes,
+								selectedAttribute,
+								'post_meta',
+								{ value: key }
+							);
+						} }
+					>
+						<DropdownMenuItemLabel>
+							{ keyToLabel( key ) }
+						</DropdownMenuItemLabel>
+					</DropdownMenuCheckboxItem>
+				);
+			} ) }
+		</DropdownMenuGroup>
+	);
+}
+
+export default {
+	name: 'post_meta',
+	label: 'Post Meta',
+	component: PostMetaComponent,
+	useSource( props, sourceAttributes ) {
+		const { context } = props;
+		const { value: metaKey } = sourceAttributes;
+		const [ meta, setMeta ] = useEntityProp(
+			'postType',
+			context.postType,
+			'meta',
+			context.postId
+		);
+		const metaValue = meta[ metaKey ];
+		const updateMetaValue = ( newValue ) => {
+			setMeta( { ...meta, [ metaKey ]: newValue } );
+		};
+		return [ metaValue, updateMetaValue ];
+	},
+};

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -11,26 +11,26 @@ import { useSelect } from '@wordpress/data';
 import { unlock } from '../lock-unlock';
 import { store as editorStore } from '../store';
 
-function PostMetaComponent( props, selectedAttribute ) {
+function PostMetaComponent( props, blockContext, selectedAttribute ) {
 	const {
 		DropdownMenuGroupV2: DropdownMenuGroup,
 		DropdownMenuItemLabelV2: DropdownMenuItemLabel,
 		DropdownMenuCheckboxItemV2: DropdownMenuCheckboxItem,
 	} = unlock( componentsPrivateApis );
-	const { context, metadata, setAttributes } = props;
+	const { metadata, setAttributes } = props;
 	// TODO: Expose the post meta in the `types` REST API endpoint and use that.
 	const data = useSelect(
 		( select ) => {
-			const postId = context.postId
-				? context.postId
+			const postId = blockContext.postId
+				? blockContext.postId
 				: select( editorStore ).getCurrentPostId();
-			const postType = context.postType
-				? context.postType
+			const postType = blockContext.postType
+				? blockContext.postType
 				: select( editorStore ).getCurrentPostType();
 			const { getEntityRecord } = select( coreStore );
 			return getEntityRecord( 'postType', postType, postId );
 		},
-		[ context.postId, context.postType ]
+		[ blockContext.postId, blockContext.postType ]
 	);
 	if ( ! data || ! data.meta ) {
 		return null;

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './bindings';
 import './hooks';
 
 export { storeConfig, store } from './store';


### PR DESCRIPTION
# WIP

This PR is still a draft. I'm opening it to discuss some of its aspects.

## What?
After discussing the initial proposal for the block bindings editor implementation (https://github.com/WordPress/gutenberg/pull/57258), we decided to try a different approach which seems more reliable. The way I'm handling it in this PR:

* Use a `block-editor` hook to insert the block bindings UI in the allowed blocks: [link](https://github.com/WordPress/gutenberg/compare/update/refactor-block-bindings-editor-code?expand=1#diff-30aed117481b123d68768ec0a43f4ec48c1d40376fa769e1a219bd2344455159R119-R125).
* Use `addFilter` to add the needed context to all the allowed blocks: [link](https://github.com/WordPress/gutenberg/compare/update/refactor-block-bindings-editor-code?expand=1#diff-30aed117481b123d68768ec0a43f4ec48c1d40376fa769e1a219bd2344455159R127-R147).
* Modify the `<BlockEdit />` attributes and setAttributes to read the bindings: [link](https://github.com/WordPress/gutenberg/compare/update/refactor-block-bindings-editor-code?expand=1#diff-99d79bdba99fe4517413b0fd9503eef924e439c03d44504c1ad0606b727cebb6R32-R100).
* Provide a helper to update the bindings attribute: [link](https://github.com/WordPress/gutenberg/compare/update/refactor-block-bindings-editor-code?expand=1#diff-a8e9b65710ff3dfe85149bf2f719240d6ea555da8202e56904b32c22edc0d178R10-R50).
* Provide an action to register a new source in the editor: [link](https://github.com/WordPress/gutenberg/compare/update/refactor-block-bindings-editor-code?expand=1#diff-4d145a0c43689f5a56c00a8e2919550768ebd233e91a6c6d04fee71a44bae9f2R243R-252).
* Provide some selectors to get all the registered sources or a specific one: [link](https://github.com/WordPress/gutenberg/compare/update/refactor-block-bindings-editor-code?expand=1#diff-23e851c3077ed95d23bb1669da8bafbae3f1e2e952897987e45b49555004dd83R173-R180).
* In the block bindings UI, iterate over the registered sources and render its component: [link](https://github.com/WordPress/gutenberg/compare/update/refactor-block-bindings-editor-code?expand=1#diff-30aed117481b123d68768ec0a43f4ec48c1d40376fa769e1a219bd2344455159R75-R108).
* Register the post meta source using this mechanism: [link](https://github.com/WordPress/gutenberg/compare/update/refactor-block-bindings-editor-code?expand=1#diff-cf4447b4134dbf24fa2819703999f0131449fb79a0611bd544c5e05fd80aa36bR1-R177).

## Why?
The filters and APIs used seem more suitable for this case.

## Testing Instructions

For all the testing we have to go to Gutenberg-Experiments and enable the Test Block Bindings option.

**Test that adding the bindings attribute works**

1. Register a new custom field however you prefer. You can use a snippet similar to this:

```PHP
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'This is the content of the text custom field',
	)
);
register_meta(
	'post',
	'url_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

2. Create a new post/page and insert a paragraph.
3. In the toolbar, click the new Bindings button.
4. Check that the available attributes are there and select the content attribute.
5. Check that the available sources are there (only post meta so far), and select it.
6. Select the custom field you created.
7. Check the value is applied in the editor and in the frontend.
8. Change the value of the custom field.
9. Check that the value is updated in the frontend (won't update the editor yet).

**Test that multiple attributes values can be connected**

Repeat the same process but using a button (or an image) to bind the content and the URL.

**Test creating a new source**

You can try creating a new source using the post meta as reference and using the APIs created. Once created, it should appear in the block bindings UI, as the post meta does. Bear in mind that the APIs will be private, so sources can only be created inside Gutenberg plugin.

