### PR TITLE
Post Lock: Use the new modal size preset

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -172,7 +172,7 @@ export default function PostLockedModal() {
 			shouldCloseOnClickOutside={ false }
 			shouldCloseOnEsc={ false }
 			isDismissible={ false }
-			className="editor-post-locked-modal"
+			size="medium"
 		>
 			<HStack alignment="top" spacing={ 6 }>
 				{ !! userAvatar && (

--- a/packages/editor/src/components/post-locked-modal/style.scss
+++ b/packages/editor/src/components/post-locked-modal/style.scss
@@ -1,9 +1,3 @@
-.editor-post-locked-modal {
-	@include break-small() {
-		max-width: $break-mobile;
-	}
-}
-
 .editor-post-locked-modal__buttons {
 	margin-top: $grid-unit-30;
 }


### PR DESCRIPTION
## What?
PR updates the "Post Lock" modal to use the new size preset. See #54471.

The preset's `medium` is slightly bigger, but I think it looks OK.

## Testing Instructions
* Add the snippet below to the theme functions.php and emulate the post-lock state.
* Confirm the avatar is correctly aligned.

<details><summary>Snippet</summary>
<p>

```php
add_filter( 'block_editor_settings_all', function( $settings, $block_editor_context ) {
	if ( empty( $block_editor_context->post ) ) {
		return $settings;
	}

	if ( isset( $settings['postLock']['user'] ) ) {
		return $settings;
	}

	$user = wp_get_current_user();
	if ( ! isset( $user->ID ) ) {
		return $settings;
	}

	$settings['postLock'] = [
		'isLocked' => true,
		'user'     => [
			'name'   => $user->display_name,
			'avatar' => get_avatar_url( $user->ID, array( 'size' => 64 ) ),
		],
	];

	return $settings;
}, 10, 2 );
```

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
**Before**
![CleanShot 2024-01-24 at 18 32 48](https://github.com/WordPress/gutenberg/assets/240569/44457d0c-2e71-42af-80c3-4092e6bec0d1)

**After**
![CleanShot 2024-01-24 at 18 32 33](https://github.com/WordPress/gutenberg/assets/240569/68545992-88b8-49fc-90c3-192ef260cd85)
