### PR TITLE
Font Library: Fix font collection filtering

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -33,7 +33,7 @@ import GoogleFontsConfirmDialog from './google-fonts-confirm-dialog';
 import { downloadFontFaceAsset } from './utils';
 
 const DEFAULT_CATEGORY = {
-	id: 'all',
+	slug: 'all',
 	name: __( 'All' ),
 };
 function FontCollection( { slug } ) {
@@ -263,8 +263,8 @@ function FontCollection( { slug } ) {
 							{ categories &&
 								categories.map( ( category ) => (
 									<option
-										value={ category.id }
-										key={ category.id }
+										value={ category.slug }
+										key={ category.slug }
 									>
 										{ category.name }
 									</option>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/filter-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/filter-fonts.js
@@ -1,16 +1,33 @@
+/**
+ * Filters a list of fonts based on the specified filters.
+ *
+ * This function filters a given array of fonts based on the criteria provided in the filters object.
+ * It supports filtering by category and a search term. If the category is provided and not equal to 'all',
+ * the function filters the fonts array to include only those fonts that belong to the specified category.
+ * Additionally, if a search term is provided, it filters the fonts array to include only those fonts
+ * whose name includes the search term, case-insensitively.
+ *
+ * @param {Array}  fonts   Array of font objects in font-collection schema fashion to be filtered. Each font object should have a 'categories' property and a 'font_family_settings' property with a 'name' key.
+ * @param {Object} filters Object containing the filter criteria. It should have a 'category' key and/or a 'search' key.
+ *                         The 'category' key is a string representing the category to filter by.
+ *                         The 'search' key is a string representing the search term to filter by.
+ * @return {Array} Array of filtered font objects based on the provided criteria.
+ */
 export default function filterFonts( fonts, filters ) {
 	const { category, search } = filters;
 	let filteredFonts = fonts || [];
 
 	if ( category && category !== 'all' ) {
 		filteredFonts = filteredFonts.filter(
-			( font ) => font.category === category
+			( font ) => font.categories.indexOf( category ) !== -1
 		);
 	}
 
 	if ( search ) {
 		filteredFonts = filteredFonts.filter( ( font ) =>
-			font.name.toLowerCase().includes( search.toLowerCase() )
+			font.font_family_settings.name
+				.toLowerCase()
+				.includes( search.toLowerCase() )
 		);
 	}
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/filter-fonts.spec.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/filter-fonts.spec.js
@@ -5,11 +5,26 @@ import filterFonts from '../filter-fonts';
 
 describe( 'filterFonts', () => {
 	const mockFonts = [
-		{ name: 'Arial', category: 'sans-serif' },
-		{ name: 'Arial Condensed', category: 'sans-serif' },
-		{ name: 'Times New Roman', category: 'serif' },
-		{ name: 'Courier New', category: 'monospace' },
-		{ name: 'Romantic', category: 'cursive' },
+		{
+			font_family_settings: { name: 'Arial' },
+			categories: [ 'sans-serif' ],
+		},
+		{
+			font_family_settings: { name: 'Arial Condensed' },
+			categories: [ 'sans-serif' ],
+		},
+		{
+			font_family_settings: { name: 'Times New Roman' },
+			categories: [ 'serif' ],
+		},
+		{
+			font_family_settings: { name: 'Courier New' },
+			categories: [ 'monospace' ],
+		},
+		{
+			font_family_settings: { name: 'Romantic' },
+			categories: [ 'cursive' ],
+		},
 	];
 
 	it( 'should return all fonts if no filters are provided', () => {
@@ -20,7 +35,10 @@ describe( 'filterFonts', () => {
 	it( 'should filter by category', () => {
 		const result = filterFonts( mockFonts, { category: 'serif' } );
 		expect( result ).toEqual( [
-			{ name: 'Times New Roman', category: 'serif' },
+			{
+				font_family_settings: { name: 'Times New Roman' },
+				categories: [ 'serif' ],
+			},
 		] );
 	} );
 
@@ -32,15 +50,24 @@ describe( 'filterFonts', () => {
 	it( 'should filter by search', () => {
 		const result = filterFonts( mockFonts, { search: 'ari' } );
 		expect( result ).toEqual( [
-			{ name: 'Arial', category: 'sans-serif' },
-			{ name: 'Arial Condensed', category: 'sans-serif' },
+			{
+				font_family_settings: { name: 'Arial' },
+				categories: [ 'sans-serif' ],
+			},
+			{
+				font_family_settings: { name: 'Arial Condensed' },
+				categories: [ 'sans-serif' ],
+			},
 		] );
 	} );
 
 	it( 'should be case insensitive when filtering by search', () => {
 		const result = filterFonts( mockFonts, { search: 'RoMANtic' } );
 		expect( result ).toEqual( [
-			{ name: 'Romantic', category: 'cursive' },
+			{
+				font_family_settings: { name: 'Romantic' },
+				categories: [ 'cursive' ],
+			},
 		] );
 	} );
 
@@ -50,7 +77,10 @@ describe( 'filterFonts', () => {
 			search: 'Times',
 		} );
 		expect( result ).toEqual( [
-			{ name: 'Times New Roman', category: 'serif' },
+			{
+				font_family_settings: { name: 'Times New Roman' },
+				categories: [ 'serif' ],
+			},
 		] );
 	} );
 


### PR DESCRIPTION
## What?
Font Library: Fix font collection filtering 

## Why?
We needed to update the code to use the new data shape from the new schema.

## How?
Updating the data expected by the filtering-related code.

## Testing Instructions
Navigate to the default Google fonts collection and filter them by name and categories.
The filters should work as expected.
