### PR TITLE
Fluid typography: pass theme.json settings to override merged theme data

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -431,7 +431,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.2.0 Added 'settings.typography.fluid.minFontSize' support.
  * @since 6.3.0 Using layout.wideSize as max viewport width, and logarithmic scale factor to calculate minimum font scale.
  * @since 6.4.0 Added configurable min and max viewport width values to the typography.fluid theme.json schema.
- * @since 6.5.0 Deprecated bool argument $should_use_fluid_typography.
+ * @since 6.6.0 Deprecated bool argument $should_use_fluid_typography.
  *
  * @param array $preset       {
  *     Required. fontSizes preset value as seen in theme.json.
@@ -463,7 +463,7 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 	 * As a bool (deprecated since 6.5), $settings acts as an override to switch fluid typography "on" (`true`) or "off" (`false`).
 	 */
 	if ( is_bool( $settings ) ) {
-		_deprecated_argument( __FUNCTION__, '6.5.0', __( '`boolean` type for second argument `$settings` is deprecated. Use `array()` instead.', 'gutenberg' ) );
+		_deprecated_argument( __FUNCTION__, '6.6.0', __( '`boolean` type for second argument `$settings` is deprecated. Use `array()` instead.', 'gutenberg' ) );
 		$settings = array(
 			'typography' => array(
 				'fluid' => $settings,

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -433,7 +433,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.4.0 Added configurable min and max viewport width values to the typography.fluid theme.json schema.
  * @since 6.5.0 Changing the type and name of the bool argument $should_use_fluid_typography.
  *
- * @param array $preset                     {
+ * @param array $preset       {
  *     Required. fontSizes preset value as seen in theme.json.
  *
  *     @type string           $name Name of the font size preset.
@@ -441,7 +441,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  *     @type string|int|float $size CSS font-size value, including units where applicable.
  * }
  * @param bool|array $settings Optional Theme JSON settings array that overrides any global theme settings.
- *                             As a bool, it acts as an override to switch fluid typography "on" (`true`) or "off" (`false`).
+ *                             As a bool (deprecated), it acts as an override to switch fluid typography "on" (`true`) or "off" (`false`).
  *                             Can be used for unit testing. Default is `array()`.
  *
  * @return string|null Font-size value or `null` if a size is not passed in $preset.
@@ -464,6 +464,7 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 	 * If the settings argument is a boolean, it's a fluid typography override.
 	 */
 	if ( is_bool( $settings ) ) {
+		_deprecated_argument( __FUNCTION__, '6.5.0', __( '`boolean` type for second argument `$settings` is deprecated. Use `array()` instead.', 'gutenberg' ) );
 		$settings = array(
 			'typography' => array(
 				'fluid' => $settings,
@@ -471,8 +472,8 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 		);
 	}
 
-	// Checks if fluid font sizes are activated.
-	$global_settings             = gutenberg_get_global_settings( array(), 'base' );
+	// Fallback to global settings as default.
+	$global_settings             = gutenberg_get_global_settings();
 	$settings                    = wp_parse_args(
 		$settings,
 		$global_settings

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -478,7 +478,7 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 		$global_settings
 	);
 	$typography_settings         = isset( $settings['typography'] ) ? $settings['typography'] : array();
-	$should_use_fluid_typography = isset( $typography_settings['fluid'] ) && ! empty( $typography_settings['fluid'] );
+	$should_use_fluid_typography = ! empty( $typography_settings['fluid'] );
 
 	if ( ! $should_use_fluid_typography ) {
 		return $preset['size'];

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -431,7 +431,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.2.0 Added 'settings.typography.fluid.minFontSize' support.
  * @since 6.3.0 Using layout.wideSize as max viewport width, and logarithmic scale factor to calculate minimum font scale.
  * @since 6.4.0 Added configurable min and max viewport width values to the typography.fluid theme.json schema.
- * @since 6.5.0 Changing the type and name of the bool argument $should_use_fluid_typography.
+ * @since 6.5.0 Deprecated bool argument $should_use_fluid_typography.
  *
  * @param array $preset       {
  *     Required. fontSizes preset value as seen in theme.json.
@@ -441,8 +441,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  *     @type string|int|float $size CSS font-size value, including units where applicable.
  * }
  * @param bool|array $settings Optional Theme JSON settings array that overrides any global theme settings.
- *                             As a bool (deprecated), it acts as an override to switch fluid typography "on" (`true`) or "off" (`false`).
- *                             Can be used for unit testing. Default is `array()`.
+ *                             Default is `array()`.
  *
  * @return string|null Font-size value or `null` if a size is not passed in $preset.
  */
@@ -461,7 +460,7 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 
 	/*
 	 * Backwards compatibility since 6.5.
-	 * If the settings argument is a boolean, it's a fluid typography override.
+	 * As a bool (deprecated since 6.5), $settings acts as an override to switch fluid typography "on" (`true`) or "off" (`false`).
 	 */
 	if ( is_bool( $settings ) ) {
 		_deprecated_argument( __FUNCTION__, '6.5.0', __( '`boolean` type for second argument `$settings` is deprecated. Use `array()` instead.', 'gutenberg' ) );
@@ -479,15 +478,15 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 		$global_settings
 	);
 	$typography_settings         = isset( $settings['typography'] ) ? $settings['typography'] : array();
-	$layout_settings             = isset( $settings['layout'] ) ? $settings['layout'] : array();
-	$should_use_fluid_typography = isset( $typography_settings['fluid'] ) &&
-		( true === $typography_settings['fluid'] || is_array( $typography_settings['fluid'] ) );
+	$should_use_fluid_typography = isset( $typography_settings['fluid'] ) && ! empty( $typography_settings['fluid'] );
 
 	if ( ! $should_use_fluid_typography ) {
 		return $preset['size'];
 	}
 
-	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
+	// $typography_settings['fluid'] can be a bool or an array. Normalize to array.
+	$fluid_settings  = is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
+	$layout_settings = isset( $settings['layout'] ) ? $settings['layout'] : array();
 
 	// Defaults.
 	$default_maximum_viewport_width       = '1600px';

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1160,7 +1160,7 @@ class WP_Theme_JSON_Gutenberg {
 		if ( null === $origins ) {
 			$origins = static::VALID_ORIGINS;
 		}
-
+		//var_dump($this->get_settings());
 		if ( is_string( $types ) ) {
 			// Dispatch error and map old arguments to new ones.
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
@@ -2082,6 +2082,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 5.8.0
 	 * @since 5.9.0 Added the `$settings` and `$properties` parameters.
 	 * @since 6.1.0 Added `$theme_json`, `$selector`, and `$use_root_padding` parameters.
+	 * @since 6.5.0 Passing current theme JSON settings to wp_get_typography_font_size_value().
 	 *
 	 * @param array   $styles Styles to process.
 	 * @param array   $settings Theme settings.
@@ -2152,7 +2153,7 @@ class WP_Theme_JSON_Gutenberg {
 				 * Values that already have a clamp() function will not pass the test,
 				 * and therefore the original $value will be returned.
 				 */
-				$value = gutenberg_get_typography_font_size_value( array( 'size' => $value ) );
+				$value = gutenberg_get_typography_font_size_value( array( 'size' => $value ), $settings );
 			}
 
 			if ( 'aspect-ratio' === $css_property ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1857,6 +1857,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * </code>
 	 *
 	 * @since 5.9.0
+	 * @since 6.6.0 Passing $settings to the callbacks defined in static::PRESETS_METADATA.
 	 *
 	 * @param array $settings        Settings to process.
 	 * @param array $preset_metadata One of the PRESETS_METADATA values.
@@ -1883,7 +1884,7 @@ class WP_Theme_JSON_Gutenberg {
 					is_callable( $preset_metadata['value_func'] )
 				) {
 					$value_func = $preset_metadata['value_func'];
-					$value      = call_user_func( $value_func, $preset );
+					$value      = call_user_func( $value_func, $preset, $settings );
 				} else {
 					// If we don't have a value, then don't add it to the result.
 					continue;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1160,7 +1160,7 @@ class WP_Theme_JSON_Gutenberg {
 		if ( null === $origins ) {
 			$origins = static::VALID_ORIGINS;
 		}
-		//var_dump($this->get_settings());
+
 		if ( is_string( $types ) ) {
 			// Dispatch error and map old arguments to new ones.
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
@@ -2152,6 +2152,7 @@ class WP_Theme_JSON_Gutenberg {
 				 * whether the incoming value can be converted to a fluid value.
 				 * Values that already have a clamp() function will not pass the test,
 				 * and therefore the original $value will be returned.
+				 * Pass the current theme_json settings to override any global settings.
 				 */
 				$value = gutenberg_get_typography_font_size_value( array( 'size' => $value ), $settings );
 			}

--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -61,6 +61,19 @@ describe( 'typography utils', () => {
 			},
 
 			{
+				message: 'should return value when fluid config is empty`',
+				preset: {
+					size: '28px',
+				},
+				settings: {
+					typography: {
+						fluid: {},
+					},
+				},
+				expected: '28px',
+			},
+
+			{
 				message:
 					'should return  clamp value with `minViewportWidth` override',
 				preset: {

--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -52,10 +52,84 @@ describe( 'typography utils', () => {
 					size: '28px',
 					fluid: false,
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected: '28px',
+			},
+
+			{
+				message:
+					'should return  clamp value with `minViewportWidth` override',
+				preset: {
+					size: '28px',
+				},
+				settings: {
+					typography: {
+						fluid: {
+							minViewportWidth: '500px',
+						},
+					},
+				},
+				expected:
+					'clamp(17.905px, 1.119rem + ((1vw - 5px) * 0.918), 28px)',
+			},
+
+			{
+				message:
+					'should return  clamp value with `maxViewportWidth` override',
+				preset: {
+					size: '28px',
+				},
+				settings: {
+					typography: {
+						fluid: {
+							maxViewportWidth: '500px',
+						},
+					},
+				},
+				expected:
+					'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 5.608), 28px)',
+			},
+
+			{
+				message:
+					'should return clamp value with `layout.wideSize` override',
+				preset: {
+					size: '28px',
+				},
+				settings: {
+					typography: {
+						fluid: true,
+					},
+					layout: {
+						wideSize: '500px',
+					},
+				},
+				expected:
+					'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 5.608), 28px)',
+			},
+
+			{
+				message:
+					'should return clamp value with `maxViewportWidth` preferred over fallback `layout.wideSize` value',
+				preset: {
+					size: '28px',
+				},
+				settings: {
+					typography: {
+						fluid: {
+							maxViewportWidth: '1000px',
+						},
+					},
+					layout: {
+						wideSize: '500px',
+					},
+				},
+				expected:
+					'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 1.485), 28px)',
 			},
 
 			{
@@ -64,8 +138,10 @@ describe( 'typography utils', () => {
 					size: 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 					fluid: false,
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
@@ -77,8 +153,10 @@ describe( 'typography utils', () => {
 					size: '1000%',
 					fluid: false,
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected: '1000%',
 			},
@@ -88,8 +166,10 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '1.75rem',
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(1.119rem, 1.119rem + ((1vw - 0.2rem) * 0.789), 1.75rem)',
@@ -101,9 +181,11 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '1.75rem',
 				},
-				typographySettings: {
-					fluid: {
-						maxViewportWidth: '1200px',
+				settings: {
+					typography: {
+						fluid: {
+							maxViewportWidth: '1200px',
+						},
 					},
 				},
 				expected:
@@ -116,9 +198,11 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '1.75rem',
 				},
-				typographySettings: {
-					fluid: {
-						minViewportWidth: '800px',
+				settings: {
+					typography: {
+						fluid: {
+							minViewportWidth: '800px',
+						},
 					},
 				},
 				expected:
@@ -130,8 +214,10 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '1.75em',
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(1.119em, 1.119rem + ((1vw - 0.2em) * 0.789), 1.75em)',
@@ -142,8 +228,10 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '70.175px',
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(37.897px, 2.369rem + ((1vw - 3.2px) * 2.522), 70.175px)',
@@ -156,8 +244,10 @@ describe( 'typography utils', () => {
 					size: 33,
 					fluid: true,
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(20.515px, 1.282rem + ((1vw - 3.2px) * 0.975), 33px)',
@@ -169,8 +259,10 @@ describe( 'typography utils', () => {
 					size: 70.175,
 					fluid: true,
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(37.897px, 2.369rem + ((1vw - 3.2px) * 2.522), 70.175px)',
@@ -183,8 +275,10 @@ describe( 'typography utils', () => {
 					size: '28px',
 					fluid: [],
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
@@ -196,8 +290,10 @@ describe( 'typography utils', () => {
 					size: '28px',
 					fluid: null,
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
@@ -213,8 +309,10 @@ describe( 'typography utils', () => {
 						max: '125px',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(70px, 4.375rem + ((1vw - 3.2px) * 4.297), 125px)',
@@ -230,9 +328,11 @@ describe( 'typography utils', () => {
 						max: '125px',
 					},
 				},
-				typographySettings: {
-					fluid: {
-						maxViewportWidth: '1100px',
+				settings: {
+					typography: {
+						fluid: {
+							maxViewportWidth: '1100px',
+						},
 					},
 				},
 				expected:
@@ -248,8 +348,10 @@ describe( 'typography utils', () => {
 						max: '7.8125rem',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(4.375rem, 4.375rem + ((1vw - 0.2rem) * 4.298), 7.8125rem)',
@@ -265,8 +367,10 @@ describe( 'typography utils', () => {
 						max: '32px',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected: 'clamp(5rem, 5rem + ((1vw - 0.2rem) * -3.75), 32px)',
 			},
@@ -280,8 +384,10 @@ describe( 'typography utils', () => {
 						max: '50%',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected: '10em',
 			},
@@ -292,8 +398,10 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '3px',
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected: '3px',
 			},
@@ -304,8 +412,10 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '14px',
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected: '14px',
 			},
@@ -320,8 +430,10 @@ describe( 'typography utils', () => {
 						max: '50rem',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(20px, 1.25rem + ((1vw - 3.2px) * 60.938), 50rem)',
@@ -336,8 +448,10 @@ describe( 'typography utils', () => {
 						min: '2.6rem',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(2.6rem, 2.6rem + ((1vw - 0.2rem) * 0.656), 50px)',
@@ -352,8 +466,10 @@ describe( 'typography utils', () => {
 						max: '80px',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 4.851), 80px)',
@@ -369,8 +485,10 @@ describe( 'typography utils', () => {
 						max: '5rem',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(0.5rem, 0.5rem + ((1vw - 0.2rem) * 5.625), 5rem)',
@@ -385,8 +503,10 @@ describe( 'typography utils', () => {
 						min: '12px',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(12px, 0.75rem + ((1vw - 3.2px) * 0.625), 20px)',
@@ -401,13 +521,14 @@ describe( 'typography utils', () => {
 						max: '20rem',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(0.875rem, 0.875rem + ((1vw - 0.2rem) * 23.906), 20rem)',
 			},
-
 			{
 				message:
 					'should return clamp value when min and max font sizes are equal',
@@ -418,8 +539,10 @@ describe( 'typography utils', () => {
 						max: '30px',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected: 'clamp(30px, 1.875rem + ((1vw - 3.2px) * 1), 30px)',
 			},
@@ -430,9 +553,11 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '15px',
 				},
-				typographySettings: {
-					fluid: {
-						minFontSize: '16%',
+				settings: {
+					typography: {
+						fluid: {
+							minFontSize: '16%',
+						},
 					},
 				},
 				expected:
@@ -445,9 +570,11 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '17px',
 				},
-				typographySettings: {
-					fluid: {
-						minFontSize: '16px',
+				settings: {
+					typography: {
+						fluid: {
+							minFontSize: '16px',
+						},
 					},
 				},
 				expected: 'clamp(16px, 1rem + ((1vw - 3.2px) * 0.078), 17px)',
@@ -459,9 +586,11 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '15px',
 				},
-				typographySettings: {
-					fluid: {
-						minFontSize: '16px',
+				settings: {
+					typography: {
+						fluid: {
+							minFontSize: '16px',
+						},
 					},
 				},
 				expected: '15px',
@@ -473,8 +602,10 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '12rem',
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(5.174rem, 5.174rem + ((1vw - 0.2rem) * 8.533), 12rem)',
@@ -486,8 +617,10 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '200px',
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(85.342px, 5.334rem + ((1vw - 3.2px) * 8.958), 200px)',
@@ -502,8 +635,10 @@ describe( 'typography utils', () => {
 						min: '100px',
 					},
 				},
-				typographySettings: {
-					fluid: true,
+				settings: {
+					typography: {
+						fluid: true,
+					},
 				},
 				expected:
 					'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
@@ -514,20 +649,22 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '17px',
 				},
-				typographySettings: {
-					fluid: {
-						minFontSize: '16px',
-						maxViewportWidth: '1200px',
-						minViewportWidth: '640px',
+				settings: {
+					typography: {
+						fluid: {
+							minFontSize: '16px',
+							maxViewportWidth: '1200px',
+							minViewportWidth: '640px',
+						},
 					},
 				},
 				expected: 'clamp(16px, 1rem + ((1vw - 6.4px) * 0.179), 17px)',
 			},
-		].forEach( ( { message, preset, typographySettings, expected } ) => {
+		].forEach( ( { message, preset, settings, expected } ) => {
 			it( `${ message }`, () => {
-				expect(
-					getTypographyFontSizeValue( preset, typographySettings )
-				).toBe( expected );
+				expect( getTypographyFontSizeValue( preset, settings ) ).toBe(
+					expected
+				);
 			} );
 		} );
 	} );
@@ -587,7 +724,7 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'should return fluid settings with merged `layout.wideSize`d',
+					'should return fluid settings with merged `layout.wideSize`',
 				settings: {
 					typography: { fluid: { minFontSize: '16px' } },
 					layout: { wideSize: '1000rem' },

--- a/packages/block-editor/src/components/global-styles/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/typography-utils.js
@@ -40,15 +40,16 @@ import {
  * Takes into account fluid typography parameters and attempts to return a css formula depending on available, valid values.
  *
  * @param {Preset}                     preset
- * @param {Object}                     typographyOptions
- * @param {boolean|TypographySettings} typographyOptions.fluid Whether fluid typography is enabled, and, optionally, fluid font size options.
+ * @param {Object}                     settings
+ * @param {boolean|TypographySettings} settings.typography.fluid  Whether fluid typography is enabled, and, optionally, fluid font size options.
+ * @param {Object?}                    settings.typography.layout Layout options.
  *
  * @return {string|*} A font-size value or the value of preset.size.
  */
-export function getTypographyFontSizeValue( preset, typographyOptions ) {
+export function getTypographyFontSizeValue( preset, settings ) {
 	const { size: defaultSize } = preset;
 
-	if ( ! isFluidTypographyEnabled( typographyOptions ) ) {
+	if ( ! isFluidTypographyEnabled( settings?.typography ) ) {
 		return defaultSize;
 	}
 	/*
@@ -60,9 +61,11 @@ export function getTypographyFontSizeValue( preset, typographyOptions ) {
 		return defaultSize;
 	}
 
-	const fluidTypographySettings =
-		typeof typographyOptions?.fluid === 'object'
-			? typographyOptions?.fluid
+	let fluidTypographySettings =
+		getFluidTypographyOptionsFromSettings( settings );
+	fluidTypographySettings =
+		typeof fluidTypographySettings?.fluid === 'object'
+			? fluidTypographySettings?.fluid
 			: {};
 
 	const fluidFontSizeValue = getComputedFluidTypographyValue( {

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -24,10 +24,7 @@ import {
 	getBlockStyleVariationSelector,
 } from './utils';
 import { getBlockCSSSelector } from './get-block-css-selector';
-import {
-	getTypographyFontSizeValue,
-	getFluidTypographyOptionsFromSettings,
-} from './typography-utils';
+import { getTypographyFontSizeValue } from './typography-utils';
 import { GlobalStylesContext } from './context';
 import { useGlobalSetting } from './hooks';
 import { getDuotoneFilter } from '../duotone/utils';
@@ -431,7 +428,7 @@ export function getStylesDeclarations(
 			 */
 			ruleValue = getTypographyFontSizeValue(
 				{ size: ruleValue },
-				getFluidTypographyOptionsFromSettings( tree?.settings )
+				tree?.settings
 			);
 		}
 

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -6,10 +6,7 @@ import fastDeepEqual from 'fast-deep-equal/es6';
 /**
  * Internal dependencies
  */
-import {
-	getTypographyFontSizeValue,
-	getFluidTypographyOptionsFromSettings,
-} from './typography-utils';
+import { getTypographyFontSizeValue } from './typography-utils';
 import { getValueFromObjectPath } from '../../utils/object';
 
 /* Supporting data. */
@@ -77,10 +74,7 @@ export const PRESET_METADATA = [
 	{
 		path: [ 'typography', 'fontSizes' ],
 		valueFunc: ( preset, settings ) =>
-			getTypographyFontSizeValue(
-				preset,
-				getFluidTypographyOptionsFromSettings( settings )
-			),
+			getTypographyFontSizeValue( preset, settings ),
 		valueKey: 'size',
 		cssVarInfix: 'font-size',
 		classes: [ { classSuffix: 'font-size', propertyName: 'font-size' } ],

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -21,10 +21,7 @@ import {
 	shouldSkipSerialization,
 } from './utils';
 import { useSettings } from '../components/use-settings';
-import {
-	getTypographyFontSizeValue,
-	getFluidTypographyOptionsFromSettings,
-} from '../components/global-styles/typography-utils';
+import { getTypographyFontSizeValue } from '../components/global-styles/typography-utils';
 
 export const FONT_SIZE_SUPPORT_KEY = 'typography.fontSize';
 
@@ -151,8 +148,9 @@ export function useIsFontSizeDisabled( { name: blockName } = {} ) {
 }
 
 function useBlockProps( { name, fontSize, style } ) {
-	const [ typography, layout ] = useSettings(
-		'typography',
+	const [ fontSizes, fluidTypographySettings, layoutSettings ] = useSettings(
+		'typography.fontSizes',
+		'typography.fluid',
 		'layout'
 	);
 
@@ -176,7 +174,12 @@ function useBlockProps( { name, fontSize, style } ) {
 			style: {
 				fontSize: getTypographyFontSizeValue(
 					{ size: style.typography.fontSize },
-					{ typography, layout }
+					{
+						typography: {
+							fluid: fluidTypographySettings,
+						},
+						layout: layoutSettings,
+					}
 				),
 			},
 		};
@@ -186,7 +189,7 @@ function useBlockProps( { name, fontSize, style } ) {
 		props = {
 			style: {
 				fontSize: getFontSize(
-					typography?.fontSizes,
+					fontSizes,
 					fontSize,
 					style?.typography?.fontSize
 				).size,

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -151,9 +151,8 @@ export function useIsFontSizeDisabled( { name: blockName } = {} ) {
 }
 
 function useBlockProps( { name, fontSize, style } ) {
-	const [ fontSizes, fluidTypographySettings, layoutSettings ] = useSettings(
-		'typography.fontSizes',
-		'typography.fluid',
+	const [ typography, layout ] = useSettings(
+		'typography',
 		'layout'
 	);
 
@@ -173,18 +172,11 @@ function useBlockProps( { name, fontSize, style } ) {
 	let props;
 
 	if ( style?.typography?.fontSize ) {
-		const fluidSettings = getFluidTypographyOptionsFromSettings( {
-			typography: {
-				fluid: fluidTypographySettings,
-			},
-			layout: layoutSettings,
-		} );
-
 		props = {
 			style: {
 				fontSize: getTypographyFontSizeValue(
 					{ size: style.typography.fontSize },
-					fluidSettings
+					{ typography, layout }
 				),
 			},
 		};
@@ -194,7 +186,7 @@ function useBlockProps( { name, fontSize, style } ) {
 		props = {
 			style: {
 				fontSize: getFontSize(
-					fontSizes,
+					typography?.fontSizes,
 					fontSize,
 					style?.typography?.fontSize
 				).size,

--- a/packages/block-editor/src/hooks/use-typography-props.js
+++ b/packages/block-editor/src/hooks/use-typography-props.js
@@ -13,10 +13,7 @@ import { privateApis as componentsPrivateApis } from '@wordpress/components';
  */
 import { getInlineStyles } from './style';
 import { getFontSizeClass } from '../components/font-sizes';
-import {
-	getTypographyFontSizeValue,
-	getFluidTypographyOptionsFromSettings,
-} from '../components/global-styles/typography-utils';
+import { getTypographyFontSizeValue } from '../components/global-styles/typography-utils';
 import { unlock } from '../lock-unlock';
 
 /*
@@ -36,14 +33,11 @@ import { unlock } from '../lock-unlock';
 export function getTypographyClassesAndStyles( attributes, settings ) {
 	const { kebabCase } = unlock( componentsPrivateApis );
 	let typographyStyles = attributes?.style?.typography || {};
-	const fluidTypographySettings =
-		getFluidTypographyOptionsFromSettings( settings );
-
 	typographyStyles = {
 		...typographyStyles,
 		fontSize: getTypographyFontSizeValue(
 			{ size: attributes?.style?.typography?.fontSize },
-			fluidTypographySettings
+			settings
 		),
 	};
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -355,14 +355,14 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output' => null,
 			),
 
-			'returns value when fluid config is empty`'  => array(
+			'returns value when fluid is `false`'  => array(
 				'font_size'       => array(
 					'size'  => '28px',
 					'fluid' => false,
 				),
 				'settings'        => array(
 					'typography' => array(
-						'fluid' => true,
+						'fluid' => false,
 					),
 				),
 				'expected_output' => '28px',

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -355,7 +355,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output' => null,
 			),
 
-			'returns value when fluid is `false`'  => array(
+			'returns value when fluid is `false`'        => array(
 				'font_size'       => array(
 					'size'  => '28px',
 					'fluid' => false,

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -355,7 +355,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output' => null,
 			),
 
-			'returns value when fluid is `false`'        => array(
+			'returns value when fluid config is empty`'  => array(
 				'font_size'       => array(
 					'size'  => '28px',
 					'fluid' => false,
@@ -363,6 +363,18 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'settings'        => array(
 					'typography' => array(
 						'fluid' => true,
+					),
+				),
+				'expected_output' => '28px',
+			),
+
+			'returns value when fluid is empty array'    => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => array(),
 					),
 				),
 				'expected_output' => '28px',

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -299,11 +299,11 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *     @type string $slug Kebab-case unique identifier for the font size preset.
 	 *     @type string $size CSS font-size value, including units where applicable.
 	 * }
-	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
+	 * @param bool   $settings        Theme JSON settings array that overrides any global theme settings.
 	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
 	 */
-	public function test_gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography, $expected_output ) {
-		$actual = gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography );
+	public function test_gutenberg_get_typography_font_size_value( $font_size, $settings, $expected_output ) {
+		$actual = gutenberg_get_typography_font_size_value( $font_size, $settings );
 
 		$this->assertSame( $expected_output, $actual );
 	}
@@ -316,291 +316,591 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	public function data_generate_font_size_preset_fixtures() {
 		return array(
 			'returns value when fluid typography is deactivated' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '28px',
 				),
-				'should_use_fluid_typography' => false,
-				'expected_output'             => '28px',
+				'settings'        => null,
+				'expected_output' => '28px',
 			),
 
 			'returns value where font size is 0'         => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => 0,
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 0,
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 0,
 			),
 
 			"returns value where font size is '0'"       => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '0',
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => '0',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => '0',
 			),
 
 			'returns value where `size` is `null`'       => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => null,
 				),
-				'should_use_fluid_typography' => false,
-				'expected_output'             => null,
+				'settings'        => null,
+				'expected_output' => null,
 			),
 
 			'returns value when fluid is `false`'        => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '28px',
 					'fluid' => false,
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => '28px',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => '28px',
+			),
+
+			'returns clamp value with minViewportWidth override' => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => array(
+							'minViewportWidth' => '500px',
+						),
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 5px) * 0.918), 28px)',
+			),
+
+			'returns clamp value with maxViewportWidth override' => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => array(
+							'maxViewportWidth' => '500px',
+						),
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 5.608), 28px)',
+			),
+
+			'returns clamp value with layout.wideSize override' => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+					'layout'     => array(
+						'wideSize' => '500px',
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 5.608), 28px)',
 			),
 
 			'returns already clamped value'              => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 					'fluid' => false,
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
 			'returns value with unsupported unit'        => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '1000%',
 					'fluid' => false,
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => '1000%',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => '1000%',
 			),
 
 			'returns clamp value with rem min and max units' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '1.75rem',
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(1.119rem, 1.119rem + ((1vw - 0.2rem) * 0.789), 1.75rem)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(1.119rem, 1.119rem + ((1vw - 0.2rem) * 0.789), 1.75rem)',
 			),
 
 			'returns clamp value with em min and max units' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '1.75em',
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(1.119em, 1.119rem + ((1vw - 0.2em) * 0.789), 1.75em)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(1.119em, 1.119rem + ((1vw - 0.2em) * 0.789), 1.75em)',
 			),
 
 			'returns clamp value for floats'             => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '70.175px',
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(37.897px, 2.369rem + ((1vw - 3.2px) * 2.522), 70.175px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(37.897px, 2.369rem + ((1vw - 3.2px) * 2.522), 70.175px)',
 			),
 
 			'coerces integer to `px` and returns clamp value' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => 33,
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(20.515px, 1.282rem + ((1vw - 3.2px) * 0.975), 33px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(20.515px, 1.282rem + ((1vw - 3.2px) * 0.975), 33px)',
 			),
 
 			'coerces float to `px` and returns clamp value' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => 70.175,
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(37.897px, 2.369rem + ((1vw - 3.2px) * 2.522), 70.175px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(37.897px, 2.369rem + ((1vw - 3.2px) * 2.522), 70.175px)',
 			),
 
 			'returns clamp value when `fluid` is empty array' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '28px',
 					'fluid' => array(),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
 			),
 
 			'returns clamp value when `fluid` is `null`' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '28px',
 					'fluid' => null,
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
 			),
 
 			'returns clamp value where min and max fluid values defined' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '80px',
 					'fluid' => array(
 						'min' => '70px',
 						'max' => '125px',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(70px, 4.375rem + ((1vw - 3.2px) * 4.297), 125px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(70px, 4.375rem + ((1vw - 3.2px) * 4.297), 125px)',
 			),
 
 			'returns clamp value where max is equal to size' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '7.8125rem',
 					'fluid' => array(
 						'min' => '4.375rem',
 						'max' => '7.8125rem',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(4.375rem, 4.375rem + ((1vw - 0.2rem) * 4.298), 7.8125rem)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(4.375rem, 4.375rem + ((1vw - 0.2rem) * 4.298), 7.8125rem)',
 			),
 
 			'returns clamp value if min font size is greater than max' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '3rem',
 					'fluid' => array(
 						'min' => '5rem',
 						'max' => '32px',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(5rem, 5rem + ((1vw - 0.2rem) * -3.75), 32px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(5rem, 5rem + ((1vw - 0.2rem) * -3.75), 32px)',
 			),
 
 			'returns value with invalid min/max fluid units' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '10em',
 					'fluid' => array(
 						'min' => '20vw',
 						'max' => '50%',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => '10em',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => '10em',
 			),
 
 			'returns value when size is < lower bounds and no fluid min/max set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '3px',
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => '3px',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => '3px',
 			),
 
 			'returns value when size is equal to lower bounds and no fluid min/max set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '14px',
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => '14px',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => '14px',
 			),
 
 			'returns clamp value with different min max units' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '28px',
 					'fluid' => array(
 						'min' => '20px',
 						'max' => '50rem',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(20px, 1.25rem + ((1vw - 3.2px) * 60.938), 50rem)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(20px, 1.25rem + ((1vw - 3.2px) * 60.938), 50rem)',
 			),
 
 			'returns clamp value where no fluid max size is set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '50px',
 					'fluid' => array(
 						'min' => '2.6rem',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(2.6rem, 2.6rem + ((1vw - 0.2rem) * 0.656), 50px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(2.6rem, 2.6rem + ((1vw - 0.2rem) * 0.656), 50px)',
 			),
 
 			'returns clamp value where no fluid min size is set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '28px',
 					'fluid' => array(
 						'max' => '80px',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 4.851), 80px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 4.851), 80px)',
 			),
 
 			'should not apply lower bound test when fluid values are set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '1.5rem',
 					'fluid' => array(
 						'min' => '0.5rem',
 						'max' => '5rem',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(0.5rem, 0.5rem + ((1vw - 0.2rem) * 5.625), 5rem)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(0.5rem, 0.5rem + ((1vw - 0.2rem) * 5.625), 5rem)',
 			),
 
 			'should not apply lower bound test when only fluid min is set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '20px',
 					'fluid' => array(
 						'min' => '12px',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(12px, 0.75rem + ((1vw - 3.2px) * 0.625), 20px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(12px, 0.75rem + ((1vw - 3.2px) * 0.625), 20px)',
 			),
 
 			'should not apply lower bound test when only fluid max is set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '0.875rem',
 					'fluid' => array(
 						'max' => '20rem',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.2rem) * 23.906), 20rem)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(0.875rem, 0.875rem + ((1vw - 0.2rem) * 23.906), 20rem)',
 			),
 
 			'returns clamp value when min and max font sizes are equal' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '4rem',
 					'fluid' => array(
 						'min' => '30px',
 						'max' => '30px',
 					),
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(30px, 1.875rem + ((1vw - 3.2px) * 1), 30px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(30px, 1.875rem + ((1vw - 3.2px) * 1), 30px)',
 			),
 
 			'should apply scaled min font size for em values when custom min font size is not set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '12rem',
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(5.174rem, 5.174rem + ((1vw - 0.2rem) * 8.533), 12rem)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(5.174rem, 5.174rem + ((1vw - 0.2rem) * 8.533), 12rem)',
 			),
 
 			'should apply scaled min font size for px values when custom min font size is not set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size' => '200px',
 				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(85.342px, 5.334rem + ((1vw - 3.2px) * 8.958), 200px)',
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(85.342px, 5.334rem + ((1vw - 3.2px) * 8.958), 200px)',
 			),
 
 			'should not apply scaled min font size for minimum font size when custom min font size is set' => array(
-				'font_size'                   => array(
+				'font_size'       => array(
 					'size'  => '200px',
 					'fluid' => array(
 						'min' => '100px',
 					),
 				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => 'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
+			),
+		);
+	}
+
+	/**
+	 * Tests backwards compatibility for deprecated second argument $should_use_fluid_typography.
+	 *
+	 * @covers ::wp_get_typography_font_size_value
+	 *
+	 * @expectedDeprecated gutenberg_get_typography_font_size_value
+	 *
+	 * @dataProvider data_generate_font_size_preset_should_use_fluid_typography_deprecated_fixtures
+	 *
+	 * @param array  $font_size                     {
+	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
+	 *
+	 *     @type string $name Name of the font size preset.
+	 *     @type string $slug Kebab-case unique identifier for the font size preset.
+	 *     @type string $size CSS font-size value, including units where applicable.
+	 * }
+	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
+	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
+	 */
+	public function test_gutenberg_get_typography_font_size_value_should_use_fluid_typography_deprecated( $font_size, $should_use_fluid_typography, $expected_output ) {
+		$actual = gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography );
+
+		$this->assertSame( $expected_output, $actual );
+	}
+
+	/**
+	 * Data provider for test_wp_get_typography_font_size_value_should_use_fluid_typography_deprecated.
+	 *
+	 * @return array
+	 */
+	public function data_generate_font_size_preset_should_use_fluid_typography_deprecated_fixtures() {
+		return array(
+			'returns value when fluid typography is deactivated' => array(
+				'font_size'                   => array(
+					'size' => '28px',
+				),
+				'should_use_fluid_typography' => false,
+				'expected_output'             => '28px',
+			),
+			'returns clamp value when fluid typography is activated' => array(
+				'font_size'                   => array(
+					'size' => '28px',
+				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
+				'expected_output'             => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
+			),
+		);
+	}
+
+	/**
+	 * Tests that theme json settings passed to gutenberg_get_typography_font_size_value
+	 * override global theme settings.
+	 *
+	 * @covers ::gutenberg_get_typography_font_size_value
+	 *
+	 * @dataProvider data_generate_should_override_theme_settings_fixtures
+	 *
+	 * @param array  $font_size                     {
+	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
+	 *
+	 *     @type string $name Name of the font size preset.
+	 *     @type string $slug Kebab-case unique identifier for the font size preset.
+	 *     @type string $size CSS font-size value, including units where applicable.
+	 * }
+	 * @param bool   $settings        Theme JSON settings array that overrides any global theme settings.
+	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
+	 */
+	public function test_should_override_theme_settings( $font_size, $settings, $expected_output ) {
+		switch_theme( 'block-theme-child-with-fluid-typography' );
+		$actual = gutenberg_get_typography_font_size_value( $font_size, $settings );
+
+		$this->assertSame( $expected_output, $actual );
+	}
+
+	/**
+	 * Data provider for test_wp_get_typography_font_size_value_should_use_fluid_typography_deprecated.
+	 *
+	 * @return array
+	 */
+	public function data_generate_should_override_theme_settings_fixtures() {
+		return array(
+			'returns clamp value when theme activates fluid typography' => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => null,
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)',
+			),
+			'returns value when settings argument deactivates fluid typography' => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => false,
+					),
+				),
+				'expected_output' => '28px',
+			),
+
+			'returns clamp value when settings argument sets a fluid.minViewportWidth value' => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => array(
+							'minViewportWidth' => '500px',
+						),
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 5px) * 0.918), 28px)',
+			),
+
+			'returns clamp value when settings argument sets a layout.wideSize value' => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => array(
+					'layout' => array(
+						'wideSize' => '500px',
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 5.608), 28px)',
+			),
+
+			'returns clamp value with maxViewportWidth preferred over fallback layout.wideSize value' => array(
+				'font_size'       => array(
+					'size' => '28px',
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => array(
+							'maxViewportWidth' => '1000px',
+						),
+					),
+					'layout'     => array(
+						'wideSize' => '500px',
+					),
+				),
+				'expected_output' => 'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 1.485), 28px)',
 			),
 		);
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1395,15 +1395,18 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_stylesheet_generates_fluid_typography_values() {
-		register_block_type( 'test/clamp-me', array(
-			'api_version' => 3,
-		) );
+		register_block_type(
+			'test/clamp-me',
+			array(
+				'api_version' => 3,
+			)
+		);
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
 					'typography' => array(
-						'fluid' => true,
+						'fluid'     => true,
 						'fontSizes' => array(
 							array(
 								'size' => '16px',
@@ -1422,14 +1425,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'typography' => array(
 						'fontSize' => '1em',
 					),
-					'elements' => array(
+					'elements'   => array(
 						'h1' => array(
 							'typography' => array(
 								'fontSize' => '100px',
 							),
 						),
 					),
-					'blocks' => array(
+					'blocks'     => array(
 						'test/clamp-me' => array(
 							'typography' => array(
 								'fontSize' => '48px',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1444,12 +1444,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'default'
 		);
 
+		unregister_block_type( 'test/clamp-me' );
+
 		// Results also include root site blocks styles.
 		$this->assertSame(
 			'body{--wp--preset--font-size--pickles: clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.156), 16px);--wp--preset--font-size--toast: clamp(14.642px, 0.915rem + ((1vw - 3.2px) * 0.575), 22px);}body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}body{font-size: clamp(0.875em, 0.875rem + ((1vw - 0.2em) * 0.156), 1em);}h1{font-size: clamp(50.171px, 3.136rem + ((1vw - 3.2px) * 3.893), 100px);}.wp-block-test-clamp-me{font-size: clamp(27.894px, 1.743rem + ((1vw - 3.2px) * 1.571), 48px);}.has-pickles-font-size{font-size: var(--wp--preset--font-size--pickles) !important;}.has-toast-font-size{font-size: var(--wp--preset--font-size--toast) !important;}',
 			$theme_json->get_stylesheet()
 		);
-		unregister_block_type( 'test/clamp-me' );
 	}
 
 	public function test_allow_indirect_properties() {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1394,6 +1394,61 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_stylesheet_generates_fluid_typography_values() {
+		register_block_type( 'test/clamp-me', array(
+			'api_version' => 3,
+		) );
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'typography' => array(
+						'fluid' => true,
+						'fontSizes' => array(
+							array(
+								'size' => '16px',
+								'slug' => 'pickles',
+								'name' => 'Pickles',
+							),
+							array(
+								'size' => '22px',
+								'slug' => 'toast',
+								'name' => 'Toast',
+							),
+						),
+					),
+				),
+				'styles'   => array(
+					'typography' => array(
+						'fontSize' => '1em',
+					),
+					'elements' => array(
+						'h1' => array(
+							'typography' => array(
+								'fontSize' => '100px',
+							),
+						),
+					),
+					'blocks' => array(
+						'test/clamp-me' => array(
+							'typography' => array(
+								'fontSize' => '48px',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		// Results also include root site blocks styles.
+		$this->assertSame(
+			'body{--wp--preset--font-size--pickles: clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.156), 16px);--wp--preset--font-size--toast: clamp(14.642px, 0.915rem + ((1vw - 3.2px) * 0.575), 22px);}body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}body{font-size: clamp(0.875em, 0.875rem + ((1vw - 0.2em) * 0.156), 1em);}h1{font-size: clamp(50.171px, 3.136rem + ((1vw - 3.2px) * 3.893), 100px);}.wp-block-test-clamp-me{font-size: clamp(27.894px, 1.743rem + ((1vw - 3.2px) * 1.571), 48px);}.has-pickles-font-size{font-size: var(--wp--preset--font-size--pickles) !important;}.has-toast-font-size{font-size: var(--wp--preset--font-size--toast) !important;}',
+			$theme_json->get_stylesheet()
+		);
+		unregister_block_type( 'test/clamp-me' );
+	}
+
 	public function test_allow_indirect_properties() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(


### PR DESCRIPTION
This is a proof of concept so far. Once an approach is settled, I'll:

- [x] as much as practicable, synchronize the JS equivalent (`getTypographyFontSizeValue`)
- [x] update tests and add more test coverage (for typography and layout.wideSize overrides)
- [x]  think about whether we need a follow up to handle preset generation via `value_func`
- [x] create a Core patch to sync https://github.com/WordPress/wordpress-develop/pull/6477

## What?
Working on something that resolves https://github.com/WordPress/gutenberg/issues/58135

Updates the second argument of `gutenberg_get_typography_font_size_value()` to be a theme_json settings array.

Add a backwards compatibility condition to handle booleans.


## Why?
To get fluid typography settings, `gutenberg_get_typography_font_size_value()` calls `gutenberg_get_global_settings()`.

`gutenberg_get_global_settings()` fetches merged theme.json data via `WP_Theme_JSON_Resolver_Gutenberg`.

However, to generate a stylesheet, theme.json settings are often passed directly to `WP_Theme_JSON_Gutenberg`.

Consider the following (modified) example provided by @costasovo in https://github.com/WordPress/gutenberg/issues/58135

```php
$theme_json_data = '{
    "version": 2,
    "settings": {
    "typography": {
        "fluid": false,
        "fontSizes" : [
                {
                    "name": "unos",
                    "size": "12px",
                    "slug": "unos"
                },
                {
                    "name": "dos",
                    "size": "20px",
                    "slug": "dos"
                }
            ]
        }
    },
    "styles": {
        "color": {
            "text": "#000000",
            "background": "#ffffff"
        },
            "typography": {
            "fontSize": "48px"
        },
        "elements": {
            "h1": {
            "typography": {
                "fontSize": "48px"
            }
            }
        },
        "blocks": {
            "test/blog": {
            "typography": {
                "fontSize": "48px"
            }
            }
        }
    }
}';
$my_theme_json = new \WP_Theme_JSON_Gutenberg( json_decode( $theme_json_data, true ), 'default' );
$css = $my_theme_json->get_stylesheet();
```

Because typography block supports looks at the global settings only, the font sizes and CSS vars will have a `clamp()` value in the returned stylesheet if the current theme has fluid typography activated. 

This is despite the explicit "false" in `$themeJsonData`. 

## How?

Passing theme.json settings to `gutenberg_get_typography_font_size_value()` as the second argument.

These settings will override any global theme settings.

Currently the argument expects a boolean, so I've added a backwards compat check.

## Testing Instructions
Using a theme that has activated fluid typography, add the above PHP snippet somewhere in the code (e.g., the theme's functions.php file) and log the output of `get_stylesheet()`.

Check that you can override the global theme settings.

Because this PR touches all fluid typography functionality, we'll also need to test basic output:

1. Check that fluid typography works as before (no regressions)
2. Check that the preset editor clamp values match the frontend output. Custom values are broken since https://github.com/WordPress/gutenberg/pull/56912#discussion_r1452946735


For example, I've been comparing themes against trunk:

<img width="1260" alt="Screenshot 2024-01-30 at 11 53 17 am" src="https://github.com/WordPress/gutenberg/assets/6458278/6069a87b-94cf-48c3-a8fe-4802a98b7c55">


Also, run tests for glory!

JS
```
npm run test:unit packages/block-editor/src/components/global-styles/test/typography-utils.js
```

PHP
```
npm run test:unit:php:base -- --filter WP_Block_Supports_Typography_Test
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
