### PR TITLE
(preferences)(17.5.1)(fix) Fix preferences migration 17.5-specific deprecation test failures

### DIFF
--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -92,6 +92,10 @@ describe( 'actions', () => {
 			expect( registry.select( editPostStore ).getEditorMode() ).toEqual(
 				'visual'
 			);
+			// Expecation added due to a 17.5.1-specific hotifx: https://github.com/WordPress/gutenberg/pull/58031
+			expect( console ).toHaveWarnedWith(
+				"wp.data.select( 'core/preferences' ).get( 'core/edit-post', 'editorMode' ) is deprecated since version 6.5. Please use wp.data.select( 'core/preferences' ).get( 'core', 'editorMode' ) instead."
+			);
 		} );
 
 		it( 'to text', () => {


### PR DESCRIPTION
## What / Why / How?

17.5-specific Follow-up to: https://github.com/WordPress/gutenberg/pull/58031. That changeset was a time-sensitive hotfix for 17.5 with benign test failures, AFAICS. This PR aims to fix those tests in the 17.5 branches so that if any other PR is cherry-picked for a future patch release, people will not get confused by the failures.

It's important to note that once 17.6 is released, this will not be too relevant anymore, but will be a good way to document the changes in https://github.com/WordPress/gutenberg/pull/58031.

The changes in https://github.com/WordPress/gutenberg/pull/58031 make the `get` proxy more resilient by falling back to the passed scope to get the preference if it's not found in the `core` scope (where the preferences in the `settingsToMoveToCore` were migrated to between 17.5 and `trunk`. Some changesets were not included in the `release/17.5` branch, causing the `get` call for them to return `undefined` to the consumers and causing unexpected fatal bugs (BSODs/WSODs). 

On `trunk` nor this PR nor https://github.com/WordPress/gutenberg/pull/58031 are needed because the it should be in a state that https://github.com/WordPress/gutenberg/pull/58016 expects -- all of the preferences listed in `settingsToMoveToCore` have indeed been moved over to the `core` scope.


## Testing Instructions

All tests should pass.


