### PR TITLE
Font Library: Update the default collection data url to the wordpress.org cdn

### DIFF
--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -136,8 +136,7 @@ $default_font_collection = array(
 	'slug'        => 'default-font-collection',
 	'name'        => 'Google Fonts',
 	'description' => __( 'Add from Google Fonts. Fonts are copied to and served from your site.', 'gutenberg' ),
-	// TODO: This URL needs to be updated to the wporg hosted one prior to the Gutenberg 17.6 release.
-	'src'         => 'https://raw.githubusercontent.com/WordPress/google-fonts-to-wordpress-collection/main/releases/gutenberg-17.6/collections/google-fonts.json',
+	'src'         => 'https://s.w.org/images/fonts/17.6/collections/google-fonts-with-preview.json',
 );
 
 wp_register_font_collection( $default_font_collection );


### PR DESCRIPTION
## What?
Update the default collection data URL to the wordpress.org cdn

## Why?
Replace the URL from a GitHub URL to the one hosted by the wordpress.org CDN.

## How?
Just by replacing the link.

## Testing Instructions
Navigate to the Font Library and check that the Google Fonts collection is loading as expected.
