### PR TITLE
Try fixing flaky Paragraph block e2e test

### DIFF
--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -236,8 +236,9 @@ test.describe( 'Paragraph', () => {
 
 				{
 					// Dragging on the top half of the heading block.
+					// Make sure to target the top dropzone by dragging > 30px inside the block.
 					await draggingUtils.dragOver(
-						headingBox.x,
+						headingBox.x + 32,
 						headingBox.y + 1
 					);
 					await expect( draggingUtils.dropZone ).toBeVisible();


### PR DESCRIPTION
## What?
Fixes #58161.

PR tries to fix flaky Paragraph block e2e test.

## How?
The fix is similar to 693e1595fc077a7bae67d5b76e78e6bc3329c1fb.

## Testing Instructions
```
npm run test:e2e:playwright -- -g "Only the first block is an empty paragraph block" --repeat-each 10
```
