### PR TITLE
core-data: Memoize `getEntitiesConfig` selector

### DIFF
--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -230,10 +230,11 @@ export function getEntitiesByKind( state: State, kind: string ): Array< any > {
  *
  * @return Array of entities with config matching kind.
  */
-export function getEntitiesConfig( state: State, kind: string ): Array< any > {
-	return state.entities.config.filter( ( entity ) => entity.kind === kind );
-}
-
+export const getEntitiesConfig = createSelector(
+	( state: State, kind: string ): Array< any > =>
+		state.entities.config.filter( ( entity ) => entity.kind === kind ),
+	( state: State, kind: string ) => state.entities.config
+);
 /**
  * Returns the entity config given its kind and name.
  *


### PR DESCRIPTION
## What?
This PR suggests memoizing the `getEntitiesConfig()` config selector. Spotted while reviewing some other PRs.

cc @jsnajdr and @ellatrix as I know they've been working to optimize some selectors (and remove some needlessly memoized ones).

## Why?
Because it will return a new array on every call (only because `.filter()` returns a new array), and in many cases, that's wasteful, as the underlying data hasn't changed. Cases like this are some of the reasons why we're memoizing selectors in the first place.

In my testing, this reduces the selector calls by 5 times during a standard site editor load. Then a few more calls are completely removed when opening the inserter. I don't see substantial improvements in the performance test results, but the more different entities are requested, the better the improvement will be.

## How?
We're straightforwardly using `createSelector()`.

## Testing Instructions
Verify all checks are green - this is well covered by tests.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
