### PR TITLE
Block Hooks: Update the compatibility layer

### DIFF
--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -272,7 +272,7 @@ function gutenberg_parse_and_serialize_blocks( $block_template ) {
 		return $block_template;
 	}
 
-	$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
+	$before_block_visitor = null; // Prior to WP 6.4, the `theme` attribute was injected in Core's _build_block_template_result_from_file.
 	$after_block_visitor  = null;
 	$hooked_blocks        = get_hooked_blocks();
 
@@ -445,7 +445,7 @@ if ( ! function_exists( 'make_before_block_visitor' ) ) {
 		 * @return string The serialized markup for the given block, with the markup for any hooked blocks prepended to it.
 		 */
 		return function ( &$block, &$parent_block = null, $prev = null ) use ( $hooked_blocks, $context ) {
-			_inject_theme_attribute_in_template_part_block( $block );
+			// No `theme` injection into Template Part blocks: Prior to WP 6.4, this was done by Core's _build_block_template_result_from_file.
 
 			$markup = '';
 

--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -109,14 +109,6 @@ function gutenberg_add_hooked_blocks( $settings, $metadata ) {
  * @return void
  */
 function gutenberg_add_hooked_block( $hooked_block, $position, $anchor_block ) {
-		$hooked_block_array = array(
-			'blockName'    => $hooked_block,
-			'attrs'        => array(),
-			'innerHTML'    => '',
-			'innerContent' => array(),
-			'innerBlocks'  => array(),
-		);
-
 		/*
 		 * The block-types REST API controller uses objects of the `WP_Block_Type` class, which are
 		 * in turn created upon block type registration. However, that class does not contain

--- a/lib/compat/wordpress-6.4/block-hooks.php
+++ b/lib/compat/wordpress-6.4/block-hooks.php
@@ -246,12 +246,11 @@ function gutenberg_add_block_hooks_field_to_block_type_controller( $inserted_blo
  * @return WP_Block_Template[] Updated array of found block templates.
  */
 function gutenberg_parse_and_serialize_block_templates( $query_result ) {
-	foreach ( $query_result as $block_template ) {
-		if ( empty( $block_template->content ) || 'custom' === $block_template->source ) {
+	foreach ( $query_result as $index => $block_template ) {
+		if ( 'custom' === $block_template->source ) {
 			continue;
 		}
-		$blocks                  = parse_blocks( $block_template->content );
-		$block_template->content = gutenberg_serialize_blocks( $blocks );
+		$query_result[ $index ] = gutenberg_parse_and_serialize_blocks( $block_template );
 	}
 
 	return $query_result;

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
@@ -28,7 +28,7 @@ class Gutenberg_REST_Block_Patterns_Controller extends WP_REST_Block_Patterns_Co
 		$response = parent::prepare_item_for_response( $item, $request );
 
 		// Run the polyfill for Block Hooks only if it isn't already handled in WordPress core.
-		if ( function_exists( 'traverse_and_serialize_blocks' ) ) {
+		if ( version_compare( get_bloginfo( 'version' ), '6.4', '>=' ) ) {
 			return $response;
 		}
 

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
@@ -38,8 +38,16 @@ class Gutenberg_REST_Block_Patterns_Controller extends WP_REST_Block_Patterns_Co
 			return $response;
 		}
 
+		$hooked_blocks = get_hooked_blocks();
+
+		$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
+		$after_block_visitor  = null;
+		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
+			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $item );
+			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $item );
+		}
 		$blocks          = parse_blocks( $data['content'] );
-		$data['content'] = gutenberg_serialize_blocks( $blocks ); // Serialize or render?
+		$data['content'] = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 
 		return rest_ensure_response( $data );
 	}

--- a/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.4/class-gutenberg-rest-block-patterns-controller.php
@@ -40,7 +40,7 @@ class Gutenberg_REST_Block_Patterns_Controller extends WP_REST_Block_Patterns_Co
 
 		$hooked_blocks = get_hooked_blocks();
 
-		$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
+		$before_block_visitor = null;
 		$after_block_visitor  = null;
 		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $item );

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -58,9 +58,17 @@ function render_block_core_pattern( $attributes ) {
 
 	// Backward compatibility for handling Block Hooks and injecting the theme attribute in the Gutenberg plugin.
 	// This can be removed when the minimum supported WordPress is >= 6.4.
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && ! function_exists( 'traverse_and_serialize_blocks' ) ) {
+	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN && version_compare( get_bloginfo( 'version' ), '6.4', '<' ) ) {
+		$hooked_blocks = get_hooked_blocks();
+
+		$before_block_visitor = null;
+		$after_block_visitor  = null;
+		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
+			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $pattern );
+			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $pattern );
+		}
 		$blocks  = parse_blocks( $content );
-		$content = gutenberg_serialize_blocks( $blocks );
+		$content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 	}
 
 	$seen_refs[ $attributes['slug'] ] = true;


### PR DESCRIPTION
## What?
Update `lib/compat/wordpress-6.4/block-hooks.php` to better reflect Block Hooks code as present in WP 6.4.

## Why?
We've found that we _might_ need a more faithful copy of the Block Hooks code as found in Core in order to unlock some new features, e.g. #58388. In addition, this _might_ be a blocker to https://github.com/WordPress/wordpress-develop/pull/5726.

## How?
By copying code from Core, and carefully replacing existing functions with it.

## Testing Instructions
TBD, but basically: Test on WP 6.3, 6.4, `trunk`.

## Questions
What's our back-compat policy for Gutenberg? This PR is removing a number of functions, plus the `gutenberg_serialize_blocks` filter.

## TODO
- [x] Insertion into Comment Template block isn't working **in the editor**. (That's a pattern, so probably that's not working?)
- [ ] Make sure we're not missing `theme` attribute injection anywhere. 
- [ ] Include compat layer for WP 6.5.
