### PR TITLE
(editor)(fix) Append the `edit-post-header-toolbar` class in NavigableToolbar for backward compatibility with plugin GUI injections

### DIFF
--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -104,6 +104,10 @@ function DocumentTools( {
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
 
 	return (
+		// Some plugins expect and use the `edit-post-header-toolbar` CSS class to
+		// find the toolbar and inject UI elements into it. This is not officially
+		// supported, but we're keeping it in the list of class names for backwards
+		// compatibility.
 		<NavigableToolbar
 			className={ classnames(
 				'editor-document-tools',

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -105,7 +105,11 @@ function DocumentTools( {
 
 	return (
 		<NavigableToolbar
-			className={ classnames( 'editor-document-tools', className ) }
+			className={ classnames(
+				'editor-document-tools',
+				'edit-post-header-toolbar',
+				className
+			) }
 			aria-label={ toolbarAriaLabel }
 			shouldUseKeyboardFocusShortcut={ ! blockToolbarCanBeFocused }
 			variant="unstyled"


### PR DESCRIPTION
## What?

Before Gutenberg 17.5, the `edit-post-header-toolbar` CSS class was hardcoded in `NavigableToolbar`s `className`, see [#](https://github.com/WordPress/gutenberg/pull/57214/files#diff-7950fa51c44e1580a29ce66d34d5ff67286d5dbc3cbfb6f973af8442e89ee3d9L126). This changeset then change the hardoded string to the following call: `{ classnames( 'editor-document-tools', className) }` while not keeping the old class in the list. 

## Why?

3rd party plugins might use that classname to select the element and inject GUIs there, like buttons. An example of that is Elementor. It uses the `edit-post-header-toolbar` CSS class to find the div it will append the `#elementor-gutenberg-button-switch-mode` button to ([see the line here](https://github.com/elementor/elementor/blob/707e171bf8730acf22ccd55113c4fee0a816b29c/assets/dev/js/admin/gutenberg.js#L32)). That div was hardcoded before the changes in https://github.com/WordPress/gutenberg/pull/57214, but now uses the following expression: `{ classnames( 'editor-document-tools', className ) }` to render its classname ([see the diff here](https://github.com/WordPress/gutenberg/pull/57214/files#diff-7950fa51c44e1580a29ce66d34d5ff67286d5dbc3cbfb6f973af8442e89ee3d9L126)), which results in `components-accessible-toolbar editor-document-tools is-unstyled` in the markup. TL;DR: Elementor can't find the element

## How?

By adding the `edit-post-header-toolbar` as one of the params of the `classnames` function call so that it will be rendered alongside them.

## Testing Instructions

1. Spin up a new WP site, install and activate Elementor (free version suffices);
2. Use Gutenberg 17.4.1;
3. Create a new page or post;
4. You should see the `Edit with elementor` button in the toolbar;
5. Now activate 17.5.1 or a custom build from `trunk`, reload the editor;
6. The button is gone.
7. Now create a custom build from this branch, install and activate it;
8. The button is back.

