### PR TITLE
Block editor: optimise getGlobalBlockCount/getClientIdsWithDescendants

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -486,7 +486,7 @@ Returns an array containing the clientIds of all descendants of the blocks given
 _Parameters_
 
 -   _state_ `Object`: Global application state.
--   _clientIds_ `string|string[]`: Client ID(s) for which descendant blocks are to be returned.
+-   _rootIds_ `string|string[]`: Client ID(s) for which descendant blocks are to be returned.
 
 _Returns_
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -270,12 +270,16 @@ export const getClientIdsOfDescendants = createSelector(
 			}
 		}
 
+		let index = 0;
+
 		// Add the descendants of the descendants, recursively.
-		for ( const id of ids ) {
+		while ( index < ids.length ) {
+			const id = ids[ index ];
 			const order = state.blocks.order.get( id );
 			if ( order ) {
-				ids.push( ...order );
+				ids.splice( index + 1, 0, ...order );
 			}
+			index++;
 		}
 
 		return ids;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Remove the recursive function calls and skip loops over empty arrays.

Too bad we cannot use the `byClientIds` apparently: #11787.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Performs 20x faster on the large test post.

Also improves site editor load by ~3%.

|Before|After|
|-|-|
|<img width="430" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/160f1612-119e-4554-a484-e26cef324038">|<img width="341" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/45eeca41-64e6-41c5-a8c3-da88e3677127">|

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
