### PR TITLE
Tooltip: accept specific tooltip props

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 -   `ToggleGroupControl`: Improve controlled value detection ([#57770](https://github.com/WordPress/gutenberg/pull/57770)).
 -   `Tooltip`: Improve props forwarding to children of nested `Tooltip` components ([#57878](https://github.com/WordPress/gutenberg/pull/57878)).
+-   `Tooltip`: revert prop types to only accept component-specific props ([#58125](https://github.com/WordPress/gutenberg/pull/58125)).
 
 ### Experimental
 

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -25,7 +25,6 @@ import type {
 } from './types';
 import Shortcut from '../shortcut';
 import { positionToPlacement } from '../popover/utils';
-import type { WordPressComponentProps } from '../context';
 
 const TooltipInternalContext = createContext< TooltipInternalContextType >( {
 	isNestedInTooltip: false,
@@ -41,7 +40,7 @@ const CONTEXT_VALUE = {
 };
 
 function UnforwardedTooltip(
-	props: WordPressComponentProps< TooltipProps, 'div', false >,
+	props: TooltipProps,
 	ref: React.ForwardedRef< any >
 ) {
 	const {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Narrow the type associated to the `Tooltip` component's prop to only the explicit component's props

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The type was widened in #57202, but the change is not necessary anymore after #57878 (and it can cause the component to behave unexpectedly in some cases).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By not using `WordPressComponentProps` when defining the type of the props object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This PR doesn't include any runtime changes.
Make sure that tests pass and that the project builds correctly.
