### PR TITLE
Tooltip: Add test for classname leakage

### DIFF
--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -487,5 +487,18 @@ describe( 'Tooltip', () => {
 				).not.toBeInTheDocument()
 			);
 		} );
+
+		it( 'should not leak Tooltip component classname to the anchor element', () => {
+			render(
+				<Tooltip>
+					<Tooltip>
+						<button>Anchor</button>
+					</Tooltip>
+				</Tooltip>
+			);
+			expect(
+				screen.getByRole( 'button', { name: 'Anchor' } )
+			).not.toHaveClass( 'components-tooltip' );
+		} );
 	} );
 } );


### PR DESCRIPTION
Follow-up to #57878

## What?

Adds a unit test for the Tooltip component to assert that it doesn't leak the `components-tooltip` CSS classname onto the anchor element when tooltips are nested.

## Why?

Although Tooltip _will_ in fact leak props to its anchor element in the nested case, it will likely not be much of a problem because consumers usually have no reason to set arbitrary props on Tooltip itself.

The test is specifically to guard against future devs from unwittingly connecting Tooltip to the Component Context System, which will automatically add and leak the `components-tooltip` class, causing visual breakage.

## Testing Instructions

Connect `Tooltip` to the Component Context System. Test should fail.

<details><summary>Diff (Don't mind the TS errors)</summary>

```diff
diff --git a/packages/components/src/tooltip/index.tsx b/packages/components/src/tooltip/index.tsx
index 87c7506a9c..7dbba65c3d 100644
--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -8,12 +8,7 @@ import * as Ariakit from '@ariakit/react';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import {
-	Children,
-	useContext,
-	createContext,
-	forwardRef,
-} from '@wordpress/element';
+import { Children, useContext, createContext } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -25,6 +20,7 @@ import type {
 } from './types';
 import Shortcut from '../shortcut';
 import { positionToPlacement } from '../popover/utils';
+import { contextConnect, useContextSystem } from '../context';
 
 const TooltipInternalContext = createContext< TooltipInternalContextType >( {
 	isNestedInTooltip: false,
@@ -53,7 +49,7 @@ function UnforwardedTooltip(
 		text,
 
 		...restProps
-	} = props;
+	} = useContextSystem( props, 'Tooltip' );
 
 	const { isNestedInTooltip } = useContext( TooltipInternalContext );
 
@@ -138,6 +134,6 @@ function UnforwardedTooltip(
 	);
 }
 
-export const Tooltip = forwardRef( UnforwardedTooltip );
+export const Tooltip = contextConnect( UnforwardedTooltip, 'Tooltip' );
 
 export default Tooltip;
```

</details> 