### PR TITLE
Block Switcher: Use consistent labels

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -218,14 +218,20 @@ export const BlockSwitcher = ( { clientIds } ) => {
 	if ( invalidBlocks ) {
 		return null;
 	}
+
+	const isSingleBlock = clientIds.length === 1;
+	const blockSwitcherLabel = isSingleBlock
+		? blockTitle
+		: __( 'Multiple blocks selected' );
 	const hideDropdown = ! hasBlockStyles && ! canRemove;
+
 	if ( hideDropdown ) {
 		return (
 			<ToolbarGroup>
 				<ToolbarButton
 					disabled
 					className="block-editor-block-switcher__no-switcher-icon"
-					title={ blockTitle }
+					title={ blockSwitcherLabel }
 					icon={
 						<>
 							<BlockIcon icon={ icon } showColors />
@@ -240,10 +246,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 			</ToolbarGroup>
 		);
 	}
-	const isSingleBlock = clientIds.length === 1;
-	const blockSwitcherLabel = isSingleBlock
-		? blockTitle
-		: __( 'Multiple blocks selected' );
+
 	const blockSwitcherDescription = isSingleBlock
 		? __( 'Change block type or style' )
 		: sprintf(


### PR DESCRIPTION
## What?
PR updates the `BlockSwitcher` component to display the correct label when multiple blocks are selected and the dropdown is disabled.

## Why?
Labels should be consistent between states.

## Testing Instructions
1. Open a post or page.
2. Insert a few blocks.
3. Lock removal for one of them, and select all blocks.
4. Inspect the block switcher button label.
5. Confirm it displays "Multiple blocks selected" instead of the first block label.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-01-25 at 13 55 22](https://github.com/WordPress/gutenberg/assets/240569/2070b69a-8eaa-4a0b-87fc-8de2129d6af0)