### PR TITLE
Fix link switching on click

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -48,7 +48,7 @@ function Edit( {
 			return;
 		}
 
-		function handleClick( event ) {
+		function handleMouseUp( event ) {
 			// There is a situation whereby there is an existing link in the rich text
 			// and the user clicks on the leftmost edge of that link and fails to activate
 			// the link format, but the click event still fires on the `<a>` element.
@@ -62,27 +62,24 @@ function Edit( {
 			setAddingLink( true );
 		}
 
-		const removeAddingLink = () => {
+		const handleMouseDown = () => {
 			setAddingLink( false );
 		};
 
-		editableContentElement.addEventListener(
-			'mousedown',
-			removeAddingLink
-		);
-		editableContentElement.addEventListener( 'mouseup', handleClick );
+		editableContentElement.addEventListener( 'mousedown', handleMouseDown );
+		editableContentElement.addEventListener( 'mouseup', handleMouseUp );
 
 		return () => {
 			editableContentElement.removeEventListener(
 				'mousedown',
-				removeAddingLink
+				handleMouseDown
 			);
 			editableContentElement.removeEventListener(
 				'mouseup',
-				handleClick
+				handleMouseUp
 			);
 		};
-	}, [ contentRef, isActive, onFocus, addingLink ] );
+	}, [ contentRef, isActive ] );
 
 	function addLink( target ) {
 		const text = getTextContent( slice( value ) );

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -62,12 +62,27 @@ function Edit( {
 			setAddingLink( true );
 		}
 
-		editableContentElement.addEventListener( 'click', handleClick );
+		const removeAddingLink = () => {
+			setAddingLink( false );
+		};
+
+		editableContentElement.addEventListener(
+			'mousedown',
+			removeAddingLink
+		);
+		editableContentElement.addEventListener( 'mouseup', handleClick );
 
 		return () => {
-			editableContentElement.removeEventListener( 'click', handleClick );
+			editableContentElement.removeEventListener(
+				'mousedown',
+				removeAddingLink
+			);
+			editableContentElement.removeEventListener(
+				'mouseup',
+				handleClick
+			);
 		};
-	}, [ contentRef, isActive ] );
+	}, [ contentRef, isActive, onFocus, addingLink ] );
 
 	function addLink( target ) {
 		const text = getTextContent( slice( value ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the following problem:

- after #57986
- when clicking on two different links in the same paragraph
- the LinkUI preview would be stuck on the previously clicked link
- clicking on a link in another paragraph
- would show the correct LinkUI Preview

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The problem:

- The LinkUI used to be shown when the currently active format was `link`
- In #57986 this is changed to show when the currently active format was `link` **but** _only when the link is clicked_, **and** _the preview would capture focus_

Semi- explanation:

- This combination caused the paragraph to never receive the focus so the browser never moved the caret to the clicked position
- Therefore the format previewed would be the previously shown one
- And the caret was stuck

This solution:

- splitting the handler that shows the LinkUI Preview from `click` to `mouseup` and `mousedown` allows the paragraph to receive focus
- on `mousedown` we hide the preview thus preventing it from capturing focus
- the paragraph gets focus and the browser places the caret where it should be
- on `mouseup` we show the preview but the format is the correct new one since the caret is in a new place, so the preview is correct

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- in a post
- add two paragraphs
- in the 1st paragraph add two different links on two different words

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/f7470296-cd8d-480c-b637-b9890b62f340

