### PR TITLE
Font Library: make the notices manually dismisable

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -97,16 +97,6 @@ function FontCollection( { slug } ) {
 		setFontsToInstall( [] );
 	}, [ selectedFont ] );
 
-	// Reset notice after 5 seconds
-	useEffect( () => {
-		if ( notice && notice?.duration !== 0 ) {
-			const timeout = setTimeout( () => {
-				setNotice( null );
-			}, notice.duration ?? 5000 );
-			return () => clearTimeout( timeout );
-		}
-	}, [ notice ] );
-
 	const collectionFonts = useMemo(
 		() => selectedCollection?.font_families ?? [],
 		[ selectedCollection ]
@@ -224,9 +214,9 @@ function FontCollection( { slug } ) {
 					<FlexItem>
 						<Spacer margin={ 2 } />
 						<Notice
-							isDismissible={ false }
 							status={ notice.type }
 							className="font-library-modal__font-collection__notice"
+							onRemove={ () => setNotice( null ) }
 						>
 							{ notice.message }
 						</Notice>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -55,7 +55,7 @@ function InstalledFonts() {
 				message: __( 'Font family uninstalled successfully.' ),
 			} );
 
-			// If the font was succesfully uninstalled it is unselected.
+			// If the font was successfully uninstalled it is unselected.
 			handleUnselectFont();
 			setIsConfirmDeleteOpen( false );
 		} catch ( error ) {
@@ -91,16 +91,6 @@ function InstalledFonts() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	// Reset notice after 5 seconds
-	useEffect( () => {
-		if ( notice ) {
-			const timeout = setTimeout( () => {
-				setNotice( null );
-			}, 5000 );
-			return () => clearTimeout( timeout );
-		}
-	}, [ notice ] );
-
 	return (
 		<TabPanelLayout
 			title={ libraryFontSelected?.name || '' }
@@ -125,9 +115,9 @@ function InstalledFonts() {
 					<FlexItem>
 						<Spacer margin={ 2 } />
 						<Notice
-							isDismissible={ false }
 							status={ notice.type }
 							className="font-library-modal__font-collection__notice"
+							onRemove={ () => setNotice( null ) }
 						>
 							{ notice.message }
 						</Notice>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/local-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/local-fonts.js
@@ -13,7 +13,7 @@ import {
 	FlexItem,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { useContext, useState, useEffect } from '@wordpress/element';
+import { useContext, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -43,16 +43,6 @@ function LocalFonts() {
 	const onFilesUpload = ( event ) => {
 		handleFilesUpload( event.target.files );
 	};
-
-	// Reset notice after 5 seconds
-	useEffect( () => {
-		if ( notice ) {
-			const timeout = setTimeout( () => {
-				setNotice( null );
-			}, 5000 );
-			return () => clearTimeout( timeout );
-		}
-	}, [ notice ] );
 
 	/**
 	 * Filters the selected files to only allow the ones with the allowed extensions
@@ -223,9 +213,9 @@ function LocalFonts() {
 					<FlexItem>
 						<Spacer margin={ 2 } />
 						<Notice
-							isDismissible={ false }
 							status={ notice.type }
 							className="font-library-modal__upload-area__notice"
+							onRemove={ () => setNotice( null ) }
 						>
 							{ notice.message }
 						</Notice>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It addresses the following suggestion from [here](https://github.com/WordPress/gutenberg/pull/55975#issuecomment-1820584893)

> Notices should not disappear. They should be dismissible. These notices appear to behave like snackbars, except they disappear much quicker, is it a new component?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Notices are set to disappear automatically after `5 sec` based on a timer. It is removed here.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Navigate to global styles, typography and font library modal.
* Install a new font.
* A notice should appear with status of font install and it should stay until user dismisses it.

## Screenshots or screencast <!-- if applicable -->

<img width="996" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/b3ac410e-9cc9-46f5-a192-75d671d8cd8c">
