### PR TITLE
Update pattern block copy in light of pattern overrides

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -37,7 +37,7 @@ Add a user’s avatar. ([Source](https://github.com/WordPress/gutenberg/tree/tru
 
 ## Pattern
 
-Designs that can be reused across your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))
+Reuse this design across your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))
 
 -	**Name:** core/block
 -	**Category:** reusable

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -37,7 +37,7 @@ Add a user’s avatar. ([Source](https://github.com/WordPress/gutenberg/tree/tru
 
 ## Pattern
 
-Create and save content to reuse across your site. Update the pattern, and the changes apply everywhere it’s used. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))
+Designs that can be reused across your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))
 
 -	**Name:** core/block
 -	**Category:** reusable

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -4,7 +4,7 @@
 	"name": "core/block",
 	"title": "Pattern",
 	"category": "reusable",
-	"description": "Create and save content to reuse across your site. Update the pattern, and the changes apply everywhere it’s used.",
+	"description": "Designs that can be reused across your site.",
 	"keywords": [ "reusable" ],
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -4,7 +4,7 @@
 	"name": "core/block",
 	"title": "Pattern",
 	"category": "reusable",
-	"description": "Designs that can be reused across your site.",
+	"description": "Reuse this design across your site.",
 	"keywords": [ "reusable" ],
 	"textdomain": "default",
 	"attributes": {


### PR DESCRIPTION
## What?
In light of pattern overrides (#53705), the description of the pattern block ("Create and save content to reuse across your site. Update the pattern, and the changes apply everywhere it’s used.") is no longer accurate. (props to @fabiankaegy for spotting the issue)

In particular "the changes apply everywhere it’s used" should be rethought, as changes to pattern overrides are not synced, they're local.

The existing copy also emphasizes using patterns for 'content', which goes against the idea of overrides being used for content and the pattern being more of a design.

## How?
Simplifies the copy to "Designs that can be reused across your site.". 

Fully aware that I'm a developer, so this is open to suggestions on the copy, but this should be something that's merged sooner so that the text is available for internationalization in WordPress 6.5

Potentially we should also look at removing the description from the block card, as I don't think it makes a lot of sense next to the pattern name (see the screenshot)

## Testing Instructions
1. Add a synced pattern in a post
2. The block description in the inspector should show the updated copy

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-01-25 at 12 35 22 pm](https://github.com/WordPress/gutenberg/assets/677833/e05e767f-5a9b-4e86-a90a-75150554cc91)