### PR TITLE
Refactored download/upload logic to support font faces with multiple src assets

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -30,7 +30,7 @@ import CollectionFontDetails from './collection-font-details';
 import { toggleFont } from './utils/toggleFont';
 import { getFontsOutline } from './utils/fonts-outline';
 import GoogleFontsConfirmDialog from './google-fonts-confirm-dialog';
-import { downloadFontFaceAsset } from './utils';
+import { downloadFontFaceAssets } from './utils';
 
 const DEFAULT_CATEGORY = {
 	slug: 'all',
@@ -161,7 +161,7 @@ function FontCollection( { slug } ) {
 				await Promise.all(
 					fontFamily.fontFace.map( async ( fontFace ) => {
 						if ( fontFace.src ) {
-							fontFace.file = await downloadFontFaceAsset(
+							fontFace.file = await downloadFontFaceAssets(
 								fontFace.src
 							);
 						}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -231,8 +231,7 @@ export async function batchInstallFontFaces( fontFamilyId, fontFacesData ) {
  * Downloads a font face asset from a URL to the client and returns a File object.
  */
 export async function downloadFontFaceAssets( src ) {
-	//src could be a single string or a collection of strings.
-	//here, just make sure it's an array
+	// Normalize to an array, since `src` could be a string or array.
 	src = Array.isArray( src ) ? src : [ src ];
 
 	const files = await Promise.all(

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -164,8 +164,7 @@ export function makeFontFacesFormData( font ) {
 		const fontFacesFormData = font.fontFace.map( ( face, faceIndex ) => {
 			const formData = new FormData();
 			if ( face.file ) {
-				// file may be a single file or a collection of files.
-				// make sure it's an array
+				// Normalize to an array, since face.file may be a single file or an array of files.
 				const files = Array.isArray( face.file )
 					? face.file
 					: [ face.file ];

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -237,7 +237,7 @@ export async function downloadFontFaceAssets( src ) {
 
 	const files = await Promise.all(
 		src.map( async ( url ) => {
-			return await fetch( new Request( url ) )
+			return fetch( new Request( url ) )
 				.then( ( response ) => {
 					if ( ! response.ok ) {
 						throw new Error(


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
Refactored download/upload logic to support font faces with multiple src assets

## Why?
Font Faces can provide multiple `src` values (for instance, providing both TTF and WOFF assets).  These are provided as an array of strings instead of a string.   Currently the user interface doesn't allow font faces with multiple `src` assets to be installed.  This change fixes that.

Fixes #58173

## How?
Checks the `src` attribute and makes it an array if it is a string, downloads all assets in the array of src values and uploads all of them in the call to create font faces.  

## Testing Instructions
* Add the PHP noted in #58173 to add a Font Collection that has a font face with multiple src values.  (I just added them in `font-library.php` where the default font collection is added for testing)
* Install the sample font.  Observe the traffic. Note:
** Two font assets are downloaded
** Two font assets are uploaded in the create font face API call
** The create font face API call is successful
* Reload the Font Library Modal and observe the traffic of existing font families/faces.  Note that the newly installed font face has an array of strings in the "src" value.
* Delete the newly installed font face (without error)
* Install another font from the default collection and observe that it continues to work as expected.
