### PR TITLE
Block Bindings: Fix button popover not showing in patterns

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -26,7 +26,7 @@ const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 	'core/paragraph': [ 'content' ],
 	'core/heading': [ 'content' ],
 	'core/image': [ 'url', 'title', 'alt' ],
-	'core/button': [ 'url', 'text' ],
+	'core/button': [ 'url', 'text', 'linkTarget' ],
 };
 
 const createEditFunctionWithBindingsAttribute = () =>

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -336,7 +336,7 @@ function ButtonEdit( props ) {
 			{ isLinkTag &&
 				isSelected &&
 				( isEditingURL || isURLSet ) &&
-				! metadata?.bindings?.url && (
+				! lockUrlControls && (
 					<Popover
 						placement="bottom"
 						onClose={ () => {


### PR DESCRIPTION
## What?
Fixing a bug where the button URL popover was not showing in patterns when a binding existed.

## Why?
That's not the expected behavior.

## How?
There was a misuse with a conditional. Just changing that should fix it.

## Testing Instructions
1. Create a synced pattern.
2. In the Advanced panel "Allow instance overrides"
3. Add a button with a bindings object like this one:
```
{"metadata":{"id":"W7huMG","bindings":{"url":{"source":{"name":"pattern_attributes"}}}}}
```
4. Check that users can add a URL if wanted.
