### PR TITLE
[RNMobile] Heading block: Add integration test to cover changing heading level

### DIFF
--- a/packages/block-library/src/heading/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/heading/test/__snapshots__/index.native.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Heading block changes heading level 1`] = `
+"<!-- wp:heading {"level":6} -->
+<h6 class="wp-block-heading"></h6>
+<!-- /wp:heading -->"
+`;
+
 exports[`Heading block inserts block 1`] = `
 "<!-- wp:heading -->
 <h2 class="wp-block-heading"></h2>

--- a/packages/block-library/src/heading/test/index.native.js
+++ b/packages/block-library/src/heading/test/index.native.js
@@ -136,6 +136,7 @@ describe( 'Heading block', () => {
 			)
 		).toBeVisible();
 	} );
+
 	it( 'changes heading level', async () => {
 		// Arrange
 		await initializeEditor();

--- a/packages/block-library/src/heading/test/index.native.js
+++ b/packages/block-library/src/heading/test/index.native.js
@@ -136,6 +136,19 @@ describe( 'Heading block', () => {
 			)
 		).toBeVisible();
 	} );
+	it( 'changes heading level', async () => {
+		// Arrange
+		await initializeEditor();
+		await addBlock( screen, 'Heading' );
+
+		// Act
+		fireEvent.press( getBlock( screen, 'Heading' ) );
+		fireEvent.press( screen.getByLabelText( 'Change level' ) );
+		fireEvent.press( screen.getByLabelText( 'Heading 6' ) );
+
+		// Assert
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
 
 	it( 'should merge with an empty Paragraph block and keep being the Heading block', async () => {
 		// Arrange

--- a/packages/block-library/src/heading/test/index.native.js
+++ b/packages/block-library/src/heading/test/index.native.js
@@ -39,7 +39,7 @@ describe( 'Heading block', () => {
 		await addBlock( screen, 'Heading' );
 
 		// Get block
-		const headingBlock = await getBlock( screen, 'Heading' );
+		const headingBlock = getBlock( screen, 'Heading' );
 		fireEvent.press( headingBlock );
 		expect( headingBlock ).toBeVisible();
 
@@ -122,7 +122,7 @@ describe( 'Heading block', () => {
 		// Arrange
 		const screen = await initializeEditor();
 		await addBlock( screen, 'Heading' );
-		const headingBlock = await getBlock( screen, 'Heading' );
+		const headingBlock = getBlock( screen, 'Heading' );
 
 		// Act
 		fireEvent.press( headingBlock );

--- a/packages/block-library/src/heading/test/index.native.js
+++ b/packages/block-library/src/heading/test/index.native.js
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import {
+	addBlock,
 	fireEvent,
+	getBlock,
 	getEditorHtml,
 	initializeEditor,
-	addBlock,
-	getBlock,
+	screen,
 	typeInRichText,
 	waitFor,
 	within,
@@ -33,7 +34,7 @@ afterAll( () => {
 
 describe( 'Heading block', () => {
 	it( 'inserts block', async () => {
-		const screen = await initializeEditor();
+		await initializeEditor();
 
 		// Add block
 		await addBlock( screen, 'Heading' );
@@ -48,7 +49,7 @@ describe( 'Heading block', () => {
 
 	it( 'should set a text color', async () => {
 		// Arrange
-		const screen = await initializeEditor();
+		await initializeEditor();
 		await addBlock( screen, 'Heading' );
 
 		// Act
@@ -86,7 +87,7 @@ describe( 'Heading block', () => {
 
 	it( 'should set a background color', async () => {
 		// Arrange
-		const screen = await initializeEditor();
+		await initializeEditor();
 		await addBlock( screen, 'Heading' );
 
 		// Act
@@ -120,7 +121,7 @@ describe( 'Heading block', () => {
 
 	it( 'change level dropdown displays active selection', async () => {
 		// Arrange
-		const screen = await initializeEditor();
+		await initializeEditor();
 		await addBlock( screen, 'Heading' );
 		const headingBlock = getBlock( screen, 'Heading' );
 
@@ -138,7 +139,7 @@ describe( 'Heading block', () => {
 
 	it( 'should merge with an empty Paragraph block and keep being the Heading block', async () => {
 		// Arrange
-		const screen = await initializeEditor();
+		await initializeEditor();
 		await addBlock( screen, 'Paragraph' );
 
 		// Act


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds integration test to cover changing the heading level in the Heading block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We identified a crash in production (fixed in https://github.com/WordPress/gutenberg/pull/58088) that could have been caught by this test case.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add integration test.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Tests pass
* Observe that all CI jobs pass.

### Check that the test case could have caught the crash
* Revert changes introduced in https://github.com/WordPress/gutenberg/pull/58088.
* Run the command `npm run test:native -- heading/test/index`.
* Observe that the test case `changes heading level` fails.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A