### PR TITLE
Reduce prominence of editable block outlines within a content-locked container

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -305,30 +305,27 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 
 // Indicate which blocks are editable within a locked context.
 // 1. User must be hovering an editor with renderingMode = 'template-lock'; or...
-.is-template-locked:hover,
-// ...a container block.
-.block-editor-block-list__block:hover {
-	// 2. Look for locked blocks; or...
-	.block-editor-block-list__block.is-editing-disabled,
-	// ...container blocks that have locked children.
-	&:has(> .block-editor-block-list__block.is-editing-disabled) {
-		// 3. Highlight any unlocked children of that locked block.
-		& > .block-editor-block-list__block:not(.is-editing-disabled):not(.is-selected):not(.has-child-selected) {
-			&::after {
-				content: "";
-				border-style: dotted;
-				position: absolute;
-				pointer-events: none;
-				top: $border-width;
-				left: $border-width;
-				right: $border-width;
-				bottom: $border-width;
-				border: 1px dotted var(--wp-admin-theme-color);
-				border-radius: $radius-block-ui - $border-width;
-			}
+.is-template-locked.is-hovered,
+// ...a pattern block.
+.is-reusable.is-hovered {
+	// 2. Highlight any unlocked children.
+	.block-editor-block-list__block:not(.is-editing-disabled):not(.is-selected):not(.has-child-selected) {
+		&::after {
+			content: "";
+			border-style: dotted;
+			position: absolute;
+			pointer-events: none;
+			top: $border-width;
+			left: $border-width;
+			right: $border-width;
+			bottom: $border-width;
+			border: 1px dotted var(--wp-admin-theme-color);
+			border-radius: $radius-block-ui - $border-width;
+		}
 
-			&.is-hovered::after {
-				background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+		// 3. Don't do grandchildren.
+		.block-editor-block-list__block:not(.is-editing-disabled):not(.is-selected):not(.has-child-selected) {
+			&::after {
 				border: none;
 			}
 		}

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -40,6 +40,7 @@ import {
 } from '../block-edit/context';
 import { useTypingObserver } from '../observe-typing';
 import { unlock } from '../../lock-unlock';
+import { useIsHovered } from './use-block-props/use-is-hovered';
 
 export const IntersectionObserver = createContext();
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
@@ -103,6 +104,7 @@ function Root( { className, ...settings } ) {
 				useBlockSelectionClearer(),
 				useInBetweenInserter(),
 				useTypingObserver(),
+				useIsHovered( { isEnabled: true } ),
 			] ),
 			className: classnames( 'is-root-container', className, {
 				'is-outline-mode': isOutlineMode,


### PR DESCRIPTION
## What?
Follow up to https://github.com/WordPress/gutenberg/pull/57901. Implements the suggestions made by @SaxonF in https://github.com/WordPress/gutenberg/pull/57901#issuecomment-1905234935.

## Why?
See the discussion leading to https://github.com/WordPress/gutenberg/pull/57901#issuecomment-1905234935.

## How?
Updates the CSS added in https://github.com/WordPress/gutenberg/pull/57901 to use `.is-hovered` instead of `:hover`. This prevents multiple outlines appearing in nested blocks because `.is-hovered` uses `event.preventDefault()` internally.

## Testing Instructions
See https://github.com/WordPress/gutenberg/pull/57901.

## Screenshots or screencast 
https://github.com/WordPress/gutenberg/assets/612155/7e2d20fe-5044-4db7-84f3-bd9903e29fd5

