### PR TITLE
List View: Try a WYSIWYG drag chip (make it feel like you are really dragging the item)

### DIFF
--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -16,6 +16,7 @@ import ListViewBlockSelectButton from './block-select-button';
 import BlockDraggable from '../block-draggable';
 import { store as blockEditorStore } from '../../store';
 import { useListViewContext } from './context';
+import useDragChip from './use-drag-chip';
 
 const ListViewBlockContents = forwardRef(
 	(
@@ -49,10 +50,19 @@ const ListViewBlockContents = forwardRef(
 
 		const {
 			AdditionalBlockContent,
+			blockDropTarget,
 			insertedBlock,
 			listViewInstanceId,
 			setInsertedBlock,
+			treeGridElementRef,
 		} = useListViewContext();
+
+		const { dragChipOnDragStart, dragChipOnDragEnd } = useDragChip( {
+			blockDropTarget,
+			cloneClassname: 'block-editor-list-view-draggable-chip',
+			listViewRef: treeGridElementRef,
+			elementId: `list-view-${ listViewInstanceId }-block-${ clientId }`,
+		} );
 
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;
@@ -81,9 +91,9 @@ const ListViewBlockContents = forwardRef(
 				<BlockDraggable
 					appendToOwnerDocument
 					clientIds={ draggableClientIds }
-					cloneClassname={ 'block-editor-list-view-draggable-chip' }
-					dragComponent={ null }
-					elementId={ `list-view-${ listViewInstanceId }-block-${ clientId }` }
+					cloneClassname={
+						'block-editor-list-view-default-draggable-chip'
+					}
 				>
 					{ ( { draggable, onDragStart, onDragEnd } ) => (
 						<ListViewBlockSelectButton
@@ -97,8 +107,14 @@ const ListViewBlockContents = forwardRef(
 							siblingBlockCount={ siblingBlockCount }
 							level={ level }
 							draggable={ draggable }
-							onDragStart={ onDragStart }
-							onDragEnd={ onDragEnd }
+							onDragStart={ ( event ) => {
+								onDragStart( event );
+								dragChipOnDragStart( event );
+							} }
+							onDragEnd={ ( event ) => {
+								onDragEnd( event );
+								dragChipOnDragEnd( event );
+							} }
 							isExpanded={ isExpanded }
 							{ ...props }
 						/>

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -47,8 +47,12 @@ const ListViewBlockContents = forwardRef(
 			[]
 		);
 
-		const { AdditionalBlockContent, insertedBlock, setInsertedBlock } =
-			useListViewContext();
+		const {
+			AdditionalBlockContent,
+			insertedBlock,
+			listViewInstanceId,
+			setInsertedBlock,
+		} = useListViewContext();
 
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;
@@ -78,6 +82,8 @@ const ListViewBlockContents = forwardRef(
 					appendToOwnerDocument
 					clientIds={ draggableClientIds }
 					cloneClassname={ 'block-editor-list-view-draggable-chip' }
+					dragComponent={ null }
+					elementId={ `list-view-${ listViewInstanceId }-block-${ clientId }` }
 				>
 					{ ( { draggable, onDragStart, onDragEnd } ) => (
 						<ListViewBlockSelectButton

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -6,35 +6,16 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalTruncate as Truncate,
-	Popover,
-} from '@wordpress/components';
+import { Popover } from '@wordpress/components';
 
 import { getScrollContainer } from '@wordpress/dom';
 import { useCallback, useMemo } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import BlockIcon from '../block-icon';
-import useBlockDisplayInformation from '../use-block-display-information';
-import useBlockDisplayTitle from '../block-title/use-block-display-title';
-import ListViewExpander from './expander';
-
 export default function ListViewDropIndicatorPreview( {
-	draggedBlockClientId,
 	listViewRef,
 	blockDropTarget,
 } ) {
-	const blockInformation = useBlockDisplayInformation( draggedBlockClientId );
-	const blockTitle = useBlockDisplayTitle( {
-		clientId: draggedBlockClientId,
-		context: 'list-view',
-	} );
-
 	const { rootClientId, clientId, dropPosition } = blockDropTarget || {};
 
 	const [ rootBlockElement, blockElement ] = useMemo( () => {
@@ -153,56 +134,6 @@ export default function ListViewDropIndicatorPreview( {
 		};
 	}, [ getDropIndicatorWidth, targetElement ] );
 
-	const horizontalScrollOffsetStyle = useMemo( () => {
-		if ( ! targetElement ) {
-			return {};
-		}
-
-		const scrollContainer = getScrollContainer( targetElement );
-		const ownerDocument = targetElement.ownerDocument;
-		const windowScroll =
-			scrollContainer === ownerDocument.body ||
-			scrollContainer === ownerDocument.documentElement;
-
-		if ( scrollContainer && ! windowScroll ) {
-			const scrollContainerRect = scrollContainer.getBoundingClientRect();
-			const targetElementRect = targetElement.getBoundingClientRect();
-
-			const distanceBetweenContainerAndTarget = rtl
-				? scrollContainerRect.right - targetElementRect.right
-				: targetElementRect.left - scrollContainerRect.left;
-
-			if ( ! rtl && scrollContainerRect.left > targetElementRect.left ) {
-				return {
-					transform: `translateX( ${ distanceBetweenContainerAndTarget }px )`,
-				};
-			}
-
-			if ( rtl && scrollContainerRect.right < targetElementRect.right ) {
-				return {
-					transform: `translateX( ${
-						distanceBetweenContainerAndTarget * -1
-					}px )`,
-				};
-			}
-		}
-
-		return {};
-	}, [ rtl, targetElement ] );
-
-	const ariaLevel = useMemo( () => {
-		if ( ! rootBlockElement ) {
-			return 1;
-		}
-
-		const _ariaLevel = parseInt(
-			rootBlockElement.getAttribute( 'aria-level' ),
-			10
-		);
-
-		return _ariaLevel ? _ariaLevel + 1 : 1;
-	}, [ rootBlockElement ] );
-
 	const hasAdjacentSelectedBranch = useMemo( () => {
 		if ( ! targetElement ) {
 			return false;
@@ -309,40 +240,7 @@ export default function ListViewDropIndicatorPreview( {
 							hasAdjacentSelectedBranch,
 					}
 				) }
-			>
-				<div
-					className="block-editor-list-view-leaf"
-					aria-level={ ariaLevel }
-				>
-					<div
-						className={ classnames(
-							'block-editor-list-view-block-select-button',
-							'block-editor-list-view-block-contents'
-						) }
-						style={ horizontalScrollOffsetStyle }
-					>
-						<ListViewExpander onClick={ () => {} } />
-						<BlockIcon
-							icon={ blockInformation?.icon }
-							showColors
-							context="list-view"
-						/>
-						<HStack
-							alignment="center"
-							className="block-editor-list-view-block-select-button__label-wrapper"
-							justify="flex-start"
-							spacing={ 1 }
-						>
-							<span className="block-editor-list-view-block-select-button__title">
-								<Truncate ellipsizeMode="auto">
-									{ blockTitle }
-								</Truncate>
-							</span>
-						</HStack>
-					</div>
-					<div className="block-editor-list-view-block__menu-cell"></div>
-				</div>
-			</div>
+			></div>
 		</Popover>
 	);
 }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -275,6 +275,7 @@ function ListViewComponent(
 	const contextValue = useMemo(
 		() => ( {
 			blockDropPosition,
+			blockDropTarget,
 			blockDropTargetIndex,
 			blockIndexes,
 			draggedClientIds,
@@ -292,6 +293,7 @@ function ListViewComponent(
 		} ),
 		[
 			blockDropPosition,
+			blockDropTarget,
 			blockDropTargetIndex,
 			blockIndexes,
 			draggedClientIds,

--- a/packages/block-editor/src/components/list-view/leaf.js
+++ b/packages/block-editor/src/components/list-view/leaf.js
@@ -37,6 +37,9 @@ const ListViewLeaf = forwardRef(
 			clientId: props[ 'data-block' ],
 			enableAnimation: true,
 			triggerAnimationOnChange: path,
+			elementSelector: isDragged
+				? '.block-editor-list-view-draggable-chip .block-editor-list-view-leaf'
+				: undefined,
 		} );
 
 		const mergedRef = useMergeRefs( [ ref, animationRef ] );

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -437,6 +437,11 @@
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
 $block-navigation-max-indent: 8;
 
+.block-editor-list-view-default-draggable-chip {
+	// Hide the default draggable chip
+	display: none;
+}
+
 .block-editor-list-view-draggable-chip {
 	.block-editor-list-view-leaf {
 		background-color: $white;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -438,12 +438,8 @@
 $block-navigation-max-indent: 8;
 
 .block-editor-list-view-draggable-chip {
-	opacity: 0.8;
-
 	.block-editor-list-view-leaf {
-		// The drag chip uses a transparent background to ensure that the nesting level
-		// for where a user drops the dragged block is visible.
-		background-color: rgba(255, 255, 255, 0.5);
+		background-color: $white;
 		border-radius: $radius-block-ui;
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		display: flex;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -439,6 +439,62 @@ $block-navigation-max-indent: 8;
 
 .block-editor-list-view-draggable-chip {
 	opacity: 0.8;
+
+	.block-editor-list-view-leaf {
+		// The drag chip uses a transparent background to ensure that the nesting level
+		// for where a user drops the dragged block is visible.
+		background-color: rgba(255, 255, 255, 0.5);
+		border-radius: $radius-block-ui;
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		display: flex;
+		height: 36px;
+		// Where possible, restrict the width of the cloned row to the width of the list view.
+		max-width: 338px;
+		opacity: 1;
+
+		// Reset colors to use the admin color.
+		td {
+			background: none !important;
+			.block-editor-list-view-block-select-button,
+			.block-editor-block-icon,
+			.components-button.has-icon {
+				color: var(--wp-admin-theme-color) !important;
+			}
+		}
+
+		.block-editor-list-view__expander {
+			// Remove indent on the expander, as the dragged component offsets the entire row.
+			margin-left: 0 !important;
+		}
+
+		// Apply a margin offset to account for nesting level.
+		&[aria-level] {
+			margin-left: ( $icon-size ) * $block-navigation-max-indent + 4 * ( $block-navigation-max-indent - 1 );
+		}
+
+		// When updating the margin for each indentation level, the corresponding
+		// indentation in `use-list-view-drop-zone.js` must be updated as well
+		// to ensure the drop zone is aligned with the indentation.
+		@for $i from 0 to $block-navigation-max-indent {
+			&[aria-level="#{ $i + 1 }"] {
+				@if $i - 1 >= 0 {
+					margin-left: ( $icon-size * $i ) + 4 * ($i - 1) !important;
+				}
+				@else {
+					margin-left: ( $icon-size * $i ) !important;
+				}
+			}
+		}
+
+		.block-editor-list-view-block__contents-cell {
+			flex: 1;
+		}
+
+		.block-editor-list-view-block__menu-cell {
+			display: flex;
+			align-items: center;
+		}
+	}
 }
 
 .block-editor-list-view-block__contents-cell,

--- a/packages/block-editor/src/components/list-view/use-drag-chip.js
+++ b/packages/block-editor/src/components/list-view/use-drag-chip.js
@@ -1,0 +1,231 @@
+/**
+ * WordPress dependencies
+ */
+import { throttle } from '@wordpress/compose';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+
+const dragImageClass = 'components-draggable__invisible-drag-image';
+const cloneWrapperClass = 'components-draggable__clone';
+const clonePadding = 0;
+const bodyClass = 'is-dragging-components-draggable';
+
+export default function useDragChip( {
+	blockDropTarget,
+	cloneClassname,
+	listViewRef,
+	elementId,
+	transferData,
+	__experimentalTransferDataType: transferDataType = 'text',
+} ) {
+	const { clientId, rootClientId } = blockDropTarget || {};
+	// const horizontalOffset = useRef( 0 );
+	const targetAriaLevelRef = useRef( 1 );
+	const originalAriaLevelRef = useRef( 1 );
+	const cleanup = useRef( () => {} );
+	const [ isWithinListView, setIsWithinListView ] = useState( false );
+
+	// TODO: Add RTL support.
+	// const rtl = isRTL();
+
+	const [ rootBlockElement ] = useMemo( () => {
+		if ( ! listViewRef.current ) {
+			return [];
+		}
+		// The rootClientId will be defined whenever dropping into inner
+		// block lists, but is undefined when dropping at the root level.
+		const _rootBlockElement = rootClientId
+			? listViewRef.current.querySelector(
+					`[data-block="${ rootClientId }"]`
+			  )
+			: undefined;
+		// The clientId represents the sibling block, the dragged block will
+		// usually be inserted adjacent to it. It will be undefined when
+		// dropping a block into an empty block list.
+		const _blockElement = clientId
+			? listViewRef.current.querySelector(
+					`[data-block="${ clientId }"]`
+			  )
+			: undefined;
+		return [ _rootBlockElement, _blockElement ];
+	}, [ listViewRef, rootClientId, clientId ] );
+
+	useEffect( () => {
+		let ariaLevel = 1;
+
+		if ( rootBlockElement ) {
+			const _ariaLevel = parseInt(
+				rootBlockElement.getAttribute( 'aria-level' ),
+				10
+			);
+
+			ariaLevel = _ariaLevel ? _ariaLevel + 1 : 1;
+		}
+
+		targetAriaLevelRef.current = ariaLevel;
+	}, [ rootBlockElement ] );
+
+	/**
+	 * Removes the element clone, resets cursor, and removes drag listener.
+	 *
+	 * @param {DragEvent} event The non-custom DragEvent.
+	 */
+	function end( event ) {
+		event.preventDefault();
+		cleanup.current();
+	}
+
+	/**
+	 * This method does a couple of things:
+	 *
+	 * - Clones the current element and spawns clone over original element.
+	 * - Adds a fake temporary drag image to avoid browser defaults.
+	 * - Sets transfer data.
+	 * - Adds dragover listener.
+	 *
+	 * @param {DragEvent} event The non-custom DragEvent.
+	 */
+	function start( event ) {
+		const { ownerDocument } = event.target;
+
+		event.dataTransfer.setData(
+			transferDataType,
+			JSON.stringify( transferData )
+		);
+
+		const cloneWrapper = ownerDocument.createElement( 'div' );
+		// Reset position to 0,0. Natural stacking order will position this lower, even with a transform otherwise.
+		cloneWrapper.style.top = '0';
+		cloneWrapper.style.left = '0';
+
+		const dragImage = ownerDocument.createElement( 'div' );
+
+		// Set a fake drag image to avoid browser defaults. Remove from DOM
+		// right after. event.dataTransfer.setDragImage is not supported yet in
+		// IE, we need to check for its existence first.
+		if ( 'function' === typeof event.dataTransfer.setDragImage ) {
+			dragImage.classList.add( dragImageClass );
+			ownerDocument.body.appendChild( dragImage );
+			event.dataTransfer.setDragImage( dragImage, 0, 0 );
+		}
+
+		cloneWrapper.classList.add( cloneWrapperClass );
+
+		if ( cloneClassname ) {
+			cloneWrapper.classList.add( cloneClassname );
+		}
+
+		let x = 0;
+		let y = 0;
+
+		const element = ownerDocument.getElementById( elementId );
+
+		const _originalAriaLevel = element.getAttribute( 'aria-level' );
+
+		if ( _originalAriaLevel ) {
+			originalAriaLevelRef.current = parseInt( _originalAriaLevel, 10 );
+		}
+
+		// Prepare element clone and append to element wrapper.
+		const elementRect = element.getBoundingClientRect();
+		const elementTopOffset = elementRect.top;
+		const elementLeftOffset = elementRect.left;
+
+		cloneWrapper.style.width = `${
+			elementRect.width + clonePadding * 2
+		}px`;
+
+		const clone = element.cloneNode( true );
+		clone.id = `clone-${ elementId }`;
+
+		// Position clone right over the original element (20px padding).
+		x = elementLeftOffset - clonePadding;
+		y = elementTopOffset - clonePadding;
+		cloneWrapper.style.transform = `translate( ${ x }px, ${ y }px )`;
+
+		// Hack: Remove iFrames as it's causing the embeds drag clone to freeze.
+		Array.from( clone.querySelectorAll( 'iframe' ) ).forEach( ( child ) =>
+			child.parentNode?.removeChild( child )
+		);
+
+		cloneWrapper.appendChild( clone );
+
+		ownerDocument.body.appendChild( cloneWrapper );
+
+		// Mark the current cursor coordinates.
+		let cursorLeft = event.clientX;
+		let cursorTop = event.clientY;
+
+		function over( e ) {
+			if ( listViewRef.current ) {
+				if (
+					! isWithinListView &&
+					listViewRef.current.contains( e.target )
+				) {
+					setIsWithinListView( true );
+				} else if (
+					isWithinListView &&
+					! listViewRef.current.contains( e.target )
+				) {
+					setIsWithinListView( false );
+				}
+			}
+
+			// Skip doing any work if mouse has not moved.
+			if ( cursorLeft === e.clientX && cursorTop === e.clientY ) {
+				return;
+			}
+
+			const horizontalOffset =
+				( targetAriaLevelRef.current - originalAriaLevelRef.current ) *
+				28;
+
+			const nextY = y + e.clientY - cursorTop;
+			const nextX = x + horizontalOffset;
+
+			cloneWrapper.style.transform = `translate( ${ nextX }px, ${ nextY }px )`;
+			cursorLeft = e.clientX;
+			cursorTop = e.clientY;
+			// x = nextX;
+			y = nextY;
+		}
+
+		// Aim for 60fps (16 ms per frame) for now. We can potentially use requestAnimationFrame (raf) instead,
+		// note that browsers may throttle raf below 60fps in certain conditions.
+		// @ts-ignore
+		const throttledDragOver = throttle( over, 16 );
+
+		ownerDocument.addEventListener( 'dragover', throttledDragOver );
+
+		// Update cursor to 'grabbing', document wide.
+		ownerDocument.body.classList.add( bodyClass );
+
+		cleanup.current = () => {
+			// Remove drag clone.
+			if ( cloneWrapper && cloneWrapper.parentNode ) {
+				cloneWrapper.parentNode.removeChild( cloneWrapper );
+			}
+
+			if ( dragImage && dragImage.parentNode ) {
+				dragImage.parentNode.removeChild( dragImage );
+			}
+
+			// Reset cursor.
+			ownerDocument.body.classList.remove( bodyClass );
+
+			ownerDocument.removeEventListener( 'dragover', throttledDragOver );
+		};
+	}
+
+	useEffect(
+		() => () => {
+			cleanup.current();
+		},
+		[]
+	);
+
+	return {
+		dragChipOnDragStart: start,
+		dragChipOnDragEnd: end,
+		isWithinListView,
+	};
+}

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -490,7 +490,7 @@ export default function useListViewDropZone( {
 	const throttled = useThrottle(
 		useCallback(
 			( event, currentTarget ) => {
-				const position = { x: event.clientX, y: event.clientY };
+				let position = { x: event.clientX, y: event.clientY };
 				const isBlockDrag = !! draggedBlockClientIds?.length;
 
 				const blockElements = Array.from(
@@ -530,6 +530,22 @@ export default function useListViewDropZone( {
 							: true,
 					};
 				} );
+
+				const { ownerDocument } = currentTarget || {};
+				const dragChipBlockElement = ownerDocument?.querySelector(
+					'.block-editor-list-view-draggable-chip .block-editor-block-icon'
+				);
+
+				if ( dragChipBlockElement ) {
+					const dragChipBlockRect =
+						dragChipBlockElement.getBoundingClientRect();
+					position = {
+						x: rtl
+							? dragChipBlockRect.right
+							: dragChipBlockRect.left,
+						y: dragChipBlockRect.top + dragChipBlockRect.height / 2,
+					};
+				}
 
 				const newTarget = getListViewDropTarget(
 					blocksData,

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -490,7 +490,7 @@ export default function useListViewDropZone( {
 	const throttled = useThrottle(
 		useCallback(
 			( event, currentTarget ) => {
-				let position = { x: event.clientX, y: event.clientY };
+				const position = { x: event.clientX, y: event.clientY };
 				const isBlockDrag = !! draggedBlockClientIds?.length;
 
 				const blockElements = Array.from(
@@ -530,22 +530,6 @@ export default function useListViewDropZone( {
 							: true,
 					};
 				} );
-
-				const { ownerDocument } = currentTarget || {};
-				const dragChipBlockElement = ownerDocument?.querySelector(
-					'.block-editor-list-view-draggable-chip .block-editor-block-icon'
-				);
-
-				if ( dragChipBlockElement ) {
-					const dragChipBlockRect =
-						dragChipBlockElement.getBoundingClientRect();
-					position = {
-						x: rtl
-							? dragChipBlockRect.right
-							: dragChipBlockRect.left,
-						y: dragChipBlockRect.top + dragChipBlockRect.height / 2,
-					};
-				}
 
 				const newTarget = getListViewDropTarget(
 					blocksData,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follows on from: https://github.com/WordPress/gutenberg/pull/56625/, resolves: https://github.com/WordPress/gutenberg/issues/56539

In the List View, when dragging a block, make the drag chip resemble the list row that is being dragged.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It creates a smoother experience (🤞) while dragging if we keep the thing that the user is dragging visibly similar to what the user clicked on — it means the UI has less "jump" and it hopefully feels like the user is really dragging that item, rather than an abstraction (the former drag chip)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Borrow the last working state of the code from https://github.com/WordPress/gutenberg/pull/56625

* Update `useMovingAnimation` so that it always looks at the rect of where the element really is
* Allow `useMovingAnimation` to accept a selector for the element to match the position of
* Pass in an `id` of the element to be used for the drag chip, so that that element can be copied for the drag chip, and so that it can be referenced when animating the item in to its final position

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Try dragging and dropping within the list view:

* Test the post and site editors
* Test the dark mode navigation editor in the site editor's browse mode
* Test the list view in the right hand sidebar when editing a navigation block
* Try dragging a multi selection
* Try dragging to different levels of nesting

## Screenshots or screencast <!-- if applicable -->

Light mode is looking pretty good:

https://github.com/WordPress/gutenberg/assets/14988353/0b6f6727-5544-458f-98ba-71ce614fc9db

Dark mode could use some work:

https://github.com/WordPress/gutenberg/assets/14988353/75b1a487-3dc7-4e70-ab59-fa856e740c65