### PR TITLE
DataViews: make the "Manage Pages" stable

### DIFF
--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -38,8 +38,14 @@ export default function useLayoutAreas() {
 		};
 	}
 
-	if ( path === '/pages' && window?.__experimentalAdminViews ) {
-		const isListLayout = isCustom !== 'true' && layout === 'list';
+	// List layout is still experimental.
+	// Extracted it here out of the conditionals so it doesn't unintentionally becomes stable.
+	const isListLayout =
+		isCustom !== 'true' &&
+		layout === 'list' &&
+		window?.__experimentalAdminViews;
+
+	if ( path === '/pages' ) {
 		return {
 			areas: {
 				content: <PagePages />,
@@ -64,10 +70,6 @@ export default function useLayoutAreas() {
 
 	// Templates
 	if ( path === '/wp_template/all' ) {
-		const isListLayout =
-			isCustom !== 'true' &&
-			layout === 'list' &&
-			window?.__experimentalAdminViews;
 		return {
 			areas: {
 				content: (
@@ -87,10 +89,6 @@ export default function useLayoutAreas() {
 
 	// Template parts
 	if ( path === '/wp_template_part/all' ) {
-		const isListLayout =
-			isCustom !== 'true' &&
-			layout === 'list' &&
-			window?.__experimentalAdminViews;
 		return {
 			areas: {
 				content: (

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -44,6 +44,9 @@ import { unlock } from '../../lock-unlock';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
+const SUPPORTED_LAYOUTS = window?.__experimentalAdminViews
+	? [ LAYOUT_GRID, LAYOUT_TABLE, LAYOUT_LIST ]
+	: [ LAYOUT_GRID, LAYOUT_TABLE ];
 
 function useView( postType ) {
 	const { params } = useLocation();
@@ -418,6 +421,7 @@ export default function PagePages() {
 				view={ view }
 				onChangeView={ onChangeView }
 				onSelectionChange={ onSelectionChange }
+				supportedLayouts={ SUPPORTED_LAYOUTS }
 			/>
 		</Page>
 	);

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -47,11 +47,13 @@ export default function DataViewsSidebarContent() {
 					);
 				} ) }
 			</ItemGroup>
-			<CustomDataViewsList
-				activeView={ activeView }
-				type={ type }
-				isCustom="true"
-			/>
+			{ window?.__experimentalAdminViews && (
+				<CustomDataViewsList
+					activeView={ activeView }
+					type={ type }
+					isCustom="true"
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-pages/index.js
@@ -137,14 +137,6 @@ export default function SidebarNavigationScreenPages() {
 	};
 
 	const pagesLink = useLink( { path: '/pages' } );
-	const manageAllPagesProps = window?.__experimentalAdminViews
-		? { ...pagesLink }
-		: {
-				href: 'edit.php?post_type=page',
-				onClick: () => {
-					document.location = 'edit.php?post_type=page';
-				},
-		  };
 
 	return (
 		<>
@@ -230,7 +222,7 @@ export default function SidebarNavigationScreenPages() {
 						) ) }
 						<SidebarNavigationItem
 							className="edit-site-sidebar-navigation-screen-pages__see-all"
-							{ ...manageAllPagesProps }
+							{ ...pagesLink }
 						>
 							{ __( 'Manage all pages' ) }
 						</SidebarNavigationItem>

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -68,11 +68,9 @@ function SidebarScreens() {
 			<SidebarScreenWrapper path="/page">
 				<SidebarNavigationScreenPages />
 			</SidebarScreenWrapper>
-			{ window?.__experimentalAdminViews && (
-				<SidebarScreenWrapper path="/pages">
-					<SidebarNavigationScreenPagesDataViews />
-				</SidebarScreenWrapper>
-			) }
+			<SidebarScreenWrapper path="/pages">
+				<SidebarNavigationScreenPagesDataViews />
+			</SidebarScreenWrapper>
 			<SidebarScreenWrapper path="/page/:postId">
 				<SidebarNavigationScreenPage />
 			</SidebarScreenWrapper>

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -14,8 +14,9 @@ export default function getIsListPage(
 	isMobileViewport
 ) {
 	return (
-		[ '/wp_template/all', '/wp_template_part/all' ].includes( path ) ||
-		( path === '/pages' && window?.__experimentalAdminViews ) ||
+		[ '/wp_template/all', '/wp_template_part/all', '/pages' ].includes(
+			path
+		) ||
 		( path === '/patterns' &&
 			// Don't treat "/patterns" without categoryType and categoryId as a
 			// list page in mobile because the sidebar covers the whole page.


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Makes the "Pages > Manage all pages" stable, with the `table` and `grid` layouts available. Before, it redirected to the wp-admin.

<img width="1500" alt="Captura de ecrã 2024-01-24, às 09 26 21" src="https://github.com/WordPress/gutenberg/assets/583546/c1207900-70b2-4c0e-ab09-0cd259c6d1e8">

## Why?

It follows what we do for Templates & Parts.

## How?

- Make the page stable, with `table` and `grid` layouts available. But keep `list` layout experimental.
- Make the default views stable, but keep the custom views experimental.

## Testing Instructions

With the "admin views" experiment disabled:

- go to "Pages > Manage all pages"
- verify that you see the dataviews-powered page, it has the `table` and `grid` layouts available, and it only shows the default views in the sidebar

https://github.com/WordPress/gutenberg/assets/583546/343e8a97-dc4b-4305-8e81-28b8c25a0176

With the "admin views" experiment enabled:

- go to "Pages > Manage all pages"
- verify that you see the dataviews-powered page, it has all the layouts available, and it also shows the custom views in the sidebar

https://github.com/WordPress/gutenberg/assets/583546/39ded018-03ae-4909-b62a-05507c95218e


