### PR TITLE
Components: Add stylelint rule for theme var regressions

### DIFF
--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -16,9 +16,15 @@
 	.components-placeholder__error {
 		word-break: break-word;
 	}
+}
 
-	.components-placeholder__learn-more {
-		margin-top: 1em;
+.wp-block-embed__learn-more {
+	margin-top: 1em;
+
+	@at-root .wp-block-post-content & {
+		a {
+			color: var(--wp-admin-theme-color);
+		}
 	}
 }
 

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -37,7 +37,7 @@ const EmbedPlaceholder = ( {
 					{ _x( 'Embed', 'button label' ) }
 				</Button>
 			</form>
-			<div className="components-placeholder__learn-more">
+			<div className="wp-block-embed__learn-more">
 				<ExternalLink
 					href={ __(
 						'https://wordpress.org/documentation/article/embeds/'

--- a/packages/components/.stylelintrc.js
+++ b/packages/components/.stylelintrc.js
@@ -1,0 +1,23 @@
+/** @type {import('stylelint').Config} */
+module.exports = {
+	extends: '../../.stylelintrc.json',
+	rules: {
+		'declaration-property-value-disallowed-list': [
+			{
+				'/.*/': '/--wp-admin-theme-/',
+			},
+			{
+				message:
+					'--wp-admin-theme-* variables do not support component theming. Use Sass variables from packages/components/src/utils/theme-variables.scss instead.',
+			},
+		],
+	},
+	overrides: [
+		{
+			files: [ './src/utils/theme-variables.scss' ],
+			rules: {
+				'declaration-property-value-disallowed-list': null,
+			},
+		},
+	],
+};

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Experimental
 
+-   `Guide`, `Modal`: Restore accent color themability ([#58098](https://github.com/WordPress/gutenberg/pull/58098)).
 -   `BoxControl`: Update design ([#56665](https://github.com/WordPress/gutenberg/pull/56665)).
 -   `CustomSelect`: adjust `renderSelectedValue` to fix sizing ([#57865](https://github.com/WordPress/gutenberg/pull/57865)).
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -164,11 +164,13 @@
 
 		&:hover:not(:disabled, [aria-disabled="true"]) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
+			/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		}
 
 		&:active:not(:disabled, [aria-disabled="true"]) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
+			/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 		}
 

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -82,7 +82,7 @@
 		}
 
 		li[aria-current="step"] .components-button {
-			color: var(--wp-components-color-accent, var(--wp-admin-theme-color));
+			color: $components-color-accent;
 		}
 	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -160,7 +160,7 @@
 	}
 
 	&.is-scrollable:focus-visible {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -148,11 +148,6 @@
 			padding: 0 $grid-unit-10 2px;
 		}
 	}
-	.components-placeholder__learn-more {
-		.components-external-link {
-			color: var(--wp-admin-theme-color);
-		}
-	}
 }
 
 


### PR DESCRIPTION
Part of #44116

## What?

Adds a Stylelint rule for stylesheets under `packages/components` to prevent unknowing usage of `--wp-admin-theme-*` color variables.

## Why?

`--wp-admin-theme-*` variables are coupled with wp-admin and do not support our component theming system.

There were already three new occurrences of the variable since we removed them all, and that excludes the ones we [caught](https://github.com/WordPress/gutenberg/pull/46276#discussion_r1041306894) in review. So I think it's worth setting up a lint rule.

I'll set up a separate rule for Eslint so we can also catch them in JS files (#58130).

## Testing Instructions

1. Check out the first commit `2877a67` that adds the stylelint rule, and run `npm run lint:css`. It should error on the offending files under `packages/components`.
2. The lint should pass after all the stylesheet fixes.