### PR TITLE
Font Library: buttons position and accessibility

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-variant.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-variant.js
@@ -39,8 +39,7 @@ function CollectionFontVariant( {
 			className="font-library-modal__library-font-variant"
 			htmlFor={ checkboxId }
 		>
-			<Flex justify="space-between" align="center" gap="1rem">
-				<FontFaceDemo fontFace={ face } text={ displayName } />
+			<Flex justify="flex-start" align="center" gap="1rem">
 				<CheckboxControl
 					checked={ selected }
 					onChange={ handleToggleActivation }
@@ -48,6 +47,7 @@ function CollectionFontVariant( {
 					id={ checkboxId }
 					label={ false }
 				/>
+				<FontFaceDemo fontFace={ face } text={ displayName } />
 			</Flex>
 		</label>
 	);

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -191,11 +191,15 @@ function Footer( { shouldDisplayDeleteButton, handleUninstallClick } ) {
 	const { saveFontFamilies, fontFamiliesHasChanges, isInstalling } =
 		useContext( FontLibraryContext );
 	return (
-		<HStack justify="space-between">
+		<HStack justify="flex-end">
 			{ isInstalling && <ProgressBar /> }
 			<div>
 				{ shouldDisplayDeleteButton && (
-					<Button variant="tertiary" onClick={ handleUninstallClick }>
+					<Button
+						isDestructive
+						variant="tertiary"
+						onClick={ handleUninstallClick }
+					>
 						{ __( 'Delete' ) }
 					</Button>
 				) }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/library-font-variant.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/library-font-variant.js
@@ -49,8 +49,7 @@ function LibraryFontVariant( { face, font } ) {
 			className="font-library-modal__library-font-variant"
 			htmlFor={ checkboxId }
 		>
-			<Flex justify="space-between" align="center" gap="1rem">
-				<FontFaceDemo fontFace={ face } text={ displayName } />
+			<Flex justify="flex-start" align="center" gap="1rem">
 				<CheckboxControl
 					checked={ isIstalled }
 					onChange={ handleToggleActivation }
@@ -58,6 +57,7 @@ function LibraryFontVariant( { face, font } ) {
 					id={ checkboxId }
 					label={ false }
 				/>
+				<FontFaceDemo fontFace={ face } text={ displayName } />
 			</Flex>
 		</label>
 	);


### PR DESCRIPTION
## What?
- Makes checkbox controls closer to the font face previews.
- Makes the delete button red.
- Move the delete button close to the save button.

## Why?
- Low vision users, users who use screen amgnifiers, etc. struggle to find user interface controls that are places far from each other.
- Controls for destructive actions should be red.
- Buttons should be placed close each other even when one of the buttons action is a destructive action.

See https://github.com/WordPress/gutenberg/issues/58083 for reference.


## Testing Instructions
- Visual testing of the change.

## Screenshots:

| Before | After |
| --- | --- |
| ![before](https://github.com/WordPress/gutenberg/assets/1310626/c553e502-0e70-46f8-b7ba-7b74e2e17272) | ![after](https://github.com/WordPress/gutenberg/assets/1310626/02074faa-bc01-4ac5-aa50-b443f3294433) |

--- 
Fixes: https://github.com/WordPress/gutenberg/issues/58083






