### PR TITLE
Avoid running pattern overrides migration in WordPress core

### DIFF
--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -77,33 +77,37 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 		newAttributes.legacy = true;
 	}
 
-	// Convert pattern overrides added during experimental phase.
-	// Only four blocks were supported initially.
-	// These checks can be removed in WordPress 6.6.
-	if (
-		newAttributes.metadata?.bindings &&
-		( name === 'core/paragraph' ||
-			name === 'core/heading' ||
-			name === 'core/image' ||
-			name === 'core/button' )
-	) {
-		const bindings = [
-			'content',
-			'url',
-			'title',
-			'alt',
-			'text',
-			'linkTarget',
-		];
-		bindings.forEach( ( binding ) => {
-			if (
-				newAttributes.metadata.bindings[ binding ]?.source?.name ===
-				'pattern_attributes'
-			) {
-				newAttributes.metadata.bindings[ binding ].source =
-					'core/pattern-overrides';
-			}
-		} );
+	// The following code is only relevant for the Gutenberg plugin.
+	// It's a stand-alone if statement for dead-code elimination.
+	if ( process.env.IS_GUTENBERG_PLUGIN ) {
+		// Convert pattern overrides added during experimental phase.
+		// Only four blocks were supported initially.
+		// These checks can be removed in WordPress 6.6.
+		if (
+			newAttributes.metadata?.bindings &&
+			( name === 'core/paragraph' ||
+				name === 'core/heading' ||
+				name === 'core/image' ||
+				name === 'core/button' )
+		) {
+			const bindings = [
+				'content',
+				'url',
+				'title',
+				'alt',
+				'text',
+				'linkTarget',
+			];
+			bindings.forEach( ( binding ) => {
+				if (
+					newAttributes.metadata.bindings[ binding ]?.source?.name ===
+					'pattern_attributes'
+				) {
+					newAttributes.metadata.bindings[ binding ].source =
+						'core/pattern-overrides';
+				}
+			} );
+		}
 	}
 	return [ name, newAttributes ];
 }


### PR DESCRIPTION
## What?
Related #58483

Avoids the unnecessary overheads of migrating pattern overrides block data in wordpress core.

The changes only apply to gutenberg plugin releases, so follows the suggestion of @gziolo by adding a check for `process.env.IS_GUTENBERG_PLUGIN` is added.