### PR TITLE
Move zoom out into PreviewDropdown

### DIFF
--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -158,6 +158,7 @@ function EditorCanvas( {
 			renderAppender={ showBlockAppender }
 			styles={ styles }
 			iframeProps={ {
+				expand: isZoomOutMode,
 				scale,
 				frameSize,
 				className: classnames(

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -158,7 +158,6 @@ function EditorCanvas( {
 			renderAppender={ showBlockAppender }
 			styles={ styles }
 			iframeProps={ {
-				expand: isZoomOutMode,
 				scale,
 				frameSize,
 				className: classnames(

--- a/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
@@ -1,16 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useViewportMatch } from '@wordpress/compose';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { chevronUpDown } from '@wordpress/icons';
-import { Button, ToolbarItem } from '@wordpress/components';
-import {
-	store as editorStore,
-	privateApis as editorPrivateApis,
-} from '@wordpress/editor';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -19,11 +12,7 @@ import { unlock } from '../../../lock-unlock';
 
 const { DocumentTools: EditorDocumentTools } = unlock( editorPrivateApis );
 
-export default function DocumentTools( {
-	blockEditorMode,
-	hasFixedToolbar,
-	isDistractionFree,
-} ) {
+export default function DocumentTools() {
 	const { isVisualMode } = useSelect( ( select ) => {
 		const { getEditorMode } = select( editorStore );
 
@@ -31,38 +20,11 @@ export default function DocumentTools( {
 			isVisualMode: getEditorMode() === 'visual',
 		};
 	}, [] );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
-	const { setDeviceType } = useDispatch( editorStore );
-	const isLargeViewport = useViewportMatch( 'medium' );
-	const isZoomedOutViewExperimentEnabled =
-		window?.__experimentalEnableZoomedOutView && isVisualMode;
-	const isZoomedOutView = blockEditorMode === 'zoom-out';
 
 	return (
 		<EditorDocumentTools
 			disableBlockTools={ ! isVisualMode }
 			listViewLabel={ __( 'List View' ) }
-		>
-			{ isZoomedOutViewExperimentEnabled &&
-				isLargeViewport &&
-				! isDistractionFree &&
-				! hasFixedToolbar && (
-					<ToolbarItem
-						as={ Button }
-						className="edit-site-header-edit-mode__zoom-out-view-toggle"
-						icon={ chevronUpDown }
-						isPressed={ isZoomedOutView }
-						/* translators: button label text should, if possible, be under 16 characters. */
-						label={ __( 'Zoom-out View' ) }
-						onClick={ () => {
-							setDeviceType( 'Desktop' );
-							__unstableSetEditorMode(
-								isZoomedOutView ? 'edit' : 'zoom-out'
-							);
-						} }
-						size="compact"
-					/>
-				) }
-		</EditorDocumentTools>
+		/>
 	);
 }

--- a/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-tools/index.js
@@ -3,7 +3,10 @@
  */
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import {
+	privateApis as editorPrivateApis,
+	store as editorStore,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -107,15 +107,6 @@
 	gap: $grid-unit-10;
 }
 
-.edit-site-header-edit-mode__preview-options {
-	opacity: 1;
-	transition: opacity 0.3s;
-
-	&.is-zoomed-out {
-		opacity: 0;
-	}
-}
-
 // Button text label styles
 
 .edit-site-header-edit-mode.show-icon-labels {

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -10,14 +10,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	check,
-	desktop,
-	mobile,
-	tablet,
-	external,
-	chevronUpDown,
-} from '@wordpress/icons';
+import { check, desktop, mobile, tablet, external } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -86,11 +79,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			popoverProps={ popoverProps }
 			toggleProps={ toggleProps }
 			menuProps={ menuProps }
-			icon={
-				isZoomedOutView
-					? chevronUpDown
-					: deviceIcons[ deviceType.toLowerCase() ]
-			}
+			icon={ deviceIcons[ deviceType.toLowerCase() ] }
 			label={ __( 'View' ) }
 			disableOpenOnArrowDown={ disabled }
 		>
@@ -102,11 +91,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 								setDeviceType( 'Desktop' );
 								__unstableSetEditorMode( 'edit' );
 							} }
-							icon={
-								deviceType === 'Desktop' &&
-								! isZoomedOutView &&
-								check
-							}
+							icon={ deviceType === 'Desktop' && check }
 						>
 							{ __( 'Desktop' ) }
 						</MenuItem>
@@ -133,10 +118,15 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						<MenuGroup>
 							<MenuItem
 								onClick={ () => {
-									setDeviceType( 'Desktop' );
-									__unstableSetEditorMode(
-										isZoomedOutView ? 'edit' : 'zoom-out'
-									);
+									__unstableSetEditorMode( 'edit' );
+								} }
+								icon={ ! isZoomedOutView && check }
+							>
+								{ __( 'Zoom to 100%' ) }
+							</MenuItem>
+							<MenuItem
+								onClick={ () => {
+									__unstableSetEditorMode( 'zoom-out' );
 								} }
 								icon={ isZoomedOutView && check }
 							>

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -86,7 +86,11 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			popoverProps={ popoverProps }
 			toggleProps={ toggleProps }
 			menuProps={ menuProps }
-			icon={ deviceIcons[ deviceType.toLowerCase() ] }
+			icon={
+				isZoomedOutView
+					? chevronUpDown
+					: deviceIcons[ deviceType.toLowerCase() ]
+			}
 			label={ __( 'View' ) }
 			disableOpenOnArrowDown={ disabled }
 		>
@@ -94,7 +98,10 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 				<>
 					<MenuGroup>
 						<MenuItem
-							onClick={ () => setDeviceType( 'Desktop' ) }
+							onClick={ () => {
+								setDeviceType( 'Desktop' );
+								__unstableSetEditorMode( 'edit' );
+							} }
 							icon={
 								deviceType === 'Desktop' &&
 								! isZoomedOutView &&
@@ -131,9 +138,9 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 										isZoomedOutView ? 'edit' : 'zoom-out'
 									);
 								} }
-								icon={ isZoomedOutView ? check : chevronUpDown }
+								icon={ isZoomedOutView && check }
 							>
-								{ __( 'Zoom out' ) }
+								{ __( 'Zoom to 50%' ) }
 							</MenuItem>
 						</MenuGroup>
 					) }

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -10,7 +10,14 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { check, desktop, mobile, tablet, external } from '@wordpress/icons';
+import {
+	check,
+	desktop,
+	mobile,
+	tablet,
+	external,
+	chevronUpDown,
+} from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -79,7 +86,11 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			popoverProps={ popoverProps }
 			toggleProps={ toggleProps }
 			menuProps={ menuProps }
-			icon={ deviceIcons[ deviceType.toLowerCase() ] }
+			icon={
+				isZoomedOutView
+					? chevronUpDown
+					: deviceIcons[ deviceType.toLowerCase() ]
+			}
 			label={ __( 'View' ) }
 			disableOpenOnArrowDown={ disabled }
 		>
@@ -91,7 +102,11 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 								setDeviceType( 'Desktop' );
 								__unstableSetEditorMode( 'edit' );
 							} }
-							icon={ deviceType === 'Desktop' && check }
+							icon={
+								deviceType === 'Desktop' &&
+								! isZoomedOutView &&
+								check
+							}
 						>
 							{ __( 'Desktop' ) }
 						</MenuItem>
@@ -118,15 +133,10 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						<MenuGroup>
 							<MenuItem
 								onClick={ () => {
-									__unstableSetEditorMode( 'edit' );
-								} }
-								icon={ ! isZoomedOutView && check }
-							>
-								{ __( 'Zoom to 100%' ) }
-							</MenuItem>
-							<MenuItem
-								onClick={ () => {
-									__unstableSetEditorMode( 'zoom-out' );
+									setDeviceType( 'Desktop' );
+									__unstableSetEditorMode(
+										isZoomedOutView ? 'edit' : 'zoom-out'
+									);
 								} }
 								icon={ isZoomedOutView && check }
 							>

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -102,11 +102,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 								setDeviceType( 'Desktop' );
 								__unstableSetEditorMode( 'edit' );
 							} }
-							icon={
-								deviceType === 'Desktop' &&
-								! isZoomedOutView &&
-								check
-							}
+							icon={ deviceType === 'Desktop' && check }
 						>
 							{ __( 'Desktop' ) }
 						</MenuItem>
@@ -134,9 +130,16 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 							<MenuItem
 								onClick={ () => {
 									setDeviceType( 'Desktop' );
-									__unstableSetEditorMode(
-										isZoomedOutView ? 'edit' : 'zoom-out'
-									);
+									__unstableSetEditorMode( 'edit' );
+								} }
+								icon={ ! isZoomedOutView && check }
+							>
+								{ __( 'Zoom to 100%' ) }
+							</MenuItem>
+							<MenuItem
+								onClick={ () => {
+									setDeviceType( 'Desktop' );
+									__unstableSetEditorMode( 'zoom-out' );
 								} }
 								icon={ isZoomedOutView && check }
 							>

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -10,14 +10,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	check,
-	desktop,
-	mobile,
-	tablet,
-	external,
-	chevronUpDown,
-} from '@wordpress/icons';
+import { check, desktop, mobile, tablet, external } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -86,11 +79,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			popoverProps={ popoverProps }
 			toggleProps={ toggleProps }
 			menuProps={ menuProps }
