### PR TITLE
Interactivity Router: Fix initial page cache

### DIFF
--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -23,7 +23,9 @@ store( 'core/query', {
 		*navigate( event ) {
 			const ctx = getContext();
 			const { ref } = getElement();
-			const { queryRef } = ctx;
+			const queryRef = ref.closest(
+				'.wp-block-query[data-wp-router-region]'
+			);
 			const isDisabled = queryRef?.dataset.wpNavigationDisabled;
 
 			if ( isValidLink( ref ) && isValidEvent( event ) && ! isDisabled ) {
@@ -41,8 +43,10 @@ store( 'core/query', {
 			}
 		},
 		*prefetch() {
-			const { queryRef } = getContext();
 			const { ref } = getElement();
+			const queryRef = ref.closest(
+				'.wp-block-query[data-wp-router-region]'
+			);
 			const isDisabled = queryRef?.dataset.wpNavigationDisabled;
 			if ( isValidLink( ref ) && ! isDisabled ) {
 				const { actions } = yield import(
@@ -62,11 +66,6 @@ store( 'core/query', {
 				);
 				yield actions.prefetch( ref.href );
 			}
-		},
-		setQueryRef() {
-			const ctx = getContext();
-			const { ref } = getElement();
-			ctx.queryRef = ref;
 		},
 	},
 } );

--- a/packages/interactivity-router/src/index.js
+++ b/packages/interactivity-router/src/index.js
@@ -5,7 +5,7 @@ import { render, store, privateApis } from '@wordpress/interactivity';
 
 const { directivePrefix, getRegionRootFragment, initialVdom, toVdom } =
 	privateApis(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.'
+		'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
 	);
 
 // The cache of visited and prefetched pages.

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -2,7 +2,9 @@
  * Internal dependencies
  */
 import registerDirectives from './directives';
-import { init } from './init';
+import { init, getRegionRootFragment, initialVdom } from './init';
+import { directivePrefix } from './constants';
+import { toVdom } from './vdom';
 
 export { store } from './store';
 export { directive, getContext, getElement, getNamespace } from './hooks';
@@ -15,13 +17,26 @@ export {
 	useCallback,
 	useMemo,
 } from './utils';
-export { directivePrefix } from './constants';
-export { toVdom } from './vdom';
-export { getRegionRootFragment } from './init';
 
 export { h as createElement, cloneElement, render } from 'preact';
 export { useContext, useState, useRef } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';
+
+const requiredConsent =
+	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.';
+
+export const privateApis = ( lock ) => {
+	if ( lock === requiredConsent ) {
+		return {
+			directivePrefix,
+			getRegionRootFragment,
+			initialVdom,
+			toVdom,
+		};
+	}
+
+	throw new Error( 'TODO: Add a more appropriate message.' );
+};
 
 document.addEventListener( 'DOMContentLoaded', async () => {
 	registerDirectives();

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -23,7 +23,7 @@ export { useContext, useState, useRef } from 'preact/hooks';
 export { deepSignal } from 'deepsignal';
 
 const requiredConsent =
-	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.';
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';
 
 export const privateApis = ( lock ) => {
 	if ( lock === requiredConsent ) {

--- a/packages/interactivity/src/index.js
+++ b/packages/interactivity/src/index.js
@@ -35,7 +35,7 @@ export const privateApis = ( lock ) => {
 		};
 	}
 
-	throw new Error( 'TODO: Add a more appropriate message.' );
+	throw new Error( 'Forbidden access.' );
 };
 
 document.addEventListener( 'DOMContentLoaded', async () => {

--- a/packages/interactivity/src/init.js
+++ b/packages/interactivity/src/init.js
@@ -28,6 +28,9 @@ function yieldToMain() {
 	} );
 }
 
+// Initial vDOM regions associated with its DOM element.
+export const initialVdom = new WeakMap();
+
 // Initialize the router with the initial DOM.
 export const init = async () => {
 	const nodes = document.querySelectorAll(
@@ -39,6 +42,7 @@ export const init = async () => {
 			await yieldToMain();
 			const fragment = getRegionRootFragment( node );
 			const vdom = toVdom( node );
+			initialVdom.set( node, vdom );
 			await yieldToMain();
 			hydrate( vdom, fragment );
 		}

--- a/packages/interactivity/src/vdom.js
+++ b/packages/interactivity/src/vdom.js
@@ -35,7 +35,12 @@ const nsPathRegExp = /^([\w-_\/]+)::(.+)$/;
 
 export const hydratedIslands = new WeakSet();
 
-// Recursive function that transforms a DOM tree into vDOM.
+/**
+ * Recursive function that transforms a DOM tree into vDOM.
+ *
+ * @param {Node} root The root element or node to start traversing on.
+ * @return {import('preact').VNode[]} The resulting vDOM tree.
+ */
 export function toVdom( root ) {
 	const treeWalker = document.createTreeWalker(
 		root,


### PR DESCRIPTION
## What?

Epic: https://github.com/WordPress/gutenberg/issues/56803

This PR ensures the first page is cached using the vDOM tree generated during hydration.

## Why?

As the `@wordpress/interactivity-router` module is loaded asynchronously, it currently caches the first page traversing the current DOM, which interactive blocks could have modified. This PR prevents that issue by using the same vDOM hydrated.

## How?

Exposing from the `@wordpress/interactivity` module a `WeakMap` called `initialVdom`, relating the generated vDOM trees with the root node where they are hydrated. This `initialVdom` weak map is exposed from a function named `private APIs`, which also returns other APIs meant to only be used internally.

## Testing Instructions

1. In the site editor, at the homepage template, disable "Force page reload" for the Query block.
2. Visit the homepage.
3. In the Query block, click on "Next page".
4. Ensure the next page is rendered as expected.
5. Go back.
6. Ensure the previous page is rendered as expected.