### PR TITLE
Revert "Block editor: avoid list re-rendering on select"

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -155,25 +155,38 @@ function Items( {
 	__experimentalAppenderTagName,
 	layout = defaultLayout,
 } ) {
-	const { order, temporarilyEditingAsBlocks } = useSelect(
-		( select ) => {
-			const {
-				getBlockOrderWithAsyncFlag,
-				__unstableGetTemporarilyEditingAsBlocks,
-			} = unlock( select( blockEditorStore ) );
-			return {
-				order: getBlockOrderWithAsyncFlag( rootClientId ),
-				temporarilyEditingAsBlocks:
-					__unstableGetTemporarilyEditingAsBlocks(),
-			};
-		},
-		[ rootClientId ]
-	);
+	const { order, selectedBlocks, visibleBlocks, temporarilyEditingAsBlocks } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlockOrder,
+					getSelectedBlockClientIds,
+					__unstableGetVisibleBlocks,
+					__unstableGetTemporarilyEditingAsBlocks,
+				} = select( blockEditorStore );
+				return {
+					order: getBlockOrder( rootClientId ),
+					selectedBlocks: getSelectedBlockClientIds(),
+					visibleBlocks: __unstableGetVisibleBlocks(),
+					temporarilyEditingAsBlocks:
+						__unstableGetTemporarilyEditingAsBlocks(),
+				};
+			},
+			[ rootClientId ]
+		);
 
 	return (
 		<LayoutProvider value={ layout }>
-			{ order.map( ( { clientId, isAsync } ) => (
-				<AsyncModeProvider key={ clientId } value={ isAsync }>
+			{ order.map( ( clientId ) => (
+				<AsyncModeProvider
+					key={ clientId }
+					value={
+						// Only provide data asynchronously if the block is
+						// not visible and not selected.
+						! visibleBlocks.has( clientId ) &&
+						! selectedBlocks.includes( clientId )
+					}
+				>
 					<BlockListBlock
 						rootClientId={ rootClientId }
 						clientId={ clientId }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -14,8 +14,6 @@ import {
 	__experimentalGetParsedPattern,
 	canInsertBlockType,
 	__experimentalGetAllowedPatterns,
-	getSelectedBlockClientIds,
-	__unstableGetVisibleBlocks,
 } from './selectors';
 import { getAllPatterns, checkAllowListRecursive } from './utils';
 
@@ -288,25 +286,3 @@ export const hasAllowedPatterns = createSelector(
 export function getLastFocus( state ) {
 	return state.lastFocus;
 }
-
-export const getBlockOrderWithAsyncFlag = createSelector(
-	( state, rootClientId ) => {
-		const order = getBlockOrder( state, rootClientId );
-		const selectedBlocks = getSelectedBlockClientIds( state );
-		const visibleBlocks = __unstableGetVisibleBlocks( state );
-		return order.map( ( clientId ) => ( {
-			clientId,
-			// Only provide data asynchronously if the block is
-			// not visible and not selected.
-			isAsync:
-				! visibleBlocks?.has( clientId ) &&
-				! selectedBlocks?.includes( clientId ),
-		} ) );
-	},
-	( state ) => [
-		state.blocks.order,
-		state.selection.selectionStart.clientId,
-		state.selection.selectionEnd.clientId,
-		state.blockVisibility,
-	]
-);


### PR DESCRIPTION
Reverts WordPress/gutenberg#57188

This introduced a typing performance regression.