### PR TITLE
Layout block supports use `str_contains`

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -820,7 +820,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 
 		$class_attribute = $processor->get_attribute( 'class' );
-		if ( is_string( $class_attribute ) && false !== strpos( $class_attribute, $inner_block_wrapper_classes ) ) {
+		if ( is_string( $class_attribute ) && str_contains( $class_attribute, $inner_block_wrapper_classes ) ) {
 			break;
 		}
 	} while ( $processor->next_tag() );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes changes suggested in per https://github.com/WordPress/wordpress-develop/pull/5935#discussion_r1466303939.

Once merged I will update the Core PR to target _this_ Gutenberg PR.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

~During the sync commit for https://github.com/WordPress/gutenberg/pull/56171 changes were requested in order to merge to WP Core. This PR backports those changes to Gutenberg.~

As @dmsnell [suggested](https://github.com/WordPress/wordpress-develop/pull/5935#discussion_r1466793502) it would be easier to commit the change to Gutenberg first and then proceed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses `str_contains`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
