### PR TITLE
Block Bindings: Simplify block bindings object

### DIFF
--- a/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
@@ -28,7 +28,7 @@ if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 		}
 	};
 	wp_block_bindings_register_source(
-		'pattern_attributes',
+		'core/pattern-attributes',
 		array(
 			'label' => __( 'Pattern Attributes' ),
 			'apply' => $pattern_source_callback,

--- a/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
@@ -6,6 +6,10 @@
  */
 if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 	$post_meta_source_callback = function ( $source_attrs ) {
+		if ( ! isset( $source_attrs['key'] ) ) {
+			return null;
+		}
+
 		// Use the postId attribute if available
 		if ( isset( $source_attrs['postId'] ) ) {
 			$post_id = $source_attrs['postId'];

--- a/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
@@ -14,7 +14,7 @@ if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 			$post_id = get_the_ID();
 		}
 
-		return get_post_meta( $post_id, $source_attrs['value'], true );
+		return get_post_meta( $post_id, $source_attrs['key'], true );
 	};
 	wp_block_bindings_register_source(
 		'core/post-meta',

--- a/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
@@ -17,7 +17,7 @@ if ( function_exists( 'wp_block_bindings_register_source' ) ) {
 		return get_post_meta( $post_id, $source_attrs['value'], true );
 	};
 	wp_block_bindings_register_source(
-		'post_meta',
+		'core/post-meta',
 		array(
 			'label' => __( 'Post Meta' ),
 			'apply' => $post_meta_source_callback,

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -77,12 +77,12 @@ if ( ! function_exists( 'gutenberg_process_block_bindings' ) ) {
 		 * "bindings": {
 		 *   "title": {
 		 *     "source": "core/post-meta",
-		 *     "args": { "value": "text_custom_field" }
+		 *     "args": { "key": "text_custom_field" }
 		 *   },
 		 *   "url": {
 		 *     "source": {
 		 *       "name": "core/post-meta",
-		 *       "attributes": { "value": "text_custom_field" }
+		 *       "args": { "key": "text_custom_field" }
 		 *     }
 		 *   }
 		 * }
@@ -103,10 +103,10 @@ if ( ! function_exists( 'gutenberg_process_block_bindings' ) ) {
 
 			$source_callback = $block_bindings_sources[ $binding_source['source']['name'] ]['apply'];
 			// Get the value based on the source.
-			if ( ! isset( $binding_source['source']['attributes'] ) ) {
+			if ( ! isset( $binding_source['source']['args'] ) ) {
 				$source_args = array();
 			} else {
-				$source_args = $binding_source['source']['attributes'];
+				$source_args = $binding_source['source']['args'];
 			}
 			$source_value = $source_callback( $source_args, $block_instance, $binding_attribute );
 			// If the value is null, process next attribute.

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -97,16 +97,16 @@ if ( ! function_exists( 'gutenberg_process_block_bindings' ) ) {
 				continue;
 			}
 			// If no source is provided, or that source is not registered, process next attribute.
-			if ( ! isset( $binding_source['source'] ) || ! isset( $binding_source['source']['name'] ) || ! isset( $block_bindings_sources[ $binding_source['source']['name'] ] ) ) {
+			if ( ! isset( $binding_source['source'] ) || ! is_string( $binding_source['source'] ) || ! isset( $block_bindings_sources[ $binding_source['source'] ] ) ) {
 				continue;
 			}
 
-			$source_callback = $block_bindings_sources[ $binding_source['source']['name'] ]['apply'];
+			$source_callback = $block_bindings_sources[ $binding_source['source'] ]['apply'];
 			// Get the value based on the source.
-			if ( ! isset( $binding_source['source']['args'] ) ) {
+			if ( ! isset( $binding_source['args'] ) ) {
 				$source_args = array();
 			} else {
-				$source_args = $binding_source['source']['args'];
+				$source_args = $binding_source['args'];
 			}
 			$source_value = $source_callback( $source_args, $block_instance, $binding_attribute );
 			// If the value is null, process next attribute.

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -80,10 +80,8 @@ if ( ! function_exists( 'gutenberg_process_block_bindings' ) ) {
 		 *     "args": { "key": "text_custom_field" }
 		 *   },
 		 *   "url": {
-		 *     "source": {
-		 *       "name": "core/post-meta",
-		 *       "args": { "key": "text_custom_field" }
-		 *     }
+		 *     "source": "core/post-meta",
+		 *     "args": { "key": "url_custom_field" }
 		 *   }
 		 * }
 		 */

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -76,14 +76,12 @@ if ( ! function_exists( 'gutenberg_process_block_bindings' ) ) {
 		 *
 		 * "bindings": {
 		 *   "title": {
-		 *     "source": {
-		 *       "name": "post_meta",
-		 *       "attributes": { "value": "text_custom_field" }
-		 *     }
+		 *     "source": "core/post-meta",
+		 *     "args": { "value": "text_custom_field" }
 		 *   },
 		 *   "url": {
 		 *     "source": {
-		 *       "name": "post_meta",
+		 *       "name": "core/post-meta",
 		 *       "attributes": { "value": "text_custom_field" }
 		 *     }
 		 *   }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -160,8 +160,7 @@ export function RichTextWrapper(
 				if (
 					blockTypeAttributes?.[ attribute ]?.source ===
 						'rich-text' &&
-					getBlockBindingsSource( args.source.name )
-						?.lockAttributesEditing
+					getBlockBindingsSource( args.source )?.lockAttributesEditing
 				) {
 					shouldDisableEditing = true;
 					break;

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -52,10 +52,7 @@ const createEditFunctionWithBindingsAttribute = () =>
 							const {
 								placeholder,
 								useValue: [ metaValue = null ] = [],
-							} = source.useSource(
-								props,
-								settings.source.attributes
-							);
+							} = source.useSource( props, settings.source.args );
 
 							if ( placeholder && ! metaValue ) {
 								// If the attribute is `src` or `href`, a placeholder can't be used because it is not a valid url.

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -44,7 +44,7 @@ const createEditFunctionWithBindingsAttribute = () =>
 				Object.entries( updatedAttributes.metadata.bindings ).forEach(
 					( [ attributeName, settings ] ) => {
 						const source = getBlockBindingsSource(
-							settings.source.name
+							settings.source
 						);
 
 						if ( source ) {
@@ -52,7 +52,7 @@ const createEditFunctionWithBindingsAttribute = () =>
 							const {
 								placeholder,
 								useValue: [ metaValue = null ] = [],
-							} = source.useSource( props, settings.source.args );
+							} = source.useSource( props, settings.args );
 
 							if ( placeholder && ! metaValue ) {
 								// If the attribute is `src` or `href`, a placeholder can't be used because it is not a valid url.

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -45,14 +45,15 @@ function isPartiallySynced( block ) {
 		) &&
 		!! block.attributes.metadata?.bindings &&
 		Object.values( block.attributes.metadata.bindings ).some(
-			( binding ) => binding.source.name === 'pattern_attributes'
+			( binding ) => binding.source.name === 'core/pattern-attributes'
 		)
 	);
 }
 function getPartiallySyncedAttributes( block ) {
 	return Object.entries( block.attributes.metadata.bindings )
 		.filter(
-			( [ , binding ] ) => binding.source.name === 'pattern_attributes'
+			( [ , binding ] ) =>
+				binding.source.name === 'core/pattern-attributes'
 		)
 		.map( ( [ attributeKey ] ) => attributeKey );
 }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -45,15 +45,14 @@ function isPartiallySynced( block ) {
 		) &&
 		!! block.attributes.metadata?.bindings &&
 		Object.values( block.attributes.metadata.bindings ).some(
-			( binding ) => binding.source.name === 'core/pattern-attributes'
+			( binding ) => binding.source === 'core/pattern-attributes'
 		)
 	);
 }
 function getPartiallySyncedAttributes( block ) {
 	return Object.entries( block.attributes.metadata.bindings )
 		.filter(
-			( [ , binding ] ) =>
-				binding.source.name === 'core/pattern-attributes'
+			( [ , binding ] ) => binding.source === 'core/pattern-attributes'
 		)
 		.map( ( [ attributeKey ] ) => attributeKey );
 }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -245,9 +245,8 @@ function ButtonEdit( props ) {
 			return {
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
-					getBlockBindingsSource(
-						metadata?.bindings?.url?.source?.name
-					)?.lockAttributesEditing === true,
+					getBlockBindingsSource( metadata?.bindings?.url?.source )
+						?.lockAttributesEditing === true,
 			};
 		},
 		[ isSelected ]

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -347,9 +347,8 @@ export function ImageEdit( {
 			return {
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
-					getBlockBindingsSource(
-						metadata?.bindings?.url?.source?.name
-					)?.lockAttributesEditing === true,
+					getBlockBindingsSource( metadata?.bindings?.url?.source )
+						?.lockAttributesEditing === true,
 			};
 		},
 		[ isSelected ]

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -433,15 +433,15 @@ export default function Image( {
 			return {
 				lockUrlControls:
 					!! urlBinding &&
-					getBlockBindingsSource( urlBinding?.source?.name )
+					getBlockBindingsSource( urlBinding?.source )
 						?.lockAttributesEditing === true,
 				lockAltControls:
 					!! altBinding &&
-					getBlockBindingsSource( altBinding?.source?.name )
+					getBlockBindingsSource( altBinding?.source )
 						?.lockAttributesEditing === true,
 				lockTitleControls:
 					!! titleBinding &&
-					getBlockBindingsSource( titleBinding?.source?.name )
+					getBlockBindingsSource( titleBinding?.source )
 						?.lockAttributesEditing === true,
 			};
 		},

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { store as editorStore } from '../store';
 
 export default {
-	name: 'post_meta',
+	name: 'core/post-meta',
 	label: __( 'Post Meta' ),
 	useSource( props, sourceAttributes ) {
 		const { getCurrentPostType } = useSelect( editorStore );

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -15,7 +15,7 @@ export default {
 	useSource( props, sourceAttributes ) {
 		const { getCurrentPostType } = useSelect( editorStore );
 		const { context } = props;
-		const { value: metaKey } = sourceAttributes;
+		const { key: metaKey } = sourceAttributes;
 		const postType = context.postType
 			? context.postType
 			: getCurrentPostType();

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -19,7 +19,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 	const syncedAttributes = PARTIAL_SYNCING_SUPPORTED_BLOCKS[ name ];
 	const attributeSources = Object.keys( syncedAttributes ).map(
 		( attributeName ) =>
-			attributes.metadata?.bindings?.[ attributeName ]?.source?.name
+			attributes.metadata?.bindings?.[ attributeName ]?.source
 	);
 	const isConnectedToOtherSources = attributeSources.every(
 		( source ) => source && source !== 'core/pattern-attributes'
@@ -38,7 +38,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 		if ( ! isChecked ) {
 			for ( const attributeName of Object.keys( syncedAttributes ) ) {
 				if (
-					updatedBindings[ attributeName ]?.source?.name ===
+					updatedBindings[ attributeName ]?.source ===
 					'core/pattern-attributes'
 				) {
 					delete updatedBindings[ attributeName ];
@@ -59,9 +59,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 		for ( const attributeName of Object.keys( syncedAttributes ) ) {
 			if ( ! updatedBindings[ attributeName ] ) {
 				updatedBindings[ attributeName ] = {
-					source: {
-						name: 'core/pattern-attributes',
-					},
+					source: 'core/pattern-attributes',
 				};
 			}
 		}

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -22,7 +22,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			attributes.metadata?.bindings?.[ attributeName ]?.source?.name
 	);
 	const isConnectedToOtherSources = attributeSources.every(
-		( source ) => source && source !== 'pattern_attributes'
+		( source ) => source && source !== 'core/pattern-attributes'
 	);
 
 	// Render nothing if all supported attributes are connected to other sources.
@@ -39,7 +39,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			for ( const attributeName of Object.keys( syncedAttributes ) ) {
 				if (
 					updatedBindings[ attributeName ]?.source?.name ===
-					'pattern_attributes'
+					'core/pattern-attributes'
 				) {
 					delete updatedBindings[ attributeName ];
 				}
@@ -60,7 +60,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			if ( ! updatedBindings[ attributeName ] ) {
 				updatedBindings[ attributeName ] = {
 					source: {
-						name: 'pattern_attributes',
+						name: 'core/pattern-attributes',
 					},
 				};
 			}
@@ -96,7 +96,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 					__nextHasNoMarginBottom
 					label={ __( 'Allow instance overrides' ) }
 					checked={ attributeSources.some(
-						( source ) => source === 'pattern_attributes'
+						( source ) => source === 'core/pattern-attributes'
 					) }
 					onChange={ ( isChecked ) => {
 						updateBindings( isChecked );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -92,7 +92,7 @@ test.describe( 'Pattern Overrides', () => {
 							id: expect.any( String ),
 							bindings: {
 								content: {
-									source: { name: 'core/pattern-attributes' },
+									source: 'core/pattern-attributes',
 								},
 							},
 						},
@@ -222,7 +222,7 @@ test.describe( 'Pattern Overrides', () => {
 		const paragraphId = 'paragraph-id';
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
-			content: `<!-- wp:paragraph {"metadata":{"id":"${ paragraphId }","bindings":{"content":{"source":{"name":"core/pattern-attributes"}}}}} -->
+			content: `<!-- wp:paragraph {"metadata":{"id":"${ paragraphId }","bindings":{"content":{"source":"core/pattern-attributes"}}}} -->
 <p>Editable</p>
 <!-- /wp:paragraph -->`,
 			status: 'publish',
@@ -270,7 +270,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern with overrides',
 			content: `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"metadata":{"id":"${ buttonId }","bindings":{"text":{"source":{"name":"core/pattern-attributes"}},"url":{"source":{"name":"core/pattern-attributes"}},"linkTarget":{"source":{"name":"core/pattern-attributes"}}}}} -->
+<div class="wp-block-buttons"><!-- wp:button {"metadata":{"id":"${ buttonId }","bindings":{"text":{"source":"core/pattern-attributes"},"url":{"source":"core/pattern-attributes"},"linkTarget":{"source":"core/pattern-attributes"}}}} -->
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="http://wp.org" target="_blank" rel="noreferrer noopener">wp.org</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`,

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -92,7 +92,7 @@ test.describe( 'Pattern Overrides', () => {
 							id: expect.any( String ),
 							bindings: {
 								content: {
-									source: { name: 'pattern_attributes' },
+									source: { name: 'core/pattern-attributes' },
 								},
 							},
 						},
@@ -222,7 +222,7 @@ test.describe( 'Pattern Overrides', () => {
 		const paragraphId = 'paragraph-id';
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
-			content: `<!-- wp:paragraph {"metadata":{"id":"${ paragraphId }","bindings":{"content":{"source":{"name":"pattern_attributes"}}}}} -->
+			content: `<!-- wp:paragraph {"metadata":{"id":"${ paragraphId }","bindings":{"content":{"source":{"name":"core/pattern-attributes"}}}}} -->
 <p>Editable</p>
 <!-- /wp:paragraph -->`,
 			status: 'publish',
@@ -270,7 +270,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern with overrides',
 			content: `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"metadata":{"id":"${ buttonId }","bindings":{"text":{"source":{"name":"pattern_attributes"}},"url":{"source":{"name":"pattern_attributes"}},"linkTarget":{"source":{"name":"pattern_attributes"}}}}} -->
+<div class="wp-block-buttons"><!-- wp:button {"metadata":{"id":"${ buttonId }","bindings":{"text":{"source":{"name":"core/pattern-attributes"}},"url":{"source":{"name":"core/pattern-attributes"}},"linkTarget":{"source":{"name":"core/pattern-attributes"}}}}} -->
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="http://wp.org" target="_blank" rel="noreferrer noopener">wp.org</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As explained [here](https://github.com/WordPress/gutenberg/issues/53300#issuecomment-1911676567), the syntax of the block bindings object might change. I'm working on this pull request in case we want to follow that approach. The changes made are:
* Use namespaces in sources: `core/post-meta`.
* Change `value` for `key`.
* Change `attributes` for `args`.
* Remove the `source` level in the object.

## Why?
The new syntax could simplify and clarify the bindings definition.

## How?
* Adapt the PHP functions defined in `blocks.php` to this format.
* Adapt the pattern and the post meta sources to the new syntax.
* Update the `use-bindings-attributes` hook used in the editor.
* Update the patterns control to reflect the changes.
* Update the locking edit logic of RichText, button, and image to read the new syntax.

## Testing Instructions

0. Register a new custom field however you prefer. You can use a snippet similar to this:

```PHP
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'This is the content of the text custom field',
	)
);
register_meta(
	'post',
	'url_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

### In a page

**_Test paragraph_**
1. Add a paragraph with the content connected to a custom field:

```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<p>Hello</p>
<!-- /wp:paragraph -->
```

2. Add a paragraph without any bindings.
3. Check that the paragraph with the bindings became non-editable.
4. Check that the paragraph shows the content of the custom field.
5. Check that the normal paragraph works as expected.
6. Go to the frontend and check that the value of the custom field is shown there.

**_Test heading_**

Repeat the paragraph test but using a heading.

**_Test button_**

1. Add a button with the text connected to a custom field.
2. Add another button with the URL connected to a custom field.
3. Add a button with the text and the URL connected to custom fields.

```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"bindings":{"text":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">TEXT</a></div>
<!-- /wp:button -->

<!-- wp:button {"metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg">URL</a></div>
<!-- /wp:button -->

<!-- wp:button {"metadata":{"bindings":{"text":{"source":"core/post-meta","args":{"key":"text_custom_field"}},"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg">TEXT</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

4. Check that for the buttons with the text connected, they are not editable and they show the content of the custom field.
5. Check that for the buttons with the URL connected, the buttons to change the URL disappear from the UI.
6. Check that everything works in the frontend.

**_Test image_**

1. Add an image with the URL connected to a custom field.
2. Add an image with the alt attribute connected to a custom field.
3. Add an image with the title attribute connected to a custom field.
4. Add an image with more than one connection.

```
<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Image url and alt connected</h3>
<!-- /wp:heading -->

<!-- wp:image {"id":134,"sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"page_url_custom_field"}},"alt":{"source":"core/post-meta","args":{"key":"page_text_custom_field"}}}}} -->
<figure class="wp-block-image size-large"><img src="https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg" alt="Content of the page_text_custom_field" class="wp-image-134" title="Content of the PAGE text custom field"/></figure>
<!-- /wp:image -->

<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Alt connected</h3>
<!-- /wp:heading -->

<!-- wp:image {"sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"alt":{"source":"core/post-meta","args":{"key":"page_text_custom_field"}}}}} -->
<figure class="wp-block-image size-large"><img src="https://wpmovies.dev/wp-content/uploads/2023/04/q6y0Go1tsGEsmtFryDOJo3dEmqu-683x1024.jpg" alt="Content of the page_text_custom_field" title=""/></figure>
<!-- /wp:image -->

<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Nothing connected</h3>
<!-- /wp:heading -->

<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://wpmovies.dev/wp-content/uploads/2023/04/q6y0Go1tsGEsmtFryDOJo3dEmqu-683x1024.jpg" alt=""/></figure>
<!-- /wp:image -->
```

5. For the images with the URL connected, check that the related buttons to link an image have disappeared and the image shows the URL from the custom field.
6. For the images with the alt/title connected, check that, in the right sidebar, they are disabled. Showing the value of the custom field instead and a message saying it is connected to custom fields.

### In a template

Go to a page template, for example, and repeat the process. In this case, the blocks can't show the value of the custom fields because it depends on each page. They should show a placeholder instead.

### Test pattern syncing overrides

1. Go to the Site Editor -> Patterns -> Create new synced pattern.
2. Add a paragraph, go to the Advanced section, and enable "Allow instance overrides".
3. Add a heading, go to the Advanced section, and enable "Allow instance overrides".
4. Add an image block, upload or select any media, go to the Advanced section, and enable "Allow instance overrides".
5. Add a button block, go to the Advanced section, and enable "Allow instance overrides".
6. Go to a page an insert the new pattern.
7. Modify the values of the blocks.
8. Check that the updated values are reflected in the frontend
