### PR TITLE
Block toolbar: Add tranform to Gallery button when selecting multiple image blocks

### DIFF
--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -26,17 +26,25 @@ function BlockGroupToolbar() {
 
 	const { canInsertGallery, canRemove, variations } = useSelect(
 		( select ) => {
-			const { canRemoveBlocks } = select( blockEditorStore );
-			const { getBlockVariations, getBlockType } = select( blocksStore );
+			const {
+				canRemoveBlocks,
+				getBlockRootClientId,
+				getBlockTransformItems,
+			} = select( blockEditorStore );
+			const { getBlockVariations } = select( blocksStore );
 
-			const isGalleryBlockAvailable = !! getBlockType( 'core/gallery' );
-
-			const areAllBlocksImages = blocksSelection.every(
-				( { name } ) => name === 'core/image'
+			const rootClientId = getBlockRootClientId( blocksSelection[ 0 ] );
+			const possibleBlockTransformations = getBlockTransformItems(
+				blocksSelection,
+				rootClientId
+			);
+			const canTransformToGallery = possibleBlockTransformations.some(
+				( { name, isDisabled } ) =>
+					name === 'core/gallery' && ! isDisabled
 			);
 
 			return {
-				canInsertGallery: isGalleryBlockAvailable && areAllBlocksImages,
+				canInsertGallery: canTransformToGallery,
 				canRemove: canRemoveBlocks( clientIds ),
 				variations: getBlockVariations(
 					groupingBlockName,

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -4,7 +4,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { group, row, stack } from '@wordpress/icons';
+import { gallery, group, row, stack } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -24,12 +24,19 @@ function BlockGroupToolbar() {
 		useConvertToGroupButtonProps();
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
-	const { canRemove, variations } = useSelect(
+	const { canInsertGallery, canRemove, variations } = useSelect(
 		( select ) => {
 			const { canRemoveBlocks } = select( blockEditorStore );
-			const { getBlockVariations } = select( blocksStore );
+			const { getBlockVariations, getBlockType } = select( blocksStore );
+
+			const isGalleryBlockAvailable = !! getBlockType( 'core/gallery' );
+
+			const areAllBlocksImages = blocksSelection.every(
+				( { name } ) => name === 'core/image'
+			);
 
 			return {
+				canInsertGallery: isGalleryBlockAvailable && areAllBlocksImages,
 				canRemove: canRemoveBlocks( clientIds ),
 				variations: getBlockVariations(
 					groupingBlockName,
@@ -37,8 +44,16 @@ function BlockGroupToolbar() {
 				),
 			};
 		},
-		[ clientIds, groupingBlockName ]
+		[ blocksSelection, clientIds, groupingBlockName ]
 	);
+
+	const onConvertToGallery = () => {
+		const newBlocks = switchToBlockType( blocksSelection, 'core/gallery' );
+
+		if ( newBlocks && newBlocks.length > 0 ) {
+			replaceBlocks( clientIds, newBlocks );
+		}
+	};
 
 	const onConvertToGroup = ( layout ) => {
 		const newBlocks = switchToBlockType(
@@ -78,6 +93,13 @@ function BlockGroupToolbar() {
 
 	return (
 		<ToolbarGroup>
+			{ canInsertGallery && (
+				<ToolbarButton
+					icon={ gallery }
+					label={ _x( 'Gallery', 'block name' ) }
+					onClick={ onConvertToGallery }
+				/>
+			) }
 			<ToolbarButton
 				icon={ group }
 				label={ _x( 'Group', 'verb' ) }

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -27,17 +27,25 @@ function BlockGroupToolbar() {
 
 	const { canInsertGallery, canRemove, variations } = useSelect(
 		( select ) => {
-			const { canRemoveBlocks } = select( blockEditorStore );
-			const { getBlockVariations, getBlockType } = select( blocksStore );
+			const {
+				canRemoveBlocks,
+				getBlockRootClientId,
+				getBlockTransformItems,
+			} = select( blockEditorStore );
+			const { getBlockVariations } = select( blocksStore );
 
-			const isGalleryBlockAvailable = !! getBlockType( 'core/gallery' );
-
-			const areAllBlocksImages = blocksSelection.every(
-				( { name } ) => name === 'core/image'
+			const rootClientId = getBlockRootClientId( blocksSelection[ 0 ] );
+			const possibleBlockTransformations = getBlockTransformItems(
+				blocksSelection,
+				rootClientId
+			);
+			const canTransformToGallery = possibleBlockTransformations.some(
+				( { name, isDisabled } ) =>
+					name === 'core/gallery' && ! isDisabled
 			);
 
 			return {
-				canInsertGallery: isGalleryBlockAvailable && areAllBlocksImages,
+				canInsertGallery: canTransformToGallery,
 				canRemove: canRemoveBlocks( clientIds ),
 				variations: getBlockVariations(
 					groupingBlockName,
@@ -101,7 +109,10 @@ function BlockGroupToolbar() {
 			{ canInsertGallery && (
 				<ToolbarButton
 					icon={ gallery }
-					label={ _x( 'Gallery', 'block name' ) }
+					label={ _x(
+						'Gallery',
+						'action: convert blocks to gallery'
+					) }
 					onClick={ onConvertToGallery }
 				/>
 			) }

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -25,7 +25,7 @@ function BlockGroupToolbar() {
 		useConvertToGroupButtonProps();
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
-	const { canInsertGallery, canRemove, variations } = useSelect(
+	const { canTransformToGallery, canRemove, variations } = useSelect(
 		( select ) => {
 			const {
 				canRemoveBlocks,
@@ -39,13 +39,11 @@ function BlockGroupToolbar() {
 				blocksSelection,
 				rootClientId
 			);
-			const canTransformToGallery = possibleBlockTransformations.some(
-				( { name, isDisabled } ) =>
-					name === 'core/gallery' && ! isDisabled
-			);
-
 			return {
-				canInsertGallery: canTransformToGallery,
+				canTransformToGallery: possibleBlockTransformations.some(
+					( { name, isDisabled } ) =>
+						name === 'core/gallery' && ! isDisabled
+				),
 				canRemove: canRemoveBlocks( clientIds ),
 				variations: getBlockVariations(
 					groupingBlockName,
@@ -106,7 +104,7 @@ function BlockGroupToolbar() {
 
 	return (
 		<ToolbarGroup>
-			{ canInsertGallery && (
+			{ canTransformToGallery && (
 				<ToolbarButton
 					icon={ gallery }
 					label={ _x(

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -4,7 +4,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { group, row, stack, grid } from '@wordpress/icons';
+import { gallery, group, row, stack, grid } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -25,12 +25,19 @@ function BlockGroupToolbar() {
 		useConvertToGroupButtonProps();
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
-	const { canRemove, variations } = useSelect(
+	const { canInsertGallery, canRemove, variations } = useSelect(
 		( select ) => {
 			const { canRemoveBlocks } = select( blockEditorStore );
-			const { getBlockVariations } = select( blocksStore );
+			const { getBlockVariations, getBlockType } = select( blocksStore );
+
+			const isGalleryBlockAvailable = !! getBlockType( 'core/gallery' );
+
+			const areAllBlocksImages = blocksSelection.every(
+				( { name } ) => name === 'core/image'
+			);
 
 			return {
+				canInsertGallery: isGalleryBlockAvailable && areAllBlocksImages,
 				canRemove: canRemoveBlocks( clientIds ),
 				variations: getBlockVariations(
 					groupingBlockName,
@@ -38,8 +45,16 @@ function BlockGroupToolbar() {
 				),
 			};
 		},
-		[ clientIds, groupingBlockName ]
+		[ blocksSelection, clientIds, groupingBlockName ]
 	);
+
+	const onConvertToGallery = () => {
+		const newBlocks = switchToBlockType( blocksSelection, 'core/gallery' );
+
+		if ( newBlocks && newBlocks.length > 0 ) {
+			replaceBlocks( clientIds, newBlocks );
+		}
+	};
 
 	const onConvertToGroup = ( layout ) => {
 		const newBlocks = switchToBlockType(
@@ -83,6 +98,13 @@ function BlockGroupToolbar() {
 
 	return (
 		<ToolbarGroup>
+			{ canInsertGallery && (
+				<ToolbarButton
+					icon={ gallery }
+					label={ _x( 'Gallery', 'block name' ) }
+					onClick={ onConvertToGallery }
+				/>
+			) }
 			<ToolbarButton
 				icon={ group }
 				label={ _x( 'Group', 'action: convert blocks to group' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When a multi-selection contains only image blocks, expose a button in the block toolbar to quickly convert to the Gallery block.

Based on an idea from @tellthemachines while looking at the transforms in #57749

> [!NOTE]
> This is a fairly prominent button — I'm happy to close out this PR if it isn't desired behaviour

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Make it easier for folks to select image blocks and convert to a gallery. The assumption here is that if folks are selecting multiple image blocks, and no other blocks, converting to a gallery will be a common task, so it should be a bit more prominent.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the convert to group logic, add an additional toolbar item for converting to a Gallery block, exposed only if the transform "to" a Gallery block is available given the current block selection (i.e. the selection is only image blocks).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Select multiple image blocks in a post or template.
* In the block toolbar you should now see a Gallery icon next to the group, row, and stack buttons.
* Pressing the Gallery icon will transform the images into a Gallery block.
* Reselect images from within the Gallery — if they're selected as a child of a Gallery block, the Gallery toolbar item should not appear.
* Try selecting images alongside any other block — the Gallery option should not be available (i.e if the selection is not entirely of image blocks then we can't transform to the Gallery).
* For thoroughness, in a post or page containing images, open up the developer console and run `wp.blocks.unregisterBlockType( 'core/gallery' );` — after calling that, go to select multiple image blocks. The Gallery button should no longer be available.

## Screenshots or screencast <!-- if applicable -->

<img width="2548" height="1568" alt="image" src="https://github.com/user-attachments/assets/28a8aecd-a333-4a27-81f5-87db02882aca" />

https://github.com/WordPress/gutenberg/assets/14988353/ed720e38-660d-4326-a081-e71121b3b311