### PR TITLE
Scripts: Add viewScriptModule block.json support

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add experimental support for `viewScriptModule` field in block.json for `build` and `start` scripts ([#57437](https://github.com/WordPress/gutenberg/pull/57437)).
+
+### Deprecations
+
+-   Experimental support for `viewModule` field in block.json is deprecated in favor of `viewScriptModule` ([#57437](https://github.com/WordPress/gutenberg/pull/57437)).
+
 ## 27.1.0 (2024-01-24)
 
 ## 27.0.0 (2024-01-10)

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -108,9 +108,9 @@ This script automatically use the optimized config but sometimes you may want to
 -   `--webpack-src-dir` – Allows customization of the source code directory. Default is `src`.
 -   `--output-path` – Allows customization of the output directory. Default is `build`.
 
-Experimental support for the block.json `viewModule` field is available via the
+Experimental support for the block.json `viewScriptModule` field is available via the
 `--experimental-modules` option. With this option enabled, script and module fields will all be
-compiled. The `viewModule` field is analogous to the `viewScript` field, but will compile a module
+compiled. The `viewScriptModule` field is analogous to the `viewScript` field, but will compile a module
 and should be registered in WordPress using the Modules API.
 
 #### Advanced information
@@ -396,9 +396,9 @@ This script automatically use the optimized config but sometimes you may want to
 -   `--webpack-src-dir` – Allows customization of the source code directory. Default is `src`.
 -   `--output-path` – Allows customization of the output directory. Default is `build`.
 
-Experimental support for the block.json `viewModule` field is available via the
+Experimental support for the block.json `viewScriptModule` field is available via the
 `--experimental-modules` option. With this option enabled, script and module fields will all be
-compiled. The `viewModule` field is analogous to the `viewScript` field, but will compile a module
+compiled. The `viewScriptModule` field is analogous to the `viewScript` field, but will compile a module
 and should be registered in WordPress using the Modules API.
 
 #### Advanced information

--- a/packages/scripts/utils/block-json.js
+++ b/packages/scripts/utils/block-json.js
@@ -1,4 +1,4 @@
-const moduleFields = new Set( [ 'viewModule' ] );
+const moduleFields = new Set( [ 'viewScriptModule', 'viewModule' ] );
 const scriptFields = new Set( [ 'viewScript', 'script', 'editorScript' ] );
 
 /**


### PR DESCRIPTION
## What?

Support `viewScriptModule` for building view script modules.

`viewModule` is still supported but has been deprecated.

## Why?

The Module API was changed to use naming like "script module" instead of "module" so we're following that pattern with `viewScriptModule`.

See https://github.com/WordPress/wordpress-develop/pull/5860

## How?

Support is added just like `viewModule` was in #57461.

## Testing Instructions

Testing instructions are just like https://github.com/WordPress/gutenberg/pull/57461, but make sure you switch `viewModule` to `viewScriptModule`.

> To test this, you'll want to check this out and link a project that depends on @wordpress/scripts to use this PR.
> 
> If you use wp-scripts build or wp-scripts start, there should be no significant changes with the current behavior.
> 
> You can test the experimental build by adding a viewModule field to block.json in a project, then running a script like wp-scripts -- build --experimental-modules to build it.
> 
> I've been running the experimental build of https://github.com/sirreal/wp-scripts-interactivity-module-demo (the packages is linked to my development copy locally). The build produces the expected results with both scripts and modules. With https://github.com/WordPress/gutenberg/pull/57437 (handling viewModule in block registration), this results in a working plugin.