### PR TITLE
Font Library Preview: fix quoting of fontFamily property

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -9,6 +9,7 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { FONT_WEIGHTS, FONT_STYLES } from './constants';
 import { unlock } from '../../../../lock-unlock';
 import { fetchInstallFontFace } from '../resolvers';
+import { formatFontFamily } from './preview-styles';
 
 /**
  * Browser dependencies
@@ -97,10 +98,14 @@ export async function loadFontFaceInBrowser( fontFace, source, addTo = 'all' ) {
 		return;
 	}
 
-	const newFont = new window.FontFace( fontFace.fontFamily, dataSource, {
-		style: fontFace.fontStyle,
-		weight: fontFace.fontWeight,
-	} );
+	const newFont = new window.FontFace(
+		formatFontFamily( fontFace.fontFamily ),
+		dataSource,
+		{
+			style: fontFace.fontStyle,
+			weight: fontFace.fontWeight,
+		}
+	);
 
 	const loadedFace = await newFont.load();
 

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -93,10 +93,11 @@ export async function loadFontFaceInBrowser( fontFace, source, addTo = 'all' ) {
 		// eslint-disable-next-line no-undef
 	} else if ( source instanceof File ) {
 		dataSource = await source.arrayBuffer();
+	} else {
+		return;
 	}
 
-	// eslint-disable-next-line no-undef
-	const newFont = new FontFace( fontFace.fontFamily, dataSource, {
+	const newFont = new window.FontFace( fontFace.fontFamily, dataSource, {
 		style: fontFace.fontStyle,
 		weight: fontFace.fontWeight,
 	} );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -35,9 +35,9 @@ export function formatFontFamily( input ) {
 		.split( ',' )
 		.map( ( font ) => {
 			font = font.trim(); // Remove any leading or trailing white spaces
-			// If the font doesn't have single quotes and contains a space, then add single quotes around it
-			if ( ! font.startsWith( "'" ) && font.indexOf( ' ' ) !== -1 ) {
-				return `'${ font }'`;
+			// If the font doesn't start with quotes and contains a space, then wrap in quotes.
+			if ( ! font.startsWith( '"\'' ) && font.indexOf( ' ' ) !== -1 ) {
+				return `"${ font }"`;
 			}
 			return font; // Return font as is if no transformation is needed
 		} )

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/preview-styles.js
@@ -36,7 +36,11 @@ export function formatFontFamily( input ) {
 		.map( ( font ) => {
 			font = font.trim(); // Remove any leading or trailing white spaces
 			// If the font doesn't start with quotes and contains a space, then wrap in quotes.
-			if ( ! font.startsWith( '"\'' ) && font.indexOf( ' ' ) !== -1 ) {
+			// Check that string starts with a single or double quote and not a space
+			if (
+				! ( font.startsWith( '"' ) || font.startsWith( "'" ) ) &&
+				font.indexOf( ' ' ) !== -1
+			) {
 				return `"${ font }"`;
 			}
 			return font; // Return font as is if no transformation is needed

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/preview-styles.spec.js
@@ -123,13 +123,13 @@ describe( 'getFamilyPreviewStyle', () => {
 describe( 'formatFontFamily', () => {
 	it( 'should transform "Baloo 2, system-ui" correctly', () => {
 		expect( formatFontFamily( 'Baloo 2, system-ui' ) ).toBe(
-			"'Baloo 2', system-ui"
+			'"Baloo 2", system-ui'
 		);
 	} );
 
 	it( 'should ignore extra spaces', () => {
 		expect( formatFontFamily( '  Baloo 2   , system-ui' ) ).toBe(
-			"'Baloo 2', system-ui"
+			'"Baloo 2", system-ui'
 		);
 	} );
 
@@ -144,18 +144,18 @@ describe( 'formatFontFamily', () => {
 	} );
 
 	it( 'should wrap single font name with spaces in quotes', () => {
-		expect( formatFontFamily( 'Baloo 2' ) ).toBe( "'Baloo 2'" );
+		expect( formatFontFamily( 'Baloo 2' ) ).toBe( '"Baloo 2"' );
 	} );
 
 	it( 'should wrap multiple font names with spaces in quotes', () => {
 		expect( formatFontFamily( 'Baloo Bhai 2, Baloo 2' ) ).toBe(
-			"'Baloo Bhai 2', 'Baloo 2'"
+			'"Baloo Bhai 2", "Baloo 2"'
 		);
 	} );
 
 	it( 'should wrap only those font names with spaces which are not already quoted', () => {
 		expect( formatFontFamily( 'Baloo Bhai 2, Arial' ) ).toBe(
-			"'Baloo Bhai 2', Arial"
+			'"Baloo Bhai 2", Arial'
 		);
 	} );
 } );


### PR DESCRIPTION
## What?

- Fix font face previews in the font library, which may not show up when the font family contains a space, e.g. Alegreya Sans
- Fix a console error when loading the preview

## Why?

To see previews for installed font faces.

## How?

Make sure font family names are quoted only once.

## Testing Instructions

- Install a font in the Font Library that has a name with a space, like "Alegreya Sans"
- Without this branch
    - The font face previews (after you click on the font name to see its variants) will not preview correctly
    - You may see a console error: `Uncaught (in promise) DOMException: An invalid or illegal string was specified - loadFontFaceInBrowser index.js:104`
- With this branch
    - Previews show correctly
    - There is not console error