### PR TITLE
Change cover block's "Media settings" label to "Settings"

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -167,7 +167,7 @@ export default function CoverInspectorControls( {
 		<>
 			<InspectorControls>
 				{ !! url && (
-					<PanelBody title={ __( 'Media' ) }>
+					<PanelBody title={ __( 'Settings' ) }>
 						{ isImageBackground && (
 							<>
 								<ToggleControl

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -167,7 +167,7 @@ export default function CoverInspectorControls( {
 		<>
 			<InspectorControls>
 				{ !! url && (
-					<PanelBody title={ __( 'Media settings' ) }>
+					<PanelBody title={ __( 'Media' ) }>
 						{ isImageBackground && (
 							<>
 								<ToggleControl

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -163,7 +163,7 @@ describe( 'Cover block', () => {
 				await setup();
 				expect(
 					screen.queryByRole( 'button', {
-						name: 'Media settings',
+						name: 'Settings',
 					} )
 				).not.toBeInTheDocument();
 			} );
@@ -175,7 +175,7 @@ describe( 'Cover block', () => {
 				await selectBlock( 'Block: Cover' );
 				expect(
 					screen.getByRole( 'button', {
-						name: 'Media settings',
+						name: 'Settings',
 					} )
 				).toBeInTheDocument();
 			} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Uses the consistent "Settings" label. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a cover block.
3. Open block inspector. 
4. See changes.

## Screenshots or screencast <!-- if applicable -->
| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-30 at 13 29 48](https://github.com/WordPress/gutenberg/assets/1813435/2313bd06-ad67-4dc9-9513-2ef892735af7)|![CleanShot 2024-01-30 at 13 30 31](https://github.com/WordPress/gutenberg/assets/1813435/f41879d2-a7bc-42ea-9ac8-8dc9c225206d)|

