### PR TITLE
Block Bindings: Fix bindings image placeholder showing in patterns overrides

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -25,6 +25,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
+import { unlock } from '../lock-unlock';
 import Image from './image';
 
 /**
@@ -333,7 +334,26 @@ export function ImageEdit( {
 	} );
 
 	// Much of this description is duplicated from MediaPlaceholder.
-	const isUrlAttributeConnected = !! metadata?.bindings?.url;
+	const { lockUrlControls = false } = useSelect(
+		( select ) => {
+			if ( ! isSelected ) {
+				return {};
+			}
+
+			const { getBlockBindingsSource } = unlock(
+				select( blockEditorStore )
+			);
+
+			return {
+				lockUrlControls:
+					!! metadata?.bindings?.url &&
+					getBlockBindingsSource(
+						metadata?.bindings?.url?.source?.name
+					)?.lockAttributesEditing === true,
+			};
+		},
+		[ isSelected ]
+	);
 	const placeholder = ( content ) => {
 		return (
 			<Placeholder
@@ -342,10 +362,10 @@ export function ImageEdit( {
 						!! borderProps.className && ! isSelected,
 				} ) }
 				withIllustration={ true }
-				icon={ isUrlAttributeConnected ? pluginsIcon : icon }
+				icon={ lockUrlControls ? pluginsIcon : icon }
 				label={ __( 'Image' ) }
 				instructions={
-					! isUrlAttributeConnected &&
+					! lockUrlControls &&
 					__(
 						'Upload an image file, pick one from your media library, or add one with a URL.'
 					)
@@ -361,7 +381,7 @@ export function ImageEdit( {
 					...borderProps.style,
 				} }
 			>
-				{ isUrlAttributeConnected ? (
+				{ lockUrlControls ? (
 					<span
 						className={ 'block-bindings-media-placeholder-message' }
 					>


### PR DESCRIPTION
## What?
Fix an issue where the image placeholder we created for block bindings was showing when adding an empty image in a pattern overrides.

## Why?
Pattern overrides creators should be able to insert any media if wanted.

## How?
I'm changing the conditional to understand that, in case of pattern overrides, it should show the normal placeholder.

## Testing Instructions
1. Go to Site Editor and add a synced pattern.
2. Insert an image block but don't add any image.
3. Go to the Advanced section of the block settings and enable the "Allow instance overrides".
4. Select the image and check that the controls to upload it appear.

In `trunk` right now, this placeholder is shown instead:

![Screenshot 2024-01-25 at 13 42 10](https://github.com/WordPress/gutenberg/assets/34552881/e28183dd-bf3a-48b5-a5cc-fa7df6bfe17b)

