### PR TITLE
Improve SiteIcon display and transition

### DIFF
--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -54,7 +54,6 @@
 }
 
 .edit-site-site-hub__site-title {
-	margin-left: $grid-unit-05;
 	flex-grow: 1;
 	color: $gray-200;
 }

--- a/packages/edit-site/src/components/site-icon/index.js
+++ b/packages/edit-site/src/components/site-icon/index.js
@@ -36,7 +36,7 @@ function SiteIcon( { className } ) {
 	) : (
 		<Icon
 			className="edit-site-site-icon__icon"
-			size="48px"
+			size="60px"
 			icon={ wordpress }
 		/>
 	);

--- a/packages/edit-site/src/components/site-icon/index.js
+++ b/packages/edit-site/src/components/site-icon/index.js
@@ -36,8 +36,8 @@ function SiteIcon( { className } ) {
 	) : (
 		<Icon
 			className="edit-site-site-icon__icon"
-			size="48px"
 			icon={ wordpress }
+			size={ 48 }
 		/>
 	);
 

--- a/packages/edit-site/src/components/site-icon/index.js
+++ b/packages/edit-site/src/components/site-icon/index.js
@@ -36,7 +36,7 @@ function SiteIcon( { className } ) {
 	) : (
 		<Icon
 			className="edit-site-site-icon__icon"
-			size="60px"
+			size="48px"
 			icon={ wordpress }
 		/>
 	);

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -1,10 +1,19 @@
 .edit-site-site-icon__icon {
 	fill: currentColor;
+	// Make the WordPress icon not so big.
+	padding: $grid-unit-05 * 0.5;
+	// Matches SiteIcon motion, smoothing out the transition.
+	transition: padding	0.3s ease-out;
+
+	.edit-site-layout.is-full-canvas & {
+		// Make the WordPress icon not so big in full canvas.
+		padding: $grid-unit-15;
+	}
 }
 
 .edit-site-site-icon__image {
 	width: 100%;
-	height: auto;
+	height: 100%;
 	border-radius: $radius-block-ui * 2;
 	object-fit: cover;
 	background: #333;

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -1,7 +1,8 @@
 .edit-site-site-icon__icon {
 	fill: currentColor;
 	// Matches SiteIcon motion, smoothing out the transition.
-	transition: padding	0.3s ease-out;
+	transition: padding 0.3s ease-out;
+	@include reduce-motion("transition");
 
 	.edit-site-layout.is-full-canvas & {
 		// Make the WordPress icon not so big in full canvas.

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -1,13 +1,11 @@
 .edit-site-site-icon__icon {
 	fill: currentColor;
-	// Make the WordPress icon not so small.
-	padding: $grid-unit-05 * 0.5;
 	// Matches SiteIcon motion, smoothing out the transition.
 	transition: padding	0.3s ease-out;
 
 	.edit-site-layout.is-full-canvas & {
 		// Make the WordPress icon not so big in full canvas.
-		padding: $grid-unit-15;
+		padding: $grid-unit-15 * 0.5; // 6px.
 	}
 }
 

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -1,6 +1,6 @@
 .edit-site-site-icon__icon {
 	fill: currentColor;
-	// Make the WordPress icon not so big.
+	// Make the WordPress icon not so small.
 	padding: $grid-unit-05 * 0.5;
 	// Matches SiteIcon motion, smoothing out the transition.
 	transition: padding	0.3s ease-out;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Ensures site icon displays square. 
- Makes the WordPress icon the same size as the post editor with in the editor canvas.
- Makes the WordPress icon not so small when not in the editor canvas.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor. 
2. See changes. 
3. Add a site logo/icon. 
4. Refresh.
5. See changes.

## Screenshots or screencast <!-- if applicable -->

### Proposed: 

Without site icon:  

https://github.com/WordPress/gutenberg/assets/1813435/faedb296-0dea-4dc5-a3bb-e6451760ac84

With site icon: 

https://github.com/WordPress/gutenberg/assets/1813435/64275d77-8c4a-4aaf-a9ae-40539261a7eb

### Current: 

Without site icon: 

https://github.com/WordPress/gutenberg/assets/1813435/82542399-f6bc-4753-a5eb-74601eb26f9a

With site icon: 

https://github.com/WordPress/gutenberg/assets/1813435/da3fe21b-ec31-49c7-b9ad-585507467f21



