### PR TITLE
RNMobile: Avoid crashes by ensuring RichText value exists prior to `toString` calls

### DIFF
--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -884,8 +884,8 @@ export class RichText extends Component {
 		// On android if content is empty we need to send no content or else the placeholder will not show.
 		if (
 			! this.isIOS &&
-			( value.toString() === '' ||
-				value.toString() === EMPTY_PARAGRAPH_TAGS )
+			( value?.toString() === '' ||
+				value?.toString() === EMPTY_PARAGRAPH_TAGS )
 		) {
 			return '';
 		}

--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -264,7 +264,7 @@ export class RichText extends Component {
 	onCreateUndoLevel() {
 		const { __unstableOnCreateUndoLevel: onCreateUndoLevel } = this.props;
 		// If the content is the same, no level needs to be created.
-		if ( this.lastHistoryValue.toString() === this.value.toString() ) {
+		if ( this.lastHistoryValue?.toString() === this.value?.toString() ) {
 			return;
 		}
 
@@ -317,7 +317,7 @@ export class RichText extends Component {
 			event.nativeEvent.text
 		);
 		// On iOS, onChange can be triggered after selection changes, even though there are no content changes.
-		if ( contentWithoutRootTag === this.value.toString() ) {
+		if ( contentWithoutRootTag === this.value?.toString() ) {
 			return;
 		}
 		this.lastEventCount = event.nativeEvent.eventCount;
@@ -333,7 +333,7 @@ export class RichText extends Component {
 		);
 
 		this.debounceCreateUndoLevel();
-		const refresh = this.value.toString() !== contentWithoutRootTag;
+		const refresh = this.value?.toString() !== contentWithoutRootTag;
 		this.value = contentWithoutRootTag;
 
 		// We don't want to refresh if our goal is just to create a record.
@@ -564,7 +564,7 @@ export class RichText extends Component {
 		// Check if value is up to date with latest state of native AztecView.
 		if (
 			event.nativeEvent.text &&
-			event.nativeEvent.text !== this.props.value.toString()
+			event.nativeEvent.text !== this.props.value?.toString()
 		) {
 			this.onTextUpdate( event );
 		}
@@ -589,7 +589,7 @@ export class RichText extends Component {
 		// this approach is not perfectly reliable.
 		const isManual =
 			this.lastAztecEventType !== 'input' &&
-			this.props.value.toString() === this.value.toString();
+			this.props.value?.toString() === this.value?.toString();
 		if ( hasChanged && isManual ) {
 			const value = this.createRecord();
 			const activeFormats = getActiveFormats( value );
@@ -659,7 +659,7 @@ export class RichText extends Component {
 			event.nativeEvent.text
 		);
 		if (
-			contentWithoutRootTag === this.value.toString() &&
+			contentWithoutRootTag === this.value?.toString() &&
 			realStart === this.selectionStart &&
 			realEnd === this.selectionEnd
 		) {
@@ -756,7 +756,7 @@ export class RichText extends Component {
 			typeof nextProps.value !== 'undefined' &&
 			typeof this.props.value !== 'undefined' &&
 			( ! this.comesFromAztec || ! this.firedAfterTextChanged ) &&
-			nextProps.value.toString() !== this.props.value.toString()
+			nextProps.value?.toString() !== this.props.value?.toString()
 		) {
 			// Gutenberg seems to try to mirror the caret state even on events that only change the content so,
 			//  let's force caret update if state has selection set.
@@ -824,7 +824,7 @@ export class RichText extends Component {
 		const { style, tagName } = this.props;
 		const { currentFontSize } = this.state;
 
-		if ( this.props.value.toString() !== this.value.toString() ) {
+		if ( this.props.value?.toString() !== this.value?.toString() ) {
 			this.value = this.props.value;
 		}
 		const { __unstableIsSelected: prevIsSelected } = prevProps;

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [**] Video block: Fix logic for displaying empty state based on source presence [#58015]
+-   [**] Fix crash when RichText values are not defined [#58088]
 
 ## 1.111.0
 -   [**] Image block media uploads display a custom error message when there is no internet connection [#56937]


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22432

* Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6563

## What?

In this PR, we ensure the RichText value exists prior to making a `toString` call. 

## Why?

We've received several crash reports in the most recent WPiOS release (`24.0`) that point to a failed `toString` call:

```
RCTFatalException: Unhandled JS Exception: TypeError: Cannot read property 'toString' of undefined This error is located at: in I in Unknown in WithPreferredColorScheme(Component) in Unknown in WithSelect(WithPreferredColorScheme(Co...
```

As per the discussion and extra logs in https://github.com/wordpress-mobile/WordPress-iOS/issues/22432, we believe this emerged following the changes in https://github.com/WordPress/gutenberg/pull/57028, with the cause being that the RichText value can sometimes be undefined.

## How?

Optional chaining has been used to ensure the RichText value exists prior to making the `onString` call. If it doesn't, the call will now fail gracefully, without crashing the app. 

Note, we've had difficulty reproducing the crash. We believe it's root cause is performance related, as described [here](https://github.com/wordpress-mobile/gutenberg-mobile/issues/6359#issuecomment-1841384537). As such, the proposed fix in this PR is considered a temporary patch, and the hope is to address the more complex performance-related issues separately.

## Testing Instructions

Due to the difficulty reproducing the crash, there aren't specific steps to ensure the fix resolves it. We can, however, manually set the RichText value to `undefined` locally, and verify the app does not crash:

```patch
diff --git a/packages/block-editor/src/components/rich-text/native/index.native.js b/packages/block-editor/src/components/rich-text/native/index.native.js
index 97e3c2be3f..1d639e8148 100644
--- a/packages/block-editor/src/components/rich-text/native/index.native.js
+++ b/packages/block-editor/src/components/rich-text/native/index.native.js
@@ -824,6 +824,8 @@ export class RichText extends Component {
 		const { style, tagName } = this.props;
 		const { currentFontSize } = this.state;
 
+		this.value = undefined;
+
 		if ( this.props.value?.toString() !== this.value?.toString() ) {
 			this.value = this.props.value;
 		}
```