### PR TITLE
Docs: Use 'key' in 'editor.BlockEdit' filter code examples

### DIFF
--- a/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
+++ b/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
@@ -208,13 +208,13 @@ export const withBookQueryControls = ( BlockEdit ) => ( props ) => {
 	// function to handle that.
 	return isMyBooksVariation( props ) ? (
 		<>
-			<BlockEdit { ...props } />
+			<BlockEdit key="edit" { ...props } />
 			<InspectorControls>
 				<BookAuthorSelector /> { /** Our custom component */ }
 			</InspectorControls>
 		</>
 	) : (
-		<BlockEdit { ...props } />
+		<BlockEdit key="edit" { ...props } />
 	);
 };
 

--- a/docs/reference-guides/filters/block-filters.md
+++ b/docs/reference-guides/filters/block-filters.md
@@ -189,7 +189,7 @@ const withMyPluginControls = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
 		return (
 			<>
-				<BlockEdit { ...props } />
+				<BlockEdit key="edit" { ...props } />
 				<InspectorControls>
 					<PanelBody>My custom control</PanelBody>
 				</InspectorControls>


### PR DESCRIPTION
## What?
PR updates the `editor.BlockEdit` filter code examples and sets static `key` for the original `BlockEdit` component.

## Why?
tl;dr - it is just good practice, and most folks don't need to worry about technical details.

The `key` prevents the `BlockEdit` component from remounting if its position changes after the initial render. When the `key` is provided, React will use it as a part of the position instead of the order in the parent component.

Remounting can have [unexpected side effects](https://github.com/WordPress/gutenberg/pull/50292) and sometimes even affect the performance.

## Testing Instructions
None