### PR TITLE
Font Library: avoid mutating fontface data

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -161,7 +161,8 @@ export function makeFontFamilyFormData( fontFamily ) {
 
 export function makeFontFacesFormData( font ) {
 	if ( font?.fontFace ) {
-		const fontFacesFormData = font.fontFace.map( ( face, faceIndex ) => {
+		const fontFacesFormData = font.fontFace.map( ( item, faceIndex ) => {
+			const face = { ...item };
 			const formData = new FormData();
 			if ( face.file ) {
 				// Normalize to an array, since face.file may be a single file or an array of files.


### PR DESCRIPTION
## What?
Fix error when you install a font face twice.
Fix: https://github.com/WordPress/gutenberg/issues/58471

## Why?
To avoid the error described here: https://github.com/WordPress/gutenberg/issues/58471


## How?
Avoid mutating font face data during the installation process.

## Testing Instructions
Try to install a font face twice and check install process works as expected.
The error described in https://github.com/WordPress/gutenberg/issues/58471 should not happen.


