### PR TITLE
Block editor: avoid list re-rendering on select

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -172,7 +172,7 @@ function Items( {
 				if ( visibleBlocks.has( clientId ) ) {
 					hasVisibleBlocks = true;
 				}
-				if ( order.includes( clientId ) ) {
+				if ( selectedBlocks.includes( clientId ) ) {
 					hasSelectedBlocks = true;
 				}
 			}

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -155,25 +155,42 @@ function Items( {
 	__experimentalAppenderTagName,
 	layout = defaultLayout,
 } ) {
+	const selected = useSelect(
+		( select ) => {
+			const {
+				getBlockOrder,
+				getSelectedBlockClientIds,
+				__unstableGetVisibleBlocks,
+				__unstableGetTemporarilyEditingAsBlocks,
+			} = select( blockEditorStore );
+			const order = getBlockOrder( rootClientId );
+			const selectedBlocks = getSelectedBlockClientIds();
+			const visibleBlocks = __unstableGetVisibleBlocks();
+			let hasVisibleBlocks = false;
+			let hasSelectedBlocks = false;
+			for ( const clientId of selectedBlocks ) {
+				if ( visibleBlocks.has( clientId ) ) {
+					hasVisibleBlocks = true;
+				}
+				if ( order.includes( clientId ) ) {
+					hasSelectedBlocks = true;
+				}
+			}
+			return {
+				order,
+				// Only pass selectedBlocks and visibleBlocks if they are
+				// relevant to the root block. Otherwise changes in visible
+				// blocks or selected blocks cause all block lists to re-render.
+				selectedBlocks: hasSelectedBlocks ? selectedBlocks : null,
+				visibleBlocks: hasVisibleBlocks ? visibleBlocks : null,
+				temporarilyEditingAsBlocks:
+					__unstableGetTemporarilyEditingAsBlocks(),
+			};
+		},
+		[ rootClientId ]
+	);
 	const { order, selectedBlocks, visibleBlocks, temporarilyEditingAsBlocks } =
-		useSelect(
-			( select ) => {
-				const {
-					getBlockOrder,
-					getSelectedBlockClientIds,
-					__unstableGetVisibleBlocks,
-					__unstableGetTemporarilyEditingAsBlocks,
-				} = select( blockEditorStore );
-				return {
-					order: getBlockOrder( rootClientId ),
-					selectedBlocks: getSelectedBlockClientIds(),
-					visibleBlocks: __unstableGetVisibleBlocks(),
-					temporarilyEditingAsBlocks:
-						__unstableGetTemporarilyEditingAsBlocks(),
-				};
-			},
-			[ rootClientId ]
-		);
+		selected;
 
 	return (
 		<LayoutProvider value={ layout }>
@@ -183,8 +200,8 @@ function Items( {
 					value={
 						// Only provide data asynchronously if the block is
 						// not visible and not selected.
-						! visibleBlocks.has( clientId ) &&
-						! selectedBlocks.includes( clientId )
+						! visibleBlocks?.has( clientId ) &&
+						! selectedBlocks?.includes( clientId )
 					}
 				>
 					<BlockListBlock


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Attempts my original implementation of #57188 again. Normally this should also improve

---

This PR avoids the re-rendering of `Items` if the selection changes, but the list doesn't include the selected (or visible) block at all.

Note: while we could create another `useSelect` call for each block, check if it's selected, and then turn on the AsyncProvider, there's a balance to be struck between optimising type and block select. I think typing is more important that block select, so let's avoid introducing another `useSelect` per block.

But we can avoid re-renders for other block lists. For example, in the large posts, there are many list and quote blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
