### PR TITLE
Fix url escaping for array parameters in Navigation links

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -132,6 +132,10 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 	$query_params   = wp_parse_args( $query );
 
 	foreach ( $query_params as $query_param ) {
+		$can_query_param_be_encoded = is_string( $query_param ) && ! empty( $query_param );
+		if ( ! $can_query_param_be_encoded ) {
+			continue;
+		}
 		if ( rawurldecode( $query_param ) !== $query_param ) {
 			$is_url_encoded = true;
 			break;

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -25,7 +25,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$navigation_link_block = new WP_Block( $parsed_block, $context );
 
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
-		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer' );
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
 		$method     = $reflection->getMethod( 'get_markup_for_inner_block' );
 		$method->setAccessible( true );
 		// Invoke the private method.
@@ -53,7 +53,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$site_title_block = new WP_Block( $parsed_block, $context );
 
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
-		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer' );
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
 		$method     = $reflection->getMethod( 'get_markup_for_inner_block' );
 		$method->setAccessible( true );
 		// Invoke the private method.
@@ -71,7 +71,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	 * @covers WP_Navigation_Block_Renderer::get_inner_blocks_from_navigation_post
 	 */
 	public function test_gutenberg_get_inner_blocks_from_navigation_post_returns_empty_block_list() {
-		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer' );
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
 		$method     = $reflection->getMethod( 'get_inner_blocks_from_navigation_post' );
 		$method->setAccessible( true );
 		$attributes = array( 'ref' => 0 );

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -25,7 +25,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$navigation_link_block = new WP_Block( $parsed_block, $context );
 
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
-		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer' );
 		$method     = $reflection->getMethod( 'get_markup_for_inner_block' );
 		$method->setAccessible( true );
 		// Invoke the private method.
@@ -53,7 +53,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$site_title_block = new WP_Block( $parsed_block, $context );
 
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
-		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer' );
 		$method     = $reflection->getMethod( 'get_markup_for_inner_block' );
 		$method->setAccessible( true );
 		// Invoke the private method.
@@ -71,7 +71,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	 * @covers WP_Navigation_Block_Renderer::get_inner_blocks_from_navigation_post
 	 */
 	public function test_gutenberg_get_inner_blocks_from_navigation_post_returns_empty_block_list() {
-		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer' );
 		$method     = $reflection->getMethod( 'get_inner_blocks_from_navigation_post' );
 		$method->setAccessible( true );
 		$attributes = array( 'ref' => 0 );

--- a/phpunit/class-block-library-navigation-link-test.php
+++ b/phpunit/class-block-library-navigation-link-test.php
@@ -222,12 +222,14 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 			'https://example.com/?id=10&data=lzB%252Fzd%252FZA%253D%253D',
 			'https://example.com/?id=10&data=lzB%2Fzd%FZA%3D%3D',
 			'https://example.com/?id=10&data=1234',
+			'https://example.com/?arrayParams[]=1&arrayParams[]=2&arrayParams[]=3',
 		);
 
 		$urls_after_render = array(
 			'https://example.com/?id=10&#038;data=lzB%2Fzd%2FZA%3D%3D',
 			'https://example.com/?id=10&#038;data=lzB%2Fzd%FZA%3D%3D',
 			'https://example.com/?id=10&#038;data=1234',
+			'https://example.com/?arrayParams%5B%5D=1&#038;arrayParams%5B%5D=2&#038;arrayParams%5B%5D=3',
 		);
 
 		foreach ( $urls_before_render as $idx => $link ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #58020

## Why?

It's a bug fix.

## How?

Check if the parameter is a string before attempting to url encode /decode.

## Testing Instructions

- in a post
- in a navigation block
- add a link
- set the link to 'https://example.com/index.php?param[0]=test&param[1]=another-test'`
- save **the saving should work**
- preview the post
- **the post should render with no errors**

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A