### PR TITLE
Fix font face files not being removed when deleting family

### DIFF
--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -239,7 +239,7 @@ if ( ! function_exists( '_wp_before_delete_font_face' ) ) {
 			return;
 		}
 
-		$font_files = get_post_meta( $post_id, '_wp_font_face_files', false );
+		$font_files = get_post_meta( $post_id, '_wp_font_face_file', false );
 
 		foreach ( $font_files as $font_file ) {
 			wp_delete_file( wp_get_font_dir()['path'] . '/' . $font_file );


### PR DESCRIPTION
Fixes a typo that was preventing font files from not being removed when the parent font family or font face is removed.

## Testing Instructions

- Install a font from the default font library
- Delete it
- See that font files are also deleted from `wp-content/fonts`