### PR TITLE
Avatar block: fix broken alignments in the editor

### DIFF
--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -192,22 +192,12 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 				avatar={ avatar }
 				setAttributes={ setAttributes }
 			/>
-			<div>
-				{ attributes.isLink ? (
-					<a
-						href="#avatar-pseudo-link"
-						className="wp-block-avatar__link"
-						onClick={ ( event ) => event.preventDefault() }
-					>
-						<ResizableAvatar
-							attributes={ attributes }
-							avatar={ avatar }
-							blockProps={ blockProps }
-							isSelected={ isSelected }
-							setAttributes={ setAttributes }
-						/>
-					</a>
-				) : (
+			{ attributes.isLink ? (
+				<a
+					href="#avatar-pseudo-link"
+					className="wp-block-avatar__link"
+					onClick={ ( event ) => event.preventDefault() }
+				>
 					<ResizableAvatar
 						attributes={ attributes }
 						avatar={ avatar }
@@ -215,8 +205,16 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 						isSelected={ isSelected }
 						setAttributes={ setAttributes }
 					/>
-				) }
-			</div>
+				</a>
+			) : (
+				<ResizableAvatar
+					attributes={ attributes }
+					avatar={ avatar }
+					blockProps={ blockProps }
+					isSelected={ isSelected }
+					setAttributes={ setAttributes }
+				/>
+			) }
 		</>
 	);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/54714

Right alignments don't work in the editor (and presumably left alignments on RTL mode was broken too) for the avatar block

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

An extra div in the editor was causing the global alignment rules to not apply correctly:

`body .is-layout-constrained > .alignright { float: right; }`

was never working for the block

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I removed the extra div, I couldn't find a reason for it there, and it's been there since [block creation](https://github.com/WordPress/gutenberg/pull/38591)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Insert the avatar block in the editor
Align it left right or center, it should work both in the editor and the frontend

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="974" alt="Screenshot 2024-01-23 at 12 02 56" src="https://github.com/WordPress/gutenberg/assets/3593343/4baaad1e-8e9b-41af-8235-e9ceddc62b63">


After:

<img width="717" alt="Screenshot 2024-01-23 at 11 55 21" src="https://github.com/WordPress/gutenberg/assets/3593343/4da50e29-e2cf-44fe-a2b6-9f3e1aa1caac">


