### PR TITLE
Update caniuse-lite package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,7 +166,7 @@
 				"babel-plugin-transform-remove-console": "6.9.4",
 				"benchmark": "2.1.4",
 				"browserslist": "4.21.10",
-				"caniuse-lite": "1.0.30001538",
+				"caniuse-lite": "1.0.30001579",
 				"chalk": "4.1.1",
 				"change-case": "4.1.2",
 				"commander": "9.2.0",
@@ -21350,9 +21350,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001538",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
-			"integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
+			"version": "1.0.30001579",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+			"integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -73290,9 +73290,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001538",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
-			"integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw=="
+			"version": "1.0.30001579",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+			"integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA=="
 		},
 		"capital-case": {
 			"version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
 		"babel-plugin-transform-remove-console": "6.9.4",
 		"benchmark": "2.1.4",
 		"browserslist": "4.21.10",
-		"caniuse-lite": "1.0.30001538",
+		"caniuse-lite": "1.0.30001579",
 		"chalk": "4.1.1",
 		"change-case": "4.1.2",
 		"commander": "9.2.0",

--- a/packages/readable-js-assets-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/readable-js-assets-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReadableJsAssetsWebpackPlugin should produce the expected output: Asset file index.js should match snapshot 1`] = `
-"/******/ (function() { // webpackBootstrap
+"/******/ (() => { // webpackBootstrap
 var __webpack_exports__ = {};
 function notMinified() {
 	// eslint-disable-next-line no-console
@@ -16,7 +16,7 @@ notMinified();
 exports[`ReadableJsAssetsWebpackPlugin should produce the expected output: Asset file index.min.js should match snapshot 1`] = `"console.log("hello");"`;
 
 exports[`ReadableJsAssetsWebpackPlugin should produce the expected output: Asset file view.js should match snapshot 1`] = `
-"/******/ (function() { // webpackBootstrap
+"/******/ (() => { // webpackBootstrap
 var __webpack_exports__ = {};
 function notMinified() {
 	// eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Update the `caniuse-lite` package.

## Why?

This package determines how Gutenberg is compiled. It's a database of browsers and the features they support and affects how compilation tools like webpack and babel behave.

When the package is out of date, the data is inaccurate especially around things like the global usage percentages and "last X versions" we rely on:

https://github.com/WordPress/gutenberg/blob/f4c34a4656521fdb7f151d687d89679c6caebada/packages/browserslist-config/index.js#L3-L11

Some of this outdated data is currently blocking some work on modules: #57924

This should also improve the build size in some minor ways overall.

## How?

Update the package to its latest version.

## Testing Instructions

Not necessary, although you can confirm the differences in browser support by comparing this branch and trunk. Run `npx browserslist` from the `packages/browserslist-config` directory. Here's the change in support as a diff:

```diff
diff --git a/trunk b/branch
index e9d29a4086..ca38107653 100644
--- a/trunk
+++ b/branch
@@ -1,22 +1,18 @@
-and_chr 117
-and_uc 15.5
-android 117
-chrome 117
-chrome 116
-chrome 115
-chrome 114
+and_chr 120
+android 120
+chrome 120
+chrome 119
 chrome 109
-edge 117
-edge 116
-edge 115
-firefox 117
-firefox 116
-ios_saf 17.0
-ios_saf 16.6
-ios_saf 16.5
-ios_saf 15.6-15.7
-op_mini all
-opera 102
-opera 101
-safari 16.6
-safari 16.5
+edge 120
+edge 119
+firefox 121
+firefox 120
+ios_saf 17.2
+ios_saf 17.1
+ios_saf 16.6-16.7
+op_mob 73
+opera 106
+opera 105
+safari 17.2
+safari 17.1
+samsung 23
```
