### PR TITLE
Aspect ratio: remove support on the Group block for now

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -341,7 +341,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (aspectRatio, minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, button, gradients, heading, link, text), dimensions (minHeight), layout (allowSizingOnChildren), position (sticky), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, tagName, templateLock
 
 ## Heading

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -55,7 +55,6 @@
 			}
 		},
 		"dimensions": {
-			"aspectRatio": true,
 			"minHeight": true
 		},
 		"__experimentalBorder": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following on from feedback on #56897, let's remove aspect ratio support from the Group block for now.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Aspect ratio support is a natural fit for the Cover block where folks are actively using min-height controls and the block has a default min height, with everything centred by default. With the Group block, positioning controls aren't exposed by default, and the use case for aspect ratio there is quite nuanced (likely only really works well with particular Row and Stack blocks, and depending on the kind of contents in use)

So, until we have a solid use case for re-enabling it and/or a good way to hide the control until it's really needed, this PR proposes leaving Group block without aspect ratio support for WP 6.5. This will give us a bit more time to consider whether or not it should be included with the Group block further down the track, as it will be much easier to re-add the control than to remove it once it's in a major release.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the Group block's `block.json` file to remove aspect ratio support

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* With this PR applied, add a Group block to a post or page — there should be no aspect ratio control available
* Add a Cover block. There should still be an aspect ratio control available

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Group block dimensions | Cover block dimensions |
| --- | --- |
| <img width="302" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/a8dcda02-1eca-4a74-b2cb-7d7b724936de"> | <img width="298" alt="image" src="https://github.com/WordPress/gutenberg/assets/14988353/2891dc66-f7cf-43dd-acc5-290962872582"> |