### PR TITLE
Data views: Update styling details in list item layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -387,16 +387,14 @@
 				border-radius: $grid-unit-05;
 			}
 		}
-		h3 {
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
+		.dataviews-view-list__primary-field {
+			min-height: $grid-unit-05 * 5;
 		}
 	}
 
 	.dataviews-view-list__media-wrapper {
-		width: $grid-unit-40;
-		height: $grid-unit-40;
+		width: $grid-unit-50;
+		height: $grid-unit-50;
 		border-radius: $grid-unit-05;
 		overflow: hidden;
 		position: relative;
@@ -429,17 +427,13 @@
 
 	.dataviews-view-list__fields {
 		color: $gray-700;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		display: flex;
+		gap: $grid-unit-10;
+		flex-wrap: wrap;
+		font-size: 12px;
+		line-height: $grid-unit-20;
 
 		.dataviews-view-list__field {
-			margin-right: $grid-unit-15;
-
-			&:last-child {
-				margin-right: 0;
-			}
-
 			&:empty {
 				display: none;
 			}

--- a/packages/dataviews/src/view-list.js
+++ b/packages/dataviews/src/view-list.js
@@ -85,7 +85,11 @@ export default function ViewList( {
 								className="dataviews-view-list__item"
 								onClick={ () => onSelectionChange( [ item ] ) }
 							>
-								<HStack spacing={ 3 } justify="start">
+								<HStack
+									spacing={ 3 }
+									justify="start"
+									alignment="flex-start"
+								>
 									<div className="dataviews-view-list__media-wrapper">
 										{ mediaField?.render( { item } ) || (
 											<div className="dataviews-view-list__media-placeholder"></div>


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/58384.

## What?
Update various metrics in List layout's individual items.

## Why?
Polishing visual details.

## Testing Instructions
1. Enable data views experiment
2. Browse List layout in both Pages and Template management views


## Screenshots

| Pages before | Pages after |
| --- | --- |
| <img width="379" alt="Screenshot 2024-01-29 at 16 11 37" src="https://github.com/WordPress/gutenberg/assets/846565/62801b5c-87f6-40dd-9f79-87ae52bd5265"> | <img width="380" alt="Screenshot 2024-01-29 at 16 30 23" src="https://github.com/WordPress/gutenberg/assets/846565/46eafc80-e9e5-4e77-bee0-daff9e68d197"> |

* Values no longer truncate, resolving an issue where fields could be hidden when 'too many' were added.
* Fields will wrap as required (see Templates below).
* Fields font size reduced slightly.
* Thumbnail height now matches title + fields height (both 40px).


| Templates before | Templates after |
| --- | --- |
| <img width="381" alt="Screenshot 2024-01-29 at 16 36 38" src="https://github.com/WordPress/gutenberg/assets/846565/e185ef26-55ce-4a54-a09a-497cab555ca1"> | <img width="379" alt="Screenshot 2024-01-29 at 16 32 13" src="https://github.com/WordPress/gutenberg/assets/846565/bb44caf1-d8ed-49f7-8486-2ab4ff05ca9e"> |

* Preview aligns to the top of the container.
* Increased vertical space between fields to improve clarity.
