### PR TITLE
DataViews: revert list view as default for templates

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -55,13 +55,10 @@ export default function useLayoutAreas() {
 	}
 
 	// Templates
-	if (
-		path === '/wp_template/all' ||
-		( path === '/wp_template' && window?.__experimentalAdminViews )
-	) {
+	if ( path === '/wp_template/all' ) {
 		const isListLayout =
 			isCustom !== 'true' &&
-			( ! layout || layout === 'list' ) &&
+			layout === 'list' &&
 			window?.__experimentalAdminViews;
 		return {
 			areas: {

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -60,7 +60,9 @@ export default function useLayoutAreas() {
 		( path === '/wp_template' && window?.__experimentalAdminViews )
 	) {
 		const isListLayout =
-			isCustom !== 'true' && ( ! layout || layout === 'list' );
+			isCustom !== 'true' &&
+			( ! layout || layout === 'list' ) &&
+			window?.__experimentalAdminViews;
 		return {
 			areas: {
 				content: <PageTemplates />,

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -75,7 +75,7 @@ const defaultConfigPerViewType = {
 };
 
 const DEFAULT_VIEW = {
-	type: LAYOUT_LIST,
+	type: LAYOUT_TABLE,
 	search: '',
 	page: 1,
 	perPage: 20,
@@ -178,18 +178,6 @@ export default function DataviewsTemplates() {
 			}
 		},
 		[ history, params, view?.type ]
-	);
-
-	const onDetailsChange = useCallback(
-		( items ) => {
-			if ( items?.length === 1 ) {
-				history.push( {
-					postId: items[ 0 ].id,
-					postType: TEMPLATE_POST_TYPE,
-				} );
-			}
-		},
-		[ history ]
 	);
 
 	const authors = useMemo( () => {
@@ -390,7 +378,6 @@ export default function DataviewsTemplates() {
 				view={ view }
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
-				onDetailsChange={ onDetailsChange }
 				deferredRendering={ ! view.hiddenFields?.includes( 'preview' ) }
 			/>
 		</Page>

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -75,7 +75,7 @@ const defaultConfigPerViewType = {
 };
 
 const DEFAULT_VIEW = {
-	type: window?.__experimentalAdminViews ? LAYOUT_LIST : LAYOUT_TABLE,
+	type: LAYOUT_LIST,
 	search: '',
 	page: 1,
 	perPage: 20,

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -76,11 +76,7 @@ function SidebarScreens() {
 				<SidebarNavigationScreenPage />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/:postType(wp_template)">
-				{ window?.__experimentalAdminViews ? (
-					<SidebarNavigationScreenTemplatesBrowse />
-				) : (
-					<SidebarNavigationScreenTemplates />
-				) }
+				<SidebarNavigationScreenTemplates />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/patterns">
 				<SidebarNavigationScreenPatterns />

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -207,11 +207,7 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 		return {};
 	}, [ homepageId, postType, postId, path ] );
 
-	if (
-		( path === '/wp_template/all' ||
-			( path === '/wp_template' && window?.__experimentalAdminViews ) ) &&
-		postId
-	) {
+	if ( path === '/wp_template/all' && postId ) {
 		return { isReady: true, postType: 'wp_template', postId, context };
 	}
 

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -16,7 +16,6 @@ export default function getIsListPage(
 	return (
 		[ '/wp_template/all', '/wp_template_part/all' ].includes( path ) ||
 		( path === '/page' && window?.__experimentalAdminViews ) ||
-		( path === '/wp_template' && window?.__experimentalAdminViews ) ||
 		( path === '/patterns' &&
 			// Don't treat "/patterns" without categoryType and categoryId as a
 			// list page in mobile because the sidebar covers the whole page.

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -18,11 +18,7 @@ test.describe( 'Templates', () => {
 		] );
 	} );
 	test( 'Sorting', async ( { admin, page } ) => {
-		await admin.visitSiteEditor( { path: '/wp_template' } );
-		// Switch to table layout.
-		await page.getByLabel( 'View options' ).click();
-		await page.getByRole( 'menuitem', { name: 'Layout' } ).click();
-		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+		await admin.visitSiteEditor( { path: '/wp_template/all' } );
 		// Descending by title.
 		await page
 			.getByRole( 'button', { name: 'Template', exact: true } )
@@ -52,13 +48,7 @@ test.describe( 'Templates', () => {
 			title: 'Date Archives',
 			content: 'hi',
 		} );
-		await admin.visitSiteEditor( { path: '/wp_template' } );
-
-		// Switch to table layout.
-		await page.getByLabel( 'View options' ).click();
-		await page.getByRole( 'menuitem', { name: 'Layout' } ).click();
-		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
-
+		await admin.visitSiteEditor( { path: '/wp_template/all' } );
 		// Global search.
 		await page.getByRole( 'searchbox', { name: 'Filter list' } ).click();
 		await page.keyboard.type( 'tag' );
@@ -94,13 +84,7 @@ test.describe( 'Templates', () => {
 		await expect( titles ).toHaveCount( 2 );
 	} );
 	test( 'Field visibility', async ( { admin, page } ) => {
-		await admin.visitSiteEditor( { path: '/wp_template' } );
-
-		// Switch to table layout.
-		await page.getByLabel( 'View options' ).click();
-		await page.getByRole( 'menuitem', { name: 'Layout' } ).click();
-		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
-
+		await admin.visitSiteEditor( { path: '/wp_template/all' } );
 		await page.getByRole( 'button', { name: 'Description' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Hide' } ).click();
 		await expect(


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

This reverts using the list view as default when the "new admin views" experiment is active. The dataviews-powered page for Templates can be accessed via "Templates > Manage all templates".

## Why?

After running the current state with designers & Matías, there are some flows issues that need to be ironed out before making this stable. The list layout won't make it to 6.5, hence it is best to de-emphasize it and give it some time for it to mature.

## How

- Removes the details action from the list item view.
- Makes the table layout the default, whether the experiment is active or not.
- Makes the root page for Templates the same, whether the experiment is active or not.
- Access to dataviews is constrained to "Templates > Manage all templates".

## Testing Instructions

With the "admin views" experiment disabled:

- Visit Templates > Manage all templates. You should see the table layout and no way to change layouts.

https://github.com/WordPress/gutenberg/assets/583546/857748f4-7369-4d32-bc33-211d03982bf9

With the "admin views" experiment enabled:

- Visit Templates > Manage all templates. You should see the table layout, and you can change layouts.

https://github.com/WordPress/gutenberg/assets/583546/8530404c-1c11-49da-b78c-808de87ab39d

