### PR TITLE
Fix/58341 footnotes for cpts

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -66,8 +66,27 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
  * Registers the `core/footnotes` block on the server.
  *
  * @since 6.3.0
+ * @since 6.5.0 Added support for custom post types.
  */
 function register_block_core_footnotes() {
+	/*
+	 * Backward compatibility support.
+	 *
+	 * This code was initially registered to run on the `init` hook at the default
+	 * priority of 10. In WordPress 6.5 the code was modified to support custom
+	 * post types and needs to run on a higher priority to ensure that the meta
+	 * data is registered following the registration of custom post types.
+	 *
+	 * This code ensures that themes and plugins that were removing the action
+	 * on the `init` hook at the default priority of 10 to prevent the block's
+	 * registration will continue to work.
+	 */
+	if ( doing_action( 'init' ) && has_action( 'init', 'register_block_core_footnotes', 10 ) ) {
+		remove_action( 'init', 'register_block_core_footnotes', 10 );
+		add_action( 'init', 'register_block_core_footnotes', 100 );
+		return;
+	}
+
 	$post_types = get_post_types(
 		array(
 			'show_in_rest' => true,

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -74,16 +74,20 @@ function register_block_core_footnotes() {
 	 *
 	 * This code was initially registered to run on the `init` hook at the default
 	 * priority of 10. In WordPress 6.5 the code was modified to support custom
-	 * post types and needs to run on a higher priority to ensure that the meta
-	 * data is registered following the registration of custom post types.
+	 * post types and needs to run after the registration of custom post types
+	 * by plugins and themes.
 	 *
-	 * This code ensures that themes and plugins that were removing the action
-	 * on the `init` hook at the default priority of 10 to prevent the block's
-	 * registration will continue to work.
+	 * Due to an order of operations issue this function was running before themes
+	 * or plugins could register to CTPs to run on the default `init` hook. This
+	 * shuffles the priority while allowing for extenders to deregister the block.
+	 *
+	 * As the REST API cancels operations prior to `init, 100` running, this now
+	 * runs on `rest_api_init` too.
 	 */
 	if ( doing_action( 'init' ) && has_action( 'init', 'register_block_core_footnotes', 10 ) ) {
-		remove_action( 'init', 'register_block_core_footnotes', 10 );
+		remove_action( 'init', 'register_block_core_footnotes' );
 		add_action( 'init', 'register_block_core_footnotes', 100 );
+		add_action( 'rest_api_init', 'register_block_core_footnotes', 100 );
 		return;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Modifies the registration of the footnote block to ensure it runs after the registration of CPTs by themes and plugins.

Fixes #58341

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Once merged in to WordPress Core `register_block_core_footnotes` runs prior to most actions on the `init` hook. Including all actions added to the hook by themes and plugins. This prevents the function from picking up CPTs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It registers the block later on the `init` hook. To allow for the REST API blocking calling `die()` prior to the later running `inti` actions, it also runs the function on `rest_api_init`.

There may be a better approach that I am happy to implement. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

> [!Note]
>
> Even with the Gutenberg plugin enabled, I had to copy these code changes over to the WP Core files to test these changes. 

1. Enable the test plugin below to register a CPT.
2. Copy the rewritten function over the function in WP Core
3. Create a post, ensure the footnotes are working as expected (check revisions)
4. Create a custom post, ensure the footnotes are working as expected (check revisions)

### Plugin for testing

```php
<?php
/**
 * Plugin Name: Testing CPT Footnotes without custom fields.
 */

namespace PWCC\TestingCptFootnotes;

// This ensures the post type is registered after the footnotes
// block is registered on the Gutenberg trunk. This will help
// similate the bug seen in Core.
add_action( 'init', function() {
	add_action( 'init', __NAMESPACE__ . '\register_cpts' );
}, 5 );

function register_cpts() {
	register_post_type(
		'cpt-with-footnotes',
		[
			'public' => true,
			'show_in_rest' => true,
			'labels' => [
				'name'          => 'CPT Supporting Footnotes',
				'singular_name' => 'CPT Supporting Footnote',
				'plural_name'   => 'CPTs Supporting Footnotes',
			],
			'supports' => [
				'title',
				'editor',
				'revisions',
				'custom-fields',
			],
		]
	);
}
```