-			icon={
-				isZoomedOutView
-					? chevronUpDown
-					: deviceIcons[ deviceType.toLowerCase() ]
-			}
+			icon={ deviceIcons[ deviceType.toLowerCase() ] }
 			label={ __( 'View' ) }
 			disableOpenOnArrowDown={ disabled }
 		>
@@ -129,7 +118,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						<MenuGroup>
 							<MenuItem
 								onClick={ () => {
-									setDeviceType( 'Desktop' );
 									__unstableSetEditorMode( 'edit' );
 								} }
 								icon={ ! isZoomedOutView && check }
@@ -142,6 +130,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 									__unstableSetEditorMode( 'zoom-out' );
 								} }
 								icon={ isZoomedOutView && check }
+								disabled={ deviceType !== 'Desktop' }
 							>
 								{ __( 'Zoom to 50%' ) }
 							</MenuItem>


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Related to https://github.com/WordPress/gutenberg/pull/56806, moving the standalone zoom control into the PreviewDropdown. This aligns the display and zoom tools into one area, as they are directly related. 

Previously, invoking zoom would hide the preview device controls (as the zoom UI was separate from the preview UI). With this change we don't need to get smart on that front; just include the like actions in the same area. 

I am curious if we need to have this behind an experimental flag, not that it's much more integrated into the existing UI — rather than appended at the top of the toolbar. Sure, there are further refinements that the zoomed out view may hold, but it's nice to be able to see more of a page all at once. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1.  Turn on the zoom experiment.
2. Open a post or page.
3. Open the PreviewDropdown.
4. Try activating the various preview options. 
5. Do the same in the site editor. 
6. Ensure the changes are not reflected when the experiment is off. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/1813435/459f09c7-b4bd-48f3-b8df-70cb356401d4

## Follow-up
1. I set this zoom percentage to 50%, but it would be nice to have a "Zoom to fit" control, which would zoom out enough so you can see the entire page. 

2. With that fit control in mind alongside 50%, we may need to be more clear about zooming back to 100%, like below. Although "Zoom to 100%" and "Desktop" have the same behavior. cc @WordPress/gutenberg-design.

![CleanShot 2024-01-24 at 10 33 31](https://github.com/WordPress/gutenberg/assets/1813435/e597e483-cd8d-4db9-8679-605ed596f425)
