### PR TITLE
Element: start reexporting PureComponent

### DIFF
--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Started exporting the `PureComponent` React API.
+
 ## 5.26.0 (2024-01-10)
 
 ## 5.25.0 (2023-12-13)

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--   Started exporting the `PureComponent` React API.
+-   Started exporting the `PureComponent` React API ([#58076](https://github.com/WordPress/gutenberg/pull/58076)).
 
 ## 5.26.0 (2024-01-10)
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -262,6 +262,12 @@ const placeholderLabel = Platform.select( {
 } );
 ```
 
+### PureComponent
+
+_Related_
+
+-   <https://reactjs.org/docs/react-api.html#reactpurecomponent>
+
 ### RawHTML
 
 Component used as equivalent of Fragment with unescaped HTML, in cases where it is desirable to render dangerous HTML without needing a wrapper element. To preserve additional props, a `div` wrapper _will_ be created if any props aside from `children` are passed.

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -13,6 +13,7 @@ import {
 	Fragment,
 	isValidElement,
 	memo,
+	PureComponent,
 	StrictMode,
 	useCallback,
 	useContext,
@@ -237,6 +238,11 @@ export { lazy };
  * @see https://reactjs.org/docs/react-api.html#reactsuspense
  */
 export { Suspense };
+
+/**
+ * @see https://reactjs.org/docs/react-api.html#reactpurecomponent
+ */
+export { PureComponent };
 
 /**
  * Concatenate two or more React children objects.


### PR DESCRIPTION
Follow-up to discussion in #57173: start re-exporting `PureComponent` from `@wordpress/element`. The goal is to keep parity with `react`, without any gotchas or surprises.

`PureComponent` is marked as "legacy API" by React docs, but so are all class component APIs like `Component` or `createRef`, and also functions like `cloneElement` which we use quite often. They are all still ubiquitous in a lot of React code.