### PR TITLE
ConfirmDialog: Add `__next40pxDefaultSize` to buttons

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `ConfirmDialog`: Add `__next40pxDefaultSize` to buttons ([#58421](https://github.com/WordPress/gutenberg/pull/58421)).
+
 ### Bug Fix
 
 -   `Placeholder`: Fix Placeholder component padding when body text font size is changed ([#58323](https://github.com/WordPress/gutenberg/pull/58323)).

--- a/packages/components/src/confirm-dialog/component.tsx
+++ b/packages/components/src/confirm-dialog/component.tsx
@@ -96,6 +96,7 @@ const UnconnectedConfirmDialog = (
 						<Text>{ children }</Text>
 						<Flex direction="row" justify="flex-end">
 							<Button
+								__next40pxDefaultSize
 								ref={ cancelButtonRef }
 								variant="tertiary"
 								onClick={ handleEvent( onCancel ) }
@@ -103,6 +104,7 @@ const UnconnectedConfirmDialog = (
 								{ cancelLabel }
 							</Button>
 							<Button
+								__next40pxDefaultSize
 								ref={ confirmButtonRef }
 								variant="primary"
 								onClick={ handleEvent( onConfirm ) }


### PR DESCRIPTION
## What?

This PR adds a `__next40pxDefaultSize` prop to make the two buttons inside the `ConfirmDialog` component 40px tall. As a result, the issue reported in #58374 will also be closed.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/e90f6f4d-a069-4bed-afb1-0715dc427271) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/ecc89669-aa08-427b-a0f2-d6d7a0be4366) | 

## Why?

Support the consistent component effort in https://github.com/WordPress/gutenberg/issues/46734.

Also, for example, in the Site Editor's renameing modal, the button height is already 40px. By applying this PR, the height of the buttons in the rename/delete modal dialog will be unified.

![image](https://github.com/WordPress/gutenberg/assets/54422211/45d3de7b-3dbc-4a88-b822-11ed7f099448)
![image](https://github.com/WordPress/gutenberg/assets/54422211/fe0d8eda-cf2e-4b73-a828-ff64024f45a8)


## Testing Instructions

- Launch Storybook and access the following URL to check the button height: http://localhost:50240/?path=/story/components-experimental-confirmdialog--default
- Access the Site Editor and open a modal dialog where the `ConfirmDialog` component is used. For example, click the Delete button in the dropdown on the template page.
- Make sure the height of the button is 40px.
