### PR TITLE
Build: Add package build shebang and sync comments

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * External dependencies
  */

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -1,4 +1,8 @@
 const WORDPRESS_NAMESPACE = '@wordpress/';
+
+// !!
+// This list must be kept in sync with the same list in tools/webpack/packages.js
+// !!
 const BUNDLED_PACKAGES = [
 	'@wordpress/dataviews',
 	'@wordpress/icons',

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -24,12 +24,16 @@ const WORDPRESS_NAMESPACE = '@wordpress/';
 // Experimental or other packages that should be private are bundled when used.
 // That way, we can iterate on these package without making them part of the public API.
 // See: https://github.com/WordPress/gutenberg/pull/19809
+//
+// !!
+// This list must be kept in sync with the matching list in packages/dependency-extraction-webpack-plugin/lib/util.js
+// !!
 const BUNDLED_PACKAGES = [
+	'@wordpress/dataviews',
 	'@wordpress/icons',
 	'@wordpress/interface',
-	'@wordpress/undo-manager',
 	'@wordpress/sync',
-	'@wordpress/dataviews',
+	'@wordpress/undo-manager',
 ];
 
 // PHP files in packages that have to be copied during build.


### PR DESCRIPTION

## What?

Two small build-related improvements I added to #58258 then extracted here.

- Add shebang to `bin/packages/build.js`. This allows it to be called directly. It was already executable but was missing this.
- Add comments to `BUNDLED_PACKAGES` stating that they should remain in sync and referencing the other location.

## Why?

Self explanatory.

## Testing Instructions

This works:

```sh
./bin/packages/build.js
```
