### PR TITLE
DataViews: add primary filter API

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -201,6 +201,7 @@ Example:
 -   `enableHiding`: whether the field can be hidden. True by default.
 -   `filterBy`: configuration for the filters.
     - `operators`: the list of operators supported by the field.
+    - `isPrimary`: whether it is a primary filter. A primary filter is always visible and is not listed in the "Add filter" component, except for the list layout where it behaves like a secondary filter.
 
 ## Actions
 

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -38,11 +38,7 @@ function WithSeparators( { children } ) {
 }
 
 export default function AddFilter( { filters, view, onChangeView } ) {
-	const filtersToDisplay = filters.filter(
-		( filter ) => ! filter.isPrimary || view.type === LAYOUT_LIST
-	);
-
-	if ( filtersToDisplay.length === 0 ) {
+	if ( filters.length === 0 ) {
 		return null;
 	}
 
@@ -76,7 +72,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 		>
 			<WithSeparators>
 				<DropdownMenuGroup>
-					{ filtersToDisplay.map( ( filter ) => {
+					{ filters.map( ( filter ) => {
 						const filterInView = view.filters.find(
 							( f ) => f.field === filter.field
 						);

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -38,7 +38,12 @@ function WithSeparators( { children } ) {
 }
 
 export default function AddFilter( { filters, view, onChangeView } ) {
-	if ( filters.length === 0 ) {
+	let _filters = filters;
+	if ( view.type !== LAYOUT_LIST ) {
+		_filters = filters.filter( ( { isPrimary } ) => ! isPrimary );
+	}
+
+	if ( _filters.length === 0 ) {
 		return null;
 	}
 
@@ -72,7 +77,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 		>
 			<WithSeparators>
 				<DropdownMenuGroup>
-					{ filters.map( ( filter ) => {
+					{ _filters.map( ( filter ) => {
 						const filterInView = view.filters.find(
 							( f ) => f.field === filter.field
 						);

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -49,6 +49,22 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 		return acc;
 	}, 0 );
 
+	const isPrimary = ( field ) =>
+		filters.some( ( f ) => f.field === field && f.isPrimary );
+	let isDisabled = true;
+	if ( view.search !== '' ) {
+		isDisabled = false;
+	} else if (
+		view.filters?.length > 0 &&
+		( view.filters.some( ( filter ) => filter.value !== undefined ) ||
+			view.filters.some(
+				( filter ) =>
+					filter.value === undefined && ! isPrimary( filter.field )
+			) )
+	) {
+		isDisabled = false;
+	}
+
 	return (
 		<DropdownMenu
 			trigger={
@@ -243,9 +259,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					} ) }
 				</DropdownMenuGroup>
 				<DropdownMenuItem
-					disabled={
-						view.search === '' && view.filters?.length === 0
-					}
+					disabled={ isDisabled }
 					hideOnClick={ false }
 					onClick={ () => {
 						onChangeView( {

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -38,12 +38,9 @@ function WithSeparators( { children } ) {
 }
 
 export default function AddFilter( { filters, view, onChangeView } ) {
-	const filtersToDisplay = [];
-	filters.forEach( ( filter ) => {
-		if ( ! filter.isPrimary || view.type === LAYOUT_LIST ) {
-			filtersToDisplay.push( filter );
-		}
-	} );
+	const filtersToDisplay = filters.filter(
+		( filter ) => ! filter.isPrimary || view.type === LAYOUT_LIST
+	);
 
 	if ( filtersToDisplay.length === 0 ) {
 		return null;

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -51,10 +51,8 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 
 	const isPrimary = ( field ) =>
 		filters.some( ( f ) => f.field === field && f.isPrimary );
-	let isDisabled = true;
-	if ( view.search !== '' ) {
-		isDisabled = false;
-	} else if (
+	let isResetDisabled = true;
+	if (
 		view.filters?.length > 0 &&
 		( view.filters.some( ( filter ) => filter.value !== undefined ) ||
 			view.filters.some(
@@ -62,7 +60,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					filter.value === undefined && ! isPrimary( filter.field )
 			) )
 	) {
-		isDisabled = false;
+		isResetDisabled = false;
 	}
 
 	return (
@@ -259,7 +257,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 					} ) }
 				</DropdownMenuGroup>
 				<DropdownMenuItem
-					disabled={ isDisabled }
+					disabled={ isResetDisabled }
 					hideOnClick={ false }
 					onClick={ () => {
 						onChangeView( {

--- a/packages/dataviews/src/add-filter.js
+++ b/packages/dataviews/src/add-filter.js
@@ -38,12 +38,14 @@ function WithSeparators( { children } ) {
 }
 
 export default function AddFilter( { filters, view, onChangeView } ) {
-	let _filters = filters;
-	if ( view.type !== LAYOUT_LIST ) {
-		_filters = filters.filter( ( { isPrimary } ) => ! isPrimary );
-	}
+	const filtersToDisplay = [];
+	filters.forEach( ( filter ) => {
+		if ( ! filter.isPrimary || view.type === LAYOUT_LIST ) {
+			filtersToDisplay.push( filter );
+		}
+	} );
 
-	if ( _filters.length === 0 ) {
+	if ( filtersToDisplay.length === 0 ) {
 		return null;
 	}
 
@@ -77,7 +79,7 @@ export default function AddFilter( { filters, view, onChangeView } ) {
 		>
 			<WithSeparators>
 				<DropdownMenuGroup>
-					{ _filters.map( ( filter ) => {
+					{ filtersToDisplay.map( ( filter ) => {
 						const filterInView = view.filters.find(
 							( f ) => f.field === filter.field
 						);

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -26,8 +26,11 @@ const sanitizeOperators = ( field ) => {
 	);
 };
 
+const isPrimaryFilter = ( field ) => field.filterBy?.isPrimary;
+
 const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 	const filters = [];
+	const primaryFilters = [];
 	fields.forEach( ( field ) => {
 		if ( ! field.type ) {
 			return;
@@ -43,6 +46,18 @@ const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 				if ( ! field.elements?.length ) {
 					return;
 				}
+
+				if ( isPrimaryFilter( field ) ) {
+					primaryFilters.push( {
+						field: field.id,
+						name: field.header,
+						elements: field.elements,
+						operators,
+						isVisible: true,
+					} );
+					return;
+				}
+
 				filters.push( {
 					field: field.id,
 					name: field.header,
@@ -74,6 +89,16 @@ const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 				return null;
 			}
 
+			return (
+				<FilterSummary
+					key={ filter.field }
+					filter={ filter }
+					view={ view }
+					onChangeView={ onChangeView }
+				/>
+			);
+		} ),
+		...primaryFilters.map( ( filter ) => {
 			return (
 				<FilterSummary
 					key={ filter.field }

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -28,7 +28,6 @@ const sanitizeOperators = ( field ) => {
 
 const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 	const filters = [];
-	let primaryFilters = 0;
 	fields.forEach( ( field ) => {
 		if ( ! field.type ) {
 			return;
@@ -62,9 +61,6 @@ const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 						),
 					isPrimary,
 				} );
-				if ( isPrimary ) {
-					primaryFilters++;
-				}
 		}
 	} );
 
@@ -94,24 +90,15 @@ const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 		} ),
 	];
 
-	// Reset should be hidden when either:
-	//
-	// - the layout is list
-	// - or there is only one primary filter and none secondary filters
-	if (
-		view.type === LAYOUT_LIST ||
-		( filters.length === 1 && primaryFilters === 1 )
-	) {
-		return filterComponents;
+	if ( filterComponents.length > 1 && view.type !== LAYOUT_LIST ) {
+		filterComponents.push(
+			<ResetFilters
+				key="reset-filters"
+				view={ view }
+				onChangeView={ onChangeView }
+			/>
+		);
 	}
-
-	filterComponents.push(
-		<ResetFilters
-			key="reset-filters"
-			view={ view }
-			onChangeView={ onChangeView }
-		/>
-	);
 
 	return filterComponents;
 } );

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -51,15 +51,15 @@ const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 					name: field.header,
 					elements: field.elements,
 					operators,
-					isVisible: isPrimary
-						? true
-						: view.filters.some(
-								( f ) =>
-									f.field === field.id &&
-									[ OPERATOR_IN, OPERATOR_NOT_IN ].includes(
-										f.operator
-									)
-						  ),
+					isVisible:
+						isPrimary ||
+						view.filters.some(
+							( f ) =>
+								f.field === field.id &&
+								[ OPERATOR_IN, OPERATOR_NOT_IN ].includes(
+									f.operator
+								)
+						),
 					isPrimary,
 				} );
 				if ( isPrimary ) {

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -113,7 +113,7 @@ const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 	// Reset should be hidden when either:
 	//
 	// - the layout is list
-	// - or there is only one primary filter
+	// - or there is only one primary filter and none secondary filters
 	if (
 		( filters.length > 0 || primaryFilters > 1 ) &&
 		view.type !== LAYOUT_LIST

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -110,7 +110,14 @@ const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 		} ),
 	];
 
-	if ( filterComponents.length > 1 && view.type !== LAYOUT_LIST ) {
+	// Reset should be hidden when either:
+	//
+	// - the layout is list
+	// - or there is only one primary filter
+	if (
+		( filters.length > 0 || primaryFilters > 1 ) &&
+		view.type !== LAYOUT_LIST
+	) {
 		filterComponents.push(
 			<ResetFilters
 				key="reset-filters"

--- a/packages/dataviews/src/filters.js
+++ b/packages/dataviews/src/filters.js
@@ -94,6 +94,7 @@ const Filters = memo( function Filters( { fields, view, onChangeView } ) {
 		filterComponents.push(
 			<ResetFilters
 				key="reset-filters"
+				filters={ filters }
 				view={ view }
 				onChangeView={ onChangeView }
 			/>

--- a/packages/dataviews/src/reset-filters.js
+++ b/packages/dataviews/src/reset-filters.js
@@ -4,10 +4,26 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function ResetFilter( { view, onChangeView } ) {
+export default function ResetFilter( { filters, view, onChangeView } ) {
+	const isPrimary = ( field ) =>
+		filters.some( ( f ) => f.field === field && f.isPrimary );
+	let isDisabled = true;
+	if ( view.search !== '' ) {
+		isDisabled = false;
+	} else if (
+		view.filters?.length > 0 &&
+		( view.filters.some( ( filter ) => filter.value !== undefined ) ||
+			view.filters.some(
+				( filter ) =>
+					filter.value === undefined && ! isPrimary( filter.field )
+			) )
+	) {
+		isDisabled = false;
+	}
+
 	return (
 		<Button
-			disabled={ view.search === '' && view.filters?.length === 0 }
+			disabled={ isDisabled }
 			__experimentalIsFocusable
 			size="compact"
 			variant="tertiary"

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -320,6 +320,9 @@ export default function PagePages() {
 						value: id,
 						label: name,
 					} ) ) || [],
+				filterBy: {
+					isPrimary: true,
+				},
 			},
 			{
 				header: __( 'Status' ),

--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -320,9 +320,6 @@ export default function PagePages() {
 						value: id,
 						label: name,
 					} ) ) || [],
-				filterBy: {
-					isPrimary: true,
-				},
 			},
 			{
 				header: __( 'Status' ),
@@ -335,6 +332,7 @@ export default function PagePages() {
 				enableSorting: false,
 				filterBy: {
 					operators: [ OPERATOR_IN ],
+					isPrimary: true,
 				},
 			},
 			{

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -83,7 +83,7 @@ const DEFAULT_VIEW = {
 	layout: {
 		...defaultConfigPerViewType[ LAYOUT_GRID ],
 	},
-	filters: [ { field: 'sync-status', operator: 'in', value: undefined } ],
+	filters: [],
 };
 
 const SYNC_FILTERS = [
@@ -278,7 +278,6 @@ export default function DataviewsPatterns() {
 			syncStatus: viewSyncStatus,
 		}
 	);
-
 	const fields = useMemo( () => {
 		const _fields = [
 			{

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -325,6 +325,7 @@ export default function DataviewsPatterns() {
 				elements: SYNC_FILTERS,
 				filterBy: {
 					operators: [ OPERATOR_IN ],
+					isPrimary: true,
 				},
 				enableSorting: false,
 			} );


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Alternative to https://github.com/WordPress/gutenberg/pull/58367

## What?

This PR implements the primary filter API. Primary filters are always visible and not listed in the "Add filter" component unless the layout is the list view.

Patterns: a single primary filter.

https://github.com/WordPress/gutenberg/assets/583546/2edc7174-debc-4d8b-9a28-91c2eac2d47c

Pages: primary and secondary filters (**to remove before merging: it's only here to see how it works holistically.**):

https://github.com/WordPress/gutenberg/assets/583546/28c8ffa6-61d5-4ef6-98fa-09645d2ba348

## Why?

This would allow us to have filters that are permanently visible.

## How?

- Adds a `isPrimary` to `field.filterBy` API that consumers can use.
- Reset button:
  - Primary filters: it should reset its value.
  - Secondary filters: it should reset its value and remove them from UI (as of now). 
- AddComponent: work as before, lists both primary and secondary filters.

## Testing Instructions

Patterns:

- Visit the "Site Editor > Patterns" page and verify that there is a single primary filter (always visible).

Pages:

- Visit "Site Editor > Pages > Manage all pages".
- Verify that the "status" filter is always visible, unless the layout is list, in which case it'll be hidden.
- Verify that the reset works as expected:
  - reset the value of primary filters but do not remove them from UI
  - reset & remove from UI secondary filters

## Questions

See [answers](https://github.com/WordPress/gutenberg/pull/58427#issuecomment-1916669943).

- ~How users can tell apart primary and secondary filters when they are visible? Do we need to tell them apart?~
- ~How primary & secondary filters are sorted when they are visible? This PR keeps the order as it was. It's the consumer who controls the order (first declared, first displayed). They are listed in the same order in the AddComponent and in the summaries.~
