### PR TITLE
Font Library: Replace manage fonts icon with button with visible text

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -5,11 +5,8 @@ import { __ } from '@wordpress/i18n';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	Button,
-	Tooltip,
 } from '@wordpress/components';
-import { typography } from '@wordpress/icons';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -38,21 +35,7 @@ function FontFamilies() {
 			) }
 
 			<VStack spacing={ 3 }>
-				<HStack justify="space-between">
-					<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
-					<HStack justify="flex-end">
-						<Tooltip text={ __( 'Manage fonts' ) }>
-							<Button
-								onClick={ () =>
-									toggleModal( 'installed-fonts' )
-								}
-								aria-label={ __( 'Manage fonts' ) }
-								icon={ typography }
-								size={ 'small' }
-							/>
-						</Tooltip>
-					</HStack>
-				</HStack>
+				<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
 				{ hasFonts ? (
 					<ItemGroup isBordered isSeparated>
 						{ customFonts.map( ( font ) => (
@@ -65,6 +48,14 @@ function FontFamilies() {
 				) : (
 					<>{ __( 'No fonts installed.' ) }</>
 				) }
+				<Button
+					className="edit-site-global-styles-font-families__manage-fonts-button"
+					variant="secondary"
+					onClick={ () => toggleModal( 'installed-fonts' ) }
+					size={ 'compact' }
+				>
+					{ __( 'Manage all fonts' ) }
+				</Button>
 			</VStack>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -117,6 +117,10 @@
 	}
 }
 
+.edit-site-global-styles-font-families__manage-fonts-button {
+	justify-content: center;
+}
+
 .edit-site-global-styles-icon-with-current-color {
 	fill: currentColor;
 }

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -19,10 +19,10 @@ test.describe( 'Font Library', () => {
 			await page
 				.getByRole( 'button', { name: /typography styles/i } )
 				.click();
-			const manageFontsIcon = page.getByRole( 'button', {
-				name: /manage fonts/i,
+			const manageFontsButton = page.getByRole( 'button', {
+				name: /Manage all fonts/i,
 			} );
-			await expect( manageFontsIcon ).toBeVisible();
+			await expect( manageFontsButton ).toBeVisible();
 		} );
 	} );
 
@@ -41,10 +41,10 @@ test.describe( 'Font Library', () => {
 			await page
 				.getByRole( 'button', { name: /typography styles/i } )
 				.click();
-			const manageFontsIcon = page.getByRole( 'button', {
-				name: /manage fonts/i,
+			const manageFontsButton = page.getByRole( 'button', {
+				name: /Manage all fonts/i,
 			} );
-			await expect( manageFontsIcon ).toBeVisible();
+			await expect( manageFontsButton ).toBeVisible();
 		} );
 
 		test( 'should open the "Manage Fonts" modal when clicking the "Manage Fonts" icon', async ( {
@@ -56,7 +56,7 @@ test.describe( 'Font Library', () => {
 				.click();
 			await page
 				.getByRole( 'button', {
-					name: /manage fonts/i,
+					name: /Manage all fonts/i,
 				} )
 				.click();
 			await expect( page.getByRole( 'dialog' ) ).toBeVisible();
@@ -74,7 +74,7 @@ test.describe( 'Font Library', () => {
 				.click();
 			await page
 				.getByRole( 'button', {
-					name: /manage fonts/i,
+					name: /Manage all fonts/i,
 				} )
 				.click();
 			await page.getByRole( 'button', { name: /system font/i } ).click();


### PR DESCRIPTION
Fixes #58082

## What?

This PR changes the button for opening the Font Library modal dialog from an icon button to a button with text, and also moves its position.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/edb83f77-1b1f-4a11-805c-3f2b17ee96e9) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/1ee1ce0a-47bd-4fc4-b54b-bdf9b4cc6748) | 

When the fonts are not registered:

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/f704fb12-e239-4b1d-a0c4-907da926a854) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/b9fc297b-db0a-4ba6-b2c7-afc3a26e8397) | 


## Why?

The current icon doesn't actually represent the concept of "font management". It's also the same as the icon in the Elements panel, which confuses users even more. Even if he changes this icon to Cog (Gear), the user may not know at first glance what this icon means. See #58082 for a more detailed discussion.

## How?

- I placed a button below with a secondary variation and text. The secondary variation also corresponds to the "Explore all patterns" button to open the patterns dialog.
- I applied a height of 32px to the button. I felt that 40px was a little too noticeable.

Note: As mentioned in [this comment](https://github.com/WordPress/gutenberg/issues/58082#issuecomment-1906275971), we should consider whether to include "all" in the future. For now, I've included "all" to match the existing rules.

## Testing Instructions

Confirm that the Font Library modal toggle works as before.

### Testing Instructions for Keyboard

- Make sure you can reach this button using only the keyboard.
- Make sure your screen reader reads the appropriate text.
- Verify that you can toggle the Font Library modal by pressing the Enter key.
