### PR TITLE
Try: Disable text selection for post content placeholder block.

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -54,6 +54,7 @@
 @import "./query-pagination-numbers/editor.scss";
 @import "./post-featured-image/editor.scss";
 @import "./post-comments-form/editor.scss";
+@import "./post-content/editor.scss";
 
 @import "./editor-elements.scss";
 

--- a/packages/block-library/src/post-content/editor.scss
+++ b/packages/block-library/src/post-content/editor.scss
@@ -1,0 +1,4 @@
+// Disable text selection in the post content placeholder.
+.wp-block-post-content.wp-block-post-content {
+	user-select: none;
+}


### PR DESCRIPTION
## What?

Makes tiny progress on #58136 by trying to disable text selection of the post content placeholder block.

## Why?

This is intended to make it clearer that this text is not editable.

## Testing Instructions

Open the site editor, edit a template that features a Post Content block, and using the mouse try and select text inside the placeholder.

## Screenshots or screencast <!-- if applicable -->

Before, you could make a text selection:

![before, selecting text](https://github.com/WordPress/gutenberg/assets/1204802/7cd10d51-98e1-4d7f-8f4a-2c479c41671f)

After, you cannot:

![after, can't select text](https://github.com/WordPress/gutenberg/assets/1204802/8e9ea692-97a9-4d8e-aeb9-81957320f1f6)
