### PR TITLE
DataViews: Use button for patterns, pages and templates preview field

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -285,9 +285,9 @@
 		width: 100%;
 		min-height: 200px;
 		aspect-ratio: 1/1;
-		overflow: hidden;
 		border-bottom: 1px solid $gray-200;
 		background-color: $gray-100;
+		border-radius: 3px 3px 0 0;
 
 		img {
 			object-fit: cover;

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
@@ -171,11 +166,10 @@ function FeaturedImage( { item, viewType } ) {
 			} }
 		>
 			<button
-				className={ classNames( 'page-pages-preview-field__button' ) }
+				className="page-pages-preview-field__button"
 				type="button"
 				onClick={ onClick }
-				aria-label={ item.title?.rendered || item.title }
-				aria-disabled={ ! hasMedia }
+				aria-label={ item.title?.rendered || __( '(no title)' ) }
 			>
 				{ hasMedia && (
 					<Media

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
@@ -40,6 +45,7 @@ import {
 import AddNewPageModal from '../add-new-page';
 import Media from '../media';
 import { unlock } from '../../lock-unlock';
+
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
@@ -156,21 +162,24 @@ function FeaturedImage( { item, viewType } ) {
 		postType: item.type,
 		canvas: 'edit',
 	} );
+	const hasMedia = !! item.featured_media;
 	return (
 		<span
-			className={
-				viewType === LAYOUT_TABLE
-					? 'edit-site-page-pages__media-wrapper'
-					: ''
-			}
+			className={ {
+				'edit-site-page-pages__media-wrapper':
+					viewType === LAYOUT_TABLE,
+			} }
 		>
-			{ !! item.featured_media ? (
-				<button
-					className="page-pages-preview-field__button"
-					type="button"
-					onClick={ onClick }
-					aria-label={ item.title?.rendered || item.title }
-				>
+			<button
+				className={ classNames( 'page-pages-preview-field__button', {
+					'is-inactive': ! hasMedia,
+				} ) }
+				type="button"
+				onClick={ hasMedia ? onClick : undefined }
+				aria-label={ item.title?.rendered || item.title }
+				aria-disabled={ ! hasMedia }
+			>
+				{ hasMedia && (
 					<Media
 						className="edit-site-page-pages__featured-image"
 						id={ item.featured_media }
@@ -180,8 +189,8 @@ function FeaturedImage( { item, viewType } ) {
 								: [ 'thumbnail', 'medium', 'large', 'full' ]
 						}
 					/>
-				</button>
-			) : null }
+				) }
+			</button>
 		</span>
 	);
 }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -171,11 +171,9 @@ function FeaturedImage( { item, viewType } ) {
 			} }
 		>
 			<button
-				className={ classNames( 'page-pages-preview-field__button', {
-					'is-inactive': ! hasMedia,
-				} ) }
+				className={ classNames( 'page-pages-preview-field__button' ) }
 				type="button"
