### PR TITLE
Data views: Remove min-width style on table cells

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -87,10 +87,6 @@
 		padding: $grid-unit-15;
 		white-space: nowrap;
 
-		@include break-huge() {
-			min-width: 200px;
-		}
-
 		&[data-field-id="actions"] {
 			text-align: right;
 		}

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -298,7 +298,7 @@ export default function PagePages() {
 							__( '(no title)' )
 					);
 				},
-				maxWidth: 400,
+				maxWidth: 300,
 				enableHiding: false,
 			},
 			{


### PR DESCRIPTION
## What?
Removes the min-width style currently applied to table cells and decreases the width of the title column in the pages table.

## Why?
With the recent layout updates this style isn't serving a useful purpose. In fact it causes horizontal scrolling to occur too aggressively on the Pages table when all fields are visible and some pages have long titles.

| Trunk @ 1280px | This branch @1280px |
| --- | --- |
| <img width="1279" alt="Screenshot 2024-01-24 at 15 36 00" src="https://github.com/WordPress/gutenberg/assets/846565/1b8133f9-5d8d-4254-b5df-29afb03b4477"> | <img width="1280" alt="Screenshot 2024-01-24 at 15 34 10" src="https://github.com/WordPress/gutenberg/assets/846565/96ad343e-bcd9-4e26-a66f-137cd7ceddf6"> |

| Trunk @ >1440px | This branch @ >1440px |
| --- | --- |
| <img width="1451" alt="Screenshot 2024-01-24 at 15 39 13" src="https://github.com/WordPress/gutenberg/assets/846565/16e6d4fc-c129-4cc0-8a18-02cd8bedcc52"> | <img width="1449" alt="Screenshot 2024-01-24 at 15 39 45" src="https://github.com/WordPress/gutenberg/assets/846565/805afbbe-aae9-4615-b923-b8f1a2d76edf"> |

## To test

* Navigate to Manage all pages
* Toggle the date field
* Observe that horizontal scrolling occurs less frequently compared with trunk.
