### PR TITLE
DataViews: revert list view as default for pages

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -24,23 +24,28 @@ export default function useLayoutAreas() {
 
 	// Regular page
 	if ( path === '/page' ) {
-		const isListLayout =
-			isCustom !== 'true' && ( ! layout || layout === 'list' );
 		return {
 			areas: {
-				content: window.__experimentalAdminViews ? (
-					<PagePages />
-				) : undefined,
-				preview: ( isListLayout ||
-					! window.__experimentalAdminViews ) && (
+				content: undefined,
+				preview: <Editor isLoading={ isSiteEditorLoading } />,
+			},
+			widths: {
+				content: undefined,
+			},
+		};
+	}
+
+	if ( path === '/pages' && window?.__experimentalAdminViews ) {
+		const isListLayout = isCustom !== 'true' && layout === 'list';
+		return {
+			areas: {
+				content: <PagePages />,
+				preview: isListLayout && (
 					<Editor isLoading={ isSiteEditorLoading } />
 				),
 			},
 			widths: {
-				content:
-					window.__experimentalAdminViews && isListLayout
-						? 380
-						: undefined,
+				content: isListLayout ? 380 : undefined,
 			},
 		};
 	}

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -169,18 +169,6 @@ export default function PagePages() {
 		[ history, params, view?.type, isCustom ]
 	);
 
-	const onDetailsChange = useCallback(
-		( items ) => {
-			if ( !! postType && items?.length === 1 ) {
-				history.push( {
-					postId: items[ 0 ].id,
-					postType,
-				} );
-			}
-		},
-		[ history, postType ]
-	);
-
 	const queryArgs = useMemo( () => {
 		const filters = {};
 		view.filters.forEach( ( filter ) => {
@@ -421,7 +409,6 @@ export default function PagePages() {
 				view={ view }
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
-				onDetailsChange={ onDetailsChange }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -29,7 +29,7 @@ export const DEFAULT_CONFIG_PER_VIEW_TYPE = {
 };
 
 const DEFAULT_PAGE_BASE = {
-	type: LAYOUT_LIST,
+	type: LAYOUT_TABLE,
 	search: '',
 	filters: [],
 	page: 1,

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -15,7 +15,7 @@ import DataViewItem from './dataview-item';
 import CustomDataViewsList from './custom-dataviews-list';
 
 const PATH_TO_TYPE = {
-	'/page': 'page',
+	'/pages': 'page',
 };
 
 export default function DataViewsSidebarContent() {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages-dataviews/index.js
@@ -78,6 +78,7 @@ export default function SidebarNavigationScreenPagesDataViews() {
 			title={ __( 'Pages' ) }
 			description={ __( 'Browse and manage pages.' ) }
 			content={ <DataViewsSidebarContent /> }
+			backPath="/page"
 			footer={
 				<VStack spacing={ 0 }>
 					{ templates?.map( ( item ) => (

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -66,11 +66,10 @@ function SidebarScreens() {
 				<SidebarNavigationScreenGlobalStyles />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page">
-				{ window?.__experimentalAdminViews ? (
-					<SidebarNavigationScreenPagesDataViews />
-				) : (
-					<SidebarNavigationScreenPages />
-				) }
+				<SidebarNavigationScreenPages />
+			</SidebarScreenWrapper>
+			<SidebarScreenWrapper path="/pages">
+				<SidebarNavigationScreenPagesDataViews />
 			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page/:postId">
 				<SidebarNavigationScreenPage />

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -68,9 +68,11 @@ function SidebarScreens() {
 			<SidebarScreenWrapper path="/page">
 				<SidebarNavigationScreenPages />
 			</SidebarScreenWrapper>
-			<SidebarScreenWrapper path="/pages">
-				<SidebarNavigationScreenPagesDataViews />
-			</SidebarScreenWrapper>
+			{ window?.__experimentalAdminViews && (
+				<SidebarScreenWrapper path="/pages">
+					<SidebarNavigationScreenPagesDataViews />
+				</SidebarScreenWrapper>
+			) }
 			<SidebarScreenWrapper path="/page/:postId">
 				<SidebarNavigationScreenPage />
 			</SidebarScreenWrapper>

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -160,7 +160,7 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 			}
 
 			// Some URLs in list views are different
-			if ( path === '/page' && postId ) {
+			if ( path === '/pages' && postId ) {
 				return resolveTemplateForPostTypeAndId( 'page', postId );
 			}
 
@@ -196,7 +196,7 @@ function useResolveEditedEntityAndContext( { path, postId, postType } ) {
 		}
 
 		// Some URLs in list views are different
-		if ( path === '/page' && postId ) {
+		if ( path === '/pages' && postId ) {
 			return { postType: 'page', postId };
 		}
 

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -104,8 +104,6 @@ export default function useSyncPathWithURL() {
 			} else if (
 				// These sidebar paths are special in the sense that the url in these pages may or may not have a postId and we need to retain it if it has.
 				// The "type" property should be kept as well.
-				( navigatorLocation.path === '/page' &&
-					window?.__experimentalAdminViews ) ||
 				( navigatorLocation.path === '/wp_template' &&
 					window?.__experimentalAdminViews ) ||
 				( navigatorLocation.path === '/wp_template/all' &&

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -106,6 +106,8 @@ export default function useSyncPathWithURL() {
 				// The "type" property should be kept as well.
 				( navigatorLocation.path === '/wp_template' &&
 					window?.__experimentalAdminViews ) ||
+				( navigatorLocation.path === '/pages' &&
+					window?.__experimentalAdminViews ) ||
 				( navigatorLocation.path === '/wp_template/all' &&
 					! window?.__experimentalAdminViews )
 			) {

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -104,9 +104,9 @@ export default function useSyncPathWithURL() {
 			} else if (
 				// These sidebar paths are special in the sense that the url in these pages may or may not have a postId and we need to retain it if it has.
 				// The "type" property should be kept as well.
-				( navigatorLocation.path === '/wp_template' &&
-					window?.__experimentalAdminViews ) ||
 				( navigatorLocation.path === '/pages' &&
+					window?.__experimentalAdminViews ) ||
+				( navigatorLocation.path === '/wp_template' &&
 					window?.__experimentalAdminViews ) ||
 				( navigatorLocation.path === '/wp_template/all' &&
 					! window?.__experimentalAdminViews )

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -15,6 +15,7 @@ export default function getIsListPage(
 ) {
 	return (
 		[ '/wp_template/all', '/wp_template_part/all' ].includes( path ) ||
+		( path === '/pages' && window?.__experimentalAdminViews ) ||
 		( path === '/patterns' &&
 			// Don't treat "/patterns" without categoryType and categoryId as a
 			// list page in mobile because the sidebar covers the whole page.

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -15,7 +15,6 @@ export default function getIsListPage(
 ) {
 	return (
 		[ '/wp_template/all', '/wp_template_part/all' ].includes( path ) ||
-		( path === '/page' && window?.__experimentalAdminViews ) ||
 		( path === '/patterns' &&
 			// Don't treat "/patterns" without categoryType and categoryId as a
 			// list page in mobile because the sidebar covers the whole page.


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Related https://github.com/WordPress/gutenberg/pull/58079

## What?

This reverts using the list view as default when the "new admin views" experiment is active for the Pages page. The dataviews-powered page for Pages can be accessed via "Pages > Manage all pages", when the experiment is active.

## Why?

After running the current state with designers & Matías, there are some flows issues that need to be ironed out before making this stable. The list layout won't make it to 6.5, hence it is best to de-emphasize it and give it some time for it to mature.

## How

- Removes the details action from the list item view.
- Makes the table layout the default, whether the experiment is active or not.
- Makes the root page for Pages be the same, whether the experiment is active or not.
- Access to dataviews is constrained to "Pages > Manage all pages".

## Testing Instructions

With the "admin views" experiment disabled:

- Visit Pages > Manage all Pages. You should be taken to the wp-admin screen, as before.


https://github.com/WordPress/gutenberg/assets/583546/4e68ac05-5fcf-4438-a2b3-e9f46ab2a3ac

With the "admin views" experiment enabled:

- Visit Pages > Manage all pages. You should see the table layout, and you can change layouts.

https://github.com/WordPress/gutenberg/assets/583546/1f11b359-8900-4657-9279-2b06d5b0276a

