### PR TITLE
Font size: Allow for custom font size handling

### DIFF
--- a/packages/block-editor/src/hooks/test/font-size.js
+++ b/packages/block-editor/src/hooks/test/font-size.js
@@ -20,6 +20,14 @@ import _fontSize from '../font-size';
 
 const noop = () => {};
 
+function addUseSettingFilter( callback ) {
+	addFilter(
+		'blockEditor.useSetting.before',
+		'test/useSetting.before',
+		callback
+	);
+}
+
 describe( 'useBlockProps', () => {
 	const blockSettings = {
 		save: () => noop,
@@ -37,35 +45,35 @@ describe( 'useBlockProps', () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
 		} );
+		removeFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before'
+		);
 	} );
 
 	it( 'should return preset classname', () => {
 		registerBlockType( blockSettings.name, blockSettings );
-		addFilter(
-			'blockEditor.useSetting.before',
-			'test/useSetting.before',
-			( result, path ) => {
-				if ( 'typography.fontSizes' === path ) {
-					return [
-						{
-							name: 'A larger font',
-							size: '32px',
-							slug: 'larger',
-						},
-					];
-				}
-
-				if ( 'typography.fluid' === path ) {
-					return false;
-				}
-
-				if ( 'layout' === path ) {
-					return {};
-				}
-
-				return result;
+		addUseSettingFilter( ( result, path ) => {
+			if ( 'typography.fontSizes' === path ) {
+				return [
+					{
+						name: 'A larger font',
+						size: '32px',
+						slug: 'larger',
+					},
+				];
 			}
-		);
+
+			if ( 'typography.fluid' === path ) {
+				return false;
+			}
+
+			if ( 'layout' === path ) {
+				return {};
+			}
+
+			return result;
+		} );
 
 		const { result } = renderHook( () =>
 			_fontSize.useBlockProps( {
@@ -85,25 +93,21 @@ describe( 'useBlockProps', () => {
 
 	it( 'should return custom font size', () => {
 		registerBlockType( blockSettings.name, blockSettings );
-		addFilter(
-			'blockEditor.useSetting.before',
-			'test/useSetting.before',
-			( result, path ) => {
-				if ( 'typography.fontSizes' === path ) {
-					return [];
-				}
-
-				if ( 'typography.fluid' === path ) {
-					return false;
-				}
-
-				if ( 'layout' === path ) {
-					return {};
-				}
-
-				return result;
+		addUseSettingFilter( ( result, path ) => {
+			if ( 'typography.fontSizes' === path ) {
+				return [];
 			}
-		);
+
+			if ( 'typography.fluid' === path ) {
+				return false;
+			}
+
+			if ( 'layout' === path ) {
+				return {};
+			}
+
+			return result;
+		} );
 
 		const { result } = renderHook( () =>
 			_fontSize.useBlockProps( {
@@ -126,25 +130,21 @@ describe( 'useBlockProps', () => {
 
 	it( 'should convert custom font sizes to fluid', () => {
 		registerBlockType( blockSettings.name, blockSettings );
-		addFilter(
-			'blockEditor.useSetting.before',
-			'test/useSetting.before',
-			( result, path ) => {
-				if ( 'typography.fontSizes' === path ) {
-					return [];
-				}
-
-				if ( 'typography.fluid' === path ) {
-					return true;
-				}
-
-				if ( 'layout' === path ) {
-					return {};
-				}
-
-				return result;
+		addUseSettingFilter( ( result, path ) => {
+			if ( 'typography.fontSizes' === path ) {
+				return [];
 			}
-		);
+
+			if ( 'typography.fluid' === path ) {
+				return true;
+			}
+
+			if ( 'layout' === path ) {
+				return {};
+			}
+
+			return result;
+		} );
 
 		const { result } = renderHook( () =>
 			_fontSize.useBlockProps( {
@@ -159,11 +159,6 @@ describe( 'useBlockProps', () => {
 		const { style } = result.current;
 		expect( style.fontSize ).toBe(
 			'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)'
-		);
-
-		removeFilter(
-			'blockEditor.useSetting.before',
-			'test/useSetting.before'
 		);
 	} );
 } );

--- a/packages/block-editor/src/hooks/test/font-size.js
+++ b/packages/block-editor/src/hooks/test/font-size.js
@@ -1,0 +1,169 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import {
+	getBlockTypes,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import _fontSize from '../font-size';
+
+const noop = () => {};
+
+describe( 'useBlockProps', () => {
+	const blockSettings = {
+		save: () => noop,
+		category: 'text',
+		title: 'font size title',
+		name: 'test/font-size',
+		supports: {
+			typography: {
+				fontSize: true,
+			},
+		},
+	};
+
+	afterEach( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'should return preset classname', () => {
+		registerBlockType( blockSettings.name, blockSettings );
+		addFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before',
+			( result, path ) => {
+				if ( 'typography.fontSizes' === path ) {
+					return [
+						{
+							name: 'A larger font',
+							size: '32px',
+							slug: 'larger',
+						},
+					];
+				}
+
+				if ( 'typography.fluid' === path ) {
+					return false;
+				}
+
+				if ( 'layout' === path ) {
+					return {};
+				}
+
+				return result;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			_fontSize.useBlockProps( {
+				name: blockSettings.name,
+				fontSize: 'larger',
+			} )
+		);
+		const { style, className } = result.current;
+		expect( className ).toBe( 'has-larger-font-size' );
+		expect( style.fontSize ).toBe( '32px' );
+
+		removeFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before'
+		);
+	} );
+
+	it( 'should return custom font size', () => {
+		registerBlockType( blockSettings.name, blockSettings );
+		addFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before',
+			( result, path ) => {
+				if ( 'typography.fontSizes' === path ) {
+					return [];
+				}
+
+				if ( 'typography.fluid' === path ) {
+					return false;
+				}
+
+				if ( 'layout' === path ) {
+					return {};
+				}
+
+				return result;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			_fontSize.useBlockProps( {
+				name: blockSettings.name,
+				style: {
+					typography: {
+						fontSize: '28px',
+					},
+				},
+			} )
+		);
+		const { style } = result.current;
+		expect( style.fontSize ).toBe( '28px' );
+
+		removeFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before'
+		);
+	} );
+
+	it( 'should convert custom font sizes to fluid', () => {
+		registerBlockType( blockSettings.name, blockSettings );
+		addFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before',
+			( result, path ) => {
+				if ( 'typography.fontSizes' === path ) {
+					return [];
+				}
+
+				if ( 'typography.fluid' === path ) {
+					return true;
+				}
+
+				if ( 'layout' === path ) {
+					return {};
+				}
+
+				return result;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			_fontSize.useBlockProps( {
+				name: blockSettings.name,
+				style: {
+					typography: {
+						fontSize: '28px',
+					},
+				},
+			} )
+		);
+		const { style } = result.current;
+		expect( style.fontSize ).toBe(
+			'clamp(17.905px, 1.119rem + ((1vw - 3.2px) * 0.789), 28px)'
+		);
+
+		removeFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before'
+		);
+	} );
+} );


### PR DESCRIPTION
## What?
Allow for custom font size handling in font size useBlockProps

### TODO

- [x] Work out why browsers are rendering an unexpected clamp value (in all logging the value looks find, e.g., in block hooks and blocks themselves, it's only in the browser I think) _Not sure why, but the output is okay. Seems to be a formula optimization_
- [x] Clean up tests, maybe add a couple more

## Why?
To fix a regression. See: https://github.com/WordPress/gutenberg/pull/56912#pullrequestreview-1822552911

## How?
Checking for the presence of a custom font size. If one exists, run it through `getTypographyFontSizeValue()`, which will return either the custom value or `clamp()` value if the theme supports fluid typography. 

## Testing Instructions
1. Fire up the branch locally or use https://playground.wordpress.net/gutenberg.html?pr=58422
2. Activate a theme that has fluid typography, e.g., 2023 or 2024
3. In the editor add a text block and give it a custom font size 
4. Observe that the font size is clamped.
