### PR TITLE
Font Libary: Add missing translation functions

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/google-fonts-confirm-dialog.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/google-fonts-confirm-dialog.js
@@ -24,7 +24,7 @@ function GoogleFontsConfirmDialog() {
 		<div className="font-library__google-fonts-confirm">
 			<Card>
 				<CardBody>
-					<Text as="h3">Connect to Google Fonts</Text>
+					<Text as="h3">{ __( 'Connect to Google Fonts' ) }</Text>
 					<Spacer margin={ 6 } />
 					<Text as="p">
 						{ __(


### PR DESCRIPTION
## What?

I noticed that some text in files related to the Font Library is not translatable.

## How?

~~Along with adding translation functions, I changed the text domain from `default` to `gutenberg`.~~

## Testing Instructions

All GitHub Actions should be green. These texts probably don't exist in core or Gutenberg, so if you change the language of your site, they shouldn't still be localized.
