### PR TITLE
Docs: Update link to the correct Fundamentals doc.

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -715,7 +715,7 @@ Compare this to a statically rendered block like the Paragraph block.
 
 The HTML of the paragraph is stored in post content and saved in the database.
 
-You can learn more about dynamic and static rendering in the [Fundamentals documentation](https://developer.wordpress.org/block-editor/getting-started/fundamentals/). While most blocks are either dynamically or statically rendered, you can build a block that utilizes both methods.
+You can learn more about dynamic and static rendering in the [Fundamentals documentation](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/). While most blocks are either dynamically or statically rendered, you can build a block that utilizes both methods.
 
 ### Why add static rendering?
 


### PR DESCRIPTION
This is a minor PR that updates the link in the Tutorial to the correct Fundamentals article. At the time the Tutorial was created, the new [Static or Dynamic rendering of a block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/) doc was still being written.
