### PR TITLE
Document files/directories requiring backmerging to WP Core for major release

### DIFF
--- a/docs/contributors/code/back-merging-to-wp-core.md
+++ b/docs/contributors/code/back-merging-to-wp-core.md
@@ -1,0 +1,33 @@
+# Back Merging code to WordPress Core
+
+For major releases of the WordPress software, Gutenberg features need to be merged into WordPress Core. Typically this involves taking changes made in `.php` files within the Gutenberg repository and making the equivalent updates in the WP Core codebase.
+
+## Files/Directories
+
+Changes to files within the following files/directories will typically require back-merging to WP Core:
+
+-   `lib/`
+-   `phpunit/`
+
+## Ignored directories/files
+
+The following directories/files do _not_ require back-merging to WP Core:
+
+-   `lib`
+    -   `load.php` - Plugin specific code.
+    -   `experiments-page.php` - experiments are Plugin specific.
+-   `packages`
+    -   `block-library` - this is handled automatically during the packages sync process.
+    -   `e2e-tests/plugins` - PHP files related to e2e tests only. Mostly fixture data generators.
+-   ## `phpunit`
+
+Please note this list is not exhaustive.
+
+## Pull Request Criteria
+
+In general, all PHP code committed to the Gutenberg repository since the date of the final Gutenberg release that was included in [the _last_ stable WP Core release](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/) should be considered for back merging to WP Core.
+
+There are however certain exceptions to that rule. PRs with the following criteria do _not_ require back-merging to WP Core:
+
+-   Does not contain changes to PHP code.
+-   Has label `Backport from WordPress Core` - this code is already in WP Core.

--- a/docs/contributors/code/back-merging-to-wp-core.md
+++ b/docs/contributors/code/back-merging-to-wp-core.md
@@ -19,7 +19,6 @@ The following directories/files do _not_ require back-merging to WP Core:
 -   `packages`
     -   `block-library` - this is handled automatically during the packages sync process.
     -   `e2e-tests/plugins` - PHP files related to e2e tests only. Mostly fixture data generators.
--   ## `phpunit`
 
 Please note this list is not exhaustive.
 

--- a/docs/contributors/code/back-merging-to-wp-core.md
+++ b/docs/contributors/code/back-merging-to-wp-core.md
@@ -13,12 +13,11 @@ Changes to files within the following files/directories will typically require b
 
 The following directories/files do _not_ require back-merging to WP Core:
 
--   `lib`
-    -   `load.php` - Plugin specific code.
-    -   `experiments-page.php` - experiments are Plugin specific.
--   `packages`
-    -   `block-library` - this is handled automatically during the packages sync process.
-    -   `e2e-tests/plugins` - PHP files related to e2e tests only. Mostly fixture data generators.
+-   `lib/load.php` - Plugin specific code.
+-   `lib/experiments-page.php` - experiments are Plugin specific.
+-   `packages/block-library` - this is handled automatically during the packages sync process.
+-   `packages/e2e-tests/plugins` - PHP files related to e2e tests only. Mostly fixture data generators.
+-   `phpunit/blocks` - the code is maintained in Gutenberg so the test should be as well.
 
 Please note this list is not exhaustive.
 

--- a/docs/contributors/code/back-merging-to-wp-core.md
+++ b/docs/contributors/code/back-merging-to-wp-core.md
@@ -1,4 +1,4 @@
-# Back Merging code to WordPress Core
+# Back-merging code to WordPress Core
 
 For major releases of the WordPress software, Gutenberg features need to be merged into WordPress Core. Typically this involves taking changes made in `.php` files within the Gutenberg repository and making the equivalent updates in the WP Core codebase.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Documents the files/paths that do/don't needing back merging to WP Core for a major release.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently release leads spend a lot of time answering "Should this be backported?" questions. By documenting the basics we relieve some burden on those individuals and make it easier for future release leads.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Document the high level scope for files that need back merging
- Document any exceptions

We should also bring `bin/generate-php-sync-issue.mjs` into line with whatever is documented here.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
