### PR TITLE
Patterns: Update the bindings attribs of blocks added during experimental phase

### DIFF
--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -84,12 +84,24 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 		name === 'core/image' ||
 		name === 'core/button'
 	) {
-		if (
-			newAttributes.metadata?.bindings?.content?.source?.name ===
-			'pattern_attributes'
-		) {
-			newAttributes.metadata.bindings.content.source =
-				'core/pattern-overrides';
+		if ( newAttributes.metadata?.bindings ) {
+			const bindings = [
+				'content',
+				'url',
+				'title',
+				'alt',
+				'text',
+				'linkTarget',
+			];
+			bindings.forEach( ( binding ) => {
+				if (
+					newAttributes.metadata.bindings[ binding ]?.source?.name ===
+					'pattern_attributes'
+				) {
+					newAttributes.metadata.bindings[ binding ].source =
+						'core/pattern-overrides';
+				}
+			} );
 		}
 	}
 	return [ name, newAttributes ];

--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -78,31 +78,32 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 	}
 
 	// Convert pattern overrides added during experimental phase.
+	// Only four blocks were supported initially.
+	// These checks can be removed in WordPress 6.6.
 	if (
-		name === 'core/paragraph' ||
-		name === 'core/heading' ||
-		name === 'core/image' ||
-		name === 'core/button'
+		newAttributes.metadata?.bindings &&
+		( name === 'core/paragraph' ||
+			name === 'core/heading' ||
+			name === 'core/image' ||
+			name === 'core/button' )
 	) {
-		if ( newAttributes.metadata?.bindings ) {
-			const bindings = [
-				'content',
-				'url',
-				'title',
-				'alt',
-				'text',
-				'linkTarget',
-			];
-			bindings.forEach( ( binding ) => {
-				if (
-					newAttributes.metadata.bindings[ binding ]?.source?.name ===
-					'pattern_attributes'
-				) {
-					newAttributes.metadata.bindings[ binding ].source =
-						'core/pattern-overrides';
-				}
-			} );
-		}
+		const bindings = [
+			'content',
+			'url',
+			'title',
+			'alt',
+			'text',
+			'linkTarget',
+		];
+		bindings.forEach( ( binding ) => {
+			if (
+				newAttributes.metadata.bindings[ binding ]?.source?.name ===
+				'pattern_attributes'
+			) {
+				newAttributes.metadata.bindings[ binding ].source =
+					'core/pattern-overrides';
+			}
+		} );
 	}
 	return [ name, newAttributes ];
 }

--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -77,5 +77,20 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 		newAttributes.legacy = true;
 	}
 
+	// Convert pattern overrides added during experimental phase.
+	if (
+		name === 'core/paragraph' ||
+		name === 'core/heading' ||
+		name === 'core/image' ||
+		name === 'core/button'
+	) {
+		if (
+			newAttributes.metadata?.bindings?.content?.source?.name ===
+			'pattern_attributes'
+		) {
+			newAttributes.metadata.bindings.content.source =
+				'core/pattern-overrides';
+		}
+	}
 	return [ name, newAttributes ];
 }


### PR DESCRIPTION
## What?
Maps the old source attribute name of `name: 'pattern_attributes'` to `core/pattern-overrides`

## Why?
In https://github.com/WordPress/gutenberg/pull/58434 the binding attribute was updated which means that any pattern overrides add before this change no longer work, and it isn't possible to manually update them as the `Allow pattern overrides` toggle does not appear.

## How?
Uses the ` convertLegacyBlockNameAndAttributes` method to map to the new naming.

## Testing Instructions

- Before checking out this branch add a save a pattern with all the possible override sources, eg. 

```
<!-- wp:paragraph {"metadata":{"id":"Y_Tl0H","bindings":{"content":{"source":{"name":"pattern_attributes"}}}}} -->
<p>jjsdfsdf</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"metadata":{"id":"9Qopga","bindings":{"content":{"source":{"name":"pattern_attributes"}}}}} -->
<h2 class="wp-block-heading">sdfsdf</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":52,"sizeSlug":"large","linkDestination":"none","metadata":{"id":"KuONEg","bindings":{"url":{"source":{"name":"pattern_attributes"}},"title":{"source":{"name":"pattern_attributes"}},"alt":{"source":{"name":"pattern_attributes"}}}}} -->
<figure class="wp-block-image size-large"><img src="http://gutenbergcorestable.local/wp-content/uploads/2023/12/PXL_20231207_020914826.MP_-2-1024x768.jpg" alt="" class="wp-image-52"/></figure>
<!-- /wp:image -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"id":"yHW9vL","bindings":{"text":{"source":{"name":"pattern_attributes"}},"url":{"source":{"name":"pattern_attributes"}},"linkTarget":{"source":{"name":"pattern_attributes"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">asdasd</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

```

- Check out this branch and check that the pattern can be edited in the pattern editor and that it works as expected in post/page editor and frontend.


## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/WordPress/gutenberg/assets/3629020/b5e863cb-16d2-4bbc-be88-4895019bda82

After:

https://github.com/WordPress/gutenberg/assets/3629020/5e137349-521b-45a3-b1e3-e3e6ac496e22






