### PR TITLE
Script Modules API: Add import map polyfill

### DIFF
--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -167,6 +167,8 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 			add_action( $position, array( $this, 'print_import_map' ) );
 			add_action( $position, array( $this, 'print_enqueued_script_modules' ) );
 			add_action( $position, array( $this, 'print_script_module_preloads' ) );
+			// Prints the script that loads the import map polyfill in the footer.
+			add_action( 'wp_footer', array( $this, 'print_import_map_polyfill' ), 11 );
 		}
 
 		/**
@@ -226,6 +228,27 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 			}
 		}
 
+		/**
+		 * Prints the necessary script to load import map polyfill for browsers that
+		 * do not support import maps.
+		 *
+		 * TODO: Replace the polyfill with a simpler version that only provides
+		 * support for import maps and load it only when the browser doesn't support
+		 * import maps (https://github.com/guybedford/es-module-shims/issues/371).
+		 *
+		 * @since 6.5.0
+		 */
+		public function print_import_map_polyfill() {
+			$import_map = $this->get_import_map();
+			if ( ! empty( $import_map['imports'] ) ) {
+				wp_print_script_tag(
+					array(
+						'src'   => defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/importmap-polyfill.min.js' ),
+						'defer' => true,
+					)
+				);
+			}
+		}
 		/**
 		 * Returns the import map array.
 		 *

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -257,7 +257,7 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 						)
 					),
 					array(
-						'id' => 'wp-polyfill-importmap',
+						'id' => 'wp-load-polyfill-importmap',
 					)
 				);
 			}

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -248,7 +248,7 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 				* at the `document.write`. Its caveat of synchronous mid-stream
 				* blocking write is exactly the behavior we need though.
 				*/
-				'document.write( \'<script src="' .
+				'document.write( \'<script id="wp-js-module-importmap" src="' .
 				$src .
 				'"></scr\' + \'ipt>\' );</script>'
 				);

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -234,7 +234,7 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 		 *
 		 * TODO: Replace the polyfill with a simpler version that only provides
 		 * support for import maps and load it only when the browser doesn't support
