### PR TITLE
Search block: Update docs with removed attributes

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -9,10 +9,9 @@
  * Dynamically renders the `core/search` block.
  *
  * @since 6.3.0 Using block.json `viewScript` to register script, and update `view_script_handles()` only when needed.
+ * @since 6.5.0 $content and $block parameters are no longer used.
  *
- * @param array    $attributes The block attributes.
- * @param string   $content    The saved content.
- * @param WP_Block $block      The parsed block.
+ * @param array $attributes The block attributes.
  *
  * @return string The search block markup.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Remove not used params in `render_block_core_search` function. Added a removal comment.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Requested in https://github.com/WordPress/wordpress-develop/pull/5922#discussion_r1469463802


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a filter to `render_block_core_search` or replace and use `$block` or `$content`. They should still be available in your functions. 
