### PR TITLE
CheckboxControl: Add custom label example to Storybook

### DIFF
--- a/packages/components/src/checkbox-control/stories/index.story.tsx
+++ b/packages/components/src/checkbox-control/stories/index.story.tsx
@@ -13,6 +13,7 @@ import { useState } from '@wordpress/element';
  */
 import CheckboxControl from '..';
 import { VStack } from '../../v-stack';
+import { HStack } from '../../h-stack';
 
 const meta: Meta< typeof CheckboxControl > = {
 	component: CheckboxControl,
@@ -113,5 +114,48 @@ export const Indeterminate: StoryFn< typeof CheckboxControl > = ( {
 };
 Indeterminate.args = {
 	label: 'Select all',
+	__nextHasNoMarginBottom: true,
+};
+
+/**
+ * For more complex designs, a custom `<label>` element can be associated with the checkbox
+ * by leaving the `label` prop undefined and using the `id` and `htmlFor` props instead.
+ * Because the label element also functions as a click target for the checkbox, [do not
+ * place interactive elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#interactive_content)
+ * such as links or buttons inside the `<label>` node.
+ *
+ * Similarly, a custom description can be added by omitting the `help` prop
+ * and using the `aria-describedby` prop instead.
+ */
+export const WithCustomLabel: StoryFn< typeof CheckboxControl > = ( {
+	onChange,
+	...args
+} ) => {
+	const [ isChecked, setChecked ] = useState( true );
+
+	return (
+		<HStack justify="flex-start" alignment="top" spacing={ 0 }>
+			<CheckboxControl
+				{ ...args }
+				checked={ isChecked }
+				onChange={ ( v ) => {
+					setChecked( v );
+					onChange( v );
+				} }
+				id="my-checkbox-with-custom-label"
+				aria-describedby="my-custom-description"
+			/>
+			<VStack>
+				<label htmlFor="my-checkbox-with-custom-label">
+					My custom label
+				</label>
+				<div id="my-custom-description" style={ { fontSize: 13 } }>
+					A custom description.
+				</div>
+			</VStack>
+		</HStack>
+	);
+};
+WithCustomLabel.args = {
 	__nextHasNoMarginBottom: true,
 };


### PR DESCRIPTION
Part of #51740

## What?

In the Storybook for CheckboxControl, adds an example of how to accessibly implement custom labels/descriptions.

## Why?

To help developers build custom implementations without breaking accessibility requirements.

## Testing Instructions

See the "With Custom Label" story for CheckboxControl. The story description should be clear, and the example should meet the accessibility requirements for a checkbox.

## Screenshots

<img width="208" alt="Example of a custom checkbox implementation" src="https://github.com/WordPress/gutenberg/assets/555336/5420edfa-5792-4e75-9cc1-004da9925bc1">
