### PR TITLE
[RNMobile] Address Android E2E tests failure by setting fixed versions of Appium drivers

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -15,9 +15,7 @@ concurrency:
 jobs:
     test:
         runs-on: macos-12
-        # Disable for now until we fix failures in the job.
-        if: false
-        # if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
                 native-test-name: [gutenberg-editor-rendering]


### PR DESCRIPTION
**Related PRs:**
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6588

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Set fixed versions of Appium drivers to address failures in Android E2E tests encountered after merging https://github.com/WordPress/gutenberg/pull/58274.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes and re-enables Android E2E tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Appium drivers are cached using the checksum of the `package-lock.json` file ([reference](https://github.com/WordPress/gutenberg/blob/155b0ff5432a966418186c3f0b31672fbc156ee0/.github/workflows/rnmobile-android-runner.yml#L43-L44)). This implies that when this file is modified, the Appium drivers are installed. However, we are installing the most recent version which might be incompatible with the current Appium version as it can be read in the [Appium CLI documentation of `update` command](https://appium.io/docs/en/2.2/cli/extensions/#update):

> [...] By default, Appium will not automatically update any extension that has a revision in its major version, so as to prevent unintended breaking changes.

The usage of different versions can be seen in the CI jobs of release PRs:
- **Release 1.111.1:** [Used UIAutomator2 version `2.42.2` => Android E2E tests passed ✅.](https://github.com/WordPress/gutenberg/actions/runs/7629344490/job/20782551845#step:6:19)
- **Release 1.111.2:** [Used UIAutomator2 version `2.43.1` => Android E2E tests failed ❌.](https://github.com/WordPress/gutenberg/actions/runs/7674550396/job/20919320346#step:6:19)

For this reason, we are setting a fixed version for Appium drivers to address potential issues when running E2E tests.

Additionally, this PR reverts https://github.com/WordPress/gutenberg/pull/58376 to re-enable Android E2E tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
* Observe that `React Native E2E Tests (Android)` CI job succeeds.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A