### PR TITLE
Use a patch format and support `linkTarget` of `core/button` for Pattern Overrides

### DIFF
--- a/lib/experimental/block-bindings/sources/pattern.php
+++ b/lib/experimental/block-bindings/sources/pattern.php
@@ -9,8 +9,20 @@ if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 		if ( ! _wp_array_get( $block_instance->attributes, array( 'metadata', 'id' ), false ) ) {
 			return null;
 		}
-		$block_id = $block_instance->attributes['metadata']['id'];
-		return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, $attribute_name ), null );
+		$block_id           = $block_instance->attributes['metadata']['id'];
+		$attribute_override = _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, $attribute_name ), null );
+		if ( null === $attribute_override ) {
+			return null;
+		}
+		switch ( $attribute_override[0] ) {
+			case 0: // remove
+				// This currently skip this attribute instead of removing it until the binding API supports different operations.
+				return null;
+			case 1: // replace
+				return $attribute_override[1];
+			default:
+				return null;
+		}
 	};
 	wp_block_bindings_register_source(
 		'pattern_attributes',

--- a/lib/experimental/block-bindings/sources/pattern.php
+++ b/lib/experimental/block-bindings/sources/pattern.php
@@ -16,8 +16,11 @@ if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 		}
 		switch ( $attribute_override[0] ) {
 			case 0: // remove
-				// This currently skip this attribute instead of removing it until the binding API supports different operations.
-				return null;
+				/**
+				 * TODO: This currently doesn't remove the attribute, but only set it to an empty string.
+				 * It's a temporary solution until the block binding API supports different operations.
+				 */
+				return '';
 			case 1: // replace
 				return $attribute_override[1];
 			default:

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -101,7 +101,7 @@ if ( $gutenberg_experiments && (
 				'core/paragraph' => array( 'content' ),
 				'core/heading'   => array( 'content' ),
 				'core/image'     => array( 'url', 'title', 'alt' ),
-				'core/button'    => array( 'url', 'text' ),
+				'core/button'    => array( 'url', 'text', 'linkTarget' ),
 			);
 
 			// If the block doesn't have the bindings property or isn't one of the allowed block types, return.

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -88,6 +88,26 @@ const useInferredLayout = ( blocks, parentLayout ) => {
 	}, [ blocks, parentLayout ] );
 };
 
