### PR TITLE
Font Library: Rename the slug of the google fonts collection from 'default-font-collection' to 'google-fonts'

### DIFF
--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -132,14 +132,14 @@ if ( ! function_exists( 'wp_unregister_font_collection' ) ) {
 
 }
 
-$default_font_collection = array(
-	'slug'        => 'default-font-collection',
+$google_fonts = array(
+	'slug'        => 'google-fonts',
 	'name'        => 'Google Fonts',
 	'description' => __( 'Add from Google Fonts. Fonts are copied to and served from your site.', 'gutenberg' ),
 	'src'         => 'https://s.w.org/images/fonts/17.6/collections/google-fonts-with-preview.json',
 );
 
-wp_register_font_collection( $default_font_collection );
+wp_register_font_collection( $google_fonts );
 
 // @core-merge: This code should probably go into Core's src/wp-includes/functions.php.
 if ( ! function_exists( 'wp_get_font_dir' ) ) {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -36,12 +36,12 @@ const DEFAULT_CATEGORY = {
 	name: __( 'All' ),
 };
 function FontCollection( { slug } ) {
-	const requiresPermission = slug === 'default-font-collection';
+	const requiresPermission = slug === 'google-fonts';
 
 	const getGoogleFontsPermissionFromStorage = () => {
 		return (
 			window.localStorage.getItem(
-				'wp-font-library-default-font-collection-permission'
+				'wp-font-library-google-fonts-permission'
 			) === 'true'
 		);
 	};

--- a/packages/edit-site/src/components/global-styles/font-library-modal/google-fonts-confirm-dialog.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/google-fonts-confirm-dialog.js
@@ -14,7 +14,7 @@ function GoogleFontsConfirmDialog() {
 	const handleConfirm = () => {
 		// eslint-disable-next-line no-undef
 		window.localStorage.setItem(
-			'wp-font-library-default-font-collection-permission',
+			'wp-font-library-google-fonts-permission',
 			'true'
 		);
 		window.dispatchEvent( new Event( 'storage' ) );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -34,7 +34,7 @@ const tabsFromCollections = ( collections ) =>
 	collections.map( ( { slug, name } ) => ( {
 		id: slug,
 		title:
-			collections.length === 1 && slug === 'default-font-collection'
+			collections.length === 1 && slug === 'google-fonts'
 				? __( 'Install Fonts' )
 				: name,
 	} ) );


### PR DESCRIPTION
## What?
Rename the slug of the google fonts [Font Collection](https://github.com/WordPress/gutenberg/issues/57980) from 'default-font-collection' to 'google-fonts'.

This just updates the slug of the collection no  behaviour changes are expected with this PR.



## Why?
To make the purpose of this font collection more explicit.

## How?
Updating the slug

## Testing Instructions
- Use the font library and navigate to the Google Fonts  Collection. It should continue working as expected
