### PR TITLE
Block Hooks API: Update Navigation block feature gate

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -192,7 +192,7 @@ class WP_Navigation_Block_Renderer {
 			// it encounters whitespace. This code strips it.
 			$blocks = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
 
-			if ( function_exists( 'get_hooked_blocks' ) ) {
+			if ( function_exists( 'get_hooked_block_markup' ) ) {
 				// Run Block Hooks algorithm to inject hooked blocks.
 				$markup         = block_core_navigation_insert_hooked_blocks( $blocks, $navigation_post );
 				$root_nav_block = parse_blocks( $markup )[0];
@@ -987,7 +987,7 @@ function block_core_navigation_get_fallback_blocks() {
 		// In this case default to the (Page List) fallback.
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 
-		if ( function_exists( 'get_hooked_blocks' ) ) {
+		if ( function_exists( 'get_hooked_block_markup' ) ) {
 			// Run Block Hooks algorithm to inject hooked blocks.
 			// We have to run it here because we need the post ID of the Navigation block to track ignored hooked blocks.
 			$markup = block_core_navigation_insert_hooked_blocks( $fallback_blocks, $navigation_post );
@@ -1415,7 +1415,7 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 
 // Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.4
 // that are not present in Gutenberg's WP 6.4 compatibility layer.
-if ( function_exists( 'get_hooked_blocks' ) ) {
+if ( function_exists( 'get_hooked_block_markup' ) ) {
 	add_action( 'rest_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta', 10, 3 );
 }
 
@@ -1447,6 +1447,6 @@ function block_core_navigation_insert_hooked_blocks_into_rest_response( $respons
 
 // Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.4
 // that are not present in Gutenberg's WP 6.4 compatibility layer.
-if ( function_exists( 'get_hooked_blocks' ) ) {
+if ( function_exists( 'get_hooked_block_markup' ) ) {
 	add_filter( 'rest_prepare_wp_navigation', 'block_core_navigation_insert_hooked_blocks_into_rest_response', 10, 3 );
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1413,8 +1413,8 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 	}
 }
 
-// Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.4
-// that are not present in Gutenberg's WP 6.4 compatibility layer.
+// Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
+// that are not present in Gutenberg's WP 6.5 compatibility layer.
 if ( function_exists( 'get_hooked_block_markup' ) ) {
 	add_action( 'rest_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta', 10, 3 );
 }
@@ -1445,8 +1445,8 @@ function block_core_navigation_insert_hooked_blocks_into_rest_response( $respons
 	return $response;
 }
 
-// Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.4
-// that are not present in Gutenberg's WP 6.4 compatibility layer.
+// Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
+// that are not present in Gutenberg's WP 6.5 compatibility layer.
 if ( function_exists( 'get_hooked_block_markup' ) ) {
 	add_filter( 'rest_prepare_wp_navigation', 'block_core_navigation_insert_hooked_blocks_into_rest_response', 10, 3 );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the feature gate for usage of the Block Hooks API to insert inner blocks into the core Navigation block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We were previously checking for `get_hooked_blocks` to gate this feature against WordPress 6.3 and below, however this feature also depends upon the metadata `ignoredHookedBlocks` functionality to work correctly which isn't present within WordPress 6.4, [resulting in a bug surfacing itself](https://github.com/WordPress/gutenberg/pull/57754#issuecomment-1914846569). 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've updated the feature gate to check for the function responsible for the `ignoredHookedBlocks` logic that we need, which prevents this running on WP 6.4 until compat code is ported over.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

**On WP 6.4**

1. Add the below code to your themes function file and check on the frontend and within the Editor that the Search block does not get inserted into your Navigation

**On WP 6.5 Beta**

1. Add the below code to your themes functions file to register the core/search block as an inner block
3. Load header template part, change the width of the Search block and save template part
4. Load frontend and check that only 1 Search block is rendered.

```php
function register_navigation_last_child( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'core/navigation' && $position === 'last_child' ) {
		$hooked_blocks[] = 'core/search';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'register_navigation_last_child', 10, 4 );
```
