### PR TITLE
E2E Utils: Ensure deleteAllUsers does not delete current user

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/users.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/users.ts
@@ -5,6 +5,7 @@ import type { RequestUtils } from './index';
 
 export interface User {
 	id: number;
+	name: string;
 	email: string;
 }
 
@@ -110,8 +111,11 @@ async function deleteAllUsers( this: RequestUtils ) {
 	// The users endpoint doesn't support batch request yet.
 	const responses = await Promise.all(
 		users
-			// Do not delete root user.
-			.filter( ( user: User ) => user.id !== 1 )
+			// Do not delete neither root user nor the current user.
+			.filter(
+				( user: User ) =>
+					user.id !== 1 && user.name !== this.user.username
+			)
 			.map( ( user: User ) => deleteUser.bind( this )( user.id ) )
 	);
 


### PR DESCRIPTION
## What?
When calling `deleteAllUsers`, let's ensure we don't attempt to delete the current user, which can be a non-admin user.

## Testing Instructions
Create a non-admin account and provide the credentials (export `WP_USERNAME` and `WP_PASSWORD`). Run e.g. the `autocomplete-and-mentions.spec.js` suite and ensure it doesn't attempt to delete the current user in the `afterAll` hook.