### PR TITLE
Fix losing overrides after detaching patterns

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/pattern-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/pattern-blocks.test.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Pattern blocks allows conversion back to blocks when the reusable block has unsaved edits 1`] = `
-"<!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph -->"
-`;
-
 exports[`Pattern blocks can be created from multiselection and converted back to regular blocks 1`] = `
 "<!-- wp:paragraph -->
 <p>Hello there!</p>

--- a/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/pattern-blocks.test.js
@@ -252,34 +252,6 @@ describe( 'Pattern blocks', () => {
 		);
 	} );
 
-	// Check for regressions of https://github.com/WordPress/gutenberg/issues/26421.
-	// Skip reason: This is broken at the time with Pattern Overrides.
-	// See https://github.com/WordPress/gutenberg/issues/58122
-	it.skip( 'allows conversion back to blocks when the reusable block has unsaved edits', async () => {
-		await createReusableBlock( '1', 'Edited block' );
-
-		// Make an edit to the reusable block and assert that there's only a
-		// paragraph in a reusable block.
-		await canvas().waitForSelector( 'p[aria-label="Block: Paragraph"]' );
-		await canvas().click( 'p[aria-label="Block: Paragraph"]' );
-		await page.keyboard.type( '2' );
-		const selector =
-			'//div[@aria-label="Block: Pattern"]//p[@aria-label="Block: Paragraph"][.="12"]';
-		const reusableBlockWithParagraph = await page.$x( selector );
-		expect( reusableBlockWithParagraph ).toBeTruthy();
-
-		// Convert back to regular blocks.
-		await clickBlockToolbarButton( 'Select parent block: Edited block' );
-		await clickBlockToolbarButton( 'Options' );
-		await clickMenuItem( 'Detach' );
-		await page.waitForXPath( selector, {
-			hidden: true,
-		} );
-
-		// Check that there's only a paragraph.
-		expect( await getEditedPostContent() ).toMatchSnapshot();
-	} );
-
 	// Test for regressions of https://github.com/WordPress/gutenberg/issues/27243.
 	it( 'should allow a block with styles to be converted to a reusable block', async () => {
 		// Insert a quote and reload the page.

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -104,7 +104,12 @@ export const convertSyncedPatternToStatic =
 				}
 				return cloneBlock(
 					block,
-					{ metadata },
+					{
+						metadata:
+							Object.keys( metadata ).length > 0
+								? metadata
+								: undefined,
+					},
 					cloneBlocksAndRemoveBindings( block.innerBlocks )
 				);
 			} );

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 
-import { parse } from '@wordpress/blocks';
+import { cloneBlock } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
@@ -90,25 +90,32 @@ export const createPatternFromFile =
 export const convertSyncedPatternToStatic =
 	( clientId ) =>
 	( { registry } ) => {
-		const oldBlock = registry
+		const patternBlock = registry
 			.select( blockEditorStore )
 			.getBlock( clientId );
-		const pattern = registry
-			.select( 'core' )
-			.getEditedEntityRecord(
-				'postType',
-				'wp_block',
-				oldBlock.attributes.ref
-			);
 
-		const newBlocks = parse(
-			typeof pattern.content === 'function'
-				? pattern.content( pattern )
-				: pattern.content
-		);
+		function cloneBlocksAndRemoveBindings( blocks ) {
+			return blocks.map( ( block ) => {
+				let metadata = block.attributes.metadata;
+				if ( metadata ) {
+					metadata = { ...metadata };
+					delete metadata.id;
+					delete metadata.bindings;
+				}
+				return cloneBlock(
+					block,
+					{ metadata },
+					cloneBlocksAndRemoveBindings( block.innerBlocks )
+				);
+			} );
+		}
+
 		registry
 			.dispatch( blockEditorStore )
-			.replaceBlocks( oldBlock.clientId, newBlocks );
+			.replaceBlocks(
+				patternBlock.clientId,
+				cloneBlocksAndRemoveBindings( patternBlock.innerBlocks )
+			);
 	};
 
 /**

--- a/packages/patterns/src/store/actions.js
+++ b/packages/patterns/src/store/actions.js
@@ -106,7 +106,7 @@ export const convertSyncedPatternToStatic =
 					block,
 					{
 						metadata:
-							Object.keys( metadata ).length > 0
+							metadata && Object.keys( metadata ).length > 0
 								? metadata
 								: undefined,
 					},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix #58122. Also migrated a test into Playwright.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of #53705.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It's undecided whether we should keep the blocks' `id`s and `bindings` after detaching, but at this stage I think it's easier to remove them all. We can add them back in a follow-up if needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331 to create a 
pattern with overrides and add it to a post.
2. Make some edits to one of the editable blocks.
3. Select the pattern.
4. Detach the pattern via the block toolbar.
5. Expect the overrides to remain after detaching.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/05142f1e-63da-4576-a1a8-d6d94edcf064

