### PR TITLE
Try/admin color lighten colors

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -428,6 +428,14 @@
 	// Hexadecimal css vars do not work in the rgba function.
 	--wp-admin-theme-color: #{$color-primary};
 	--wp-admin-theme-color--rgb: #{hex-to-rgb($color-primary)};
+
+	// Lighter shades.
+	--wp-admin-theme-color-lighter-120: #{lighten($color-primary, 62%)};
+	--wp-admin-theme-color-lighter-120--rgb: #{hex-to-rgb(lighten($color-primary, 62%))};
+
+	--wp-admin-theme-color-lighter-125: #{lighten($color-primary, 63%)};
+	--wp-admin-theme-color-lighter-125--rgb: #{hex-to-rgb(lighten($color-primary, 63%))};
+
 	// Darker shades.
 	--wp-admin-theme-color-darker-10: #{darken($color-primary, 5%)};
 	--wp-admin-theme-color-darker-10--rgb: #{hex-to-rgb(darken($color-primary, 5%))};

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -430,11 +430,11 @@
 	--wp-admin-theme-color--rgb: #{hex-to-rgb($color-primary)};
 
 	// Lighter shades.
-	--wp-admin-theme-color-lighter-120: #{lighten($color-primary, 62%)};
-	--wp-admin-theme-color-lighter-120--rgb: #{hex-to-rgb(lighten($color-primary, 62%))};
+	--wp-admin-theme-color-lighter-120: #{lighten($color-primary, 61%)};
+	--wp-admin-theme-color-lighter-120--rgb: #{hex-to-rgb(lighten($color-primary, 61%))};
 
-	--wp-admin-theme-color-lighter-125: #{lighten($color-primary, 63%)};
-	--wp-admin-theme-color-lighter-125--rgb: #{hex-to-rgb(lighten($color-primary, 63%))};
+	--wp-admin-theme-color-lighter-125: #{lighten($color-primary, 62%)};
+	--wp-admin-theme-color-lighter-125--rgb: #{hex-to-rgb(lighten($color-primary, 62%))};
 
 	// Darker shades.
 	--wp-admin-theme-color-darker-10: #{darken($color-primary, 5%)};

--- a/packages/block-editor/src/components/block-content-overlay/content.scss
+++ b/packages/block-editor/src/components/block-content-overlay/content.scss
@@ -19,7 +19,7 @@
 	}
 
 	&:hover:not(.is-dragging-blocks):not(.is-multi-selected)::before {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background: var(--wp-admin-theme-color-lighter-125);
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -110,7 +110,7 @@
 		border-bottom-right-radius: $radius-block-ui;
 	}
 	&.is-branch-selected:not(.is-selected):not(.is-synced-branch) {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background: var(--wp-admin-theme-color-lighter-125);
 	}
 	&.is-synced-branch.is-branch-selected {
 		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
@@ -521,14 +521,14 @@ $block-navigation-max-indent: 8;
 	}
 
 	.block-editor-list-view-drop-indicator__line {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background: var(--wp-admin-theme-color-lighter-125);
 		height: 36px;
 		border-radius: 4px;
 		overflow: hidden;
 	}
 
 	.block-editor-list-view-drop-indicator__line--darker {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.09);
+		background: var(--wp-admin-theme-color-lighter-120);
 	}
 }
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -165,13 +165,13 @@
 		&:hover:not(:disabled, [aria-disabled="true"]) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			/* stylelint-disable-next-line declaration-property-value-disallowed-list */
