### PR TITLE
Update types for debounce utility function parameter

### DIFF
--- a/packages/compose/src/utils/debounce/index.ts
+++ b/packages/compose/src/utils/debounce/index.ts
@@ -100,7 +100,7 @@ export interface DebouncedFunc< T extends ( ...args: any[] ) => any > {
  *
  * @return Returns the new debounced function.
  */
-export const debounce = < FunctionT extends ( ...args: unknown[] ) => unknown >(
+export const debounce = < FunctionT extends ( ...args: any[] ) => any >(
 	func: FunctionT,
 	wait: number,
 	options?: Partial< DebounceOptions >


### PR DESCRIPTION
## What?
Update the types for the debounce utility function from unknown to any.

## Why?
We were getting type errors using the debounce function in an external Typescript project. 
This seems to match the lodash debounce types better [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/602f1ec4a83355e7a41ea142a454704a46a3288f/types/lodash/common/function.d.ts#L425) and resolves the type errors we were seeing.

I don't believe this causes any errors or should cause any problems for other uses of this function, but if this is not the right approach or an appropriate fix please feel free to close. 

## Testing Instructions
Ensure tests run appropriately and no type errors are introduced
