### PR TITLE
Global styles revisions: fix is-selected rules from affecting other areas of the editor

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -41,12 +41,24 @@
 		// This border serves as a background color in Windows High Contrast mode.
 		border: 4px solid transparent;
 	}
+
 	&.is-selected {
 		border-radius: $radius-block-ui;
 
 		// Only visible in Windows High Contrast mode.
 		outline: 3px solid transparent;
 		outline-offset: -2px;
+
+		color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+
+		.edit-site-global-styles-screen-revisions__revision-button {
+			opacity: 1;
+		}
+
+		.edit-site-global-styles-screen-revisions__date {
+			color: var(--wp-admin-theme-color);
+		}
 
 		&::before {
 			background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
@@ -78,17 +90,6 @@
 		z-index: 1;
 		position: relative;
 		outline-offset: -2px;
-	}
-}
-
-.is-selected {
-	color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-	background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-	.edit-site-global-styles-screen-revisions__revision-button {
-		opacity: 1;
-	}
-	.edit-site-global-styles-screen-revisions__date {
-		color: var(--wp-admin-theme-color);
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Move a few of the rules for selected items in the global styles revisions screen so that they're scoped to the revisions item.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As flagged in https://github.com/WordPress/gutenberg/pull/55913#pullrequestreview-1841704592, the existing rules are affecting other areas of the editor (notably the custom color picker button when folks are creating their own color palettes). These rules appear to only have been intended for the global styles revision item.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Move rules up to live in `edit-site-global-styles-screen-revisions__revision-item.is-selected` so that they're scoped to the revision item classname.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the site editor, go to the revisions screen and ensure that selected revisions in the list look the same as on trunk
2. In global styles, go to Colors > Palette > and then click to add a Custom color to the color palette. With this PR applied, that custom color palette button should no longer have a light blue background when selected.

## Screenshots or screencast <!-- if applicable -->

### The color palette regression that's fixed by this PR

It's pretty subtle, but note that in the `trunk` screenshot there is an unintentional subtle blue background.

| Trunk | This PR |
| --- | --- |
| ![image](https://github.com/WordPress/gutenberg/assets/14988353/82a032c9-e2d9-47c9-9f3d-76aa9228ec3f) | ![image](https://github.com/WordPress/gutenberg/assets/14988353/e4debc09-ac3d-46d9-a3f9-39ac09505d30) |

### What shouldn't have changed

This is the area where these rules were intended to have an effect. There should be no change to the selected or hovered items in the revisions screen to what's on `trunk`:

![image](https://github.com/WordPress/gutenberg/assets/14988353/2bc9d46b-92de-4d1c-a9b1-776cd8f7e830)
