### PR TITLE
Patterns: Change the pattern block overrides attribute name to `content`

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -42,7 +42,7 @@ Reuse this design across your site. ([Source](https://github.com/WordPress/guten
 -	**Name:** core/block
 -	**Category:** reusable
 -	**Supports:** ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
--	**Attributes:** overrides, ref
+-	**Attributes:** content, ref
 
 ## Button
 

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -11,7 +11,7 @@
 		"ref": {
 			"type": "number"
 		},
-		"overrides": {
+		"content": {
 			"type": "object"
 		}
 	},

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -46,7 +46,7 @@ function render_block_core_block( $attributes ) {
 	$content = $wp_embed->run_shortcode( $reusable_block->post_content );
 	$content = $wp_embed->autoembed( $content );
 
-	$has_pattern_overrides = isset( $attributes['overrides'] );
+	$has_pattern_overrides = isset( $attributes['content'] );
 
 	/**
 	 * We set the `pattern/overrides` context through the `render_block_context`
@@ -55,7 +55,7 @@ function render_block_core_block( $attributes ) {
 	 */
 	if ( $has_pattern_overrides ) {
 		$filter_block_context = static function ( $context ) use ( $attributes ) {
-			$context['pattern/overrides'] = $attributes['overrides'];
+			$context['pattern/overrides'] = $attributes['content'];
 			return $context;
 		};
 		add_filter( 'render_block_context', $filter_block_context, 1 );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -170,7 +170,7 @@ test.describe( 'Pattern Overrides', () => {
 					name: 'core/block',
 					attributes: {
 						ref: patternId,
-						overrides: {
+						content: {
 							[ editableParagraphId ]: {
 								content: [ 1, 'I would word it this way' ],
 							},
@@ -181,7 +181,7 @@ test.describe( 'Pattern Overrides', () => {
 					name: 'core/block',
 					attributes: {
 						ref: patternId,
-						overrides: {
+						content: {
 							[ editableParagraphId ]: {
 								content: [ 1, 'This one is different' ],
 							},
@@ -305,7 +305,7 @@ test.describe( 'Pattern Overrides', () => {
 				name: 'core/block',
 				attributes: {
 					ref: id,
-					overrides: {
+					content: {
 						[ buttonId ]: {
 							linkTarget: [ 0 ],
 						},


### PR DESCRIPTION
## What?
Changes the override attributes name from `overrides` to `content`

## Why?
Feedback was received that this would be a more appropriate name.

## How?
Renamed all the instances of the attribute in editor and frontend code.

## Testing Instructions

- Add a synced pattern with overrides
- In the post editor add the pattern and in the code editor view check that the override content has been added to an attribute called `content`
- Save the post and view in frontend and make sure override content displays

Before:

```json
<!-- wp:block {"ref":233,"overrides":{"WZUl8h":{"content":[1,"my new content"]}} /-->

```

After:

```json
<!-- wp:block {"ref":233,"content":{"WZUl8h":{"content":[1,"my new content"]}} /-->

```
