### PR TITLE
DataViews Fix: Preview not displayed in Templates table layout

### DIFF
--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -1,6 +1,7 @@
 .page-templates-preview-field {
 	display: flex;
 	flex-direction: column;
+	width: 100%;
 	height: 100%;
 	border-radius: 3px 3px 0 0;
 


### PR DESCRIPTION
Probably a regression in #57804

## What?

This PR fixes an issue where the preview is not displayed when the Template's data view is a table layout.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/31cfa2ed-7ef3-40d4-aede-4516becf2ea8)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/d5f9455a-9f89-4d8e-baf5-daa7450ad9fb)

## Why?

In #57804, `display:flex` was applied to elements with the `.dataviews-view-table__cell-content-wrapper` class.

The child of this element is the element with the `page-templates-preview-field` class, but because it is a flexbox child, if it contains no content and does not have an explicit width, the width will always be zero.

![preview-zero](https://github.com/WordPress/gutenberg/assets/54422211/bcd06ce7-a5ae-4926-8b24-e4b35df2f45b)

As a result, I found that the `BlockPreview` component failed to obtain the width using the `useResizeObserver()` hook, and the preview was not rendered.

https://github.com/WordPress/gutenberg/blob/61f7d059dbd2a47f9954cea81d895d1c5ec10966/packages/block-editor/src/components/block-preview/auto.js#L130-L135

## How?

I applied 100% width to an element with `page-templates-preview-field` class. We can also solve this by applying `flex:1` instead, but I think `width` is more intuitive.

## Testing Instructions

- Go to Appearance > Editor > Templates > Manage all templates.
- Switch to the table layout.
- Activate the "Preview" field.
- You should see a preview in the "Preview" column.