### PR TITLE
Block Hooks API: Remove $post check from Navigation hooked blocks meta fn

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1397,10 +1397,6 @@ function block_core_navigation_insert_hooked_blocks( $inner_blocks, $post = null
  * @param WP_Post $post Post object.
  */
 function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
-	if ( ! isset( $post->ID ) ) {
-		return;
-	}
-
 	// We run the Block Hooks mechanism so it will return the list of ignored hooked blocks
 	// in the mock root Navigation block's metadata attribute.
 	// We ignore the rest of the returned `$markup`; `$post->post_content` already has the hooked


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove the check on `$post->ID` _and_ silent return in `block_core_navigation_update_ignore_hooked_blocks_meta` since Core guarantees its existence.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This part of the code was picked up during the package updates for 6.5 [here](https://github.com/WordPress/wordpress-develop/pull/5922#discussion_r1469428475). Core pretty much guarantees this data will be available within the callback as seen [here](https://github.com/WordPress/wordpress-develop/blob/9b0d0af28bf508969d505a6883906e7cefc47a33/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L676-L708) and [here](https://github.com/WordPress/wordpress-develop/blob/9b0d0af28bf508969d505a6883906e7cefc47a33/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L879-L894).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This removes the code which executes a silent return on an unnecessary check.

## Testing Instructions

If required, regression testing steps on this feature can be found on this PR https://github.com/WordPress/gutenberg/pull/57754