### PR TITLE
Fix site editor layout regressions

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -292,9 +292,8 @@
 	color: $gray-800;
 	background: $white;
 	flex-grow: 1;
-	overflow: auto;
 	margin: 0;
-	margin-top: $header-height;
+	overflow: hidden;
 	@include break-medium() {
 		border-radius: 8px;
 		margin: $canvas-padding $canvas-padding $canvas-padding 0;

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -289,8 +289,6 @@
 }
 
 .edit-site-layout__area {
-	color: $gray-800;
-	background: $white;
 	flex-grow: 1;
 	margin: 0;
 	overflow: hidden;

--- a/packages/edit-site/src/components/page/style.scss
+++ b/packages/edit-site/src/components/page/style.scss
@@ -4,11 +4,7 @@
 	flex-grow: 1;
 	overflow: hidden;
 	margin: 0;
-	margin-top: $header-height;
-	@include break-medium() {
-		border-radius: 8px;
-		margin: $canvas-padding $canvas-padding $canvas-padding 0;
-	}
+	height: 100%;
 }
 
 .edit-site-page-header {

--- a/packages/edit-site/src/components/page/style.scss
+++ b/packages/edit-site/src/components/page/style.scss
@@ -1,9 +1,6 @@
 .edit-site-page {
 	color: $gray-800;
 	background: $white;
-	flex-grow: 1;
-	overflow: hidden;
-	margin: 0;
 	height: 100%;
 }
 


### PR DESCRIPTION
Fix some of the regressions introduced in https://github.com/WordPress/gutenberg/pull/57938, as noted in https://github.com/WordPress/gutenberg/issues/58044. Specifically:

* Sticky header & pagination in data views
* Rounded corners in content area
* "Extra space on top and right side"

### Before

<img width="1688" alt="Screenshot 2024-01-22 at 14 31 30" src="https://github.com/WordPress/gutenberg/assets/846565/ca6d3659-febd-4be0-9f7a-4f23f4bdfdb6">

### After

<img width="1690" alt="Screenshot 2024-01-22 at 14 31 01" src="https://github.com/WordPress/gutenberg/assets/846565/fe19b1d7-654a-4653-bbff-a9aea88753c7">

