### PR TITLE
Block editor: reduce getBlockEditingMode calls

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/index.js
+++ b/packages/block-editor/src/components/block-content-overlay/index.js
@@ -8,6 +8,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
+// Note: this selector no longer seems to be used anywhere. Deprecate?
 export default function useBlockOverlayActive( clientId ) {
 	return useSelect(
 		( select ) => {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -615,6 +615,7 @@ function BlockListBlockProvider( props ) {
 				className: hasLightBlockWrapper
 					? attributes.className
 					: undefined,
+				hasLightBlockWrapper,
 			};
 		},
 		[ clientId, rootClientId ]
@@ -653,6 +654,7 @@ function BlockListBlockProvider( props ) {
 		canInsertMovingBlock,
 		isEditingDisabled,
 		className,
+		hasLightBlockWrapper,
 	} = selectedProps;
 
 	// Block is sometimes not mounted at the right time, causing it be
@@ -689,6 +691,7 @@ function BlockListBlockProvider( props ) {
 		mayDisplayControls,
 		mayDisplayParentControls,
 		themeSupportsLayout,
+		hasLightBlockWrapper,
 	};
 
 	// Here we separate between the props passed to BlockListBlock and any other

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -15,8 +15,6 @@ import {
 	switchToBlockType,
 	getDefaultBlockName,
 	isUnmodifiedBlock,
-	isReusableBlock,
-	getBlockDefaultClassName,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
@@ -519,7 +517,6 @@ function BlockListBlockProvider( props ) {
 				isBlockBeingDragged,
 				hasBlockMovingClientId,
 				canInsertBlockType,
-				getBlockRootClientId,
 				__unstableHasActiveBlockOverlayActive,
 				__unstableGetEditorMode,
 				getSelectedBlocksInitialCaretPosition,
@@ -555,6 +552,7 @@ function BlockListBlockProvider( props ) {
 			const typing = isTyping();
 			const hasLightBlockWrapper = blockType?.apiVersion > 1;
 			const movingClientId = hasBlockMovingClientId();
+			const blockEditingMode = getBlockEditingMode( clientId );
 
 			return {
 				mode: getBlockMode( clientId ),
@@ -574,7 +572,7 @@ function BlockListBlockProvider( props ) {
 				themeSupportsLayout: supportsLayout,
 				isTemporarilyEditingAsBlocks:
 					__unstableGetTemporarilyEditingAsBlocks() === clientId,
-				blockEditingMode: getBlockEditingMode( clientId ),
+				blockEditingMode,
 				mayDisplayControls:
 					_isSelected ||
 					( isFirstMultiSelectedBlock( clientId ) &&
@@ -603,7 +601,6 @@ function BlockListBlockProvider( props ) {
 					isMultiSelected &&
 					! __unstableIsFullySelected() &&
 					! __unstableSelectionHasUnmergeableBlock(),
-				isReusable: isReusableBlock( blockType ),
 				isDragging: isBlockBeingDragged( clientId ),
 				hasChildSelected: isAncestorOfSelectedBlock,
 				removeOutline: _isSelected && outlineMode && typing,
@@ -612,15 +609,11 @@ function BlockListBlockProvider( props ) {
 					movingClientId &&
 					canInsertBlockType(
 						getBlockName( movingClientId ),
-						getBlockRootClientId( clientId )
+						rootClientId
 					),
-				isEditingDisabled:
-					getBlockEditingMode( clientId ) === 'disabled',
+				isEditingDisabled: blockEditingMode === 'disabled',
 				className: hasLightBlockWrapper
 					? attributes.className
-					: undefined,
-				defaultClassName: hasLightBlockWrapper
-					? getBlockDefaultClassName( blockName )
 					: undefined,
 			};
 		},
@@ -653,7 +646,6 @@ function BlockListBlockProvider( props ) {
 		isHighlighted,
 		isMultiSelected,
 		isPartiallySelected,
-		isReusable,
 		isDragging,
 		hasChildSelected,
 		removeOutline,
@@ -661,7 +653,6 @@ function BlockListBlockProvider( props ) {
 		canInsertMovingBlock,
 		isEditingDisabled,
 		className,
-		defaultClassName,
 	} = selectedProps;
 
 	// Block is sometimes not mounted at the right time, causing it be
@@ -688,7 +679,6 @@ function BlockListBlockProvider( props ) {
 		isHighlighted,
 		isMultiSelected,
 		isPartiallySelected,
-		isReusable,
 		isDragging,
 		hasChildSelected,
 		removeOutline,
@@ -696,7 +686,6 @@ function BlockListBlockProvider( props ) {
 		canInsertMovingBlock,
 		isEditingDisabled,
 		isTemporarilyEditingAsBlocks,
-		defaultClassName,
 		mayDisplayControls,
 		mayDisplayParentControls,
 		themeSupportsLayout,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -8,7 +8,11 @@ import classnames from 'classnames';
  */
 import { useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
+import {
+	__unstableGetBlockProps as getBlockProps,
+	getBlockDefaultClassName,
+	isReusableBlock,
+} from '@wordpress/blocks';
 import { useMergeRefs, useDisabled } from '@wordpress/compose';
 import warning from '@wordpress/warning';
 
@@ -88,7 +92,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isHighlighted,
 		isMultiSelected,
 		isPartiallySelected,
-		isReusable,
 		isDragging,
 		hasChildSelected,
 		removeOutline,
@@ -96,7 +99,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		canInsertMovingBlock,
 		isEditingDisabled,
 		isTemporarilyEditingAsBlocks,
-		defaultClassName,
 	} = useContext( PrivateBlockContext );
 
 	// translators: %s: Type of block (i.e. Text, Image etc)
@@ -145,7 +147,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				'is-highlighted': isHighlighted,
 				'is-multi-selected': isMultiSelected,
 				'is-partially-selected': isPartiallySelected,
-				'is-reusable': isReusable,
+				'is-reusable': isReusableBlock( name ),
 				'is-dragging': isDragging,
 				'has-child-selected': hasChildSelected,
 				'remove-outline': removeOutline,
@@ -158,7 +160,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			className,
 			props.className,
 			wrapperProps.className,
-			defaultClassName
+			getBlockDefaultClassName( name )
 		),
 		style: { ...wrapperProps.style, ...props.style },
 	};

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -99,6 +99,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		canInsertMovingBlock,
 		isEditingDisabled,
 		isTemporarilyEditingAsBlocks,
+		hasLightBlockWrapper,
 	} = useContext( PrivateBlockContext );
 
 	// translators: %s: Type of block (i.e. Text, Image etc)
@@ -160,7 +161,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			className,
 			props.className,
 			wrapperProps.className,
-			getBlockDefaultClassName( name )
+			hasLightBlockWrapper ? getBlockDefaultClassName( name ) : undefined
 		),
 		style: { ...wrapperProps.style, ...props.style },
 	};

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -74,9 +74,11 @@ export function useInBetweenInserter() {
 					rootClientId = blockElement.getAttribute( 'data-block' );
 				}
 
+				const blockEditingMode = getBlockEditingMode( rootClientId );
+
 				if (
 					getTemplateLock( rootClientId ) ||
-					getBlockEditingMode( rootClientId ) === 'disabled' ||
+					blockEditingMode === 'disabled' ||
 					getBlockName( rootClientId ) === 'core/block'
 				) {
 					return;
@@ -124,7 +126,7 @@ export function useInBetweenInserter() {
 				const clientId = element.id.slice( 'block-'.length );
 				if (
 					! clientId ||
-					__unstableIsWithinBlockOverlay( clientId )
+					__unstableIsWithinBlockOverlay( clientId, blockEditingMode )
 				) {
 					return;
 				}

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -25,7 +25,10 @@ import useInnerBlockTemplateSync from './use-inner-block-template-sync';
 import useBlockContext from './use-block-context';
 import { BlockListItems } from '../block-list';
 import { BlockContextProvider } from '../block-context';
-import { useBlockEditContext } from '../block-edit/context';
+import {
+	useBlockEditContext,
+	blockEditingModeKey,
+} from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import useBlockDropZone from '../use-block-drop-zone';
@@ -183,11 +186,13 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		__unstableDisableDropZone,
 		dropZoneElement,
 	} = options;
+	const context = useBlockEditContext();
 	const {
 		clientId,
 		layout = null,
 		__unstableLayoutClassNames: layoutClassNames = '',
-	} = useBlockEditContext();
+	} = context;
+	const blockEditingMode = context[ blockEditingModeKey ];
 	const {
 		__experimentalCaptureToolbars,
 		hasOverlay,
@@ -213,13 +218,11 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getBlockRootClientId,
 				__unstableIsWithinBlockOverlay,
 				__unstableHasActiveBlockOverlayActive,
-				getBlockEditingMode,
 			} = select( blockEditorStore );
 			const { hasBlockSupport, getBlockType } = select( blocksStore );
 			const blockName = getBlockName( clientId );
 			const enableClickThrough =
 				__unstableGetEditorMode() === 'navigation';
-			const blockEditingMode = getBlockEditingMode( clientId );
 			const _parentClientId = getBlockRootClientId( clientId );
 			return {
 				__experimentalCaptureToolbars: hasBlockSupport(
@@ -239,11 +242,17 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				parentClientId: _parentClientId,
 				isDropZoneDisabled:
 					blockEditingMode !== 'default' ||
-					__unstableHasActiveBlockOverlayActive( clientId ) ||
-					__unstableIsWithinBlockOverlay( clientId ),
+					__unstableHasActiveBlockOverlayActive(
+						clientId,
+						blockEditingMode
+					) ||
+					__unstableIsWithinBlockOverlay(
+						clientId,
+						blockEditingMode
+					),
 			};
 		},
-		[ clientId ]
+		[ clientId, blockEditingMode ]
 	);
 
 	const blockDropZoneRef = useBlockDropZone( {

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -49,3 +49,39 @@ export const getAllPatternsDependants = ( state ) => {
 		state.blockPatterns,
 	];
 };
+
+export function canRemoveBlockCheck(
+	attributes,
+	blockEditingMode,
+	templateLock
+) {
+	if ( attributes === null ) {
+		return true;
+	}
+	if ( attributes.lock?.remove !== undefined ) {
+		return ! attributes.lock.remove;
+	}
+	if ( templateLock ) {
+		return false;
+	}
+
+	return blockEditingMode !== 'disabled';
+}
+
+export function canMoveBlockCheck(
+	attributes,
+	blockEditingMode,
+	templateLock
+) {
+	if ( attributes === null ) {
+		return true;
+	}
+	if ( attributes.lock?.move !== undefined ) {
+		return ! attributes.lock.move;
+	}
+	if ( templateLock === 'all' ) {
+		return false;
+	}
+
+	return blockEditingMode !== 'disabled';
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We are currently calling `getBlockEditingMode` about ~78 000 times in the post editor for a large post (1400+ blocks) and ~168 000 in the site editor for that some post.

This PR reduces to amount of calls to ~13 000 for the post editor and ~36 000 for the site editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
