### PR TITLE
PaletteEdit: Fix palette item accessibility

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 -   `ToggleGroupControl`: Improve controlled value detection ([#57770](https://github.com/WordPress/gutenberg/pull/57770)).
 -   `Tooltip`: Improve props forwarding to children of nested `Tooltip` components ([#57878](https://github.com/WordPress/gutenberg/pull/57878)).
+-   `PaletteEdit`: Fix palette item accessibility in details view ([#58214](https://github.com/WordPress/gutenberg/pull/58214)).
 -   `Tooltip`: revert prop types to only accept component-specific props ([#58125](https://github.com/WordPress/gutenberg/pull/58125)).
 -   `Button`: prevent the component from trashing and re-creating the HTML element ([#56490](https://github.com/WordPress/gutenberg/pull/56490)).
 

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -206,7 +206,7 @@ function Option< T extends Color | Gradient >( {
 					: sprintf(
 							// translators: %s is a color or gradient name, e.g. "Red".
 							__( 'Edit: %s' ),
-							element.name
+							element.name.trim().length ? element.name : value
 					  )
 			}
 			ref={ setPopoverAnchor }
@@ -234,7 +234,12 @@ function Option< T extends Color | Gradient >( {
 							}
 						/>
 					) : (
-						<NameContainer>{ element.name }</NameContainer>
+						<NameContainer>
+							{ element.name.trim().length
+								? element.name
+								: /* Fall back to non-breaking space to maintain height */
+								  '\u00A0' }
+						</NameContainer>
 					) }
 				</FlexItem>
 				{ isEditing && ! canOnlyChangeValues && (

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -198,23 +198,22 @@ function Option< T extends Color | Gradient >( {
 	return (
 		<PaletteItem
 			className={ isEditing ? 'is-selected' : undefined }
-			as="div"
+			as={ isEditing ? 'div' : 'button' }
 			onClick={ onStartEditing }
+			aria-label={
+				isEditing
+					? undefined
+					: sprintf(
+							// translators: %s is a color or gradient name, e.g. "Red".
+							__( 'Edit: %s' ),
+							element.name
+					  )
+			}
 			ref={ setPopoverAnchor }
-			{ ...( isEditing
-				? { ...focusOutsideProps }
-				: {
-						style: {
-							cursor: 'pointer',
-						},
-				  } ) }
+			{ ...( isEditing ? { ...focusOutsideProps } : {} ) }
 		>
 			<HStack justify="flex-start">
-				<FlexItem>
-					<IndicatorStyled
-						style={ { background: value, color: 'transparent' } }
-					/>
-				</FlexItem>
+				<IndicatorStyled colorValue={ value } />
 				<FlexItem>
 					{ isEditing && ! canOnlyChangeValues ? (
 						<NameInput

--- a/packages/components/src/palette-edit/stories/index.story.tsx
+++ b/packages/components/src/palette-edit/stories/index.story.tsx
@@ -56,6 +56,7 @@ Default.args = {
 	colors: [
 		{ color: '#1a4548', name: 'Primary', slug: 'primary' },
 		{ color: '#0000ff', name: 'Secondary', slug: 'secondary' },
+		{ color: '#fb326b', name: 'Tertiary', slug: 'tertiary' },
 	],
 	paletteLabel: 'Colors',
 	emptyMessage: 'Colors are empty',

--- a/packages/components/src/palette-edit/styles.ts
+++ b/packages/components/src/palette-edit/styles.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import Button from '../button';
 import { Heading } from '../heading';
 import { HStack } from '../h-stack';
 import { space } from '../utils/space';
-import { COLORS, CONFIG } from '../utils';
+import { COLORS, CONFIG, font } from '../utils';
 import { View } from '../view';
 import InputControl from '../input-control';
 import {
@@ -18,12 +19,14 @@ import {
 	Input,
 	BackdropUI as InputBackdropUI,
 } from '../input-control/styles/input-control-styles';
-import CircularOptionPicker from '../circular-option-picker';
+import ColorIndicator from '../color-indicator';
 
-export const IndicatorStyled = styled( CircularOptionPicker.Option )`
-	width: ${ space( 6 ) };
-	height: ${ space( 6 ) };
-	pointer-events: none;
+export const IndicatorStyled = styled( ColorIndicator )`
+	&& {
+		flex-shrink: 0;
+		width: ${ space( 6 ) };
+		height: ${ space( 6 ) };
+	}
 `;
 
 export const NameInputControl = styled( InputControl )`
@@ -40,20 +43,66 @@ export const NameInputControl = styled( InputControl )`
 	}
 `;
 
+const buttonStyleReset = ( {
+	as,
+}: {
+	as: React.ComponentProps< typeof View >[ 'as' ];
+} ) => {
+	if ( as === 'button' ) {
+		return css`
+			display: flex;
+			align-items: center;
+			width: 100%;
+			appearance: none;
+			background: transparent;
+			border: none;
+			border-radius: 0;
+			padding: 0;
+			cursor: pointer;
+
+			&:hover {
+				color: ${ COLORS.theme.accent };
+			}
+		`;
+	}
+	return null;
+};
+
 export const PaletteItem = styled( View )`
+	${ buttonStyleReset }
+
 	padding-block: 3px;
 	padding-inline-start: ${ space( 3 ) };
 	border: 1px solid ${ CONFIG.surfaceBorderColor };
 	border-bottom-color: transparent;
-	&:first-of-type {
-		border-top-left-radius: ${ CONFIG.controlBorderRadius };
-		border-top-right-radius: ${ CONFIG.controlBorderRadius };
+	font-size: ${ font( 'default.fontSize' ) };
+
+	&:focus-visible {
+		border-color: transparent;
+		box-shadow: 0 0 0 var( --wp-admin-border-width-focus )
+			var(
+				--wp-components-color-accent,
+				var( --wp-admin-theme-color, ${ COLORS.theme.accent } )
+			);
+		// Windows high contrast mode.
+		outline: 2px solid transparent;
+		outline-offset: 0;
 	}
-	&:last-of-type {
+
+	border-top-left-radius: ${ CONFIG.controlBorderRadius };
+	border-top-right-radius: ${ CONFIG.controlBorderRadius };
+
+	& + & {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+	}
+
+	&:last-child {
 		border-bottom-left-radius: ${ CONFIG.controlBorderRadius };
 		border-bottom-right-radius: ${ CONFIG.controlBorderRadius };
 		border-bottom-color: ${ CONFIG.surfaceBorderColor };
 	}
+
 	&.is-selected + & {
 		border-top-color: transparent;
 	}
@@ -68,9 +117,6 @@ export const NameContainer = styled.div`
 	margin-right: ${ space( 2 ) };
 	white-space: nowrap;
 	overflow: hidden;
-	${ PaletteItem }:hover & {
-		color: ${ COLORS.theme.accent };
-	}
 `;
 
 export const PaletteHeading = styled( Heading )`

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -295,7 +295,7 @@ describe( 'PaletteEdit', () => {
 				name: 'Show details',
 			} )
 		);
-		await click( screen.getByText( 'Primary' ) );
+		await click( screen.getByRole( 'button', { name: 'Edit: Primary' } ) );
 		await click(
 			screen.getByRole( 'button', {
 				name: 'Remove color',
@@ -328,7 +328,7 @@ describe( 'PaletteEdit', () => {
 				name: 'Show details',
 			} )
 		);
-		await click( screen.getByText( 'Primary' ) );
+		await click( screen.getByRole( 'button', { name: 'Edit: Primary' } ) );
 		const nameInput = screen.getByRole( 'textbox', {
 			name: 'Color name',
 		} );


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/57645#discussion_r1447602423
Fixes #49041

## What?

Fixes palette item accessibility in the details view of the PaletteEdit component.

> [!NOTE]  
> This doesn't fix the issue where focus gets stuck in the ColorPicker popover (#58188).

## Why?

Only the swatch was a focusable button, and it was unlabeled.

## Testing Instructions

There should be no changes in behavior when navigating by pointer.

### Testing Instructions for Keyboard

Either in Storybook or the Editor (Global Styles ▸ Colors ▸ Palette):

1. Go into the details view by clicking the "Add color" button or "Color options ▸ Show details" dropdown menu item.
2. <kbd>Tab</kbd> through the palette items. Each entire row should be a correctly labeled, focusable button.

> [!NOTE]
> There is currently a [style leak](https://github.com/WordPress/gutenberg/pull/55913/files#r1465111138) in the Editor that causes the palette item to have an unintentional background color when in editing mode.

## Screenshots or screencast <!-- if applicable -->

<img width="271" alt="Focused palette item button" src="https://github.com/WordPress/gutenberg/assets/555336/65a075c1-3043-4d10-91da-fa8fd728e14e">

### Before

https://github.com/WordPress/gutenberg/assets/555336/a1d265e8-6ff4-44e2-9fda-a0295043e885

### After

https://github.com/WordPress/gutenberg/assets/555336/709c0b24-00de-4191-8d39-1a51d2c09589


