### PR TITLE
Post Content: Update placeholder when editing template

### DIFF
--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -15,6 +15,8 @@ import {
 	store as coreStore,
 } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { Placeholder } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
@@ -104,25 +106,18 @@ function Content( props ) {
 	);
 }
 
-function Placeholder( { layoutClassNames } ) {
+function PostContentPlaceholder( { layoutClassNames } ) {
 	const blockProps = useBlockProps( { className: layoutClassNames } );
 	return (
 		<div { ...blockProps }>
-			<p>
-				{ __(
-					'This is the Content block, it will display all the blocks in any single post or page.'
-				) }
-			</p>
-			<p>
-				{ __(
-					'That might be a simple arrangement like consecutive paragraphs in a blog post, or a more elaborate composition that includes image galleries, videos, tables, columns, and any other block types.'
-				) }
-			</p>
-			<p>
-				{ __(
-					'If there are any Custom Post Types registered at your site, the Content block can display the contents of those entries as well.'
-				) }
-			</p>
+			<Placeholder
+				className="wp-block-post-content__placeholder"
+				withIllustration
+			>
+				<p>
+					{ __( 'This block will be replaced with your content.' ) }
+				</p>
+			</Placeholder>
 		</div>
 	);
 }
@@ -157,7 +152,7 @@ export default function PostContentEdit( {
 					layoutClassNames={ layoutClassNames }
 				/>
 			) : (
-				<Placeholder layoutClassNames={ layoutClassNames } />
+				<PostContentPlaceholder layoutClassNames={ layoutClassNames } />
 			) }
 		</RecursionProvider>
 	);

--- a/packages/block-library/src/post-content/editor.scss
+++ b/packages/block-library/src/post-content/editor.scss
@@ -1,4 +1,21 @@
-// Disable text selection in the post content placeholder.
-.wp-block-post-content.wp-block-post-content {
-	user-select: none;
+.wp-block-post-content__placeholder {
+	&.has-illustration::before {
+		background: none;
+		border: 1px solid currentColor;
+	}
+
+	.components-placeholder__illustration {
+		opacity: 0.1;
+	}
+
+	.components-placeholder__fieldset {
+		align-self: center;
+		font-family: inherit;
+		font-size: inherit;
+
+		p {
+			font-family: inherit;
+			font-size: inherit;
+		}
+	}
 }

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -23,8 +23,8 @@ async function addPageContent( editor, page ) {
 		.getByRole( 'document', {
 			name: 'Block: Content',
 		} )
-		.getByRole( 'document', {
-			name: 'Empty block; start writing or type forward slash to choose a block',
+		.getByRole( 'button', {
+			name: 'Start blank',
 		} )
 		.click();
 
@@ -124,9 +124,7 @@ test.describe( 'Pages', () => {
 			editor.canvas.getByRole( 'document', {
 				name: 'Block: Content',
 			} )
-		).toContainText(
-			'This is the Content block, it will display all the blocks in any single post or page.'
-		);
+		).toContainText( 'This block will be replaced with your content.' );
 		await expect(
 			page.locator(
 				'role=button[name="Dismiss this notice"i] >> text="Editing template. Changes made here affect all posts and pages that use the template."'


### PR DESCRIPTION
## What?
Updates the Post Content block's placeholder when viewing it in the context of editing a template.

| Before | After |
| - | - |
| <img width="1265" alt="Screenshot 2024-01-29 at 13 44 01" src="https://github.com/WordPress/gutenberg/assets/612155/47f21dfa-2d0b-47a3-a0a6-77d7d3fcceec"> | <img width="1265" alt="Screenshot 2024-01-29 at 13 43 37" src="https://github.com/WordPress/gutenberg/assets/612155/8dd2ba7c-bbc8-4bde-b32b-76ac573ed25e"> |

I pulled this out of https://github.com/WordPress/gutenberg/pull/57572. Props to my boy @ramonjd.

## Why?
A common painpoint when using the site editor is that users delete the Post Content block without meaning to. We hope to reduce this by making it look more like placeholder content and less like actual content.


## Testing Instructions
1. Go to Appearance → Editor → Pages and create/edit a page.
2. Edit the template e.g. by selecting Template in the sidebar and clicking _Edit template_.