### PR TITLE
Font Library: Update font collection component to accommodate the new font collection schema

### DIFF
--- a/lib/experimental/fonts/font-library/font-library.php
+++ b/lib/experimental/fonts/font-library/font-library.php
@@ -130,7 +130,8 @@ $google_fonts = array(
 	'slug'        => 'google-fonts',
 	'name'        => 'Google Fonts',
 	'description' => __( 'Add from Google Fonts. Fonts are copied to and served from your site.', 'gutenberg' ),
-	'src'         => 'https://s.w.org/images/fonts/17.6/collections/google-fonts-with-preview.json',
+	// TODO: update this url to the wordpress.org cdn hosted file.
+	'src'         => 'https://raw.githubusercontent.com/WordPress/google-fonts-to-wordpress-collection/main/releases/gutenberg-17.6/collections/google-fonts-with-preview.json',
 );
 
 wp_register_font_collection( $google_fonts );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-card.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-card.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import FontCard from './font-card';
+
+function CollectionFontCard( { font, onClick } ) {
+	// Transform the shape of the data coming from font collection
+	// into a format understood by the FontCard component and the install related functions.
+	const fontFamily = {
+		...font.font_family_settings,
+		preview: font.preview,
+		fontFace: font.font_faces.map( ( face ) => ( {
+			...face.font_face_settings,
+			preview: face.preview,
+		} ) ),
+	};
+
+	return (
+		<FontCard font={ fontFamily } onClick={ () => onClick( fontFamily ) } />
+	);
+}
+
+export default CollectionFontCard;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -23,7 +23,7 @@ import { search, closeSmall } from '@wordpress/icons';
 import TabPanelLayout from './tab-panel-layout';
 import { FontLibraryContext } from './context';
 import FontsGrid from './fonts-grid';
-import FontCard from './font-card';
+import CollectionFontCard from './collection-font-card';
 import filterFonts from './utils/filter-fonts';
 import CollectionFontDetails from './collection-font-details';
 import { toggleFont } from './utils/toggleFont';
@@ -148,13 +148,14 @@ function FontCollection( { slug } ) {
 		const fontFamily = fontsToInstall[ 0 ];
 
 		try {
-			if ( fontFamily?.fontFace ) {
+			if ( fontFamily?.font_faces ) {
 				await Promise.all(
-					fontFamily.fontFace.map( async ( fontFace ) => {
-						if ( fontFace.src ) {
-							fontFace.file = await downloadFontFaceAssets(
-								fontFace.src
-							);
+					fontFamily.font_faces.map( async ( face ) => {
+						if ( face.font_face_setttings.src ) {
+							face.font_face_setttings.file =
+								await downloadFontFaceAssets(
+									face.font_face_setttings.src
+								);
 						}
 					} )
 				);
@@ -277,12 +278,10 @@ function FontCollection( { slug } ) {
 			{ ! renderConfirmDialog && ! selectedFont && (
 				<FontsGrid>
 					{ fonts.map( ( font ) => (
-						<FontCard
+						<CollectionFontCard
 							key={ font.font_family_settings.slug }
-							font={ font.font_family_settings }
-							onClick={ () => {
-								setSelectedFont( font.font_family_settings );
-							} }
+							font={ font }
+							onClick={ setSelectedFont }
 						/>
 					) ) }
 				</FontsGrid>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Update font collection component to accommodate the new font collection schema.
- Update the Google Fonts collection URL to load the dev version of the file. (Needs to be changed later)

## Why?
The font collection schema was updated to move the `preview` property out out of the font family and font face settings  so we need to update the code consuming that data.

## How?
Transforming the new schema into a theme.json like format understood by the rest of the code.

## Testing Instructions
Use the font library google fonts collection to install some fonts. Everything should work as expected.

