### PR TITLE
Block Editor: Hide the 'Content' panel for locked blocks when there's no content

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -56,9 +56,11 @@ function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
 			/>
 			<BlockVariationTransforms blockClientId={ topLevelLockedBlock } />
 			<BlockInfo.Slot />
-			<PanelBody title={ __( 'Content' ) }>
-				<BlockQuickNavigation clientIds={ contentClientIds } />
-			</PanelBody>
+			{ contentClientIds.length > 0 && (
+				<PanelBody title={ __( 'Content' ) }>
+					<BlockQuickNavigation clientIds={ contentClientIds } />
+				</PanelBody>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
## What?
PR updates the `BlockInspectorLockedBlock` component to only render the content panel when blocks are available.

## Why?
This is more noticeable when working with synced patterns. The block sets editing mode to `disabled` for its children. See: #57036.

## Testing Instructions
 1. Open a post or page.
 2. Insert synced Pattern block.
 3. Confirm that the empty panel isn't displayed

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-01-25 at 17 45 00](https://github.com/WordPress/gutenberg/assets/240569/0b3aa4ad-d0c5-422c-8645-12acf8ffe49a)
