### PR TITLE
Add missing PanelBody title for the columns block inspector

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -106,7 +106,7 @@ function ColumnsEditContainer( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody>
+				<PanelBody title={ __( 'Settings' ) }>
 					{ canInsertColumnBlock && (
 						<>
 							<RangeControl

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -127,7 +127,7 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await pageUtils.pressKeys( 'ctrl+`' );
 
 		// Navigate to the block settings sidebar and tweak the column count.
-		await pageUtils.pressKeys( 'Tab', { times: 4 } );
+		await pageUtils.pressKeys( 'Tab', { times: 5 } );
 		await expect(
 			page.getByRole( 'slider', { name: 'Columns' } )
 		).toBeFocused();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
While reviewing block inspector controls, I noticed that the columns block was missing the "Settings" label that nearly every other block uses.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
 1. Open a post or page.
2. Insert a columns block.
3. Select the columns block. 
4. View block inspector. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-30 at 09 39 23](https://github.com/WordPress/gutenberg/assets/1813435/3f3eefb8-b6c5-4480-a794-e61f66617e9c)|![CleanShot 2024-01-30 at 09 38 48](https://github.com/WordPress/gutenberg/assets/1813435/243d0d06-7b4f-4dd1-afb1-5101b23de0f6)|



