### PR TITLE
Script loader 6.4 compat: check for init hook completion

### DIFF
--- a/lib/compat/wordpress-6.4/script-loader.php
+++ b/lib/compat/wordpress-6.4/script-loader.php
@@ -17,7 +17,7 @@
  * @param WP_Scripts $scripts WP_Scripts object.
  */
 function gutenberg_update_wp_date_settings( $scripts ) {
-	if ( $scripts->query( 'wp-date', 'registered' ) ) {
+	if ( did_action( 'init' ) && $scripts->query( 'wp-date', 'registered' ) ) {
 		global $wp_locale;
 		// Calculate the timezone abbr (EDT, PST) if possible.
 		$timezone_string = get_option( 'timezone_string', 'UTC' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What, why, how?
Core [checks that the init hook is complete](https://github.com/ramonjd/wordpress-develop/blame/trunk/src/wp-includes/script-loader.php#L666) before trying to use the global `$wp_locale` value in [wp_default_packages_inline_scripts](https://github.com/ramonjd/wordpress-develop/blame/trunk/src/wp-includes/script-loader.php#L344), which is where the date settings are set for inline JS. 

This change backports that from Core.

> [!NOTE]
> No Core backport required as the changes from https://github.com/WordPress/gutenberg/pull/53931 were ported over in https://github.com/WordPress/wordpress-develop/pull/5101




## Testing Instructions
Test steps in https://github.com/WordPress/gutenberg/pull/53931 should work as expected.

