### PR TITLE
Shadows: Prevent empty style object when removing shadow

### DIFF
--- a/packages/block-editor/src/hooks/effects.js
+++ b/packages/block-editor/src/hooks/effects.js
@@ -11,6 +11,7 @@ import StylesEffectsPanel, {
 } from '../components/global-styles/effects-panel';
 import { InspectorControls } from '../components';
 import { store as blockEditorStore } from '../store';
+import { cleanEmptyObject } from './utils';
 
 export const SHADOW_SUPPORT_KEY = 'shadow';
 export const EFFECTS_SUPPORT_KEYS = [ SHADOW_SUPPORT_KEY ];
@@ -30,17 +31,14 @@ function EffectsInspectorControl( { children, resetAllFilter } ) {
 }
 export function EffectsPanel( { clientId, setAttributes, settings } ) {
 	const isEnabled = useHasEffectsPanel( settings );
-	const blockAttributes = useSelect(
-		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
+	const value = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
 		[ clientId ]
 	);
-	const shadow = blockAttributes?.style?.shadow;
-	const value = { shadow };
 
-	const onChange = ( newValue ) => {
-		setAttributes( {
-			style: { ...blockAttributes.style, shadow: newValue.shadow },
-		} );
+	const onChange = ( newStyle ) => {
+		setAttributes( { style: cleanEmptyObject( newStyle ) } );
 	};
 
 	if ( ! isEnabled ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

- Prevents empty style object being serialized to a block instance's attributes.
- Also cleaned up unnecessary double handling of the style object

## Why?

Consistency with other supports and a tiny reduction of fluff in the block markup.

## How?

- Use `cleanEmptyObject` to prevent saving an empty `style` object

## Testing Instructions

1. Add a button to a post
2. Select the button and apply a shadow
3. Via the effects panel's dropdown, reset the shadow
4. Switch to code editor view and there should be no empty style object in the block markup
5. Switch back to the visual editor and apply styles from other panels e.g. padding, border etc
6. Adjust the shadow style and ensure the other styles remain
7. Finally, reset the shadow and confirm only the shadow is reset.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="871" alt="Screenshot 2024-01-24 at 10 42 20 am" src="https://github.com/WordPress/gutenberg/assets/60436221/7b46aa6a-3a2e-4039-abc8-6385a18e817e"> | <img width="872" alt="Screenshot 2024-01-24 at 11 01 04 am" src="https://github.com/WordPress/gutenberg/assets/60436221/7f1df9ce-74be-4e1f-9847-eebc548dbdd8"> | 