### PR TITLE
Preview (block/patterns): optimise store registration

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -37,7 +37,13 @@ const PreviewProvider = withRegistry( ( props ) => {
 			blockEditorStoreName,
 			storeConfig
 		);
-		store.dispatch( __experimentalUpdateSettings( settings ) );
+		store.dispatch(
+			__experimentalUpdateSettings( {
+				...settings,
+				__internalIsInitialized: true,
+				__unstableIsPreviewMode: true,
+			} )
+		);
 		store.dispatch( resetBlocks( value ) );
 		return newRegistry;
 	}, [ registry, value, settings ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We don't need a full blown provider that allows syncing blocks etc. We can create closer to the metal, simple registry provider where we preload the state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously we were setting state after rendering on an empty store, which means all subscribers are called.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
