### PR TITLE
Fix: use old template panel if user doesn’t have access to view templates

### DIFF
--- a/packages/editor/src/components/post-template/panel.js
+++ b/packages/editor/src/components/post-template/panel.js
@@ -47,7 +47,11 @@ export default function PostTemplatePanel() {
 		return canCreateTemplates;
 	}, [] );
 
-	if ( ! isBlockTheme && isVisible ) {
+	const canViewTemplates = useSelect( ( select ) => {
+		return select( coreStore ).canUser( 'read', 'templates' ) ?? false;
+	}, [] );
+
+	if ( ( ! isBlockTheme || ! canViewTemplates ) && isVisible ) {
 		return (
 			<PostPanelRow label={ __( 'Template' ) }>
 				<ClassicThemeControl />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Make it possible for non administrators to switch between templates again.

Closing: #58037 

This fix is an alternative approach to #58301. #58301 tries to solve it whilst still retaining the ability for editors to preview the template in the editor where as this PR here only restores the old behavior. 

I personally would very much preffer #58301 since I think the template preview is a very valuable feature that editors should have access to. But as far as 6.5 goes this here may be the stop gap solution we need.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because a regression was introduced in https://github.com/WordPress/gutenberg/pull/56817

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By checking if the current user can view the templates post type and if not rendering the classic control.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Make sure your theme supports at least 1 additional custom template besides the default single post template.
2. Open the post editor with a user account that is an Editor or lower role
3. See that you are no longer able to switch between the available templates

