### PR TITLE
Interactivity API: Break up long hydration task in interactivity init

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Break up init with yielding to main to prevent long task from hydration. ([#58227](https://github.com/WordPress/gutenberg/pull/58227))
+
 ## 4.0.0 (2024-01-24)
 
 ### Enhancements

--- a/packages/interactivity/src/init.js
+++ b/packages/interactivity/src/init.js
@@ -39,6 +39,7 @@ export const init = async () => {
 			await yieldToMain();
 			const fragment = getRegionRootFragment( node );
 			const vdom = toVdom( node );
+			await yieldToMain();
 			hydrate( vdom, fragment );
 		}
 	}

--- a/packages/interactivity/src/init.js
+++ b/packages/interactivity/src/init.js
@@ -21,15 +21,25 @@ export const getRegionRootFragment = ( region ) => {
 	return regionRootFragments.get( region );
 };
 
+function yieldToMain() {
+	return new Promise( ( resolve ) => {
+		// TODO: Use scheduler.yield() when available.
+		setTimeout( resolve, 0 );
+	} );
+}
+
 // Initialize the router with the initial DOM.
 export const init = async () => {
-	document
-		.querySelectorAll( `[data-${ directivePrefix }-interactive]` )
-		.forEach( ( node ) => {
-			if ( ! hydratedIslands.has( node ) ) {
-				const fragment = getRegionRootFragment( node );
-				const vdom = toVdom( node );
-				hydrate( vdom, fragment );
-			}
-		} );
+	const nodes = document.querySelectorAll(
+		`[data-${ directivePrefix }-interactive]`
+	);
+
+	for ( const node of nodes ) {
+		if ( ! hydratedIslands.has( node ) ) {
+			await yieldToMain();
+			const fragment = getRegionRootFragment( node );
+			const vdom = toVdom( node );
+			hydrate( vdom, fragment );
+		}
+	}
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #58225.

## What?
<!-- In a few words, what is the PR actually doing? -->

Avoid long task during interactivity initialization

## Why?

Long tasks create a poor user experience and can negatively impact Largest Contentful Paint (LCP), Total Blocking Time (TBT), First Input Delay (FID), and Interaction to Next Paint (INP).

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

As outlined in [Optimize Long Tasks](https://web.dev/articles/optimize-long-tasks), this breaks up the long task in the `init()` by yielding to main after each node is hydrated.


<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Add 20 blocks using interactivity to a post.
2. Run profiling in DevTools with and without 6x CPU slowdown.
3. Check for improvements to whether initialization causes a long task.

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


## Screenshots or screencast <!-- if applicable -->

### Without CPU Throttling

Before | After
-----|-----
![image](https://github.com/WordPress/gutenberg/assets/134745/8f410f7c-d2a5-4b46-bf6a-ede8ebced7ae) | ![image](https://github.com/WordPress/gutenberg/assets/134745/a1cf52e6-f08a-4cf7-8aa2-4cfdc301024c)

### With 6x CPU Throttling

Before | After
-----|-----
![image](https://github.com/WordPress/gutenberg/assets/134745/75ab6f59-326f-4a1d-b9bb-fc6815d9f1da) | ![image](https://github.com/WordPress/gutenberg/assets/134745/212d2c19-6f23-430c-85e2-eb2cb79ab8ac)

### Lighthouse Performance Audit

Before | After
--|--
![image](https://github.com/WordPress/gutenberg/assets/134745/ddd08e00-12e7-45b4-a271-92372f192884) | ![image](https://github.com/WordPress/gutenberg/assets/134745/dbf07755-be36-49e8-bb7d-233fe9d44b52)
