### PR TITLE
Pagination Numbers: Add `data-wp-key` to pagination numbers if enhanced pagination is enabled

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -91,14 +91,19 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 	}
 
 	if ( $enhanced_pagination ) {
-		$p = new WP_HTML_Tag_Processor( $content );
+		$p      = new WP_HTML_Tag_Processor( $content );
+		$dots_i = 0;
 		while ( $p->next_tag(
-			array(
-				'tag_name'   => 'a',
-				'class_name' => 'page-numbers',
-			)
+			array( 'class_name' => 'page-numbers' )
 		) ) {
-			$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
+			if ( 'A' === $p->get_tag() ) {
+				$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
+				$p->set_attribute( 'data-wp-key', $p->get_attribute( 'href' ) );
+			} elseif ( $p->has_class( 'current' ) ) {
+				$p->set_attribute( 'data-wp-key', 'current' );
+			} elseif ( $p->has_class( 'dots' ) ) {
+				$p->set_attribute( 'data-wp-key', 'dots-' . $dots_i++ );
+			}
 		}
 		$content = $p->get_updated_html();
 	}

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -91,18 +91,16 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 	}
 
 	if ( $enhanced_pagination ) {
-		$p      = new WP_HTML_Tag_Processor( $content );
-		$dots_i = 0;
+		$p         = new WP_HTML_Tag_Processor( $content );
+		$tag_index = 0;
 		while ( $p->next_tag(
 			array( 'class_name' => 'page-numbers' )
 		) ) {
+			if ( null === $p->get_attribute( 'data-wp-key' ) ) {
+				$p->set_attribute( 'data-wp-key', 'index-' . $tag_index++ );
+			}
 			if ( 'A' === $p->get_tag() ) {
 				$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
-				$p->set_attribute( 'data-wp-key', $p->get_attribute( 'href' ) );
-			} elseif ( $p->has_class( 'current' ) ) {
-				$p->set_attribute( 'data-wp-key', 'current' );
-			} elseif ( $p->has_class( 'dots' ) ) {
-				$p->set_attribute( 'data-wp-key', 'dots-' . $dots_i++ );
 			}
 		}
 		$content = $p->get_updated_html();


### PR DESCRIPTION
## What?

Adds the `data-wp-key` directive to the elements rendered by the Pagination Numbers block to prevent issues after client-side navigations. This is done only when the "enhanced pagination" is enabled.

## Why?

Currently, after a couple of navigations, numbers start to turn into ellipsis characters due to the preact library having problems reconciling the new HTML with the current one.

## How?

Using each tag's position index to generate the key instead of a unique ID for each link. I know it's not appropriate to use `data-wp-key`, but it seems to be the only way to prevent text nodes between numbers from disappearing. If those are removed, the numbers "collapse" as there is no space in between. (Preact seems to remove the text nodes in between while re-ordering tags as text nodes don't have any key).

| No fix | Unique ID | Tag Index |
| --- | --- | --- |
| <video src="https://github.com/WordPress/gutenberg/assets/6917969/0e876438-a384-47cb-9f5e-d3c9a2f2e4a1"></video> | <video src="https://github.com/WordPress/gutenberg/assets/6917969/ca67582d-b6dc-4b6e-8986-03f1ebb8726d"></video> | <video src="https://github.com/WordPress/gutenberg/assets/6917969/cb0e417d-6ac1-40c4-bbaa-93cbbcd3f14f"></video> |

## Testing Instructions
1. In the site editor, go to the home template and disable "Force page reload" in the Query block.
2. Visit the homepage.
3. Navigate using the pagination links.
4. Ensure no duplicated or extra numbers appear in the pagination numbers.
5. Ensure links work as expected.
