### PR TITLE
Add context for the All translatable string and enforce l10n best practices

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -59,22 +59,16 @@ export function PatternsFilter( {
 		() => [
 			{
 				value: 'all',
-				label: _x( 'All', 'Option that shows all patterns' ),
+				label: _x( 'All', 'patterns' ),
 			},
 			{
 				value: INSERTER_SYNC_TYPES.full,
-				label: _x(
-					'Synced',
-					'Option that shows all synchronized patterns'
-				),
+				label: _x( 'Synced', 'patterns' ),
 				disabled: shouldDisableSyncFilter,
 			},
 			{
 				value: INSERTER_SYNC_TYPES.unsynced,
-				label: _x(
-					'Not synced',
-					'Option that shows all patterns that are not synchronized'
-				),
+				label: _x( 'Not synced', 'patterns' ),
 				disabled: shouldDisableSyncFilter,
 			},
 		],
@@ -85,7 +79,7 @@ export function PatternsFilter( {
 		() => [
 			{
 				value: 'all',
-				label: __( 'All' ),
+				label: _x( 'All', 'patterns' ),
 				disabled: shouldDisableNonUserSources,
 			},
 			{

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 export const INSERTER_PATTERN_TYPES = {
 	user: 'user',
@@ -17,7 +17,7 @@ export const INSERTER_SYNC_TYPES = {
 
 export const allPatternsCategory = {
 	name: 'allPatterns',
-	label: __( 'All' ),
+	label: _x( 'All', 'patterns' ),
 };
 
 export const myPatternsCategory = {

--- a/packages/block-editor/src/components/responsive-block-control/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { ToggleControl } from '@wordpress/components';
 
@@ -26,8 +26,7 @@ function ResponsiveBlockControl( props ) {
 		isResponsive = false,
 		defaultLabel = {
 			id: 'all',
-			/* translators: 'Label. Used to signify a layout property (eg: margin, padding) will apply uniformly to all screensizes.' */
-			label: __( 'All' ),
+			label: _x( 'All', 'screen sizes' ),
 		},
 		viewports = [
 			{
@@ -52,12 +51,11 @@ function ResponsiveBlockControl( props ) {
 	const toggleControlLabel =
 		toggleLabel ||
 		sprintf(
-			/* translators: 'Toggle control label. Should the property be the same across all screen sizes or unique per screen size.'. %s property value for the control (eg: margin, padding...etc) */
+			/* translators: %s: Property value for the control (eg: margin, padding, etc.). */
 			__( 'Use the same %s on all screensizes.' ),
 			property
 		);
 
-	/* translators: 'Help text for the responsive mode toggle control.' */
 	const toggleHelpText = __(
 		'Toggle between using the same value for all screen sizes or using a unique value per screen size.'
 	);

--- a/packages/components/src/query-controls/index.native.js
+++ b/packages/components/src/query-controls/index.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useCallback, memo } from '@wordpress/element';
 
 /**
@@ -23,12 +23,12 @@ const options = [
 		value: 'date/asc',
 	},
 	{
-		/* translators: label for ordering posts by title in ascending order */
+		/* translators: Label for ordering posts by title in ascending order. */
 		label: __( 'A → Z' ),
 		value: 'title/asc',
 	},
 	{
-		/* translators: label for ordering posts by title in descending order */
+		/* translators: Label for ordering posts by title in descending order. */
 		label: __( 'Z → A' ),
 		value: 'title/desc',
 	},
@@ -76,7 +76,7 @@ const QueryControls = memo(
 					<CategorySelect
 						categoriesList={ categoriesList }
 						label={ __( 'Category' ) }
-						noOptionLabel={ __( 'All' ) }
+						noOptionLabel={ _x( 'All', 'categories' ) }
 						selectedCategoryId={ selectedCategoryId }
 						onChange={ onCategoryChange }
 						hideCancelButton={ true }

--- a/packages/components/src/query-controls/index.tsx
+++ b/packages/components/src/query-controls/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -96,12 +96,12 @@ export function QueryControls( {
 								value: 'date/asc',
 							},
 							{
-								/* translators: label for ordering posts by title in ascending order */
+								/* translators: Label for ordering posts by title in ascending order.translators: */
 								label: __( 'A → Z' ),
 								value: 'title/asc',
 							},
 							{
-								/* translators: label for ordering posts by title in descending order */
+								/* translators: Label for ordering posts by title in descending order. */
 								label: __( 'Z → A' ),
 								value: 'title/desc',
 							},
@@ -137,7 +137,7 @@ export function QueryControls( {
 							key="query-controls-category-select"
 							categoriesList={ props.categoriesList }
 							label={ __( 'Category' ) }
-							noOptionLabel={ __( 'All' ) }
+							noOptionLabel={ _x( 'All', 'categories' ) }
 							selectedCategoryId={ props.selectedCategoryId }
 							onChange={ props.onCategoryChange }
 						/>
@@ -174,7 +174,7 @@ export function QueryControls( {
 						key="query-controls-author-select"
 						authorList={ authorList }
 						label={ __( 'Author' ) }
-						noOptionLabel={ __( 'All' ) }
+						noOptionLabel={ _x( 'All', 'authors' ) }
 						selectedAuthorId={ selectedAuthorId }
 						onChange={ onAuthorChange }
 					/>

--- a/packages/components/src/query-controls/index.tsx
+++ b/packages/components/src/query-controls/index.tsx
@@ -96,7 +96,7 @@ export function QueryControls( {
 								value: 'date/asc',
 							},
 							{
-								/* translators: Label for ordering posts by title in ascending order.translators: */
+								/* translators: Label for ordering posts by title in ascending order. */
 								label: __( 'A → Z' ),
 								value: 'title/asc',
 							},

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -15,7 +15,7 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { search, closeSmall } from '@wordpress/icons';
 
 /**
@@ -34,7 +34,7 @@ import { downloadFontFaceAsset } from './utils';
 
 const DEFAULT_CATEGORY = {
 	slug: 'all',
-	name: __( 'All' ),
+	name: _x( 'All', 'font categories' ),
 };
 function FontCollection( { slug } ) {
 	const requiresPermission = slug === 'default-font-collection';

--- a/packages/edit-site/src/components/global-styles/font-library-modal/library-font-card.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/library-font-card.js
@@ -20,7 +20,7 @@ function LibraryFontCard( { font, ...props } ) {
 		font.source
 	).length;
 	const variantsText = sprintf(
-		/* translators: %1$d: Active font variants, %2$d: Total font variants */
+		/* translators: 1: Active font variants, 2: Total font variants. */
 		__( '%1$s/%2$s variants active' ),
 		variantsActive,
 		variantsInstalled

--- a/packages/edit-site/src/components/global-styles/screen-typography-element.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography-element.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -67,9 +67,7 @@ function ScreenTypographyElement( { element } ) {
 					>
 						<ToggleGroupControlOption
 							value="heading"
-							/* translators: 'All' refers to selecting all heading levels 
-							and applying the same style to h1-h6. */
-							label={ __( 'All' ) }
+							label={ _x( 'All', 'heading levels' ) }
 						/>
 						<ToggleGroupControlOption
 							value="h1"

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 
 /**
@@ -49,7 +49,7 @@ const DEFAULT_PAGE_BASE = {
 export const DEFAULT_VIEWS = {
 	page: [
 		{
-			title: __( 'All' ),
+			title: _x( 'All', 'pages' ),
 			slug: 'all',
 			view: DEFAULT_PAGE_BASE,
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58185

## What?
<!-- In a few words, what is the PR actually doing? -->
The `__( 'All'  )` string needs more context to be correctly translatable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Languages other htan English may have genres.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add context via the `_x()` function.
- Fixes usage of the `_x()` second parameter: must be short and lowercase.
- Removes unnecessary translators comments.
- Improves existing translators comments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Not fully appplicable.
I guess a code review is enough in this case.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
