### PR TITLE
E2E Utils: Wait for canvas instead of window.wp

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
@@ -23,9 +23,7 @@ export async function getBlocks(
 	this: Editor,
 	{ clientId, full = false }: { clientId?: string; full?: boolean } = {}
 ) {
-	await this.page.waitForFunction(
-		() => window?.wp?.blocks && window?.wp?.data
-	);
+	await this.canvas.locator( 'body' ).waitFor( { state: 'visible' } );
 
 	return await this.page.evaluate(
 		( [ _full, _clientId ] ) => {

--- a/packages/e2e-test-utils-playwright/src/editor/get-edited-post-content.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-edited-post-content.ts
@@ -11,7 +11,7 @@ import type { Editor } from './index';
  * @return Promise resolving with post content markup.
  */
 export async function getEditedPostContent( this: Editor ) {
-	await this.page.waitForFunction( () => window?.wp?.data );
+	await this.canvas.locator( 'body' ).waitFor( { state: 'visible' } );
 
 	return await this.page.evaluate( () =>
 		window.wp.data.select( 'core/editor' ).getEditedPostContent()

--- a/packages/e2e-test-utils-playwright/src/editor/insert-block.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/insert-block.ts
@@ -22,9 +22,7 @@ async function insertBlock(
 	blockRepresentation: BlockRepresentation,
 	{ clientId }: { clientId?: string } = {}
 ) {
-	await this.page.waitForFunction(
-		() => window?.wp?.blocks && window?.wp?.data
-	);
+	await this.canvas.locator( 'body' ).waitFor( { state: 'visible' } );
 
 	await this.page.evaluate(
 		( [ _blockRepresentation, _clientId ] ) => {

--- a/packages/e2e-test-utils-playwright/src/editor/set-content.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/set-content.ts
@@ -10,9 +10,7 @@ import type { Editor } from './index';
  * @param html Serialized block HTML.
  */
 async function setContent( this: Editor, html: string ) {
-	await this.page.waitForFunction(
-		() => window?.wp?.blocks && window?.wp?.data
-	);
+	await this.canvas.locator( 'body' ).waitFor( { state: 'visible' } );
 
 	await this.page.evaluate( ( _html ) => {
 		const blocks = window.wp.blocks.parse( _html );

--- a/packages/e2e-test-utils-playwright/src/editor/set-is-fixed-toolbar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/set-is-fixed-toolbar.ts
@@ -10,7 +10,7 @@ import type { Editor } from './index';
  * @param isFixed Boolean value true/false for on/off.
  */
 export async function setIsFixedToolbar( this: Editor, isFixed: boolean ) {
-	await this.page.waitForFunction( () => window?.wp?.data );
+	await this.canvas.locator( 'body' ).waitFor( { state: 'visible' } );
 
 	await this.page.evaluate( ( _isFixed ) => {
 		window.wp.data

--- a/packages/e2e-test-utils-playwright/src/editor/set-preferences.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/set-preferences.ts
@@ -20,7 +20,7 @@ export async function setPreferences(
 	context: PreferencesContext,
 	preferences: Record< string, any >
 ) {
-	await this.page.waitForFunction( () => window?.wp?.data );
+	await this.canvas.locator( 'body' ).waitFor( { state: 'visible' } );
 
 	await this.page.evaluate(
 		async ( props ) => {

--- a/packages/e2e-test-utils-playwright/src/editor/switch-to-legacy-canvas.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/switch-to-legacy-canvas.ts
@@ -9,7 +9,7 @@ import type { Editor } from './index';
  * @param this
  */
 export async function switchToLegacyCanvas( this: Editor ) {
-	await this.page.waitForFunction( () => window?.wp?.blocks );
+	await this.canvas.locator( 'body' ).waitFor( { state: 'visible' } );
 
 	await this.page.evaluate( () => {
 		window.wp.blocks.registerBlockType( 'test/v2', {

--- a/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
@@ -10,9 +10,7 @@ import type { Editor } from './index';
  * @param name Block name.
  */
 export async function transformBlockTo( this: Editor, name: string ) {
-	await this.page.waitForFunction(
-		() => window?.wp?.blocks && window?.wp?.data
-	);
+	await this.canvas.locator( 'body' ).waitFor( { state: 'visible' } );
 
 	await this.page.evaluate(
 		( [ blockName ] ) => {


### PR DESCRIPTION
## What?
In testing against a slower env (wp.com in my case) it turned out that the `window.wp.*` is ready before the canvas is, so calling utils like `insertBlock` immediately after creating a post has no effect. Waiting for the canvas instead gives stable results and makes the affected utils work as expected.

## Why?
For stability.

## Testing Instructions
Nothing particular. All the tests should pass.
