### PR TITLE
Theme: Set `color` on wrapper

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 -   `BoxControl`: Update design ([#56665](https://github.com/WordPress/gutenberg/pull/56665)).
 -   `CustomSelect`: adjust `renderSelectedValue` to fix sizing ([#57865](https://github.com/WordPress/gutenberg/pull/57865)).
+-   `Theme`: Set `color` on wrapper div ([#58095](https://github.com/WordPress/gutenberg/pull/58095)).
 
 ## 25.15.0 (2024-01-10)
 

--- a/packages/components/src/theme/styles.ts
+++ b/packages/components/src/theme/styles.ts
@@ -30,4 +30,6 @@ export const colorVariables = ( { colors }: ThemeOutputValues ) => {
 	];
 };
 
-export const Wrapper = styled.div``;
+export const Wrapper = styled.div`
+	color: var( --wp-components-color-foreground, currentColor );
+`;


### PR DESCRIPTION
Part of #44116

## What?

Set the themed foreground color as the `color` for the wrapper div on the `Theme` component.

## Why?

While working on #58014, I noticed that the `Theme` component does not set the foreground color as a `color` for its wrapper div.

## How?

Sets `currentColor` as the fallback when `--wp-components-color-foreground` is not defined. This can happen when the consumer has not provided a `background` prop on Theme.

I briefly considered falling back to `GRAY[ 900 ]`, but that would probably be a bit too intrusive 🤔 We can revisit this if necessary.

## Testing Instructions

1. Look at a Storybook story with some text that is not explicitly colored, e.g. the `View` component.
2. Using the Theme switcher in the toolbar, try out the different presets.

    - For the two presets that set a `background` color, the text color should responsively change to either `#ffffff` or `#1e1e1e` depending on the background.
    - In the "Classic" preset that only sets an `accent` color, the text color will stay as `#000000` (= `currentColor`).
    - In [trunk](https://wordpress.github.io/gutenberg/?path=/docs/components-experimental-view--docs), the text colors won't change at all.

https://github.com/WordPress/gutenberg/assets/555336/b3b5b3d3-5754-474d-b71f-307b651de6cc


