### PR TITLE
[WIP] Patterns: Investigate using block name to name override attributes

### DIFF
--- a/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
@@ -6,10 +6,10 @@
  */
 if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 	$pattern_source_callback = function ( $source_attrs, $block_instance, $attribute_name ) {
-		if ( ! _wp_array_get( $block_instance->attributes, array( 'metadata', 'id' ), false ) ) {
+		if ( ! _wp_array_get( $block_instance->attributes, array( 'metadata', 'name' ), false ) ) {
 			return null;
 		}
-		$block_id           = $block_instance->attributes['metadata']['id'];
+		$block_id           = $block_instance->attributes['metadata']['name'];
 		$attribute_override = _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, $attribute_name ), null );
 		if ( null === $attribute_override ) {
 			return null;

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -115,7 +115,7 @@ function applyInitialOverrides( blocks, overrides = {}, defaultValues ) {
 			overrides,
 			defaultValues
 		);
-		const blockId = block.attributes.metadata?.id;
+		const blockId = block.attributes.metadata?.name;
 		if ( ! isPartiallySynced( block ) || ! blockId )
 			return { ...block, innerBlocks };
 		const attributes = getPartiallySyncedAttributes( block );
@@ -152,7 +152,7 @@ function getOverridesFromBlocks( blocks, defaultValues ) {
 			getOverridesFromBlocks( block.innerBlocks, defaultValues )
 		);
 		/** @type {string} */
-		const blockId = block.attributes.metadata?.id;
+		const blockId = block.attributes.metadata?.name;
 		if ( ! isPartiallySynced( block ) || ! blockId ) continue;
 		const attributes = getPartiallySyncedAttributes( block );
 		for ( const attributeKey of attributes ) {

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { nanoid } from 'nanoid';
-
-/**
  * WordPress dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
@@ -66,7 +61,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			}
 		}
 
-		if ( typeof attributes.metadata?.id === 'string' ) {
+		if ( typeof attributes.metadata?.name === 'string' ) {
 			setAttributes( {
 				metadata: {
 					...attributes.metadata,
@@ -76,11 +71,9 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			return;
 		}
 
-		const id = nanoid( 6 );
 		setAttributes( {
 			metadata: {
 				...attributes.metadata,
-				id,
 				bindings: updatedBindings,
 			},
 		} );


### PR DESCRIPTION
## What?
This is just a quick test to see how things look/work if we use only the block name as the override attribute identifier

## Why?
Why not :-)

## How?
Changes the attribute meta field from id to name

## Testing Instructions

- Add a synced pattern and set some pattern overrides. Make sure you set a block name for each of the overridden blocks - currently there is no UX to warn of the need for this
- Add an instance of the pattern to a post and override the content and make sure it saves in the pattern attributes under the block name
- Check the overridden content displays in the frontend.
