### PR TITLE
Tweak FocalPointPicker inspector controls

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -189,7 +189,7 @@ export default function CoverInspectorControls( {
 							<FocalPointPicker
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize
-								label={ __( 'Focal point picker' ) }
+								label={ __( 'Focal point' ) }
 								url={ url }
 								value={ focalPoint }
 								onDragStart={ imperativeFocalPointPreview }

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -188,6 +188,7 @@ export default function CoverInspectorControls( {
 						{ showFocalPointPicker && (
 							<FocalPointPicker
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 								label={ __( 'Focal point picker' ) }
 								url={ url }
 								value={ focalPoint }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -256,7 +256,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 				<FocalPointPicker
 					__nextHasNoMarginBottom
 					__next40pxDefaultSize
-					label={ __( 'Focal point picker' ) }
+					label={ __( 'Focal point' ) }
 					url={ mediaUrl }
 					value={ focalPoint }
 					onChange={ ( value ) =>

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -255,6 +255,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 			{ imageFill && mediaUrl && mediaType === 'image' && (
 				<FocalPointPicker
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 					label={ __( 'Focal point picker' ) }
 					url={ mediaUrl }
 					value={ focalPoint }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Uses `__next40pxDefaultSize` 
- Changes label from "Focal point picker" to "Focal point", which indicates what you're changing, not what the control is.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a cove block.
3. Add an image. 
4. See changes. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-30 at 09 01 49](https://github.com/WordPress/gutenberg/assets/1813435/7972de9f-9859-4d35-9000-9b05dd36410c)|![CleanShot 2024-01-30 at 09 01 13](https://github.com/WordPress/gutenberg/assets/1813435/022e07e3-97a0-43a7-b0d9-c598fac4d852)|