### PR TITLE
Block editor: Image link update active status when lightbox is enabled

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -241,11 +241,11 @@ const ImageURLInputUI = ( {
 			<ToolbarButton
 				icon={ linkIcon }
 				className="components-toolbar__control"
-				label={ url ? __( 'Edit link' ) : __( 'Add link' ) }
+				label={ __( 'Link' ) }
 				aria-expanded={ isOpen }
 				onClick={ openLinkUI }
 				ref={ setPopoverAnchor }
-				isActive={ !! url }
+				isActive={ !! url || lightboxEnabled }
 			/>
 			{ isOpen && (
 				<URLPopover

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -670,7 +670,7 @@ test.describe( 'Image', () => {
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
 		);
 
-		await page.getByLabel( 'Block tools' ).getByLabel( 'Add link' ).click();
+		await page.getByLabel( 'Block tools' ).getByLabel( 'Link' ).click();
 
 		// This form lacks distinguishing qualities other than the
 		// class name, so we use page.locator() instead of page.getByRole()


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Changes requested in https://github.com/WordPress/gutenberg/pull/57608#issuecomment-1917763720

Change block editor image label link for images with and without Lightbox enabled. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Changes are already in 17.6, but were done in a merged PR, so we need to update trunk with the change.
