### PR TITLE
Use consistent labels, remove additional settings, and copySmall icon LinkControl

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -11,7 +11,6 @@ import {
 	Button,
 	ExternalLink,
 	__experimentalTruncate as Truncate,
-	Tooltip,
 } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
@@ -65,7 +64,7 @@ export default function LinkPreview( {
 
 	const { createNotice } = useDispatch( noticesStore );
 	const ref = useCopyToClipboard( value.url, () => {
-		createNotice( 'info', __( 'Copied URL to clipboard.' ), {
+		createNotice( 'info', __( 'Link copied to clipboard.' ), {
 			isDismissible: true,
 			type: 'snackbar',
 		} );
@@ -98,16 +97,14 @@ export default function LinkPreview( {
 					<span className="block-editor-link-control__search-item-details">
 						{ ! isEmptyURL ? (
 							<>
-								<Tooltip text={ value.url }>
-									<ExternalLink
-										className="block-editor-link-control__search-item-title"
-										href={ value.url }
-									>
-										<Truncate numberOfLines={ 1 }>
-											{ displayTitle }
-										</Truncate>
-									</ExternalLink>
-								</Tooltip>
+								<ExternalLink
+									className="block-editor-link-control__search-item-title"
+									href={ value.url }
+								>
+									<Truncate numberOfLines={ 1 }>
+										{ displayTitle }
+									</Truncate>
+								</ExternalLink>
 								{ value?.url && displayTitle !== displayURL && (
 									<span className="block-editor-link-control__search-item-info">
 										<Truncate numberOfLines={ 1 }>
@@ -123,11 +120,9 @@ export default function LinkPreview( {
 						) }
 					</span>
 				</span>
-
 				<Button
 					icon={ edit }
 					label={ __( 'Edit link' ) }
-					className="block-editor-link-control__search-item-action"
 					onClick={ onEditClick }
 					size="compact"
 				/>
@@ -135,7 +130,6 @@ export default function LinkPreview( {
 					<Button
 						icon={ linkOff }
 						label={ __( 'Remove link' ) }
-						className="block-editor-link-control__search-item-action block-editor-link-control__unlink"
 						onClick={ onRemove }
 						size="compact"
 					/>
@@ -143,7 +137,6 @@ export default function LinkPreview( {
 				<Button
 					icon={ copySmall }
 					label={ __( 'Copy link' ) }
-					className="block-editor-link-control__search-item-action block-editor-link-control__copy"
 					ref={ ref }
 					disabled={ isEmptyURL }
 					size="compact"

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	ExternalLink,
@@ -137,10 +137,12 @@ export default function LinkPreview( {
 				) }
 				<Button
 					icon={ copySmall }
-					// Ends up looking like "Copy link: https://example.com"
-					label={ `${ __( 'Copy link' ) }${
-						isEmptyURL ? '' : `: ${ value.url }`
-					}` }
+					label={ sprintf(
+						// Translators: %1$s is a placeholder for an optional colon, %2$s is a placeholder for the link URL (if present).
+						__( 'Copy link%1$s%2$s' ), // Ends up looking like "Copy link: https://example.com".
+						isEmptyURL ? '' : ': ',
+						value.url
+					) }
 					ref={ ref }
 					disabled={ isEmptyURL }
 					size="compact"

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -137,7 +137,10 @@ export default function LinkPreview( {
 				) }
 				<Button
 					icon={ copySmall }
-					label={ __( 'Copy link' ) }
+					// Ends up looking like "Copy link: https://example.com"
+					label={ `${ __( 'Copy link' ) }${
+						isEmptyURL ? '' : `: ${ value.url }`
+					}` }
 					ref={ ref }
 					disabled={ isEmptyURL }
 					size="compact"

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -15,7 +15,7 @@ import {
 } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
-import { Icon, globe, info, linkOff, edit, copy } from '@wordpress/icons';
+import { Icon, globe, info, linkOff, edit, copySmall } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -33,7 +33,6 @@ export default function LinkPreview( {
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
 	onRemove,
-	additionalControls,
 } ) {
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
@@ -127,7 +126,7 @@ export default function LinkPreview( {
 
 				<Button
 					icon={ edit }
-					label={ __( 'Edit' ) }
+					label={ __( 'Edit link' ) }
 					className="block-editor-link-control__search-item-action"
 					onClick={ onEditClick }
 					size="compact"
@@ -135,15 +134,15 @@ export default function LinkPreview( {
 				{ hasUnlinkControl && (
 					<Button
 						icon={ linkOff }
-						label={ __( 'Unlink' ) }
+						label={ __( 'Remove link' ) }
 						className="block-editor-link-control__search-item-action block-editor-link-control__unlink"
 						onClick={ onRemove }
 						size="compact"
 					/>
 				) }
 				<Button
-					icon={ copy }
-					label={ __( 'Copy URL' ) }
+					icon={ copySmall }
+					label={ __( 'Copy link' ) }
 					className="block-editor-link-control__search-item-action block-editor-link-control__copy"
 					ref={ ref }
 					disabled={ isEmptyURL }
@@ -151,7 +150,6 @@ export default function LinkPreview( {
 				/>
 				<ViewerSlot fillProps={ value } />
 			</div>
-			{ additionalControls && additionalControls() }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -32,6 +32,7 @@ export default function LinkPreview( {
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
 	onRemove,
+	additionalControls,
 } ) {
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
@@ -143,6 +144,7 @@ export default function LinkPreview( {
 				/>
 				<ViewerSlot fillProps={ value } />
 			</div>
+			{ additionalControls && additionalControls() }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -352,11 +352,6 @@ $block-editor-link-control-number-of-actions: 1;
 	position: relative;
 }
 
-.block-editor-link-control__unlink {
-	padding-left: $grid-unit-20;
-	padding-right: $grid-unit-20;
-}
-
 .block-editor-link-control__setting {
 	margin-bottom: 0;
 	flex: 1;
@@ -424,9 +419,4 @@ $block-editor-link-control-number-of-actions: 1;
 .block-editor-link-control .block-editor-link-control__search-input-wrapper.has-actions .components-spinner {
 	top: calc(50% + #{$spinner-size} / 4); // Add top spacing because this input has a visual label.
 	right: $grid-unit-15;
-}
-
-.block-editor-link-control__search-item-action {
-	margin-left: auto; // push to far right hand side
-	flex-shrink: 0;
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -245,6 +245,10 @@ $block-editor-link-control-number-of-actions: 1;
 		border-radius: $radius-block-ui;
 		line-height: 1.1;
 
+		&:focus {
+			box-shadow: none;
+		}
+
 		&:focus-visible {
 			@include block-toolbar-button-style__focus();
 			text-decoration: none;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1816,66 +1816,6 @@ describe( 'Selecting links', () => {
 } );
 
 describe( 'Addition Settings UI', () => {
-	it( 'should allow toggling the "Opens in new tab" setting control (only) on the link preview', async () => {
-		const user = userEvent.setup();
-		const selectedLink = fauxEntitySuggestions[ 0 ];
-		const mockOnChange = jest.fn();
-
-		const customSettings = [
-			{
-				id: 'opensInNewTab',
-				title: 'Open in new tab',
-			},
-			{
-				id: 'noFollow',
-				title: 'No follow',
-			},
-		];
-
-		const LinkControlConsumer = () => {
-			const [ link, setLink ] = useState( selectedLink );
-
-			return (
-				<LinkControl
-					value={ link }
-					settings={ customSettings }
-					onChange={ ( newVal ) => {
-						mockOnChange( newVal );
-						setLink( newVal );
-					} }
-				/>
-			);
-		};
-
-		render( <LinkControlConsumer /> );
-
-		const opensInNewTabField = screen.queryByRole( 'checkbox', {
-			name: 'Open in new tab',
-			checked: false,
-		} );
-
-		expect( opensInNewTabField ).toBeInTheDocument();
-
-		// No matter which settings are passed in only the `Opens in new tab`
-		// setting should be shown on the link preview (non-editing) state.
-		const noFollowField = screen.queryByRole( 'checkbox', {
-			name: 'No follow',
-		} );
-		expect( noFollowField ).not.toBeInTheDocument();
-
-		// Check that the link value is updated immediately upon checking
-		// the checkbox.
-		await user.click( opensInNewTabField );
-
-		expect( opensInNewTabField ).toBeChecked();
-
-		expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
-		expect( mockOnChange ).toHaveBeenCalledWith( {
-			...selectedLink,
-			opensInNewTab: true,
-		} );
-	} );
-
 	it( 'should hide advanced link settings and toggle when not editing a link', async () => {
 		const selectedLink = fauxEntitySuggestions[ 0 ];
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -321,7 +321,7 @@ describe( 'Basic rendering', () => {
 
 			// Click the "Edit" button to trigger into the editing mode.
 			const editButton = screen.queryByRole( 'button', {
-				name: 'Edit',
+				name: 'Edit link',
 			} );
 
 			await user.click( editButton );
@@ -379,7 +379,7 @@ describe( 'Basic rendering', () => {
 			render( <LinkControl value={ { url: 'https://example.com' } } /> );
 
 			const unLinkButton = screen.queryByRole( 'button', {
-				name: 'Unlink',
+				name: 'Remove link',
 			} );
 
 			expect( unLinkButton ).not.toBeInTheDocument();
@@ -397,7 +397,7 @@ describe( 'Basic rendering', () => {
 			);
 
 			const unLinkButton = screen.queryByRole( 'button', {
-				name: 'Unlink',
+				name: 'Remove link',
 			} );
 			expect( unLinkButton ).toBeVisible();
 
@@ -418,7 +418,7 @@ describe( 'Basic rendering', () => {
 			);
 
 			const unLinkButton = screen.queryByRole( 'button', {
-				name: 'Unlink',
+				name: 'Remove link',
 			} );
 			expect( unLinkButton ).toBeVisible();
 
@@ -822,7 +822,7 @@ describe( 'Manual link entry', () => {
 
 			// Click the "Edit" button to trigger into the editing mode.
 			let editButton = screen.queryByRole( 'button', {
-				name: 'Edit',
+				name: 'Edit link',
 			} );
 
 			await user.click( editButton );
@@ -856,7 +856,7 @@ describe( 'Manual link entry', () => {
 
 			// Re-query the edit button as it's been replaced.
 			editButton = screen.queryByRole( 'button', {
-				name: 'Edit',
+				name: 'Edit link',
 			} );
 
 			await user.click( editButton );
@@ -1060,7 +1060,7 @@ describe( 'Default search suggestions', () => {
 		// shown.
 		const currentLinkUI = screen.getByLabelText( 'Currently selected' );
 		const currentLinkBtn = within( currentLinkUI ).getByRole( 'button', {
-			name: 'Edit',
+			name: 'Edit link',
 		} );
 		await user.click( currentLinkBtn );
 
@@ -1502,7 +1502,7 @@ describe( 'Selecting links', () => {
 
 		expect( currentLink ).toBeVisible();
 		expect(
-			screen.queryByRole( 'button', { name: 'Edit' } )
+			screen.queryByRole( 'button', { name: 'Edit link' } )
 		).toBeVisible();
 		expect( currentLinkAnchor ).toBeVisible();
 	} );
@@ -1527,7 +1527,7 @@ describe( 'Selecting links', () => {
 		// Required in order to select the button below.
 		let currentLinkUI = screen.getByLabelText( 'Currently selected' );
 		const currentLinkBtn = within( currentLinkUI ).getByRole( 'button', {
-			name: 'Edit',
+			name: 'Edit link',
 		} );
 
 		// Simulate searching for a term.
@@ -1597,7 +1597,7 @@ describe( 'Selecting links', () => {
 
 				// Check that this suggestion is now shown as selected.
 				expect(
-					screen.getByRole( 'button', { name: 'Edit' } )
+					screen.getByRole( 'button', { name: 'Edit link' } )
 				).toBeVisible();
 				expect( currentLinkAnchor ).toBeVisible();
 			}
@@ -1709,7 +1709,7 @@ describe( 'Selecting links', () => {
 
 				expect( currentLink ).toBeVisible();
 				expect(
-					screen.getByRole( 'button', { name: 'Edit' } )
+					screen.getByRole( 'button', { name: 'Edit link' } )
 				).toBeVisible();
 				expect( currentLinkAnchor ).toBeVisible();
 			}
@@ -1995,25 +1995,6 @@ describe( 'Addition Settings UI', () => {
 				opensInNewTab: true,
 			} )
 		);
-	} );
-
-	it( 'should show tooltip with full URL alongside filtered display', async () => {
-		const user = userEvent.setup();
-		const url =
-			'http://www.wordpress.org/wp-content/uploads/a-document.pdf';
-		render( <LinkControl value={ { url } } /> );
-
-		const link = screen.getByRole( 'link' );
-
-		expect( link ).toHaveTextContent( 'a-document.pdf' );
-
-		await user.hover( link );
-
-		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent( url );
-
-		await user.unhover( link );
-
-		expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
 	} );
 } );
 

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -105,7 +105,7 @@ describe( 'General media replace flow', () => {
 
 		await user.click(
 			screen.getByRole( 'button', {
-				name: 'Edit',
+				name: 'Edit link',
 			} )
 		);
 

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -52,6 +52,7 @@ export { default as color } from './library/color';
 export { default as column } from './library/column';
 export { default as columns } from './library/columns';
 export { default as copy } from './library/copy';
+export { default as copySmall } from './library/copy-small';
 export { default as comment } from './library/comment';
 export { default as commentAuthorAvatar } from './library/comment-author-avatar';
 export { default as commentAuthorName } from './library/comment-author-name';

--- a/packages/icons/src/library/copy-small.js
+++ b/packages/icons/src/library/copy-small.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const copySmall = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M5.625 5.5h9.75c.069 0 .125.056.125.125v9.75a.125.125 0 0 1-.125.125h-9.75a.125.125 0 0 1-.125-.125v-9.75c0-.069.056-.125.125-.125ZM4 5.625C4 4.728 4.728 4 5.625 4h9.75C16.273 4 17 4.728 17 5.625v9.75c0 .898-.727 1.625-1.625 1.625h-9.75A1.625 1.625 0 0 1 4 15.375v-9.75Zm14.5 11.656v-9H20v9C20 18.8 18.77 20 17.251 20H6.25v-1.5h11.001c.69 0 1.249-.528 1.249-1.219Z"
+		/>
+	</SVG>
+);
+
+export default copySmall;

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -228,7 +228,9 @@ test.describe( 'Links', () => {
 		await LinkUtils.createLink();
 
 		// Click on the Edit button.
-		await page.getByRole( 'button', { name: 'Edit', exact: true } ).click();
+		await page
+			.getByRole( 'button', { name: 'Edit link', exact: true } )
+			.click();
 
 		// Change the URL.
 		// getByPlaceholder required in order to handle Link Control component
@@ -255,7 +257,9 @@ test.describe( 'Links', () => {
 
 		const linkPopover = LinkUtils.getLinkPopover();
 
-		await linkPopover.getByRole( 'button', { name: 'Unlink' } ).click();
+		await linkPopover
+			.getByRole( 'button', { name: 'Remove link' } )
+			.click();
 
 		// The link should have been removed.
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -305,7 +305,7 @@ test.describe( 'Pattern Overrides', () => {
 			exact: true,
 		} );
 		const editLinkButton = page.getByRole( 'button', {
-			name: 'Edit',
+			name: 'Edit link',
 			exact: true,
 		} );
 		const saveLinkButton = page.getByRole( 'button', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the "Open in new tab" control from the preview, originally applied in https://github.com/WordPress/gutenberg/pull/53566 as a stop-gap (now that https://github.com/WordPress/gutenberg/pull/57726 has landed, and https://github.com/WordPress/gutenberg/issues/50892 is on the way.)  

Also: 

- Changes tooltips to "Edit link", "Remove link", and "Copy link". 
- Adds new copySmall icon, as it fits better in this footprint. 


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-01-24 at 08 06 15](https://github.com/WordPress/gutenberg/assets/1813435/fd08b9d2-88e1-4b0b-830f-c08d417af575)

