### PR TITLE
Patterns: Add lock icon when user doesn't have permission to edit a pattern

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -14,6 +14,7 @@ import {
 	Spinner,
 	ToolbarButton,
 	ToolbarGroup,
+	Tooltip,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
@@ -29,6 +30,7 @@ import {
 } from '@wordpress/block-editor';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { parse, cloneBlock } from '@wordpress/blocks';
+import { lock, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -348,18 +350,29 @@ export default function ReusableBlockEdit( {
 
 	return (
 		<RecursionProvider uniqueId={ ref }>
-			{ userCanEdit && editOriginalProps && (
-				<BlockControls>
-					<ToolbarGroup>
+			<BlockControls group="other">
+				<ToolbarGroup>
+					{ userCanEdit && editOriginalProps && (
 						<ToolbarButton
 							href={ editOriginalProps.href }
 							onClick={ handleEditOriginal }
 						>
 							{ __( 'Edit original' ) }
 						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
+					) }
+					{ ! userCanEdit && (
+						<Tooltip
+							text={ __(
+								'You do not have permission to edit the content of this block'
+							) }
+						>
+							<div className="components-button components-toolbar-button has-icon">
+								<Icon icon={ lock } />
+							</div>
+						</Tooltip>
+					) }
+				</ToolbarGroup>
+			</BlockControls>
 
 			{ hasOverridableBlocks && (
 				<BlockControls>


### PR DESCRIPTION
## What?
Add a lock icon in the toolbar if a user does not have permission to edit the current synced pattern

## Why?
When the experiment that includes https://github.com/WordPress/gutenberg/pull/57036 is made public users that do not have edit permission for a synced pattern will not be able to edit the content of the pattern at all, so it would be good to give some indication that this is intentional. 

## How?
Adds a lock icon to the toolbar with tooltip if the synced pattern has no overrides set and the user is not the owner or an admin.

## Testing Instructions

- Enable pattern overrides experiment
- As an admin add a new synced pattern with no overrides
- Insert the pattern and make sure you see an `Edit original` button
- Create a second pattern and add some overrides
- Log in as an `author` user and insert the pattern and make sure you see a lock icon in the tool bar and the pattern is not editable
- Add a new synced pattern as the author user - insert it and make sure you now see the `Edit original` pattern
- Add the pattern with overrides and check that no button or icon appears in the toolbar

## Screenshots or screencast <!-- if applicable -->

Author user and pattern they don't own:

<img width="673" alt="locked" src="https://github.com/WordPress/gutenberg/assets/3629020/01e44dd6-90c2-482b-b998-755e4a41326c">

Author user and pattern they created:

<img width="704" alt="Screenshot 2024-01-24 at 5 11 01 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/dd291a71-e247-4230-9c39-5c88bea9c732">