-				onClick={ hasMedia ? onClick : undefined }
+				onClick={ onClick }
 				aria-label={ item.title?.rendered || item.title }
 				aria-disabled={ ! hasMedia }
 			>

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -15,7 +15,7 @@ import { DataViews } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import Page from '../page';
-import Link from '../routes/link';
+import { default as Link, useLink } from '../routes/link';
 import {
 	DEFAULT_VIEWS,
 	DEFAULT_CONFIG_PER_VIEW_TYPE,
@@ -150,6 +150,42 @@ const STATUSES = [
 ];
 const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.
 
+function FeaturedImage( { item, viewType } ) {
+	const { onClick } = useLink( {
+		postId: item.id,
+		postType: item.type,
+		canvas: 'edit',
+	} );
+	return (
+		<span
+			className={
+				viewType === LAYOUT_TABLE
+					? 'edit-site-page-pages__media-wrapper'
+					: ''
+			}
+		>
+			{ !! item.featured_media ? (
+				<button
+					className="page-pages-preview-field__button"
+					type="button"
+					onClick={ onClick }
+					aria-label={ item.title?.rendered || item.title }
+				>
+					<Media
+						className="edit-site-page-pages__featured-image"
+						id={ item.featured_media }
+						size={
+							viewType === LAYOUT_GRID
+								? [ 'large', 'full', 'medium', 'thumbnail' ]
+								: [ 'thumbnail', 'medium', 'large', 'full' ]
+						}
+					/>
+				</button>
+			) : null }
+		</span>
+	);
+}
+
 export default function PagePages() {
 	const postType = 'page';
 	const [ view, setView ] = useView( postType );
@@ -243,35 +279,7 @@ export default function PagePages() {
 				header: __( 'Featured Image' ),
 				getValue: ( { item } ) => item.featured_media,
 				render: ( { item } ) => (
-					<span
-						className={
-							view.type === LAYOUT_TABLE
-								? 'edit-site-page-pages__media-wrapper'
-								: ''
-						}
-					>
-						{ !! item.featured_media ? (
-							<Media
-								className="edit-site-page-pages__featured-image"
-								id={ item.featured_media }
-								size={
-									view.type === LAYOUT_GRID
-										? [
-												'large',
-												'full',
-												'medium',
-												'thumbnail',
-										  ]
-										: [
-												'thumbnail',
-												'medium',
-												'large',
-												'full',
-										  ]
-								}
-							/>
-						) : null }
-					</span>
+					<FeaturedImage item={ item } viewType={ view.type } />
 				),
 				enableSorting: false,
 			},

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -34,9 +34,11 @@
 	cursor: pointer;
 	overflow: hidden;
 	height: 100%;
+	width: 100%;
+	border-radius: 3px 3px 0 0;
 
 	&:focus {
-		box-shadow: inset 0 0 0 0 $white, 0 0 0 2px var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 	}

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -42,11 +42,4 @@
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 	}
-
-	&.is-inactive {
-		cursor: default;
-	}
-	&.is-inactive:focus {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $gray-800;
-	}
 }

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -24,3 +24,27 @@
 		width: 100%;
 	}
 }
+
+.page-pages-preview-field__button {
+	box-shadow: none;
+	border: none;
+	padding: 0;
+	background-color: unset;
+	box-sizing: border-box;
+	cursor: pointer;
+	overflow: hidden;
+	height: 100%;
+
+	&:focus {
+		box-shadow: inset 0 0 0 0 $white, 0 0 0 2px var(--wp-admin-theme-color);
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+	}
+
+	&.is-inactive {
+		cursor: default;
+	}
+	&.is-inactive:focus {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $gray-800;
+	}
+}

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -37,7 +37,7 @@
 	width: 100%;
 	border-radius: 3px 3px 0 0;
 
