### PR TITLE
Only allow links to be created for selected text and fix CMD + K shortcut

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -42,6 +42,8 @@ function Edit( {
 	// We only need to store the button element that opened the popover. We can ignore the other states, as they will be handled by the onFocus prop to return to the rich text field.
 	const [ openedBy, setOpenedBy ] = useState( null );
 
+	const canMakeLink = ! isCollapsed( value ) || addingLink || isActive;
+
 	useLayoutEffect( () => {
 		const editableContentElement = contentRef.current;
 		if ( ! editableContentElement ) {
@@ -138,7 +140,13 @@ function Edit( {
 
 	return (
 		<>
-			<RichTextShortcut type="primary" character="k" onUse={ addLink } />
+			{ canMakeLink && (
+				<RichTextShortcut
+					type="primary"
+					character="k"
+					onUse={ addLink }
+				/>
+			) }
 			<RichTextShortcut
 				type="primaryShift"
 				character="k"
@@ -156,6 +164,7 @@ function Edit( {
 				shortcutCharacter="k"
 				aria-haspopup="true"
 				aria-expanded={ addingLink }
+				disabled={ ! canMakeLink }
 			/>
 			{ addingLink && (
 				<InlineLinkUI


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently it's possible to create a link in rich text when there is no text selection. This disables the ability to do that.

This has the nice (and intended) side effect of meaning the the Cmd + K shortcut will only be active if there is a text selection, thereby leaving it free to invoke the Command Palette.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Allowing links to be created from no text selection causes all manner of [bugs and edge cases](https://github.com/WordPress/gutenberg/pull/58771). 

Moreover, it's annoying that the Link UI gets invoked when there is no text selection, when in most cases the user will have intended to invoke the Command Palette.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Disables the ability to invoke the Link UI via UI or keyboard shortcut unless:

- there is a text selection.
- there is an existing active link.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add some text
- Place cursor in rich text but do not make a selection.
- Test that Link icon within block toolbar is disabled.
- Test that Cmd + K does not invoke link UI but instead invokes Command Palette.
- Now make a text selection and repeat. See that you can use both methods to create a link.
- Test that interacting with existing links is still possible using toolbar and keyboard shortcut to bring up the Link UI.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/94631d9e-87e9-4c0c-9e8c-4fad495b5afe

