### PR TITLE
Fix fonts modal dialog buttons accessibility.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/tab-panel-layout.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/tab-panel-layout.js
@@ -12,6 +12,7 @@ import {
 	FlexBlock,
 } from '@wordpress/components';
 import { chevronLeft } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 function TabPanelLayout( {
 	title,
@@ -33,6 +34,7 @@ function TabPanelLayout( {
 								onClick={ handleBack }
 								icon={ chevronLeft }
 								size="small"
+								label={ __( 'Back' ) }
 							/>
 						) }
 						{ title && (

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -192,7 +192,7 @@ function UploadFonts() {
 								className="font-library-modal__upload-area"
 								onClick={ openFileDialog }
 							>
-								<span>{ __( 'Upload font' ) }</span>
+								{ __( 'Upload font' ) }
 							</Button>
 						) }
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58060

## What?
<!-- In a few words, what is the PR actually doing? -->
The back button in the Fonts modal dialog is unlabeled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All icon buttons must be labelled and show a tooltip, to visually expose their accessible name.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds missing label prop.
- Aside: removes unnecessary `<span>` element from the Upload font button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to Site editor > Styles > Typography > Manage fonts.
- In the fonts modal dialog, click one of the fonts.
- In the font sub-view, observe the Back button.
- Hover or focus the button and observe it shows a tooltip with text 'Back'.
- Go to the Upload tab.
- Observe the big gray upload area (which is a button) is visually unchanged and works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
