### PR TITLE
Block editor canvas iframe: play around with restricting max height of iframe

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -107,6 +107,7 @@ function Iframe( {
 	scale = 1,
 	frameSize = 0,
 	expand = false,
+	maxHeight,
 	readonly,
 	forwardedRef: ref,
 	...props
@@ -239,7 +240,12 @@ function Iframe( {
 	// We need to counter the margin created by scaling the iframe. If the scale
 	// is e.g. 0.45, then the top + bottom margin is 0.55 (1 - scale). Just the
 	// top or bottom margin is 0.55 / 2 ((1 - scale) / 2).
-	const marginFromScaling = ( contentHeight * ( 1 - scale ) ) / 2;
+	// const maxHeight = props.style?.maxHeight || 0;
+	const maxContentHeight =
+		maxHeight && contentHeight > maxHeight
+			? maxHeight / ( 1 - scale )
+			: contentHeight;
+	const marginFromScaling = ( maxContentHeight * ( 1 - scale ) ) / 2;
 
 	return (
 		<>
@@ -250,7 +256,7 @@ function Iframe( {
 				style={ {
 					border: 0,
 					...props.style,
-					height: expand ? contentHeight : props.style?.height,
+					height: expand ? maxContentHeight : props.style?.height,
 					marginTop:
 						scale !== 1
 							? -marginFromScaling + frameSize
@@ -263,7 +269,7 @@ function Iframe( {
 						scale !== 1
 							? `scale( ${ scale } )`
 							: props.style?.transform,
-					transition: 'all .3s',
+					transition: props.style?.transition || 'all .3s',
 				} }
 				ref={ useMergeRefs( [ ref, setRef ] ) }
 				tabIndex={ tabIndex }

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -25,7 +25,13 @@ import {
 
 const { EditorCanvas: EditorCanvasRoot } = unlock( editorPrivateApis );
 
-function EditorCanvas( { enableResizing, settings, children, ...props } ) {
+function EditorCanvas( {
+	enableResizing,
+	settings,
+	children,
+	containerHeight,
+	...props
+} ) {
 	const { hasBlocks, isFocusMode, templateType, canvasMode, isZoomOutMode } =
 		useSelect( ( select ) => {
 			const { getBlockCount, __unstableGetEditorMode } =
@@ -109,13 +115,20 @@ function EditorCanvas( { enableResizing, settings, children, ...props } ) {
 			iframeProps={ {
 				expand: isZoomOutMode,
 				scale: isZoomOutMode ? 0.45 : undefined,
-				frameSize: isZoomOutMode ? 100 : undefined,
+				frameSize: isZoomOutMode ? 50 : undefined,
 				className: classnames(
 					'edit-site-visual-editor__editor-canvas',
 					{
 						'is-focused': isFocused && canvasMode === 'view',
 					}
 				),
+				maxHeight:
+					isZoomOutMode && containerHeight
+						? containerHeight
+						: undefined,
+				style: {
+					transition: isZoomOutMode ? 'none' : undefined,
+				},
 				...props,
 				...( canvasMode === 'view' ? viewModeProps : {} ),
 			} }

--- a/packages/edit-site/src/components/block-editor/editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/editor-canvas.js
@@ -115,7 +115,7 @@ function EditorCanvas( {
 			iframeProps={ {
 				expand: isZoomOutMode,
 				scale: isZoomOutMode ? 0.45 : undefined,
-				frameSize: isZoomOutMode ? 50 : undefined,
+				frameSize: isZoomOutMode ? 100 : undefined,
 				className: classnames(
 					'edit-site-visual-editor__editor-canvas',
 					{

--- a/packages/edit-site/src/components/block-editor/site-editor-canvas.js
+++ b/packages/edit-site/src/components/block-editor/site-editor-canvas.js
@@ -6,8 +6,12 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useViewportMatch, useResizeObserver } from '@wordpress/compose';
-
+import {
+	useViewportMatch,
+	useResizeObserver,
+	useRefEffect,
+} from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -59,12 +63,25 @@ export default function SiteEditorCanvas() {
 	const isTemplateTypeNavigation = templateType === NAVIGATION_POST_TYPE;
 	const isNavigationFocusMode = isTemplateTypeNavigation && isFocusMode;
 	const forceFullHeight = isNavigationFocusMode;
+	const [ containerHeight, setContainerHeight ] = useState();
+	const containerRef = useRefEffect(
+		( node ) => {
+			if ( ! node && ! node?.offsetHeight ) {
+				return;
+			}
+			setContainerHeight( node?.offsetHeight );
+		},
+		[ window.innerHeight ]
+	);
 
 	return (
 		<EditorCanvasContainer.Slot>
 			{ ( [ editorCanvasView ] ) =>
 				editorCanvasView ? (
-					<div className="edit-site-visual-editor is-focus-mode">
+					<div
+						className="edit-site-visual-editor is-focus-mode"
+						ref={ containerRef }
+					>
 						{ editorCanvasView }
 					</div>
 				) : (
@@ -73,6 +90,7 @@ export default function SiteEditorCanvas() {
 							'is-focus-mode': isFocusMode || !! editorCanvasView,
 							'is-view-mode': isViewMode,
 						} ) }
+						ref={ containerRef }
 					>
 						<BackButton />
 						<ResizableEditor
@@ -86,6 +104,7 @@ export default function SiteEditorCanvas() {
 							<EditorCanvas
 								enableResizing={ enableResizing }
 								settings={ settings }
+								containerHeight={ containerHeight }
 							>
 								{ resizeObserver }
 							</EditorCanvas>


### PR DESCRIPTION
An experiment only:

- pass block editor canvas container element properties (height) down to iframe. For this experiment just pass container height.
- Use container height as the max height of the iframe.
- Set maxheight of iframe when in iframe zoom mode to avoid iframe stretching where blocks have vh set
- Turn off unhelpful transition animations
- Use container height as the max height of the iframe.
- Set maxheight of iframe when in iframe zoom mode to avoid iframe stretching where blocks have vh set
- Turn off unhelpful transition animations

Some example HTML


```html
<!-- wp:group {"style":{"dimensions":{"minHeight":"100vh"}},"layout":{"type":"constrained"}} -->
<!-- wp:group {"style":{"dimensions":{"minHeight":"30.8vh"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="min-height:30.8vh"><!-- wp:image {"id":37,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://localhost:8888/wp-content/uploads/2024/01/white-bellied-swallow.jpg" alt="" class="wp-image-37"/></figure>
<!-- /wp:image --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```


### Before

https://github.com/WordPress/gutenberg/assets/6458278/04473afa-197e-446b-ba6f-eae9c3c07369



### After

https://github.com/WordPress/gutenberg/assets/6458278/0e116e83-fc07-4398-8b27-1fb487ccb4ab




<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
