### PR TITLE
Reference Gutenberg in PHP docs from main docs

### DIFF
--- a/docs/contributors/code/back-merging-to-wp-core.md
+++ b/docs/contributors/code/back-merging-to-wp-core.md
@@ -2,14 +2,16 @@
 
 For major releases of the WordPress software, Gutenberg features need to be merged into WordPress Core. Typically this involves taking changes made in `.php` files within the Gutenberg repository and making the equivalent updates in the WP Core codebase.
 
-## Files/Directories
+## Criteria
+
+### Files/Directories
 
 Changes to files within the following files/directories will typically require back-merging to WP Core:
 
 -   `lib/`
 -   `phpunit/`
 
-## Ignored directories/files
+### Ignored directories/files
 
 The following directories/files do _not_ require back-merging to WP Core:
 
@@ -21,11 +23,16 @@ The following directories/files do _not_ require back-merging to WP Core:
 
 Please note this list is not exhaustive.
 
-## Pull Request Criteria
+### Pull Request Criteria
 
 In general, all PHP code committed to the Gutenberg repository since the date of the final Gutenberg release that was included in [the _last_ stable WP Core release](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/) should be considered for back merging to WP Core.
 
 There are however certain exceptions to that rule. PRs with the following criteria do _not_ require back-merging to WP Core:
 
 -   Does not contain changes to PHP code.
--   Has label `Backport from WordPress Core` - this code is already in WP Core.
+-   Has label `Backport from WordPress Core` - this code is already in WP Core and is being synchronized back to Gutenberg.
+-   Has label `Backport to WordPress Core` - this code has already been syncrhonized to WP Core.
+
+## Further Reading
+
+Please see also additional documentation regarding [Gutenberg PHP code](/lib/README.md).


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a "Further Reading" recommendation to the main docs section which links to previously hidden documentation within the lib folder regarding Gutenberg PHP.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's too easy to forget this documentation exists, but it's actually a great reference when working with PHP code in Gutenberg. It's very useful during a release period.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a reference in existing docs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
