### PR TITLE
InnerBlocks: fix continuous re-rendering on inner blocks change

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -71,7 +71,6 @@ function UncontrolledInnerBlocks( props ) {
 		layout,
 		name,
 		blockType,
-		innerBlocks,
 		parentLock,
 	} = props;
 
@@ -92,7 +91,6 @@ function UncontrolledInnerBlocks( props ) {
 
 	useInnerBlockTemplateSync(
 		clientId,
-		innerBlocks,
 		template,
 		templateLock,
 		templateInsertUpdatesSelection
@@ -193,7 +191,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		hasOverlay,
 		name,
 		blockType,
-		innerBlocks,
 		parentLock,
 		parentClientId,
 		isDropZoneDisabled,
@@ -208,7 +205,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				isBlockSelected,
 				hasSelectedInnerBlock,
 				__unstableGetEditorMode,
-				getBlocks,
 				getTemplateLock,
 				getBlockRootClientId,
 				__unstableIsWithinBlockOverlay,
@@ -234,7 +230,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 					enableClickThrough,
 				name: blockName,
 				blockType: getBlockType( blockName ),
-				innerBlocks: getBlocks( clientId ),
 				parentLock: getTemplateLock( _parentClientId ),
 				parentClientId: _parentClientId,
 				isDropZoneDisabled:
@@ -263,7 +258,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		layout,
 		name,
 		blockType,
-		innerBlocks,
 		parentLock,
 		...options,
 	};

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -105,17 +105,12 @@ function UncontrolledInnerBlocks( props ) {
 
 	const context = useBlockContext( clientId );
 
-	const { nestingLevel, innerBlocks, parentLock } = useSelect(
+	const { nestingLevel, parentLock } = useSelect(
 		( select ) => {
-			const {
-				getBlockParents,
-				getBlocks,
-				getTemplateLock,
-				getBlockRootClientId,
-			} = select( blockEditorStore );
+			const { getBlockParents, getTemplateLock, getBlockRootClientId } =
+				select( blockEditorStore );
 			return {
 				nestingLevel: getBlockParents( clientId )?.length,
-				innerBlocks: getBlocks( clientId ),
 				parentLock: getTemplateLock( getBlockRootClientId( clientId ) ),
 			};
 		},
@@ -139,7 +134,6 @@ function UncontrolledInnerBlocks( props ) {
 
 	useInnerBlockTemplateSync(
 		clientId,
-		innerBlocks,
 		template,
 		templateLock,
 		templateInsertUpdatesSelection

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -23,7 +23,6 @@ import { store as blockEditorStore } from '../../store';
  * then we replace the inner blocks with the correct value after synchronizing it with the template.
  *
  * @param {string}  clientId                       The block client ID.
- * @param {Array}   innerBlocks
  * @param {Object}  template                       The template to match.
  * @param {string}  templateLock                   The template lock state for the inner blocks. For
  *                                                 example, if the template lock is set to "all",
@@ -37,7 +36,6 @@ import { store as blockEditorStore } from '../../store';
  */
 export default function useInnerBlockTemplateSync(
 	clientId,
-	innerBlocks,
 	template,
 	templateLock,
 	templateInsertUpdatesSelection
@@ -112,5 +110,5 @@ export default function useInnerBlockTemplateSync(
 		return () => {
 			isCancelled = true;
 		};
-	}, [ innerBlocks, template, templateLock, clientId ] );
+	}, [ template, templateLock, clientId ] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently when typing in a list (or any block using inner block such as group, quote, etc.) the whole list re-renders. This is because all inner blocks hooks are subscribed to their inner blocks.

Subscribing to inner blocks doesn't seem to be needed because `useInnerBlockTemplateSync` does _nothing_ unless the template changes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

|Before|After|
|-|-|
|![before](https://github.com/WordPress/gutenberg/assets/4710635/d3ae5b43-3453-434d-8fbe-564eb503ca0f)|![after](https://github.com/WordPress/gutenberg/assets/4710635/f0f5efae-2876-4db0-adff-afc6bec976d0)|

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
