### PR TITLE
Add spacing between input controls with custom values

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -4,6 +4,7 @@
 import {
 	BaseControl,
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -114,7 +115,7 @@ export default function SpacingSizesControl( {
 					/>
 				) }
 			</HStack>
-			{ renderControls() }
+			<VStack spacing={ 0.5 }>{ renderControls() }</VStack>
 		</fieldset>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A [tiny detail](https://rich.blog/tiny-details/), adding a small amount of space between the input controls, so when you have multiple custom values for padding or margin, the UI elements don't run into each other. 


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added a `VStack` with a spacing prop of `0.5`. I chose the small value (2px) to not displace the controls too much; just enough so that they don't clash. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a group block.
3. Add custom values for padding. 
4. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-29 at 15 19 30](https://github.com/WordPress/gutenberg/assets/1813435/0eb4412e-d776-44df-a688-f52724557d0e)|![CleanShot 2024-01-29 at 15 13 51](https://github.com/WordPress/gutenberg/assets/1813435/fcea3b64-c990-41ab-a730-1911ec5cbda5)|


