### PR TITLE
[RNMobile] Disables saving react root view from parent

### DIFF
--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -666,6 +666,10 @@ public class WPAndroidGlueCode {
         mReactRootView = new ReactRootView(new MutableContextWrapper(initContext));
         mReactRootView.setBackgroundColor(colorBackground);
 
+        // Workaround to prevent saving large RN view hierarchies that lead to a `TransactionTooLargeException`
+        // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/9685#issuecomment-1908452392
+        mReactRootView.setSaveFromParentEnabled(false);
+
         ReactInstanceManagerBuilder builder =
                 ReactInstanceManager.builder()
                                     .setApplication(application)


### PR DESCRIPTION
*Related PRs:*
**WordPress-Android PR:** https://github.com/wordpress-mobile/WordPress-Android/pull/20046
**Gutenberg-mobile PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/6575

## What?
<!-- In a few words, what is the PR actually doing? -->
The introduced change prevents the [EditPostActivity.onSaveInstanceState method](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1161) of the Android app from saving the React Native view hierarchy.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR attempts to resolve the `TransactionTooLargeException` Android crash occurring due to the large view data on large post (see https://github.com/wordpress-mobile/WordPress-Android/issues/9685).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The change applied prevents the [EditPostActivity.onSaveInstanceState method](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1161) from saving [the view hierarchy below ReactRootView](https://github.com/WordPress/gutenberg/pull/58266/commits/1fa36f54b9895225cf0c878480cc9f08c42aa25b) resulting in a consistently small `Bundle` regardless of the post size.
For comparison [this is the Bundle of a post before](https://github.com/wordpress-mobile/WordPress-Android/files/14063061/before.txt) and [with the fix applied on this PR](https://github.com/wordpress-mobile/WordPress-Android/files/14063063/after.txt)

## Testing Instructions
See https://github.com/wordpress-mobile/WordPress-Android/pull/20046
