### PR TITLE
Fix Placeholder component padding when body text font size is changed

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   `Placeholder`: Fix Placeholder component padding when body text font size is changed ([#58323](https://github.com/WordPress/gutenberg/pull/58323)).
 -   `Placeholder`: Fix Global Styles typography settings bleeding into placeholder component ([#58303](https://github.com/WordPress/gutenberg/pull/58303)).
 -   `PaletteEdit`: Fix palette item accessibility in details view ([#58214](https://github.com/WordPress/gutenberg/pull/58214)).
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -1,5 +1,6 @@
 // This needs specificity to override individual block styles.
 .components-placeholder.components-placeholder {
+	font-size: $default-font-size;
 	box-sizing: border-box;
 	position: relative;
 	padding: 1em;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to https://github.com/WordPress/gutenberg/pull/58303

This fixes the padding on the placeholder component when the Global styles typography settings change the font size of the body text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The font size selected by the user or the theme for the body of the document is bleeding into the placeholder. The placeholder's padding will be bigger or smaller depending on the font size of the theme's body.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The placeholder uses a padding of 1em. Because the wrapper of the component doesn't define a font size, CSS uses the one that is being inherited. In this case the one from the body. This PR defines a font size for the component, which will stay the same regardless of GS selections

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Insert an image block to see the placeholder
Open Global styles / Typography / Text and change the font size value. With this PR the padding of the placeholder should stay the same.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before

<img width="1282" alt="Screenshot 2024-01-26 at 16 32 28" src="https://github.com/WordPress/gutenberg/assets/3593343/c9a8bcae-7ea6-4aa8-921f-d519c9892c8f">


After


<img width="1218" alt="Screenshot 2024-01-26 at 16 32 04" src="https://github.com/WordPress/gutenberg/assets/3593343/d2333ad1-636d-40f5-8389-77bd2901aafa">
