### PR TITLE
Improve Escaping within `build_dropdown_script_block_core_categories()`.

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -63,7 +63,7 @@ function render_block_core_categories( $attributes ) {
 /**
  * Generates the inline script for a categories dropdown field.
  *
- * @param string $dropdown_id ID of the dropdown field.
+ * @param string $dropdown_id HTML ID of the dropdown field.
  *
  * @return string Returns the dropdown onChange redirection script.
  */
@@ -72,10 +72,11 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	?>
 	<script>
 	( function() {
-		var dropdown = document.getElementById( '<?php echo esc_js( $dropdown_id ); ?>' );
+		var dropdown = document.getElementById( <?php echo wp_json_encode( $dropdown_id ); ?> );
+		var categoryUrl = <?php echo wp_json_encode( esc_url_raw( home_url( '?cat=' ) ) ); ?>;
 		function onCatChange() {
 			if ( dropdown.options[ dropdown.selectedIndex ].value > 0 ) {
-				location.href = "<?php echo esc_url( home_url() ); ?>/?cat=" + dropdown.options[ dropdown.selectedIndex ].value;
+				location.href = categoryUrl + dropdown.options[ dropdown.selectedIndex ].value;
 			}
 		}
 		dropdown.onchange = onCatChange;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Modifying how the escaping is done in `build_dropdown_script_block_core_categories()`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's pretty nitpicky but the escaping is slightly incorrect.

* `esc_js` is used for HTML tag attributes (eg, `onclick=`) rather than escaping within a `script` tag.
* Using `esc_url` for use within the JS `location` API can mess up URLs containing special characters (eg, `&`) legal in directory names

I don't think the former is likely to be hit, the latter will only be hit if someone installs WP in a subdirectory of a domain with an unusual character structure.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* `esc_js` replaced with `wp_json_encode`
* `esc_url` replaced with `esc_url_raw` and json encoded to ensure the variable is JS safe.

## Testing Instructions

1. Create a number of categories
2. Create a post
3. Insert the categories block
   * Enable Display as dropdown
   * Enable Show empty categories
4. Ensure selecting a dropdown redirects as expected on the front end.

To ensure the URL redirects are expected

5. In the wp-config file, set `define('WP_HOME', 'http://localhost/pens&pencisl' );` -- replace host as required
6. Disable pretty permalinks
7. Reload the post created earlier
8. Select a category
9. Ensure the destination URL contains an ampersand rather than `&amp;`, `&#038;` or similar -- not the destination URL may 404.

_Remember to remove the `WP_HOME` definition once you finish testing to avoid buggy behavior later._

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