-	&:focus {
+	&:focus-visible {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -104,7 +109,7 @@ const SYNC_FILTERS = [
 	},
 ];
 
-function Preview( { item, viewType } ) {
+function Preview( { item, categoryId, viewType } ) {
 	const descriptionId = useId();
 	const isUserPattern = item.type === PATTERN_TYPES.user;
 	const isNonUserPattern = item.type === PATTERN_TYPES.theme;
@@ -129,15 +134,45 @@ function Preview( { item, viewType } ) {
 		);
 	}
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
+	const { onClick } = useLink( {
+		postType: item.type,
+		postId: isUserPattern ? item.id : item.name,
+		categoryId,
+		categoryType: isTemplatePart ? item.type : PATTERN_TYPES.theme,
+	} );
+
 	return (
 		<>
 			<div
 				className={ `page-patterns-preview-field is-viewtype-${ viewType }` }
 				style={ { backgroundColor } }
 			>
-				{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
-				{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
-				{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
+				<button
+					className={ classnames(
+						'page-patterns-preview-field__button',
+						{ 'is-inactive': isNonUserPattern }
+					) }
+					type="button"
+					onClick={
+						item.type !== PATTERN_TYPES.theme ? onClick : undefined
+					}
+					aria-disabled={ item.type === PATTERN_TYPES.theme }
+					aria-label={ item.title }
+					aria-describedby={
+						ariaDescriptions.length
+							? ariaDescriptions
+									.map(
+										( _, index ) =>
+											`${ descriptionId }-${ index }`
+									)
+									.join( ' ' )
+							: undefined
+					}
+				>
+					{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
+					{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
+					{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
+				</button>
 			</div>
 			{ ariaDescriptions.map( ( ariaDescription, index ) => (
 				<div
@@ -245,7 +280,11 @@ export default function DataviewsPatterns() {
 				header: __( 'Preview' ),
 				id: 'preview',
 				render: ( { item } ) => (
-					<Preview item={ item } viewType={ view.type } />
+					<Preview
+						item={ item }
+						categoryId={ categoryId }
+						viewType={ view.type }
+					/>
 				),
 				enableSorting: false,
 				enableHiding: false,

--- a/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/dataviews-patterns.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -109,6 +104,23 @@ const SYNC_FILTERS = [
 	},
 ];
 
+function PreviewWrapper( { item, onClick, ariaDescribedBy, children } ) {
+	if ( item.type === PATTERN_TYPES.theme ) {
+		return children;
+	}
+	return (
+		<button
+			className="page-patterns-preview-field__button"
+			type="button"
+			onClick={ onClick }
+			aria-label={ item.title }
+			aria-describedby={ ariaDescribedBy }
+		>
+			{ children }
+		</button>
+	);
+}
+
 function Preview( { item, categoryId, viewType } ) {
 	const descriptionId = useId();
 	const isUserPattern = item.type === PATTERN_TYPES.user;
@@ -147,18 +159,10 @@ function Preview( { item, categoryId, viewType } ) {
 				className={ `page-patterns-preview-field is-viewtype-${ viewType }` }
 				style={ { backgroundColor } }
 			>
-				<button
-					className={ classnames(
-						'page-patterns-preview-field__button',
-						{ 'is-inactive': isNonUserPattern }
-					) }
-					type="button"
-					onClick={
-						item.type !== PATTERN_TYPES.theme ? onClick : undefined
-					}
-					aria-disabled={ item.type === PATTERN_TYPES.theme }
-					aria-label={ item.title }
-					aria-describedby={
+				<PreviewWrapper
+					item={ item }
+					onClick={ onClick }
+					ariaDescribedBy={
 						ariaDescriptions.length
 							? ariaDescriptions
 									.map(
@@ -172,7 +176,7 @@ function Preview( { item, categoryId, viewType } ) {
 					{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
 					{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
 					{ ! isEmpty && <BlockPreview blocks={ item.blocks } /> }
-				</button>
+				</PreviewWrapper>
 			</div>
 			{ ariaDescriptions.map( ( ariaDescription, index ) => (
 				<div

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -258,13 +258,6 @@
 				// Windows High Contrast mode will show this outline, but not the box-shadow.
 				outline: 2px solid transparent;
 			}
-
-			&.is-inactive {
-				cursor: default;
-			}
-			&.is-inactive:focus {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $gray-800;
-			}
 		}
 	}
 

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -231,9 +231,38 @@
  */
 .edit-site-page-patterns-dataviews {
 	.page-patterns-preview-field {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+
 		&.is-viewtype-grid {
 			.block-editor-block-preview__container {
-				height: auto;
+				height: 100%;
+			}
+		}
+
+		.page-patterns-preview-field__button {
+			box-shadow: none;
+			border: none;
+			padding: 0;
+			background-color: unset;
+			box-sizing: border-box;
+			cursor: pointer;
+			overflow: hidden;
+			height: 100%;
+
+			&:focus {
+				box-shadow: inset 0 0 0 0 $white, 0 0 0 2px var(--wp-admin-theme-color);
+				// Windows High Contrast mode will show this outline, but not the box-shadow.
+				outline: 2px solid transparent;
+			}
+
+			&.is-inactive {
+				cursor: default;
+			}
+			&.is-inactive:focus {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $gray-800;
+				opacity: 0.8;
 			}
 		}
 	}

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -262,7 +262,6 @@
 			}
 			&.is-inactive:focus {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $gray-800;
-				opacity: 0.8;
 			}
 		}
 	}

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -234,6 +234,7 @@
 		display: flex;
 		flex-direction: column;
 		height: 100%;
+		border-radius: 3px 3px 0 0;
 
 		&.is-viewtype-grid {
 			.block-editor-block-preview__container {
@@ -250,9 +251,10 @@
 			cursor: pointer;
 			overflow: hidden;
 			height: 100%;
+			border-radius: 3px 3px 0 0;
 
 			&:focus {
-				box-shadow: inset 0 0 0 0 $white, 0 0 0 2px var(--wp-admin-theme-color);
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 				// Windows High Contrast mode will show this outline, but not the box-shadow.
 				outline: 2px solid transparent;
 			}

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -253,7 +253,7 @@
 			height: 100%;
 			border-radius: 3px 3px 0 0;
 
-			&:focus {
+			&:focus-visible {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 				// Windows High Contrast mode will show this outline, but not the box-shadow.
 				outline: 2px solid transparent;

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -239,6 +239,7 @@
 		&.is-viewtype-grid {
 			.block-editor-block-preview__container {
 				height: 100%;
+				border-radius: 3px 3px 0 0;
 			}
 		}
 

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import removeAccents from 'remove-accents';
+import classNames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -143,9 +144,7 @@ function Preview( { content, viewType } ) {
 		postType: item.type,
 		canvas: 'edit',
 	} );
-	if ( ! blocks?.length ) {
-		return null;
-	}
+	const isEmpty = ! blocks?.length;
 	// Wrap everything in a block editor provider to ensure 'styles' that are needed
 	// for the previews are synced between the site editor store and the block editor store.
 	// Additionally we need to have the `__experimentalBlockPatterns` setting in order to
@@ -160,12 +159,16 @@ function Preview( { content, viewType } ) {
 				style={ { backgroundColor } }
 			>
 				<button
-					className="page-templates-preview-field__button"
+					className={ classNames(
+						'page-templates-preview-field__button',
+						{ 'is-inactive': isEmpty }
+					) }
 					type="button"
-					onClick={ onClick }
+					onClick={ ! isEmpty ? onClick : undefined }
 					aria-label={ item.title?.rendered || item.title }
+					aria-disabled={ isEmpty }
 				>
-					<BlockPreview blocks={ blocks } />
+					{ ! isEmpty && <BlockPreview blocks={ blocks } /> }
 				</button>
 			</div>
 		</ExperimentalBlockEditorProvider>

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -132,7 +132,7 @@ function AuthorField( { item, viewType } ) {
 	);
 }
 
-function Preview( { content, viewType } ) {
+function Preview( { item, viewType } ) {
 	const settings = usePatternSettings();
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
 	const blocks = useMemo( () => {
@@ -163,11 +163,11 @@ function Preview( { content, viewType } ) {
 					onClick={ onClick }
 					aria-label={ item.title?.rendered || item.title }
 				>
-					{ isEmpty ? (
-						__( 'Empty template' )
-					) : (
-						<BlockPreview blocks={ blocks } />
-					) }
+					{ isEmpty &&
+						( item.type === TEMPLATE_POST_TYPE
+							? __( 'Empty template' )
+							: __( 'Empty template part' ) ) }
+					{ ! isEmpty && <BlockPreview blocks={ blocks } /> }
 				</button>
 			</div>
 		</ExperimentalBlockEditorProvider>
@@ -224,12 +224,7 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 				header: __( 'Preview' ),
 				id: 'preview',
 				render: ( { item } ) => {
-					return (
-						<Preview
-							content={ item.content.raw }
-							viewType={ view.type }
-						/>
-					);
+					return <Preview item={ item } viewType={ view.type } />;
 				},
 				minWidth: 120,
 				maxWidth: 120,

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -160,11 +160,10 @@ function Preview( { content, viewType } ) {
 			>
 				<button
 					className={ classNames(
-						'page-templates-preview-field__button',
-						{ 'is-inactive': isEmpty }
+						'page-templates-preview-field__button'
 					) }
 					type="button"
-					onClick={ ! isEmpty ? onClick : undefined }
+					onClick={ onClick }
 					aria-label={ item.title?.rendered || item.title }
 					aria-disabled={ isEmpty }
 				>

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -32,7 +32,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  * Internal dependencies
  */
 import Page from '../page';
-import Link from '../routes/link';
+import { default as Link, useLink } from '../routes/link';
 import AddNewTemplate from '../add-new-template';
 import { useAddedBy, AvatarImage } from '../list/added-by';
 import {
@@ -136,8 +136,13 @@ function Preview( { content, viewType } ) {
 	const settings = usePatternSettings();
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
 	const blocks = useMemo( () => {
-		return parse( content );
-	}, [ content ] );
+		return parse( item.content.raw );
+	}, [ item.content.raw ] );
+	const { onClick } = useLink( {
+		postId: item.id,
+		postType: item.type,
+		canvas: 'edit',
+	} );
 	if ( ! blocks?.length ) {
 		return null;
 	}
@@ -154,7 +159,14 @@ function Preview( { content, viewType } ) {
 				className={ `page-templates-preview-field is-viewtype-${ viewType }` }
 				style={ { backgroundColor } }
 			>
-				<BlockPreview blocks={ blocks } />
+				<button
+					className="page-templates-preview-field__button"
+					type="button"
+					onClick={ onClick }
+					aria-label={ item.title?.rendered || item.title }
+				>
+					<BlockPreview blocks={ blocks } />
+				</button>
 			</div>
 		</ExperimentalBlockEditorProvider>
 	);

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -163,7 +163,11 @@ function Preview( { content, viewType } ) {
 					onClick={ onClick }
 					aria-label={ item.title?.rendered || item.title }
 				>
-					{ ! isEmpty && <BlockPreview blocks={ blocks } /> }
+					{ isEmpty ? (
+						__( 'Empty template' )
+					) : (
+						<BlockPreview blocks={ blocks } />
+					) }
 				</button>
 			</div>
 		</ExperimentalBlockEditorProvider>

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import removeAccents from 'remove-accents';
-import classNames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -159,13 +158,10 @@ function Preview( { content, viewType } ) {
 				style={ { backgroundColor } }
 			>
 				<button
-					className={ classNames(
-						'page-templates-preview-field__button'
-					) }
+					className="page-templates-preview-field__button"
 					type="button"
 					onClick={ onClick }
 					aria-label={ item.title?.rendered || item.title }
-					aria-disabled={ isEmpty }
 				>
 					{ ! isEmpty && <BlockPreview blocks={ blocks } /> }
 				</button>

--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -15,7 +15,7 @@
 		height: 100%;
 		border-radius: 3px 3px 0 0;
 
-		&:focus {
+		&:focus-visible {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;

--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -24,7 +24,6 @@
 		}
 		&.is-inactive:focus {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $gray-800;
-			opacity: 0.8;
 		}
 	}
 

--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -1,4 +1,33 @@
 .page-templates-preview-field {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+
+	.page-templates-preview-field__button {
+		box-shadow: none;
+		border: none;
+		padding: 0;
+		background-color: unset;
+		box-sizing: border-box;
+		cursor: pointer;
+		overflow: hidden;
+		height: 100%;
+
+		&:focus {
+			box-shadow: inset 0 0 0 0 $white, 0 0 0 2px var(--wp-admin-theme-color);
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
+		}
+
+		&.is-inactive {
+			cursor: default;
+		}
+		&.is-inactive:focus {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $gray-800;
+			opacity: 0.8;
+		}
+	}
+
 	&.is-viewtype-list {
 		.block-editor-block-preview__container {
 			height: 120px;

--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -13,7 +13,7 @@
 		cursor: pointer;
 		overflow: hidden;
 		height: 100%;
-		border-radius: 3px 3px 0 0;
+		border-radius: 3px;
 
 		&:focus-visible {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
@@ -38,6 +38,10 @@
 	&.is-viewtype-grid {
 		.block-editor-block-preview__container {
 			height: auto;
+		}
+
+		.page-templates-preview-field__button {
+			border-radius: 3px 3px 0 0;
 		}
 	}
 }

--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -20,13 +20,6 @@
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;
 		}
-
-		&.is-inactive {
-			cursor: default;
-		}
-		&.is-inactive:focus {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $gray-800;
-		}
 	}
 
 	&.is-viewtype-list {

--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	border-radius: 3px 3px 0 0;
 
 	.page-templates-preview-field__button {
 		box-shadow: none;
@@ -12,9 +13,10 @@
 		cursor: pointer;
 		overflow: hidden;
 		height: 100%;
+		border-radius: 3px 3px 0 0;
 
 		&:focus {
-			box-shadow: inset 0 0 0 0 $white, 0 0 0 2px var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/58046

This PR adds a button wrapper to patterns' and templates' previews to link to the entity. This is an adhoc solution in order to have this functionality for now and explore a possible alternative API to provide a 'main/edit' link or something similar that could be used in a generic way in other places too, if needed.

## Testing Instructions
1. In patterns page only the ones under `My patterns` sections are actually linked, so you have to test the clickable preview there.
2. In templates pages test the clickable preview


### Notes
1. Currently there is a bug where the block previews are not rendered in `table` view and there is a possible fix [here](https://github.com/WordPress/gutenberg/pull/58062).
2. Should we do the same with `pages`?

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/16275880/5b05e4e2-389e-4985-83d6-bfe2430e80f1


