### PR TITLE
DataViews: in patterns page, show sync status filter by default

### DIFF
--- a/packages/dataviews/src/reset-filters.js
+++ b/packages/dataviews/src/reset-filters.js
@@ -4,17 +4,10 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function hasActiveFilters( view ) {
-	return (
-		view.search !== '' ||
-		view.filters?.some( ( { value } ) => value !== undefined )
-	);
-}
-
 export default function ResetFilter( { view, onChangeView } ) {
 	return (
 		<Button
-			disabled={ ! hasActiveFilters( view ) }
+			disabled={ view.search === '' && view.filters?.length === 0 }
 			__experimentalIsFocusable
 			size="compact"
 			variant="tertiary"

--- a/packages/dataviews/src/reset-filters.js
+++ b/packages/dataviews/src/reset-filters.js
@@ -4,10 +4,17 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+function hasActiveFilters( view ) {
+	return (
+		view.search !== '' ||
+		view.filters?.some( ( { value } ) => value !== undefined )
+	);
+}
+
 export default function ResetFilter( { view, onChangeView } ) {
 	return (
 		<Button
-			disabled={ view.search === '' && view.filters?.length === 0 }
+			disabled={ ! hasActiveFilters( view ) }
 			__experimentalIsFocusable
 			size="compact"
 			variant="tertiary"

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -83,7 +83,7 @@ const DEFAULT_VIEW = {
 	layout: {
 		...defaultConfigPerViewType[ LAYOUT_GRID ],
 	},
-	filters: [],
+	filters: [ { field: 'sync-status', operator: 'in', value: undefined } ],
 };
 
 const SYNC_FILTERS = [
@@ -278,6 +278,7 @@ export default function DataviewsPatterns() {
 			syncStatus: viewSyncStatus,
 		}
 	);
+
 	const fields = useMemo( () => {
 		const _fields = [
 			{


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
See alternative at https://github.com/WordPress/gutenberg/pull/58427

## What?

Makes the sync filter visible, but with no option selected by default.

Users can still remove it by "resetting the filters".

| Before | After | 
| --- | --- |
| <img width="1505" alt="Captura de ecrã 2024-01-29, às 10 56 28" src="https://github.com/WordPress/gutenberg/assets/583546/69c4ceea-62a2-46a7-b993-da67d6e1e3db"> | <img width="1505" alt="Captura de ecrã 2024-01-29, às 10 56 21" src="https://github.com/WordPress/gutenberg/assets/583546/6f549de5-f278-4606-afd2-32119e1cc421"> |

## Why?

To give the sync status filter more prominence.

## How?

Configures the default view to have it present.

## Testing Instructions

- Go to "Site Editor > Page patterns" and verify the filter is visible, but has no option selected.
- Verify that users can still remove it.