### PR TITLE
DataViews: better management of `layout` param in templates

### DIFF
--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -166,7 +166,9 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 	const defaultView = useMemo( () => {
 		return {
 			...DEFAULT_VIEW,
-			type: layout ?? DEFAULT_VIEW.type,
+			type: window?.__experimentalAdminViews
+				? layout ?? DEFAULT_VIEW.type
+				: DEFAULT_VIEW.type,
 		};
 	}, [ layout ] );
 	const [ view, setView ] = useState( defaultView );

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -120,6 +120,8 @@ export default function useSyncPathWithURL() {
 				( navigatorLocation.path === '/page' &&
 					window?.__experimentalAdminViews ) ||
 				( navigatorLocation.path === '/wp_template/all' &&
+					window?.__experimentalAdminViews ) ||
+				( navigatorLocation.path === '/wp_template_part/all' &&
 					window?.__experimentalAdminViews )
 			) {
 				updateUrlParams( {

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -102,6 +102,19 @@ export default function useSyncPathWithURL() {
 					path: navigatorLocation.path,
 				} );
 			} else if (
+				navigatorLocation.path === '/wp_template/all' &&
+				! window?.__experimentalAdminViews
+			) {
+				// When the experiment is disabled, we only support table layout.
+				// Clear it out from the URL, so layouts other than table cannot be accessed.
+				updateUrlParams( {
+					postType: undefined,
+					categoryType: undefined,
+					categoryId: undefined,
+					path: navigatorLocation.path,
+					layout: undefined,
+				} );
+			} else if (
 				// These sidebar paths are special in the sense that the url in these pages may or may not have a postId and we need to retain it if it has.
 				// The "type" property should be kept as well.
 				( navigatorLocation.path === '/page' &&
@@ -109,7 +122,7 @@ export default function useSyncPathWithURL() {
 				( navigatorLocation.path === '/wp_template' &&
 					window?.__experimentalAdminViews ) ||
 				( navigatorLocation.path === '/wp_template/all' &&
-					! window?.__experimentalAdminViews )
+					window?.__experimentalAdminViews )
 			) {
 				updateUrlParams( {
 					postType: undefined,

--- a/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-sync-path-with-url.js
@@ -119,8 +119,6 @@ export default function useSyncPathWithURL() {
 				// The "type" property should be kept as well.
 				( navigatorLocation.path === '/page' &&
 					window?.__experimentalAdminViews ) ||
-				( navigatorLocation.path === '/wp_template' &&
-					window?.__experimentalAdminViews ) ||
 				( navigatorLocation.path === '/wp_template/all' &&
 					window?.__experimentalAdminViews )
 			) {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/58079

## What

Improves how the `layout` URL parameter is handled.

- With the "admin views" experiment enabled, reloading the page maintains the layout parameter if it was present.
- With the "admin views" experiment disabled:
  - the `layout` param is removed from the URL
  - no layouts other than table are loaded

## Why?

The templates page has both a stable & an experimental dataviews-powered page. We need to make sure both experiences work great without leaking into each other.

## How?

- Updates the conditions to clear the URL parameters.
- Adds conditional logic in the templates page.

## Testing Instructions

With the "admin views" experiment **disabled**:

- Navigate to "Site Editor > Templates > Manage all templates". Verify all you see is the table layout.
- Add the `layout=grid` to the URL and hit enter. Verify it's removed, and the table layout is still displayed.

https://github.com/WordPress/gutenberg/assets/583546/36141f00-5f9e-4db4-be6b-c83dede0244a

With the "admin views" experiment **enabled**:

- Navigate to "Site Editor > Templates > Manage all templates". Verify the table layout is the default.
- Change layout to `list` and verify that it's updated, and the URL has a `layout=list` parameter.
- Hit the browser's reload page and verify that the layout parameter is retained in the URL and that the list layout is loaded.

https://github.com/WordPress/gutenberg/assets/583546/9f4aa38c-a48b-450b-908a-99d7b571ec56
