### PR TITLE
Storybook: Add badges to private components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
 				"@emotion/babel-plugin": "11.3.0",
 				"@emotion/jest": "11.7.1",
 				"@emotion/native": "11.0.0",
+				"@geometricpanda/storybook-addon-badges": "2.0.1",
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.6.0",
@@ -5150,6 +5151,31 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
 			"integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+		},
+		"node_modules/@geometricpanda/storybook-addon-badges": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@geometricpanda/storybook-addon-badges/-/storybook-addon-badges-2.0.1.tgz",
+			"integrity": "sha512-dCEK/xJewuFe1d+ndF0hQIAJRnUsV9q5kuDmp7zvO7fTd7cDz0X9Bjz0lNRn6n4Z9bL9/iFHKzJESDHFfs4ihQ==",
+			"dev": true,
+			"peerDependencies": {
+				"@storybook/blocks": "^7.0.0",
+				"@storybook/components": "^7.0.0",
+				"@storybook/core-events": "^7.0.0",
+				"@storybook/manager-api": "^7.0.0",
+				"@storybook/preview-api": "^7.0.0",
+				"@storybook/theming": "^7.0.0",
+				"@storybook/types": "^7.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.2.1",
@@ -59791,6 +59817,12 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
 			"integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+		},
+		"@geometricpanda/storybook-addon-badges": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@geometricpanda/storybook-addon-badges/-/storybook-addon-badges-2.0.1.tgz",
+			"integrity": "sha512-dCEK/xJewuFe1d+ndF0hQIAJRnUsV9q5kuDmp7zvO7fTd7cDz0X9Bjz0lNRn6n4Z9bL9/iFHKzJESDHFfs4ihQ==",
+			"dev": true
 		},
 		"@hapi/hoek": {
 			"version": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"@emotion/babel-plugin": "11.3.0",
 		"@emotion/jest": "11.7.1",
 		"@emotion/native": "11.0.0",
+		"@geometricpanda/storybook-addon-badges": "2.0.1",
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",

--- a/packages/components/src/custom-select-control-v2/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control-v2/stories/index.story.tsx
@@ -26,6 +26,7 @@ const meta: Meta< typeof CustomSelect > = {
 		value: { control: { type: null } },
 	},
 	parameters: {
+		badges: [ 'wip' ],
 		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: {

--- a/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
@@ -58,6 +58,7 @@ const meta: Meta< typeof DropdownMenu > = {
 	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
+		badges: [ 'private' ],
 		controls: { expanded: true },
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/packages/components/src/progress-bar/stories/index.story.tsx
+++ b/packages/components/src/progress-bar/stories/index.story.tsx
@@ -15,6 +15,7 @@ const meta: Meta< typeof ProgressBar > = {
 		value: { control: { type: 'number', min: 0, max: 100, step: 1 } },
 	},
 	parameters: {
+		badges: [ 'private' ],
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -30,6 +30,7 @@ const meta: Meta< typeof Tabs > = {
 	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
+		badges: [ 'private' ],
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/theme/stories/index.story.tsx
+++ b/packages/components/src/theme/stories/index.story.tsx
@@ -19,6 +19,7 @@ const meta: Meta< typeof Theme > = {
 		background: { control: { type: 'color' } },
 	},
 	parameters: {
+		badges: [ 'private' ],
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -52,6 +52,7 @@ module.exports = {
 		'@storybook/addon-toolbars',
 		'@storybook/addon-actions',
 		'storybook-source-link',
+		'@geometricpanda/storybook-addon-badges',
 	],
 	framework: {
 		name: '@storybook/react-webpack5',

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -114,6 +114,14 @@ export const parameters = {
 				],
 			},
 		},
+		wip: {
+			title: '🚧 WIP',
+			styles: { backgroundColor: '#FFF0BD' },
+			tooltip: {
+				title: 'Component is a work in progress',
+				desc: 'This component is not ready for use in production, including the Gutenberg codebase. DO NOT export outside of @wordpress/components.',
+			},
+		},
 	},
 	controls: {
 		sort: 'requiredFirst',

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -99,6 +99,22 @@ export const decorators = [
 ];
 
 export const parameters = {
+	// For @geometricpanda/storybook-addon-badges
+	badgesConfig: {
+		private: {
+			title: '🔒 Private',
+			tooltip: {
+				title: 'Component is locked as a private API',
+				desc: 'We do not yet recommend using this outside of the Gutenberg codebase.',
+				links: [
+					{
+						title: 'About @wordpress/private-apis',
+						href: 'https://developer.wordpress.org/block-editor/reference-guides/packages/packages-private-apis/',
+					},
+				],
+			},
+		},
+	},
 	controls: {
 		sort: 'requiredFirst',
 	},


### PR DESCRIPTION
## What?

Adds an informational badge to the Storybook pages of any components that are still locked as private.

## Why?

We currently don't have a way to tell from the Storybook which components are "experimental" (implicitly public) vs. "private".

I think we should prefer badge-based solutions like this rather than groupings in the sidebar, because the grouping names affect URLs and will break hyperlinks whenever there are status changes.

## How?

Uses an addon called [Storybook Addon Badges](https://storybook.js.org/addons/@geometricpanda/storybook-addon-badges), which seems to be the most popular addon of its kind.

## Testing Instructions

See the Storybook pages for any private component, e.g. Tabs or ProgressBar.

## Screenshots or screencast <!-- if applicable -->
<img src="https://github.com/WordPress/gutenberg/assets/555336/5e443fe0-ef37-49fa-adf1-4569fcb050f0" alt="Storybook for Tabs, with the Private badge in the toolbar" width="400"> 
<img src="https://github.com/WordPress/gutenberg/assets/555336/b0508438-989e-4f2c-a191-fffdbb4dfce6" alt="The private badge with the informational popover expanded" width="400">

