### PR TITLE
DataViews: Fix some small issues with featured image

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -282,6 +282,7 @@ export default function PagePages() {
 					<FeaturedImage item={ item } viewType={ view.type } />
 				),
 				enableSorting: false,
+				width: '1%',
 			},
 			{
 				header: __( 'Title' ),

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
@@ -62,6 +67,9 @@ function useView( postType ) {
 			return {
 				...defaultView,
 				type: layout,
+				layout: {
+					...( DEFAULT_CONFIG_PER_VIEW_TYPE[ layout ] || {} ),
+				},
 			};
 		}
 		return defaultView;
@@ -165,7 +173,6 @@ function FeaturedImage( { item, viewType } ) {
 		viewType === LAYOUT_GRID
 			? [ 'large', 'full', 'medium', 'thumbnail' ]
 			: [ 'thumbnail', 'medium', 'large', 'full' ];
-
 	const media = hasMedia ? (
 		<Media
 			className="edit-site-page-pages__featured-image"
@@ -173,26 +180,21 @@ function FeaturedImage( { item, viewType } ) {
 			size={ size }
 		/>
 	) : null;
-
+	if ( viewType === LAYOUT_LIST ) {
+		return media;
+	}
 	return (
-		<span
-			className={ {
+		<button
+			className={ classNames( 'page-pages-preview-field__button', {
 				'edit-site-page-pages__media-wrapper':
 					viewType === LAYOUT_TABLE,
-			} }
+			} ) }
+			type="button"
+			onClick={ onClick }
+			aria-label={ item.title?.rendered || __( '(no title)' ) }
 		>
-			{ viewType === LAYOUT_LIST && media }
-			{ viewType !== LAYOUT_LIST && (
-				<button
-					className="page-pages-preview-field__button"
-					type="button"
-					onClick={ onClick }
-					aria-label={ item.title?.rendered || __( '(no title)' ) }
-				>
-					{ media }
-				</button>
-			) }
-		</span>
+			{ media }
+		</button>
 	);
 }
 

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -17,8 +17,8 @@
 	}
 
 	&.edit-site-page-pages__media-wrapper {
-		width: $grid-unit-50;
-		height: $grid-unit-50;
+		width: $grid-unit-40;
+		height: $grid-unit-40;
 		display: block;
 		border-radius: $grid-unit-05;
 		position: relative;

--- a/packages/edit-site/src/components/page-pages/style.scss
+++ b/packages/edit-site/src/components/page-pages/style.scss
@@ -1,30 +1,3 @@
-.edit-site-page-pages__media-wrapper {
-	width: $grid-unit-50;
-	height: $grid-unit-50;
-	display: block;
-	border-radius: $grid-unit-05;
-	position: relative;
-	background-color: $gray-100;
-	overflow: hidden;
-
-	.edit-site-page-pages__featured-image {
-		height: 100%;
-		object-fit: cover;
-		width: 100%;
-	}
-
-	&::after {
-		border-radius: 4px;
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-		content: "";
-		height: 100%;
-		left: 0;
-		position: absolute;
-		top: 0;
-		width: 100%;
-	}
-}
-
 .page-pages-preview-field__button {
 	box-shadow: none;
 	border: none;
@@ -41,5 +14,33 @@
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
+	}
+
+	&.edit-site-page-pages__media-wrapper {
+		width: $grid-unit-50;
+		height: $grid-unit-50;
+		display: block;
+		border-radius: $grid-unit-05;
+		position: relative;
+		background-color: $gray-100;
+		overflow: hidden;
+		flex-grow: 0 !important;
+
+		.edit-site-page-pages__featured-image {
+			height: 100%;
+			object-fit: cover;
+			width: 100%;
+		}
+
+		&::after {
+			border-radius: 4px;
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+			content: "";
+			height: 100%;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
 	}
 }

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -42,7 +42,7 @@ const DEFAULT_PAGE_BASE = {
 	// better to keep track of the hidden ones.
 	hiddenFields: [ 'date', 'featured-image' ],
 	layout: {
-		...DEFAULT_CONFIG_PER_VIEW_TYPE[ LAYOUT_LIST ],
+		...DEFAULT_CONFIG_PER_VIEW_TYPE[ LAYOUT_TABLE ],
 	},
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently if we are in the `Manage all pages` page and in `table` view, we cannot select the `featured image` field to be shown.

Additionally I'm removing an extra wrapper we had for the featured image and fixed a bug, where we weren't adding a css class conditionally. 



## Testing Instructions 
1. Go `Manage all pages` page
4. test that you can show the `featured image` field through the options when in `table` view. Verify that is displayed as should. Noting that the column cannot be smaller due to the field's `header`.
5. Verify that the `featured image` field is displayed as expect in the other views(list and grid).
