### PR TITLE
Blocks: directly check blockType vs hasBlockSupport

### DIFF
--- a/packages/block-editor/src/components/autocomplete/index.js
+++ b/packages/block-editor/src/components/autocomplete/index.js
@@ -7,7 +7,7 @@ import {
 	__unstableUseAutocompleteProps as useAutocompleteProps,
 } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
-import { getDefaultBlockName, getBlockSupport } from '@wordpress/blocks';
+import { getDefaultBlockName, getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ function useCompleters( { completers = EMPTY_ARRAY } ) {
 
 		if (
 			name === getDefaultBlockName() ||
-			getBlockSupport( name, '__experimentalSlashInserter', false )
+			getBlockType( name ).supports?.__experimentalSlashInserter
 		) {
 			filteredCompleters = [ ...filteredCompleters, blockAutocompleter ];
 		}

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -7,11 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { withFilters } from '@wordpress/components';
-import {
-	getBlockDefaultClassName,
-	hasBlockSupport,
-	getBlockType,
-} from '@wordpress/blocks';
+import { getBlockDefaultClassName, getBlockType } from '@wordpress/blocks';
 import { useContext, useMemo } from '@wordpress/element';
 
 /**
@@ -72,7 +68,7 @@ const EditWithGeneratedProps = ( props ) => {
 	}
 
 	// Generate a class name for the block's editable form.
-	const generatedClassName = hasBlockSupport( blockType, 'className', true )
+	const generatedClassName = blockType.supports?.className
 		? getBlockDefaultClassName( name )
 		: null;
 	const className = classnames(

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -3,7 +3,6 @@
  */
 import { useMemo } from '@wordpress/element';
 
-import { hasBlockSupport } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -30,6 +29,7 @@ export default function BlockEdit( {
 	mayDisplayControls,
 	mayDisplayParentControls,
 	blockEditingMode,
+	blockType,
 	// The remaining props are passed through the BlockEdit filters and are thus
 	// public API!
 	...props
@@ -43,8 +43,8 @@ export default function BlockEdit( {
 	} = props;
 	const { layout = null } = attributes;
 	const layoutSupport =
-		hasBlockSupport( name, 'layout', false ) ||
-		hasBlockSupport( name, '__experimentalLayout', false );
+		blockType?.supports?.layout ||
+		blockType?.supports?.__experimentalLayout;
 	return (
 		<BlockEditContextProvider
 			// It is important to return the same object if props haven't

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -109,6 +109,7 @@ function BlockListBlock( {
 	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
 
 	const parentLayout = useLayout() || {};
+	const blockType = getBlockType( name );
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces
@@ -134,10 +135,9 @@ function BlockListBlock( {
 			mayDisplayControls={ mayDisplayControls }
 			mayDisplayParentControls={ mayDisplayParentControls }
 			blockEditingMode={ context.blockEditingMode }
+			blockType={ blockType }
 		/>
 	);
-
-	const blockType = getBlockType( name );
 
 	// Determine whether the block has props to apply to the wrapper.
 	if ( blockType?.getEditWrapperProps ) {
@@ -534,10 +534,7 @@ function BlockListBlockProvider( props ) {
 				return;
 			}
 
-			const {
-				hasBlockSupport: _hasBlockSupport,
-				getActiveBlockVariation,
-			} = select( blocksStore );
+			const { getActiveBlockVariation } = select( blocksStore );
 			const _isSelected = isBlockSelected( clientId );
 			const templateLock = getTemplateLock( rootClientId );
 			const canRemove = canRemoveBlock( clientId, rootClientId );
@@ -582,11 +579,9 @@ function BlockListBlockProvider( props ) {
 							( id ) => getBlockName( id ) === blockName
 						) ),
 				mayDisplayParentControls:
-					_hasBlockSupport(
-						getBlockName( clientId ),
-						'__experimentalExposeControlsToChildren',
-						false
-					) && hasSelectedInnerBlock( clientId ),
+					!! blockType?.supports
+						?.__experimentalExposeControlsToChildren &&
+					hasSelectedInnerBlock( clientId ),
 				index: getBlockIndex( clientId ),
 				blockApiVersion: blockType?.apiVersion || 1,
 				blockTitle: match?.title || blockType?.title,

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -10,7 +10,6 @@ import { useMergeRefs } from '@wordpress/compose';
 import { forwardRef, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
-	getBlockSupport,
 	store as blocksStore,
 	__unstableGetInnerBlocksProps as getInnerBlocksProps,
 } from '@wordpress/blocks';
@@ -69,7 +68,6 @@ function UncontrolledInnerBlocks( props ) {
 		orientation,
 		placeholder,
 		layout,
-		name,
 		blockType,
 		innerBlocks,
 		parentLock,
@@ -99,8 +97,8 @@ function UncontrolledInnerBlocks( props ) {
 	);
 
 	const defaultLayoutBlockSupport =
-		getBlockSupport( name, 'layout' ) ||
-		getBlockSupport( name, '__experimentalLayout' ) ||
+		blockType?.supports?.layout ||
+		blockType?.supports?.__experimentalLayout ||
 		EMPTY_OBJECT;
 
 	const { allowSizingOnChildren = false } = defaultLayoutBlockSupport;
@@ -191,7 +189,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	const {
 		__experimentalCaptureToolbars,
 		hasOverlay,
-		name,
 		blockType,
 		innerBlocks,
 		parentLock,
@@ -215,25 +212,23 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				__unstableHasActiveBlockOverlayActive,
 				getBlockEditingMode,
 			} = select( blockEditorStore );
-			const { hasBlockSupport, getBlockType } = select( blocksStore );
+			const { getBlockType } = select( blocksStore );
 			const blockName = getBlockName( clientId );
 			const enableClickThrough =
 				__unstableGetEditorMode() === 'navigation';
 			const blockEditingMode = getBlockEditingMode( clientId );
 			const _parentClientId = getBlockRootClientId( clientId );
+			const _blockType = getBlockType( blockName );
 			return {
-				__experimentalCaptureToolbars: hasBlockSupport(
-					blockName,
-					'__experimentalExposeControlsToChildren',
-					false
-				),
+				__experimentalCaptureToolbars:
+					!! _blockType?.supports
+						?.__experimentalExposeControlsToChildren,
 				hasOverlay:
 					blockName !== 'core/template' &&
 					! isBlockSelected( clientId ) &&
 					! hasSelectedInnerBlock( clientId, true ) &&
 					enableClickThrough,
-				name: blockName,
-				blockType: getBlockType( blockName ),
+				blockType: _blockType,
 				innerBlocks: getBlocks( clientId ),
 				parentLock: getTemplateLock( _parentClientId ),
 				parentClientId: _parentClientId,
@@ -261,7 +256,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	const innerBlocksProps = {
 		__experimentalCaptureToolbars,
 		layout,
-		name,
 		blockType,
 		innerBlocks,
 		parentLock,

--- a/packages/block-editor/src/components/use-settings/index.js
+++ b/packages/block-editor/src/components/use-settings/index.js
@@ -3,7 +3,7 @@
  */
 import {
 	__EXPERIMENTAL_PATHS_WITH_MERGE as PATHS_WITH_MERGE,
-	hasBlockSupport,
+	getBlockType,
 } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
@@ -162,11 +162,8 @@ export function useSettings( ...paths ) {
 							select( blockEditorStore ).getBlockName(
 								candidateClientId
 							);
-						return hasBlockSupport(
-							candidateBlockName,
-							'__experimentalSettings',
-							false
-						);
+						return !! getBlockType( candidateBlockName )?.supports
+							?.__experimentalSettings;
 				  } )
 				: [];
 

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -91,7 +91,7 @@ export function addAttribute( settings ) {
 	if ( 'type' in ( settings.attributes?.align ?? {} ) ) {
 		return settings;
 	}
-	if ( hasBlockSupport( settings, 'align' ) ) {
+	if ( settings.supports?.align ) {
 		// Gracefully handle if settings.attributes is undefined.
 		settings.attributes = {
 			...settings.attributes,
@@ -157,8 +157,8 @@ export default {
 	useBlockProps,
 	addSaveProps: addAssignedAlign,
 	attributeKeys: [ 'align' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, 'align', false );
+	hasSupport( supports ) {
+		return !! supports.align;
 	},
 };
 
@@ -188,8 +188,8 @@ function useBlockProps( { name, align } ) {
  */
 export function addAssignedAlign( props, blockType, attributes ) {
 	const { align } = attributes;
-	const blockAlign = getBlockSupport( blockType, 'align' );
-	const hasWideBlockSupport = hasBlockSupport( blockType, 'alignWide', true );
+	const blockAlign = blockType.supports?.align;
+	const hasWideBlockSupport = blockType.supports?.alignWide ?? true;
 
 	// Compute valid alignments without taking into account if
 	// the theme supports wide alignments or not.

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -4,7 +4,6 @@
 import { addFilter } from '@wordpress/hooks';
 import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { hasBlockSupport } from '@wordpress/blocks';
 import { Platform } from '@wordpress/element';
 
 /**
@@ -40,7 +39,7 @@ export function addAttribute( settings ) {
 	if ( 'type' in ( settings.attributes?.anchor ?? {} ) ) {
 		return settings;
 	}
-	if ( hasBlockSupport( settings, 'anchor' ) ) {
+	if ( settings.supports?.anchor ) {
 		// Gracefully handle if settings.attributes is undefined.
 		settings.attributes = {
 			...settings.attributes,
@@ -123,8 +122,8 @@ export default {
 	addSaveProps,
 	edit: BlockEditAnchorControlPure,
 	attributeKeys: [ 'anchor' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, 'anchor' );
+	hasSupport( supports ) {
+		return !! supports.anchor;
 	},
 };
 
@@ -140,7 +139,7 @@ export default {
  * @return {Object} Filtered props applied to save element.
  */
 export function addSaveProps( extraProps, blockType, attributes ) {
-	if ( hasBlockSupport( blockType, 'anchor' ) ) {
+	if ( blockType.supports?.anchor ) {
 		extraProps.id = attributes.anchor === '' ? null : attributes.anchor;
 	}
 

--- a/packages/block-editor/src/hooks/aria-label.js
+++ b/packages/block-editor/src/hooks/aria-label.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport } from '@wordpress/blocks';
 
 const ARIA_LABEL_SCHEMA = {
 	type: 'string',
@@ -24,7 +23,7 @@ export function addAttribute( settings ) {
 	if ( settings?.attributes?.ariaLabel?.type ) {
 		return settings;
 	}
-	if ( hasBlockSupport( settings, 'ariaLabel' ) ) {
+	if ( settings.supports?.ariaLabel ) {
 		// Gracefully handle if settings.attributes is undefined.
 		settings.attributes = {
 			...settings.attributes,
@@ -47,7 +46,7 @@ export function addAttribute( settings ) {
  * @return {Object} Filtered props applied to save element.
  */
 export function addSaveProps( extraProps, blockType, attributes ) {
-	if ( hasBlockSupport( blockType, 'ariaLabel' ) ) {
+	if ( blockType.supports?.ariaLabel ) {
 		extraProps[ 'aria-label' ] =
 			attributes.ariaLabel === '' ? null : attributes.ariaLabel;
 	}
@@ -58,8 +57,8 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 export default {
 	addSaveProps,
 	attributeKeys: [ 'ariaLabel' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, 'ariaLabel' );
+	hasSupport( supports ) {
+		return !! supports.ariaLabel;
 	},
 };
 

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -214,6 +214,7 @@ function BlockHooksControlPure( { name, clientId } ) {
 
 export default {
 	edit: BlockHooksControlPure,
+	enableForAllBlocks: true,
 	hasSupport() {
 		return true;
 	},

--- a/packages/block-editor/src/hooks/block-renaming.js
+++ b/packages/block-editor/src/hooks/block-renaming.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
 
@@ -24,11 +23,8 @@ export function addLabelCallback( settings ) {
 		return settings;
 	}
 
-	const supportsBlockNaming = hasBlockSupport(
-		settings,
-		'renaming',
-		true // default value
-	);
+	// Defaults to true.
+	const supportsBlockNaming = settings?.supports?.renaming ?? true;
 
 	// Check whether block metadata is supported before using it.
 	if ( supportsBlockNaming ) {
@@ -66,8 +62,8 @@ function BlockRenameControlPure( { metadata, setAttributes } ) {
 export default {
 	edit: BlockRenameControlPure,
 	attributeKeys: [ 'metadata' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, 'renaming', true );
+	hasSupport( supports ) {
+		return !! supports.renaming;
 	},
 };
 

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -172,17 +172,17 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 /**
  * Determine whether there is block support for border properties.
  *
- * @param {string} blockName Block name.
+ * @param {Object} blockType Block type.
  * @param {string} feature   Border feature to check support for.
  *
  * @return {boolean} Whether there is support.
  */
-export function hasBorderSupport( blockName, feature = 'any' ) {
+export function hasBorderSupport( blockType, feature = 'any' ) {
 	if ( Platform.OS !== 'web' ) {
 		return false;
 	}
 
-	const support = getBlockSupport( blockName, BORDER_SUPPORT_KEY );
+	const support = blockType?.supports?.[ BORDER_SUPPORT_KEY ];
 
 	if ( support === true ) {
 		return true;
@@ -252,16 +252,16 @@ function addAttributes( settings ) {
 /**
  * Override props assigned to save component to inject border color.
  *
- * @param {Object}        props           Additional props applied to save element.
- * @param {Object|string} blockNameOrType Block type definition.
- * @param {Object}        attributes      Block's attributes.
+ * @param {Object} props      Additional props applied to save element.
+ * @param {Object} blockType  Block type definition.
+ * @param {Object} attributes Block's attributes.
  *
  * @return {Object} Filtered props to apply to save element.
  */
-function addSaveProps( props, blockNameOrType, attributes ) {
+function addSaveProps( props, blockType, attributes ) {
 	if (
-		! hasBorderSupport( blockNameOrType, 'color' ) ||
-		shouldSkipSerialization( blockNameOrType, BORDER_SUPPORT_KEY, 'color' )
+		! hasBorderSupport( blockType, 'color' ) ||
+		shouldSkipSerialization( blockType, BORDER_SUPPORT_KEY, 'color' )
 	) {
 		return props;
 	}
@@ -294,12 +294,12 @@ export function getBorderClasses( attributes ) {
 	} );
 }
 
-function useBlockProps( { name, borderColor, style } ) {
+function useBlockProps( { blockType, borderColor, style } ) {
 	const { colors } = useMultipleOriginColorsAndGradients();
 
 	if (
-		! hasBorderSupport( name, 'color' ) ||
-		shouldSkipSerialization( name, BORDER_SUPPORT_KEY, 'color' )
+		! hasBorderSupport( blockType, 'color' ) ||
+		shouldSkipSerialization( blockType, BORDER_SUPPORT_KEY, 'color' )
 	) {
 		return {};
 	}
@@ -335,7 +335,7 @@ function useBlockProps( { name, borderColor, style } ) {
 
 	return addSaveProps(
 		{ style: cleanEmptyObject( extraStyles ) || {} },
-		name,
+		blockType,
 		{ borderColor, style }
 	);
 }
@@ -344,8 +344,8 @@ export default {
 	useBlockProps,
 	addSaveProps,
 	attributeKeys: [ 'borderColor', 'style' ],
-	hasSupport( name ) {
-		return hasBorderSupport( name, 'color' );
+	hasSupport( supports ) {
+		return !! supports.color;
 	},
 };
 

--- a/packages/block-editor/src/hooks/compat.js
+++ b/packages/block-editor/src/hooks/compat.js
@@ -1,15 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { hasBlockSupport } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 
 function migrateLightBlockWrapper( settings ) {
 	const { apiVersion = 1 } = settings;
-	if (
-		apiVersion < 2 &&
-		hasBlockSupport( settings, 'lightBlockWrapper', false )
-	) {
+	if ( apiVersion < 2 && settings.supports?.lightBlockWrapper ) {
 		settings.apiVersion = 2;
 	}
 

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -25,7 +25,7 @@ import { useBlockEditingMode } from '../components/block-editing-mode';
  * @return {Object} Filtered block settings.
  */
 export function addAttribute( settings ) {
-	if ( hasBlockSupport( settings, 'customClassName', true ) ) {
+	if ( settings?.supports?.className ?? true ) {
 		// Gracefully handle if settings.attributes is undefined.
 		settings.attributes = {
 			...settings.attributes,
@@ -67,8 +67,8 @@ export default {
 	edit: CustomClassNameControlsPure,
 	addSaveProps,
 	attributeKeys: [ 'className' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, 'customClassName', true );
+	hasSupport( supports ) {
+		return !! supports.customClassName;
 	},
 };
 

--- a/packages/block-editor/src/hooks/custom-class-name.native.js
+++ b/packages/block-editor/src/hooks/custom-class-name.native.js
@@ -64,7 +64,7 @@ addFilter(
 export default {
 	addSaveProps,
 	attributeKeys: [ 'className' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, 'customClassName', true );
+	hasSupport( supports ) {
+		return !! supports.customClassName;
 	},
 };

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -158,8 +158,9 @@ export function hasDimensionsSupport( blockName, feature = 'any' ) {
 export default {
 	useBlockProps,
 	attributeKeys: [ 'minHeight', 'style' ],
-	hasSupport( name ) {
-		return hasDimensionsSupport( name, 'aspectRatio' );
+	hasSupport( supports ) {
+		const support = supports[ DIMENSIONS_SUPPORT_KEY ];
+		return support === true || !! support?.aspectRatio;
 	},
 };
 

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -7,11 +7,7 @@ import namesPlugin from 'colord/plugins/names';
 /**
  * WordPress dependencies
  */
-import {
-	getBlockSupport,
-	getBlockType,
-	hasBlockSupport,
-} from '@wordpress/blocks';
+import { getBlockSupport, getBlockType } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { useMemo, useEffect } from '@wordpress/element';
@@ -179,8 +175,8 @@ export default {
 	edit: DuotonePanelPure,
 	useBlockProps,
 	attributeKeys: [ 'style' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, 'filter.duotone' );
+	hasSupport( supports ) {
+		return !! supports.filter?.duotone;
 	},
 };
 
@@ -195,7 +191,7 @@ export default {
 function addDuotoneAttributes( settings ) {
 	// Previous `color.__experimentalDuotone` support flag is migrated via
 	// block_type_metadata_settings filter in `lib/block-supports/duotone.php`.
-	if ( ! hasBlockSupport( settings, 'filter.duotone' ) ) {
+	if ( ! settings?.supports?.filter?.duotone ) {
 		return settings;
 	}
 

--- a/packages/block-editor/src/hooks/font-family.js
+++ b/packages/block-editor/src/hooks/font-family.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport } from '@wordpress/blocks';
 import TokenList from '@wordpress/token-list';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
@@ -23,7 +22,7 @@ export const FONT_FAMILY_SUPPORT_KEY = 'typography.__experimentalFontFamily';
  * @return {Object}         Filtered block settings
  */
 function addAttributes( settings ) {
-	if ( ! hasBlockSupport( settings, FONT_FAMILY_SUPPORT_KEY ) ) {
+	if ( ! settings.supports?.[ FONT_FAMILY_SUPPORT_KEY ] ) {
 		return settings;
 	}
 
@@ -48,7 +47,7 @@ function addAttributes( settings ) {
  * @return {Object}           Filtered props applied to save element
  */
 function addSaveProps( props, blockType, attributes ) {
-	if ( ! hasBlockSupport( blockType, FONT_FAMILY_SUPPORT_KEY ) ) {
+	if ( ! blockType.supports?.[ FONT_FAMILY_SUPPORT_KEY ] ) {
 		return props;
 	}
 
@@ -84,8 +83,8 @@ export default {
 	useBlockProps,
 	addSaveProps,
 	attributeKeys: [ 'fontFamily' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, FONT_FAMILY_SUPPORT_KEY );
+	hasSupport( supports ) {
+		return !! supports[ FONT_FAMILY_SUPPORT_KEY ];
 	},
 };
 

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -39,7 +39,7 @@ export const FONT_SIZE_SUPPORT_KEY = 'typography.fontSize';
  * @return {Object} Filtered block settings.
  */
 function addAttributes( settings ) {
-	if ( ! hasBlockSupport( settings, FONT_SIZE_SUPPORT_KEY ) ) {
+	if ( ! settings.supports?.[ FONT_SIZE_SUPPORT_KEY ] ) {
 		return settings;
 	}
 
@@ -213,8 +213,8 @@ export default {
 	useBlockProps,
 	addSaveProps,
 	attributeKeys: [ 'fontSize', 'style' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, FONT_SIZE_SUPPORT_KEY );
+	hasSupport( supports ) {
+		return !! supports[ FONT_SIZE_SUPPORT_KEY ];
 	},
 };
 

--- a/packages/block-editor/src/hooks/generated-class-name.js
+++ b/packages/block-editor/src/hooks/generated-class-name.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport, getBlockDefaultClassName } from '@wordpress/blocks';
+import { getBlockDefaultClassName } from '@wordpress/blocks';
 
 /**
  * Override props assigned to save component to inject generated className if
@@ -16,7 +16,7 @@ import { hasBlockSupport, getBlockDefaultClassName } from '@wordpress/blocks';
  */
 export function addGeneratedClassName( extraProps, blockType ) {
 	// Adding the generated className.
-	if ( hasBlockSupport( blockType, 'className', true ) ) {
+	if ( blockType?.supports?.className ?? true ) {
 		if ( typeof extraProps.className === 'string' ) {
 			// We have some extra classes and want to add the default classname
 			// We use uniq to prevent duplicate classnames.

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { getBlockSupport, getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
 	Button,
@@ -32,13 +32,6 @@ import { useBlockSettings, useStyleOverride } from './utils';
 import { unlock } from '../lock-unlock';
 
 const layoutBlockSupportKey = 'layout';
-
-function hasLayoutBlockSupport( blockName ) {
-	return (
-		hasBlockSupport( blockName, 'layout' ) ||
-		hasBlockSupport( blockName, '__experimentalLayout' )
-	);
-}
 
 /**
  * Generates the utility classnames for the given block's layout attributes.
@@ -292,8 +285,8 @@ export default {
 	shareWithChildBlocks: true,
 	edit: LayoutPanelPure,
 	attributeKeys: [ 'layout' ],
-	hasSupport( name ) {
-		return hasLayoutBlockSupport( name );
+	hasSupport( supports ) {
+		return !! supports.layout || !! supports.__experimentalLayout;
 	},
 };
 
@@ -326,7 +319,10 @@ export function addAttribute( settings ) {
 	if ( 'type' in ( settings.attributes?.layout ?? {} ) ) {
 		return settings;
 	}
-	if ( hasLayoutBlockSupport( settings ) ) {
+	if (
+		settings?.supports?.layout ||
+		settings?.supports?.__experimentalLayout
+	) {
 		settings.attributes = {
 			...settings.attributes,
 			layout: {
@@ -395,7 +391,10 @@ function BlockWithLayoutStyles( { block: BlockListBlock, props } ) {
  */
 export const withLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const blockSupportsLayout = hasLayoutBlockSupport( props.name );
+		const blockType = getBlockType( props.name );
+		const blockSupportsLayout =
+			blockType?.supports?.layout ||
+			blockType?.supports?.__experimentalLayout;
 		const shouldRenderLayoutStyles = useSelect(
 			( select ) => {
 				// The callback returns early to avoid block editor subscription.

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -323,8 +323,8 @@ export default {
 	},
 	useBlockProps,
 	attributeKeys: [ 'style' ],
-	hasSupport( name ) {
-		return hasBlockSupport( name, POSITION_SUPPORT_KEY );
+	hasSupport( supports ) {
+		return !! supports[ POSITION_SUPPORT_KEY ];
 	},
 };
 

--- a/packages/block-editor/src/hooks/settings.js
+++ b/packages/block-editor/src/hooks/settings.js
@@ -2,13 +2,9 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport } from '@wordpress/blocks';
-
-const hasSettingsSupport = ( blockType ) =>
-	hasBlockSupport( blockType, '__experimentalSettings', false );
 
 function addAttribute( settings ) {
-	if ( ! hasSettingsSupport( settings ) ) {
+	if ( ! settings?.supports?.__experimentalSettings ) {
 		return settings;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -10,7 +10,6 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getBlockVariations,
-	hasBlockSupport,
 	getPossibleBlockTransformations,
 	parse,
 	switchToBlockType,
@@ -1778,7 +1777,7 @@ export function canEditBlock( state, clientId ) {
  * @return {boolean} Whether a given block type can be locked/unlocked.
  */
 export function canLockBlockType( state, nameOrType ) {
-	if ( ! hasBlockSupport( nameOrType, 'lock', true ) ) {
+	if ( getBlockType( nameOrType )?.supports?.lock === false ) {
 		return false;
 	}
 
@@ -1810,7 +1809,7 @@ function getInsertUsage( state, id ) {
  * @return {boolean} Whether the given block type is allowed to be shown in the inserter.
  */
 const canIncludeBlockTypeInInserter = ( state, blockType, rootClientId ) => {
-	if ( ! hasBlockSupport( blockType, 'inserter', true ) ) {
+	if ( blockType?.supports?.inserter === false ) {
 		return false;
 	}
 
@@ -1894,7 +1893,7 @@ const buildBlockTypeItem =
 		const id = blockType.name;
 
 		let isDisabled = false;
-		if ( ! hasBlockSupport( blockType.name, 'multiple', true ) ) {
+		if ( blockType?.supports?.multiple === false ) {
 			isDisabled = getBlocksByClientId(
 				state,
 				getClientIdsWithDescendants( state )
@@ -2805,11 +2804,9 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 	// also enabled in all modes for blocks that have controlled children
 	// (reusable block, template part, navigation), unless explicitly disabled
 	// with `supports.__experimentalDisableBlockOverlay`.
-	const blockSupportDisable = hasBlockSupport(
-		getBlockName( state, clientId ),
-		'__experimentalDisableBlockOverlay',
-		false
-	);
+	const blockSupportDisable = !! getBlockType(
+		getBlockName( state, clientId )
+	)?.supports?.__experimentalDisableBlockOverlay;
 	const shouldEnableIfUnselected =
 		editorMode === 'navigation' ||
 		( blockSupportDisable

--- a/packages/blocks/src/api/parser/fix-custom-classname.js
+++ b/packages/blocks/src/api/parser/fix-custom-classname.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { hasBlockSupport } from '../registration';
 import { getSaveContent } from '../serializer';
 import { parseWithAttributeSchema } from './get-block-attributes';
 
@@ -42,7 +41,7 @@ export function getHTMLRootElementClasses( innerHTML ) {
  * @return {Object} Filtered block attributes.
  */
 export function fixCustomClassname( blockAttributes, blockType, innerHTML ) {
-	if ( hasBlockSupport( blockType, 'customClassName', true ) ) {
+	if ( blockType?.supports?.customClassName ?? true ) {
 		// To determine difference, serialize block given the known set of
 		// attributes, with the exception of `className`. This will determine
 		// the default set of classes. From there, any difference in innerHTML

--- a/packages/edit-post/src/hooks/validate-multiple-use/index.js
+++ b/packages/edit-post/src/hooks/validate-multiple-use/index.js
@@ -6,7 +6,6 @@ import {
 	findTransform,
 	getBlockTransforms,
 	getBlockType,
-	hasBlockSupport,
 } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -28,7 +27,8 @@ const enhance = compose(
 	 * @return {Component} Enhanced component with merged state data props.
 	 */
 	withSelect( ( select, block ) => {
-		const multiple = hasBlockSupport( block.name, 'multiple', true );
+		const blockType = getBlockType( block.name );
+		const multiple = blockType?.supports?.multiple;
 
 		// For block types with `multiple` support, there is no "original
 		// block" to be found in the content, as the block itself is valid.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

WIP

For a large post, there's about 35 000 calls, which underneath uses split('.') to parse the block supports key. In many cases, we already have access to the block type, or it's easy to get. Direct access from the block type is cleaner and more performant. E.g. instead of `hasBlockSupport( blockTypeOrName, 'filter.duotone' )`, you can simply check `blockType.supports?.filter?.duotone`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
