### PR TITLE
feat: Improve the writing prompt

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -48,7 +48,7 @@ export function DefaultBlockAppender( {
 	const value =
 		typeof placeholder === 'string'
 			? decodeEntities( placeholder )
-			: __( 'Start writing…' );
+			: __( 'Type / to choose a block' );
 
 	const appenderStyles = [
 		styles.blockHolder,

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -19,6 +19,7 @@ const allowedParentBlockAlignments = [ 'left', 'center', 'right' ];
 function ParagraphBlock( {
 	attributes,
 	mergeBlocks,
+	isSelected,
 	onReplace,
 	setAttributes,
 	style,
@@ -93,7 +94,9 @@ function ParagraphBlock( {
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
-				placeholder={ placeholder || __( 'Start writing…' ) }
+				placeholder={
+					placeholder || ( isSelected ? __( 'Start writing…' ) : '' )
+				}
 				textAlign={ textAlignment }
 				__unstableEmbedURLOnPaste
 			/>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -95,7 +95,8 @@ function ParagraphBlock( {
 				onReplace={ onReplace }
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 				placeholder={
-					placeholder || ( isSelected ? __( 'Start writing…' ) : '' )
+					placeholder ||
+					( isSelected ? __( 'Type / to choose a block' ) : '' )
 				}
 				textAlign={ textAlignment }
 				__unstableEmbedURLOnPaste

--- a/packages/components/src/mobile/html-text-input/index.native.js
+++ b/packages/components/src/mobile/html-text-input/index.native.js
@@ -125,7 +125,7 @@ export class HTMLTextInput extends Component {
 						value={ this.state.value }
 						onChangeText={ this.edit }
 						onBlur={ this.stopEditing }
-						placeholder={ __( 'Start writing…' ) }
+						placeholder={ __( 'Start writing with text or HTML' ) }
 						placeholderTextColor={ placeholderStyle.color }
 						scrollEnabled={ false }
 						// [Only iOS] This prop prevents the text input from


### PR DESCRIPTION
> [!NOTE]
> This is a work in progress and the PR was opened for testing purposes.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent redundant writing prompts and update the prompt to introduce the slash
inserter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Reduce noise and more closely align with the web editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- feat: Hide writing prompt unless block is selected
- feat: Update writing prompt to present slash inserter

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
TBD

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
TBD

## Screenshots or screencast <!-- if applicable -->
TBD
