### PR TITLE
Interactivity API: Add `supports.interactivity` to the Query block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -703,7 +703,7 @@ An advanced block that allows displaying post types based on different query par
 
 -	**Name:** core/query
 -	**Category:** theme
--	**Supports:** align (full, wide), layout, ~~html~~
+-	**Supports:** align (full, wide), interactivity, layout, ~~html~~
 -	**Attributes:** enhancedPagination, namespace, query, queryId, tagName
 
 ## No results

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -47,6 +47,7 @@
 		"enhancedPagination": "enhancedPagination"
 	},
 	"supports": {
+		"interactivity": true,
 		"align": [ "wide", "full" ],
 		"html": false,
 		"layout": true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Adds `supports.interactivity` to the Query block.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because without it, the new Server Directive Processing doesn't process it.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding the property to the `block.json`.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the Site Editor
- Add a Query block
- Inside the Query block, add an HTML block
- Put this code
  ```html
  <div
    data-wp-interactive='{ "namespace": "test" }'
    data-wp-context='{ "text": "testing server directive processing" }'
  >
    <span data-wp-text="context.text"></span>
  </div>
  ```
- Save and inspect the HTML of the site
  - Don't inspect using the Chrome DevTools!!
  - Use Right-click, "View Page Source" in Chrome
- In the rendered HTML, search for `testing server directive processing`
- If the server directive processing worked, the text should also be inside the `<span>` tag:
  ```html
  <div
    data-wp-interactive='{ "namespace": "test" }'
    data-wp-context='{ "text": "testing server directive processing" }'
  >
    <span data-wp-text="context.text">testing server directive processing</span>
  </div>
  ```
