### PR TITLE
Fix theme font sizes not working when the slug matches Gutenberg defaults

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -155,7 +155,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		array(
 			'path'              => array( 'typography', 'fontSizes' ),
-			'prevent_override'  => array( 'typography', 'defaultFontSizes' ),
+			'prevent_override'  => false,
 			'use_default_names' => true,
 			'value_func'        => 'gutenberg_get_typography_font_size_value',
 			'css_vars'          => '--wp--preset--font-size--$slug',


### PR DESCRIPTION
## What?
This is an attempt to fix https://github.com/WordPress/gutenberg/issues/57889.

I must say that I am not familiar with this part of the codebase so maybe this is not the right approach.

## Why?
Right now, if a theme defines a fontSize with the same slug as Gutenberg defaults (small, medium, large, etc.), the value is overridden by the Gutenberg default value.

## How?
I just changed the `prevent_override` option to false, which seems to allow themes to override Gutenberg defaults.

## Testing Instructions
* In a site, install a theme with fontSizes defined in the `theme.json` using the `slug` and name "small" and a size you can identify:
```
        {
          "fluid": false,
          "name": "Small",
          "size": "20px",
          "slug": "small"
        },
```
You can do the same with medium and large.
* In a page or in the Site editor, go to the styles of a paragraph and check that the value defined by the theme is applied. Before this pull request it applies Gutenberg value.
* Go to the frontend and check that works as well.
* Remove the "small" font size you added.
* Check now that the "small" font size is still there but with the Gutenberg default value.
