### PR TITLE
Fix Link UI popover anchor in rich text

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -212,7 +212,17 @@ function InlineLinkUI( {
 	//  This caches the last truthy value of the selection anchor reference.
 	// This ensures the Popover is positioned correctly on initial submission of the link.
 	const cachedRect = useCachedTruthy( popoverAnchor.getBoundingClientRect() );
-	popoverAnchor.getBoundingClientRect = () => cachedRect;
+
+	// If the link is not active (i.e. it is a new link) then we need to
+	// override the getBoundingClientRect method on the anchor element
+	// to return the cached value of the selection represented by the text
+	// that the user selected to be linked.
+	// If the link is active (i.e. it is an existing link) then we allow
+	// the default behaviour of the popover anchor to be used. This will get
+	// the anchor based on the `<a>` element in the rich text.
+	if ( ! isActive ) {
+		popoverAnchor.getBoundingClientRect = () => cachedRect;
+	}
 
 	async function handleCreate( pageTitle ) {
 		const page = await createPageEntity( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes bug where Link UI Popover anchor becomes divorced from the link that "owns" it (see Issue).

Closes https://github.com/WordPress/gutenberg/issues/58280

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Link UI should always be anchored to the link that was clicked/activated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Ensures that the anchor position is allowed to be dynamically calculated for existing links where there is a `<a>` tag in the contenteditable element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Type a line of text 
- Link several individual pieces of text along the line
- Click on each link in turn checking that the popover is anchored to the link in question
- Try starting and ending on different links when clicking to stress test

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/444434/776813ca-632d-4d60-8eb6-9e04b5591058

