### PR TITLE
Font Library: Update function signature of wp register font collection

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -80,8 +80,8 @@ class WP_Font_Collection {
 	 *
 	 * @since 6.5.0
 	 *
+	 * @param string $slug  The font collection's unique slug.
 	 * @param array $config Font collection config options. {
-	 *      @type string $slug        The font collection's unique slug.
 	 *      @type string $name        The font collection's name.
 	 *      @type string $description The font collection's description.
 	 *      @type string $src         The font collection's source.
@@ -89,10 +89,10 @@ class WP_Font_Collection {
 	 *      @type array  $categories The font collection's categories.
 	 *  }
 	 */
-	public function __construct( $config ) {
-		$this->is_config_valid( $config );
+	public function __construct( $slug, $config ) {
+		$this->is_config_valid( $slug, $config );
 
-		$this->slug          = isset( $config['slug'] ) ? $config['slug'] : '';
+		$this->slug          = isset( $slug ) ? $slug : '';
 		$this->name          = isset( $config['name'] ) ? $config['name'] : '';
 		$this->description   = isset( $config['description'] ) ? $config['description'] : '';
 		$this->src           = isset( $config['src'] ) ? $config['src'] : '';
@@ -105,8 +105,8 @@ class WP_Font_Collection {
 	 *
 	 * @since 6.5.0
 	 *
+	 * @param string $slug Font collection slug.
 	 * @param array $config Font collection config options. {
-	 *      @type string $slug        The font collection's unique slug.
 	 *      @type string $name        The font collection's name.
 	 *      @type string $description The font collection's description.
 	 *      @type string $src         The font collection's source.
@@ -115,30 +115,42 @@ class WP_Font_Collection {
 	 *  }
 	 * @return bool True if the font collection config is valid and false otherwise.
 	 */
-	public static function is_config_valid( $config ) {
+	public static function is_config_valid( $slug, $config ) {
+		if ( empty( $slug ) || ! is_string( $slug ) ) {
+			_doing_it_wrong( __METHOD__, __( 'Font Collection slug is required as a non-empty string.', 'gutenberg' ), '6.5.0' );
+			return false;
+		}
+
 		if ( empty( $config ) || ! is_array( $config ) ) {
 			_doing_it_wrong( __METHOD__, __( 'Font Collection config options are required as a non-empty array.', 'gutenberg' ), '6.5.0' );
 			return false;
 		}
 
-		$required_keys = array( 'slug', 'name' );
-		foreach ( $required_keys as $key ) {
-			if ( empty( $config[ $key ] ) ) {
-				_doing_it_wrong(
-					__METHOD__,
-					// translators: %s: Font collection config key.
-					sprintf( __( 'Font Collection config %s is required as a non-empty string.', 'gutenberg' ), $key ),
-					'6.5.0'
-				);
-				return false;
-			}
+		if ( empty( $config['name'] ) || ! is_string( $config['name'] ) ) {
+			_doing_it_wrong( __METHOD__, __( 'Font Collection name is required as a non-empty string.', 'gutenberg' ), '6.5.0' );
+			return false;
 		}
 
 		if (
-			( empty( $config['src'] ) && empty( $config['font_families'] ) ) ||
-			( ! empty( $config['src'] ) && ! empty( $config['font_families'] ) )
+			( isset( $config['src'] ) && isset( $config['font_families'] ) ) ||
+			( ! isset( $config['src'] ) && ! isset( $config['font_families'] ) )
 		) {
 			_doing_it_wrong( __METHOD__, __( 'Font Collection config "src" option OR "font_families" option are required.', 'gutenberg' ), '6.5.0' );
+			return false;
+		}
+
+		if ( isset( $config['src'] ) && ! is_string( $config['src'] ) ) {
+			_doing_it_wrong( __METHOD__, __( 'Font Collection config "src" option is required as a non-empty string.', 'gutenberg' ), '6.5.0' );
+			return false;
+		}
+
+		if ( isset( $config['font_families'] ) && ( empty( $config['font_families'] ) || ! is_array( $config['font_families'] ) ) ) {
+			_doing_it_wrong( __METHOD__, __( 'Font Collection config "font_families" option is required as a non-empty array.', 'gutenberg' ), '6.5.0' );
+			return false;
+		}
+
+		if ( isset( $config['categories'] ) && ( empty( $config['categories'] ) || ! is_array( $config['categories'] ) ) ) {
+			_doing_it_wrong( __METHOD__, __( 'Font Collection config "categories" option is required as a non-empty array.', 'gutenberg' ), '6.5.0' );
 			return false;
 		}
 

--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -117,7 +117,8 @@ class WP_Font_Collection {
 	 */
 	public static function is_config_valid( $slug, $config ) {
 		if ( empty( $slug ) || ! is_string( $slug ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Font Collection slug is required as a non-empty string.', 'gutenberg' ), '6.5.0' );
+			/* translators: %s: Font collection slug */
+			_doing_it_wrong( __METHOD__, sprintf( __( 'Font Collection "%s" is required as a non-empty string.', 'gutenberg' ), 'slug' ), '6.5.0' );
 			return false;
 		}
 
@@ -127,7 +128,8 @@ class WP_Font_Collection {
 		}
 
 		if ( empty( $config['name'] ) || ! is_string( $config['name'] ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Font Collection name is required as a non-empty string.', 'gutenberg' ), '6.5.0' );
+			/* translators: %s: Font collection name config property */
+			_doing_it_wrong( __METHOD__, sprintf( __( 'Font Collection "%s" is required as a non-empty string.', 'gutenberg' ), 'name' ), '6.5.0' );
 			return false;
 		}
 
@@ -135,22 +137,26 @@ class WP_Font_Collection {
 			( isset( $config['src'] ) && isset( $config['font_families'] ) ) ||
 			( ! isset( $config['src'] ) && ! isset( $config['font_families'] ) )
 		) {
-			_doing_it_wrong( __METHOD__, __( 'Font Collection config "src" option OR "font_families" option are required.', 'gutenberg' ), '6.5.0' );
+			/* translators: %1$s: Font collection src config property, %2$s: Font collection font_families config property */
+			_doing_it_wrong( __METHOD__, sprintf( __( 'Font Collection config "%1$s" option OR "%2$s" option are required.', 'gutenberg' ), 'src', 'font_families' ), '6.5.0' );
 			return false;
 		}
 
 		if ( isset( $config['src'] ) && ! is_string( $config['src'] ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Font Collection config "src" option is required as a non-empty string.', 'gutenberg' ), '6.5.0' );
+			/* translators: %s: Font collection src config property */
+			_doing_it_wrong( __METHOD__, sprintf( __( 'Font Collection config "%s" option is required as a non-empty string.', 'gutenberg' ), 'src' ), '6.5.0' );
 			return false;
 		}
 
 		if ( isset( $config['font_families'] ) && ( empty( $config['font_families'] ) || ! is_array( $config['font_families'] ) ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Font Collection config "font_families" option is required as a non-empty array.', 'gutenberg' ), '6.5.0' );
+			/* translators: %s: Font collection font_families config property */
+			_doing_it_wrong( __METHOD__, sprintf( __( 'Font Collection config "%s" option is required as a non-empty array.', 'gutenberg' ), 'font_families' ), '6.5.0' );
 			return false;
 		}
 
 		if ( isset( $config['categories'] ) && ( empty( $config['categories'] ) || ! is_array( $config['categories'] ) ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Font Collection config "categories" option is required as a non-empty array.', 'gutenberg' ), '6.5.0' );
+			/* translators: %s: Font collection categories config property */
+			_doing_it_wrong( __METHOD__, sprintf( __( 'Font Collection config "%s" option is required as a non-empty array.', 'gutenberg' ), 'categories' ), '6.5.0' );
 			return false;
 		}
 

--- a/lib/experimental/fonts/font-library/class-wp-font-library.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-library.php
@@ -57,23 +57,24 @@ class WP_Font_Library {
 	 *
 	 * @since 6.5.0
 	 *
+	 * @param string $slug  Font collection slug.
 	 * @param array $config Font collection config options.
 	 *                      See {@see wp_register_font_collection()} for the supported fields.
 	 * @return WP_Font_Collection|WP_Error A font collection is it was registered successfully and a WP_Error otherwise.
 	 */
-	public static function register_font_collection( $config ) {
-		if ( ! WP_Font_Collection::is_config_valid( $config ) ) {
+	public static function register_font_collection( $slug, $config ) {
+		if ( ! WP_Font_Collection::is_config_valid( $slug, $config ) ) {
 			$error_message = __( 'Font collection config is invalid.', 'gutenberg' );
 			return new WP_Error( 'font_collection_registration_error', $error_message );
 		}
 
-		$new_collection = new WP_Font_Collection( $config );
+		$new_collection = new WP_Font_Collection( $slug, $config );
 
-		if ( self::is_collection_registered( $new_collection->get_config()['slug'] ) ) {
+		if ( self::is_collection_registered( $slug ) ) {
 			$error_message = sprintf(
 				/* translators: %s: Font collection slug. */
 				__( 'Font collection with slug: "%s" is already registered.', 'gutenberg' ),
-				$config['slug']
+				$slug
 			);
 			_doing_it_wrong(
 				__METHOD__,
@@ -82,7 +83,7 @@ class WP_Font_Library {
 			);
 			return new WP_Error( 'font_collection_registration_error', $error_message );
 		}
-		self::$collections[ $new_collection->get_config()['slug'] ] = $new_collection;
+		self::$collections[ $slug ] = $new_collection;
 		return $new_collection;
 	}
 

--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -103,18 +103,22 @@ if ( ! function_exists( 'wp_register_font_collection' ) ) {
 	 *
 	 * @since 6.5.0
 	 *
+	 * @param string   $slug   The font collection's unique slug.
 	 * @param string[] $config {
 	 *     Font collection associative array of configuration options.
 	 *
-	 *     @type string $id             The font collection's unique ID.
-	 *     @type string $src            The font collection's data as a JSON file path.
-	 *     @type array  $data           The font collection's data as a PHP array.
+	 *     @type string name           The font collection's name.
+	 *     @type string description    The font collection's description.
+	 *     @type string src            The font collection's data as a JSON file path.
+	 *     @type array font_families   The font collection's font families.
+	 *     @type array categories      The font collection's caegories.
+	 *
 	 * }
 	 * @return WP_Font_Collection|WP_Error A font collection is it was registered
 	 *                                     successfully, else WP_Error.
 	 */
-	function wp_register_font_collection( $config ) {
-		return WP_Font_Library::register_font_collection( $config );
+	function wp_register_font_collection( $slug, $config ) {
+		return WP_Font_Library::register_font_collection( $slug, $config );
 	}
 }
 
@@ -124,22 +128,21 @@ if ( ! function_exists( 'wp_unregister_font_collection' ) ) {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string $collection_id The font collection ID.
+	 * @param string $slug The font collection ID.
 	 */
-	function wp_unregister_font_collection( $collection_id ) {
-		WP_Font_Library::unregister_font_collection( $collection_id );
+	function wp_unregister_font_collection( $slug ) {
+		WP_Font_Library::unregister_font_collection( $slug );
 	}
 
 }
 
 $default_font_collection = array(
-	'slug'        => 'default-font-collection',
 	'name'        => 'Google Fonts',
 	'description' => __( 'Add from Google Fonts. Fonts are copied to and served from your site.', 'gutenberg' ),
 	'src'         => 'https://s.w.org/images/fonts/17.6/collections/google-fonts-with-preview.json',
 );
 
-wp_register_font_collection( $default_font_collection );
+wp_register_font_collection( 'default-font-collection', $default_font_collection );
 
 // @core-merge: This code should probably go into Core's src/wp-includes/functions.php.
 if ( ! function_exists( 'wp_get_font_dir' ) ) {

--- a/phpunit/tests/fonts/font-library/wpFontCollection/__construct.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/__construct.php
@@ -26,12 +26,11 @@ class Tests_Fonts_WpFontCollection_Construct extends WP_UnitTestCase {
 		$src->setAccessible( true );
 
 		$config     = array(
-			'slug'        => 'my-collection',
 			'name'        => 'My Collection',
 			'description' => 'My collection description',
 			'src'         => 'my-collection-data.json',
 		);
-		$collection = new WP_Font_Collection( $config );
+		$collection = new WP_Font_Collection( 'my-collection', $config );
 
 		$actual_slug = $slug->getValue( $collection );
 		$this->assertSame( 'my-collection', $actual_slug, 'Provided slug and initialized slug should match.' );
@@ -55,9 +54,9 @@ class Tests_Fonts_WpFontCollection_Construct extends WP_UnitTestCase {
 	 *
 	 * @param mixed  $config Config of the font collection.
 	 */
-	public function test_should_do_it_wrong( $config ) {
+	public function test_should_do_it_wrong( $slug, $config ) {
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::is_config_valid' );
-		new WP_Font_Collection( $config );
+		new WP_Font_Collection( $slug, $config );
 	}
 
 	/**
@@ -67,37 +66,100 @@ class Tests_Fonts_WpFontCollection_Construct extends WP_UnitTestCase {
 	 */
 	public function data_should_do_it_wrong() {
 		return array(
-			'no id'                           => array(
-				array(
+			'with empty slug'                       => array(
+				'slug'   => '',
+				'config' => array(
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 					'src'         => 'my-collection-data.json',
 				),
 			),
 
-			'no config'                       => array(
-				'',
+			'with wrong slug data type'             => array(
+				'slug'   => true,
+				'config' => array(
+					'name'        => 'My Collection',
+					'description' => 'My collection description',
+					'src'         => 'my-collection-data.json',
+				),
 			),
 
-			'empty array'                     => array(
-				array(),
+			'with config as empty array'            => array(
+				'slug'   => 'my-collection',
+				'config' => array(),
 			),
 
-			'boolean instead of config array' => array(
-				false,
+			'with wrong config data type'           => array(
+				'slug'   => 'my-collection',
+				'config' => true,
 			),
 
-			'null instead of config array'    => array(
-				null,
+			'with config missing name'              => array(
+				'slug'   => 'my-collection',
+				'config' => array(
+					'description' => 'My collection description',
+					'src'         => 'my-collection-data.json',
+				),
 			),
 
-			'missing src'                     => array(
-				array(
-					'slug'        => 'my-collection',
+			'with config missing src'               => array(
+				'slug'   => 'my-collection',
+				'config' => array(
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 				),
 			),
+
+			'with both src and font families'       => array(
+				'slug'   => 'my-collection',
+				'config' => array(
+					'name'          => 'My Collection',
+					'description'   => 'My collection description',
+					'src'           => 'my-collection-data.json',
+					'font_families' => array( 'mock' ),
+				),
+			),
+
+			'with empty families'                   => array(
+				'slug'   => 'my-collection',
+				'config' => array(
+					'name'          => 'My Collection',
+					'description'   => 'My collection description',
+					'font_families' => array(),
+				),
+			),
+
+			'with font families wrong data type'    => array(
+				'slug'   => 'my-collection',
+				'config' => array(
+					'name'          => 'My Collection',
+					'description'   => 'My collection description',
+					'font_families' => 'I am not an array',
+				),
+			),
+
+			'with empty categories'                 => array(
+				'slug'   => 'my-collection',
+				'config' => array(
+					'name'          => 'My Collection',
+					'description'   => 'My collection description',
+					'src'           => 'my-collection-data.json',
+					'font_families' => array( 'mock' ),
+					'categories'    => array(),
+				),
+			),
+
+			'with empty categories wrong data type' => array(
+				'slug'   => 'my-collection',
+				'config' => array(
+					'name'          => 'My Collection',
+					'description'   => 'My collection description',
+					'src'           => 'my-collection-data.json',
+					'font_families' => array( 'mock' ),
+					'categories'    => 'I am not an array',
+				),
+			),
+
 		);
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getConfig.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getConfig.php
@@ -14,11 +14,12 @@ class Tests_Fonts_WpFontCollection_GetConfig extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_should_get_config
 	 *
+	 * @param string $slug Font collection slug.
 	 * @param array $config Font collection config options.
 	 * @param array $expected_data Expected data.
 	 */
-	public function test_should_get_config( $config, $expected_data ) {
-		$collection = new WP_Font_Collection( $config );
+	public function test_should_get_config( $slug, $config, $expected_data ) {
+		$collection = new WP_Font_Collection( $slug, $config );
 		$this->assertSame( $expected_data, $collection->get_config() );
 	}
 
@@ -33,8 +34,8 @@ class Tests_Fonts_WpFontCollection_GetConfig extends WP_UnitTestCase {
 
 		return array(
 			'with a file'        => array(
+				'slug'          => 'my-collection',
 				'config'        => array(
-					'slug'        => 'my-collection',
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 					'src'         => $mock_file,
@@ -46,8 +47,8 @@ class Tests_Fonts_WpFontCollection_GetConfig extends WP_UnitTestCase {
 				),
 			),
 			'with a url'         => array(
+				'slug'          => 'my-collection-with-url',
 				'config'        => array(
-					'slug'        => 'my-collection-with-url',
 					'name'        => 'My Collection with URL',
 					'description' => 'My collection description',
 					'src'         => 'https://localhost/fonts/mock-font-collection.json',
@@ -59,8 +60,8 @@ class Tests_Fonts_WpFontCollection_GetConfig extends WP_UnitTestCase {
 				),
 			),
 			'with font_families' => array(
+				'slug'          => 'my-collection',
 				'config'        => array(
-					'slug'          => 'my-collection',
 					'name'          => 'My Collection',
 					'description'   => 'My collection description',
 					'font_families' => array( array() ),

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getContent.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getContent.php
@@ -49,11 +49,12 @@ class Tests_Fonts_WpFontCollection_GetContent extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_should_get_content
 	 *
-	 * @param array $config Font collection config options.
-	 * @param array $expected_data Expected output data.
+	 * @param string $slug Font collection slug.
+	 * @param array  $config Font collection config options.
+	 * @param array  $expected_data Expected output data.
 	 */
-	public function test_should_get_content( $config, $expected_data ) {
-		$collection = new WP_Font_Collection( $config );
+	public function test_should_get_content( $slug, $config, $expected_data ) {
+		$collection = new WP_Font_Collection( $slug, $config );
 		$this->assertSame( $expected_data, $collection->get_content() );
 	}
 
@@ -68,8 +69,8 @@ class Tests_Fonts_WpFontCollection_GetContent extends WP_UnitTestCase {
 
 		return array(
 			'with a file'                           => array(
+				'slug'          => 'my-collection',
 				'config'        => array(
-					'slug'        => 'my-collection',
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 					'src'         => $mock_file,
@@ -80,8 +81,8 @@ class Tests_Fonts_WpFontCollection_GetContent extends WP_UnitTestCase {
 				),
 			),
 			'with a url'                            => array(
+				'slug'          => 'my-collection-with-url',
 				'config'        => array(
-					'slug'        => 'my-collection-with-url',
 					'name'        => 'My Collection with URL',
 					'description' => 'My collection description',
 					'src'         => 'https://localhost/fonts/mock-font-collection.json',
@@ -92,8 +93,8 @@ class Tests_Fonts_WpFontCollection_GetContent extends WP_UnitTestCase {
 				),
 			),
 			'with font_families and categories'     => array(
+				'slug'          => 'my-collection',
 				'config'        => array(
-					'slug'          => 'my-collection',
 					'name'          => 'My Collection',
 					'description'   => 'My collection description',
 					'font_families' => array( 'mock' ),
@@ -105,8 +106,8 @@ class Tests_Fonts_WpFontCollection_GetContent extends WP_UnitTestCase {
 				),
 			),
 			'with font_families without categories' => array(
+				'slug'          => 'my-collection',
 				'config'        => array(
-					'slug'          => 'my-collection',
 					'name'          => 'My Collection',
 					'description'   => 'My collection description',
 					'font_families' => array( 'mock' ),

--- a/phpunit/tests/fonts/font-library/wpFontCollection/isConfigValid.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/isConfigValid.php
@@ -17,23 +17,23 @@ class Tests_Fonts_WpFontCollection_IsConfigValid extends WP_UnitTestCase {
 	 *
 	 * @param array $config Font collection config options.
 	 */
-	public function test_is_config_valid( $config ) {
-		$this->assertTrue( WP_Font_Collection::is_config_valid( $config ) );
+	public function test_is_config_valid( $slug, $config ) {
+		$this->assertTrue( WP_Font_Collection::is_config_valid( $slug, $config ) );
 	}
 
 	public function data_is_config_valid() {
 		return array(
 			'with src'           => array(
+				'slug'   => 'my-collection',
 				'config' => array(
-					'slug'        => 'my-collection',
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 					'src'         => 'my-collection-data.json',
 				),
 			),
 			'with font families' => array(
+				'slug'   => 'my-collection',
 				'config' => array(
-					'slug'          => 'my-collection',
 					'name'          => 'My Collection',
 					'description'   => 'My collection description',
 					'font_families' => array( 'mock' ),
@@ -48,54 +48,65 @@ class Tests_Fonts_WpFontCollection_IsConfigValid extends WP_UnitTestCase {
 	 *
 	 * @param mixed  $config Config of the font collection.
 	 */
-	public function test_is_config_valid_should_call_doing_it_wrong( $config ) {
+	public function test_is_config_valid_should_call_doing_it_wrong( $slug, $config ) {
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::is_config_valid', 'Should call _doing_it_wrong if the config is not valid.' );
-		$this->assertFalse( WP_Font_Collection::is_config_valid( $config ), 'Should return false if the config is not valid.' );
+		$this->assertFalse( WP_Font_Collection::is_config_valid( $slug, $config ), 'Should return false if the config is not valid.' );
 	}
 
 	public function data_is_config_valid_should_call_doing_it_wrong() {
 		return array(
-			'with missing slug'               => array(
+			'with empty slug'                    => array(
+				'slug'   => '',
 				'config' => array(
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 					'src'         => 'my-collection-data.json',
 				),
 			),
-			'with missing name'               => array(
+			'with invalig slug data type'        => array(
+				'slug'   => 100,
 				'config' => array(
-					'slug'        => 'my-collection',
+					'name'        => 'My Collection',
 					'description' => 'My collection description',
 					'src'         => 'my-collection-data.json',
 				),
 			),
-			'with missing src'                => array(
+			'with missing name'                  => array(
+				'slug'   => 'my-collection',
 				'config' => array(
-					'slug'        => 'my-collection',
+					'description' => 'My collection description',
+					'src'         => 'my-collection-data.json',
+				),
+			),
+			'with missing src'                   => array(
+				'slug'   => 'my-collection',
+				'config' => array(
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 				),
 			),
-			'with both src and font_families' => array(
+			'with both src and font_families'    => array(
+				'slug'   => 'my-collection',
 				'config' => array(
-					'slug'          => 'my-collection',
 					'name'          => 'My Collection',
 					'description'   => 'My collection description',
 					'src'           => 'my-collection-data.json',
 					'font_families' => array( 'mock' ),
 				),
 			),
-			'without src or font_families'    => array(
+			'without src or font_families'       => array(
+				'slug'   => 'my-collection',
 				'config' => array(
-					'slug'        => 'my-collection',
 					'name'        => 'My Collection',
 					'description' => 'My collection description',
 				),
 			),
-			'with empty config'               => array(
+			'with empty config'                  => array(
+				'slug'   => 'my-collection',
 				'config' => array(),
 			),
-			'without an array'                => array(
+			'with a config of a wrong data type' => array(
+				'slug'   => 'my-collection',
 				'config' => 'not an array',
 			),
 		);

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollection.php
@@ -14,12 +14,11 @@ class Tests_Fonts_WpFontLibrary_GetFontCollection extends WP_Font_Library_UnitTe
 
 	public function test_should_get_font_collection() {
 		$my_font_collection_config = array(
-			'slug'        => 'my-font-collection',
 			'name'        => 'My Font Collection',
 			'description' => 'Demo about how to a font collection to your WordPress Font Library.',
 			'src'         => path_join( __DIR__, 'my-font-collection-data.json' ),
 		);
-		wp_register_font_collection( $my_font_collection_config );
+		wp_register_font_collection( 'my-font-collection', $my_font_collection_config );
 		$font_collection = WP_Font_Library::get_font_collection( 'my-font-collection' );
 		$this->assertInstanceOf( 'WP_Font_Collection', $font_collection );
 	}

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollections.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollections.php
@@ -18,13 +18,12 @@ class Tests_Fonts_WpFontLibrary_GetFontCollections extends WP_Font_Library_UnitT
 
 	public function test_should_get_mock_font_collection() {
 		$my_font_collection_config = array(
-			'slug'        => 'my-font-collection',
 			'name'        => 'My Font Collection',
 			'description' => 'Demo about how to a font collection to your WordPress Font Library.',
 			'src'         => path_join( __DIR__, 'my-font-collection-data.json' ),
 		);
 
-		WP_Font_Library::register_font_collection( $my_font_collection_config );
+		WP_Font_Library::register_font_collection( 'my-font-collection', $my_font_collection_config );
 
 		$font_collections = WP_Font_Library::get_font_collections();
 		$this->assertNotEmpty( $font_collections, 'Sould return an array of font collections.' );

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/registerFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/registerFontCollection.php
@@ -14,12 +14,11 @@ class Tests_Fonts_WpFontLibrary_RegisterFontCollection extends WP_Font_Library_U
 
 	public function test_should_register_font_collection() {
 		$config     = array(
-			'slug'        => 'my-collection',
 			'name'        => 'My Collection',
 			'description' => 'My Collection Description',
 			'src'         => 'my-collection-data.json',
 		);
-		$collection = WP_Font_Library::register_font_collection( $config );
+		$collection = WP_Font_Library::register_font_collection( 'my-collection', $config );
 		$this->assertInstanceOf( 'WP_Font_Collection', $collection );
 	}
 
@@ -30,31 +29,29 @@ class Tests_Fonts_WpFontLibrary_RegisterFontCollection extends WP_Font_Library_U
 			'src'         => 'my-collection-data.json',
 		);
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::is_config_valid' );
-		$collection = WP_Font_Library::register_font_collection( $config );
+		$collection = WP_Font_Library::register_font_collection( '', $config );
 		$this->assertWPError( $collection, 'A WP_Error should be returned.' );
 	}
 
 	public function test_should_return_error_if_name_is_missing() {
 		$config = array(
-			'slug'        => 'my-collection',
 			'description' => 'My Collection Description',
 			'src'         => 'my-collection-data.json',
 		);
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::is_config_valid' );
-		$collection = WP_Font_Library::register_font_collection( $config );
+		$collection = WP_Font_Library::register_font_collection( 'my-collection', $config );
 		$this->assertWPError( $collection, 'A WP_Error should be returned.' );
 	}
 
 	public function test_should_return_error_if_config_is_empty() {
 		$config = array();
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::is_config_valid' );
-		$collection = WP_Font_Library::register_font_collection( $config );
+		$collection = WP_Font_Library::register_font_collection( 'my-collection', $config );
 		$this->assertWPError( $collection, 'A WP_Error should be returned.' );
 	}
 
 	public function test_should_return_error_if_slug_is_repeated() {
 		$config1 = array(
-			'slug'        => 'my-collection-1',
 			'name'        => 'My Collection 1',
 			'description' => 'My Collection 1 Description',
 			'src'         => 'my-collection-1-data.json',
@@ -67,13 +64,13 @@ class Tests_Fonts_WpFontLibrary_RegisterFontCollection extends WP_Font_Library_U
 		);
 
 		// Register first collection.
-		$collection1 = WP_Font_Library::register_font_collection( $config1 );
+		$collection1 = WP_Font_Library::register_font_collection( 'my-collection-1', $config1 );
 		$this->assertInstanceOf( 'WP_Font_Collection', $collection1, 'A collection should be registered.' );
 
 		// Expects a _doing_it_wrong notice.
 		$this->setExpectedIncorrectUsage( 'WP_Font_Library::register_font_collection' );
 		// Try to register a second collection with same slug.
-		$collection2 = WP_Font_Library::register_font_collection( $config2 );
+		$collection2 = WP_Font_Library::register_font_collection( 'my-collection-1', $config2 );
 		$this->assertWPError( $collection2, 'A WP_Error should be returned.' );
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/unregisterFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/unregisterFontCollection.php
@@ -15,20 +15,18 @@ class Tests_Fonts_WpFontLibrary_UnregisterFontCollection extends WP_Font_Library
 	public function test_should_unregister_font_collection() {
 		// Registers two mock font collections.
 		$config = array(
-			'slug'        => 'mock-font-collection-1',
 			'name'        => 'Mock Collection to be unregistered',
 			'description' => 'A mock font collection to be unregistered.',
 			'src'         => 'my-collection-data.json',
 		);
-		WP_Font_Library::register_font_collection( $config );
+		WP_Font_Library::register_font_collection( 'mock-font-collection-1', $config );
 
 		$config = array(
-			'slug'        => 'mock-font-collection-2',
 			'name'        => 'Mock Collection',
 			'description' => 'A mock font collection.',
 			'src'         => 'my-mock-data.json',
 		);
-		WP_Font_Library::register_font_collection( $config );
+		WP_Font_Library::register_font_collection( 'mock-font-collection-2', $config );
 
 		// Unregister mock font collection.
 		WP_Font_Library::unregister_font_collection( 'mock-font-collection-1' );

--- a/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
@@ -31,9 +31,9 @@ class WP_REST_Font_Collections_Controller_Test extends WP_Test_REST_Controller_T
 		file_put_contents( $mock_file, '{"font_families": [ "mock" ], "categories": [ "mock" ] }' );
 
 		wp_register_font_collection(
+			'mock-col-slug',
 			array(
 				'name' => 'My Collection',
-				'slug' => 'mock-col-slug',
 				'src'  => $mock_file,
 			)
 		);


### PR DESCRIPTION
## What?
- Updates function signature of `wp_register_font_collection` from `wp_register_font_collection( $config )` to `wp_register_font_collection( $slug, $config )`.
- Updates the WP_Font_Collection constructor and settings validation function.
- Updates and improves unit tests.

## Why?
To make the function more likely to other core functions.
Requested here: https://github.com/WordPress/gutenberg/pull/57884#discussion_r1458255220

## How?
Change the parameters received by the functions.

## Testing Instructions
- Use the font library and check that font collections continue working as expected.
- Run unit tests
