### PR TITLE
Block Editor: Optimize the 'useBlockDisplayTitle' hook

### DIFF
--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -13,65 +13,39 @@ import { useSelect } from '@wordpress/data';
  */
 import BlockTitle from '../';
 
+const blockTypeMap = {
+	'name-not-exists': null,
+	'name-exists': { title: 'Block Title' },
+	'name-with-label': { title: 'Block With Label' },
+	'name-with-custom-label': { title: 'Block With Custom Label' },
+	'name-with-long-label': { title: 'Block With Long Label' },
+	'reusable-block': { title: 'Reusable Block' },
+};
+
+const blockLabelMap = {
+	'Block With Label': 'Test Label',
+	'Block With Long Label':
+		'This is a longer label than typical for blocks to have.',
+	'Block With Custom Label': 'A Custom Label like a Block Variation Label',
+};
+
 jest.mock( '@wordpress/blocks', () => {
 	return {
-		getBlockType( name ) {
-			switch ( name ) {
-				case 'name-not-exists':
-					return null;
-
-				case 'name-exists':
-					return { title: 'Block Title' };
-
-				case 'name-with-label':
-					return { title: 'Block With Label' };
-
-				case 'name-with-custom-label':
-					return { title: 'Block With Custom Label' };
-
-				case 'name-with-long-label':
-					return { title: 'Block With Long Label' };
-			}
+		isReusableBlock( { title } ) {
+			return title === 'Reusable Block';
 		},
 		__experimentalGetBlockLabel( { title } ) {
-			switch ( title ) {
-				case 'Block With Label':
-					return 'Test Label';
-
-				case 'Block With Long Label':
-					return 'This is a longer label than typical for blocks to have.';
-
-				case 'Block With Custom Label':
-					return 'A Custom Label like a Block Variation Label';
-
-				default:
-					return title;
-			}
+			return blockLabelMap[ title ] || title;
 		},
 	};
 } );
 
-jest.mock( '../../use-block-display-information', () => {
-	const resultsMap = {
-		'id-name-exists': { title: 'Block Title' },
-		'id-name-with-label': { title: 'Block With Label' },
-		'id-name-with-long-label': { title: 'Block With Long Label' },
-	};
-	return jest.fn( ( clientId ) => resultsMap[ clientId ] );
-} );
-
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+// This allows us to tweak the returned value on each test.
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 
 describe( 'BlockTitle', () => {
 	it( 'renders nothing if name is falsey', () => {
-		useSelect.mockImplementation( () => ( {
-			name: null,
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( () => null );
 
 		const { container } = render( <BlockTitle /> );
 
@@ -79,10 +53,12 @@ describe( 'BlockTitle', () => {
 	} );
 
 	it( 'renders nothing if block type does not exist', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'name-not-exists',
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getBlockName: () => 'name-not-exists',
+				getBlockType: () => null,
+			} ) )
+		);
 
 		const { container } = render(
 			<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
@@ -92,10 +68,14 @@ describe( 'BlockTitle', () => {
 	} );
 
 	it( 'renders title if block type exists', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'name-exists',
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getBlockName: () => 'name-exists',
+				getBlockType: ( name ) => blockTypeMap[ name ],
+				getBlockAttributes: () => null,
+				getActiveBlockVariation: () => null,
+			} ) )
+		);
 
 		render( <BlockTitle clientId="id-name-exists" /> );
 
@@ -103,10 +83,13 @@ describe( 'BlockTitle', () => {
 	} );
 
 	it( 'renders label if it is set', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'name-with-label',
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getBlockName: () => 'name-with-label',
+				getBlockType: ( name ) => blockTypeMap[ name ],
+				getBlockAttributes: () => null,
+			} ) )
+		);
 
 		render( <BlockTitle clientId="id-name-with-label" /> );
 
@@ -114,23 +97,29 @@ describe( 'BlockTitle', () => {
 	} );
 
 	it( 'should prioritize reusable block title over title', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'name-with-label',
-			reusableBlockTitle: 'Reuse me!',
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getBlockName: () => 'reusable-block',
+				getBlockType: ( name ) => blockTypeMap[ name ],
+				getBlockAttributes: () => ( { ref: 1 } ),
+				__experimentalGetReusableBlockTitle: () => 'Reuse me!',
+			} ) )
+		);
 
-		render( <BlockTitle clientId="id-name-with-label" /> );
+		render( <BlockTitle clientId="id-reusable-block" /> );
 
 		expect( screen.queryByText( 'Test Label' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Reuse me!' ) ).toBeVisible();
 	} );
 
 	it( 'should prioritize block label over title', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'name-with-custom-label',
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getBlockName: () => 'name-with-custom-label',
+				getBlockType: ( name ) => blockTypeMap[ name ],
+				getBlockAttributes: () => null,
+			} ) )
+		);
 
 		render( <BlockTitle clientId="id-name-with-label" /> );
 
@@ -140,22 +129,31 @@ describe( 'BlockTitle', () => {
 		).toBeVisible();
 	} );
 
-	it( 'should default to block information title if no reusable title or block name is available', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'some-rando-name',
-			attributes: null,
-		} ) );
+	it( 'should default to block variation title if no reusable title or block name is available', () => {
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getBlockName: () => 'name-exists',
+				getBlockType: ( name ) => blockTypeMap[ name ],
+				getBlockAttributes: () => null,
+				getActiveBlockVariation: () => ( {
+					title: 'Block Variation Label',
+				} ),
+			} ) )
+		);
 
-		render( <BlockTitle clientId="id-name-with-label" /> );
+		render( <BlockTitle clientId="id-name-exists" /> );
 
-		expect( screen.getByText( 'Block With Label' ) ).toBeVisible();
+		expect( screen.getByText( 'Block Variation Label' ) ).toBeVisible();
 	} );
 
 	it( 'truncates the label with custom truncate length', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'name-with-long-label',
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getBlockName: () => 'name-with-long-label',
+				getBlockType: ( name ) => blockTypeMap[ name ],
+				getBlockAttributes: () => null,
+			} ) )
+		);
 
 		render(
 			<BlockTitle
@@ -168,10 +166,13 @@ describe( 'BlockTitle', () => {
 	} );
 
 	it( 'should not truncate the label if maximum length is undefined', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'name-with-long-label',
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getBlockName: () => 'name-with-long-label',
+				getBlockType: ( name ) => blockTypeMap[ name ],
+				getBlockAttributes: () => null,
+			} ) )
+		);
 
 		render( <BlockTitle clientId="id-name-with-long-label" /> );
 


### PR DESCRIPTION
## What?
Based on previous work: #32118 and #40004.

PR optimizes the `useBlockDisplayTitle` hook to avoid re-renders when attributes change.

The attributes returned from the selector where are used to derive the block title string. This small optimization derives the title inside the selector and prevents unnecessary re-renders.

I have also removed the `useBlockDisplayInformation` usage. How hook directly checks variation match title. This should reduce store subscriptions created by the hook.

## Testing Instructions
 1. Open a post or page.
 2. Test block titles for Variations, synced Patterns, and Template Parts. They should work as before.
 3. Enable the top toolbar.
 4. Add paragraph block.
 5. Enable "Highlight updates when components render." in React DevTools.
 6. The block switcher button should not re-render when typing in the paragraph.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
