### PR TITLE
Site editor: avoid double post content parse (alternative)

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	createContext,
-	useContext,
-	useCallback,
-	useMemo,
-} from '@wordpress/element';
+import { createContext, useContext, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 
@@ -132,6 +127,8 @@ export function useEntityProp( kind, name, prop, _id ) {
 	return [ value, setValue, fullValue ];
 }
 
+const parsedBlocksCache = new WeakMap();
+
 /**
  * Hook that returns block content getters and setters for
  * the nearest provided entity of the specified type.
@@ -153,16 +150,36 @@ export function useEntityProp( kind, name, prop, _id ) {
 export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
-	const { content, editedBlocks, meta } = useSelect(
+	const { blocks, meta } = useSelect(
 		( select ) => {
 			if ( ! id ) {
 				return {};
 			}
-			const { getEditedEntityRecord } = select( STORE_NAME );
+			const { getEditedEntityRecord, getEntityRecord } =
+				select( STORE_NAME );
 			const editedRecord = getEditedEntityRecord( kind, name, id );
+
+			let editedBlocks = editedRecord.blocks;
+
+			if ( ! editedBlocks ) {
+				if (
+					editedRecord.content &&
+					typeof editedRecord.content !== 'function'
+				) {
+					// Attach the cache to the original record.
+					const entityRecord = getEntityRecord( kind, name, id );
+					editedBlocks = parsedBlocksCache.get( entityRecord );
+					if ( ! editedBlocks ) {
+						editedBlocks = parse( editedRecord.content );
+						parsedBlocksCache.set( entityRecord, editedBlocks );
+					}
+				} else {
+					editedBlocks = EMPTY_ARRAY;
+				}
+			}
+
 			return {
-				editedBlocks: editedRecord.blocks,
-				content: editedRecord.content,
+				blocks: editedBlocks,
 				meta: editedRecord.meta,
 			};
 		},
@@ -170,20 +187,6 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	);
 	const { __unstableCreateUndoLevel, editEntityRecord } =
 		useDispatch( STORE_NAME );
-
-	const blocks = useMemo( () => {
-		if ( ! id ) {
-			return undefined;
-		}
-
-		if ( editedBlocks ) {
-			return editedBlocks;
-		}
-
-		return content && typeof content !== 'function'
-			? parse( content )
-			: EMPTY_ARRAY;
-	}, [ id, editedBlocks, content ] );
 
 	const updateFootnotes = useCallback(
 		( _blocks ) => updateFootnotesFromMeta( _blocks, meta ),

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -155,19 +155,18 @@ const parsedBlocksCache = new WeakMap();
 export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
-	const { content, editedBlocks, meta, entityRecord } = useSelect(
+	const { getEntityRecord } = useSelect( STORE_NAME );
+	const { content, editedBlocks, meta } = useSelect(
 		( select ) => {
 			if ( ! id ) {
 				return {};
 			}
-			const { getEditedEntityRecord, getEntityRecord } =
-				select( STORE_NAME );
+			const { getEditedEntityRecord } = select( STORE_NAME );
 			const editedRecord = getEditedEntityRecord( kind, name, id );
 			return {
 				editedBlocks: editedRecord.blocks,
 				content: editedRecord.content,
 				meta: editedRecord.meta,
-				entityRecord: getEntityRecord( kind, name, id ),
 			};
 		},
 		[ kind, name, id ]
@@ -188,6 +187,7 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return EMPTY_ARRAY;
 		}
 
+		const entityRecord = getEntityRecord( kind, name, id );
 		let _blocks = parsedBlocksCache.get( entityRecord );
 
 		if ( ! _blocks ) {
@@ -196,7 +196,7 @@ export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 		}
 
 		return _blocks;
-	}, [ id, editedBlocks, content ] );
+	}, [ kind, name, id, editedBlocks, content, getEntityRecord ] );
 
 	const updateFootnotes = useCallback(
 		( _blocks ) => updateFootnotesFromMeta( _blocks, meta ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Similar to #57863, but without changes to existing selectors.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In the Site Editor, `useEntityBlockEditor` is called twice (top level and inside the post content block) with the same record ID, so the content gets parsed twice because it only memos by hook instance. 

Improves the site editor load metric by at least 2%.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We can cache the parsed result with a weak map.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