-			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			background: var(--wp-admin-theme-color-lighter-125);
 		}
 
 		&:active:not(:disabled, [aria-disabled="true"]) {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			/* stylelint-disable-next-line declaration-property-value-disallowed-list */
-			background: rgba(var(--wp-admin-theme-color--rgb), 0.08);
+			background: var(--wp-admin-theme-color-lighter-120);
 		}
 
 		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -147,11 +147,11 @@
 		}
 
 		&.is-selected {
-			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			background-color: var(--wp-admin-theme-color-lighter-125);
 			color: $gray-700;
 
 			&:hover {
-				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
+				background-color: var(--wp-admin-theme-color-lighter-120);
 			}
 		}
 	}

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -58,7 +58,7 @@
 			}
 
 			&:hover {
-				background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+				background: var(--wp-admin-theme-color-lighter-125);
 
 				* {
 					color: var(--wp-admin-theme-color);
@@ -156,7 +156,7 @@
 
 	.edit-site-add-new-template__template-icon {
 		padding: $grid-unit-10;
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background: var(--wp-admin-theme-color-lighter-120);
 		border-radius: 100%;
 		max-height: $grid-unit-50;
 		max-width: $grid-unit-50;
@@ -186,7 +186,7 @@
 
 		&:hover {
 			color: var(--wp-admin-theme-color-darker-10);
-			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			background: var(--wp-admin-theme-color-lighter-120);
 			border-color: transparent;
 
 			span {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -15,7 +15,7 @@
 	flex-direction: column;
 
 	&:hover {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background: var(--wp-admin-theme-color-lighter-125);
 		.edit-site-global-styles-screen-revisions__date {
 			color: var(--wp-admin-theme-color);
 		}
@@ -50,7 +50,7 @@
 		outline-offset: -2px;
 
 		color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background: var(--wp-admin-theme-color-lighter-120);
 
 		.edit-site-global-styles-screen-revisions__revision-button {
 			opacity: 1;


### PR DESCRIPTION
## What?

This is an experiment to replace (and standardize) adhoc admin color rgba "variations" with solid admin colors.

Example, replacing `rgba(var(--wp-admin-theme-color--rgb), ${ alpha_value } )` with `var(--wp-admin-theme-color-lighter-${ lighten_value })`

> [!NOTE]
> It's difficult to get exact matches of current `rgba` variations using SASS's `lighten` function. Notice how the `rgba` colors are greyer. This PR opts for the `lighten` function to complement the `darken` color set, by assuming that the color palette will be more uniform. 

Where `--wp-admin-theme-color--rgb === 0, 124, 186`:

| Before  | After |
| ------------- | ------------- |
| `rgba(0, 124, 186, 0.08)`  | `rgb(242, 251, 255)`  |
| <img width="84" alt="007cba14" src="https://github.com/WordPress/gutenberg/assets/6458278/f72ab8ff-e19f-4c58-afcc-64076b5bf45f">  | <img width="103" alt="f2fbff" src="https://github.com/WordPress/gutenberg/assets/6458278/a10bc42f-c4d0-45ec-8388-c6b290b73edd"> |
| `rgba(0, 124, 186, 0.04)`  | `rgb(247, 252, 255)`  |
| <img width="84" alt="007cba0a" src="https://github.com/WordPress/gutenberg/assets/6458278/6a6b6bba-556f-43c3-826f-27a6c74c326d"> | <img width="97" alt="f7fcff" src="https://github.com/WordPress/gutenberg/assets/6458278/df464143-25a2-4bbe-8e58-bd6fadbb6c7b"> |

Example output:

```css
:root{
  --wp-admin-theme-color:#007cba;
  --wp-admin-theme-color--rgb:0, 124, 186;
  /* new lighten vars */
  --wp-admin-theme-color-lighter-120:#f2fbff;
  --wp-admin-theme-color-lighter-120--rgb:242, 251, 255;
  --wp-admin-theme-color-lighter-125:#f7fcff;
  --wp-admin-theme-color-lighter-125--rgb:247, 252, 255;
}
```

## Why?
To rein in random admin color alpha-variants, and allow better control over the color palette, color contrast ratios etc.

See related comments in:

- https://github.com/WordPress/gutenberg/issues/58121
- https://github.com/WordPress/gutenberg/pull/58340

## How?
Use SASS's `lighten` function to create admin-color CSS vars.

## Testing Instructions

Compare trunk with this branch for components that have changed:

| Before  | After |
| ------------- | ------------- |
| <img width="278" alt="before-revisions" src="https://github.com/WordPress/gutenberg/assets/6458278/9d37907f-3ac7-4c93-b5d5-335413a9814c"> | <img width="282" alt="after-revisions" src="https://github.com/WordPress/gutenberg/assets/6458278/88776a79-4177-4c2f-89aa-43dda41e5236"> |
| <img width="341" alt="before-list" src="https://github.com/WordPress/gutenberg/assets/6458278/3a0a9997-550e-4052-b717-48323e7add13"> | <img width="348" alt="after-list" src="https://github.com/WordPress/gutenberg/assets/6458278/538b0d53-e90a-4d91-9318-223a0a81b602"> |


In action:

### Before

https://github.com/WordPress/gutenberg/assets/6458278/4378b5ce-2010-4478-ab44-12a6fd0a27ac

### After

https://github.com/WordPress/gutenberg/assets/6458278/7b696cff-57df-4a0d-93e5-bd1b048f739a










