### PR TITLE
DownloadableBlocksPanel: remove withSelect in favor of useSelect

### DIFF
--- a/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
@@ -16,13 +16,7 @@ function InserterMenuDownloadableBlocksPanel() {
 
 	return (
 		<__unstableInserterMenuExtension>
-			{ ( {
-				onSelect,
-				onHover,
-				filterValue,
-				hasItems,
-				rootClientId,
-			} ) => {
+			{ ( { onSelect, onHover, filterValue, hasItems } ) => {
 				if ( debouncedFilterValue !== filterValue ) {
 					debouncedSetFilterValue( filterValue );
 				}
@@ -35,7 +29,6 @@ function InserterMenuDownloadableBlocksPanel() {
 					<DownloadableBlocksPanel
 						onSelect={ onSelect }
 						onHover={ onHover }
-						rootClientId={ rootClientId }
 						filterValue={ debouncedFilterValue }
 						hasLocalBlocks={ hasItems }
 						isTyping={ filterValue !== debouncedFilterValue }


### PR DESCRIPTION
Fixing something I noticed when discussing #58058: `DownloadableBlocksPanel` is a functional component and yet it uses `withSelect`. This PR migrates that to a custom hook with `useSelect`.

**How to test:** Open block inserter in the left sidebar. Try to search for something. Verify that you are offered a list of downloadable matching blocks from the WP.org registry.