-		 * import maps (https://github.com/guybedford/es-module-shims/issues/371).
+		 * import maps (https://github.com/guybedford/es-module-shims/issues/406).
 		 *
 		 * @since 6.5.0
 		 */

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -243,7 +243,7 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 			if ( ! empty( $import_map['imports'] ) ) {
 				wp_print_script_tag(
 					array(
-						'src'   => defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/importmap-polyfill.min.js' ),
+						'src'   => defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/vendor/importmap-polyfill.min.js' ),
 						'defer' => true,
 					)
 				);

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -246,7 +246,7 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 					'wp-polyfill-importmap',
 					gutenberg_url( '/build/modules/importmap-polyfill.min.js' ),
 					array(),
-					get_bloginfo( 'version' ),
+					'1.8.2',
 					true
 				);
 				wp_print_inline_script_tag(

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -236,7 +236,7 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 		 */
 		public function print_import_map_polyfill() {
 			$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
-			$src  = defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/vendor/importmap-polyfill.min.js' ),
+			$src  = defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/vendor/importmap-polyfill.min.js' );
 
 			echo (
 			// Test presence of feature...

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -168,7 +168,7 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 			add_action( $position, array( $this, 'print_enqueued_script_modules' ) );
 			add_action( $position, array( $this, 'print_script_module_preloads' ) );
 			// Prints the script that loads the import map polyfill in the footer.
-			add_action( 'wp_head', array( $this, 'print_import_map_polyfill' ), 11 );
+			add_action( 'wp_footer', array( $this, 'print_import_map_polyfill' ), 11 );
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -235,21 +235,24 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 		 * @since 6.5.0
 		 */
 		public function print_import_map_polyfill() {
-			$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
-			$src  = defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' );
+			$import_map = $this->get_import_map();
+			if ( ! empty( $import_map['imports'] ) ) {
+				$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
+				$src  = defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' );
 
-			echo (
-			// Test presence of feature...
-			'<script>( ' . $test . ' ) || ' .
-			/*
-			 * ...appending polyfill on any failures. Cautious viewers may balk
-			 * at the `document.write`. Its caveat of synchronous mid-stream
-			 * blocking write is exactly the behavior we need though.
-			 */
-			'document.write( \'<script src="' .
-			$src .
-			'"></scr\' + \'ipt>\' );</script>'
-			);
+				echo (
+				// Test presence of feature...
+				'<script>( ' . $test . ' ) || ' .
+				/*
+				* ...appending polyfill on any failures. Cautious viewers may balk
+				* at the `document.write`. Its caveat of synchronous mid-stream
+				* blocking write is exactly the behavior we need though.
+				*/
+				'document.write( \'<script src="' .
+				$src .
+				'"></scr\' + \'ipt>\' );</script>'
+				);
+			}
 		}
 		/**
 		 * Returns the import map array.

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -236,7 +236,7 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 		 */
 		public function print_import_map_polyfill() {
 			$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
-			$src  = defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/vendor/importmap-polyfill.min.js' );
+			$src  = defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' );
 
 			echo (
 			// Test presence of feature...

--- a/lib/compat/wordpress-6.5/class-wp-script-modules.php
+++ b/lib/compat/wordpress-6.5/class-wp-script-modules.php
@@ -237,20 +237,28 @@ if ( ! class_exists( 'WP_Script_Modules' ) ) {
 		public function print_import_map_polyfill() {
 			$import_map = $this->get_import_map();
 			if ( ! empty( $import_map['imports'] ) ) {
-				$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
-				$src  = defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ? gutenberg_url( '/build/modules/importmap-polyfill.min.js' ) : includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' );
-
-				echo (
-				// Test presence of feature...
-				'<script>( ' . $test . ' ) || ' .
+				global $wp_scripts;
 				/*
-				* ...appending polyfill on any failures. Cautious viewers may balk
-				* at the `document.write`. Its caveat of synchronous mid-stream
-				* blocking write is exactly the behavior we need though.
-				*/
-				'document.write( \'<script id="wp-js-module-importmap" src="' .
-				$src .
-				'"></scr\' + \'ipt>\' );</script>'
+				 * In Core, the polyfill is registered with a different approach.
+				 * See: https://github.com/WordPress/wordpress-develop/blob/4b23ba81ddb067110e41d05550de7f2a4f09dad3/src/wp-includes/script-loader.php#L99
+				 */
+				wp_register_script(
+					'wp-polyfill-importmap',
+					gutenberg_url( '/build/modules/importmap-polyfill.min.js' ),
+					array(),
+					get_bloginfo( 'version' ),
+					true
+				);
+				wp_print_inline_script_tag(
+					wp_get_script_polyfill(
+						$wp_scripts,
+						array(
+							'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")' => 'wp-polyfill-importmap',
+						)
+					),
+					array(
+						'id' => 'wp-polyfill-importmap',
+					)
 				);
 			}
 		}

--- a/lib/compat/wordpress-6.5/scripts-modules.php
+++ b/lib/compat/wordpress-6.5/scripts-modules.php
@@ -20,13 +20,14 @@ if ( ! function_exists( 'wp_script_modules' ) ) {
 	 * @return WP_Script_Modules The main WP_Script_Modules instance.
 	 */
 	function wp_script_modules(): WP_Script_Modules {
-		static $instance = null;
-		if ( is_null( $instance ) ) {
-			$instance = new WP_Script_Modules();
-			$instance->add_hooks();
+		global $wp_script_modules;
+
+		if ( ! ( $wp_script_modules instanceof WP_Script_Modules ) ) {
+			$wp_script_modules = new WP_Script_Modules();
 		}
-		return $instance;
+		return $wp_script_modules;
 	}
+	wp_script_modules()->add_hooks();
 }
 
 if ( ! function_exists( 'wp_register_script_module' ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add the print import map polyfill again. It was accidentally removed in https://github.com/WordPress/gutenberg/pull/57778

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We need for browsers that don't allow import map.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- In trunk branch, there shouldn't be a `importmap-polyfill.min.js` at the footer of the site.
- In this PR branch, there should be.

## Backport PR
https://github.com/WordPress/wordpress-develop/pull/5947
