### PR TITLE
Add support for transform and letter spacing controls in Global Styles > Typography > Elements

### DIFF
--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -52,7 +52,7 @@ function filterElementBlockSupports( blockSupports, name, element ) {
 			return false;
 		}
 
-		// This is only available for heading
+		// This is only available for heading, button, caption and text
 		if (
 			support === 'textTransform' &&
 			! name &&
@@ -68,7 +68,7 @@ function filterElementBlockSupports( blockSupports, name, element ) {
 			return false;
 		}
 
-		// This is only available for headings
+		// This is only available for heading, button, caption and text
 		if (
 			support === 'letterSpacing' &&
 			! name &&

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -56,8 +56,13 @@ function filterElementBlockSupports( blockSupports, name, element ) {
 		if (
 			support === 'textTransform' &&
 			! name &&
-			! [ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
-				element
+			! (
+				[ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
+					element
+				) ||
+				element === 'button' ||
+				element === 'caption' ||
+				element === 'text'
 			)
 		) {
 			return false;
@@ -67,8 +72,13 @@ function filterElementBlockSupports( blockSupports, name, element ) {
 		if (
 			support === 'letterSpacing' &&
 			! name &&
-			! [ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
-				element
+			! (
+				[ 'heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes(
+					element
+				) ||
+				element === 'button' ||
+				element === 'caption' ||
+				element === 'text'
 			)
 		) {
 			return false;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/58080

Adds `textTransform` and `letterSpacing` supports to the text, caption and button elements

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It makes sense for these elements to have these controls

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I just added the elements to the exception in the filter, but I wonder if we could just remove the exception altogether since we are basically adding them to everything except `cite`. What do you think @richtabor ?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

On a block theme, go to Global styles > Typography > Elements
Change try setting the buttons to uppercase and give them some letter spacing
The changes should be reflected on the editor and the frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1417" alt="Screenshot 2024-01-23 at 19 18 56" src="https://github.com/WordPress/gutenberg/assets/3593343/3ca0e1f0-00d9-40be-bea8-ba62f80aac78">

