### PR TITLE
Footnotes: combine format store subscription

### DIFF
--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -15,7 +15,7 @@ import {
 	privateApis,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
+import { store as coreDataStore } from '@wordpress/core-data';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 
 /**
@@ -54,43 +54,42 @@ export const format = {
 			getBlockName,
 			getBlockParentsByBlockName,
 		} = registry.select( blockEditorStore );
-		const hasFootnotesBlockType = useSelect(
-			( select ) =>
-				!! select( blocksStore ).getBlockType( 'core/footnotes' ),
-			[]
-		);
-		/*
-		 * This useSelect exists because we need to use its return value
-		 * outside the event callback.
-		 */
-		const isBlockWithinPattern = useSelect( ( select ) => {
-			const {
-				getBlockParentsByBlockName: _getBlockParentsByBlockName,
-				getSelectedBlockClientId: _getSelectedBlockClientId,
-			} = select( blockEditorStore );
-			const parentCoreBlocks = _getBlockParentsByBlockName(
-				_getSelectedBlockClientId(),
-				SYNCED_PATTERN_BLOCK_NAME
-			);
-			return parentCoreBlocks && parentCoreBlocks.length > 0;
-		}, [] );
+		const isFootnotesSupported = useSelect(
+			( select ) => {
+				if (
+					! select( blocksStore ).getBlockType( 'core/footnotes' )
+				) {
+					return false;
+				}
 
-		const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId );
-		const footnotesSupported = 'string' === typeof meta?.footnotes;
+				const { meta } = select( coreDataStore ).getEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+
+				if ( 'string' !== typeof meta?.footnotes ) {
+					return false;
+				}
+
+				// Checks if the selected block lives within a pattern.
+				const {
+					getBlockParentsByBlockName: _getBlockParentsByBlockName,
+					getSelectedBlockClientId: _getSelectedBlockClientId,
+				} = select( blockEditorStore );
+				const parentCoreBlocks = _getBlockParentsByBlockName(
+					_getSelectedBlockClientId(),
+					SYNCED_PATTERN_BLOCK_NAME
+				);
+				return ! parentCoreBlocks || parentCoreBlocks.length === 0;
+			},
+			[ postType, postId ]
+		);
 
 		const { selectionChange, insertBlock } =
 			useDispatch( blockEditorStore );
 
-		if ( ! hasFootnotesBlockType ) {
-			return null;
-		}
-
-		if ( ! footnotesSupported ) {
-			return null;
-		}
-
-		// Checks if the selected block lives within a pattern.
-		if ( isBlockWithinPattern ) {
+		if ( ! isFootnotesSupported ) {
 			return null;
 		}
 

--- a/packages/block-library/src/footnotes/format.js
+++ b/packages/block-library/src/footnotes/format.js
@@ -62,13 +62,13 @@ export const format = {
 					return false;
 				}
 
-				const { meta } = select( coreDataStore ).getEntityRecord(
+				const entityRecord = select( coreDataStore ).getEntityRecord(
 					'postType',
 					postType,
 					postId
 				);
 
-				if ( 'string' !== typeof meta?.footnotes ) {
+				if ( 'string' !== typeof entityRecord?.meta?.footnotes ) {
 					return false;
 				}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I'm not sure if this is the cause of the small recent typing performance regression, but it's worth optimising anyway I think.

Instead of using `useEntityProp`, we can directly use the `getEntityRecord`. Under the hook, `useEntityProp` is a bit heavier because it also checks the `getEditedEntityRecord` selector. Additionally it will trigger component re-renders when any meta value changes. We only need the unedited entity record here to quickly check if footnotes is supported. The type of footnotes meta shouldn't change.

Additionally we can combine all `useSelect` calls into a single one that returns a boolean value, so the component will only re-render when this value changes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
