### PR TITLE
DataViews: Fix nested buttons and placeholder text in list layout

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -161,6 +161,10 @@ function FeaturedImage( { item, viewType } ) {
 		canvas: 'edit',
 	} );
 	const hasMedia = !! item.featured_media;
+	const size =
+		viewType === LAYOUT_GRID
+			? [ 'large', 'full', 'medium', 'thumbnail' ]
+			: [ 'thumbnail', 'medium', 'large', 'full' ];
 	return (
 		<span
 			className={ {
@@ -168,24 +172,29 @@ function FeaturedImage( { item, viewType } ) {
 					viewType === LAYOUT_TABLE,
 			} }
 		>
-			<button
-				className="page-pages-preview-field__button"
-				type="button"
-				onClick={ onClick }
-				aria-label={ item.title?.rendered || __( '(no title)' ) }
-			>
-				{ hasMedia && (
-					<Media
-						className="edit-site-page-pages__featured-image"
-						id={ item.featured_media }
-						size={
-							viewType === LAYOUT_GRID
-								? [ 'large', 'full', 'medium', 'thumbnail' ]
-								: [ 'thumbnail', 'medium', 'large', 'full' ]
-						}
-					/>
-				) }
-			</button>
+			{ viewType === LAYOUT_LIST && hasMedia && (
+				<Media
+					className="edit-site-page-pages__featured-image"
+					id={ item.featured_media }
+					size={ size }
+				/>
+			) }
+			{ viewType !== LAYOUT_LIST && (
+				<button
+					className="page-pages-preview-field__button"
+					type="button"
+					onClick={ onClick }
+					aria-label={ item.title?.rendered || __( '(no title)' ) }
+				>
+					{ hasMedia && (
+						<Media
+							className="edit-site-page-pages__featured-image"
+							id={ item.featured_media }
+							size={ size }
+						/>
+					) }
+				</button>
+			) }
 		</span>
 	);
 }

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -165,6 +165,15 @@ function FeaturedImage( { item, viewType } ) {
 		viewType === LAYOUT_GRID
 			? [ 'large', 'full', 'medium', 'thumbnail' ]
 			: [ 'thumbnail', 'medium', 'large', 'full' ];
+
+	const media = hasMedia ? (
+		<Media
+			className="edit-site-page-pages__featured-image"
+			id={ item.featured_media }
+			size={ size }
+		/>
+	) : null;
+
 	return (
 		<span
 			className={ {
@@ -172,13 +181,7 @@ function FeaturedImage( { item, viewType } ) {
 					viewType === LAYOUT_TABLE,
 			} }
 		>
-			{ viewType === LAYOUT_LIST && hasMedia && (
-				<Media
-					className="edit-site-page-pages__featured-image"
-					id={ item.featured_media }
-					size={ size }
-				/>
-			) }
+			{ viewType === LAYOUT_LIST && media }
 			{ viewType !== LAYOUT_LIST && (
 				<button
 					className="page-pages-preview-field__button"
@@ -186,13 +189,7 @@ function FeaturedImage( { item, viewType } ) {
 					onClick={ onClick }
 					aria-label={ item.title?.rendered || __( '(no title)' ) }
 				>
-					{ hasMedia && (
-						<Media
-							className="edit-site-page-pages__featured-image"
-							id={ item.featured_media }
-							size={ size }
-						/>
-					) }
+					{ media }
 				</button>
 			) }
 		</span>

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -166,9 +166,10 @@ function Preview( { item, viewType } ) {
 				className={ `page-templates-preview-field is-viewtype-${ viewType }` }
 				style={ { backgroundColor } }
 			>
-				{ viewType === LAYOUT_LIST ? (
+				{ viewType === LAYOUT_LIST && ! isEmpty && (
 					<BlockPreview blocks={ blocks } />
-				) : (
+				) }
+				{ viewType !== LAYOUT_LIST && (
 					<button
 						className="page-templates-preview-field__button"
 						type="button"

--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -151,6 +151,7 @@ function Preview( { item, viewType } ) {
 		postType: item.type,
 		canvas: 'edit',
 	} );
+
 	const isEmpty = ! blocks?.length;
 	// Wrap everything in a block editor provider to ensure 'styles' that are needed
 	// for the previews are synced between the site editor store and the block editor store.
@@ -165,18 +166,22 @@ function Preview( { item, viewType } ) {
 				className={ `page-templates-preview-field is-viewtype-${ viewType }` }
 				style={ { backgroundColor } }
 			>
-				<button
-					className="page-templates-preview-field__button"
-					type="button"
-					onClick={ onClick }
-					aria-label={ item.title?.rendered || item.title }
-				>
-					{ isEmpty &&
-						( item.type === TEMPLATE_POST_TYPE
-							? __( 'Empty template' )
-							: __( 'Empty template part' ) ) }
-					{ ! isEmpty && <BlockPreview blocks={ blocks } /> }
-				</button>
+				{ viewType === LAYOUT_LIST ? (
+					<BlockPreview blocks={ blocks } />
+				) : (
+					<button
+						className="page-templates-preview-field__button"
+						type="button"
+						onClick={ onClick }
+						aria-label={ item.title?.rendered || item.title }
+					>
+						{ isEmpty &&
+							( item.type === TEMPLATE_POST_TYPE
+								? __( 'Empty template' )
+								: __( 'Empty template part' ) ) }
+						{ ! isEmpty && <BlockPreview blocks={ blocks } /> }
+					</button>
+				) }
 			</div>
 		</ExperimentalBlockEditorProvider>
 	);


### PR DESCRIPTION
Related to #58071

## What?

This PR solves the following two problems with Templates and Pages list layout.

### Preview consists of nested buttons

![nested-button](https://github.com/WordPress/gutenberg/assets/54422211/33656a7d-c1cf-40d2-a2d7-bda396378d3a)

### Placeholder text overflows

![empty-template](https://github.com/WordPress/gutenberg/assets/54422211/6013212a-e83e-45cf-b0bc-db52b7ad4d0d)


## Why?

### Preview consists of nested buttons

When in the list layout, the entire row has a button role. Therefore, the preview inside it should not have been a button element.

### Placeholder text overflows

Placeholder text works fine in the grid layout, but in the list layout, the media width is only 32px, so the text cannot be displayed properly.

## How?

###Preview consists of nested buttons

When in the list view, unwrap the button element.

### Placeholder text overflows

When in the list view, the placeholder text itself is not displayed.

## Testing Instructions

### Pages

- Switch to the list layout.
- The featured image should not be wrapped in a button element.
- For non-list layouts, it should always be a button element.

### Templates

- Create a template with empty content.
- Switch to the list layout.
- The preview should not be wrapped in a button element.
- For templates with no content, placeholder text should not be displayed.
- For non-list layouts, it should always be a button element.