### PR TITLE
Tweak Media & Text inspector controls

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -230,6 +230,15 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 
 	const mediaTextGeneralSettings = (
 		<PanelBody title={ __( 'Settings' ) }>
+			<RangeControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ __( 'Media width' ) }
+				value={ temporaryMediaWidth || mediaWidth }
+				onChange={ commitWidthChange }
+				min={ WIDTH_CONSTRAINT_PERCENTAGE }
+				max={ 100 - WIDTH_CONSTRAINT_PERCENTAGE }
+			/>
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Stack on mobile' ) }
@@ -291,17 +300,6 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					imageSizeHelp={ __(
 						'Select the size of the source image.'
 					) }
-				/>
-			) }
-			{ mediaUrl && (
-				<RangeControl
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					label={ __( 'Media width' ) }
-					value={ temporaryMediaWidth || mediaWidth }
-					onChange={ commitWidthChange }
-					min={ WIDTH_CONSTRAINT_PERCENTAGE }
-					max={ 100 - WIDTH_CONSTRAINT_PERCENTAGE }
 				/>
 			) }
 		</PanelBody>

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -243,7 +243,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 			{ mediaType === 'image' && (
 				<ToggleControl
 					__nextHasNoMarginBottom
-					label={ __( 'Crop image to fill entire column' ) }
+					label={ __( 'Crop image to fill' ) }
 					checked={ !! imageFill }
 					onChange={ () =>
 						setAttributes( {
@@ -296,6 +296,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 			{ mediaUrl && (
 				<RangeControl
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'Media width' ) }
 					value={ temporaryMediaWidth || mediaWidth }
 					onChange={ commitWidthChange }

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -182,7 +182,7 @@ class MediaTextEdit extends Component {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
-						label={ __( 'Crop image to fill entire column' ) }
+						label={ __( 'Crop image to fill' ) }
 						checked={ imageFill }
 						onChange={ this.onSetImageFill }
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Use `__next40pxDefaultSize` on the RangeControl. 
- Update label to be consistent with other UI (use of fit and fill). 
- Move width to the top, consistent with columns. 
- Make width always render, not dependent on media (stack isn't already). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a media & text block.
3. Add image. 
4. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-30 at 08 49 38](https://github.com/WordPress/gutenberg/assets/1813435/b9fc3bba-7a35-4fba-ac2c-243510f474ab)|![CleanShot 2024-01-30 at 09 33 24](https://github.com/WordPress/gutenberg/assets/1813435/c721eae3-7374-4297-b8f8-134604f057a9)|