### PR TITLE
Interactive Template: Use viewScriptModule

### DIFF
--- a/packages/create-block-interactive-template/index.js
+++ b/packages/create-block-interactive-template/index.js
@@ -15,7 +15,7 @@ module.exports = {
 			interactivity: true,
 		},
 		viewScript: null,
-		viewModule: 'file:./view.js',
+		viewScriptModule: 'file:./view.js',
 		render: 'file:./render.php',
 		example: {},
 		customScripts: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Use `viewScriptModule` in the interactive template.

## Why?

Module support switched to using module naming like "script module", so when implementing `viewModule` support for Core, we ended up using `viewScriptModule.

Related:
- https://github.com/WordPress/gutenberg/pull/58203


## Testing Instructions

You can check this out and run it:

```sh
path/to/gutenberg/trunk/packages/create-block/index.js \
  --template path/to/gutenberg/trunk/packages/create-block-interactive-template
```
