### PR TITLE
DataViews: Fix table view cell wrapper and BlockPreviews

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -183,7 +183,6 @@
 		}
 		.dataviews-view-table__cell-content-wrapper {
 			min-height: $grid-unit-40;
-			display: flex;
 			align-items: center;
 		}
 	}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -183,7 +183,12 @@
 		}
 		.dataviews-view-table__cell-content-wrapper {
 			min-height: $grid-unit-40;
+			display: flex;
 			align-items: center;
+
+			> * {
+				flex-grow: 1;
+			}
 		}
 	}
 	.dataviews-view-table-header-button {

--- a/packages/dataviews/src/view-table.js
+++ b/packages/dataviews/src/view-table.js
@@ -539,7 +539,7 @@ function ViewTable( {
 											minWidth: 20,
 										} }
 									>
-										<span className="dataviews-view-table__cell-content-wrapper">
+										<div className="dataviews-view-table__cell-content-wrapper">
 											<SingleSelectionCheckbox
 												id={
 													getItemId( item ) || index
@@ -553,7 +553,7 @@ function ViewTable( {
 												data={ data }
 												primaryField={ primaryField }
 											/>
-										</span>
+										</div>
 									</td>
 								) }
 								{ visibleFields.map( ( field ) => (
@@ -567,7 +567,7 @@ function ViewTable( {
 												field.maxWidth || undefined,
 										} }
 									>
-										<span
+										<div
 											className={ classnames(
 												'dataviews-view-table__cell-content-wrapper',
 												{
@@ -580,7 +580,7 @@ function ViewTable( {
 											{ field.render( {
 												item,
 											} ) }
-										</span>
+										</div>
 									</td>
 								) ) }
 								{ !! actions?.length && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/57804

It was [missed](https://github.com/WordPress/gutenberg/pull/57804#discussion_r1458793468) that we cannot have an inline element([span](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span#technical_summary)) as a wrapper because it creates invalid html.

Also, the addition of styling this as `display:flex` too, make the previews not render because of the width calculation. In this PR I'm removing this, but would love @jameskoster confirmation that doesn't affect something else..


## Testing instructions
1. Table view should work as before and as expected based on https://github.com/WordPress/gutenberg/pull/57804.
2. In templates page show the `preview` field and observe it's rendered properly.
