### PR TITLE
getBlockSettings: avoid memoized selector with clientId

### DIFF
--- a/packages/block-editor/src/store/get-block-settings.js
+++ b/packages/block-editor/src/store/get-block-settings.js
@@ -11,12 +11,7 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { getValueFromObjectPath } from '../utils/object';
-import {
-	getBlockParents,
-	getBlockName,
-	getSettings,
-	getBlockAttributes,
-} from './selectors';
+import { getBlockName, getSettings, getBlockAttributes } from './selectors';
 
 const blockedPaths = [
 	'color',
@@ -132,22 +127,17 @@ export function hasMergedOrigins( value ) {
 
 export function getBlockSettings( state, clientId, ...paths ) {
 	const blockName = getBlockName( state, clientId );
-	const candidates = clientId
-		? [
-				clientId,
-				...getBlockParents( state, clientId, /* ascending */ true ),
-		  ].filter( ( candidateClientId ) => {
-				const candidateBlockName = getBlockName(
-					state,
-					candidateClientId
-				);
-				return hasBlockSupport(
-					candidateBlockName,
-					'__experimentalSettings',
-					false
-				);
-		  } )
-		: [];
+	const candidates = [];
+
+	if ( clientId ) {
+		let id = clientId;
+		do {
+			const name = getBlockName( state, id );
+			if ( hasBlockSupport( name, '__experimentalSettings', false ) ) {
+				candidates.push( id );
+			}
+		} while ( ( id = state.blocks.parents.get( id ) ) );
+	}
 
 	return paths.map( ( path ) => {
 		if ( blockedPaths.includes( path ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Calling getBlockParent( clientId ) causes a cache lookup which may be large for a large number of blocks. We don't need a stable reference in getBlockSettings so it should be faster to directly get the parents.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We use `getBlockSettings` within the inner blocks hook, and note that every list AND list item (even without nested lists) will run this hook, as well as galleries, quotes etc.

First run site editor load -3.2%, next runs seems to be around 1%...

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
