### PR TITLE
Remove noahtallen from .wp-env codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -132,7 +132,7 @@
 /packages/report-flaky-tests                    @kevin940726
 
 # wp-env
-/packages/env                                   @noahtallen @ObliviousHarmony @t-hamano
+/packages/env                                   @ObliviousHarmony @t-hamano
 
 # PHP
 /lib                                            @spacedmonkey


### PR DESCRIPTION
I haven't had time for `wp-env` in quite a now. I'm also transitioning teams and projects at work, which means it's even less of a good fit for me now. Feel free to ping me directly if there are questions about how something works, though!