### PR TITLE
DataViews: enable grid layout for templates & parts by default

### DIFF
--- a/packages/dataviews/src/view-actions.js
+++ b/packages/dataviews/src/view-actions.js
@@ -267,13 +267,11 @@ const ViewActions = memo( function ViewActions( {
 			}
 		>
 			<DropdownMenuGroup>
-				{ window?.__experimentalAdminViews && (
-					<ViewTypeMenu
-						view={ view }
-						onChangeView={ onChangeView }
-						supportedLayouts={ supportedLayouts }
-					/>
-				) }
+				<ViewTypeMenu
+					view={ view }
+					onChangeView={ onChangeView }
+					supportedLayouts={ supportedLayouts }
+				/>
 				<SortMenu
 					fields={ fields }
 					view={ view }

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -62,6 +62,10 @@ const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
 
+const SUPPORTED_LAYOUTS = window?.__experimentalAdminViews
+	? [ LAYOUT_TABLE, LAYOUT_GRID, LAYOUT_LIST ]
+	: [ LAYOUT_TABLE, LAYOUT_GRID ];
+
 const defaultConfigPerViewType = {
 	[ LAYOUT_TABLE ]: {
 		primaryField: 'title',
@@ -441,6 +445,7 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
 				deferredRendering={ ! view.hiddenFields?.includes( 'preview' ) }
+				supportedLayouts={ SUPPORTED_LAYOUTS }
 			/>
 		</Page>
 	);


### PR DESCRIPTION
Part https://github.com/WordPress/gutenberg/issues/55083

## What?

Enables the `grid` layout for templates and parts by default.

## Why?

The grid layout is now considered stable.

## How?

Controls the layouts available via the `supportedLayout` prop.

## Testing Instructions

- With the "admin views" experiment disabled, visit "Manage all templates"/"Manage all template parts" and verify that table and grid are available.
- With the "admin views" experiment disabled, visit "Manage all templates"/"Manage all template parts" and verify all layouts are available (table, grid, list).
