### PR TITLE
Flash editable block outlines instead of always showing them

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -617,6 +617,9 @@ function BlockListBlockProvider( props ) {
 						getBlockRootClientId( clientId )
 					),
 				isEditingDisabled: blockEditingMode === 'disabled',
+				hasEditableOutline:
+					blockEditingMode !== 'disabled' &&
+					getBlockEditingMode( rootClientId ) === 'disabled',
 				className: hasLightBlockWrapper
 					? attributes.className
 					: undefined,
@@ -661,6 +664,7 @@ function BlockListBlockProvider( props ) {
 		isBlockMovingMode,
 		canInsertMovingBlock,
 		isEditingDisabled,
+		hasEditableOutline,
 		className,
 		defaultClassName,
 	} = selectedProps;
@@ -696,6 +700,7 @@ function BlockListBlockProvider( props ) {
 		isBlockMovingMode,
 		canInsertMovingBlock,
 		isEditingDisabled,
+		hasEditableOutline,
 		isTemporarilyEditingAsBlocks,
 		defaultClassName,
 		mayDisplayControls,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -538,7 +538,6 @@ function BlockListBlockProvider( props ) {
 				getActiveBlockVariation,
 			} = select( blocksStore );
 			const _isSelected = isBlockSelected( clientId );
-			const templateLock = getTemplateLock( rootClientId );
 			const canRemove = canRemoveBlock( clientId, rootClientId );
 			const canMove = canMoveBlock( clientId, rootClientId );
 			const { name: blockName, attributes, isValid } = block;
@@ -559,7 +558,8 @@ function BlockListBlockProvider( props ) {
 			return {
 				mode: getBlockMode( clientId ),
 				isSelectionEnabled: isSelectionEnabled(),
-				isLocked: !! templateLock,
+				isLocked: !! getTemplateLock( rootClientId ),
+				templateLock: getTemplateLock( clientId ),
 				canRemove,
 				canMove,
 				// Users of the editor.BlockListBlock filter used to be able to
@@ -663,6 +663,7 @@ function BlockListBlockProvider( props ) {
 		removeOutline,
 		isBlockMovingMode,
 		canInsertMovingBlock,
+		templateLock,
 		isEditingDisabled,
 		hasEditableOutline,
 		className,
@@ -699,6 +700,7 @@ function BlockListBlockProvider( props ) {
 		removeOutline,
 		isBlockMovingMode,
 		canInsertMovingBlock,
+		templateLock,
 		isEditingDisabled,
 		hasEditableOutline,
 		isTemporarilyEditingAsBlocks,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -519,7 +519,6 @@ function BlockListBlockProvider( props ) {
 				isBlockBeingDragged,
 				hasBlockMovingClientId,
 				canInsertBlockType,
-				getBlockRootClientId,
 				__unstableHasActiveBlockOverlayActive,
 				__unstableGetEditorMode,
 				getSelectedBlocksInitialCaretPosition,
@@ -556,6 +555,7 @@ function BlockListBlockProvider( props ) {
 			const hasLightBlockWrapper = blockType?.apiVersion > 1;
 			const movingClientId = hasBlockMovingClientId();
 			const blockEditingMode = getBlockEditingMode( clientId );
+
 			return {
 				mode: getBlockMode( clientId ),
 				isSelectionEnabled: isSelectionEnabled(),
@@ -614,7 +614,7 @@ function BlockListBlockProvider( props ) {
 					movingClientId &&
 					canInsertBlockType(
 						getBlockName( movingClientId ),
-						getBlockRootClientId( clientId )
+						rootClientId
 					),
 				isEditingDisabled: blockEditingMode === 'disabled',
 				hasEditableOutline:

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -300,35 +300,30 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 }
 
-// Indicate which blocks are editable within a locked context.
-// 1. User must be hovering an editor with renderingMode = 'template-lock'; or...
-.is-template-locked:hover,
-// ...a container block.
-.block-editor-block-list__block:hover {
-	// 2. Look for locked blocks; or...
-	.block-editor-block-list__block.is-editing-disabled,
-	// ...container blocks that have locked children.
-	&:has(> .block-editor-block-list__block.is-editing-disabled) {
-		// 3. Highlight any unlocked children of that locked block.
-		& > .block-editor-block-list__block:not(.is-editing-disabled):not(.is-selected):not(.has-child-selected) {
-			&::after {
-				content: "";
-				border-style: dotted;
-				position: absolute;
-				pointer-events: none;
-				top: $border-width;
-				left: $border-width;
-				right: $border-width;
-				bottom: $border-width;
-				border: 1px dotted var(--wp-admin-theme-color);
-				border-radius: $radius-block-ui - $border-width;
-			}
+@keyframes block-editor-has-editable-outline__fade-out-animation {
+	from {
+		border-color: rgba(var(--wp-admin-theme-color--rgb), 1);
+	}
+	to {
+		border-color: rgba(var(--wp-admin-theme-color--rgb), 0);
+	}
+}
 
-			&.is-hovered::after {
-				background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
-				border: none;
-			}
-		}
+.block-editor-block-list__block.has-editable-outline {
+	&::after {
+		content: "";
+		position: absolute;
+		pointer-events: none;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		border: 1px dotted rgba(var(--wp-admin-theme-color--rgb), 1);
+		border-radius: $radius-block-ui;
+		animation: block-editor-has-editable-outline__fade-out-animation 0.3s ease-out;
+		animation-delay: 3s;
+		animation-fill-mode: forwards;
+		@include reduce-motion("animation");
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -309,7 +309,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	}
 }
 
-.block-editor-block-list__block.has-editable-outline {
+.is-root-container:not([inert]) .block-editor-block-list__block.has-editable-outline {
 	&::after {
 		content: "";
 		position: absolute;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -321,7 +321,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		border: 1px dotted rgba(var(--wp-admin-theme-color--rgb), 1);
 		border-radius: $radius-block-ui;
 		animation: block-editor-has-editable-outline__fade-out-animation 0.3s ease-out;
-		animation-delay: 3s;
+		animation-delay: 1s;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");
 	}

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -25,6 +25,7 @@ import { useEventHandlers } from './use-selected-block-event-handlers';
 import { useNavModeExit } from './use-nav-mode-exit';
 import { useBlockRefProvider } from './use-block-refs';
 import { useIntersectionObserver } from './use-intersection-observer';
+import { useFlashEditableBlocks } from '../../use-flash-editable-blocks';
 
 /**
  * This hook is used to lightly mark an element as a block element. The element
@@ -98,6 +99,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		hasEditableOutline,
 		isTemporarilyEditingAsBlocks,
 		defaultClassName,
+		templateLock,
 	} = useContext( PrivateBlockContext );
 
 	// translators: %s: Type of block (i.e. Text, Image etc)
@@ -114,6 +116,10 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		useIntersectionObserver(),
 		useMovingAnimation( { triggerAnimationOnChange: index, clientId } ),
 		useDisabled( { isDisabled: ! hasOverlay } ),
+		useFlashEditableBlocks( {
+			clientId,
+			isEnabled: name === 'core/block' || templateLock === 'contentOnly',
+		} ),
 	] );
 
 	const blockEditContext = useBlockEditContext();

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -95,6 +95,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isBlockMovingMode,
 		canInsertMovingBlock,
 		isEditingDisabled,
+		hasEditableOutline,
 		isTemporarilyEditingAsBlocks,
 		defaultClassName,
 	} = useContext( PrivateBlockContext );
@@ -152,6 +153,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				'is-block-moving-mode': isBlockMovingMode,
 				'can-insert-moving-block': canInsertMovingBlock,
 				'is-editing-disabled': isEditingDisabled,
+				'has-editable-outline': hasEditableOutline,
 				'is-content-locked-temporarily-editing-as-blocks':
 					isTemporarilyEditingAsBlocks,
 			},

--- a/packages/block-editor/src/components/use-flash-editable-blocks/index.js
+++ b/packages/block-editor/src/components/use-flash-editable-blocks/index.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+export default function useFlashEditableBlocks( rootClientId = '' ) {
+	const { getEnabledClientIdsTree } = unlock( useSelect( blockEditorStore ) );
+
+	return useRefEffect( ( element ) => {
+		const flashEditableBlocks = () => {
+			getEnabledClientIdsTree( rootClientId ).forEach(
+				( { clientId } ) => {
+					const blockElement = element.querySelector(
+						`[data-block="${ clientId }"]`
+					);
+					if ( ! blockElement ) {
+						return;
+					}
+					blockElement.classList.remove( 'has-editable-outline' );
+					// Force reflow to trigger the animation.
+					// eslint-disable-next-line no-unused-expressions
+					blockElement.offsetWidth;
+					blockElement.classList.add( 'has-editable-outline' );
+				}
+			);
+		};
+
+		const handleClick = ( event ) => {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+			event.preventDefault();
+			flashEditableBlocks();
+		};
+
+		element.addEventListener( 'click', handleClick );
+		return () => {
+			element.removeEventListener( 'click', handleClick );
+		};
+	} );
+}

--- a/packages/block-editor/src/components/use-flash-editable-blocks/index.js
+++ b/packages/block-editor/src/components/use-flash-editable-blocks/index.js
@@ -33,6 +33,12 @@ export default function useFlashEditableBlocks( rootClientId = '' ) {
 		};
 
 		const handleClick = ( event ) => {
+			const shouldFlash =
+				event.target === element ||
+				event.target.classList.contains( 'is-root-container' );
+			if ( ! shouldFlash ) {
+				return;
+			}
 			if ( event.defaultPrevented ) {
 				return;
 			}

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -24,7 +24,7 @@ import {
 import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
-import useFlashEditableBlocks from './components/use-flash-editable-blocks';
+import { useFlashEditableBlocks } from './components/use-flash-editable-blocks';
 
 /**
  * Private @wordpress/block-editor APIs.

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -24,6 +24,7 @@ import {
 import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
+import useFlashEditableBlocks from './components/use-flash-editable-blocks';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -52,4 +53,5 @@ lock( privateApis, {
 	ReusableBlocksRenameHint,
 	useReusableBlocksRenameHint,
 	usesContextKey,
+	useFlashEditableBlocks,
 } );

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -313,10 +313,8 @@ export default function ReusableBlockEdit( {
 	);
 	const layoutClasses = useLayoutClasses( { layout }, name );
 
-	const flashEditableBlocksRef = useFlashEditableBlocks( patternClientId );
-
 	const blockProps = useBlockProps( {
-		ref: flashEditableBlocksRef,
+		ref: useFlashEditableBlocks( patternClientId ),
 		className: classnames(
 			'block-library-block__reusable-block-container',
 			layout && layoutClasses,
@@ -325,7 +323,6 @@ export default function ReusableBlockEdit( {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		ref: flashEditableBlocksRef,
 		templateLock: 'all',
 		layout,
 		renderAppender: innerBlocks?.length

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -35,7 +35,9 @@ import { parse, cloneBlock } from '@wordpress/blocks';
  */
 import { unlock } from '../lock-unlock';
 
-const { useLayoutClasses } = unlock( blockEditorPrivateApis );
+const { useLayoutClasses, useFlashEditableBlocks } = unlock(
+	blockEditorPrivateApis
+);
 const { PARTIAL_SYNCING_SUPPORTED_BLOCKS } = unlock( patternsPrivateApis );
 
 function isPartiallySynced( block ) {
@@ -311,7 +313,10 @@ export default function ReusableBlockEdit( {
 	);
 	const layoutClasses = useLayoutClasses( { layout }, name );
 
+	const flashEditableBlocksRef = useFlashEditableBlocks( patternClientId );
+
 	const blockProps = useBlockProps( {
+		ref: flashEditableBlocksRef,
 		className: classnames(
 			'block-library-block__reusable-block-container',
 			layout && layoutClasses,
@@ -320,6 +325,7 @@ export default function ReusableBlockEdit( {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		ref: flashEditableBlocksRef,
 		templateLock: 'all',
 		layout,
 		renderAppender: innerBlocks?.length

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -35,9 +35,7 @@ import { parse, cloneBlock } from '@wordpress/blocks';
  */
 import { unlock } from '../lock-unlock';
 
-const { useLayoutClasses, useFlashEditableBlocks } = unlock(
-	blockEditorPrivateApis
-);
+const { useLayoutClasses } = unlock( blockEditorPrivateApis );
 const { PARTIAL_SYNCING_SUPPORTED_BLOCKS } = unlock( patternsPrivateApis );
 
 function isPartiallySynced( block ) {
@@ -314,7 +312,6 @@ export default function ReusableBlockEdit( {
 	const layoutClasses = useLayoutClasses( { layout }, name );
 
 	const blockProps = useBlockProps( {
-		ref: useFlashEditableBlocks( patternClientId ),
 		className: classnames(
 			'block-library-block__reusable-block-container',
 			layout && layoutClasses,

--- a/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/editor-canvas/edit-template-blocks-notification.js
@@ -27,27 +27,18 @@ import { store as editorStore } from '../../store';
  *                                                                  editor iframe canvas.
  */
 export default function EditTemplateBlocksNotification( { contentRef } ) {
-	const { renderingMode, getPostLinkProps, templateId } = useSelect(
-		( select ) => {
-			const {
-				getRenderingMode,
-				getEditorSettings,
-				getCurrentTemplateId,
-			} = select( editorStore );
-			return {
-				renderingMode: getRenderingMode(),
-				getPostLinkProps: getEditorSettings().getPostLinkProps,
-				templateId: getCurrentTemplateId(),
-			};
-		},
-		[]
-	);
-	const editTemplate = getPostLinkProps
-		? getPostLinkProps( {
-				postId: templateId,
-				postType: 'wp_template',
-		  } )
-		: {};
+	const editTemplate = useSelect( ( select ) => {
+		const { getEditorSettings, getCurrentTemplateId } =
+			select( editorStore );
+		const { getPostLinkProps } = getEditorSettings();
+		return getPostLinkProps
+			? getPostLinkProps( {
+					postId: getCurrentTemplateId(),
+					postType: 'wp_template',
+			  } )
+			: {};
+	}, [] );
+
 	const { getNotices } = useSelect( noticesStore );
 
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
@@ -58,18 +49,17 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 
 	useEffect( () => {
 		const handleClick = async ( event ) => {
-			if ( renderingMode !== 'template-locked' ) {
-				return;
-			}
 			if ( ! event.target.classList.contains( 'is-root-container' ) ) {
 				return;
 			}
+
 			const isNoticeAlreadyShowing = getNotices().some(
 				( notice ) => notice.id === lastNoticeId.current
 			);
 			if ( isNoticeAlreadyShowing ) {
 				return;
 			}
+
 			const { notice } = await createInfoNotice(
 				__( 'Edit your template to edit this block.' ),
 				{
@@ -87,9 +77,6 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 		};
 
 		const handleDblClick = ( event ) => {
-			if ( renderingMode !== 'template-locked' ) {
-				return;
-			}
 			if ( ! event.target.classList.contains( 'is-root-container' ) ) {
 				return;
 			}
@@ -106,7 +93,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 			canvas?.removeEventListener( 'click', handleClick );
 			canvas?.removeEventListener( 'dblclick', handleDblClick );
 		};
-	}, [ lastNoticeId, renderingMode, contentRef.current ] );
+	}, [ lastNoticeId, contentRef.current ] );
 
 	return (
 		<ConfirmDialog

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -35,6 +35,7 @@ const {
 	useLayoutClasses,
 	useLayoutStyles,
 	ExperimentalBlockCanvas: BlockCanvas,
+	useFlashEditableBlocks,
 } = unlock( blockEditorPrivateApis );
 
 const noop = () => {};
@@ -287,9 +288,11 @@ function EditorCanvas( {
 
 	const localRef = useRef();
 	const typewriterRef = useTypewriter();
+	const flashEditableBlocksRef = useFlashEditableBlocks();
 	const contentRef = useMergeRefs( [
 		localRef,
 		renderingMode === 'post-only' ? typewriterRef : noop,
+		renderingMode === 'template-locked' ? flashEditableBlocksRef : noop,
 	] );
 
 	return (
@@ -364,8 +367,7 @@ function EditorCanvas( {
 						'is-' + deviceType.toLowerCase() + '-preview',
 						renderingMode !== 'post-only'
 							? 'wp-site-blocks'
-							: `${ blockListLayoutClass } wp-block-post-content`, // Ensure root level blocks receive default/flow blockGap styling rules.
-						renderingMode !== 'all' && 'is-' + renderingMode
+							: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
 					) }
 					layout={ blockListLayout }
 					dropZoneElement={
@@ -377,7 +379,9 @@ function EditorCanvas( {
 					}
 					renderAppender={ renderAppender }
 				/>
-				<EditTemplateBlocksNotification contentRef={ localRef } />
+				{ renderingMode === 'template-locked' && (
+					<EditTemplateBlocksNotification contentRef={ localRef } />
+				) }
 			</RecursionProvider>
 			{ children }
 		</BlockCanvas>

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -288,11 +288,12 @@ function EditorCanvas( {
 
 	const localRef = useRef();
 	const typewriterRef = useTypewriter();
-	const flashEditableBlocksRef = useFlashEditableBlocks();
 	const contentRef = useMergeRefs( [
 		localRef,
 		renderingMode === 'post-only' ? typewriterRef : noop,
-		renderingMode === 'template-locked' ? flashEditableBlocksRef : noop,
+		useFlashEditableBlocks( {
+			isEnabled: renderingMode === 'template-locked',
+		} ),
 	] );
 
 	return (


### PR DESCRIPTION
## What?
Iterates on https://github.com/WordPress/gutenberg/pull/57901.

Updates the editable block outlines that appear within content-locked containers (added in #57901) to appear and then fade out after 1s when:

- The page loads; or
- The user clicks on the content-locked container.

## Why?
See discussion in https://github.com/WordPress/gutenberg/pull/57901#issuecomment-1904339567. We want to reduce the prominence of these outlines as they are currently too distracting from the writing experience. 

## How?
A `.has-editable-block-outline` class is added to blocks that are editable but within a locked container. This class shows the outline and then fades it away after 1s.

Then, a private `useFlashEditableBlocks()` hook is attached to relevant containers: template-locked pages, synced patterns, and patterns with `templateLock = 'contentOnly'`. The hook listens for a `click` on a disabled element and replays the animation when this happens.

## Testing Instructions
The outlines should should appear when editing a content only locked pattern, a pattern with instance overrides, and a page in the site editor.

Content only locked patterns:

1. Add a pattern to your current theme that has a `contentOnly` lock. [Here's an example of one.](https://gist.github.com/richtabor/ddeea41ced691721318649bea8ce9db8)
2. Edit a page or template and insert the pattern.

Pattern with instance overrides:

1. Follow [these instructions](https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331) to create a pattern with instance overrides enabled.
2. Edit a page or template and insert the pattern.

Page in the site editor:

1. Go to Appearance → Editor → Pages and select a page to edit.

## Screenshots or screencast 


https://github.com/WordPress/gutenberg/assets/612155/4efbaff2-bd0c-4f73-808e-55a200daedb0

