### PR TITLE
DataViews: Don't always display horizontal scrollbar

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -60,7 +60,7 @@
 }
 
 .dataviews-view-table-wrapper {
-	overflow-x: scroll;
+	overflow-x: auto;
 }
 
 .dataviews-view-table {


### PR DESCRIPTION
## What?

This PR hides the DataView's horizontal scroll bar except when it is scrollable.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/ae1a9cee-fcbb-4961-967a-39812476e7c1)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/5ed85651-1c7a-484e-9549-bb232f2bdfc1)

## Why?

In the Chrome browser on Windows OS, if the value of `overflow` is `scroll`, the scrollbar will always be displayed, regardless of whether the content is scrollable or not. Scrollbars should only be shown if the content is actually scrollable.

## How?
If the value is `auto`, scrollbars will not be displayed if the content is not scrollable.

## Testing Instructions

To test this PR on MacOS, you may need to change the settings so that the scrollbars are always visible.

- Switch data view to table layout.
- If the browser width is wide, the horizontal scrollbar should not be displayed.
- As you narrow the width of your browser, the scrollbar should appear.