### PR TITLE
Add client-assets to backports ignore list

### DIFF
--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -22,6 +22,7 @@ const MAX_MONTHS_TO_QUERY = 4;
 // The following paths will be ignored when generating the issue content.
 const IGNORED_PATHS = [
 	'lib/load.php', // plugin specific code.
+	'lib/client-assets.php', // plugin specific code.
 	'lib/experiments-page.php', // experiments are plugin specific.
 	'packages/e2e-tests/plugins', // PHP files related to e2e tests only.
 	'packages/block-library', // this is handled automatically.

--- a/docs/contributors/code/back-merging-to-wp-core.md
+++ b/docs/contributors/code/back-merging-to-wp-core.md
@@ -14,6 +14,7 @@ Changes to files within the following files/directories will typically require b
 The following directories/files do _not_ require back-merging to WP Core:
 
 -   `lib/load.php` - Plugin specific code.
+-   `lib/client-assets.php` - Plugin specific code.
 -   `lib/experiments-page.php` - experiments are Plugin specific.
 -   `packages/block-library` - this is handled automatically during the packages sync process.
 -   `packages/e2e-tests/plugins` - PHP files related to e2e tests only. Mostly fixture data generators.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates docs and scripts to ignore client assets when considering PHP changes to be syncrhonised to WP Core for releases.

Based on https://github.com/WordPress/gutenberg/pull/57639#issuecomment-1910048792

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need a solid ignore list to reduce confusion.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updates docs and scripts.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
