### PR TITLE
Patterns: Prevent exception if a pattern with overrides is nested in another pattern

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -340,7 +340,7 @@ export default function ReusableBlockEdit( {
 		children = (
 			<Warning>
 				{ __(
-					'You cannot nest a pattern with overrides inside another pattern.'
+					'You cannot edit a pattern with overrides when it is nested in another pattern.'
 				) }
 			</Warning>
 		);

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -230,10 +230,14 @@ export default function ReusableBlockEdit( {
 		  } )
 		: {};
 
-	useEffect(
-		() => setBlockEditMode( setBlockEditingMode, innerBlocks ),
-		[ innerBlocks, setBlockEditingMode ]
-	);
+	useEffect( () => {
+		if ( hasParentPattern ) {
+			setBlockEditMode( setBlockEditingMode, innerBlocks, 'disabled' );
+			return;
+		}
+
+		setBlockEditMode( setBlockEditingMode, innerBlocks );
+	}, [ hasParentPattern, innerBlocks, setBlockEditingMode ] );
 
 	const hasOverridableBlocks = useMemo(
 		() => getHasOverridableBlocks( innerBlocks ),
@@ -335,16 +339,6 @@ export default function ReusableBlockEdit( {
 	};
 
 	let children = null;
-
-	if ( hasOverridableBlocks && hasParentPattern ) {
-		children = (
-			<Warning>
-				{ __(
-					'You cannot edit a pattern with overrides when it is nested in another pattern.'
-				) }
-			</Warning>
-		);
-	}
 
 	if ( hasAlreadyRendered ) {
 		children = (


### PR DESCRIPTION
## What?
Shows a warning if a synced pattern with overrides is nested within another pattern. 

This is just one approach to fix this and is probably the simplest for 6.5, but we should also explore what might be involved in supporting the nesting of patterns with overrides.

## Why?
Currently, an exception is thrown if a pattern with overrides is nested within another pattern.
Fixes: #58291

## How?
Checks for a parent that is a pattern for patterns that have overrides set.

## Testing Instructions

- Create two synced patterns with overrides, and one without overrides
- Next one with and one without overrides inside the other pattern withoverides
- Add the parent pattern in a post
- Check that no exceptions are thrown and  the nested pattern displays but is not editable

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="938" alt="Screenshot 2024-01-29 at 10 53 20 AM" src="https://github.com/WordPress/gutenberg/assets/3629020/f027bdc1-219e-4246-87f9-382d60ba83ea">

After:

https://github.com/WordPress/gutenberg/assets/3629020/033b0689-1d38-4109-97a4-c0f5626e44dd




