### PR TITLE
Font Library: remove font family and font face preview keys from theme.json schema

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -190,7 +190,7 @@ Settings related to typography.
 | textTransform | boolean | true |  |
 | dropCap | boolean | true |  |
 | fontSizes | array |  | fluid, name, size, slug |
-| fontFamilies | array |  | fontFace, fontFamily, name, preview, slug |
+| fontFamilies | array |  | fontFace, fontFamily, name, slug |
 
 ---
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -435,7 +435,6 @@ class WP_Theme_JSON_Gutenberg {
 			'fontFamily' => null,
 			'name'       => null,
 			'slug'       => null,
-			'preview'    => null,
 			'fontFace'   => array(
 				array(
 					'ascentOverride'        => null,
@@ -451,7 +450,6 @@ class WP_Theme_JSON_Gutenberg {
 					'sizeAdjust'            => null,
 					'src'                   => null,
 					'unicodeRange'          => null,
-					'preview'               => null,
 				),
 			),
 		),

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -643,10 +643,6 @@
 					"description": "CSS font-family value.",
 					"type": "string"
 				},
-				"preview": {
-					"description": "URL to a preview image of the font family.",
-					"type": "string"
-				},
 				"fontFace": {
 					"description": "Array of font-face declarations.",
 					"type": "array",
@@ -736,10 +732,6 @@
 							},
 							"unicodeRange": {
 								"description": "CSS unicode-range value.",
-								"type": "string"
-							},
-							"preview": {
-								"description": "URL to a preview image of the font face.",
 								"type": "string"
 							}
 						},


### PR DESCRIPTION
## What?
Font Library: remove font family and font face preview keys from theme.json schema

## Why?
See: https://github.com/WordPress/gutenberg/issues/58392

## How?
Removing the not longer needed key just added during the implementation process of the Font Library.
