### PR TITLE
Rename __experimentalGetGlobalBlocksByName to getBlocksByName

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -409,6 +409,19 @@ _Returns_
 
 -   `WPBlock[]`: Block objects.
 
+### getBlocksByName
+
+Returns all blocks that match a blockName. Results include nested blocks.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+-   _blockName_ `?string`: Optional block name, if not specified, returns an empty array.
+
+_Returns_
+
+-   `Array`: Array of clientIds of blocks with name equal to blockName.
+
 ### getBlockSelectionEnd
 
 Returns the current block selection end. This value may be null, and it may represent either a singular block selection or multi-selection end. A selection is singular if its start and end match.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -318,14 +318,14 @@ export const getGlobalBlockCount = createSelector(
 );
 
 /**
- * Returns all global blocks that match a blockName. Results include nested blocks.
+ * Returns all blocks that match a blockName. Results include nested blocks.
  *
  * @param {Object}  state     Global application state.
  * @param {?string} blockName Optional block name, if not specified, returns an empty array.
  *
  * @return {Array} Array of clientIds of blocks with name equal to blockName.
  */
-export const __experimentalGetGlobalBlocksByName = createSelector(
+export const getBlocksByName = createSelector(
 	( state, blockName ) => {
 		if ( ! blockName ) {
 			return EMPTY_ARRAY;
@@ -342,6 +342,27 @@ export const __experimentalGetGlobalBlocksByName = createSelector(
 	},
 	( state ) => [ state.blocks.order, state.blocks.byClientId ]
 );
+
+/**
+ * Returns all global blocks that match a blockName. Results include nested blocks.
+ *
+ * @deprecated
+ *
+ * @param {Object}  state     Global application state.
+ * @param {?string} blockName Optional block name, if not specified, returns an empty array.
+ *
+ * @return {Array} Array of clientIds of blocks with name equal to blockName.
+ */
+export function __experimentalGetGlobalBlocksByName( state, blockName ) {
+	deprecated(
+		"wp.data.select( 'core/block-editor' ).__experimentalGetGlobalBlocksByName",
+		{
+			since: '6.5',
+			alternative: `wp.data.select( 'core/block-editor' ).getBlocksByName`,
+		}
+	);
+	return getBlocksByName( state, blockName );
+}
 
 /**
  * Given an array of block client IDs, returns the corresponding array of block

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -72,7 +72,7 @@ const {
 	__unstableGetClientIdsTree,
 	__experimentalGetPatternTransformItems,
 	wasBlockJustInserted,
-	__experimentalGetGlobalBlocksByName,
+	getBlocksByName,
 	getBlockEditingMode,
 } = selectors;
 
@@ -975,7 +975,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '__experimentalGetGlobalBlocksByName', () => {
+	describe( 'getBlocksByName', () => {
 		const state = {
 			blocks: {
 				byClientId: new Map(
@@ -1017,31 +1017,25 @@ describe( 'selectors', () => {
 		};
 
 		it( 'should return the clientIds of blocks of a given type', () => {
-			expect(
-				__experimentalGetGlobalBlocksByName( state, 'core/heading' )
-			).toStrictEqual( [ '123' ] );
+			expect( getBlocksByName( state, 'core/heading' ) ).toStrictEqual( [
+				'123',
+			] );
 		} );
 
 		it( 'should return the clientIds of blocks of a given type even if blocks are nested', () => {
-			expect(
-				__experimentalGetGlobalBlocksByName( state, 'core/paragraph' )
-			).toStrictEqual( [ '456', '1415', '1213' ] );
+			expect( getBlocksByName( state, 'core/paragraph' ) ).toStrictEqual(
+				[ '456', '1415', '1213' ]
+			);
 		} );
 
 		it( 'Should return empty array if no blocks match. The empty array should be the same reference', () => {
-			const result = __experimentalGetGlobalBlocksByName(
-				state,
-				'test/missing'
+			const result = getBlocksByName( state, 'test/missing' );
+			expect( getBlocksByName( state, 'test/missing' ) ).toStrictEqual(
+				[]
 			);
-			expect(
-				__experimentalGetGlobalBlocksByName( state, 'test/missing' )
-			).toStrictEqual( [] );
-			expect(
-				__experimentalGetGlobalBlocksByName(
-					state,
-					'test/missing2'
-				) === result
-			).toBe( true );
+			expect( getBlocksByName( state, 'test/missing2' ) === result ).toBe(
+				true
+			);
 		} );
 	} );
 

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -17,7 +17,7 @@ function getLatestHeadings( select, clientId ) {
 		getBlockAttributes,
 		getBlockName,
 		getClientIdsWithDescendants,
-		__experimentalGetGlobalBlocksByName: getGlobalBlocksByName,
+		getBlocksByName,
 	} = select( blockEditorStore );
 
 	// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
@@ -28,7 +28,7 @@ function getLatestHeadings( select, clientId ) {
 	// eslint-disable-next-line @wordpress/data-no-store-string-literals
 	const permalink = select( 'core/editor' ).getPermalink() ?? null;
 
-	const isPaginated = getGlobalBlocksByName( 'core/nextpage' ).length !== 0;
+	const isPaginated = getBlocksByName( 'core/nextpage' ).length !== 0;
 	const { onlyIncludeCurrentPage } = getBlockAttributes( clientId ) ?? {};
 
 	// Get the client ids of all blocks in the editor.

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -250,9 +250,7 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 		);
 
 		const clientIds =
-			select( blockEditorStore ).__experimentalGetGlobalBlocksByName(
-				'core/template-part'
-			);
+			select( blockEditorStore ).getBlocksByName( 'core/template-part' );
 		const blocks =
 			select( blockEditorStore ).getBlocksByClientId( clientIds );
 

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -44,9 +44,9 @@ function DisableBlock( { clientId } ) {
 export default function DisableNonPageContentBlocks() {
 	useBlockEditingMode( 'disabled' );
 	const clientIds = useSelect( ( select ) => {
-		const { __experimentalGetGlobalBlocksByName } =
-			select( blockEditorStore );
-		return __experimentalGetGlobalBlocksByName( PAGE_CONTENT_BLOCK_TYPES );
+		return select( blockEditorStore ).getBlocksByName(
+			PAGE_CONTENT_BLOCK_TYPES
+		);
 	}, [] );
 
 	return clientIds.map( ( clientId ) => {

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -30,7 +30,7 @@ export const getInsertionPoint = createRegistrySelector(
 
 		if ( getRenderingMode( state ) === 'template-locked' ) {
 			const [ postContentClientId ] =
-				select( blockEditorStore ).__experimentalGetGlobalBlocksByName(
+				select( blockEditorStore ).getBlocksByName(
 					'core/post-content'
 				);
 			if ( postContentClientId ) {


### PR DESCRIPTION
## What?
Stabilise the `__experimentalGetGlobalBlocksByName` selector.

## Why?
This has been around for a while and is used widely.

## How?
I removed the `__experimental` prefix.

The old selector is maintained and `deprecated()`. We can't remove this as it's shipped in Core.

I also changed the name to omit the word "global" which I think just causes confusion. None of the other selectors in `block-editor` use this convention. It's implied that a selector is global unless you pass a `rootClientId`.