### PR TITLE
Interactivity: Fix broken react usage in published package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -406,5 +406,11 @@ module.exports = {
 				],
 			},
 		},
+		{
+			files: [ 'packages/interactivity*/src/**' ],
+			rules: {
+				'react/react-in-jsx-scope': 'error',
+			},
+		},
 	],
 };

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Break up init with yielding to main to prevent long task from hydration. ([#58227](https://github.com/WordPress/gutenberg/pull/58227))
 
+### Bug Fixes
+
+-   Ensure Preact is used in published packages ([58258](https://github.com/WordPress/gutenberg/pull/58258).
+
 ## 4.0.0 (2024-01-24)
 
 ### Enhancements

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -1,6 +1,9 @@
+/* @jsx createElement */
+
 /**
  * External dependencies
  */
+import { h as createElement } from 'preact';
 import { useContext, useMemo, useRef } from 'preact/hooks';
 import { deepSignal, peek } from 'deepsignal';
 

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -1,7 +1,14 @@
+/* @jsx createElement */
+
 /**
  * External dependencies
  */
-import { h, options, createContext, cloneElement } from 'preact';
+import {
+	h as createElement,
+	options,
+	createContext,
+	cloneElement,
+} from 'preact';
 import { useRef, useCallback, useContext } from 'preact/hooks';
 import type { VNode, Context, RefObject } from 'preact';
 
@@ -59,7 +66,7 @@ interface Scope {
 	evaluate: Evaluate;
 	context: Context< any >;
 	ref: RefObject< HTMLElement >;
-	attributes: h.JSX.HTMLAttributes;
+	attributes: createElement.JSX.HTMLAttributes;
 }
 
 interface Evaluate {
@@ -372,7 +379,7 @@ options.vnode = ( vnode: VNode< any > ) => {
 				priorityLevels,
 				originalProps: props,
 				type: vnode.type,
-				element: h( vnode.type as any, props ),
+				element: createElement( vnode.type as any, props ),
 				top: true,
 			};
 			vnode.type = Directives;

--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -57,13 +57,7 @@ module.exports = {
 							configFile: false,
 							presets: [
 								'@babel/preset-typescript',
-								[
-									'@babel/preset-react',
-									{
-										runtime: 'automatic',
-										importSource: 'preact',
-									},
-								],
+								'@babel/preset-react',
 							],
 						},
 					},

--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -17,8 +17,8 @@ module.exports = {
 	...baseConfig,
 	name: 'interactivity',
 	entry: {
-		index: `./packages/interactivity/src/index.js`,
-		router: `./packages/interactivity-router/src/index.js`,
+		index: './packages/interactivity',
+		router: './packages/interactivity-router',
 		navigation: './packages/block-library/src/navigation/view.js',
 		query: './packages/block-library/src/query/view.js',
 		image: './packages/block-library/src/image/view.js',


### PR DESCRIPTION
## What?

Fix broken `@wordpress/interactivity` published package.

## Why?

`@wordpress/interactivity` depends on preact, not react.

Packages are built two ways:
- For the Gutenberg plugin
- To publish to npm

When this package is built for the plugin, it uses a different webpack config that correctly handles the jsx transform and the preact jsx auto imports:

https://github.com/WordPress/gutenberg/blob/388a1e951e2c87a94c2fb7adbaf08be5a1ec6fe9/tools/webpack/interactivity.js#L58-L67

However, when built for NPM it uses the standard configuration which imports `createElement` from `react` resulting in a package that doesn't work as expected. [You can see the unexpected react import here.](https://unpkg.com/browse/@wordpress/interactivity@4.0.0/build-module/directives.js)

## How?

I consider this a short-term fix:

- Enable the "no react in scope" eslint rule for the interactivity packages.
- Add pragmas to set the JSX transform the use `createElement`.
- Import Preact's `h` as `createElement` explicitly.

This setup ensures that `@wordpress/babel-plugin-import-jsx-pragma` does not add a `createElement` import from `react` (because it detects `createElement` is already in scope.

It is fragile because if we don't alias the preact `h` import to `createElement` then `@wordpress/babel-plugin-import-jsx-pragma` would add a react import.

## Testing Instructions

I've tested this 2 ways

In WordPress, locally build and run WordPress and confirm that interactivity is still working. I tested with the default themes navigation block query loop by disabling its "force page reload" setting.

As an npm package. I published a version of this for testing [(confirm no react here)](https://unpkg.com/browse/jons-test-wp-interactivity@0.0.1/build-module/directives.js) and made a small app that I compiled with `webpack-cli` (default config) and served locally. [Gist of the source is here.](https://gist.github.com/sirreal/7b9f1004b88e97c7bd6f822fcf53c2fc)

## Next

This is a short term fix so the package is not broken in the short term.

It would be nice to see if we can remove and deprecate some of our custom babel transforms and use babel's react preset with the automatic JSX runtime. That's a bigger and more complicated change.

## Concerns

This is fragile and not a long term solution. It relies on adding and aliasing an import and there are limited safeguards to ensure it's done correctly.

Fortunately, I don't believe the other things using the Interactivity API ([the view files listed here](https://github.com/WordPress/gutenberg/blob/5795b6e1f2bbe065c3a3cb02a2e6d531dfaa17bc/tools/webpack/interactivity.js#L22-L26)) can use Preact directly, which mitigates some of the problems.