### PR TITLE
(Preferences)(17.5.1)(fix) Remove non-core-migrated preferences from the deprecation proxy for `get`

### DIFF
--- a/packages/preferences/src/store/selectors.js
+++ b/packages/preferences/src/store/selectors.js
@@ -7,10 +7,8 @@ const withDeprecatedKeys = ( originalGet ) => ( state, scope, name ) => {
 	const settingsToMoveToCore = [
 		'allowRightClickOverrides',
 		'distractionFree',
-		'editorMode',
 		'fixedToolbar',
 		'focusMode',
-		'hiddenBlockTypes',
 		'inactivePanels',
 		'keepCaretInsideBlock',
 		'mostUsedBlocks',
@@ -31,15 +29,6 @@ const withDeprecatedKeys = ( originalGet ) => ( state, scope, name ) => {
 				alternative: `wp.data.select( 'core/preferences' ).get( 'core', '${ name }' )`,
 			}
 		);
-
-		const value = originalGet( state, 'core', name );
-
-		// Hotfix for 17.5. Some of the preferences in the list above haven't been
-		// migrated to core in 17.5 (i.e: `editorMode`, https://github.com/WordPress/gutenberg/pull/57642))
-		// so we should fallback to the passed scope to avoid unexpected `undefined` values.
-		if ( value === undefined ) {
-			return originalGet( state, scope, name );
-		}
 
 		return originalGet( state, 'core', name );
 	}


### PR DESCRIPTION
## What / Why / How

Follow up to (in chronological order):
* https://github.com/WordPress/gutenberg/pull/58016
* https://github.com/WordPress/gutenberg/pull/58031
* https://github.com/WordPress/gutenberg/pull/58100
* https://github.com/WordPress/gutenberg/pull/58145

https://github.com/WordPress/gutenberg/pull/58031 augmented the proxy added in https://github.com/WordPress/gutenberg/pull/58016 to make it fallback to the original scope if the setting (preference) was not found in the `core` scope. However, as part of this path, a deprecation message is also output. This deprecation message ends up breaking a lot of Jest tests because [@wordpress/jest-console](https://www.npmjs.com/package/@wordpress/jest-console) explicitly requires deprecation messages to be expected (using `toHaveWarnedWith`).

At first, I thought about "fixing" those by ignoring those deprecation messages in the `release/17.5` branch, but after a discussion with @youknowriad, he correctly pointed out that a better 17.5-specific solution would be to just fallback to the `originalGet` call for any of the preferences that were not refactored to the `core` scope in `release/17.5`, which this PR aims to do.

## Testing instructions

All JS-related checks should pass.