### PR TITLE
Updates Font Families and Font Faces endpoints context param

### DIFF
--- a/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
@@ -79,7 +79,7 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
-						'context' => $this->get_context_param( array( 'default' => 'edit' ) ),
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 					),
 				),
 				array(
@@ -427,7 +427,7 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 			$data['font_face_settings'] = $this->get_settings_from_post( $item );
 		}
 
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'edit';
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
 
@@ -471,7 +471,7 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 				'id'                 => array(
 					'description' => __( 'Unique identifier for the post.', 'default' ),
 					'type'        => 'integer',
-					'context'     => array( 'edit', 'embed' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
 				'theme_json_version' => array(
@@ -480,19 +480,19 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 					'default'     => 2,
 					'minimum'     => 2,
 					'maximum'     => 2,
-					'context'     => array( 'edit', 'embed' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'parent'             => array(
 					'description' => __( 'The ID for the parent font family of the font face.', 'gutenberg' ),
 					'type'        => 'integer',
-					'context'     => array( 'edit', 'embed' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				// Font face settings come directly from theme.json schema
 				// See https://schemas.wp.org/trunk/theme.json
 				'font_face_settings' => array(
 					'description'          => __( 'font-face declaration in theme.json format.', 'gutenberg' ),
 					'type'                 => 'object',
-					'context'              => array( 'edit', 'embed' ),
+					'context'              => array( 'view', 'edit', 'embed' ),
 					'properties'           => array(
 						'fontFamily'            => array(
 							'description' => __( 'CSS font-family value.', 'gutenberg' ),
@@ -600,8 +600,6 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 	 */
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();
-
-		$query_params['context']['default'] = 'edit';
 
 		// Remove unneeded params.
 		unset( $query_params['after'] );

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -230,7 +230,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 			$data['font_family_settings'] = $this->get_settings_from_post( $item );
 		}
 
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'edit';
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
 
@@ -274,7 +274,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 				'id'                   => array(
 					'description' => __( 'Unique identifier for the post.', 'default' ),
 					'type'        => 'integer',
-					'context'     => array( 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
 				'theme_json_version'   => array(
@@ -283,12 +283,12 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 					'default'     => 2,
 					'minimum'     => 2,
 					'maximum'     => 2,
-					'context'     => array( 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'font_faces'           => array(
 					'description' => __( 'The IDs of the child font faces in the font family.', 'gutenberg' ),
 					'type'        => 'array',
-					'context'     => array( 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'items'       => array(
 						'type' => 'integer',
 					),
@@ -298,7 +298,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 				'font_family_settings' => array(
 					'description'          => __( 'font-face declaration in theme.json format.', 'gutenberg' ),
 					'type'                 => 'object',
-					'context'              => array( 'edit' ),
+					'context'              => array( 'view', 'edit', 'embed' ),
 					'properties'           => array(
 						'name'       => array(
 							'description' => 'Name of the font family preset, translatable.',
@@ -338,8 +338,6 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();
 
-		$query_params['context']['default'] = 'edit';
-
 		// Remove unneeded params.
 		unset( $query_params['after'] );
 		unset( $query_params['modified_after'] );
@@ -360,21 +358,6 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 		 * @param array $query_params JSON Schema-formatted collection parameters.
 		 */
 		return apply_filters( 'rest_wp_font_family_collection_params', $query_params );
-	}
-
-	/**
-	 * Retrieves the query params for the font family collection, defaulting to the 'edit' context.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param array $args Optional. Additional arguments for context parameter. Default empty array.
-	 * @return array Context parameter details.
-	 */
-	public function get_context_param( $args = array() ) {
-		if ( isset( $args['default'] ) ) {
-			$args['default'] = 'edit';
-		}
-		return parent::get_context_param( $args );
 	}
 
 	/**

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -136,16 +136,16 @@ class WP_REST_Font_Faces_Controller_Test extends WP_Test_REST_Controller_Testcas
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertArrayNotHasKey( 'allow_batch', $data['endpoints'][0] );
-		$this->assertSame( 'edit', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertSame( array( 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 
 		// Single.
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces/' . self::$font_face_id1 );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertArrayNotHasKey( 'allow_batch', $data['endpoints'][0] );
-		$this->assertSame( 'edit', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertSame( array( 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 	/**

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -151,16 +151,16 @@ class WP_REST_Font_Families_Controller_Test extends WP_Test_REST_Controller_Test
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertArrayNotHasKey( 'allow_batch', $data['endpoints'][0] );
-		$this->assertSame( 'edit', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertSame( array( 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 
 		// Single.
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/font-families/' . self::$font_family_id1 );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertArrayNotHasKey( 'allow_batch', $data['endpoints'][0] );
-		$this->assertSame( 'edit', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertSame( array( 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 


### PR DESCRIPTION
## What?

Updates the `wp/v2/font-families` and `wp/v2/font-families/<id>/font-faces` endpoints `context` param

- Default `context` to view, to be consistent with other Core endpoints
- Accept `view`, `edit`, and `embed`, since viewing, editing, and embedding are valid contexts for both objects

## Why?

As pointed out by @matiasbenedetto [here](https://github.com/WordPress/gutenberg/pull/58222#discussion_r1466962332), the context param seems to be not about where the request is being called from (front-end vs. editor), but about what information is needed to take a specific action on the object.

## How?

Updates the endpoint schema and defaults.

## Testing Instructions

- Make requests to the following endpoints using `view`, `edit`, `embed` and no value for `?context=`
    - `GET wp/v2/font-families`
    - `GET wp/v2/font-families`
    - `GET wp/v2/font-families/<id>/font-faces`
    - `GET wp/v2/font-families/<id>/font-faces/<id>`
- See that all fields are returned for all contexts
- You can also check `OPTIONS` requests to see that the `context` param correctly defaults to `view` and accepts any of those three contexts as valid
