### PR TITLE
DataViews: Fix applied default layout props

### DIFF
--- a/packages/edit-site/src/components/page-templates-template-parts/index.js
+++ b/packages/edit-site/src/components/page-templates-template-parts/index.js
@@ -192,11 +192,13 @@ export default function PageTemplatesTemplateParts( { postType } ) {
 	const { params } = useLocation();
 	const { activeView = 'all', layout } = params;
 	const defaultView = useMemo( () => {
+		const usedType = window?.__experimentalAdminViews
+			? layout ?? DEFAULT_VIEW.type
+			: DEFAULT_VIEW.type;
 		return {
 			...DEFAULT_VIEW,
-			type: window?.__experimentalAdminViews
-				? layout ?? DEFAULT_VIEW.type
-				: DEFAULT_VIEW.type,
+			type: usedType,
+			layout: defaultConfigPerViewType[ usedType ],
 			filters:
 				activeView !== 'all'
 					? [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Addresses: https://github.com/WordPress/gutenberg/pull/58371#issuecomment-1915130216

There is a bug when applying the initial view when using the`layout` url param. We should always set the appropriate default layout params too.

## Testing Instructions
1. Visit http://localhost:8888/wp-admin/site-editor.php?path=%2Fwp_template%2Fall&layout=list and observe that the featured image is not available to show, under the view options->fields.

