### PR TITLE
Global styles revisions: update text color contrast 

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -15,7 +15,7 @@
 	flex-direction: column;
 
 	&:hover {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background-color: #f6fbfe;
 		.edit-site-global-styles-screen-revisions__date {
 			color: var(--wp-admin-theme-color);
 		}
@@ -63,6 +63,12 @@
 		&::before {
 			background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
 		}
+
+		.edit-site-global-styles-screen-revisions__changes,
+		.edit-site-global-styles-screen-revisions__meta,
+		.edit-site-global-styles-screen-revisions__applied-text {
+			color: $gray-900;
+		}
 	}
 
 	&::after {
@@ -100,10 +106,11 @@
 	margin: 0 $grid-unit-15 $grid-unit-15 $grid-unit-50;
 }
 
+.edit-site-global-styles-screen-revisions__changes,
+.edit-site-global-styles-screen-revisions__meta,
 .edit-site-global-styles-screen-revisions__applied-text {
-	color: $gray-600;
+	color: $gray-700;
 	font-size: 12px;
-	font-style: italic;
 }
 
 .edit-site-global-styles-screen-revisions__description {
@@ -120,12 +127,10 @@
 
 .edit-site-global-styles-screen-revisions__changes,
 .edit-site-global-styles-screen-revisions__meta {
-	color: $gray-600;
 	display: flex;
 	justify-content: start;
 	width: 100%;
 	align-items: flex-start;
-	font-size: 12px;
 	text-align: left;
 	img {
 		width: $grid-unit-20;

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -15,7 +15,7 @@
 	flex-direction: column;
 
 	&:hover {
-		background-color: #f6fbfe;
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		.edit-site-global-styles-screen-revisions__date {
 			color: var(--wp-admin-theme-color);
 		}


### PR DESCRIPTION


## What?
Starter PR that one day resolves https://github.com/WordPress/gutenberg/issues/58121

1. darkens meta text for highlighted revisions
2. removes italics for message `These styles are already applied to your site.`

## Why?

1. It's been suggested that these changes will improve readability.
2. See 1


## Testing Instructions

1. Open the site editor and save a few changes to your global styles.
2. Open the styles revisions and observe the color of the text. It should be sufficiently dark.

## Screenshots or screencast <!-- if applicable -->

<img width="268" alt="Screenshot 2024-01-27 at 9 46 01 am" src="https://github.com/WordPress/gutenberg/assets/6458278/c0a586fa-9b6b-4924-8507-287fe5536331">

