### PR TITLE
Search block - File block: Add deprecated vars to `render_callback` functions

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -8,13 +8,14 @@
 /**
  * When the `core/file` block is rendering, check if we need to enqueue the `wp-block-file-view` script.
  *
- * @param array    $attributes The block attributes.
- * @param string   $content    The block content.
- * @param WP_Block $block      The parsed block.
+ * @param array                $attributes The block attributes.
+ * @param string               $content    The block content.
+ * @deprecated 6.5.0 @param WP_Block $block The parsed block.
  *
  * @return string Returns the block content.
  */
-function render_block_core_file( $attributes, $content ) {
+//phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+function render_block_core_file( $attributes, $content, $deprecated_block ) {
 	// Update object's aria-label attribute if present in block HTML.
 	// Match an aria-label attribute from an object tag.
 	$pattern = '@<object.+(?<attribute>aria-label="(?<filename>[^"]+)?")@i';

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -11,12 +11,13 @@
  * @since 6.3.0 Using block.json `viewScript` to register script, and update `view_script_handles()` only when needed.
  *
  * @param array    $attributes The block attributes.
- * @param string   $content    The saved content.
- * @param WP_Block $block      The parsed block.
+ * @deprecated 6.5.0 @param string   $content    The saved content.
+ * @deprecated 6.5.0 @param WP_Block $block      The parsed block.
  *
  * @return string The search block markup.
  */
-function render_block_core_search( $attributes ) {
+//phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+function render_block_core_search( $attributes, $deprecated_content, $deprecated_block ) {
 	// Older versions of the Search block defaulted the label and buttonText
 	// attributes to `__( 'Search' )` meaning that many posts contain `<!--
 	// wp:search /-->`. Support these by defaulting an undefined label and


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In last Interactivity API changes, we added-removed the three variables that are passed through the render_callback.
As these functions may be have been used by external developers, we need to "deprecate them", but only in the docs.

`_deprecated_argument` is not being used, cause if it is added, it will appear in all blocks rendered, as the callback is always passing those values (even if they are not being used)

Doing this:
![Screenshot 2024-01-29 at 18 36 29](https://github.com/WordPress/gutenberg/assets/37012961/655f3a3a-fd7d-4912-b3ba-10391ebd4e44)

Would cause this:
![Screenshot 2024-01-29 at 18 35 26](https://github.com/WordPress/gutenberg/assets/37012961/6429688a-6357-4fa0-a312-c7f53e0e977a)

So the cleanest way to deal with this issue is to leave the variables, skip the linting issue, and add them as deprecated in the docs.
