### PR TITLE
Improve translators comments for wp.date.setSettings in compat file

### DIFF
--- a/lib/compat/wordpress-6.5/script-loader.php
+++ b/lib/compat/wordpress-6.5/script-loader.php
@@ -51,27 +51,27 @@ function gutenberg_update_wp_date_settings( $scripts ) {
 								'past'   => __( '%s ago', 'gutenberg' ),
 								/* translators: One second from or to a particular datetime, e.g., "a second ago" or "a second from now". */
 								's'      => __( 'a second', 'gutenberg' ),
-								/* translators: %s: Duration in seconds from or to a particular datetime, e.g., "4 seconds ago" or "4 seconds from now". */
+								/* translators: %d: Duration in seconds from or to a particular datetime, e.g., "4 seconds ago" or "4 seconds from now". */
 								'ss'     => __( '%d seconds', 'gutenberg' ),
 								/* translators: One minute from or to a particular datetime, e.g., "a minute ago" or "a minute from now". */
 								'm'      => __( 'a minute', 'gutenberg' ),
-								/* translators: %s: Duration in minutes from or to a particular datetime, e.g., "4 minutes ago" or "4 minutes from now". */
+								/* translators: %d: Duration in minutes from or to a particular datetime, e.g., "4 minutes ago" or "4 minutes from now". */
 								'mm'     => __( '%d minutes', 'gutenberg' ),
-								/* translators: %s: One hour from or to a particular datetime, e.g., "an hour ago" or "an hour from now". */
+								/* translators: One hour from or to a particular datetime, e.g., "an hour ago" or "an hour from now". */
 								'h'      => __( 'an hour', 'gutenberg' ),
-								/* translators: %s: Duration in hours from or to a particular datetime, e.g., "4 hours ago" or "4 hours from now". */
+								/* translators: %d: Duration in hours from or to a particular datetime, e.g., "4 hours ago" or "4 hours from now". */
 								'hh'     => __( '%d hours', 'gutenberg' ),
-								/* translators: %s: One day from or to a particular datetime, e.g., "a day ago" or "a day from now". */
+								/* translators: One day from or to a particular datetime, e.g., "a day ago" or "a day from now". */
 								'd'      => __( 'a day', 'gutenberg' ),
-								/* translators: %s: Duration in days from or to a particular datetime, e.g., "4 days ago" or "4 days from now". */
+								/* translators: %d: Duration in days from or to a particular datetime, e.g., "4 days ago" or "4 days from now". */
 								'dd'     => __( '%d days', 'gutenberg' ),
-								/* translators: %s: One month from or to a particular datetime, e.g., "a month ago" or "a month from now". */
+								/* translators: One month from or to a particular datetime, e.g., "a month ago" or "a month from now". */
 								'M'      => __( 'a month', 'gutenberg' ),
-								/* translators: %s: Duration in months from or to a particular datetime, e.g., "4 months ago" or "4 months from now". */
+								/* translators: %d: Duration in months from or to a particular datetime, e.g., "4 months ago" or "4 months from now". */
 								'MM'     => __( '%d months', 'gutenberg' ),
-								/* translators: %s: One year from or to a particular datetime, e.g., "a year ago" or "a year from now". */
+								/* translators: One year from or to a particular datetime, e.g., "a year ago" or "a year from now". */
 								'y'      => __( 'a year', 'gutenberg' ),
-								/* translators: %s: Duration in years from or to a particular datetime, e.g., "4 years ago" or "4 years from now". */
+								/* translators: %d: Duration in years from or to a particular datetime, e.g., "4 years ago" or "4 years from now". */
 								'yy'     => __( '%d years', 'gutenberg' ),
 							),
 							'startOfWeek'   => (int) get_option( 'start_of_week', 0 ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow-up to https://github.com/WordPress/gutenberg/pull/56682 and https://github.com/WordPress/gutenberg/pull/58479

While looking at the above pull requests I noticed some translators comments can be improved.
These comments need to be improved for Core as well. The Trac ticket https://core.trac.wordpress.org/ticket/60105 can be a good place to do that.

## What?
<!-- In a few words, what is the PR actually doing? -->
A few translators comments have incorrect placeholders reference or unnecessary ones.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To make translators happy.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use correct format for translators comments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
This quick PR only changes translators comments. 


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
