### PR TITLE
Block Bindings: Change `core/pattern-attributes` source for `core/pattern-overrides`

### DIFF
--- a/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
@@ -35,7 +35,7 @@ function gutenberg_register_block_bindings_pattern_overrides_source() {
 	register_block_bindings_source(
 		'core/pattern-overrides',
 		array(
-			'label'              => _x( 'Pattern Overrides', 'Label for the block bindings source used for partially synced overrides' ),
+			'label'              => _x( 'Pattern Overrides', 'Label for the block bindings source used for synced pattern overrides' ),
 			'get_value_callback' => 'gutenberg_block_bindings_pattern_overrides_callback',
 		)
 	);

--- a/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
@@ -35,7 +35,7 @@ function gutenberg_register_block_bindings_pattern_overrides_source() {
 	register_block_bindings_source(
 		'core/pattern-overrides',
 		array(
-			'label'              => _x( 'Pattern Overrides', 'Label for the block bindings source used for synced pattern overrides' ),
+			'label'              => _x( 'Pattern Overrides', 'block bindings source' ),
 			'get_value_callback' => 'gutenberg_block_bindings_pattern_overrides_callback',
 		)
 	);

--- a/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
@@ -28,14 +28,14 @@ function gutenberg_block_bindings_pattern_overrides_callback( $source_attrs, $bl
 }
 
 function gutenberg_register_block_bindings_pattern_overrides_source() {
-	// Override the "core/pattern-attributes" source from core.
-	if ( array_key_exists( 'core/pattern-attributes', get_all_registered_block_bindings_sources() ) ) {
-		unregister_block_bindings_source( 'core/pattern-attributes' );
+	// Override the "core/pattern-overrides" source from core.
+	if ( array_key_exists( 'core/pattern-overrides', get_all_registered_block_bindings_sources() ) ) {
+		unregister_block_bindings_source( 'core/pattern-overrides' );
 	}
 	register_block_bindings_source(
-		'core/pattern-attributes',
+		'core/pattern-overrides',
 		array(
-			'label'              => __( 'Pattern Attributes' ),
+			'label'              => __( 'Pattern Overrides' ),
 			'get_value_callback' => 'gutenberg_block_bindings_pattern_overrides_callback',
 		)
 	);

--- a/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
@@ -35,7 +35,7 @@ function gutenberg_register_block_bindings_pattern_overrides_source() {
 	register_block_bindings_source(
 		'core/pattern-overrides',
 		array(
-			'label'              => __( 'Pattern Overrides' ),
+			'label'              => _x( 'Pattern Overrides', 'Label for the block bindings source used for partially synced overrides' ),
 			'get_value_callback' => 'gutenberg_block_bindings_pattern_overrides_callback',
 		)
 	);

--- a/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
@@ -35,7 +35,7 @@ function gutenberg_register_block_bindings_post_meta_source() {
 	register_block_bindings_source(
 		'core/post-meta',
 		array(
-			'label'              => _x( 'Post Meta', 'Label for the block bindings source used to connect with post meta' ),
+			'label'              => _x( 'Post Meta', 'block bindings source' ),
 			'get_value_callback' => 'gutenberg_block_bindings_post_meta_callback',
 		)
 	);

--- a/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
@@ -28,7 +28,7 @@ function gutenberg_register_block_bindings_post_meta_source() {
 	register_block_bindings_source(
 		'core/post-meta',
 		array(
-			'label'              => __( 'Post Meta' ),
+			'label'              => _x( 'Post Meta', 'Label for the block bindings source used to connect with post meta' ),
 			'get_value_callback' => 'gutenberg_block_bindings_post_meta_callback',
 		)
 	);

--- a/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/post-meta.php
@@ -17,6 +17,13 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs ) {
 		$post_id = get_the_ID();
 	}
 
+	// If a post isn't public, we need to prevent
+	// unauthorized users from accessing the post meta.
+	$post = get_post( $post_id );
+	if ( ( $post && 'publish' !== $post->post_status && ! current_user_can( 'read_post', $post_id ) ) || post_password_required( $post_id ) ) {
+		return null;
+	}
+
 	return get_post_meta( $post_id, $source_attrs['key'], true );
 }
 

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -45,14 +45,14 @@ function isPartiallySynced( block ) {
 		) &&
 		!! block.attributes.metadata?.bindings &&
 		Object.values( block.attributes.metadata.bindings ).some(
-			( binding ) => binding.source === 'core/pattern-attributes'
+			( binding ) => binding.source === 'core/pattern-overrides'
 		)
 	);
 }
 function getPartiallySyncedAttributes( block ) {
 	return Object.entries( block.attributes.metadata.bindings )
 		.filter(
-			( [ , binding ] ) => binding.source === 'core/pattern-attributes'
+			( [ , binding ] ) => binding.source === 'core/pattern-overrides'
 		)
 		.map( ( [ attributeKey ] ) => attributeKey );
 }

--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -22,7 +22,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			attributes.metadata?.bindings?.[ attributeName ]?.source
 	);
 	const isConnectedToOtherSources = attributeSources.every(
-		( source ) => source && source !== 'core/pattern-attributes'
+		( source ) => source && source !== 'core/pattern-overrides'
 	);
 
 	// Render nothing if all supported attributes are connected to other sources.
@@ -39,7 +39,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			for ( const attributeName of Object.keys( syncedAttributes ) ) {
 				if (
 					updatedBindings[ attributeName ]?.source ===
-					'core/pattern-attributes'
+					'core/pattern-overrides'
 				) {
 					delete updatedBindings[ attributeName ];
 				}
@@ -59,7 +59,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 		for ( const attributeName of Object.keys( syncedAttributes ) ) {
 			if ( ! updatedBindings[ attributeName ] ) {
 				updatedBindings[ attributeName ] = {
-					source: 'core/pattern-attributes',
+					source: 'core/pattern-overrides',
 				};
 			}
 		}
@@ -94,7 +94,7 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 					__nextHasNoMarginBottom
 					label={ __( 'Allow instance overrides' ) }
 					checked={ attributeSources.some(
-						( source ) => source === 'core/pattern-attributes'
+						( source ) => source === 'core/pattern-overrides'
 					) }
 					onChange={ ( isChecked ) => {
 						updateBindings( isChecked );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -92,7 +92,7 @@ test.describe( 'Pattern Overrides', () => {
 							id: expect.any( String ),
 							bindings: {
 								content: {
-									source: 'core/pattern-attributes',
+									source: 'core/pattern-overrides',
 								},
 							},
 						},
@@ -222,7 +222,7 @@ test.describe( 'Pattern Overrides', () => {
 		const paragraphId = 'paragraph-id';
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
-			content: `<!-- wp:paragraph {"metadata":{"id":"${ paragraphId }","bindings":{"content":{"source":"core/pattern-attributes"}}}} -->
+			content: `<!-- wp:paragraph {"metadata":{"id":"${ paragraphId }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
 <p>Editable</p>
 <!-- /wp:paragraph -->`,
 			status: 'publish',
@@ -270,7 +270,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern with overrides',
 			content: `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"metadata":{"id":"${ buttonId }","bindings":{"text":{"source":"core/pattern-attributes"},"url":{"source":"core/pattern-attributes"},"linkTarget":{"source":"core/pattern-attributes"}}}} -->
+<div class="wp-block-buttons"><!-- wp:button {"metadata":{"id":"${ buttonId }","bindings":{"text":{"source":"core/pattern-overrides"},"url":{"source":"core/pattern-overrides"},"linkTarget":{"source":"core/pattern-overrides"}}}} -->
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="http://wp.org" target="_blank" rel="noreferrer noopener">wp.org</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`,


### PR DESCRIPTION
## What?
I'm renaming the `core/pattern-attributes` source for `core/pattern-overrides` as discussed [here](https://github.com/WordPress/gutenberg/pull/58337#discussion_r1469214793).

I also took the opportunity to add a small check to the post meta source that was included in the WordPress backport: [link](https://github.com/WordPress/wordpress-develop/pull/5888/files#r1467885715) and it was lacking in Gutenberg.

## Why?
It seems to be more aligned with the current naming.

## How?
Just search and replace.

## Testing Instructions
Test pattern syncing overrides:

1. Go to the Site Editor -> Patterns -> Create new synced pattern.
2. Add a paragraph, go to the Advanced section, and enable "Allow instance overrides".
3. Add a heading, go to the Advanced section, and enable "Allow instance overrides".
4. Add an image block, upload or select any media, go to the Advanced section, and enable "Allow instance overrides".
5. Add a button block, go to the Advanced section, and enable "Allow instance overrides".
6. Go to a page and insert the new pattern.
7. Modify the values of the blocks.
8. Check that the updated values are reflected in the frontend.
