### PR TITLE
Fix font variants count color contrast ratio and l10n.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-family-item.js
+++ b/packages/edit-site/src/components/global-styles/font-family-item.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { _n } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import {
 	__experimentalHStack as HStack,
 	__experimentalItem as Item,
@@ -32,9 +32,12 @@ function FontFamilyItem( { font } ) {
 		<Item onClick={ handleClick }>
 			<HStack justify="space-between">
 				<FlexItem style={ previewStyle }>{ font.name }</FlexItem>
-				<FlexItem style={ { color: '#9e9e9e' } }>
-					{ variantsCount }{ ' ' }
-					{ _n( 'variant', 'variants', variantsCount ) }
+				<FlexItem className="edit-site-global-styles-screen-typography__font-variants-count">
+					{ sprintf(
+						/* translators: %d: Number of font variants. */
+						_n( '%d variant', '%d variants', variantsCount ),
+						variantsCount
+					) }
 				</FlexItem>
 			</HStack>
 		</Item>

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -42,6 +42,10 @@
 	border-radius: $radius-block-ui;
 }
 
+.edit-site-global-styles-screen-typography__font-variants-count {
+	color: $gray-700;
+}
+
 .edit-site-global-styles-screen-colors {
 	margin: $grid-unit-20;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58110

## What?
<!-- In a few words, what is the PR actually doing? -->
- The font variants count has a too low color contrast ratio. Also, it uses an unique color that isn't in the color palette.
- The usage of the `_n()` function doesn't follow the WordPress localization best practices.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- A minimum color contrast ratio of 4.5:1 is required for all text (with the exception of large text and disabled controls).
- Concatenation is not allowed for translatable strings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Uses the `$gray-700` color, which is the lightest gray that can be used on a white background.
- Uses a `sprintf` and a placeholder instead of concatenation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to Site editor > Styles > Typography.
- Observe the font variants count text is now gray `#757575`.
- Observe singular / plural form is still working properly.

Screenshot before and after:

![Screenshot 2024-01-23 at 10 46 31](https://github.com/WordPress/gutenberg/assets/1682452/34db0148-622c-4abb-9102-6139614e9bd6)



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
