### PR TITLE
Fix line-height in block card.

### DIFF
--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -14,14 +14,16 @@
 
 	&.block-editor-block-card__title {
 		font-size: $default-font-size;
-		line-height: $button-size-small;
+		line-height: $default-line-height;
 		margin: 0;
+		padding: 3px 0; // This makes the title as high as the icon.
 	}
 }
 
 .block-editor-block-card__description {
 	display: block;
 	font-size: $default-font-size;
+	line-height: $default-line-height;
 	margin-top: $grid-unit-05;
 }
 

--- a/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/style.scss
+++ b/packages/edit-site/src/components/sidebar-edit-mode/sidebar-card/style.scss
@@ -11,7 +11,10 @@
 		font-weight: 500;
 		line-height: $icon-size;
 		&.edit-site-sidebar-card__title {
+			font-size: $default-font-size;
+			line-height: $default-line-height;
 			margin: 0;
+			padding: 3px 0; // This makes the title as high as the icon.
 		}
 	}
 


### PR DESCRIPTION
## What?

When the block card has a long title, the title in the inspector wraps and has a too tall lineheight:

![before, long title](https://github.com/WordPress/gutenberg/assets/1204802/4e9a4ec2-f01c-429f-9101-f82c7b8a1955)

Here's a short title, where it's not visible:

![before, short title](https://github.com/WordPress/gutenberg/assets/1204802/f8cb2a6c-a614-4d9d-bc25-33fcfcc1cc13)

This PR makes the title line-height the same as the description, addressing this:

![after, long title](https://github.com/WordPress/gutenberg/assets/1204802/480afa90-6b76-4127-9446-da2be9355c21)

Short titles look the same:

![after, short title](https://github.com/WordPress/gutenberg/assets/1204802/fa717d98-e95f-4388-8c3e-c46f12ca5631)


## Testing Instructions

Create a synced block with a very long title, and observe the line-height of the wrapping title in the inspector to be the same as that of the description below.