+/**
+ * Enum for patch operations.
+ * We use integers here to minimize the size of the serialized data.
+ * This has to be deserialized accordingly on the server side.
+ * See block-bindings/sources/pattern.php
+ */
+const PATCH_OPERATIONS = {
+	/** @type {0} */
+	Remove: 0,
+	/** @type {1} */
+	Replace: 1,
+	// Other operations are reserved for future use. (e.g. Add)
+};
+
+/**
+ * @typedef {[typeof PATCH_OPERATIONS.Remove]} RemovePatch
+ * @typedef {[typeof PATCH_OPERATIONS.Replace, unknown]} ReplacePatch
+ * @typedef {RemovePatch | ReplacePatch} OverridePatch
+ */
+
 function applyInitialOverrides( blocks, overrides = {}, defaultValues ) {
 	return blocks.map( ( block ) => {
 		const innerBlocks = applyInitialOverrides(
@@ -104,9 +124,15 @@ function applyInitialOverrides( blocks, overrides = {}, defaultValues ) {
 			defaultValues[ blockId ] ??= {};
 			defaultValues[ blockId ][ attributeKey ] =
 				block.attributes[ attributeKey ];
-			if ( overrides[ blockId ]?.[ attributeKey ] !== undefined ) {
-				newAttributes[ attributeKey ] =
-					overrides[ blockId ][ attributeKey ];
+			/** @type {OverridePatch} */
+			const overrideAttribute = overrides[ blockId ]?.[ attributeKey ];
+			if ( ! overrideAttribute ) {
+				continue;
+			}
+			if ( overrideAttribute[ 0 ] === PATCH_OPERATIONS.Remove ) {
+				delete newAttributes[ attributeKey ];
+			} else if ( overrideAttribute[ 0 ] === PATCH_OPERATIONS.Replace ) {
+				newAttributes[ attributeKey ] = overrideAttribute[ 1 ];
 			}
 		}
 		return {
@@ -118,13 +144,14 @@ function applyInitialOverrides( blocks, overrides = {}, defaultValues ) {
 }
 
 function getOverridesFromBlocks( blocks, defaultValues ) {
-	/** @type {Record<string, Record<string, unknown>>} */
+	/** @type {Record<string, Record<string, OverridePatch>>} */
 	const overrides = {};
 	for ( const block of blocks ) {
 		Object.assign(
 			overrides,
 			getOverridesFromBlocks( block.innerBlocks, defaultValues )
 		);
+		/** @type {string} */
 		const blockId = block.attributes.metadata?.id;
 		if ( ! isPartiallySynced( block ) || ! blockId ) continue;
 		const attributes = getPartiallySyncedAttributes( block );
@@ -134,10 +161,23 @@ function getOverridesFromBlocks( blocks, defaultValues ) {
 				defaultValues[ blockId ][ attributeKey ]
 			) {
 				overrides[ blockId ] ??= {};
-				// TODO: We need a way to represent `undefined` in the serialized overrides.
-				// Also see: https://github.com/WordPress/gutenberg/pull/57249#discussion_r1452987871
-				overrides[ blockId ][ attributeKey ] =
-					block.attributes[ attributeKey ];
+				/**
+				 * Create a patch operation for the binding attribute.
+				 * We use a tuple here to minimize the size of the serialized data.
+				 * The first item is the operation type, the second item is the value if any.
+				 */
+				if ( block.attributes[ attributeKey ] === undefined ) {
+					/** @type {RemovePatch} */
+					overrides[ blockId ][ attributeKey ] = [
+						PATCH_OPERATIONS.Remove,
+					];
+				} else {
+					/** @type {ReplacePatch} */
+					overrides[ blockId ][ attributeKey ] = [
+						PATCH_OPERATIONS.Replace,
+						block.attributes[ attributeKey ],
+					];
+				}
 			}
 		}
 	}

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -27,6 +27,7 @@ export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 	'core/button': {
 		text: __( 'Text' ),
 		url: __( 'URL' ),
+		linkTarget: __( 'Link Target' ),
 	},
 	'core/image': {
 		url: __( 'URL' ),

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -176,7 +176,7 @@ test.describe( 'Pattern Overrides', () => {
 						ref: patternId,
 						overrides: {
 							[ editableParagraphId ]: {
-								content: 'I would word it this way',
+								content: [ 1, 'I would word it this way' ],
 							},
 						},
 					},
@@ -187,7 +187,7 @@ test.describe( 'Pattern Overrides', () => {
 						ref: patternId,
 						overrides: {
 							[ editableParagraphId ]: {
-								content: 'This one is different',
+								content: [ 1, 'This one is different' ],
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #53705. An alternative to #57993 without the Block Binding API changes.

Supports the `linkTarget` attribute of the `core/button` block when unchecking "Open in new tab".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/pull/57249#discussion_r1461315424 and https://github.com/WordPress/gutenberg/pull/57993. To minimize the breaking changes, we decided that using a patch format is more flexible and "future-proof".

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use a patch format similar to [JSON patch](https://jsonpatch.com/) to represent overriding an attribute.

```ts
enum Operation {
    Remove = 0,
    Replace = 1,
};

type RemovePatch = [ Operation.Remove ];
type ReplacePatch = [ Operation.Replace, unknown ];
type OverridePatch = RemovePatch | ReplacePatch;
```

We use tuples and integers to minimize the size saved in the serialized string. Other operations (like `add`) and the third element of the tuple are reserved for future uses (e.g. support only overriding a partial path of an object).

Currently, we use an empty string for the `pattern_attributes` binding to "unset" the attribute. This is intentionally kept ambiguous until the block binding API supports different operations.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331 to create a pattern with overrides.

1. If you already have a button block with overrides then you'll need to re-toggle the "Allow instance overrides" setting in the source pattern to include the linkTarget attribute. (This could become a backward-compat concern that we'll need to deal with in a follow-up task.)
2. Add a link to the button block in the source pattern and check the "Open in new tab" checkbox.
3. Insert the pattern into a post. Uncheck the "Open in new tab" checkbox for the instance and save the post.
4. Visit the post in the frontend, clicking on the button should not open a new tab.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/7753001/19e67c0a-6c7c-4a49-89e2-8b5e511b9186

(My browser was slow in the video for unrelated reasons)