### PR TITLE
(WIP) Ignore deprecation messages for non-core-migrated preferences in the deprecation proxy

### DIFF
--- a/packages/preferences/src/store/selectors.js
+++ b/packages/preferences/src/store/selectors.js
@@ -20,31 +20,30 @@ const withDeprecatedKeys = ( originalGet ) => ( state, scope, name ) => {
 		'showListViewByDefault',
 	];
 
+	// Check if setting is in the list and scope is either 'core/edit-post' or 'core/edit-site'
 	if (
 		settingsToMoveToCore.includes( name ) &&
 		[ 'core/edit-post', 'core/edit-site' ].includes( scope )
 	) {
-		deprecated(
-			`wp.data.select( 'core/preferences' ).get( '${ scope }', '${ name }' )`,
-			{
-				since: '6.5',
-				alternative: `wp.data.select( 'core/preferences' ).get( 'core', '${ name }' )`,
-			}
-		);
-
 		const value = originalGet( state, 'core', name );
 
-		// Hotfix for 17.5. Some of the preferences in the list above haven't been
-		// migrated to core in 17.5 (i.e: `editorMode`, https://github.com/WordPress/gutenberg/pull/57642))
-		// so we should fallback to the passed scope to avoid unexpected `undefined` values.
-		if ( value === undefined ) {
-			console.error('KAWABANGA', name );
-			return originalGet( state, scope, name );
+		// If the value is found in the 'core' scope, return it and show deprecation message
+		if ( value !== undefined ) {
+			deprecated(
+				`wp.data.select( 'core/preferences' ).get( '${ scope }', '${ name }' )`,
+				{
+					since: '6.5',
+					alternative: `wp.data.select( 'core/preferences' ).get( 'core', '${ name }' )`,
+				}
+			);
+
+			return value;
 		}
 
-		return originalGet( state, 'core', name );
+		// If the value is not found in the 'core' scope, return it from the original scope without deprecation message
 	}
 
+	// Fallback to original scope for other cases
 	return originalGet( state, scope, name );
 };
 

--- a/packages/preferences/src/store/selectors.js
+++ b/packages/preferences/src/store/selectors.js
@@ -38,6 +38,7 @@ const withDeprecatedKeys = ( originalGet ) => ( state, scope, name ) => {
 		// migrated to core in 17.5 (i.e: `editorMode`, https://github.com/WordPress/gutenberg/pull/57642))
 		// so we should fallback to the passed scope to avoid unexpected `undefined` values.
 		if ( value === undefined ) {
+			console.error('KAWABANGA', name );
 			return originalGet( state, scope, name );
 		}
 


### PR DESCRIPTION
## What / Why / How

Follow up to (in chronological order):
* https://github.com/WordPress/gutenberg/pull/58016
* https://github.com/WordPress/gutenberg/pull/58031
* https://github.com/WordPress/gutenberg/pull/58100

https://github.com/WordPress/gutenberg/pull/58031 augmented the proxy added in https://github.com/WordPress/gutenberg/pull/58016 to make it fallback to the original scope if the setting (preference) was not found in the `core` scope. However, as part of this path, a deprecation message is also output. This deprecation message ends up breaking a lot of Jest tests because [@wordpress/jest-console](https://www.npmjs.com/package/@wordpress/jest-console) explicitly requires deprecation messages to be expected (using `toHaveWarnedWith`.

~At first, I thought about "fixing" those by ignoring those deprecation messages in the `release/17.5` branch, but after a discussion with @youknowriad, he correctly pointed out that a better 17.5-specific solution would be to just fallback to the `originalGet` call for any of the preferences that were not refactored to the `core` scope in `release/17.5`, which this PR aims to do.~

Actually, a more pragmatic solution would be to skip the deprecation message if:
* The original `get` call was asking for the preference in the `edit-site` or `edit-post` scope;
* and the preference cannot be found in the `core` scope.

This means that the preference has not been migrated yet to `core` in Gutenberg, and a deprecation message *should not* be shown.


## Testing Instructions

All checks should pass.


