### PR TITLE
Font Library: Prevent error when installing a system font twice

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -286,10 +286,15 @@ function FontLibraryProvider( { children } ) {
 
 			// Use the sucessfully installed font faces
 			// As well as any font faces that were already installed (those will be activated)
-			fontFamilyToInstall.fontFace = [
-				...sucessfullyInstalledFontFaces,
-				...alreadyInstalledFontFaces,
-			];
+			if (
+				sucessfullyInstalledFontFaces?.length > 0 ||
+				alreadyInstalledFontFaces?.length > 0
+			) {
+				fontFamilyToInstall.fontFace = [
+					...sucessfullyInstalledFontFaces,
+					...alreadyInstalledFontFaces,
+				];
+			}
 
 			// Activate the font family (add the font family to the global styles).
 			activateCustomFontFamilies( [ fontFamilyToInstall ] );


### PR DESCRIPTION
## What?

Prevent an error when installing a system font twice. See this comment for an example:

https://github.com/WordPress/gutenberg/pull/57688#issuecomment-1906237768

## Why?

The desired behavior for installing duplicate fonts is to handle it gracefully, and take no action rather than throwing an error.

## How?

Add a check to make sure the `fontFace` property is only added to installed fonts when there are actual font faces (which system fonts do not have).

## Testing Instructions

- Install the Modern Fonts Stack example as a plugin on your site from: https://github.com/matiasbenedetto/modern-fonts-stacks-for-wp-font-library/pull/1
- Install any of the fonts from that collection twice. See that you do not get an error when installing the second time.