### PR TITLE
Font Library: Fix font preview vertical alignment and respect reduce motion preference

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-demo.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-demo.js
@@ -39,10 +39,6 @@ function FontFaceDemo( { customPreviewUrl, fontFace, text, style = {} } ) {
 		...faceStyles,
 		...style,
 	};
-	const imageDemoStyle = {
-		height: '23px',
-		width: 'auto',
-	};
 
 	useEffect( () => {
 		const observer = new window.IntersectionObserver( ( [ entry ] ) => {
@@ -71,7 +67,7 @@ function FontFaceDemo( { customPreviewUrl, fontFace, text, style = {} } ) {
 					src={ previewUrl }
 					loading="lazy"
 					alt={ text }
-					style={ imageDemoStyle }
+					className="font-library-modal__font-variant_demo-image"
 				/>
 			) : (
 				<Text style={ textDemoStyle }>{ text }</Text>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-demo.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-demo.js
@@ -31,11 +31,7 @@ function FontFaceDemo( { customPreviewUrl, fontFace, text, style = {} } ) {
 
 	const faceStyles = getFacePreviewStyle( fontFace );
 	const textDemoStyle = {
-		whiteSpace: 'nowrap',
-		flexShrink: 0,
-		fontSize: '18px',
 		opacity: isAssetLoaded ? '1' : '0',
-		transition: 'opacity 0.3s ease-in-out',
 		...faceStyles,
 		...style,
 	};
@@ -70,7 +66,12 @@ function FontFaceDemo( { customPreviewUrl, fontFace, text, style = {} } ) {
 					className="font-library-modal__font-variant_demo-image"
 				/>
 			) : (
-				<Text style={ textDemoStyle }>{ text }</Text>
+				<Text
+					style={ textDemoStyle }
+					className="font-library-modal__font-variant_demo-text"
+				>
+					{ text }
+				</Text>
 			) }
 		</div>
 	);

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -65,6 +65,17 @@
 	margin-top: -1px; /* To collapse the margin with the previous element */
 }
 
+.font-library-modal__font-variant_demo-image {
+	display: block;
+	height: $grid-unit-30;
+	width: auto;
+}
+
+.font-library-modal__font-variant {
+	border-bottom: 1px solid $gray-200;
+	padding-bottom: $grid-unit-20;
+}
+
 .font-library-modal__tabs {
 	[role="tablist"] {
 		position: sticky;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -71,6 +71,14 @@
 	width: auto;
 }
 
+.font-library-modal__font-variant_demo-text {
+	white-space: nowrap;
+	flex-shrink: 0;
+	font-size: 18px;
+	transition: opacity 0.3s ease-in-out;
+	@include reduce-motion("transition");
+}
+
 .font-library-modal__font-variant {
 	border-bottom: 1px solid $gray-200;
 	padding-bottom: $grid-unit-20;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58439

## What?
<!-- In a few words, what is the PR actually doing? -->
- Vertical alignment of the font preview _image_ is a little off and can be improved.
- The CSS animation set on the font preview _text_ doesn't respect the OS preference 'reduce motion'. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- A more consistent vertical alignment of the preview image with the preview text is good.
- All CSS transitions and animations must respect the OS preferences 'reduce motion'.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Moves a few inline styls from the JS to the .scss file.
- Sets `display: block` on the preview _image_ to remove native descender space.
- Sets the image preview height to 24 pixels and uses existing scss variable for that.
- Uses the `reduce-motion` scss  mixin.

Note:
A pixel-perfect vertical alignment isn't really possible because the font preview _image_ isn't consistent. even after improving the CSS and removing the native image descender space, the actual font preview _within the image_ has a different size and, more importantly, it may be not vertically centered _within the image_. A couple images to better illustrate:

![Screenshot 2024-01-30 at 14 55 36](https://github.com/WordPress/gutenberg/assets/1682452/a445ec54-9e89-4777-86fd-0a17f7d490c4)

![Screenshot 2024-01-30 at 14 55 09](https://github.com/WordPress/gutenberg/assets/1682452/b7190c5b-0bbd-41fc-9b95-21143cca2468)

Even though the two images have the same height, the actual preview is placed differently within the image 'canvas', which is actually the viewport of the SVG image. See for example https://s.w.org/images/fonts/17.6/previews/aldrich/aldrich.svg
Maybe, the SVG metrics could be improved but this is out of the scope of this PR.

Also, trying to adjust the image size to a 'magic number' doesn't make much sense as the font previews will render fonts with different metrics anyways. See for example the screenshot below: all the font preview images do have the same height but the actual visible height of the previewed font is always different because the font metrics are different:

![Screenshot 2024-01-30 at 14 54 51](https://github.com/WordPress/gutenberg/assets/1682452/4de67160-e157-4174-9d39-3da72a8d2e43)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to Site editor > Styles > Typography > Manage fonts.
- Click on a font that has an image-based preview e.g. the Google Fonts > Actor.
- Observe the alignment of the checkbox and image has improved.

Before:

![font preview image](https://github.com/WordPress/gutenberg/assets/1682452/5e1f55c2-ccab-4d52-8e60-af60d1c92ad3)


After:

![after](https://github.com/WordPress/gutenberg/assets/1682452/a99073b1-b17e-4e88-b41c-e035e83b101b)





### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
