### PR TITLE
Font Library: Update font collection json schema

### DIFF
--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -7,6 +7,18 @@
 			"description": "JSON schema URI for font-collection.json.",
 			"type": "string"
 		},
+		"slug": {
+			"type": "string",
+			"description": "Slug of the font collection. Must be unique and URL friendly."
+		},
+		"name": {
+			"type": "string",
+			"description": "Name of the font collection."
+		},
+		"description": {
+			"type": "string",
+			"description": "Description of the font collection."
+		},
 		"font_families": {
 			"type": "array",
 			"description": "Array of font families ready to be installed",
@@ -14,10 +26,44 @@
 				"type": "object",
 				"properties": {
 					"font_family_settings": {
-						"description": "Font family settings as in theme.json",
-						"allOf": [
-							{ "$ref": "./theme.json#/definitions/fontFamily" }
-						]
+						"description": "Font family settings similar to theme.json but without fontFace key.",
+						"type": "object",
+						"properties": {
+							"name": {
+								"description": "Name of the font family preset, translatable.",
+								"type": "string"
+							},
+							"slug": {
+								"description": "Kebab-case unique identifier for the font family preset.",
+								"type": "string"
+							},
+							"fontFamily": {
+								"description": "CSS font-family value.",
+								"type": "string"
+							}
+						},
+						"additionalProperties": false
+					},
+					"font_faces": {
+						"description": "Array of font-face declarations.",
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"preview": {
+									"type": "string",
+									"description": "URL to a preview image of the font face"
+								},
+								"font_face_settings": {
+									"description": "Font face settings as in theme.json",
+									"allOf": [
+										{
+											"$ref": "./theme.json#/definitions/fontFace"
+										}
+									]
+								}
+							}
+						}
 					},
 					"categories": {
 						"type": "array",
@@ -25,6 +71,10 @@
 						"items": {
 							"type": "string"
 						}
+					},
+					"preview": {
+						"type": "string",
+						"description": "URL to a preview image of the font family"
 					}
 				},
 				"required": [ "font_family_settings" ],
@@ -50,5 +100,5 @@
 		}
 	},
 	"additionalProperties": false,
-	"required": [ "$schema", "font_families" ]
+	"required": [ "$schema", "slug", "name", "font_families" ]
 }

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -619,7 +619,30 @@
 							"description": "Font family presets for the font family selector.\nGenerates a single custom property (`--wp--preset--font-family--{slug}`) per preset value.",
 							"type": "array",
 							"items": {
-								"$ref": "#/definitions/fontFamily"
+								"type": "object",
+								"description": "Font family preset",
+								"properties": {
+									"name": {
+										"description": "Name of the font family preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the font family preset.",
+										"type": "string"
+									},
+									"fontFamily": {
+										"description": "CSS font-family value.",
+										"type": "string"
+									},
+									"fontFace": {
+										"description": "Array of font-face declarations.",
+										"type": "array",
+										"items": {
+											"$ref": "#/definitions/fontFace"
+										}
+									}
+								},
+								"additionalProperties": false
 							}
 						}
 					},
@@ -627,119 +650,90 @@
 				}
 			}
 		},
