### PR TITLE
DataViews: Fix safari grid row height issue

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -256,6 +256,7 @@
 .dataviews-view-grid {
 	margin-bottom: $grid-unit-30;
 	grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+	grid-template-rows: max-content;
 	padding: 0 $grid-unit-40;
 
 	@include break-xlarge() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR addresses a display issue on Safari that affects the DataViews `grid` view, when we have a single row in the showed items.

## Testing Instructions
1. In any page where the DataViews are used(templates, patterns, etc..) filter the items to have a single row of results, while being in `grid` view.
2. Observe that the height of the items doesn't fill the viewport.
3. Verify that in other browsers like Chrome, it still works as before


### Before
<img width="1544" alt="Screenshot 2024-01-26 at 12 13 10 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/57ea1eac-a4c8-41c5-88f6-02b86e3526f6">



### After
<img width="1544" alt="Screenshot 2024-01-26 at 12 13 23 PM" src="https://github.com/WordPress/gutenberg/assets/16275880/0b17c51d-dffd-4e53-af9f-5e8cd685c812">


