### PR TITLE
Patterns: Change text on pattern reset button

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -408,7 +408,7 @@ export default function ReusableBlockEdit( {
 							disabled={ ! overrides }
 							__experimentalIsFocusable
 						>
-							{ __( 'Reset to original' ) }
+							{ __( 'Reset' ) }
 						</ToolbarButton>
 					</ToolbarGroup>
 				</BlockControls>


### PR DESCRIPTION
## What?

Changes the text of the `Reset to original` button to just `Reset`

## Why?
Feedback suggested this was better.

## How?
Updated the button text.

## Testing Instructions

- Add a synced pattern with overrides and check the reset button just says `Reset` and works as expected.


## Screenshots or screencast <!-- if applicable -->

Before:

<img width="644" alt="Screenshot 2024-01-26 at 10 56 22 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/6b736be7-9c56-44a4-aace-83331716c930">

After:

<img width="643" alt="Screenshot 2024-01-26 at 10 50 35 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/006c49c9-fcda-48ab-94c9-4213f4526bb8">