-		"fontFamily": {
+		"fontFace": {
 			"type": "object",
-			"description": "Font family preset",
 			"properties": {
-				"name": {
-					"description": "Name of the font family preset, translatable.",
-					"type": "string"
-				},
-				"slug": {
-					"description": "Kebab-case unique identifier for the font family preset.",
-					"type": "string"
-				},
 				"fontFamily": {
 					"description": "CSS font-family value.",
-					"type": "string"
+					"type": "string",
+					"default": ""
 				},
-				"fontFace": {
-					"description": "Array of font-face declarations.",
-					"type": "array",
-					"items": {
-						"type": "object",
-						"properties": {
-							"fontFamily": {
-								"description": "CSS font-family value.",
-								"type": "string",
-								"default": ""
-							},
-							"fontStyle": {
-								"description": "CSS font-style value.",
-								"type": "string",
-								"default": "normal"
-							},
-							"fontWeight": {
-								"description": "List of available font weights, separated by a space.",
-								"default": "400",
-								"oneOf": [
-									{
-										"type": "string"
-									},
-									{
-										"type": "integer"
-									}
-								]
-							},
-							"fontDisplay": {
-								"description": "CSS font-display value.",
-								"type": "string",
-								"default": "fallback",
-								"enum": [
-									"auto",
-									"block",
-									"fallback",
-									"swap",
-									"optional"
-								]
-							},
-							"src": {
-								"description": "Paths or URLs to the font files.",
-								"oneOf": [
-									{
-										"type": "string"
-									},
-									{
-										"type": "array",
-										"items": {
-											"type": "string"
-										}
-									}
-								],
-								"default": []
-							},
-							"fontStretch": {
-								"description": "CSS font-stretch value.",
-								"type": "string"
-							},
-							"ascentOverride": {
-								"description": "CSS ascent-override value.",
-								"type": "string"
-							},
-							"descentOverride": {
-								"description": "CSS descent-override value.",
-								"type": "string"
-							},
-							"fontVariant": {
-								"description": "CSS font-variant value.",
-								"type": "string"
-							},
-							"fontFeatureSettings": {
-								"description": "CSS font-feature-settings value.",
-								"type": "string"
-							},
-							"fontVariationSettings": {
-								"description": "CSS font-variation-settings value.",
-								"type": "string"
-							},
-							"lineGapOverride": {
-								"description": "CSS line-gap-override value.",
-								"type": "string"
-							},
-							"sizeAdjust": {
-								"description": "CSS size-adjust value.",
-								"type": "string"
-							},
-							"unicodeRange": {
-								"description": "CSS unicode-range value.",
+				"fontStyle": {
+					"description": "CSS font-style value.",
+					"type": "string",
+					"default": "normal"
+				},
+				"fontWeight": {
+					"description": "List of available font weights, separated by a space.",
+					"default": "400",
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "integer"
+						}
+					]
+				},
+				"fontDisplay": {
+					"description": "CSS font-display value.",
+					"type": "string",
+					"default": "fallback",
+					"enum": [ "auto", "block", "fallback", "swap", "optional" ]
+				},
+				"src": {
+					"description": "Paths or URLs to the font files.",
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "array",
+							"items": {
 								"type": "string"
 							}
-						},
-						"required": [ "fontFamily", "src" ],
-						"additionalProperties": false
-					}
+						}
+					],
+					"default": []
+				},
+				"fontStretch": {
+					"description": "CSS font-stretch value.",
+					"type": "string"
+				},
+				"ascentOverride": {
+					"description": "CSS ascent-override value.",
+					"type": "string"
+				},
+				"descentOverride": {
+					"description": "CSS descent-override value.",
+					"type": "string"
+				},
+				"fontVariant": {
+					"description": "CSS font-variant value.",
+					"type": "string"
+				},
+				"fontFeatureSettings": {
+					"description": "CSS font-feature-settings value.",
+					"type": "string"
+				},
+				"fontVariationSettings": {
+					"description": "CSS font-variation-settings value.",
+					"type": "string"
+				},
+				"lineGapOverride": {
+					"description": "CSS line-gap-override value.",
+					"type": "string"
+				},
+				"sizeAdjust": {
+					"description": "CSS size-adjust value.",
+					"type": "string"
+				},
+				"unicodeRange": {
+					"description": "CSS unicode-range value.",
+					"type": "string"
 				}
 			},
+			"required": [ "fontFamily", "src" ],
 			"additionalProperties": false
 		},
 		"settingsPropertiesCustom": {


### PR DESCRIPTION
## What?
Update font collection JSON schema.

## Why?
To accommodate the changes added in:
- https://github.com/WordPress/gutenberg/pull/58395
- https://github.com/WordPress/gutenberg/pull/58363  

## How?
Updating the schema.

## Testing Instructions
- Create a JSON file with this content.
- Open this file in an editor like VS code, you should not see any validation errors. Apart from that, you should have autocomplete properties utility and error highlighting working.

```json
{
    "$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/c637a411be0b6a73d5f73260cc4b83e6e27cb65e/schemas/json/font-collection.json",
    "name": "My Font Collection",
    "slug": "my-font-collection",
    "description": "A collection of my favorite fonts",
    "categories": [
        {
            "name": "sans-serif",
            "slug": "sans-serif"
        }
    ],
    "font_families": [
        {
            "preview": "https://example.com/preview.png",
            "font_family_settings": {
                "fontFamily": "Arial",
                "name": "Arial",
                "slug": "arial"
            },
            "categories": [
                "sans-serif"
            ],
            "font_faces": [
                {
                    "preview": "https://example.com/preview.png",
                    "font_face_settings": {
                        "fontFamily": "Arial",
                        "src": "https://example.com/arial.woff",
                        "fontWeight": "normal",
                        "fontStyle": "normal"
                    }
                }
            ]
        }
    ]
}
```

