### PR TITLE
Navigation Submenu Block: Make block name affect list view

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -33,6 +33,8 @@ export const settings = {
 		if ( context === 'list-view' && ( customName || label ) ) {
 			return attributes?.metadata?.name || label;
 		}
+
+		return label;
 	},
 	edit,
 	save,

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -21,16 +21,21 @@ export const settings = {
 		if ( context === 'list-view' ) {
 			return page;
 		}
-
 		return addSubmenu;
 	},
+	__experimentalLabel( attributes, { context } ) {
+		const { label } = attributes;
 
-	__experimentalLabel: ( { label } ) => label,
+		const customName = attributes?.metadata?.name;
 
+		// In the list view, use the block's menu label as the label.
+		// If the menu label is empty, fall back to the default label.
+		if ( context === 'list-view' && ( customName || label ) ) {
+			return attributes?.metadata?.name || label;
+		}
+	},
 	edit,
-
 	save,
-
 	transforms,
 };
 


### PR DESCRIPTION
Closes  #57954
Same as #57955, #58160

## What?
This PR fixes an issue where the block name is not reflected in the list view for the Navigation Submenu block.

![navigation-submenu](https://github.com/WordPress/gutenberg/assets/54422211/7bf7b589-5538-4b9e-ba55-d8f9b22edf86)

## Why?

If that block has opted into `__experimentLabel`, the list view will display the default block name unless we explicitly return `metadata.name` when the context is `list-view`.

For a more detailed analysis, please refer to #57954.

## How?

This block can be set with a label. According to the current specifications, if the label has text, that text is displayed in the list view, and if the label is empty, the block name (Submenu) is displayed in the list view.

Update this logic, similar to [the Heading block](https://github.com/WordPress/gutenberg/blob/f5917593d17f2f7f5cedee4cd2e0e89b88b71f3a/packages/block-library/src/heading/index.js#L34-L38), to the following logic:

- If both menu label text and block name are empty, display the default block name (Submenu)
- Display menu label text if menu label text is not empty
- Overwrite meu label text if the block name is not empty

## Testing Instructions

- Add a Navigation Submenu block to the Navigation block.
- Open the List View.
- The List View should display the menu label text.
- Empty the menu label.
- The List View should display "Submenu".
- Enter text for the block name.
- The List View should display that text.
- Enter text for the menu label.
- The block name should still remain in the list view.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/90722c27-ff5d-4611-b23c-c3c99c30b672

