### PR TITLE
Prevent usage of `gutenberg_url` in block-library

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -65,7 +65,7 @@ function register_block_core_file() {
 
 	wp_register_script_module(
 		'@wordpress/block-library/file-block',
-		gutenberg_url( '/build/interactivity/file.min.js' ),
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/file.min.js' ) : '/wp-includes/blocks/file/view.min.js',
 		array( '@wordpress/interactivity' ),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -38,7 +38,7 @@ function render_block_core_file( $attributes, $content ) {
 
 	// If it's interactive, enqueue the script module and add the directives.
 	if ( ! empty( $attributes['displayPreview'] ) ) {
-		wp_enqueue_script_module( '@wordpress/block-library/file-block' );
+		wp_enqueue_script_module( '@wordpress/block-library/file' );
 
 		$processor = new WP_HTML_Tag_Processor( $content );
 		$processor->next_tag();

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -64,8 +64,8 @@ function register_block_core_file() {
 	);
 
 	wp_register_script_module(
-		'@wordpress/block-library/file-block',
-		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/file.min.js' ) : '/wp-includes/blocks/file/view.min.js',
+		'@wordpress/block-library/file',
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/file.min.js' ) : includes_url( 'blocks/file/view.min.js' ),
 		array( '@wordpress/interactivity' ),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -325,7 +325,7 @@ function register_block_core_image() {
 
 	wp_register_script_module(
 		'@wordpress/block-library/image',
-		gutenberg_url( '/build/interactivity/image.min.js' ),
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/image.min.js' ) : '/wp-includes/blocks/image/view.min.js',
 		array( '@wordpress/interactivity' ),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -325,7 +325,7 @@ function register_block_core_image() {
 
 	wp_register_script_module(
 		'@wordpress/block-library/image',
-		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/image.min.js' ) : '/wp-includes/blocks/image/view.min.js',
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/image.min.js' ) : includes_url( 'blocks/image/view.min.js' ),
 		array( '@wordpress/interactivity' ),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -567,7 +567,7 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function handle_view_script_module_loading( $attributes, $block, $inner_blocks ) {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
-			wp_enqueue_script_module( '@wordpress/block-library/navigation-block' );
+			wp_enqueue_script_module( '@wordpress/block-library/navigation' );
 		}
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1082,7 +1082,7 @@ function register_block_core_navigation() {
 
 	wp_register_script_module(
 		'@wordpress/block-library/navigation-block',
-		gutenberg_url( '/build/interactivity/navigation.min.js' ),
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/navigation.min.js' ) : '/wp-includes/blocks/navigation/view.min.js',
 		array( '@wordpress/interactivity' ),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1081,8 +1081,8 @@ function register_block_core_navigation() {
 	);
 
 	wp_register_script_module(
-		'@wordpress/block-library/navigation-block',
-		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/navigation.min.js' ) : '/wp-includes/blocks/navigation/view.min.js',
+		'@wordpress/block-library/navigation',
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/navigation.min.js' ) : includes_url( 'blocks/navigation/view.min.js' ),
 		array( '@wordpress/interactivity' ),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -101,7 +101,7 @@ function register_block_core_query() {
 
 	wp_register_script_module(
 		'@wordpress/block-library/query',
-		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/query.min.js' ) : '/wp-includes/blocks/query/view.min.js',
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/query.min.js' ) : includes_url( 'blocks/query/view.min.js' ),
 		array(
 			array(
 				'id'     => '@wordpress/interactivity',

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -101,7 +101,7 @@ function register_block_core_query() {
 
 	wp_register_script_module(
 		'@wordpress/block-library/query',
-		gutenberg_url( '/build/interactivity/query.min.js' ),
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/query.min.js' ) : '/wp-includes/blocks/query/view.min.js',
 		array(
 			array(
 				'id'     => '@wordpress/interactivity',

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -198,8 +198,8 @@ function register_block_core_search() {
 	);
 
 	wp_register_script_module(
-		'@wordpress/block-library/search-block',
-		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/search.min.js' ) : '/wp-includes/blocks/search/view.min.js',
+		'@wordpress/block-library/search',
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/search.min.js' ) : includes_url( 'blocks/search/view.min.js' ),
 		array( '@wordpress/interactivity' ),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,7 +80,7 @@ function render_block_core_search( $attributes ) {
 		// If it's interactive, enqueue the script module and add the directives.
 		$is_expandable_searchfield = 'button-only' === $button_position;
 		if ( $is_expandable_searchfield ) {
-			wp_enqueue_script_module( '@wordpress/block-library/search-block' );
+			wp_enqueue_script_module( '@wordpress/block-library/search' );
 
 			$input->set_attribute( 'data-wp-bind--aria-hidden', '!context.isSearchInputVisible' );
 			$input->set_attribute( 'data-wp-bind--tabindex', 'state.tabindex' );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -199,7 +199,7 @@ function register_block_core_search() {
 
 	wp_register_script_module(
 		'@wordpress/block-library/search-block',
-		gutenberg_url( '/build/interactivity/search.min.js' ),
+		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/interactivity/search.min.js' ) : '/wp-includes/blocks/search/view.min.js',
 		array( '@wordpress/interactivity' ),
 		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Prevent the usage of `gutenberg_url` in the interactive blocks of the `block-library` package.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because we mistakenly left it in the https://github.com/WordPress/gutenberg/pull/57778 PR and `block-library` should never contain direct usage of Gutenberg functions because it's synced "as it is" in WordPress Core, where those functions don't exist.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By checking first if Gutenberg is activated, and if it's not, using `includes_url` instead of `gutenberg_url`.
