### PR TITLE
Try shadow DOM for block/pattern previews

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -10,7 +10,7 @@ import { Disabled } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockList from '../block-list';
-import Iframe from '../iframe';
+import ShadowDom from '../iframe/shadow-dom';
 import EditorStyles from '../editor-styles';
 import { store } from '../../store';
 
@@ -77,22 +77,22 @@ function ScaledBlockPreview( {
 				minHeight,
 			} }
 		>
-			<Iframe
-				contentRef={ useRefEffect( ( bodyElement ) => {
-					const {
-						ownerDocument: { documentElement },
-					} = bodyElement;
-					documentElement.classList.add(
-						'block-editor-block-preview__content-iframe'
-					);
-					documentElement.style.position = 'absolute';
-					documentElement.style.width = '100%';
+			<ShadowDom
+				// contentRef={ useRefEffect( ( bodyElement ) => {
+				// 	const {
+				// 		ownerDocument: { documentElement },
+				// 	} = bodyElement;
+				// 	documentElement.classList.add(
+				// 		'block-editor-block-preview__content-iframe'
+				// 	);
+				// 	documentElement.style.position = 'absolute';
+				// 	documentElement.style.width = '100%';
 
-					// Necessary for contentResizeListener to work.
-					bodyElement.style.boxSizing = 'border-box';
-					bodyElement.style.position = 'absolute';
-					bodyElement.style.width = '100%';
-				}, [] ) }
+				// 	// Necessary for contentResizeListener to work.
+				// 	bodyElement.style.boxSizing = 'border-box';
+				// 	bodyElement.style.position = 'absolute';
+				// 	bodyElement.style.width = '100%';
+				// }, [] ) }
 				aria-hidden
 				tabIndex={ -1 }
 				style={ {
@@ -112,7 +112,7 @@ function ScaledBlockPreview( {
 				<EditorStyles styles={ editorStyles } />
 				{ contentResizeListener }
 				<MemoizedBlockList renderAppender={ false } />
-			</Iframe>
+			</ShadowDom>
 		</Disabled>
 	);
 }

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -78,21 +78,21 @@ function ScaledBlockPreview( {
 			} }
 		>
 			<ShadowDom
-				// contentRef={ useRefEffect( ( bodyElement ) => {
-				// 	const {
-				// 		ownerDocument: { documentElement },
-				// 	} = bodyElement;
-				// 	documentElement.classList.add(
-				// 		'block-editor-block-preview__content-iframe'
-				// 	);
-				// 	documentElement.style.position = 'absolute';
-				// 	documentElement.style.width = '100%';
+				contentRef={ useRefEffect( ( bodyElement ) => {
+					// const {
+					// 	ownerDocument: { documentElement },
+					// } = bodyElement;
+					// documentElement.classList.add(
+					// 	'block-editor-block-preview__content-iframe'
+					// );
+					// documentElement.style.position = 'absolute';
+					// documentElement.style.width = '100%';
 
-				// 	// Necessary for contentResizeListener to work.
-				// 	bodyElement.style.boxSizing = 'border-box';
-				// 	bodyElement.style.position = 'absolute';
-				// 	bodyElement.style.width = '100%';
-				// }, [] ) }
+					// Necessary for contentResizeListener to work.
+					bodyElement.style.boxSizing = 'border-box';
+					bodyElement.style.position = 'relative';
+					bodyElement.style.width = '100%';
+				}, [] ) }
 				aria-hidden
 				tabIndex={ -1 }
 				style={ {

--- a/packages/block-editor/src/components/iframe/shadow-dom.js
+++ b/packages/block-editor/src/components/iframe/shadow-dom.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, createPortal, forwardRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useMergeRefs, useRefEffect, useDisabled } from '@wordpress/compose';
+import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getCompatibilityStyles } from './get-compatibility-styles';
+import { store as blockEditorStore } from '../../store';
+
+function Iframe( {
+	contentRef,
+	children,
+	tabIndex = 0,
+	scale = 1,
+	readonly,
+	forwardedRef: ref,
+	...props
+} ) {
+	const { resolvedAssets, isPreviewMode } = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return {
+			resolvedAssets: settings.__unstableResolvedAssets,
+			isPreviewMode: settings.__unstableIsPreviewMode,
+		};
+	}, [] );
+	const { styles = '' } = resolvedAssets;
+	const [ shadow, setShadow ] = useState();
+	const [ bodyClasses, setBodyClasses ] = useState( [] );
+	const setRef = useRefEffect( ( node ) => {
+		setShadow( node.attachShadow( { mode: 'open' } ) );
+	}, [] );
+
+	const disabledRef = useDisabled( { isDisabled: ! readonly } );
+	const bodyRef = useMergeRefs( [ contentRef, disabledRef ] );
+
+	return (
+		<>
+			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
+			<div
+				{ ...props }
+				style={ {
+					border: 0,
+					...props.style,
+					transform:
+						scale !== 1
+							? `scale( ${ scale } )`
+							: props.style?.transform,
+					transition: 'all .3s',
+				} }
+				ref={ useMergeRefs( [ ref, setRef ] ) }
+				tabIndex={ tabIndex }
+				title={ __( 'Editor canvas' ) }
+			>
+				{ shadow &&
+					createPortal(
+						<html lang="en">
+							<body
+								ref={ bodyRef }
+								className={ classnames(
+									'block-editor-iframe__body',
+									'editor-styles-wrapper',
+									...bodyClasses
+								) }
+							>
+								<div
+									dangerouslySetInnerHTML={ {
+										__html: styles,
+									} }
+								></div>
+								{ children }
+							</body>
+						</html>,
+						shadow
+					) }
+			</div>
+		</>
+	);
+}
+
+function IframeIfReady( props, ref ) {
+	const isInitialised = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().__internalIsInitialized,
+		[]
+	);
+
+	// We shouldn't render the iframe until the editor settings are initialised.
+	// The initial settings are needed to get the styles for the srcDoc, which
+	// cannot be changed after the iframe is mounted. srcDoc is used to to set
+	// the initial iframe HTML, which is required to avoid a flash of unstyled
+	// content.
+	if ( ! isInitialised ) {
+		return null;
+	}
+
+	return <Iframe { ...props } forwardedRef={ ref } />;
+}
+
+export default forwardRef( IframeIfReady );

--- a/packages/block-editor/src/components/iframe/shadow-dom.js
+++ b/packages/block-editor/src/components/iframe/shadow-dom.js
@@ -26,7 +26,7 @@ function Iframe( {
 	forwardedRef: ref,
 	...props
 } ) {
-	const { resolvedAssets, isPreviewMode } = useSelect( ( select ) => {
+	const { resolvedAssets } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 		return {
 			resolvedAssets: settings.__unstableResolvedAssets,

--- a/packages/components/src/style-provider/index.tsx
+++ b/packages/components/src/style-provider/index.tsx
@@ -40,7 +40,7 @@ export function StyleProvider( props: StyleProviderProps ) {
 		return null;
 	}
 
-	const cache = memoizedCreateCacheWithContainer( document.head );
+	const cache = memoizedCreateCacheWithContainer( document.head ?? document );
 
 	return <CacheProvider value={ cache }>{ children }</CacheProvider>;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Still a work in progress: we need a rewrite CSS `:root` rules, maybe adjust the scaling.

Best tested with the 2024 theme for now.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
