### PR TITLE
More Block: Make block name affect list view

### DIFF
--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -20,6 +20,12 @@ export const settings = {
 	icon,
 	example: {},
 	__experimentalLabel( attributes, { context } ) {
+		const customName = attributes?.metadata?.name;
+
+		if ( context === 'list-view' && customName ) {
+			return customName;
+		}
+
 		if ( context === 'accessibility' ) {
 			return attributes.customText;
 		}


### PR DESCRIPTION
Part of #57954
Same as #57955

## What?

This PR fixes an issue where the block name is not reflected in the list view for the More block.

## Why?

If that block has opted into `__experimentLabel`, the list view will display the default block name unless we explicitly return `metadata.name` when the context is `list-view`.

For a more detailed analysis, please refer to #57954.

## Testing Instructions

- Insert an More block.
- Fill the block name field with some text.
- Open the List View.
- You should see that text instead of the default block name.
