### PR TITLE
Drag and drop: Allow dropping within template parts

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -517,6 +517,7 @@ function BlockListBlockProvider( props ) {
 				__unstableIsFullySelected,
 				__unstableSelectionHasUnmergeableBlock,
 				isBlockBeingDragged,
+				isDraggingBlocks,
 				hasBlockMovingClientId,
 				canInsertBlockType,
 				getBlockRootClientId,
@@ -594,7 +595,9 @@ function BlockListBlockProvider( props ) {
 					blockEditingMode === 'disabled' &&
 					isBlockSubtreeDisabled( clientId ),
 				isOutlineEnabled: outlineMode,
-				hasOverlay: __unstableHasActiveBlockOverlayActive( clientId ),
+				hasOverlay:
+					__unstableHasActiveBlockOverlayActive( clientId ) &&
+					! isDraggingBlocks(),
 				initialPosition:
 					_isSelected && __unstableGetEditorMode() === 'edit'
 						? getSelectedBlocksInitialCaretPosition()

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -224,7 +224,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				blockType: getBlockType( blockName ),
 				parentLock: getTemplateLock( parentClientId ),
 				parentClientId,
-				isDropZoneDisabled: blockEditingMode !== 'default',
+				isDropZoneDisabled: blockEditingMode === 'disabled',
 				defaultLayout,
 			};
 		},

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -197,10 +197,9 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				__unstableGetEditorMode,
 				getTemplateLock,
 				getBlockRootClientId,
-				__unstableIsWithinBlockOverlay,
-				__unstableHasActiveBlockOverlayActive,
 				getBlockEditingMode,
 				getBlockSettings,
+				isDraggingBlocks,
 			} = unlock( select( blockEditorStore ) );
 			const { hasBlockSupport, getBlockType } = select( blocksStore );
 			const blockName = getBlockName( clientId );
@@ -219,15 +218,13 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 					blockName !== 'core/template' &&
 					! isBlockSelected( clientId ) &&
 					! hasSelectedInnerBlock( clientId, true ) &&
-					enableClickThrough,
+					enableClickThrough &&
+					! isDraggingBlocks(),
 				name: blockName,
 				blockType: getBlockType( blockName ),
 				parentLock: getTemplateLock( parentClientId ),
 				parentClientId,
-				isDropZoneDisabled:
-					blockEditingMode !== 'default' ||
-					__unstableHasActiveBlockOverlayActive( clientId ) ||
-					__unstableIsWithinBlockOverlay( clientId ),
+				isDropZoneDisabled: blockEditingMode !== 'default',
 				defaultLayout,
 			};
 		},

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -376,6 +376,10 @@ function EditorCanvas( {
 							: localRef.current?.parentNode
 					}
 					renderAppender={ renderAppender }
+					__unstableDisableDropZone={
+						// In template preview mode, disable drop zones at the root of the template.
+						renderingMode === 'template-locked' ? true : false
+					}
 				/>
 				<EditTemplateBlocksNotification contentRef={ localRef } />
 			</RecursionProvider>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #56182

Allow dragging blocks within template parts in the site editor. Also, ensure that dragging and dropping works correctly within the content area in `template-locked` mode (that is, template preview mode in the post editor, or while editing pages in the site editor).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently it's quite difficult for folks to drag blocks within a template into the header or footer areas as the editor canvas prevents users from doing so. It would be good to allow folks to be able to do this, though it does present an interesting challenge — how do folks know, before they let go of the mouse cursor, whether they are dropping within a template part, or just outside it?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update logic for `hasOverlay` so that it only applies when not dragging blocks
* Update `isDropZoneDisabled` so that it is not disabled if there is an overlay set
* Disable root drop zones in the template when in `template-locked` mode

## Questions for reviewer(s)

Is it a deal breaker that we can't see before dropping whether we're going to be dropping before, after, or within a template part? If it is a deal breaker, how might we visualise that a user will be dropping within a template part?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In the site editor, go to drag a block from within the main template area into a Header or Footer template part
2. With this PR applied, it should be possible to do so
3. Was it confusing trying to work out whether you were dropping within or next to a template part?
4. Double-check that for partially synced blocks, this PR doesn't allow you to drag between parts of the synced block that are locked
5. Also, double-check that in the post editor with template preview mode enabled, you can drag within the content area of the post, but not to anywhere within the template itself

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

Trying to drag within the Header template part drags to an adjacent position:

https://github.com/WordPress/gutenberg/assets/14988353/48863f9f-525e-4398-932c-8f86189e1909

### After

The user can now drag within the Header template part:

https://github.com/WordPress/gutenberg/assets/14988353/7227c387-471a-468c-8f63-71e34f384966
