### PR TITLE
Render edit view upon initial link creation in rich text

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, createInterpolateElement } from '@wordpress/element';
+import {
+	useMemo,
+	createInterpolateElement,
+	useState,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { Popover } from '@wordpress/components';
@@ -48,6 +52,8 @@ function InlineLinkUI( {
 	stopAddingLink,
 	contentRef,
 } ) {
+	const [ justCreated, setJustCreated ] = useState( false );
+
 	const richLinkTextValue = getRichTextValueFromSelection( value, isActive );
 
 	// Get the text content minus any HTML tags.
@@ -182,8 +188,11 @@ function InlineLinkUI( {
 		// being created for the first time. If it is then focus should remain within the
 		// Link UI because it should remain open for the user to modify the link they have
 		// just created.
-		if ( ! isNewLink ) {
+		if ( isNewLink ) {
+			setJustCreated( true );
+		} else {
 			stopAddingLink();
+			setJustCreated( false );
 		}
 
 		if ( ! isValidHref( newUrl ) ) {
@@ -250,6 +259,12 @@ function InlineLinkUI( {
 		);
 	}
 
+	// If the link is being created for the first time then force the Link UI
+	// to be in edit mode so that the user can modify the link they have just
+	// created. Passing undefined will allow the default behaviour to continue
+	// uninterrupted.
+	const forceEditMode = justCreated ? true : undefined;
+
 	return (
 		<Popover
 			anchor={ popoverAnchor }
@@ -278,6 +293,7 @@ function InlineLinkUI( {
 						perPage: 20,
 					},
 				} }
+				forceIsEditingLink={ forceEditMode }
 			/>
 		</Popover>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When a link is first created in rich text (e.g. paragraph block), the Link UI remains open and displays the "edit" view (as opposed to the "preview" view).

Closes https://github.com/WordPress/gutenberg/issues/50892

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In many scenarios seeing a preview of a link immediately upon _creation_ of that link is not helpful. In most cases users want to immediately alter the settings of the link or do some other alternation.

See Issue for further rationale.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Tracks whether this is the initial creation of the link in a new piece of state
- When the link is submitted we test the value to see if there is already a link
- If there isn't then this is the initial creation of the link
- We use the status of the "initial creation" to conditionally force the `<LinkControl>` into edit mode.
- We can also remove the `Opens in new tab` from the preview as this was only there as a stop gap.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Add text
- Make link from text
- Submit link
- See Link UI is in edit mode and allows for further changes to link
- Close Link UI
- Click on link again. Make changes. You should see it close as normal.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/d34acd5e-c1d5-40a2-abe5-4362d614bbdb

