### PR TITLE
Avoid using early returns to prevent classname duplication

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -86,16 +86,15 @@ Or for classes:
  * @package WordPress
  * @since 6.3.0
  */
-if ( class_exists( 'WP_A_Stable_Class' ) ) {
-	return;
+if ( ! class_exists( 'WP_A_Stable_Class' ) ) {
+	/**
+	 * A very stable class that does something.
+	 *
+	 * @since 6.3.0
+	 */
+	class WP_A_Stable_Class { ... }
 }
 
-/**
- * A very stable class that does something.
- *
- * @since 6.3.0
- */
-class WP_A_Stable_Class { ... }
 ```
 
 Wrapping code in `class_exists()` and `function_exists()` is usually inappropriate for evergreen code, or any plugin code that we expect to undergo constant change between WordPress releases, because it would prevent the latest versions of the code from being used. For example, the statement `class_exists( 'WP_Theme_JSON' )` would return `true` because the class already exists in Core.

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -32,10 +32,6 @@
  * @since 6.3.0
  */
 
-if ( class_exists( 'WP_Duotone_Gutenberg' ) ) {
-	return;
-}
-
 /**
  * Manages duotone block supports and global styles.
  *

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -10,10 +10,6 @@
  * @since 5.9.0
  */
 
-if ( class_exists( 'WP_REST_Global_Styles_Controller_Gutenberg' ) ) {
-	return;
-}
-
 /**
  * Base Global Styles REST API Controller.
  */

--- a/lib/class-wp-theme-json-data-gutenberg.php
+++ b/lib/class-wp-theme-json-data-gutenberg.php
@@ -6,10 +6,6 @@
  * @since 6.1.0
  */
 
-if ( class_exists( 'WP_Theme_JSON_Data_Gutenberg' ) ) {
-	return;
-}
-
 /**
  * Class to provide access to update a theme.json structure.
  */

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -6,10 +6,6 @@
  * @since 5.8.0
  */
 
-if ( class_exists( 'WP_Theme_JSON_Gutenberg' ) ) {
-	return;
-}
-
 /**
  * Class that encapsulates the processing of structures that adhere to the theme.json spec.
  *

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -6,10 +6,6 @@
  * @since 5.8.0
  */
 
-if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
-	return;
-}
-
 /**
  * Class that abstracts the processing of the different data sources
  * for site-level config and offers an API to work with them.

--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face-resolver.php
@@ -9,176 +9,175 @@
  * @core-merge: this file is located in `wp-includes/fonts/`.
  */
 
-if ( class_exists( 'WP_Font_Face_Resolver' ) ) {
-	return;
-}
-
-/**
- * The Font Face Resolver abstracts the processing of different data sources
- * (such as theme.json) for processing within the Font Face.
- *
- * This class is for internal core usage and is not supposed to be used by
- * extenders (plugins and/or themes).
- *
- * @access private
- */
-class WP_Font_Face_Resolver {
+if ( ! class_exists( 'WP_Font_Face_Resolver' ) ) {
 
 	/**
-	 * Gets fonts defined in theme.json.
+	 * The Font Face Resolver abstracts the processing of different data sources
+	 * (such as theme.json) for processing within the Font Face.
 	 *
-	 * @since 6.4.0
+	 * This class is for internal core usage and is not supposed to be used by
+	 * extenders (plugins and/or themes).
 	 *
-	 * @return array Returns the font-families, each with their font-face variations.
+	 * @access private
 	 */
-	public static function get_fonts_from_theme_json() {
-		$settings = gutenberg_get_global_settings();
+	class WP_Font_Face_Resolver {
 
-		// Bail out early if there are no font settings.
-		if ( empty( $settings['typography']['fontFamilies'] ) ) {
-			return array();
+		/**
+		 * Gets fonts defined in theme.json.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return array Returns the font-families, each with their font-face variations.
+		 */
+		public static function get_fonts_from_theme_json() {
+			$settings = gutenberg_get_global_settings();
+
+			// Bail out early if there are no font settings.
+			if ( empty( $settings['typography']['fontFamilies'] ) ) {
+				return array();
+			}
+
+			return static::parse_settings( $settings );
 		}
 
-		return static::parse_settings( $settings );
-	}
+		/**
+		 * Parse theme.json settings to extract font definitions with variations grouped by font-family.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $settings Font settings to parse.
+		 * @return array Returns an array of fonts, grouped by font-family.
+		 */
+		private static function parse_settings( array $settings ) {
+			$fonts = array();
 
-	/**
-	 * Parse theme.json settings to extract font definitions with variations grouped by font-family.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $settings Font settings to parse.
-	 * @return array Returns an array of fonts, grouped by font-family.
-	 */
-	private static function parse_settings( array $settings ) {
-		$fonts = array();
+			foreach ( $settings['typography']['fontFamilies'] as $font_families ) {
+				foreach ( $font_families as $definition ) {
 
-		foreach ( $settings['typography']['fontFamilies'] as $font_families ) {
-			foreach ( $font_families as $definition ) {
+					// Skip if "fontFace" is not defined, meaning there are no variations.
+					if ( empty( $definition['fontFace'] ) ) {
+						continue;
+					}
 
-				// Skip if "fontFace" is not defined, meaning there are no variations.
-				if ( empty( $definition['fontFace'] ) ) {
+					// Skip if "fontFamily" is not defined.
+					if ( empty( $definition['fontFamily'] ) ) {
+						continue;
+					}
+
+					$font_family_name = static::maybe_parse_name_from_comma_separated_list( $definition['fontFamily'] );
+
+					// Skip if no font family is defined.
+					if ( empty( $font_family_name ) ) {
+						continue;
+					}
+
+					// Prepare the fonts array structure for this font-family.
+					if ( ! array_key_exists( $font_family_name, $fonts ) ) {
+						$fonts[ $font_family_name ] = array();
+					}
+
+					$fonts[ $font_family_name ] = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
+				}
+			}
+
+			return $fonts;
+		}
+
+		/**
+		 * Parse font-family name from comma-separated lists.
+		 *
+		 * If the given `fontFamily` is a comma-separated lists (example: "Inter, sans-serif" ),
+		 * parse and return the fist font from the list.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param string $font_family Font family `fontFamily' to parse.
+		 * @return string Font-family name.
+		 */
+		private static function maybe_parse_name_from_comma_separated_list( $font_family ) {
+			if ( str_contains( $font_family, ',' ) ) {
+				$font_family = explode( ',', $font_family )[0];
+			}
+
+			return trim( $font_family, "\"'" );
+		}
+
+		/**
+		 * Converts font-face properties from theme.json format.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array  $font_face_definition The font-face definitions to convert.
+		 * @param string $font_family_property The value to store in the font-face font-family property.
+		 * @return array Converted font-face properties.
+		 */
+		private static function convert_font_face_properties( array $font_face_definition, $font_family_property ) {
+			$converted_font_faces = array();
+
+			foreach ( $font_face_definition as $font_face ) {
+				// Add the font-family property to the font-face.
+				$font_face['font-family'] = $font_family_property;
+
+				// Converts the "file:./" src placeholder into a theme font file URI.
+				if ( ! empty( $font_face['src'] ) ) {
+					$font_face['src'] = static::to_theme_file_uri( (array) $font_face['src'] );
+				}
+
+				// Convert camelCase properties into kebab-case.
+				$font_face = static::to_kebab_case( $font_face );
+
+				$converted_font_faces[] = $font_face;
+			}
+
+			return $converted_font_faces;
+		}
+
+		/**
+		 * Converts each 'file:./' placeholder into a URI to the font file in the theme.
+		 *
+		 * The 'file:./' is specified in the theme's `theme.json` as a placeholder to be
+		 * replaced with the URI to the font file's location in the theme. When a "src"
+		 * beings with this placeholder, it is replaced, converting the src into a URI.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $src An array of font file sources to process.
+		 * @return array An array of font file src URI(s).
+		 */
+		private static function to_theme_file_uri( array $src ) {
+			$placeholder = 'file:./';
+
+			foreach ( $src as $src_key => $src_url ) {
+				// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
+				if ( ! str_starts_with( $src_url, $placeholder ) ) {
 					continue;
 				}
 
-				// Skip if "fontFamily" is not defined.
-				if ( empty( $definition['fontFamily'] ) ) {
-					continue;
+				$src_file        = str_replace( $placeholder, '', $src_url );
+				$src[ $src_key ] = get_theme_file_uri( $src_file );
+			}
+
+			return $src;
+		}
+
+		/**
+		 * Converts all first dimension keys into kebab-case.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $data The array to process.
+		 * @return array Data with first dimension keys converted into kebab-case.
+		 */
+		private static function to_kebab_case( array $data ) {
+			foreach ( $data as $key => $value ) {
+				$kebab_case          = _wp_to_kebab_case( $key );
+				$data[ $kebab_case ] = $value;
+				if ( $kebab_case !== $key ) {
+					unset( $data[ $key ] );
 				}
-
-				$font_family_name = static::maybe_parse_name_from_comma_separated_list( $definition['fontFamily'] );
-
-				// Skip if no font family is defined.
-				if ( empty( $font_family_name ) ) {
-					continue;
-				}
-
-				// Prepare the fonts array structure for this font-family.
-				if ( ! array_key_exists( $font_family_name, $fonts ) ) {
-					$fonts[ $font_family_name ] = array();
-				}
-
-				$fonts[ $font_family_name ] = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
-			}
-		}
-
-		return $fonts;
-	}
-
-	/**
-	 * Parse font-family name from comma-separated lists.
-	 *
-	 * If the given `fontFamily` is a comma-separated lists (example: "Inter, sans-serif" ),
-	 * parse and return the fist font from the list.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param string $font_family Font family `fontFamily' to parse.
-	 * @return string Font-family name.
-	 */
-	private static function maybe_parse_name_from_comma_separated_list( $font_family ) {
-		if ( str_contains( $font_family, ',' ) ) {
-			$font_family = explode( ',', $font_family )[0];
-		}
-
-		return trim( $font_family, "\"'" );
-	}
-
-	/**
-	 * Converts font-face properties from theme.json format.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array  $font_face_definition The font-face definitions to convert.
-	 * @param string $font_family_property The value to store in the font-face font-family property.
-	 * @return array Converted font-face properties.
-	 */
-	private static function convert_font_face_properties( array $font_face_definition, $font_family_property ) {
-		$converted_font_faces = array();
-
-		foreach ( $font_face_definition as $font_face ) {
-			// Add the font-family property to the font-face.
-			$font_face['font-family'] = $font_family_property;
-
-			// Converts the "file:./" src placeholder into a theme font file URI.
-			if ( ! empty( $font_face['src'] ) ) {
-				$font_face['src'] = static::to_theme_file_uri( (array) $font_face['src'] );
 			}
 
-			// Convert camelCase properties into kebab-case.
-			$font_face = static::to_kebab_case( $font_face );
-
-			$converted_font_faces[] = $font_face;
+			return $data;
 		}
-
-		return $converted_font_faces;
-	}
-
-	/**
-	 * Converts each 'file:./' placeholder into a URI to the font file in the theme.
-	 *
-	 * The 'file:./' is specified in the theme's `theme.json` as a placeholder to be
-	 * replaced with the URI to the font file's location in the theme. When a "src"
-	 * beings with this placeholder, it is replaced, converting the src into a URI.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $src An array of font file sources to process.
-	 * @return array An array of font file src URI(s).
-	 */
-	private static function to_theme_file_uri( array $src ) {
-		$placeholder = 'file:./';
-
-		foreach ( $src as $src_key => $src_url ) {
-			// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
-			if ( ! str_starts_with( $src_url, $placeholder ) ) {
-				continue;
-			}
-
-			$src_file        = str_replace( $placeholder, '', $src_url );
-			$src[ $src_key ] = get_theme_file_uri( $src_file );
-		}
-
-		return $src;
-	}
-
-	/**
-	 * Converts all first dimension keys into kebab-case.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $data The array to process.
-	 * @return array Data with first dimension keys converted into kebab-case.
-	 */
-	private static function to_kebab_case( array $data ) {
-		foreach ( $data as $key => $value ) {
-			$kebab_case          = _wp_to_kebab_case( $key );
-			$data[ $kebab_case ] = $value;
-			if ( $kebab_case !== $key ) {
-				unset( $data[ $key ] );
-			}
-		}
-
-		return $data;
 	}
 }

--- a/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php
+++ b/lib/compat/wordpress-6.4/fonts/font-face/class-wp-font-face.php
@@ -9,428 +9,427 @@
  * @core-merge: this file is located in `wp-includes/fonts/`.
  */
 
-if ( class_exists( 'WP_Font_Face' ) ) {
-	return;
-}
-
-/**
- * Font Face generates and prints `@font-face` styles for given fonts.
- *
- * @since 6.4.0
- */
-class WP_Font_Face {
+if ( ! class_exists( 'WP_Font_Face' ) ) {
 
 	/**
-	 * The font-face property defaults.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string[]
-	 */
-	private $font_face_property_defaults = array(
-		'font-family'  => '',
-		'font-style'   => 'normal',
-		'font-weight'  => '400',
-		'font-display' => 'fallback',
-	);
-
-	/**
-	 * Valid font-face property names.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string[]
-	 */
-	private $valid_font_face_properties = array(
-		'ascent-override',
-		'descent-override',
-		'font-display',
-		'font-family',
-		'font-stretch',
-		'font-style',
-		'font-weight',
-		'font-variant',
-		'font-feature-settings',
-		'font-variation-settings',
-		'line-gap-override',
-		'size-adjust',
-		'src',
-		'unicode-range',
-	);
-
-	/**
-	 * Valid font-display values.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string[]
-	 */
-	private $valid_font_display = array( 'auto', 'block', 'fallback', 'swap', 'optional' );
-
-	/**
-	 * Array of font-face style tag's attribute(s)
-	 * where the key is the attribute name and the
-	 * value is its value.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string[]
-	 */
-	private $style_tag_attrs = array();
-
-	/**
-	 * Creates and initializes an instance of WP_Font_Face.
+	 * Font Face generates and prints `@font-face` styles for given fonts.
 	 *
 	 * @since 6.4.0
 	 */
-	public function __construct() {
-		if (
-			function_exists( 'is_admin' ) && ! is_admin()
-			&&
-			function_exists( 'current_theme_supports' ) && ! current_theme_supports( 'html5', 'style' )
-		) {
-			$this->style_tag_attrs = array( 'type' => 'text/css' );
-		}
-	}
+	class WP_Font_Face {
 
-	/**
-	 * Generates and prints the `@font-face` styles for the given fonts.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array[][] $fonts Optional. The font-families and their font variations.
-	 *                         See {@see wp_print_font_faces()} for the supported fields.
-	 *                         Default empty array.
-	 */
-	public function generate_and_print( array $fonts ) {
-		$fonts = $this->validate_fonts( $fonts );
-
-		// Bail out if there are no fonts are given to process.
-		if ( empty( $fonts ) ) {
-			return;
-		}
-
-		$css = $this->get_css( $fonts );
-
-		/*
-		 * The font-face CSS is contained within <style> tags and can only be interpreted
-		 * as CSS in the browser. Using wp_strip_all_tags() is sufficient escaping
-		 * to avoid malicious attempts to close </style> and open a <script>.
+		/**
+		 * The font-face property defaults.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string[]
 		 */
-		$css = wp_strip_all_tags( $css );
+		private $font_face_property_defaults = array(
+			'font-family'  => '',
+			'font-style'   => 'normal',
+			'font-weight'  => '400',
+			'font-display' => 'fallback',
+		);
 
-		// Bail out if there is no CSS to print.
-		if ( empty( $css ) ) {
-			return;
-		}
+		/**
+		 * Valid font-face property names.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string[]
+		 */
+		private $valid_font_face_properties = array(
+			'ascent-override',
+			'descent-override',
+			'font-display',
+			'font-family',
+			'font-stretch',
+			'font-style',
+			'font-weight',
+			'font-variant',
+			'font-feature-settings',
+			'font-variation-settings',
+			'line-gap-override',
+			'size-adjust',
+			'src',
+			'unicode-range',
+		);
 
-		printf( $this->get_style_element(), $css );
-	}
+		/**
+		 * Valid font-display values.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string[]
+		 */
+		private $valid_font_display = array( 'auto', 'block', 'fallback', 'swap', 'optional' );
 
-	/**
-	 * Validates each of the font-face properties.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $fonts The fonts to valid.
-	 * @return array Prepared font-faces organized by provider and font-family.
-	 */
-	private function validate_fonts( array $fonts ) {
-		$validated_fonts = array();
+		/**
+		 * Array of font-face style tag's attribute(s)
+		 * where the key is the attribute name and the
+		 * value is its value.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string[]
+		 */
+		private $style_tag_attrs = array();
 
-		foreach ( $fonts as $font_faces ) {
-			foreach ( $font_faces as $font_face ) {
-				$font_face = $this->validate_font_face_declarations( $font_face );
-				// Skip if failed validation.
-				if ( false === $font_face ) {
-					continue;
-				}
-
-				$validated_fonts[] = $font_face;
+		/**
+		 * Creates and initializes an instance of WP_Font_Face.
+		 *
+		 * @since 6.4.0
+		 */
+		public function __construct() {
+			if (
+				function_exists( 'is_admin' ) && ! is_admin()
+				&&
+				function_exists( 'current_theme_supports' ) && ! current_theme_supports( 'html5', 'style' )
+			) {
+				$this->style_tag_attrs = array( 'type' => 'text/css' );
 			}
 		}
 
-		return $validated_fonts;
-	}
+		/**
+		 * Generates and prints the `@font-face` styles for the given fonts.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array[][] $fonts Optional. The font-families and their font variations.
+		 *                         See {@see wp_print_font_faces()} for the supported fields.
+		 *                         Default empty array.
+		 */
+		public function generate_and_print( array $fonts ) {
+			$fonts = $this->validate_fonts( $fonts );
 
-	/**
-	 * Validates each font-face declaration (property and value pairing).
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $font_face Font face property and value pairings to validate.
-	 * @return array|false Validated font-face on success, or false on failure.
-	 */
-	private function validate_font_face_declarations( array $font_face ) {
-		$font_face = wp_parse_args( $font_face, $this->font_face_property_defaults );
+			// Bail out if there are no fonts are given to process.
+			if ( empty( $fonts ) ) {
+				return;
+			}
 
-		// Check the font-family.
-		if ( empty( $font_face['font-family'] ) || ! is_string( $font_face['font-family'] ) ) {
-			// @todo replace with `wp_trigger_error()`.
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Font font-family must be a non-empty string.' ),
-				'6.4.0'
-			);
-			return false;
+			$css = $this->get_css( $fonts );
+
+			/*
+			* The font-face CSS is contained within <style> tags and can only be interpreted
+			* as CSS in the browser. Using wp_strip_all_tags() is sufficient escaping
+			* to avoid malicious attempts to close </style> and open a <script>.
+			*/
+			$css = wp_strip_all_tags( $css );
+
+			// Bail out if there is no CSS to print.
+			if ( empty( $css ) ) {
+				return;
+			}
+
+			printf( $this->get_style_element(), $css );
 		}
 
-		// Make sure that local fonts have 'src' defined.
-		if ( empty( $font_face['src'] ) || ( ! is_string( $font_face['src'] ) && ! is_array( $font_face['src'] ) ) ) {
-			// @todo replace with `wp_trigger_error()`.
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Font src must be a non-empty string or an array of strings.' ),
-				'6.4.0'
-			);
-			return false;
+		/**
+		 * Validates each of the font-face properties.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $fonts The fonts to valid.
+		 * @return array Prepared font-faces organized by provider and font-family.
+		 */
+		private function validate_fonts( array $fonts ) {
+			$validated_fonts = array();
+
+			foreach ( $fonts as $font_faces ) {
+				foreach ( $font_faces as $font_face ) {
+					$font_face = $this->validate_font_face_declarations( $font_face );
+					// Skip if failed validation.
+					if ( false === $font_face ) {
+						continue;
+					}
+
+					$validated_fonts[] = $font_face;
+				}
+			}
+
+			return $validated_fonts;
 		}
 
-		// Validate the 'src' property.
-		foreach ( (array) $font_face['src'] as $src ) {
-			if ( empty( $src ) || ! is_string( $src ) ) {
+		/**
+		 * Validates each font-face declaration (property and value pairing).
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $font_face Font face property and value pairings to validate.
+		 * @return array|false Validated font-face on success, or false on failure.
+		 */
+		private function validate_font_face_declarations( array $font_face ) {
+			$font_face = wp_parse_args( $font_face, $this->font_face_property_defaults );
+
+			// Check the font-family.
+			if ( empty( $font_face['font-family'] ) || ! is_string( $font_face['font-family'] ) ) {
 				// @todo replace with `wp_trigger_error()`.
 				_doing_it_wrong(
 					__METHOD__,
-					__( 'Each font src must be a non-empty string.' ),
+					__( 'Font font-family must be a non-empty string.' ),
 					'6.4.0'
 				);
 				return false;
 			}
-		}
 
-		// Check the font-weight.
-		if ( ! is_string( $font_face['font-weight'] ) && ! is_int( $font_face['font-weight'] ) ) {
-			// @todo replace with `wp_trigger_error()`.
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Font font-weight must be a properly formatted string or integer.' ),
-				'6.4.0'
-			);
-			return false;
-		}
-
-		// Check the font-display.
-		if ( ! in_array( $font_face['font-display'], $this->valid_font_display, true ) ) {
-			$font_face['font-display'] = $this->font_face_property_defaults['font-display'];
-		}
-
-		// Remove invalid properties.
-		foreach ( $font_face as $property => $value ) {
-			if ( ! in_array( $property, $this->valid_font_face_properties, true ) ) {
-				unset( $font_face[ $property ] );
-			}
-		}
-
-		return $font_face;
-	}
-
-	/**
-	 * Gets the style element for wrapping the `@font-face` CSS.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return string The style element.
-	 */
-	private function get_style_element() {
-		$attributes = $this->generate_style_element_attributes();
-
-		return "<style id='wp-fonts-local'{$attributes}>\n%s\n</style>\n";
-	}
-
-	/**
-	 * Gets the defined <style> element's attributes.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return string A string of attribute=value when defined, else, empty string.
-	 */
-	private function generate_style_element_attributes() {
-		$attributes = '';
-		foreach ( $this->style_tag_attrs as $name => $value ) {
-			$attributes .= " {$name}='{$value}'";
-		}
-		return $attributes;
-	}
-
-	/**
-	 * Gets the `@font-face` CSS styles for locally-hosted font files.
-	 *
-	 * This method does the following processing tasks:
-	 *    1. Orchestrates an optimized `src` (with format) for browser support.
-	 *    2. Generates the `@font-face` for all its fonts.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $font_faces The font-faces to generate @font-face CSS styles.
-	 * @return string The `@font-face` CSS styles.
-	 */
-	private function get_css( $font_faces ) {
-		$css = '';
-
-		foreach ( $font_faces as $font_face ) {
-			// Order the font's `src` items to optimize for browser support.
-			$font_face = $this->order_src( $font_face );
-
-			// Build the @font-face CSS for this font.
-			$css .= '@font-face{' . $this->build_font_face_css( $font_face ) . '}' . "\n";
-		}
-
-		// Don't print the last newline character.
-		return rtrim( $css, "\n" );
-	}
-
-	/**
-	 * Orders `src` items to optimize for browser support.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $font_face Font face to process.
-	 * @return array Font-face with ordered src items.
-	 */
-	private function order_src( array $font_face ) {
-		if ( ! is_array( $font_face['src'] ) ) {
-			$font_face['src'] = (array) $font_face['src'];
-		}
-
-		$src         = array();
-		$src_ordered = array();
-
-		foreach ( $font_face['src'] as $url ) {
-			// Add data URIs first.
-			if ( str_starts_with( trim( $url ), 'data:' ) ) {
-				$src_ordered[] = array(
-					'url'    => $url,
-					'format' => 'data',
+			// Make sure that local fonts have 'src' defined.
+			if ( empty( $font_face['src'] ) || ( ! is_string( $font_face['src'] ) && ! is_array( $font_face['src'] ) ) ) {
+				// @todo replace with `wp_trigger_error()`.
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Font src must be a non-empty string or an array of strings.' ),
+					'6.4.0'
 				);
-				continue;
+				return false;
 			}
-			$format         = pathinfo( $url, PATHINFO_EXTENSION );
-			$src[ $format ] = $url;
+
+			// Validate the 'src' property.
+			foreach ( (array) $font_face['src'] as $src ) {
+				if ( empty( $src ) || ! is_string( $src ) ) {
+					// @todo replace with `wp_trigger_error()`.
+					_doing_it_wrong(
+						__METHOD__,
+						__( 'Each font src must be a non-empty string.' ),
+						'6.4.0'
+					);
+					return false;
+				}
+			}
+
+			// Check the font-weight.
+			if ( ! is_string( $font_face['font-weight'] ) && ! is_int( $font_face['font-weight'] ) ) {
+				// @todo replace with `wp_trigger_error()`.
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Font font-weight must be a properly formatted string or integer.' ),
+					'6.4.0'
+				);
+				return false;
+			}
+
+			// Check the font-display.
+			if ( ! in_array( $font_face['font-display'], $this->valid_font_display, true ) ) {
+				$font_face['font-display'] = $this->font_face_property_defaults['font-display'];
+			}
+
+			// Remove invalid properties.
+			foreach ( $font_face as $property => $value ) {
+				if ( ! in_array( $property, $this->valid_font_face_properties, true ) ) {
+					unset( $font_face[ $property ] );
+				}
+			}
+
+			return $font_face;
 		}
 
-		// Add woff2.
-		if ( ! empty( $src['woff2'] ) ) {
-			$src_ordered[] = array(
-				'url'    => $src['woff2'],
-				'format' => 'woff2',
-			);
-		}
-
-		// Add woff.
-		if ( ! empty( $src['woff'] ) ) {
-			$src_ordered[] = array(
-				'url'    => $src['woff'],
-				'format' => 'woff',
-			);
-		}
-
-		// Add ttf.
-		if ( ! empty( $src['ttf'] ) ) {
-			$src_ordered[] = array(
-				'url'    => $src['ttf'],
-				'format' => 'truetype',
-			);
-		}
-
-		// Add eot.
-		if ( ! empty( $src['eot'] ) ) {
-			$src_ordered[] = array(
-				'url'    => $src['eot'],
-				'format' => 'embedded-opentype',
-			);
-		}
-
-		// Add otf.
-		if ( ! empty( $src['otf'] ) ) {
-			$src_ordered[] = array(
-				'url'    => $src['otf'],
-				'format' => 'opentype',
-			);
-		}
-		$font_face['src'] = $src_ordered;
-
-		return $font_face;
-	}
-
-	/**
-	 * Builds the font-family's CSS.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $font_face Font face to process.
-	 * @return string This font-family's CSS.
-	 */
-	private function build_font_face_css( array $font_face ) {
-		$css = '';
-
-		/*
-		 * Wrap font-family in quotes if it contains spaces
-		 * and is not already wrapped in quotes.
+		/**
+		 * Gets the style element for wrapping the `@font-face` CSS.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return string The style element.
 		 */
-		if (
-			str_contains( $font_face['font-family'], ' ' ) &&
-			! str_contains( $font_face['font-family'], '"' ) &&
-			! str_contains( $font_face['font-family'], "'" )
-		) {
-			$font_face['font-family'] = '"' . $font_face['font-family'] . '"';
+		private function get_style_element() {
+			$attributes = $this->generate_style_element_attributes();
+
+			return "<style id='wp-fonts-local'{$attributes}>\n%s\n</style>\n";
 		}
 
-		foreach ( $font_face as $key => $value ) {
-			// Compile the "src" parameter.
-			if ( 'src' === $key ) {
-				$value = $this->compile_src( $value );
+		/**
+		 * Gets the defined <style> element's attributes.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return string A string of attribute=value when defined, else, empty string.
+		 */
+		private function generate_style_element_attributes() {
+			$attributes = '';
+			foreach ( $this->style_tag_attrs as $name => $value ) {
+				$attributes .= " {$name}='{$value}'";
+			}
+			return $attributes;
+		}
+
+		/**
+		 * Gets the `@font-face` CSS styles for locally-hosted font files.
+		 *
+		 * This method does the following processing tasks:
+		 *    1. Orchestrates an optimized `src` (with format) for browser support.
+		 *    2. Generates the `@font-face` for all its fonts.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $font_faces The font-faces to generate @font-face CSS styles.
+		 * @return string The `@font-face` CSS styles.
+		 */
+		private function get_css( $font_faces ) {
+			$css = '';
+
+			foreach ( $font_faces as $font_face ) {
+				// Order the font's `src` items to optimize for browser support.
+				$font_face = $this->order_src( $font_face );
+
+				// Build the @font-face CSS for this font.
+				$css .= '@font-face{' . $this->build_font_face_css( $font_face ) . '}' . "\n";
 			}
 
-			// If font-variation-settings is an array, convert it to a string.
-			if ( 'font-variation-settings' === $key && is_array( $value ) ) {
-				$value = $this->compile_variations( $value );
+			// Don't print the last newline character.
+			return rtrim( $css, "\n" );
+		}
+
+		/**
+		 * Orders `src` items to optimize for browser support.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $font_face Font face to process.
+		 * @return array Font-face with ordered src items.
+		 */
+		private function order_src( array $font_face ) {
+			if ( ! is_array( $font_face['src'] ) ) {
+				$font_face['src'] = (array) $font_face['src'];
 			}
 
-			if ( ! empty( $value ) ) {
-				$css .= "$key:$value;";
+			$src         = array();
+			$src_ordered = array();
+
+			foreach ( $font_face['src'] as $url ) {
+				// Add data URIs first.
+				if ( str_starts_with( trim( $url ), 'data:' ) ) {
+					$src_ordered[] = array(
+						'url'    => $url,
+						'format' => 'data',
+					);
+					continue;
+				}
+				$format         = pathinfo( $url, PATHINFO_EXTENSION );
+				$src[ $format ] = $url;
 			}
+
+			// Add woff2.
+			if ( ! empty( $src['woff2'] ) ) {
+				$src_ordered[] = array(
+					'url'    => $src['woff2'],
+					'format' => 'woff2',
+				);
+			}
+
+			// Add woff.
+			if ( ! empty( $src['woff'] ) ) {
+				$src_ordered[] = array(
+					'url'    => $src['woff'],
+					'format' => 'woff',
+				);
+			}
+
+			// Add ttf.
+			if ( ! empty( $src['ttf'] ) ) {
+				$src_ordered[] = array(
+					'url'    => $src['ttf'],
+					'format' => 'truetype',
+				);
+			}
+
+			// Add eot.
+			if ( ! empty( $src['eot'] ) ) {
+				$src_ordered[] = array(
+					'url'    => $src['eot'],
+					'format' => 'embedded-opentype',
+				);
+			}
+
+			// Add otf.
+			if ( ! empty( $src['otf'] ) ) {
+				$src_ordered[] = array(
+					'url'    => $src['otf'],
+					'format' => 'opentype',
+				);
+			}
+			$font_face['src'] = $src_ordered;
+
+			return $font_face;
 		}
 
-		return $css;
-	}
+		/**
+		 * Builds the font-family's CSS.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $font_face Font face to process.
+		 * @return string This font-family's CSS.
+		 */
+		private function build_font_face_css( array $font_face ) {
+			$css = '';
 
-	/**
-	 * Compiles the `src` into valid CSS.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $value Value to process.
-	 * @return string The CSS.
-	 */
-	private function compile_src( array $value ) {
-		$src = '';
+			/*
+			* Wrap font-family in quotes if it contains spaces
+			* and is not already wrapped in quotes.
+			*/
+			if (
+				str_contains( $font_face['font-family'], ' ' ) &&
+				! str_contains( $font_face['font-family'], '"' ) &&
+				! str_contains( $font_face['font-family'], "'" )
+			) {
+				$font_face['font-family'] = '"' . $font_face['font-family'] . '"';
+			}
 
-		foreach ( $value as $item ) {
-			$src .= ( 'data' === $item['format'] )
-				? ", url({$item['url']})"
-				: ", url('{$item['url']}') format('{$item['format']}')";
+			foreach ( $font_face as $key => $value ) {
+				// Compile the "src" parameter.
+				if ( 'src' === $key ) {
+					$value = $this->compile_src( $value );
+				}
+
+				// If font-variation-settings is an array, convert it to a string.
+				if ( 'font-variation-settings' === $key && is_array( $value ) ) {
+					$value = $this->compile_variations( $value );
+				}
+
+				if ( ! empty( $value ) ) {
+					$css .= "$key:$value;";
+				}
+			}
+
+			return $css;
 		}
 
-		$src = ltrim( $src, ', ' );
-		return $src;
-	}
+		/**
+		 * Compiles the `src` into valid CSS.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $value Value to process.
+		 * @return string The CSS.
+		 */
+		private function compile_src( array $value ) {
+			$src = '';
 
-	/**
-	 * Compiles the font variation settings.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param array $font_variation_settings Array of font variation settings.
-	 * @return string The CSS.
-	 */
-	private function compile_variations( array $font_variation_settings ) {
-		$variations = '';
+			foreach ( $value as $item ) {
+				$src .= ( 'data' === $item['format'] )
+					? ", url({$item['url']})"
+					: ", url('{$item['url']}') format('{$item['format']}')";
+			}
 
-		foreach ( $font_variation_settings as $key => $value ) {
-			$variations .= "$key $value";
+			$src = ltrim( $src, ', ' );
+			return $src;
 		}
 
-		return $variations;
+		/**
+		 * Compiles the font variation settings.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param array $font_variation_settings Array of font variation settings.
+		 * @return string The CSS.
+		 */
+		private function compile_variations( array $font_variation_settings ) {
+			$variations = '';
+
+			foreach ( $font_variation_settings as $key => $value ) {
+				$variations .= "$key $value";
+			}
+
+			return $variations;
+		}
 	}
 }

--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-active-formatting-elements.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-active-formatting-elements.php
@@ -7,185 +7,184 @@
  * @since 6.4.0
  */
 
-if ( class_exists( 'WP_HTML_Active_Formatting_Elements' ) ) {
-	return;
-}
+if ( ! class_exists( 'WP_HTML_Active_Formatting_Elements' ) ) {
 
-/**
- * Core class used by the HTML processor during HTML parsing
- * for managing the stack of active formatting elements.
- *
- * This class is designed for internal use by the HTML processor.
- *
- * > Initially, the list of active formatting elements is empty.
- * > It is used to handle mis-nested formatting element tags.
- * >
- * > The list contains elements in the formatting category, and markers.
- * > The markers are inserted when entering applet, object, marquee,
- * > template, td, th, and caption elements, and are used to prevent
- * > formatting from "leaking" into applet, object, marquee, template,
- * > td, th, and caption elements.
- * >
- * > In addition, each element in the list of active formatting elements
- * > is associated with the token for which it was created, so that
- * > further elements can be created for that token if necessary.
- *
- * @since 6.4.0
- *
- * @access private
- *
- * @see https://html.spec.whatwg.org/#list-of-active-formatting-elements
- * @see WP_HTML_Processor
- */
-class WP_HTML_Active_Formatting_Elements {
 	/**
-	 * Holds the stack of active formatting element references.
+	 * Core class used by the HTML processor during HTML parsing
+	 * for managing the stack of active formatting elements.
+	 *
+	 * This class is designed for internal use by the HTML processor.
+	 *
+	 * > Initially, the list of active formatting elements is empty.
+	 * > It is used to handle mis-nested formatting element tags.
+	 * >
+	 * > The list contains elements in the formatting category, and markers.
+	 * > The markers are inserted when entering applet, object, marquee,
+	 * > template, td, th, and caption elements, and are used to prevent
+	 * > formatting from "leaking" into applet, object, marquee, template,
+	 * > td, th, and caption elements.
+	 * >
+	 * > In addition, each element in the list of active formatting elements
+	 * > is associated with the token for which it was created, so that
+	 * > further elements can be created for that token if necessary.
 	 *
 	 * @since 6.4.0
 	 *
-	 * @var WP_HTML_Token[]
+	 * @access private
+	 *
+	 * @see https://html.spec.whatwg.org/#list-of-active-formatting-elements
+	 * @see WP_HTML_Processor
 	 */
-	private $stack = array();
+	class WP_HTML_Active_Formatting_Elements {
+		/**
+		 * Holds the stack of active formatting element references.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var WP_HTML_Token[]
+		 */
+		private $stack = array();
 
-	/**
-	 * Reports if a specific node is in the stack of active formatting elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param WP_HTML_Token $token Look for this node in the stack.
-	 * @return bool Whether the referenced node is in the stack of active formatting elements.
-	 */
-	public function contains_node( $token ) {
-		foreach ( $this->walk_up() as $item ) {
-			if ( $token->bookmark_name === $item->bookmark_name ) {
+		/**
+		 * Reports if a specific node is in the stack of active formatting elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param WP_HTML_Token $token Look for this node in the stack.
+		 * @return bool Whether the referenced node is in the stack of active formatting elements.
+		 */
+		public function contains_node( $token ) {
+			foreach ( $this->walk_up() as $item ) {
+				if ( $token->bookmark_name === $item->bookmark_name ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/**
+		 * Returns how many nodes are currently in the stack of active formatting elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return int How many node are in the stack of active formatting elements.
+		 */
+		public function count() {
+			return count( $this->stack );
+		}
+
+		/**
+		 * Returns the node at the end of the stack of active formatting elements,
+		 * if one exists. If the stack is empty, returns null.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return WP_HTML_Token|null Last node in the stack of active formatting elements, if one exists, otherwise null.
+		 */
+		public function current_node() {
+			$current_node = end( $this->stack );
+
+			return $current_node ? $current_node : null;
+		}
+
+		/**
+		 * Pushes a node onto the stack of active formatting elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#push-onto-the-list-of-active-formatting-elements
+		 *
+		 * @param WP_HTML_Token $token Push this node onto the stack.
+		 */
+		public function push( $token ) {
+			/*
+			* > If there are already three elements in the list of active formatting elements after the last marker,
+			* > if any, or anywhere in the list if there are no markers, that have the same tag name, namespace, and
+			* > attributes as element, then remove the earliest such element from the list of active formatting
+			* > elements. For these purposes, the attributes must be compared as they were when the elements were
+			* > created by the parser; two elements have the same attributes if all their parsed attributes can be
+			* > paired such that the two attributes in each pair have identical names, namespaces, and values
+			* > (the order of the attributes does not matter).
+			*
+			* @TODO: Implement the "Noah's Ark clause" to only add up to three of any given kind of formatting elements to the stack.
+			*/
+			// > Add element to the list of active formatting elements.
+			$this->stack[] = $token;
+		}
+
+		/**
+		 * Removes a node from the stack of active formatting elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param WP_HTML_Token $token Remove this node from the stack, if it's there already.
+		 * @return bool Whether the node was found and removed from the stack of active formatting elements.
+		 */
+		public function remove_node( $token ) {
+			foreach ( $this->walk_up() as $position_from_end => $item ) {
+				if ( $token->bookmark_name !== $item->bookmark_name ) {
+					continue;
+				}
+
+				$position_from_start = $this->count() - $position_from_end - 1;
+				array_splice( $this->stack, $position_from_start, 1 );
 				return true;
 			}
+
+			return false;
 		}
 
-		return false;
-	}
-
-	/**
-	 * Returns how many nodes are currently in the stack of active formatting elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return int How many node are in the stack of active formatting elements.
-	 */
-	public function count() {
-		return count( $this->stack );
-	}
-
-	/**
-	 * Returns the node at the end of the stack of active formatting elements,
-	 * if one exists. If the stack is empty, returns null.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return WP_HTML_Token|null Last node in the stack of active formatting elements, if one exists, otherwise null.
-	 */
-	public function current_node() {
-		$current_node = end( $this->stack );
-
-		return $current_node ? $current_node : null;
-	}
-
-	/**
-	 * Pushes a node onto the stack of active formatting elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#push-onto-the-list-of-active-formatting-elements
-	 *
-	 * @param WP_HTML_Token $token Push this node onto the stack.
-	 */
-	public function push( $token ) {
-		/*
-		 * > If there are already three elements in the list of active formatting elements after the last marker,
-		 * > if any, or anywhere in the list if there are no markers, that have the same tag name, namespace, and
-		 * > attributes as element, then remove the earliest such element from the list of active formatting
-		 * > elements. For these purposes, the attributes must be compared as they were when the elements were
-		 * > created by the parser; two elements have the same attributes if all their parsed attributes can be
-		 * > paired such that the two attributes in each pair have identical names, namespaces, and values
-		 * > (the order of the attributes does not matter).
+		/**
+		 * Steps through the stack of active formatting elements, starting with the
+		 * top element (added first) and walking downwards to the one added last.
 		 *
-		 * @TODO: Implement the "Noah's Ark clause" to only add up to three of any given kind of formatting elements to the stack.
+		 * This generator function is designed to be used inside a "foreach" loop.
+		 *
+		 * Example:
+		 *
+		 *     $html = '<em><strong><a>We are here';
+		 *     foreach ( $stack->walk_down() as $node ) {
+		 *         echo "{$node->node_name} -> ";
+		 *     }
+		 *     > EM -> STRONG -> A ->
+		 *
+		 * To start with the most-recently added element and walk towards the top,
+		 * see WP_HTML_Active_Formatting_Elements::walk_up().
+		 *
+		 * @since 6.4.0
 		 */
-		// > Add element to the list of active formatting elements.
-		$this->stack[] = $token;
-	}
+		public function walk_down() {
+			$count = count( $this->stack );
 
-	/**
-	 * Removes a node from the stack of active formatting elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param WP_HTML_Token $token Remove this node from the stack, if it's there already.
-	 * @return bool Whether the node was found and removed from the stack of active formatting elements.
-	 */
-	public function remove_node( $token ) {
-		foreach ( $this->walk_up() as $position_from_end => $item ) {
-			if ( $token->bookmark_name !== $item->bookmark_name ) {
-				continue;
+			for ( $i = 0; $i < $count; $i++ ) {
+				yield $this->stack[ $i ];
 			}
-
-			$position_from_start = $this->count() - $position_from_end - 1;
-			array_splice( $this->stack, $position_from_start, 1 );
-			return true;
 		}
 
-		return false;
-	}
-
-	/**
-	 * Steps through the stack of active formatting elements, starting with the
-	 * top element (added first) and walking downwards to the one added last.
-	 *
-	 * This generator function is designed to be used inside a "foreach" loop.
-	 *
-	 * Example:
-	 *
-	 *     $html = '<em><strong><a>We are here';
-	 *     foreach ( $stack->walk_down() as $node ) {
-	 *         echo "{$node->node_name} -> ";
-	 *     }
-	 *     > EM -> STRONG -> A ->
-	 *
-	 * To start with the most-recently added element and walk towards the top,
-	 * see WP_HTML_Active_Formatting_Elements::walk_up().
-	 *
-	 * @since 6.4.0
-	 */
-	public function walk_down() {
-		$count = count( $this->stack );
-
-		for ( $i = 0; $i < $count; $i++ ) {
-			yield $this->stack[ $i ];
-		}
-	}
-
-	/**
-	 * Steps through the stack of active formatting elements, starting with the
-	 * bottom element (added last) and walking upwards to the one added first.
-	 *
-	 * This generator function is designed to be used inside a "foreach" loop.
-	 *
-	 * Example:
-	 *
-	 *     $html = '<em><strong><a>We are here';
-	 *     foreach ( $stack->walk_up() as $node ) {
-	 *         echo "{$node->node_name} -> ";
-	 *     }
-	 *     > A -> STRONG -> EM ->
-	 *
-	 * To start with the first added element and walk towards the bottom,
-	 * see WP_HTML_Active_Formatting_Elements::walk_down().
-	 *
-	 * @since 6.4.0
-	 */
-	public function walk_up() {
-		for ( $i = count( $this->stack ) - 1; $i >= 0; $i-- ) {
-			yield $this->stack[ $i ];
+		/**
+		 * Steps through the stack of active formatting elements, starting with the
+		 * bottom element (added last) and walking upwards to the one added first.
+		 *
+		 * This generator function is designed to be used inside a "foreach" loop.
+		 *
+		 * Example:
+		 *
+		 *     $html = '<em><strong><a>We are here';
+		 *     foreach ( $stack->walk_up() as $node ) {
+		 *         echo "{$node->node_name} -> ";
+		 *     }
+		 *     > A -> STRONG -> EM ->
+		 *
+		 * To start with the first added element and walk towards the bottom,
+		 * see WP_HTML_Active_Formatting_Elements::walk_down().
+		 *
+		 * @since 6.4.0
+		 */
+		public function walk_up() {
+			for ( $i = count( $this->stack ) - 1; $i >= 0; $i-- ) {
+				yield $this->stack[ $i ];
+			}
 		}
 	}
 }

--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-open-elements.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-open-elements.php
@@ -7,430 +7,429 @@
  * @since 6.4.0
  */
 
-if ( class_exists( 'WP_HTML_Open_Elements' ) ) {
-	return;
-}
+if ( ! class_exists( 'WP_HTML_Open_Elements' ) ) {
 
-/**
- * Core class used by the HTML processor during HTML parsing
- * for managing the stack of open elements.
- *
- * This class is designed for internal use by the HTML processor.
- *
- * > Initially, the stack of open elements is empty. The stack grows
- * > downwards; the topmost node on the stack is the first one added
- * > to the stack, and the bottommost node of the stack is the most
- * > recently added node in the stack (notwithstanding when the stack
- * > is manipulated in a random access fashion as part of the handling
- * > for misnested tags).
- *
- * @since 6.4.0
- *
- * @access private
- *
- * @see https://html.spec.whatwg.org/#stack-of-open-elements
- * @see WP_HTML_Processor
- */
-class WP_HTML_Open_Elements {
 	/**
-	 * Holds the stack of open element references.
+	 * Core class used by the HTML processor during HTML parsing
+	 * for managing the stack of open elements.
+	 *
+	 * This class is designed for internal use by the HTML processor.
+	 *
+	 * > Initially, the stack of open elements is empty. The stack grows
+	 * > downwards; the topmost node on the stack is the first one added
+	 * > to the stack, and the bottommost node of the stack is the most
+	 * > recently added node in the stack (notwithstanding when the stack
+	 * > is manipulated in a random access fashion as part of the handling
+	 * > for misnested tags).
 	 *
 	 * @since 6.4.0
 	 *
-	 * @var WP_HTML_Token[]
-	 */
-	public $stack = array();
-
-	/**
-	 * Whether a P element is in button scope currently.
-	 *
-	 * This class optimizes scope lookup by pre-calculating
-	 * this value when elements are added and removed to the
-	 * stack of open elements which might change its value.
-	 * This avoids frequent iteration over the stack.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var bool
-	 */
-	private $has_p_in_button_scope = false;
-
-	/**
-	 * Reports if a specific node is in the stack of open elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param WP_HTML_Token $token Look for this node in the stack.
-	 * @return bool Whether the referenced node is in the stack of open elements.
-	 */
-	public function contains_node( $token ) {
-		foreach ( $this->walk_up() as $item ) {
-			if ( $token->bookmark_name === $item->bookmark_name ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Returns how many nodes are currently in the stack of open elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return int How many node are in the stack of open elements.
-	 */
-	public function count() {
-		return count( $this->stack );
-	}
-
-	/**
-	 * Returns the node at the end of the stack of open elements,
-	 * if one exists. If the stack is empty, returns null.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return WP_HTML_Token|null Last node in the stack of open elements, if one exists, otherwise null.
-	 */
-	public function current_node() {
-		$current_node = end( $this->stack );
-
-		return $current_node ? $current_node : null;
-	}
-
-	/**
-	 * Returns whether an element is in a specific scope.
-	 *
-	 * ## HTML Support
-	 *
-	 * This function skips checking for the termination list because there
-	 * are no supported elements which appear in the termination list.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#has-an-element-in-the-specific-scope
-	 *
-	 * @param string   $tag_name         Name of tag check.
-	 * @param string[] $termination_list List of elements that terminate the search.
-	 * @return bool Whether the element was found in a specific scope.
-	 */
-	public function has_element_in_specific_scope( $tag_name, $termination_list ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		foreach ( $this->walk_up() as $node ) {
-			if ( $node->node_name === $tag_name ) {
-				return true;
-			}
-
-			switch ( $node->node_name ) {
-				case 'HTML':
-					return false;
-			}
-
-			if ( in_array( $node->node_name, $termination_list, true ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Returns whether a particular element is in scope.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#has-an-element-in-scope
-	 *
-	 * @param string $tag_name Name of tag to check.
-	 * @return bool Whether given element is in scope.
-	 */
-	public function has_element_in_scope( $tag_name ) {
-		return $this->has_element_in_specific_scope(
-			$tag_name,
-			array(
-
-				/*
-				 * Because it's not currently possible to encounter
-				 * one of the termination elements, they don't need
-				 * to be listed here. If they were, they would be
-				 * unreachable and only waste CPU cycles while
-				 * scanning through HTML.
-				 */
-			)
-		);
-	}
-
-	/**
-	 * Returns whether a particular element is in list item scope.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#has-an-element-in-list-item-scope
-	 *
-	 * @throws WP_HTML_Unsupported_Exception Always until this function is implemented.
-	 *
-	 * @param string $tag_name Name of tag to check.
-	 * @return bool Whether given element is in scope.
-	 */
-	public function has_element_in_list_item_scope( $tag_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		throw new WP_HTML_Unsupported_Exception( 'Cannot process elements depending on list item scope.' );
-
-		return false; // The linter requires this unreachable code until the function is implemented and can return.
-	}
-
-	/**
-	 * Returns whether a particular element is in button scope.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#has-an-element-in-button-scope
-	 *
-	 * @param string $tag_name Name of tag to check.
-	 * @return bool Whether given element is in scope.
-	 */
-	public function has_element_in_button_scope( $tag_name ) {
-		return $this->has_element_in_specific_scope( $tag_name, array( 'BUTTON' ) );
-	}
-
-	/**
-	 * Returns whether a particular element is in table scope.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#has-an-element-in-table-scope
-	 *
-	 * @throws WP_HTML_Unsupported_Exception Always until this function is implemented.
-	 *
-	 * @param string $tag_name Name of tag to check.
-	 * @return bool Whether given element is in scope.
-	 */
-	public function has_element_in_table_scope( $tag_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		throw new WP_HTML_Unsupported_Exception( 'Cannot process elements depending on table scope.' );
-
-		return false; // The linter requires this unreachable code until the function is implemented and can return.
-	}
-
-	/**
-	 * Returns whether a particular element is in select scope.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#has-an-element-in-select-scope
-	 *
-	 * @throws WP_HTML_Unsupported_Exception Always until this function is implemented.
-	 *
-	 * @param string $tag_name Name of tag to check.
-	 * @return bool Whether given element is in scope.
-	 */
-	public function has_element_in_select_scope( $tag_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		throw new WP_HTML_Unsupported_Exception( 'Cannot process elements depending on select scope.' );
-
-		return false; // The linter requires this unreachable code until the function is implemented and can return.
-	}
-
-	/**
-	 * Returns whether a P is in BUTTON scope.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#has-an-element-in-button-scope
-	 *
-	 * @return bool Whether a P is in BUTTON scope.
-	 */
-	public function has_p_in_button_scope() {
-		return $this->has_p_in_button_scope;
-	}
-
-	/**
-	 * Pops a node off of the stack of open elements.
-	 *
-	 * @since 6.4.0
+	 * @access private
 	 *
 	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
-	 *
-	 * @return bool Whether a node was popped off of the stack.
+	 * @see WP_HTML_Processor
 	 */
-	public function pop() {
-		$item = array_pop( $this->stack );
+	class WP_HTML_Open_Elements {
+		/**
+		 * Holds the stack of open element references.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var WP_HTML_Token[]
+		 */
+		public $stack = array();
 
-		if ( null === $item ) {
+		/**
+		 * Whether a P element is in button scope currently.
+		 *
+		 * This class optimizes scope lookup by pre-calculating
+		 * this value when elements are added and removed to the
+		 * stack of open elements which might change its value.
+		 * This avoids frequent iteration over the stack.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var bool
+		 */
+		private $has_p_in_button_scope = false;
+
+		/**
+		 * Reports if a specific node is in the stack of open elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param WP_HTML_Token $token Look for this node in the stack.
+		 * @return bool Whether the referenced node is in the stack of open elements.
+		 */
+		public function contains_node( $token ) {
+			foreach ( $this->walk_up() as $item ) {
+				if ( $token->bookmark_name === $item->bookmark_name ) {
+					return true;
+				}
+			}
+
 			return false;
 		}
 
-		$this->after_element_pop( $item );
-		return true;
-	}
-
-	/**
-	 * Pops nodes off of the stack of open elements until one with the given tag name has been popped.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see WP_HTML_Open_Elements::pop
-	 *
-	 * @param string $tag_name Name of tag that needs to be popped off of the stack of open elements.
-	 * @return bool Whether a tag of the given name was found and popped off of the stack of open elements.
-	 */
-	public function pop_until( $tag_name ) {
-		foreach ( $this->walk_up() as $item ) {
-			$this->pop();
-
-			if ( $tag_name === $item->node_name ) {
-				return true;
-			}
+		/**
+		 * Returns how many nodes are currently in the stack of open elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return int How many node are in the stack of open elements.
+		 */
+		public function count() {
+			return count( $this->stack );
 		}
 
-		return false;
-	}
+		/**
+		 * Returns the node at the end of the stack of open elements,
+		 * if one exists. If the stack is empty, returns null.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return WP_HTML_Token|null Last node in the stack of open elements, if one exists, otherwise null.
+		 */
+		public function current_node() {
+			$current_node = end( $this->stack );
 
-	/**
-	 * Pushes a node onto the stack of open elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
-	 *
-	 * @param WP_HTML_Token $stack_item Item to add onto stack.
-	 */
-	public function push( $stack_item ) {
-		$this->stack[] = $stack_item;
-		$this->after_element_push( $stack_item );
-	}
+			return $current_node ? $current_node : null;
+		}
 
-	/**
-	 * Removes a specific node from the stack of open elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param WP_HTML_Token $token The node to remove from the stack of open elements.
-	 * @return bool Whether the node was found and removed from the stack of open elements.
-	 */
-	public function remove_node( $token ) {
-		foreach ( $this->walk_up() as $position_from_end => $item ) {
-			if ( $token->bookmark_name !== $item->bookmark_name ) {
-				continue;
+		/**
+		 * Returns whether an element is in a specific scope.
+		 *
+		 * ## HTML Support
+		 *
+		 * This function skips checking for the termination list because there
+		 * are no supported elements which appear in the termination list.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#has-an-element-in-the-specific-scope
+		 *
+		 * @param string   $tag_name         Name of tag check.
+		 * @param string[] $termination_list List of elements that terminate the search.
+		 * @return bool Whether the element was found in a specific scope.
+		 */
+		public function has_element_in_specific_scope( $tag_name, $termination_list ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			foreach ( $this->walk_up() as $node ) {
+				if ( $node->node_name === $tag_name ) {
+					return true;
+				}
+
+				switch ( $node->node_name ) {
+					case 'HTML':
+						return false;
+				}
+
+				if ( in_array( $node->node_name, $termination_list, true ) ) {
+					return true;
+				}
 			}
 
-			$position_from_start = $this->count() - $position_from_end - 1;
-			array_splice( $this->stack, $position_from_start, 1 );
+			return false;
+		}
+
+		/**
+		 * Returns whether a particular element is in scope.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#has-an-element-in-scope
+		 *
+		 * @param string $tag_name Name of tag to check.
+		 * @return bool Whether given element is in scope.
+		 */
+		public function has_element_in_scope( $tag_name ) {
+			return $this->has_element_in_specific_scope(
+				$tag_name,
+				array(
+
+					/*
+					* Because it's not currently possible to encounter
+					* one of the termination elements, they don't need
+					* to be listed here. If they were, they would be
+					* unreachable and only waste CPU cycles while
+					* scanning through HTML.
+					*/
+				)
+			);
+		}
+
+		/**
+		 * Returns whether a particular element is in list item scope.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#has-an-element-in-list-item-scope
+		 *
+		 * @throws WP_HTML_Unsupported_Exception Always until this function is implemented.
+		 *
+		 * @param string $tag_name Name of tag to check.
+		 * @return bool Whether given element is in scope.
+		 */
+		public function has_element_in_list_item_scope( $tag_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			throw new WP_HTML_Unsupported_Exception( 'Cannot process elements depending on list item scope.' );
+
+			return false; // The linter requires this unreachable code until the function is implemented and can return.
+		}
+
+		/**
+		 * Returns whether a particular element is in button scope.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#has-an-element-in-button-scope
+		 *
+		 * @param string $tag_name Name of tag to check.
+		 * @return bool Whether given element is in scope.
+		 */
+		public function has_element_in_button_scope( $tag_name ) {
+			return $this->has_element_in_specific_scope( $tag_name, array( 'BUTTON' ) );
+		}
+
+		/**
+		 * Returns whether a particular element is in table scope.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#has-an-element-in-table-scope
+		 *
+		 * @throws WP_HTML_Unsupported_Exception Always until this function is implemented.
+		 *
+		 * @param string $tag_name Name of tag to check.
+		 * @return bool Whether given element is in scope.
+		 */
+		public function has_element_in_table_scope( $tag_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			throw new WP_HTML_Unsupported_Exception( 'Cannot process elements depending on table scope.' );
+
+			return false; // The linter requires this unreachable code until the function is implemented and can return.
+		}
+
+		/**
+		 * Returns whether a particular element is in select scope.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#has-an-element-in-select-scope
+		 *
+		 * @throws WP_HTML_Unsupported_Exception Always until this function is implemented.
+		 *
+		 * @param string $tag_name Name of tag to check.
+		 * @return bool Whether given element is in scope.
+		 */
+		public function has_element_in_select_scope( $tag_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			throw new WP_HTML_Unsupported_Exception( 'Cannot process elements depending on select scope.' );
+
+			return false; // The linter requires this unreachable code until the function is implemented and can return.
+		}
+
+		/**
+		 * Returns whether a P is in BUTTON scope.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#has-an-element-in-button-scope
+		 *
+		 * @return bool Whether a P is in BUTTON scope.
+		 */
+		public function has_p_in_button_scope() {
+			return $this->has_p_in_button_scope;
+		}
+
+		/**
+		 * Pops a node off of the stack of open elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#stack-of-open-elements
+		 *
+		 * @return bool Whether a node was popped off of the stack.
+		 */
+		public function pop() {
+			$item = array_pop( $this->stack );
+
+			if ( null === $item ) {
+				return false;
+			}
+
 			$this->after_element_pop( $item );
 			return true;
 		}
 
-		return false;
-	}
-
-
-	/**
-	 * Steps through the stack of open elements, starting with the top element
-	 * (added first) and walking downwards to the one added last.
-	 *
-	 * This generator function is designed to be used inside a "foreach" loop.
-	 *
-	 * Example:
-	 *
-	 *     $html = '<em><strong><a>We are here';
-	 *     foreach ( $stack->walk_down() as $node ) {
-	 *         echo "{$node->node_name} -> ";
-	 *     }
-	 *     > EM -> STRONG -> A ->
-	 *
-	 * To start with the most-recently added element and walk towards the top,
-	 * see WP_HTML_Open_Elements::walk_up().
-	 *
-	 * @since 6.4.0
-	 */
-	public function walk_down() {
-		$count = count( $this->stack );
-
-		for ( $i = 0; $i < $count; $i++ ) {
-			yield $this->stack[ $i ];
-		}
-	}
-
-	/**
-	 * Steps through the stack of open elements, starting with the bottom element
-	 * (added last) and walking upwards to the one added first.
-	 *
-	 * This generator function is designed to be used inside a "foreach" loop.
-	 *
-	 * Example:
-	 *
-	 *     $html = '<em><strong><a>We are here';
-	 *     foreach ( $stack->walk_up() as $node ) {
-	 *         echo "{$node->node_name} -> ";
-	 *     }
-	 *     > A -> STRONG -> EM ->
-	 *
-	 * To start with the first added element and walk towards the bottom,
-	 * see WP_HTML_Open_Elements::walk_down().
-	 *
-	 * @since 6.4.0
-	 */
-	public function walk_up() {
-		for ( $i = count( $this->stack ) - 1; $i >= 0; $i-- ) {
-			yield $this->stack[ $i ];
-		}
-	}
-
-	/*
-	 * Internal helpers.
-	 */
-
-	/**
-	 * Updates internal flags after adding an element.
-	 *
-	 * Certain conditions (such as "has_p_in_button_scope") are maintained here as
-	 * flags that are only modified when adding and removing elements. This allows
-	 * the HTML Processor to quickly check for these conditions instead of iterating
-	 * over the open stack elements upon each new tag it encounters. These flags,
-	 * however, need to be maintained as items are added and removed from the stack.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param WP_HTML_Token $item Element that was added to the stack of open elements.
-	 */
-	public function after_element_push( $item ) {
-		/*
-		 * When adding support for new elements, expand this switch to trap
-		 * cases where the precalculated value needs to change.
+		/**
+		 * Pops nodes off of the stack of open elements until one with the given tag name has been popped.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see WP_HTML_Open_Elements::pop
+		 *
+		 * @param string $tag_name Name of tag that needs to be popped off of the stack of open elements.
+		 * @return bool Whether a tag of the given name was found and popped off of the stack of open elements.
 		 */
-		switch ( $item->node_name ) {
-			case 'BUTTON':
-				$this->has_p_in_button_scope = false;
-				break;
+		public function pop_until( $tag_name ) {
+			foreach ( $this->walk_up() as $item ) {
+				$this->pop();
 
-			case 'P':
-				$this->has_p_in_button_scope = true;
-				break;
+				if ( $tag_name === $item->node_name ) {
+					return true;
+				}
+			}
+
+			return false;
 		}
-	}
 
-	/**
-	 * Updates internal flags after removing an element.
-	 *
-	 * Certain conditions (such as "has_p_in_button_scope") are maintained here as
-	 * flags that are only modified when adding and removing elements. This allows
-	 * the HTML Processor to quickly check for these conditions instead of iterating
-	 * over the open stack elements upon each new tag it encounters. These flags,
-	 * however, need to be maintained as items are added and removed from the stack.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param WP_HTML_Token $item Element that was removed from the stack of open elements.
-	 */
-	public function after_element_pop( $item ) {
-		/*
-		 * When adding support for new elements, expand this switch to trap
-		 * cases where the precalculated value needs to change.
+		/**
+		 * Pushes a node onto the stack of open elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#stack-of-open-elements
+		 *
+		 * @param WP_HTML_Token $stack_item Item to add onto stack.
 		 */
-		switch ( $item->node_name ) {
-			case 'BUTTON':
-				$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
-				break;
+		public function push( $stack_item ) {
+			$this->stack[] = $stack_item;
+			$this->after_element_push( $stack_item );
+		}
 
-			case 'P':
-				$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
-				break;
+		/**
+		 * Removes a specific node from the stack of open elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param WP_HTML_Token $token The node to remove from the stack of open elements.
+		 * @return bool Whether the node was found and removed from the stack of open elements.
+		 */
+		public function remove_node( $token ) {
+			foreach ( $this->walk_up() as $position_from_end => $item ) {
+				if ( $token->bookmark_name !== $item->bookmark_name ) {
+					continue;
+				}
+
+				$position_from_start = $this->count() - $position_from_end - 1;
+				array_splice( $this->stack, $position_from_start, 1 );
+				$this->after_element_pop( $item );
+				return true;
+			}
+
+			return false;
+		}
+
+
+		/**
+		 * Steps through the stack of open elements, starting with the top element
+		 * (added first) and walking downwards to the one added last.
+		 *
+		 * This generator function is designed to be used inside a "foreach" loop.
+		 *
+		 * Example:
+		 *
+		 *     $html = '<em><strong><a>We are here';
+		 *     foreach ( $stack->walk_down() as $node ) {
+		 *         echo "{$node->node_name} -> ";
+		 *     }
+		 *     > EM -> STRONG -> A ->
+		 *
+		 * To start with the most-recently added element and walk towards the top,
+		 * see WP_HTML_Open_Elements::walk_up().
+		 *
+		 * @since 6.4.0
+		 */
+		public function walk_down() {
+			$count = count( $this->stack );
+
+			for ( $i = 0; $i < $count; $i++ ) {
+				yield $this->stack[ $i ];
+			}
+		}
+
+		/**
+		 * Steps through the stack of open elements, starting with the bottom element
+		 * (added last) and walking upwards to the one added first.
+		 *
+		 * This generator function is designed to be used inside a "foreach" loop.
+		 *
+		 * Example:
+		 *
+		 *     $html = '<em><strong><a>We are here';
+		 *     foreach ( $stack->walk_up() as $node ) {
+		 *         echo "{$node->node_name} -> ";
+		 *     }
+		 *     > A -> STRONG -> EM ->
+		 *
+		 * To start with the first added element and walk towards the bottom,
+		 * see WP_HTML_Open_Elements::walk_down().
+		 *
+		 * @since 6.4.0
+		 */
+		public function walk_up() {
+			for ( $i = count( $this->stack ) - 1; $i >= 0; $i-- ) {
+				yield $this->stack[ $i ];
+			}
+		}
+
+		/*
+		* Internal helpers.
+		*/
+
+		/**
+		 * Updates internal flags after adding an element.
+		 *
+		 * Certain conditions (such as "has_p_in_button_scope") are maintained here as
+		 * flags that are only modified when adding and removing elements. This allows
+		 * the HTML Processor to quickly check for these conditions instead of iterating
+		 * over the open stack elements upon each new tag it encounters. These flags,
+		 * however, need to be maintained as items are added and removed from the stack.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param WP_HTML_Token $item Element that was added to the stack of open elements.
+		 */
+		public function after_element_push( $item ) {
+			/*
+			* When adding support for new elements, expand this switch to trap
+			* cases where the precalculated value needs to change.
+			*/
+			switch ( $item->node_name ) {
+				case 'BUTTON':
+					$this->has_p_in_button_scope = false;
+					break;
+
+				case 'P':
+					$this->has_p_in_button_scope = true;
+					break;
+			}
+		}
+
+		/**
+		 * Updates internal flags after removing an element.
+		 *
+		 * Certain conditions (such as "has_p_in_button_scope") are maintained here as
+		 * flags that are only modified when adding and removing elements. This allows
+		 * the HTML Processor to quickly check for these conditions instead of iterating
+		 * over the open stack elements upon each new tag it encounters. These flags,
+		 * however, need to be maintained as items are added and removed from the stack.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param WP_HTML_Token $item Element that was removed from the stack of open elements.
+		 */
+		public function after_element_pop( $item ) {
+			/*
+			* When adding support for new elements, expand this switch to trap
+			* cases where the precalculated value needs to change.
+			*/
+			switch ( $item->node_name ) {
+				case 'BUTTON':
+					$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
+					break;
+
+				case 'P':
+					$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
+					break;
+			}
 		}
 	}
 }

--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-processor-state.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-processor-state.php
@@ -7,132 +7,131 @@
  * @since 6.4.0
  */
 
-if ( class_exists( 'WP_HTML_Processor_State' ) ) {
-	return;
-}
-
-/**
- * Core class used by the HTML processor during HTML parsing
- * for managing the internal parsing state.
- *
- * This class is designed for internal use by the HTML processor.
- *
- * @since 6.4.0
- *
- * @access private
- *
- * @see WP_HTML_Processor
- */
-class WP_HTML_Processor_State {
-	/*
-	 * Insertion mode constants.
-	 *
-	 * These constants exist and are named to make it easier to
-	 * discover and recognize the supported insertion modes in
-	 * the parser.
-	 *
-	 * Out of all the possible insertion modes, only those
-	 * supported by the parser are listed here. As support
-	 * is added to the parser for more modes, add them here
-	 * following the same naming and value pattern.
-	 *
-	 * @see https://html.spec.whatwg.org/#the-insertion-mode
-	 */
+if ( ! class_exists( 'WP_HTML_Processor_State' ) ) {
 
 	/**
-	 * Initial insertion mode for full HTML parser.
+	 * Core class used by the HTML processor during HTML parsing
+	 * for managing the internal parsing state.
+	 *
+	 * This class is designed for internal use by the HTML processor.
 	 *
 	 * @since 6.4.0
 	 *
-	 * @see https://html.spec.whatwg.org/#the-initial-insertion-mode
-	 * @see WP_HTML_Processor_State::$insertion_mode
-	 *
-	 * @var string
-	 */
-	const INSERTION_MODE_INITIAL = 'insertion-mode-initial';
-
-	/**
-	 * In body insertion mode for full HTML parser.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#parsing-main-inbody
-	 * @see WP_HTML_Processor_State::$insertion_mode
-	 *
-	 * @var string
-	 */
-	const INSERTION_MODE_IN_BODY = 'insertion-mode-in-body';
-
-	/**
-	 * Tracks open elements while scanning HTML.
-	 *
-	 * This property is initialized in the constructor and never null.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
-	 *
-	 * @var WP_HTML_Open_Elements
-	 */
-	public $stack_of_open_elements = null;
-
-	/**
-	 * Tracks open formatting elements, used to handle mis-nested formatting element tags.
-	 *
-	 * This property is initialized in the constructor and never null.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#list-of-active-formatting-elements
-	 *
-	 * @var WP_HTML_Active_Formatting_Elements
-	 */
-	public $active_formatting_elements = null;
-
-	/**
-	 * Tree construction insertion mode.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#insertion-mode
-	 *
-	 * @var string
-	 */
-	public $insertion_mode = self::INSERTION_MODE_INITIAL;
-
-	/**
-	 * Context node initializing fragment parser, if created as a fragment parser.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#concept-frag-parse-context
-	 *
-	 * @var [string, array]|null
-	 */
-	public $context_node = null;
-
-	/**
-	 * The frameset-ok flag indicates if a `FRAMESET` element is allowed in the current state.
-	 *
-	 * > The frameset-ok flag is set to "ok" when the parser is created. It is set to "not ok" after certain tokens are seen.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#frameset-ok-flag
-	 *
-	 * @var bool
-	 */
-	public $frameset_ok = true;
-
-	/**
-	 * Constructor - creates a new and empty state value.
-	 *
-	 * @since 6.4.0
+	 * @access private
 	 *
 	 * @see WP_HTML_Processor
 	 */
-	public function __construct() {
-		$this->stack_of_open_elements     = new WP_HTML_Open_Elements();
-		$this->active_formatting_elements = new WP_HTML_Active_Formatting_Elements();
+	class WP_HTML_Processor_State {
+		/*
+		* Insertion mode constants.
+		*
+		* These constants exist and are named to make it easier to
+		* discover and recognize the supported insertion modes in
+		* the parser.
+		*
+		* Out of all the possible insertion modes, only those
+		* supported by the parser are listed here. As support
+		* is added to the parser for more modes, add them here
+		* following the same naming and value pattern.
+		*
+		* @see https://html.spec.whatwg.org/#the-insertion-mode
+		*/
+
+		/**
+		 * Initial insertion mode for full HTML parser.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#the-initial-insertion-mode
+		 * @see WP_HTML_Processor_State::$insertion_mode
+		 *
+		 * @var string
+		 */
+		const INSERTION_MODE_INITIAL = 'insertion-mode-initial';
+
+		/**
+		 * In body insertion mode for full HTML parser.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#parsing-main-inbody
+		 * @see WP_HTML_Processor_State::$insertion_mode
+		 *
+		 * @var string
+		 */
+		const INSERTION_MODE_IN_BODY = 'insertion-mode-in-body';
+
+		/**
+		 * Tracks open elements while scanning HTML.
+		 *
+		 * This property is initialized in the constructor and never null.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#stack-of-open-elements
+		 *
+		 * @var WP_HTML_Open_Elements
+		 */
+		public $stack_of_open_elements = null;
+
+		/**
+		 * Tracks open formatting elements, used to handle mis-nested formatting element tags.
+		 *
+		 * This property is initialized in the constructor and never null.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#list-of-active-formatting-elements
+		 *
+		 * @var WP_HTML_Active_Formatting_Elements
+		 */
+		public $active_formatting_elements = null;
+
+		/**
+		 * Tree construction insertion mode.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#insertion-mode
+		 *
+		 * @var string
+		 */
+		public $insertion_mode = self::INSERTION_MODE_INITIAL;
+
+		/**
+		 * Context node initializing fragment parser, if created as a fragment parser.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#concept-frag-parse-context
+		 *
+		 * @var [string, array]|null
+		 */
+		public $context_node = null;
+
+		/**
+		 * The frameset-ok flag indicates if a `FRAMESET` element is allowed in the current state.
+		 *
+		 * > The frameset-ok flag is set to "ok" when the parser is created. It is set to "not ok" after certain tokens are seen.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#frameset-ok-flag
+		 *
+		 * @var bool
+		 */
+		public $frameset_ok = true;
+
+		/**
+		 * Constructor - creates a new and empty state value.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see WP_HTML_Processor
+		 */
+		public function __construct() {
+			$this->stack_of_open_elements     = new WP_HTML_Open_Elements();
+			$this->active_formatting_elements = new WP_HTML_Active_Formatting_Elements();
+		}
 	}
 }

--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-processor.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-processor.php
@@ -7,1481 +7,1480 @@
  * @since 6.4.0
  */
 
-if ( class_exists( 'WP_HTML_Processor' ) ) {
-	return;
-}
-
-/**
- * Core class used to safely parse and modify an HTML document.
- *
- * The HTML Processor class properly parses and modifies HTML5 documents.
- *
- * It supports a subset of the HTML5 specification, and when it encounters
- * unsupported markup, it aborts early to avoid unintentionally breaking
- * the document. The HTML Processor should never break an HTML document.
- *
- * While the `WP_HTML_Tag_Processor` is a valuable tool for modifying
- * attributes on individual HTML tags, the HTML Processor is more capable
- * and useful for the following operations:
- *
- *  - Querying based on nested HTML structure.
- *
- * Eventually the HTML Processor will also support:
- *  - Wrapping a tag in surrounding HTML.
- *  - Unwrapping a tag by removing its parent.
- *  - Inserting and removing nodes.
- *  - Reading and changing inner content.
- *  - Navigating up or around HTML structure.
- *
- * ## Usage
- *
- * Use of this class requires three steps:
- *
- *   1. Call a static creator method with your input HTML document.
- *   2. Find the location in the document you are looking for.
- *   3. Request changes to the document at that location.
- *
- * Example:
- *
- *     $processor = WP_HTML_Processor::create_fragment( $html );
- *     if ( $processor->next_tag( array( 'breadcrumbs' => array( 'DIV', 'FIGURE', 'IMG' ) ) ) ) {
- *         $processor->add_class( 'responsive-image' );
- *     }
- *
- * #### Breadcrumbs
- *
- * Breadcrumbs represent the stack of open elements from the root
- * of the document or fragment down to the currently-matched node,
- * if one is currently selected. Call WP_HTML_Processor::get_breadcrumbs()
- * to inspect the breadcrumbs for a matched tag.
- *
- * Breadcrumbs can specify nested HTML structure and are equivalent
- * to a CSS selector comprising tag names separated by the child
- * combinator, such as "DIV > FIGURE > IMG".
- *
- * Since all elements find themselves inside a full HTML document
- * when parsed, the return value from `get_breadcrumbs()` will always
- * contain any implicit outermost elements. For example, when parsing
- * with `create_fragment()` in the `BODY` context (the default), any
- * tag in the given HTML document will contain `array( 'HTML', 'BODY', … )`
- * in its breadcrumbs.
- *
- * Despite containing the implied outermost elements in their breadcrumbs,
- * tags may be found with the shortest-matching breadcrumb query. That is,
- * `array( 'IMG' )` matches all IMG elements and `array( 'P', 'IMG' )`
- * matches all IMG elements directly inside a P element. To ensure that no
- * partial matches erroneously match it's possible to specify in a query
- * the full breadcrumb match all the way down from the root HTML element.
- *
- * Example:
- *
- *     $html = '<figure><img><figcaption>A <em>lovely</em> day outside</figcaption></figure>';
- *     //               ----- Matches here.
- *     $processor->next_tag( array( 'breadcrumbs' => array( 'FIGURE', 'IMG' ) ) );
- *
- *     $html = '<figure><img><figcaption>A <em>lovely</em> day outside</figcaption></figure>';
- *     //                                  ---- Matches here.
- *     $processor->next_tag( array( 'breadcrumbs' => array( 'FIGURE', 'FIGCAPTION', 'EM' ) ) );
- *
- *     $html = '<div><img></div><img>';
- *     //                       ----- Matches here, because IMG must be a direct child of the implicit BODY.
- *     $processor->next_tag( array( 'breadcrumbs' => array( 'BODY', 'IMG' ) ) );
- *
- * ## HTML Support
- *
- * This class implements a small part of the HTML5 specification.
- * It's designed to operate within its support and abort early whenever
- * encountering circumstances it can't properly handle. This is
- * the principle way in which this class remains as simple as possible
- * without cutting corners and breaking compliance.
- *
- * ### Supported elements
- *
- * If any unsupported element appears in the HTML input the HTML Processor
- * will abort early and stop all processing. This draconian measure ensures
- * that the HTML Processor won't break any HTML it doesn't fully understand.
- *
- * The following list specifies the HTML tags that _are_ supported:
- *
- *  - Containers: ADDRESS, BLOCKQUOTE, DETAILS, DIALOG, DIV, FOOTER, HEADER, MAIN, MENU, SPAN, SUMMARY.
- *  - Form elements: BUTTON, FIELDSET, SEARCH.
- *  - Formatting elements: B, BIG, CODE, EM, FONT, I, SMALL, STRIKE, STRONG, TT, U.
- *  - Heading elements: HGROUP.
- *  - Links: A.
- *  - Lists: DL.
- *  - Media elements: FIGCAPTION, FIGURE, IMG.
- *  - Paragraph: P.
- *  - Sectioning elements: ARTICLE, ASIDE, NAV, SECTION
- *  - Deprecated elements: CENTER, DIR
- *
- * ### Supported markup
- *
- * Some kinds of non-normative HTML involve reconstruction of formatting elements and
- * re-parenting of mis-nested elements. For example, a DIV tag found inside a TABLE
- * may in fact belong _before_ the table in the DOM. If the HTML Processor encounters
- * such a case it will stop processing.
- *
- * The following list specifies HTML markup that _is_ supported:
- *
- *  - Markup involving only those tags listed above.
- *  - Fully-balanced and non-overlapping tags.
- *  - HTML with unexpected tag closers.
- *  - Some unbalanced or overlapping tags.
- *  - P tags after unclosed P tags.
- *  - BUTTON tags after unclosed BUTTON tags.
- *  - A tags after unclosed A tags that don't involve any active formatting elements.
- *
- * @since 6.4.0
- *
- * @see WP_HTML_Tag_Processor
- * @see https://html.spec.whatwg.org/
- */
-class WP_HTML_Processor extends Gutenberg_HTML_Tag_Processor_6_4 {
-	/**
-	 * The maximum number of bookmarks allowed to exist at any given time.
-	 *
-	 * HTML processing requires more bookmarks than basic tag processing,
-	 * so this class constant from the Tag Processor is overwritten.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var int
-	 */
-	const MAX_BOOKMARKS = 100;
+if ( ! class_exists( 'WP_HTML_Processor' ) ) {
 
 	/**
-	 * Static query for instructing the Tag Processor to visit every token.
+	 * Core class used to safely parse and modify an HTML document.
 	 *
-	 * @access private
+	 * The HTML Processor class properly parses and modifies HTML5 documents.
 	 *
-	 * @since 6.4.0
+	 * It supports a subset of the HTML5 specification, and when it encounters
+	 * unsupported markup, it aborts early to avoid unintentionally breaking
+	 * the document. The HTML Processor should never break an HTML document.
 	 *
-	 * @var array
-	 */
-	const VISIT_EVERYTHING = array( 'tag_closers' => 'visit' );
-
-	/**
-	 * Holds the working state of the parser, including the stack of
-	 * open elements and the stack of active formatting elements.
+	 * While the `WP_HTML_Tag_Processor` is a valuable tool for modifying
+	 * attributes on individual HTML tags, the HTML Processor is more capable
+	 * and useful for the following operations:
 	 *
-	 * Initialized in the constructor.
+	 *  - Querying based on nested HTML structure.
 	 *
-	 * @since 6.4.0
+	 * Eventually the HTML Processor will also support:
+	 *  - Wrapping a tag in surrounding HTML.
+	 *  - Unwrapping a tag by removing its parent.
+	 *  - Inserting and removing nodes.
+	 *  - Reading and changing inner content.
+	 *  - Navigating up or around HTML structure.
 	 *
-	 * @var WP_HTML_Processor_State
-	 */
-	private $state = null;
-
-	/**
-	 * Used to create unique bookmark names.
+	 * ## Usage
 	 *
-	 * This class sets a bookmark for every tag in the HTML document that it encounters.
-	 * The bookmark name is auto-generated and increments, starting with `1`. These are
-	 * internal bookmarks and are automatically released when the referring WP_HTML_Token
-	 * goes out of scope and is garbage-collected.
+	 * Use of this class requires three steps:
 	 *
-	 * @since 6.4.0
-	 *
-	 * @see WP_HTML_Processor::$release_internal_bookmark_on_destruct
-	 *
-	 * @var int
-	 */
-	private $bookmark_counter = 0;
-
-	/**
-	 * Stores an explanation for why something failed, if it did.
-	 *
-	 * @see self::get_last_error
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string|null
-	 */
-	private $last_error = null;
-
-	/**
-	 * Releases a bookmark when PHP garbage-collects its wrapping WP_HTML_Token instance.
-	 *
-	 * This function is created inside the class constructor so that it can be passed to
-	 * the stack of open elements and the stack of active formatting elements without
-	 * exposing it as a public method on the class.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var closure
-	 */
-	private $release_internal_bookmark_on_destruct = null;
-
-	/*
-	 * Public Interface Functions
-	 */
-
-	/**
-	 * Creates an HTML processor in the fragment parsing mode.
-	 *
-	 * Use this for cases where you are processing chunks of HTML that
-	 * will be found within a bigger HTML document, such as rendered
-	 * block output that exists within a post, `the_content` inside a
-	 * rendered site layout.
-	 *
-	 * Fragment parsing occurs within a context, which is an HTML element
-	 * that the document will eventually be placed in. It becomes important
-	 * when special elements have different rules than others, such as inside
-	 * a TEXTAREA or a TITLE tag where things that look like tags are text,
-	 * or inside a SCRIPT tag where things that look like HTML syntax are JS.
-	 *
-	 * The context value should be a representation of the tag into which the
-	 * HTML is found. For most cases this will be the body element. The HTML
-	 * form is provided because a context element may have attributes that
-	 * impact the parse, such as with a SCRIPT tag and its `type` attribute.
-	 *
-	 * ## Current HTML Support
-	 *
-	 *  - The only supported context is `<body>`, which is the default value.
-	 *  - The only supported document encoding is `UTF-8`, which is the default value.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param string $html     Input HTML fragment to process.
-	 * @param string $context  Context element for the fragment, must be default of `<body>`.
-	 * @param string $encoding Text encoding of the document; must be default of 'UTF-8'.
-	 * @return WP_HTML_Processor|null The created processor if successful, otherwise null.
-	 */
-	public static function create_fragment( $html, $context = '<body>', $encoding = 'UTF-8' ) {
-		if ( '<body>' !== $context || 'UTF-8' !== $encoding ) {
-			return null;
-		}
-
-		$p                        = new self( $html, self::CONSTRUCTOR_UNLOCK_CODE );
-		$p->state->context_node   = array( 'BODY', array() );
-		$p->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_BODY;
-
-		// @TODO: Create "fake" bookmarks for non-existent but implied nodes.
-		$p->bookmarks['root-node']    = new WP_HTML_Span( 0, 0 );
-		$p->bookmarks['context-node'] = new WP_HTML_Span( 0, 0 );
-
-		$p->state->stack_of_open_elements->push(
-			new WP_HTML_Token(
-				'root-node',
-				'HTML',
-				false
-			)
-		);
-
-		$p->state->stack_of_open_elements->push(
-			new WP_HTML_Token(
-				'context-node',
-				$p->state->context_node[0],
-				false
-			)
-		);
-
-		return $p;
-	}
-
-	/**
-	 * Constructor.
-	 *
-	 * Do not use this method. Use the static creator methods instead.
-	 *
-	 * @access private
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see WP_HTML_Processor::create_fragment()
-	 *
-	 * @param string      $html                                  HTML to process.
-	 * @param string|null $use_the_static_create_methods_instead This constructor should not be called manually.
-	 */
-	public function __construct( $html, $use_the_static_create_methods_instead = null ) {
-		parent::__construct( $html );
-
-		if ( self::CONSTRUCTOR_UNLOCK_CODE !== $use_the_static_create_methods_instead ) {
-			_doing_it_wrong(
-				__METHOD__,
-				sprintf(
-					/* translators: %s: WP_HTML_Processor::create_fragment(). */
-					__( 'Call %s to create an HTML Processor instead of calling the constructor directly.' ),
-					'<code>WP_HTML_Processor::create_fragment()</code>'
-				),
-				'6.4.0'
-			);
-		}
-
-		$this->state = new WP_HTML_Processor_State();
-
-		/*
-		 * Create this wrapper so that it's possible to pass
-		 * a private method into WP_HTML_Token classes without
-		 * exposing it to any public API.
-		 */
-		$this->release_internal_bookmark_on_destruct = function ( $name ) {
-			parent::release_bookmark( $name );
-		};
-	}
-
-	/**
-	 * Returns the last error, if any.
-	 *
-	 * Various situations lead to parsing failure but this class will
-	 * return `false` in all those cases. To determine why something
-	 * failed it's possible to request the last error. This can be
-	 * helpful to know to distinguish whether a given tag couldn't
-	 * be found or if content in the document caused the processor
-	 * to give up and abort processing.
-	 *
-	 * Example
-	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<template><strong><button><em><p><em>' );
-	 *     false === $processor->next_tag();
-	 *     WP_HTML_Processor::ERROR_UNSUPPORTED === $processor->get_last_error();
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see self::ERROR_UNSUPPORTED
-	 * @see self::ERROR_EXCEEDED_MAX_BOOKMARKS
-	 *
-	 * @return string|null The last error, if one exists, otherwise null.
-	 */
-	public function get_last_error() {
-		return $this->last_error;
-	}
-
-	/**
-	 * Finds the next tag matching the $query.
-	 *
-	 * @todo Support matching the class name and tag name.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @throws Exception When unable to allocate a bookmark for the next token in the input HTML document.
-	 *
-	 * @param array|string|null $query {
-	 *     Optional. Which tag name to find, having which class, etc. Default is to find any tag.
-	 *
-	 *     @type string|null $tag_name     Which tag to find, or `null` for "any tag."
-	 *     @type int|null    $match_offset Find the Nth tag matching all search criteria.
-	 *                                     1 for "first" tag, 3 for "third," etc.
-	 *                                     Defaults to first tag.
-	 *     @type string|null $class_name   Tag must contain this whole class name to match.
-	 *     @type string[]    $breadcrumbs  DOM sub-path at which element is found, e.g. `array( 'FIGURE', 'IMG' )`.
-	 *                                     May also contain the wildcard `*` which matches a single element, e.g. `array( 'SECTION', '*' )`.
-	 * }
-	 * @return bool Whether a tag was matched.
-	 */
-	public function next_tag( $query = null ) {
-		if ( null === $query ) {
-			while ( $this->step() ) {
-				if ( ! $this->is_tag_closer() ) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		if ( is_string( $query ) ) {
-			$query = array( 'breadcrumbs' => array( $query ) );
-		}
-
-		if ( ! is_array( $query ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Please pass a query array to this function.' ),
-				'6.4.0'
-			);
-			return false;
-		}
-
-		if ( ! ( array_key_exists( 'breadcrumbs', $query ) && is_array( $query['breadcrumbs'] ) ) ) {
-			while ( $this->step() ) {
-				if ( ! $this->is_tag_closer() ) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		if ( isset( $query['tag_closers'] ) && 'visit' === $query['tag_closers'] ) {
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Cannot visit tag closers in HTML Processor.' ),
-				'6.4.0'
-			);
-			return false;
-		}
-
-		$breadcrumbs  = $query['breadcrumbs'];
-		$match_offset = isset( $query['match_offset'] ) ? (int) $query['match_offset'] : 1;
-
-		while ( $match_offset > 0 && $this->step() ) {
-			if ( $this->matches_breadcrumbs( $breadcrumbs ) && 0 === --$match_offset ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Indicates if the currently-matched tag matches the given breadcrumbs.
-	 *
-	 * A "*" represents a single tag wildcard, where any tag matches, but not no tags.
-	 *
-	 * At some point this function _may_ support a `**` syntax for matching any number
-	 * of unspecified tags in the breadcrumb stack. This has been intentionally left
-	 * out, however, to keep this function simple and to avoid introducing backtracking,
-	 * which could open up surprising performance breakdowns.
+	 *   1. Call a static creator method with your input HTML document.
+	 *   2. Find the location in the document you are looking for.
+	 *   3. Request changes to the document at that location.
 	 *
 	 * Example:
 	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<div><span><figure><img></figure></span></div>' );
-	 *     $processor->next_tag( 'img' );
-	 *     true  === $processor->matches_breadcrumbs( array( 'figure', 'img' ) );
-	 *     true  === $processor->matches_breadcrumbs( array( 'span', 'figure', 'img' ) );
-	 *     false === $processor->matches_breadcrumbs( array( 'span', 'img' ) );
-	 *     true  === $processor->matches_breadcrumbs( array( 'span', '*', 'img' ) );
+	 *     $processor = WP_HTML_Processor::create_fragment( $html );
+	 *     if ( $processor->next_tag( array( 'breadcrumbs' => array( 'DIV', 'FIGURE', 'IMG' ) ) ) ) {
+	 *         $processor->add_class( 'responsive-image' );
+	 *     }
+	 *
+	 * #### Breadcrumbs
+	 *
+	 * Breadcrumbs represent the stack of open elements from the root
+	 * of the document or fragment down to the currently-matched node,
+	 * if one is currently selected. Call WP_HTML_Processor::get_breadcrumbs()
+	 * to inspect the breadcrumbs for a matched tag.
+	 *
+	 * Breadcrumbs can specify nested HTML structure and are equivalent
+	 * to a CSS selector comprising tag names separated by the child
+	 * combinator, such as "DIV > FIGURE > IMG".
+	 *
+	 * Since all elements find themselves inside a full HTML document
+	 * when parsed, the return value from `get_breadcrumbs()` will always
+	 * contain any implicit outermost elements. For example, when parsing
+	 * with `create_fragment()` in the `BODY` context (the default), any
+	 * tag in the given HTML document will contain `array( 'HTML', 'BODY', … )`
+	 * in its breadcrumbs.
+	 *
+	 * Despite containing the implied outermost elements in their breadcrumbs,
+	 * tags may be found with the shortest-matching breadcrumb query. That is,
+	 * `array( 'IMG' )` matches all IMG elements and `array( 'P', 'IMG' )`
+	 * matches all IMG elements directly inside a P element. To ensure that no
+	 * partial matches erroneously match it's possible to specify in a query
+	 * the full breadcrumb match all the way down from the root HTML element.
+	 *
+	 * Example:
+	 *
+	 *     $html = '<figure><img><figcaption>A <em>lovely</em> day outside</figcaption></figure>';
+	 *     //               ----- Matches here.
+	 *     $processor->next_tag( array( 'breadcrumbs' => array( 'FIGURE', 'IMG' ) ) );
+	 *
+	 *     $html = '<figure><img><figcaption>A <em>lovely</em> day outside</figcaption></figure>';
+	 *     //                                  ---- Matches here.
+	 *     $processor->next_tag( array( 'breadcrumbs' => array( 'FIGURE', 'FIGCAPTION', 'EM' ) ) );
+	 *
+	 *     $html = '<div><img></div><img>';
+	 *     //                       ----- Matches here, because IMG must be a direct child of the implicit BODY.
+	 *     $processor->next_tag( array( 'breadcrumbs' => array( 'BODY', 'IMG' ) ) );
+	 *
+	 * ## HTML Support
+	 *
+	 * This class implements a small part of the HTML5 specification.
+	 * It's designed to operate within its support and abort early whenever
+	 * encountering circumstances it can't properly handle. This is
+	 * the principle way in which this class remains as simple as possible
+	 * without cutting corners and breaking compliance.
+	 *
+	 * ### Supported elements
+	 *
+	 * If any unsupported element appears in the HTML input the HTML Processor
+	 * will abort early and stop all processing. This draconian measure ensures
+	 * that the HTML Processor won't break any HTML it doesn't fully understand.
+	 *
+	 * The following list specifies the HTML tags that _are_ supported:
+	 *
+	 *  - Containers: ADDRESS, BLOCKQUOTE, DETAILS, DIALOG, DIV, FOOTER, HEADER, MAIN, MENU, SPAN, SUMMARY.
+	 *  - Form elements: BUTTON, FIELDSET, SEARCH.
+	 *  - Formatting elements: B, BIG, CODE, EM, FONT, I, SMALL, STRIKE, STRONG, TT, U.
+	 *  - Heading elements: HGROUP.
+	 *  - Links: A.
+	 *  - Lists: DL.
+	 *  - Media elements: FIGCAPTION, FIGURE, IMG.
+	 *  - Paragraph: P.
+	 *  - Sectioning elements: ARTICLE, ASIDE, NAV, SECTION
+	 *  - Deprecated elements: CENTER, DIR
+	 *
+	 * ### Supported markup
+	 *
+	 * Some kinds of non-normative HTML involve reconstruction of formatting elements and
+	 * re-parenting of mis-nested elements. For example, a DIV tag found inside a TABLE
+	 * may in fact belong _before_ the table in the DOM. If the HTML Processor encounters
+	 * such a case it will stop processing.
+	 *
+	 * The following list specifies HTML markup that _is_ supported:
+	 *
+	 *  - Markup involving only those tags listed above.
+	 *  - Fully-balanced and non-overlapping tags.
+	 *  - HTML with unexpected tag closers.
+	 *  - Some unbalanced or overlapping tags.
+	 *  - P tags after unclosed P tags.
+	 *  - BUTTON tags after unclosed BUTTON tags.
+	 *  - A tags after unclosed A tags that don't involve any active formatting elements.
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param string[] $breadcrumbs DOM sub-path at which element is found, e.g. `array( 'FIGURE', 'IMG' )`.
-	 *                              May also contain the wildcard `*` which matches a single element, e.g. `array( 'SECTION', '*' )`.
-	 * @return bool Whether the currently-matched tag is found at the given nested structure.
+	 * @see WP_HTML_Tag_Processor
+	 * @see https://html.spec.whatwg.org/
 	 */
-	public function matches_breadcrumbs( $breadcrumbs ) {
-		if ( ! $this->get_tag() ) {
-			return false;
+	class WP_HTML_Processor extends Gutenberg_HTML_Tag_Processor_6_4 {
+		/**
+		 * The maximum number of bookmarks allowed to exist at any given time.
+		 *
+		 * HTML processing requires more bookmarks than basic tag processing,
+		 * so this class constant from the Tag Processor is overwritten.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var int
+		 */
+		const MAX_BOOKMARKS = 100;
+
+		/**
+		 * Static query for instructing the Tag Processor to visit every token.
+		 *
+		 * @access private
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var array
+		 */
+		const VISIT_EVERYTHING = array( 'tag_closers' => 'visit' );
+
+		/**
+		 * Holds the working state of the parser, including the stack of
+		 * open elements and the stack of active formatting elements.
+		 *
+		 * Initialized in the constructor.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var WP_HTML_Processor_State
+		 */
+		private $state = null;
+
+		/**
+		 * Used to create unique bookmark names.
+		 *
+		 * This class sets a bookmark for every tag in the HTML document that it encounters.
+		 * The bookmark name is auto-generated and increments, starting with `1`. These are
+		 * internal bookmarks and are automatically released when the referring WP_HTML_Token
+		 * goes out of scope and is garbage-collected.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see WP_HTML_Processor::$release_internal_bookmark_on_destruct
+		 *
+		 * @var int
+		 */
+		private $bookmark_counter = 0;
+
+		/**
+		 * Stores an explanation for why something failed, if it did.
+		 *
+		 * @see self::get_last_error
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string|null
+		 */
+		private $last_error = null;
+
+		/**
+		 * Releases a bookmark when PHP garbage-collects its wrapping WP_HTML_Token instance.
+		 *
+		 * This function is created inside the class constructor so that it can be passed to
+		 * the stack of open elements and the stack of active formatting elements without
+		 * exposing it as a public method on the class.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var closure
+		 */
+		private $release_internal_bookmark_on_destruct = null;
+
+		/*
+		* Public Interface Functions
+		*/
+
+		/**
+		 * Creates an HTML processor in the fragment parsing mode.
+		 *
+		 * Use this for cases where you are processing chunks of HTML that
+		 * will be found within a bigger HTML document, such as rendered
+		 * block output that exists within a post, `the_content` inside a
+		 * rendered site layout.
+		 *
+		 * Fragment parsing occurs within a context, which is an HTML element
+		 * that the document will eventually be placed in. It becomes important
+		 * when special elements have different rules than others, such as inside
+		 * a TEXTAREA or a TITLE tag where things that look like tags are text,
+		 * or inside a SCRIPT tag where things that look like HTML syntax are JS.
+		 *
+		 * The context value should be a representation of the tag into which the
+		 * HTML is found. For most cases this will be the body element. The HTML
+		 * form is provided because a context element may have attributes that
+		 * impact the parse, such as with a SCRIPT tag and its `type` attribute.
+		 *
+		 * ## Current HTML Support
+		 *
+		 *  - The only supported context is `<body>`, which is the default value.
+		 *  - The only supported document encoding is `UTF-8`, which is the default value.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param string $html     Input HTML fragment to process.
+		 * @param string $context  Context element for the fragment, must be default of `<body>`.
+		 * @param string $encoding Text encoding of the document; must be default of 'UTF-8'.
+		 * @return WP_HTML_Processor|null The created processor if successful, otherwise null.
+		 */
+		public static function create_fragment( $html, $context = '<body>', $encoding = 'UTF-8' ) {
+			if ( '<body>' !== $context || 'UTF-8' !== $encoding ) {
+				return null;
+			}
+
+			$p                        = new self( $html, self::CONSTRUCTOR_UNLOCK_CODE );
+			$p->state->context_node   = array( 'BODY', array() );
+			$p->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_BODY;
+
+			// @TODO: Create "fake" bookmarks for non-existent but implied nodes.
+			$p->bookmarks['root-node']    = new WP_HTML_Span( 0, 0 );
+			$p->bookmarks['context-node'] = new WP_HTML_Span( 0, 0 );
+
+			$p->state->stack_of_open_elements->push(
+				new WP_HTML_Token(
+					'root-node',
+					'HTML',
+					false
+				)
+			);
+
+			$p->state->stack_of_open_elements->push(
+				new WP_HTML_Token(
+					'context-node',
+					$p->state->context_node[0],
+					false
+				)
+			);
+
+			return $p;
 		}
 
-		// Everything matches when there are zero constraints.
-		if ( 0 === count( $breadcrumbs ) ) {
-			return true;
+		/**
+		 * Constructor.
+		 *
+		 * Do not use this method. Use the static creator methods instead.
+		 *
+		 * @access private
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see WP_HTML_Processor::create_fragment()
+		 *
+		 * @param string      $html                                  HTML to process.
+		 * @param string|null $use_the_static_create_methods_instead This constructor should not be called manually.
+		 */
+		public function __construct( $html, $use_the_static_create_methods_instead = null ) {
+			parent::__construct( $html );
+
+			if ( self::CONSTRUCTOR_UNLOCK_CODE !== $use_the_static_create_methods_instead ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %s: WP_HTML_Processor::create_fragment(). */
+						__( 'Call %s to create an HTML Processor instead of calling the constructor directly.' ),
+						'<code>WP_HTML_Processor::create_fragment()</code>'
+					),
+					'6.4.0'
+				);
+			}
+
+			$this->state = new WP_HTML_Processor_State();
+
+			/*
+			* Create this wrapper so that it's possible to pass
+			* a private method into WP_HTML_Token classes without
+			* exposing it to any public API.
+			*/
+			$this->release_internal_bookmark_on_destruct = function ( $name ) {
+				parent::release_bookmark( $name );
+			};
 		}
 
-		// Start at the last crumb.
-		$crumb = end( $breadcrumbs );
-
-		if ( '*' !== $crumb && $this->get_tag() !== strtoupper( $crumb ) ) {
-			return false;
+		/**
+		 * Returns the last error, if any.
+		 *
+		 * Various situations lead to parsing failure but this class will
+		 * return `false` in all those cases. To determine why something
+		 * failed it's possible to request the last error. This can be
+		 * helpful to know to distinguish whether a given tag couldn't
+		 * be found or if content in the document caused the processor
+		 * to give up and abort processing.
+		 *
+		 * Example
+		 *
+		 *     $processor = WP_HTML_Processor::create_fragment( '<template><strong><button><em><p><em>' );
+		 *     false === $processor->next_tag();
+		 *     WP_HTML_Processor::ERROR_UNSUPPORTED === $processor->get_last_error();
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see self::ERROR_UNSUPPORTED
+		 * @see self::ERROR_EXCEEDED_MAX_BOOKMARKS
+		 *
+		 * @return string|null The last error, if one exists, otherwise null.
+		 */
+		public function get_last_error() {
+			return $this->last_error;
 		}
 
-		foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
-			$crumb = strtoupper( current( $breadcrumbs ) );
+		/**
+		 * Finds the next tag matching the $query.
+		 *
+		 * @todo Support matching the class name and tag name.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @throws Exception When unable to allocate a bookmark for the next token in the input HTML document.
+		 *
+		 * @param array|string|null $query {
+		 *     Optional. Which tag name to find, having which class, etc. Default is to find any tag.
+		 *
+		 *     @type string|null $tag_name     Which tag to find, or `null` for "any tag."
+		 *     @type int|null    $match_offset Find the Nth tag matching all search criteria.
+		 *                                     1 for "first" tag, 3 for "third," etc.
+		 *                                     Defaults to first tag.
+		 *     @type string|null $class_name   Tag must contain this whole class name to match.
+		 *     @type string[]    $breadcrumbs  DOM sub-path at which element is found, e.g. `array( 'FIGURE', 'IMG' )`.
+		 *                                     May also contain the wildcard `*` which matches a single element, e.g. `array( 'SECTION', '*' )`.
+		 * }
+		 * @return bool Whether a tag was matched.
+		 */
+		public function next_tag( $query = null ) {
+			if ( null === $query ) {
+				while ( $this->step() ) {
+					if ( ! $this->is_tag_closer() ) {
+						return true;
+					}
+				}
 
-			if ( '*' !== $crumb && $node->node_name !== $crumb ) {
 				return false;
 			}
 
-			if ( false === prev( $breadcrumbs ) ) {
+			if ( is_string( $query ) ) {
+				$query = array( 'breadcrumbs' => array( $query ) );
+			}
+
+			if ( ! is_array( $query ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Please pass a query array to this function.' ),
+					'6.4.0'
+				);
+				return false;
+			}
+
+			if ( ! ( array_key_exists( 'breadcrumbs', $query ) && is_array( $query['breadcrumbs'] ) ) ) {
+				while ( $this->step() ) {
+					if ( ! $this->is_tag_closer() ) {
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			if ( isset( $query['tag_closers'] ) && 'visit' === $query['tag_closers'] ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Cannot visit tag closers in HTML Processor.' ),
+					'6.4.0'
+				);
+				return false;
+			}
+
+			$breadcrumbs  = $query['breadcrumbs'];
+			$match_offset = isset( $query['match_offset'] ) ? (int) $query['match_offset'] : 1;
+
+			while ( $match_offset > 0 && $this->step() ) {
+				if ( $this->matches_breadcrumbs( $breadcrumbs ) && 0 === --$match_offset ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/**
+		 * Indicates if the currently-matched tag matches the given breadcrumbs.
+		 *
+		 * A "*" represents a single tag wildcard, where any tag matches, but not no tags.
+		 *
+		 * At some point this function _may_ support a `**` syntax for matching any number
+		 * of unspecified tags in the breadcrumb stack. This has been intentionally left
+		 * out, however, to keep this function simple and to avoid introducing backtracking,
+		 * which could open up surprising performance breakdowns.
+		 *
+		 * Example:
+		 *
+		 *     $processor = WP_HTML_Processor::create_fragment( '<div><span><figure><img></figure></span></div>' );
+		 *     $processor->next_tag( 'img' );
+		 *     true  === $processor->matches_breadcrumbs( array( 'figure', 'img' ) );
+		 *     true  === $processor->matches_breadcrumbs( array( 'span', 'figure', 'img' ) );
+		 *     false === $processor->matches_breadcrumbs( array( 'span', 'img' ) );
+		 *     true  === $processor->matches_breadcrumbs( array( 'span', '*', 'img' ) );
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param string[] $breadcrumbs DOM sub-path at which element is found, e.g. `array( 'FIGURE', 'IMG' )`.
+		 *                              May also contain the wildcard `*` which matches a single element, e.g. `array( 'SECTION', '*' )`.
+		 * @return bool Whether the currently-matched tag is found at the given nested structure.
+		 */
+		public function matches_breadcrumbs( $breadcrumbs ) {
+			if ( ! $this->get_tag() ) {
+				return false;
+			}
+
+			// Everything matches when there are zero constraints.
+			if ( 0 === count( $breadcrumbs ) ) {
 				return true;
 			}
-		}
 
-		return false;
-	}
+			// Start at the last crumb.
+			$crumb = end( $breadcrumbs );
 
-	/**
-	 * Steps through the HTML document and stop at the next tag, if any.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @throws Exception When unable to allocate a bookmark for the next token in the input HTML document.
-	 *
-	 * @see self::PROCESS_NEXT_NODE
-	 * @see self::REPROCESS_CURRENT_NODE
-	 *
-	 * @param string $node_to_process Whether to parse the next node or reprocess the current node.
-	 * @return bool Whether a tag was matched.
-	 */
-	public function step( $node_to_process = self::PROCESS_NEXT_NODE ) {
-		// Refuse to proceed if there was a previous error.
-		if ( null !== $this->last_error ) {
-			return false;
-		}
-
-		if ( self::PROCESS_NEXT_NODE === $node_to_process ) {
-			/*
-			 * Void elements still hop onto the stack of open elements even though
-			 * there's no corresponding closing tag. This is important for managing
-			 * stack-based operations such as "navigate to parent node" or checking
-			 * on an element's breadcrumbs.
-			 *
-			 * When moving on to the next node, therefore, if the bottom-most element
-			 * on the stack is a void element, it must be closed.
-			 *
-			 * @TODO: Once self-closing foreign elements and BGSOUND are supported,
-			 *        they must also be implicitly closed here too. BGSOUND is
-			 *        special since it's only self-closing if the self-closing flag
-			 *        is provided in the opening tag, otherwise it expects a tag closer.
-			 */
-			$top_node = $this->state->stack_of_open_elements->current_node();
-			if ( $top_node && self::is_void( $top_node->node_name ) ) {
-				$this->state->stack_of_open_elements->pop();
+			if ( '*' !== $crumb && $this->get_tag() !== strtoupper( $crumb ) ) {
+				return false;
 			}
 
-			parent::next_tag( self::VISIT_EVERYTHING );
-		}
+			foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
+				$crumb = strtoupper( current( $breadcrumbs ) );
 
-		// Finish stepping when there are no more tokens in the document.
-		if ( null === $this->get_tag() ) {
+				if ( '*' !== $crumb && $node->node_name !== $crumb ) {
+					return false;
+				}
+
+				if ( false === prev( $breadcrumbs ) ) {
+					return true;
+				}
+			}
+
 			return false;
 		}
 
-		$this->state->current_token = new WP_HTML_Token(
-			$this->bookmark_tag(),
-			$this->get_tag(),
-			$this->is_tag_closer(),
-			$this->release_internal_bookmark_on_destruct
-		);
+		/**
+		 * Steps through the HTML document and stop at the next tag, if any.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @throws Exception When unable to allocate a bookmark for the next token in the input HTML document.
+		 *
+		 * @see self::PROCESS_NEXT_NODE
+		 * @see self::REPROCESS_CURRENT_NODE
+		 *
+		 * @param string $node_to_process Whether to parse the next node or reprocess the current node.
+		 * @return bool Whether a tag was matched.
+		 */
+		public function step( $node_to_process = self::PROCESS_NEXT_NODE ) {
+			// Refuse to proceed if there was a previous error.
+			if ( null !== $this->last_error ) {
+				return false;
+			}
 
-		try {
-			switch ( $this->state->insertion_mode ) {
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_BODY:
-					return $this->step_in_body();
+			if ( self::PROCESS_NEXT_NODE === $node_to_process ) {
+				/*
+				* Void elements still hop onto the stack of open elements even though
+				* there's no corresponding closing tag. This is important for managing
+				* stack-based operations such as "navigate to parent node" or checking
+				* on an element's breadcrumbs.
+				*
+				* When moving on to the next node, therefore, if the bottom-most element
+				* on the stack is a void element, it must be closed.
+				*
+				* @TODO: Once self-closing foreign elements and BGSOUND are supported,
+				*        they must also be implicitly closed here too. BGSOUND is
+				*        special since it's only self-closing if the self-closing flag
+				*        is provided in the opening tag, otherwise it expects a tag closer.
+				*/
+				$top_node = $this->state->stack_of_open_elements->current_node();
+				if ( $top_node && self::is_void( $top_node->node_name ) ) {
+					$this->state->stack_of_open_elements->pop();
+				}
+
+				parent::next_tag( self::VISIT_EVERYTHING );
+			}
+
+			// Finish stepping when there are no more tokens in the document.
+			if ( null === $this->get_tag() ) {
+				return false;
+			}
+
+			$this->state->current_token = new WP_HTML_Token(
+				$this->bookmark_tag(),
+				$this->get_tag(),
+				$this->is_tag_closer(),
+				$this->release_internal_bookmark_on_destruct
+			);
+
+			try {
+				switch ( $this->state->insertion_mode ) {
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_BODY:
+						return $this->step_in_body();
+
+					default:
+						$this->last_error = self::ERROR_UNSUPPORTED;
+						throw new WP_HTML_Unsupported_Exception( "No support for parsing in the '{$this->state->insertion_mode}' state." );
+				}
+			} catch ( WP_HTML_Unsupported_Exception $e ) {
+				/*
+				* Exceptions are used in this class to escape deep call stacks that
+				* otherwise might involve messier calling and return conventions.
+				*/
+				return false;
+			}
+		}
+
+		/**
+		 * Computes the HTML breadcrumbs for the currently-matched node, if matched.
+		 *
+		 * Breadcrumbs start at the outermost parent and descend toward the matched element.
+		 * They always include the entire path from the root HTML node to the matched element.
+		 *
+		 * @todo It could be more efficient to expose a generator-based version of this function
+		 *       to avoid creating the array copy on tag iteration. If this is done, it would likely
+		 *       be more useful to walk up the stack when yielding instead of starting at the top.
+		 *
+		 * Example
+		 *
+		 *     $processor = WP_HTML_Processor::create_fragment( '<p><strong><em><img></em></strong></p>' );
+		 *     $processor->next_tag( 'IMG' );
+		 *     $processor->get_breadcrumbs() === array( 'HTML', 'BODY', 'P', 'STRONG', 'EM', 'IMG' );
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return string[]|null Array of tag names representing path to matched node, if matched, otherwise NULL.
+		 */
+		public function get_breadcrumbs() {
+			if ( ! $this->get_tag() ) {
+				return null;
+			}
+
+			$breadcrumbs = array();
+			foreach ( $this->state->stack_of_open_elements->walk_down() as $stack_item ) {
+				$breadcrumbs[] = $stack_item->node_name;
+			}
+
+			return $breadcrumbs;
+		}
+
+		/**
+		 * Parses next element in the 'in body' insertion mode.
+		 *
+		 * This internal function performs the 'in body' insertion mode
+		 * logic for the generalized WP_HTML_Processor::step() function.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
+		 *
+		 * @see https://html.spec.whatwg.org/#parsing-main-inbody
+		 * @see WP_HTML_Processor::step
+		 *
+		 * @return bool Whether an element was found.
+		 */
+		private function step_in_body() {
+			$tag_name = $this->get_tag();
+			$op_sigil = $this->is_tag_closer() ? '-' : '+';
+			$op       = "{$op_sigil}{$tag_name}";
+
+			switch ( $op ) {
+				/*
+				* > A start tag whose tag name is "button"
+				*/
+				case '+BUTTON':
+					if ( $this->state->stack_of_open_elements->has_element_in_scope( 'BUTTON' ) ) {
+						// @TODO: Indicate a parse error once it's possible. This error does not impact the logic here.
+						$this->generate_implied_end_tags();
+						$this->state->stack_of_open_elements->pop_until( 'BUTTON' );
+					}
+
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_html_element( $this->state->current_token );
+					$this->state->frameset_ok = false;
+
+					return true;
+
+				/*
+				* > A start tag whose tag name is one of: "address", "article", "aside",
+				* > "blockquote", "center", "details", "dialog", "dir", "div", "dl",
+				* > "fieldset", "figcaption", "figure", "footer", "header", "hgroup",
+				* > "main", "menu", "nav", "ol", "p", "search", "section", "summary", "ul"
+				*/
+				case '+ADDRESS':
+				case '+ARTICLE':
+				case '+ASIDE':
+				case '+BLOCKQUOTE':
+				case '+CENTER':
+				case '+DETAILS':
+				case '+DIALOG':
+				case '+DIR':
+				case '+DIV':
+				case '+DL':
+				case '+FIELDSET':
+				case '+FIGCAPTION':
+				case '+FIGURE':
+				case '+FOOTER':
+				case '+HEADER':
+				case '+HGROUP':
+				case '+MAIN':
+				case '+MENU':
+				case '+NAV':
+				case '+P':
+				case '+SEARCH':
+				case '+SECTION':
+				case '+SUMMARY':
+					if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+						$this->close_a_p_element();
+					}
+
+					$this->insert_html_element( $this->state->current_token );
+					return true;
+
+				/*
+				* > An end tag whose tag name is one of: "address", "article", "aside", "blockquote",
+				* > "button", "center", "details", "dialog", "dir", "div", "dl", "fieldset",
+				* > "figcaption", "figure", "footer", "header", "hgroup", "listing", "main",
+				* > "menu", "nav", "ol", "pre", "search", "section", "summary", "ul"
+				*/
+				case '-ADDRESS':
+				case '-ARTICLE':
+				case '-ASIDE':
+				case '-BLOCKQUOTE':
+				case '-BUTTON':
+				case '-CENTER':
+				case '-DETAILS':
+				case '-DIALOG':
+				case '-DIR':
+				case '-DIV':
+				case '-DL':
+				case '-FIELDSET':
+				case '-FIGCAPTION':
+				case '-FIGURE':
+				case '-FOOTER':
+				case '-HEADER':
+				case '-HGROUP':
+				case '-MAIN':
+				case '-MENU':
+				case '-NAV':
+				case '-SEARCH':
+				case '-SECTION':
+				case '-SUMMARY':
+					if ( ! $this->state->stack_of_open_elements->has_element_in_scope( $tag_name ) ) {
+						// @TODO: Report parse error.
+						// Ignore the token.
+						return $this->step();
+					}
+
+					$this->generate_implied_end_tags();
+					if ( $this->state->stack_of_open_elements->current_node()->node_name !== $tag_name ) {
+						// @TODO: Record parse error: this error doesn't impact parsing.
+					}
+					$this->state->stack_of_open_elements->pop_until( $tag_name );
+					return true;
+
+				/*
+				* > An end tag whose tag name is "p"
+				*/
+				case '-P':
+					if ( ! $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+						$this->insert_html_element( $this->state->current_token );
+					}
+
+					$this->close_a_p_element();
+					return true;
+
+				// > A start tag whose tag name is "a"
+				case '+A':
+					foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
+						switch ( $item->node_name ) {
+							case 'marker':
+								break;
+
+							case 'A':
+								$this->run_adoption_agency_algorithm();
+								$this->state->active_formatting_elements->remove_node( $item );
+								$this->state->stack_of_open_elements->remove_node( $item );
+								break;
+						}
+					}
+
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_html_element( $this->state->current_token );
+					$this->state->active_formatting_elements->push( $this->state->current_token );
+					return true;
+
+				/*
+				* > A start tag whose tag name is one of: "b", "big", "code", "em", "font", "i",
+				* > "s", "small", "strike", "strong", "tt", "u"
+				*/
+				case '+B':
+				case '+BIG':
+				case '+CODE':
+				case '+EM':
+				case '+FONT':
+				case '+I':
+				case '+S':
+				case '+SMALL':
+				case '+STRIKE':
+				case '+STRONG':
+				case '+TT':
+				case '+U':
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_html_element( $this->state->current_token );
+					$this->state->active_formatting_elements->push( $this->state->current_token );
+					return true;
+
+				/*
+				* > An end tag whose tag name is one of: "a", "b", "big", "code", "em", "font", "i",
+				* > "nobr", "s", "small", "strike", "strong", "tt", "u"
+				*/
+				case '-A':
+				case '-B':
+				case '-BIG':
+				case '-CODE':
+				case '-EM':
+				case '-FONT':
+				case '-I':
+				case '-S':
+				case '-SMALL':
+				case '-STRIKE':
+				case '-STRONG':
+				case '-TT':
+				case '-U':
+					$this->run_adoption_agency_algorithm();
+					return true;
+
+				/*
+				* > A start tag whose tag name is one of: "area", "br", "embed", "img", "keygen", "wbr"
+				*/
+				case '+IMG':
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_html_element( $this->state->current_token );
+					return true;
+
+				/*
+				* > Any other start tag
+				*/
+				case '+SPAN':
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_html_element( $this->state->current_token );
+					return true;
+
+				/*
+				* Any other end tag
+				*/
+				case '-SPAN':
+					foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
+						// > If node is an HTML element with the same tag name as the token, then:
+						if ( $item->node_name === $tag_name ) {
+							$this->generate_implied_end_tags( $tag_name );
+
+							// > If node is not the current node, then this is a parse error.
+
+							$this->state->stack_of_open_elements->pop_until( $tag_name );
+							return true;
+						}
+
+						// > Otherwise, if node is in the special category, then this is a parse error; ignore the token, and return.
+						if ( self::is_special( $item->node_name ) ) {
+							return $this->step();
+						}
+					}
+					// Execution should not reach here; if it does then something went wrong.
+					return false;
 
 				default:
 					$this->last_error = self::ERROR_UNSUPPORTED;
-					throw new WP_HTML_Unsupported_Exception( "No support for parsing in the '{$this->state->insertion_mode}' state." );
+					throw new WP_HTML_Unsupported_Exception( "Cannot process {$tag_name} element." );
 			}
-		} catch ( WP_HTML_Unsupported_Exception $e ) {
-			/*
-			 * Exceptions are used in this class to escape deep call stacks that
-			 * otherwise might involve messier calling and return conventions.
-			 */
-			return false;
-		}
-	}
-
-	/**
-	 * Computes the HTML breadcrumbs for the currently-matched node, if matched.
-	 *
-	 * Breadcrumbs start at the outermost parent and descend toward the matched element.
-	 * They always include the entire path from the root HTML node to the matched element.
-	 *
-	 * @todo It could be more efficient to expose a generator-based version of this function
-	 *       to avoid creating the array copy on tag iteration. If this is done, it would likely
-	 *       be more useful to walk up the stack when yielding instead of starting at the top.
-	 *
-	 * Example
-	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<p><strong><em><img></em></strong></p>' );
-	 *     $processor->next_tag( 'IMG' );
-	 *     $processor->get_breadcrumbs() === array( 'HTML', 'BODY', 'P', 'STRONG', 'EM', 'IMG' );
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return string[]|null Array of tag names representing path to matched node, if matched, otherwise NULL.
-	 */
-	public function get_breadcrumbs() {
-		if ( ! $this->get_tag() ) {
-			return null;
 		}
 
-		$breadcrumbs = array();
-		foreach ( $this->state->stack_of_open_elements->walk_down() as $stack_item ) {
-			$breadcrumbs[] = $stack_item->node_name;
-		}
-
-		return $breadcrumbs;
-	}
-
-	/**
-	 * Parses next element in the 'in body' insertion mode.
-	 *
-	 * This internal function performs the 'in body' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
-	 *
-	 * @see https://html.spec.whatwg.org/#parsing-main-inbody
-	 * @see WP_HTML_Processor::step
-	 *
-	 * @return bool Whether an element was found.
-	 */
-	private function step_in_body() {
-		$tag_name = $this->get_tag();
-		$op_sigil = $this->is_tag_closer() ? '-' : '+';
-		$op       = "{$op_sigil}{$tag_name}";
-
-		switch ( $op ) {
-			/*
-			 * > A start tag whose tag name is "button"
-			 */
-			case '+BUTTON':
-				if ( $this->state->stack_of_open_elements->has_element_in_scope( 'BUTTON' ) ) {
-					// @TODO: Indicate a parse error once it's possible. This error does not impact the logic here.
-					$this->generate_implied_end_tags();
-					$this->state->stack_of_open_elements->pop_until( 'BUTTON' );
-				}
-
-				$this->reconstruct_active_formatting_elements();
-				$this->insert_html_element( $this->state->current_token );
-				$this->state->frameset_ok = false;
-
-				return true;
-
-			/*
-			 * > A start tag whose tag name is one of: "address", "article", "aside",
-			 * > "blockquote", "center", "details", "dialog", "dir", "div", "dl",
-			 * > "fieldset", "figcaption", "figure", "footer", "header", "hgroup",
-			 * > "main", "menu", "nav", "ol", "p", "search", "section", "summary", "ul"
-			 */
-			case '+ADDRESS':
-			case '+ARTICLE':
-			case '+ASIDE':
-			case '+BLOCKQUOTE':
-			case '+CENTER':
-			case '+DETAILS':
-			case '+DIALOG':
-			case '+DIR':
-			case '+DIV':
-			case '+DL':
-			case '+FIELDSET':
-			case '+FIGCAPTION':
-			case '+FIGURE':
-			case '+FOOTER':
-			case '+HEADER':
-			case '+HGROUP':
-			case '+MAIN':
-			case '+MENU':
-			case '+NAV':
-			case '+P':
-			case '+SEARCH':
-			case '+SECTION':
-			case '+SUMMARY':
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
-					$this->close_a_p_element();
-				}
-
-				$this->insert_html_element( $this->state->current_token );
-				return true;
-
-			/*
-			 * > An end tag whose tag name is one of: "address", "article", "aside", "blockquote",
-			 * > "button", "center", "details", "dialog", "dir", "div", "dl", "fieldset",
-			 * > "figcaption", "figure", "footer", "header", "hgroup", "listing", "main",
-			 * > "menu", "nav", "ol", "pre", "search", "section", "summary", "ul"
-			 */
-			case '-ADDRESS':
-			case '-ARTICLE':
-			case '-ASIDE':
-			case '-BLOCKQUOTE':
-			case '-BUTTON':
-			case '-CENTER':
-			case '-DETAILS':
-			case '-DIALOG':
-			case '-DIR':
-			case '-DIV':
-			case '-DL':
-			case '-FIELDSET':
-			case '-FIGCAPTION':
-			case '-FIGURE':
-			case '-FOOTER':
-			case '-HEADER':
-			case '-HGROUP':
-			case '-MAIN':
-			case '-MENU':
-			case '-NAV':
-			case '-SEARCH':
-			case '-SECTION':
-			case '-SUMMARY':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_scope( $tag_name ) ) {
-					// @TODO: Report parse error.
-					// Ignore the token.
-					return $this->step();
-				}
-
-				$this->generate_implied_end_tags();
-				if ( $this->state->stack_of_open_elements->current_node()->node_name !== $tag_name ) {
-					// @TODO: Record parse error: this error doesn't impact parsing.
-				}
-				$this->state->stack_of_open_elements->pop_until( $tag_name );
-				return true;
-
-			/*
-			 * > An end tag whose tag name is "p"
-			 */
-			case '-P':
-				if ( ! $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
-					$this->insert_html_element( $this->state->current_token );
-				}
-
-				$this->close_a_p_element();
-				return true;
-
-			// > A start tag whose tag name is "a"
-			case '+A':
-				foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
-					switch ( $item->node_name ) {
-						case 'marker':
-							break;
-
-						case 'A':
-							$this->run_adoption_agency_algorithm();
-							$this->state->active_formatting_elements->remove_node( $item );
-							$this->state->stack_of_open_elements->remove_node( $item );
-							break;
-					}
-				}
-
-				$this->reconstruct_active_formatting_elements();
-				$this->insert_html_element( $this->state->current_token );
-				$this->state->active_formatting_elements->push( $this->state->current_token );
-				return true;
-
-			/*
-			 * > A start tag whose tag name is one of: "b", "big", "code", "em", "font", "i",
-			 * > "s", "small", "strike", "strong", "tt", "u"
-			 */
-			case '+B':
-			case '+BIG':
-			case '+CODE':
-			case '+EM':
-			case '+FONT':
-			case '+I':
-			case '+S':
-			case '+SMALL':
-			case '+STRIKE':
-			case '+STRONG':
-			case '+TT':
-			case '+U':
-				$this->reconstruct_active_formatting_elements();
-				$this->insert_html_element( $this->state->current_token );
-				$this->state->active_formatting_elements->push( $this->state->current_token );
-				return true;
-
-			/*
-			 * > An end tag whose tag name is one of: "a", "b", "big", "code", "em", "font", "i",
-			 * > "nobr", "s", "small", "strike", "strong", "tt", "u"
-			 */
-			case '-A':
-			case '-B':
-			case '-BIG':
-			case '-CODE':
-			case '-EM':
-			case '-FONT':
-			case '-I':
-			case '-S':
-			case '-SMALL':
-			case '-STRIKE':
-			case '-STRONG':
-			case '-TT':
-			case '-U':
-				$this->run_adoption_agency_algorithm();
-				return true;
-
-			/*
-			 * > A start tag whose tag name is one of: "area", "br", "embed", "img", "keygen", "wbr"
-			 */
-			case '+IMG':
-				$this->reconstruct_active_formatting_elements();
-				$this->insert_html_element( $this->state->current_token );
-				return true;
-
-			/*
-			 * > Any other start tag
-			 */
-			case '+SPAN':
-				$this->reconstruct_active_formatting_elements();
-				$this->insert_html_element( $this->state->current_token );
-				return true;
-
-			/*
-			 * Any other end tag
-			 */
-			case '-SPAN':
-				foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-					// > If node is an HTML element with the same tag name as the token, then:
-					if ( $item->node_name === $tag_name ) {
-						$this->generate_implied_end_tags( $tag_name );
-
-						// > If node is not the current node, then this is a parse error.
-
-						$this->state->stack_of_open_elements->pop_until( $tag_name );
-						return true;
-					}
-
-					// > Otherwise, if node is in the special category, then this is a parse error; ignore the token, and return.
-					if ( self::is_special( $item->node_name ) ) {
-						return $this->step();
-					}
-				}
-				// Execution should not reach here; if it does then something went wrong.
-				return false;
-
-			default:
-				$this->last_error = self::ERROR_UNSUPPORTED;
-				throw new WP_HTML_Unsupported_Exception( "Cannot process {$tag_name} element." );
-		}
-	}
-
-	/*
-	 * Internal helpers
-	 */
-
-	/**
-	 * Creates a new bookmark for the currently-matched tag and returns the generated name.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @throws Exception When unable to allocate requested bookmark.
-	 *
-	 * @return string|false Name of created bookmark, or false if unable to create.
-	 */
-	private function bookmark_tag() {
-		if ( ! $this->get_tag() ) {
-			return false;
-		}
-
-		if ( ! parent::set_bookmark( ++$this->bookmark_counter ) ) {
-			$this->last_error = self::ERROR_EXCEEDED_MAX_BOOKMARKS;
-			throw new Exception( 'could not allocate bookmark' );
-		}
-
-		return "{$this->bookmark_counter}";
-	}
-
-	/*
-	 * HTML semantic overrides for Tag Processor
-	 */
-
-	/**
-	 * Returns the uppercase name of the matched tag.
-	 *
-	 * The semantic rules for HTML specify that certain tags be reprocessed
-	 * with a different tag name. Because of this, the tag name presented
-	 * by the HTML Processor may differ from the one reported by the HTML
-	 * Tag Processor, which doesn't apply these semantic rules.
-	 *
-	 * Example:
-	 *
-	 *     $processor = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
-	 *     $processor->next_tag() === true;
-	 *     $processor->get_tag() === 'DIV';
-	 *
-	 *     $processor->next_tag() === false;
-	 *     $processor->get_tag() === null;
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return string|null Name of currently matched tag in input HTML, or `null` if none found.
-	 */
-	public function get_tag() {
-		if ( null !== $this->last_error ) {
-			return null;
-		}
-
-		$tag_name = parent::get_tag();
-
-		switch ( $tag_name ) {
-			case 'IMAGE':
-				/*
-				 * > A start tag whose tag name is "image"
-				 * > Change the token's tag name to "img" and reprocess it. (Don't ask.)
-				 */
-				return 'IMG';
-
-			default:
-				return $tag_name;
-		}
-	}
-
-	/**
-	 * Removes a bookmark that is no longer needed.
-	 *
-	 * Releasing a bookmark frees up the small
-	 * performance overhead it requires.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param string $bookmark_name Name of the bookmark to remove.
-	 * @return bool Whether the bookmark already existed before removal.
-	 */
-	public function release_bookmark( $bookmark_name ) {
-		return parent::release_bookmark( "_{$bookmark_name}" );
-	}
-
-	/**
-	 * Moves the internal cursor in the HTML Processor to a given bookmark's location.
-	 *
-	 * In order to prevent accidental infinite loops, there's a
-	 * maximum limit on the number of times seek() can be called.
-	 *
-	 * @throws Exception When unable to allocate a bookmark for the next token in the input HTML document.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param string $bookmark_name Jump to the place in the document identified by this bookmark name.
-	 * @return bool Whether the internal cursor was successfully moved to the bookmark's location.
-	 */
-	public function seek( $bookmark_name ) {
-		$actual_bookmark_name = "_{$bookmark_name}";
-		$processor_started_at = $this->state->current_token
-			? $this->bookmarks[ $this->state->current_token->bookmark_name ]->start
-			: 0;
-		$bookmark_starts_at   = $this->bookmarks[ $actual_bookmark_name ]->start;
-		$direction            = $bookmark_starts_at > $processor_started_at ? 'forward' : 'backward';
-
-		switch ( $direction ) {
-			case 'forward':
-				// When moving forwards, re-parse the document until reaching the same location as the original bookmark.
-				while ( $this->step() ) {
-					if ( $bookmark_starts_at === $this->bookmarks[ $this->state->current_token->bookmark_name ]->start ) {
-						return true;
-					}
-				}
-
-				return false;
-
-			case 'backward':
-				/*
-				 * When moving backwards, clear out all existing stack entries which appear after the destination
-				 * bookmark. These could be stored for later retrieval, but doing so would require additional
-				 * memory overhead and also demand that references and bookmarks are updated as the document
-				 * changes. In time this could be a valuable optimization, but it's okay to give up that
-				 * optimization in exchange for more CPU time to recompute the stack, to re-parse the
-				 * document that may have already been parsed once.
-				 */
-				foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-					if ( $bookmark_starts_at >= $this->bookmarks[ $item->bookmark_name ]->start ) {
-						break;
-					}
-
-					$this->state->stack_of_open_elements->remove_node( $item );
-				}
-
-				foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
-					if ( $bookmark_starts_at >= $this->bookmarks[ $item->bookmark_name ]->start ) {
-						break;
-					}
-
-					$this->state->active_formatting_elements->remove_node( $item );
-				}
-
-				return parent::seek( $actual_bookmark_name );
-		}
-	}
-
-	/**
-	 * Sets a bookmark in the HTML document.
-	 *
-	 * Bookmarks represent specific places or tokens in the HTML
-	 * document, such as a tag opener or closer. When applying
-	 * edits to a document, such as setting an attribute, the
-	 * text offsets of that token may shift; the bookmark is
-	 * kept updated with those shifts and remains stable unless
-	 * the entire span of text in which the token sits is removed.
-	 *
-	 * Release bookmarks when they are no longer needed.
-	 *
-	 * Example:
-	 *
-	 *     <main><h2>Surprising fact you may not know!</h2></main>
-	 *           ^  ^
-	 *            \-|-- this `H2` opener bookmark tracks the token
-	 *
-	 *     <main class="clickbait"><h2>Surprising fact you may no…
-	 *                             ^  ^
-	 *                              \-|-- it shifts with edits
-	 *
-	 * Bookmarks provide the ability to seek to a previously-scanned
-	 * place in the HTML document. This avoids the need to re-scan
-	 * the entire document.
-	 *
-	 * Example:
-	 *
-	 *     <ul><li>One</li><li>Two</li><li>Three</li></ul>
-	 *                                 ^^^^
-	 *                                 want to note this last item
-	 *
-	 *     $p = new WP_HTML_Tag_Processor( $html );
-	 *     $in_list = false;
-	 *     while ( $p->next_tag( array( 'tag_closers' => $in_list ? 'visit' : 'skip' ) ) ) {
-	 *         if ( 'UL' === $p->get_tag() ) {
-	 *             if ( $p->is_tag_closer() ) {
-	 *                 $in_list = false;
-	 *                 $p->set_bookmark( 'resume' );
-	 *                 if ( $p->seek( 'last-li' ) ) {
-	 *                     $p->add_class( 'last-li' );
-	 *                 }
-	 *                 $p->seek( 'resume' );
-	 *                 $p->release_bookmark( 'last-li' );
-	 *                 $p->release_bookmark( 'resume' );
-	 *             } else {
-	 *                 $in_list = true;
-	 *             }
-	 *         }
-	 *
-	 *         if ( 'LI' === $p->get_tag() ) {
-	 *             $p->set_bookmark( 'last-li' );
-	 *         }
-	 *     }
-	 *
-	 * Bookmarks intentionally hide the internal string offsets
-	 * to which they refer. They are maintained internally as
-	 * updates are applied to the HTML document and therefore
-	 * retain their "position" - the location to which they
-	 * originally pointed. The inability to use bookmarks with
-	 * functions like `substr` is therefore intentional to guard
-	 * against accidentally breaking the HTML.
-	 *
-	 * Because bookmarks allocate memory and require processing
-	 * for every applied update, they are limited and require
-	 * a name. They should not be created with programmatically-made
-	 * names, such as "li_{$index}" with some loop. As a general
-	 * rule they should only be created with string-literal names
-	 * like "start-of-section" or "last-paragraph".
-	 *
-	 * Bookmarks are a powerful tool to enable complicated behavior.
-	 * Consider double-checking that you need this tool if you are
-	 * reaching for it, as inappropriate use could lead to broken
-	 * HTML structure or unwanted processing overhead.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param string $bookmark_name Identifies this particular bookmark.
-	 * @return bool Whether the bookmark was successfully created.
-	 */
-	public function set_bookmark( $bookmark_name ) {
-		return parent::set_bookmark( "_{$bookmark_name}" );
-	}
-
-	/*
-	 * HTML Parsing Algorithms
-	 */
-
-	/**
-	 * Closes a P element.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
-	 *
-	 * @see https://html.spec.whatwg.org/#close-a-p-element
-	 */
-	private function close_a_p_element() {
-		$this->generate_implied_end_tags( 'P' );
-		$this->state->stack_of_open_elements->pop_until( 'P' );
-	}
-
-	/**
-	 * Closes elements that have implied end tags.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#generate-implied-end-tags
-	 *
-	 * @param string|null $except_for_this_element Perform as if this element doesn't exist in the stack of open elements.
-	 */
-	private function generate_implied_end_tags( $except_for_this_element = null ) {
-		$elements_with_implied_end_tags = array(
-			'P',
-		);
-
-		$current_node = $this->state->stack_of_open_elements->current_node();
-		while (
-			$current_node && $current_node->node_name !== $except_for_this_element &&
-			in_array( $this->state->stack_of_open_elements->current_node(), $elements_with_implied_end_tags, true )
-		) {
-			$this->state->stack_of_open_elements->pop();
-		}
-	}
-
-	/**
-	 * Closes elements that have implied end tags, thoroughly.
-	 *
-	 * See the HTML specification for an explanation why this is
-	 * different from generating end tags in the normal sense.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see WP_HTML_Processor::generate_implied_end_tags
-	 * @see https://html.spec.whatwg.org/#generate-implied-end-tags
-	 */
-	private function generate_implied_end_tags_thoroughly() {
-		$elements_with_implied_end_tags = array(
-			'P',
-		);
-
-		while ( in_array( $this->state->stack_of_open_elements->current_node(), $elements_with_implied_end_tags, true ) ) {
-			$this->state->stack_of_open_elements->pop();
-		}
-	}
-
-	/**
-	 * Reconstructs the active formatting elements.
-	 *
-	 * > This has the effect of reopening all the formatting elements that were opened
-	 * > in the current body, cell, or caption (whichever is youngest) that haven't
-	 * > been explicitly closed.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
-	 *
-	 * @see https://html.spec.whatwg.org/#reconstruct-the-active-formatting-elements
-	 *
-	 * @return bool Whether any formatting elements needed to be reconstructed.
-	 */
-	private function reconstruct_active_formatting_elements() {
 		/*
-		 * > If there are no entries in the list of active formatting elements, then there is nothing
-		 * > to reconstruct; stop this algorithm.
+		* Internal helpers
+		*/
+
+		/**
+		 * Creates a new bookmark for the currently-matched tag and returns the generated name.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @throws Exception When unable to allocate requested bookmark.
+		 *
+		 * @return string|false Name of created bookmark, or false if unable to create.
 		 */
-		if ( 0 === $this->state->active_formatting_elements->count() ) {
-			return false;
+		private function bookmark_tag() {
+			if ( ! $this->get_tag() ) {
+				return false;
+			}
+
+			if ( ! parent::set_bookmark( ++$this->bookmark_counter ) ) {
+				$this->last_error = self::ERROR_EXCEEDED_MAX_BOOKMARKS;
+				throw new Exception( 'could not allocate bookmark' );
+			}
+
+			return "{$this->bookmark_counter}";
 		}
 
-		$last_entry = $this->state->active_formatting_elements->current_node();
-		if (
+		/*
+		* HTML semantic overrides for Tag Processor
+		*/
 
-			/*
-			 * > If the last (most recently added) entry in the list of active formatting elements is a marker;
-			 * > stop this algorithm.
-			 */
-			'marker' === $last_entry->node_name ||
+		/**
+		 * Returns the uppercase name of the matched tag.
+		 *
+		 * The semantic rules for HTML specify that certain tags be reprocessed
+		 * with a different tag name. Because of this, the tag name presented
+		 * by the HTML Processor may differ from the one reported by the HTML
+		 * Tag Processor, which doesn't apply these semantic rules.
+		 *
+		 * Example:
+		 *
+		 *     $processor = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
+		 *     $processor->next_tag() === true;
+		 *     $processor->get_tag() === 'DIV';
+		 *
+		 *     $processor->next_tag() === false;
+		 *     $processor->get_tag() === null;
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return string|null Name of currently matched tag in input HTML, or `null` if none found.
+		 */
+		public function get_tag() {
+			if ( null !== $this->last_error ) {
+				return null;
+			}
 
-			/*
-			 * > If the last (most recently added) entry in the list of active formatting elements is an
-			 * > element that is in the stack of open elements, then there is nothing to reconstruct;
-			 * > stop this algorithm.
-			 */
-			$this->state->stack_of_open_elements->contains_node( $last_entry )
-		) {
-			return false;
+			$tag_name = parent::get_tag();
+
+			switch ( $tag_name ) {
+				case 'IMAGE':
+					/*
+					* > A start tag whose tag name is "image"
+					* > Change the token's tag name to "img" and reprocess it. (Don't ask.)
+					*/
+					return 'IMG';
+
+				default:
+					return $tag_name;
+			}
 		}
 
-		$this->last_error = self::ERROR_UNSUPPORTED;
-		throw new WP_HTML_Unsupported_Exception( 'Cannot reconstruct active formatting elements when advancing and rewinding is required.' );
-	}
-
-	/**
-	 * Runs the adoption agency algorithm.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
-	 *
-	 * @see https://html.spec.whatwg.org/#adoption-agency-algorithm
-	 */
-	private function run_adoption_agency_algorithm() {
-		$budget       = 1000;
-		$subject      = $this->get_tag();
-		$current_node = $this->state->stack_of_open_elements->current_node();
-
-		if (
-			// > If the current node is an HTML element whose tag name is subject
-			$current_node && $subject === $current_node->node_name &&
-			// > the current node is not in the list of active formatting elements
-			! $this->state->active_formatting_elements->contains_node( $current_node )
-		) {
-			$this->state->stack_of_open_elements->pop();
-			return;
+		/**
+		 * Removes a bookmark that is no longer needed.
+		 *
+		 * Releasing a bookmark frees up the small
+		 * performance overhead it requires.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param string $bookmark_name Name of the bookmark to remove.
+		 * @return bool Whether the bookmark already existed before removal.
+		 */
+		public function release_bookmark( $bookmark_name ) {
+			return parent::release_bookmark( "_{$bookmark_name}" );
 		}
 
-		$outer_loop_counter = 0;
-		while ( $budget-- > 0 ) {
-			if ( $outer_loop_counter++ >= 8 ) {
-				return;
-			}
+		/**
+		 * Moves the internal cursor in the HTML Processor to a given bookmark's location.
+		 *
+		 * In order to prevent accidental infinite loops, there's a
+		 * maximum limit on the number of times seek() can be called.
+		 *
+		 * @throws Exception When unable to allocate a bookmark for the next token in the input HTML document.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param string $bookmark_name Jump to the place in the document identified by this bookmark name.
+		 * @return bool Whether the internal cursor was successfully moved to the bookmark's location.
+		 */
+		public function seek( $bookmark_name ) {
+			$actual_bookmark_name = "_{$bookmark_name}";
+			$processor_started_at = $this->state->current_token
+				? $this->bookmarks[ $this->state->current_token->bookmark_name ]->start
+				: 0;
+			$bookmark_starts_at   = $this->bookmarks[ $actual_bookmark_name ]->start;
+			$direction            = $bookmark_starts_at > $processor_started_at ? 'forward' : 'backward';
 
-			/*
-			 * > Let formatting element be the last element in the list of active formatting elements that:
-			 * >   - is between the end of the list and the last marker in the list,
-			 * >     if any, or the start of the list otherwise,
-			 * >   - and has the tag name subject.
-			 */
-			$formatting_element = null;
-			foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
-				if ( 'marker' === $item->node_name ) {
-					break;
-				}
-
-				if ( $subject === $item->node_name ) {
-					$formatting_element = $item;
-					break;
-				}
-			}
-
-			// > If there is no such element, then return and instead act as described in the "any other end tag" entry above.
-			if ( null === $formatting_element ) {
-				$this->last_error = self::ERROR_UNSUPPORTED;
-				throw new WP_HTML_Unsupported_Exception( 'Cannot run adoption agency when "any other end tag" is required.' );
-			}
-
-			// > If formatting element is not in the stack of open elements, then this is a parse error; remove the element from the list, and return.
-			if ( ! $this->state->stack_of_open_elements->contains_node( $formatting_element ) ) {
-				$this->state->active_formatting_elements->remove_node( $formatting_element->bookmark_name );
-				return;
-			}
-
-			// > If formatting element is in the stack of open elements, but the element is not in scope, then this is a parse error; return.
-			if ( ! $this->state->stack_of_open_elements->has_element_in_scope( $formatting_element->node_name ) ) {
-				return;
-			}
-
-			/*
-			 * > Let furthest block be the topmost node in the stack of open elements that is lower in the stack
-			 * > than formatting element, and is an element in the special category. There might not be one.
-			 */
-			$is_above_formatting_element = true;
-			$furthest_block              = null;
-			foreach ( $this->state->stack_of_open_elements->walk_down() as $item ) {
-				if ( $is_above_formatting_element && $formatting_element->bookmark_name !== $item->bookmark_name ) {
-					continue;
-				}
-
-				if ( $is_above_formatting_element ) {
-					$is_above_formatting_element = false;
-					continue;
-				}
-
-				if ( self::is_special( $item->node_name ) ) {
-					$furthest_block = $item;
-					break;
-				}
-			}
-
-			/*
-			 * > If there is no furthest block, then the UA must first pop all the nodes from the bottom of the
-			 * > stack of open elements, from the current node up to and including formatting element, then
-			 * > remove formatting element from the list of active formatting elements, and finally return.
-			 */
-			if ( null === $furthest_block ) {
-				foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-					$this->state->stack_of_open_elements->pop();
-
-					if ( $formatting_element->bookmark_name === $item->bookmark_name ) {
-						$this->state->active_formatting_elements->remove_node( $formatting_element );
-						return;
+			switch ( $direction ) {
+				case 'forward':
+					// When moving forwards, re-parse the document until reaching the same location as the original bookmark.
+					while ( $this->step() ) {
+						if ( $bookmark_starts_at === $this->bookmarks[ $this->state->current_token->bookmark_name ]->start ) {
+							return true;
+						}
 					}
-				}
+
+					return false;
+
+				case 'backward':
+					/*
+					* When moving backwards, clear out all existing stack entries which appear after the destination
+					* bookmark. These could be stored for later retrieval, but doing so would require additional
+					* memory overhead and also demand that references and bookmarks are updated as the document
+					* changes. In time this could be a valuable optimization, but it's okay to give up that
+					* optimization in exchange for more CPU time to recompute the stack, to re-parse the
+					* document that may have already been parsed once.
+					*/
+					foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
+						if ( $bookmark_starts_at >= $this->bookmarks[ $item->bookmark_name ]->start ) {
+							break;
+						}
+
+						$this->state->stack_of_open_elements->remove_node( $item );
+					}
+
+					foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
+						if ( $bookmark_starts_at >= $this->bookmarks[ $item->bookmark_name ]->start ) {
+							break;
+						}
+
+						$this->state->active_formatting_elements->remove_node( $item );
+					}
+
+					return parent::seek( $actual_bookmark_name );
+			}
+		}
+
+		/**
+		 * Sets a bookmark in the HTML document.
+		 *
+		 * Bookmarks represent specific places or tokens in the HTML
+		 * document, such as a tag opener or closer. When applying
+		 * edits to a document, such as setting an attribute, the
+		 * text offsets of that token may shift; the bookmark is
+		 * kept updated with those shifts and remains stable unless
+		 * the entire span of text in which the token sits is removed.
+		 *
+		 * Release bookmarks when they are no longer needed.
+		 *
+		 * Example:
+		 *
+		 *     <main><h2>Surprising fact you may not know!</h2></main>
+		 *           ^  ^
+		 *            \-|-- this `H2` opener bookmark tracks the token
+		 *
+		 *     <main class="clickbait"><h2>Surprising fact you may no…
+		 *                             ^  ^
+		 *                              \-|-- it shifts with edits
+		 *
+		 * Bookmarks provide the ability to seek to a previously-scanned
+		 * place in the HTML document. This avoids the need to re-scan
+		 * the entire document.
+		 *
+		 * Example:
+		 *
+		 *     <ul><li>One</li><li>Two</li><li>Three</li></ul>
+		 *                                 ^^^^
+		 *                                 want to note this last item
+		 *
+		 *     $p = new WP_HTML_Tag_Processor( $html );
+		 *     $in_list = false;
+		 *     while ( $p->next_tag( array( 'tag_closers' => $in_list ? 'visit' : 'skip' ) ) ) {
+		 *         if ( 'UL' === $p->get_tag() ) {
+		 *             if ( $p->is_tag_closer() ) {
+		 *                 $in_list = false;
+		 *                 $p->set_bookmark( 'resume' );
+		 *                 if ( $p->seek( 'last-li' ) ) {
+		 *                     $p->add_class( 'last-li' );
+		 *                 }
+		 *                 $p->seek( 'resume' );
+		 *                 $p->release_bookmark( 'last-li' );
+		 *                 $p->release_bookmark( 'resume' );
+		 *             } else {
+		 *                 $in_list = true;
+		 *             }
+		 *         }
+		 *
+		 *         if ( 'LI' === $p->get_tag() ) {
+		 *             $p->set_bookmark( 'last-li' );
+		 *         }
+		 *     }
+		 *
+		 * Bookmarks intentionally hide the internal string offsets
+		 * to which they refer. They are maintained internally as
+		 * updates are applied to the HTML document and therefore
+		 * retain their "position" - the location to which they
+		 * originally pointed. The inability to use bookmarks with
+		 * functions like `substr` is therefore intentional to guard
+		 * against accidentally breaking the HTML.
+		 *
+		 * Because bookmarks allocate memory and require processing
+		 * for every applied update, they are limited and require
+		 * a name. They should not be created with programmatically-made
+		 * names, such as "li_{$index}" with some loop. As a general
+		 * rule they should only be created with string-literal names
+		 * like "start-of-section" or "last-paragraph".
+		 *
+		 * Bookmarks are a powerful tool to enable complicated behavior.
+		 * Consider double-checking that you need this tool if you are
+		 * reaching for it, as inappropriate use could lead to broken
+		 * HTML structure or unwanted processing overhead.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param string $bookmark_name Identifies this particular bookmark.
+		 * @return bool Whether the bookmark was successfully created.
+		 */
+		public function set_bookmark( $bookmark_name ) {
+			return parent::set_bookmark( "_{$bookmark_name}" );
+		}
+
+		/*
+		* HTML Parsing Algorithms
+		*/
+
+		/**
+		 * Closes a P element.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
+		 *
+		 * @see https://html.spec.whatwg.org/#close-a-p-element
+		 */
+		private function close_a_p_element() {
+			$this->generate_implied_end_tags( 'P' );
+			$this->state->stack_of_open_elements->pop_until( 'P' );
+		}
+
+		/**
+		 * Closes elements that have implied end tags.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#generate-implied-end-tags
+		 *
+		 * @param string|null $except_for_this_element Perform as if this element doesn't exist in the stack of open elements.
+		 */
+		private function generate_implied_end_tags( $except_for_this_element = null ) {
+			$elements_with_implied_end_tags = array(
+				'P',
+			);
+
+			$current_node = $this->state->stack_of_open_elements->current_node();
+			while (
+				$current_node && $current_node->node_name !== $except_for_this_element &&
+				in_array( $this->state->stack_of_open_elements->current_node(), $elements_with_implied_end_tags, true )
+			) {
+				$this->state->stack_of_open_elements->pop();
+			}
+		}
+
+		/**
+		 * Closes elements that have implied end tags, thoroughly.
+		 *
+		 * See the HTML specification for an explanation why this is
+		 * different from generating end tags in the normal sense.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see WP_HTML_Processor::generate_implied_end_tags
+		 * @see https://html.spec.whatwg.org/#generate-implied-end-tags
+		 */
+		private function generate_implied_end_tags_thoroughly() {
+			$elements_with_implied_end_tags = array(
+				'P',
+			);
+
+			while ( in_array( $this->state->stack_of_open_elements->current_node(), $elements_with_implied_end_tags, true ) ) {
+				$this->state->stack_of_open_elements->pop();
+			}
+		}
+
+		/**
+		 * Reconstructs the active formatting elements.
+		 *
+		 * > This has the effect of reopening all the formatting elements that were opened
+		 * > in the current body, cell, or caption (whichever is youngest) that haven't
+		 * > been explicitly closed.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
+		 *
+		 * @see https://html.spec.whatwg.org/#reconstruct-the-active-formatting-elements
+		 *
+		 * @return bool Whether any formatting elements needed to be reconstructed.
+		 */
+		private function reconstruct_active_formatting_elements() {
+			/*
+			* > If there are no entries in the list of active formatting elements, then there is nothing
+			* > to reconstruct; stop this algorithm.
+			*/
+			if ( 0 === $this->state->active_formatting_elements->count() ) {
+				return false;
+			}
+
+			$last_entry = $this->state->active_formatting_elements->current_node();
+			if (
+
+				/*
+				* > If the last (most recently added) entry in the list of active formatting elements is a marker;
+				* > stop this algorithm.
+				*/
+				'marker' === $last_entry->node_name ||
+
+				/*
+				* > If the last (most recently added) entry in the list of active formatting elements is an
+				* > element that is in the stack of open elements, then there is nothing to reconstruct;
+				* > stop this algorithm.
+				*/
+				$this->state->stack_of_open_elements->contains_node( $last_entry )
+			) {
+				return false;
 			}
 
 			$this->last_error = self::ERROR_UNSUPPORTED;
-			throw new WP_HTML_Unsupported_Exception( 'Cannot extract common ancestor in adoption agency algorithm.' );
+			throw new WP_HTML_Unsupported_Exception( 'Cannot reconstruct active formatting elements when advancing and rewinding is required.' );
 		}
 
-		$this->last_error = self::ERROR_UNSUPPORTED;
-		throw new WP_HTML_Unsupported_Exception( 'Cannot run adoption agency when looping required.' );
+		/**
+		 * Runs the adoption agency algorithm.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
+		 *
+		 * @see https://html.spec.whatwg.org/#adoption-agency-algorithm
+		 */
+		private function run_adoption_agency_algorithm() {
+			$budget       = 1000;
+			$subject      = $this->get_tag();
+			$current_node = $this->state->stack_of_open_elements->current_node();
+
+			if (
+				// > If the current node is an HTML element whose tag name is subject
+				$current_node && $subject === $current_node->node_name &&
+				// > the current node is not in the list of active formatting elements
+				! $this->state->active_formatting_elements->contains_node( $current_node )
+			) {
+				$this->state->stack_of_open_elements->pop();
+				return;
+			}
+
+			$outer_loop_counter = 0;
+			while ( $budget-- > 0 ) {
+				if ( $outer_loop_counter++ >= 8 ) {
+					return;
+				}
+
+				/*
+				* > Let formatting element be the last element in the list of active formatting elements that:
+				* >   - is between the end of the list and the last marker in the list,
+				* >     if any, or the start of the list otherwise,
+				* >   - and has the tag name subject.
+				*/
+				$formatting_element = null;
+				foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
+					if ( 'marker' === $item->node_name ) {
+						break;
+					}
+
+					if ( $subject === $item->node_name ) {
+						$formatting_element = $item;
+						break;
+					}
+				}
+
+				// > If there is no such element, then return and instead act as described in the "any other end tag" entry above.
+				if ( null === $formatting_element ) {
+					$this->last_error = self::ERROR_UNSUPPORTED;
+					throw new WP_HTML_Unsupported_Exception( 'Cannot run adoption agency when "any other end tag" is required.' );
+				}
+
+				// > If formatting element is not in the stack of open elements, then this is a parse error; remove the element from the list, and return.
+				if ( ! $this->state->stack_of_open_elements->contains_node( $formatting_element ) ) {
+					$this->state->active_formatting_elements->remove_node( $formatting_element->bookmark_name );
+					return;
+				}
+
+				// > If formatting element is in the stack of open elements, but the element is not in scope, then this is a parse error; return.
+				if ( ! $this->state->stack_of_open_elements->has_element_in_scope( $formatting_element->node_name ) ) {
+					return;
+				}
+
+				/*
+				* > Let furthest block be the topmost node in the stack of open elements that is lower in the stack
+				* > than formatting element, and is an element in the special category. There might not be one.
+				*/
+				$is_above_formatting_element = true;
+				$furthest_block              = null;
+				foreach ( $this->state->stack_of_open_elements->walk_down() as $item ) {
+					if ( $is_above_formatting_element && $formatting_element->bookmark_name !== $item->bookmark_name ) {
+						continue;
+					}
+
+					if ( $is_above_formatting_element ) {
+						$is_above_formatting_element = false;
+						continue;
+					}
+
+					if ( self::is_special( $item->node_name ) ) {
+						$furthest_block = $item;
+						break;
+					}
+				}
+
+				/*
+				* > If there is no furthest block, then the UA must first pop all the nodes from the bottom of the
+				* > stack of open elements, from the current node up to and including formatting element, then
+				* > remove formatting element from the list of active formatting elements, and finally return.
+				*/
+				if ( null === $furthest_block ) {
+					foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
+						$this->state->stack_of_open_elements->pop();
+
+						if ( $formatting_element->bookmark_name === $item->bookmark_name ) {
+							$this->state->active_formatting_elements->remove_node( $formatting_element );
+							return;
+						}
+					}
+				}
+
+				$this->last_error = self::ERROR_UNSUPPORTED;
+				throw new WP_HTML_Unsupported_Exception( 'Cannot extract common ancestor in adoption agency algorithm.' );
+			}
+
+			$this->last_error = self::ERROR_UNSUPPORTED;
+			throw new WP_HTML_Unsupported_Exception( 'Cannot run adoption agency when looping required.' );
+		}
+
+		/**
+		 * Inserts an HTML element on the stack of open elements.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#insert-a-foreign-element
+		 *
+		 * @param WP_HTML_Token $token Name of bookmark pointing to element in original input HTML.
+		 */
+		private function insert_html_element( $token ) {
+			$this->state->stack_of_open_elements->push( $token );
+		}
+
+		/*
+		* HTML Specification Helpers
+		*/
+
+		/**
+		 * Returns whether an element of a given name is in the HTML special category.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#special
+		 *
+		 * @param string $tag_name Name of element to check.
+		 * @return bool Whether the element of the given name is in the special category.
+		 */
+		public static function is_special( $tag_name ) {
+			$tag_name = strtoupper( $tag_name );
+
+			return (
+				'ADDRESS' === $tag_name ||
+				'APPLET' === $tag_name ||
+				'AREA' === $tag_name ||
+				'ARTICLE' === $tag_name ||
+				'ASIDE' === $tag_name ||
+				'BASE' === $tag_name ||
+				'BASEFONT' === $tag_name ||
+				'BGSOUND' === $tag_name ||
+				'BLOCKQUOTE' === $tag_name ||
+				'BODY' === $tag_name ||
+				'BR' === $tag_name ||
+				'BUTTON' === $tag_name ||
+				'CAPTION' === $tag_name ||
+				'CENTER' === $tag_name ||
+				'COL' === $tag_name ||
+				'COLGROUP' === $tag_name ||
+				'DD' === $tag_name ||
+				'DETAILS' === $tag_name ||
+				'DIR' === $tag_name ||
+				'DIV' === $tag_name ||
+				'DL' === $tag_name ||
+				'DT' === $tag_name ||
+				'EMBED' === $tag_name ||
+				'FIELDSET' === $tag_name ||
+				'FIGCAPTION' === $tag_name ||
+				'FIGURE' === $tag_name ||
+				'FOOTER' === $tag_name ||
+				'FORM' === $tag_name ||
+				'FRAME' === $tag_name ||
+				'FRAMESET' === $tag_name ||
+				'H1' === $tag_name ||
+				'H2' === $tag_name ||
+				'H3' === $tag_name ||
+				'H4' === $tag_name ||
+				'H5' === $tag_name ||
+				'H6' === $tag_name ||
+				'HEAD' === $tag_name ||
+				'HEADER' === $tag_name ||
+				'HGROUP' === $tag_name ||
+				'HR' === $tag_name ||
+				'HTML' === $tag_name ||
+				'IFRAME' === $tag_name ||
+				'IMG' === $tag_name ||
+				'INPUT' === $tag_name ||
+				'KEYGEN' === $tag_name ||
+				'LI' === $tag_name ||
+				'LINK' === $tag_name ||
+				'LISTING' === $tag_name ||
+				'MAIN' === $tag_name ||
+				'MARQUEE' === $tag_name ||
+				'MENU' === $tag_name ||
+				'META' === $tag_name ||
+				'NAV' === $tag_name ||
+				'NOEMBED' === $tag_name ||
+				'NOFRAMES' === $tag_name ||
+				'NOSCRIPT' === $tag_name ||
+				'OBJECT' === $tag_name ||
+				'OL' === $tag_name ||
+				'P' === $tag_name ||
+				'PARAM' === $tag_name ||
+				'PLAINTEXT' === $tag_name ||
+				'PRE' === $tag_name ||
+				'SCRIPT' === $tag_name ||
+				'SEARCH' === $tag_name ||
+				'SECTION' === $tag_name ||
+				'SELECT' === $tag_name ||
+				'SOURCE' === $tag_name ||
+				'STYLE' === $tag_name ||
+				'SUMMARY' === $tag_name ||
+				'TABLE' === $tag_name ||
+				'TBODY' === $tag_name ||
+				'TD' === $tag_name ||
+				'TEMPLATE' === $tag_name ||
+				'TEXTAREA' === $tag_name ||
+				'TFOOT' === $tag_name ||
+				'TH' === $tag_name ||
+				'THEAD' === $tag_name ||
+				'TITLE' === $tag_name ||
+				'TR' === $tag_name ||
+				'TRACK' === $tag_name ||
+				'UL' === $tag_name ||
+				'WBR' === $tag_name ||
+				'XMP' === $tag_name ||
+
+				// MathML.
+				'MI' === $tag_name ||
+				'MO' === $tag_name ||
+				'MN' === $tag_name ||
+				'MS' === $tag_name ||
+				'MTEXT' === $tag_name ||
+				'ANNOTATION-XML' === $tag_name ||
+
+				// SVG.
+				'FOREIGNOBJECT' === $tag_name ||
+				'DESC' === $tag_name ||
+				'TITLE' === $tag_name
+			);
+		}
+
+		/**
+		 * Returns whether a given element is an HTML Void Element
+		 *
+		 * > area, base, br, col, embed, hr, img, input, link, meta, source, track, wbr
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#void-elements
+		 *
+		 * @param string $tag_name Name of HTML tag to check.
+		 * @return bool Whether the given tag is an HTML Void Element.
+		 */
+		public static function is_void( $tag_name ) {
+			$tag_name = strtoupper( $tag_name );
+
+			return (
+				'AREA' === $tag_name ||
+				'BASE' === $tag_name ||
+				'BR' === $tag_name ||
+				'COL' === $tag_name ||
+				'EMBED' === $tag_name ||
+				'HR' === $tag_name ||
+				'IMG' === $tag_name ||
+				'INPUT' === $tag_name ||
+				'LINK' === $tag_name ||
+				'META' === $tag_name ||
+				'SOURCE' === $tag_name ||
+				'TRACK' === $tag_name ||
+				'WBR' === $tag_name
+			);
+		}
+
+		/*
+		* Constants that would pollute the top of the class if they were found there.
+		*/
+
+		/**
+		 * Indicates that the next HTML token should be parsed and processed.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string
+		 */
+		const PROCESS_NEXT_NODE = 'process-next-node';
+
+		/**
+		 * Indicates that the current HTML token should be reprocessed in the newly-selected insertion mode.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string
+		 */
+		const REPROCESS_CURRENT_NODE = 'reprocess-current-node';
+
+		/**
+		 * Indicates that the parser encountered unsupported markup and has bailed.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string
+		 */
+		const ERROR_UNSUPPORTED = 'unsupported';
+
+		/**
+		 * Indicates that the parser encountered more HTML tokens than it
+		 * was able to process and has bailed.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string
+		 */
+		const ERROR_EXCEEDED_MAX_BOOKMARKS = 'exceeded-max-bookmarks';
+
+		/**
+		 * Unlock code that must be passed into the constructor to create this class.
+		 *
+		 * This class extends the WP_HTML_Tag_Processor, which has a public class
+		 * constructor. Therefore, it's not possible to have a private constructor here.
+		 *
+		 * This unlock code is used to ensure that anyone calling the constructor is
+		 * doing so with a full understanding that it's intended to be a private API.
+		 *
+		 * @access private
+		 */
+		const CONSTRUCTOR_UNLOCK_CODE = 'Use WP_HTML_Processor::create_fragment() instead of calling the class constructor directly.';
 	}
-
-	/**
-	 * Inserts an HTML element on the stack of open elements.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#insert-a-foreign-element
-	 *
-	 * @param WP_HTML_Token $token Name of bookmark pointing to element in original input HTML.
-	 */
-	private function insert_html_element( $token ) {
-		$this->state->stack_of_open_elements->push( $token );
-	}
-
-	/*
-	 * HTML Specification Helpers
-	 */
-
-	/**
-	 * Returns whether an element of a given name is in the HTML special category.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#special
-	 *
-	 * @param string $tag_name Name of element to check.
-	 * @return bool Whether the element of the given name is in the special category.
-	 */
-	public static function is_special( $tag_name ) {
-		$tag_name = strtoupper( $tag_name );
-
-		return (
-			'ADDRESS' === $tag_name ||
-			'APPLET' === $tag_name ||
-			'AREA' === $tag_name ||
-			'ARTICLE' === $tag_name ||
-			'ASIDE' === $tag_name ||
-			'BASE' === $tag_name ||
-			'BASEFONT' === $tag_name ||
-			'BGSOUND' === $tag_name ||
-			'BLOCKQUOTE' === $tag_name ||
-			'BODY' === $tag_name ||
-			'BR' === $tag_name ||
-			'BUTTON' === $tag_name ||
-			'CAPTION' === $tag_name ||
-			'CENTER' === $tag_name ||
-			'COL' === $tag_name ||
-			'COLGROUP' === $tag_name ||
-			'DD' === $tag_name ||
-			'DETAILS' === $tag_name ||
-			'DIR' === $tag_name ||
-			'DIV' === $tag_name ||
-			'DL' === $tag_name ||
-			'DT' === $tag_name ||
-			'EMBED' === $tag_name ||
-			'FIELDSET' === $tag_name ||
-			'FIGCAPTION' === $tag_name ||
-			'FIGURE' === $tag_name ||
-			'FOOTER' === $tag_name ||
-			'FORM' === $tag_name ||
-			'FRAME' === $tag_name ||
-			'FRAMESET' === $tag_name ||
-			'H1' === $tag_name ||
-			'H2' === $tag_name ||
-			'H3' === $tag_name ||
-			'H4' === $tag_name ||
-			'H5' === $tag_name ||
-			'H6' === $tag_name ||
-			'HEAD' === $tag_name ||
-			'HEADER' === $tag_name ||
-			'HGROUP' === $tag_name ||
-			'HR' === $tag_name ||
-			'HTML' === $tag_name ||
-			'IFRAME' === $tag_name ||
-			'IMG' === $tag_name ||
-			'INPUT' === $tag_name ||
-			'KEYGEN' === $tag_name ||
-			'LI' === $tag_name ||
-			'LINK' === $tag_name ||
-			'LISTING' === $tag_name ||
-			'MAIN' === $tag_name ||
-			'MARQUEE' === $tag_name ||
-			'MENU' === $tag_name ||
-			'META' === $tag_name ||
-			'NAV' === $tag_name ||
-			'NOEMBED' === $tag_name ||
-			'NOFRAMES' === $tag_name ||
-			'NOSCRIPT' === $tag_name ||
-			'OBJECT' === $tag_name ||
-			'OL' === $tag_name ||
-			'P' === $tag_name ||
-			'PARAM' === $tag_name ||
-			'PLAINTEXT' === $tag_name ||
-			'PRE' === $tag_name ||
-			'SCRIPT' === $tag_name ||
-			'SEARCH' === $tag_name ||
-			'SECTION' === $tag_name ||
-			'SELECT' === $tag_name ||
-			'SOURCE' === $tag_name ||
-			'STYLE' === $tag_name ||
-			'SUMMARY' === $tag_name ||
-			'TABLE' === $tag_name ||
-			'TBODY' === $tag_name ||
-			'TD' === $tag_name ||
-			'TEMPLATE' === $tag_name ||
-			'TEXTAREA' === $tag_name ||
-			'TFOOT' === $tag_name ||
-			'TH' === $tag_name ||
-			'THEAD' === $tag_name ||
-			'TITLE' === $tag_name ||
-			'TR' === $tag_name ||
-			'TRACK' === $tag_name ||
-			'UL' === $tag_name ||
-			'WBR' === $tag_name ||
-			'XMP' === $tag_name ||
-
-			// MathML.
-			'MI' === $tag_name ||
-			'MO' === $tag_name ||
-			'MN' === $tag_name ||
-			'MS' === $tag_name ||
-			'MTEXT' === $tag_name ||
-			'ANNOTATION-XML' === $tag_name ||
-
-			// SVG.
-			'FOREIGNOBJECT' === $tag_name ||
-			'DESC' === $tag_name ||
-			'TITLE' === $tag_name
-		);
-	}
-
-	/**
-	 * Returns whether a given element is an HTML Void Element
-	 *
-	 * > area, base, br, col, embed, hr, img, input, link, meta, source, track, wbr
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#void-elements
-	 *
-	 * @param string $tag_name Name of HTML tag to check.
-	 * @return bool Whether the given tag is an HTML Void Element.
-	 */
-	public static function is_void( $tag_name ) {
-		$tag_name = strtoupper( $tag_name );
-
-		return (
-			'AREA' === $tag_name ||
-			'BASE' === $tag_name ||
-			'BR' === $tag_name ||
-			'COL' === $tag_name ||
-			'EMBED' === $tag_name ||
-			'HR' === $tag_name ||
-			'IMG' === $tag_name ||
-			'INPUT' === $tag_name ||
-			'LINK' === $tag_name ||
-			'META' === $tag_name ||
-			'SOURCE' === $tag_name ||
-			'TRACK' === $tag_name ||
-			'WBR' === $tag_name
-		);
-	}
-
-	/*
-	 * Constants that would pollute the top of the class if they were found there.
-	 */
-
-	/**
-	 * Indicates that the next HTML token should be parsed and processed.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string
-	 */
-	const PROCESS_NEXT_NODE = 'process-next-node';
-
-	/**
-	 * Indicates that the current HTML token should be reprocessed in the newly-selected insertion mode.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string
-	 */
-	const REPROCESS_CURRENT_NODE = 'reprocess-current-node';
-
-	/**
-	 * Indicates that the parser encountered unsupported markup and has bailed.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string
-	 */
-	const ERROR_UNSUPPORTED = 'unsupported';
-
-	/**
-	 * Indicates that the parser encountered more HTML tokens than it
-	 * was able to process and has bailed.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string
-	 */
-	const ERROR_EXCEEDED_MAX_BOOKMARKS = 'exceeded-max-bookmarks';
-
-	/**
-	 * Unlock code that must be passed into the constructor to create this class.
-	 *
-	 * This class extends the WP_HTML_Tag_Processor, which has a public class
-	 * constructor. Therefore, it's not possible to have a private constructor here.
-	 *
-	 * This unlock code is used to ensure that anyone calling the constructor is
-	 * doing so with a full understanding that it's intended to be a private API.
-	 *
-	 * @access private
-	 */
-	const CONSTRUCTOR_UNLOCK_CODE = 'Use WP_HTML_Processor::create_fragment() instead of calling the class constructor directly.';
 }

--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-token.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-token.php
@@ -7,95 +7,94 @@
  * @since 6.4.0
  */
 
-if ( class_exists( 'WP_HTML_Token' ) ) {
-	return;
-}
+if ( ! class_exists( 'WP_HTML_Token' ) ) {
 
-/**
- * Core class used by the HTML processor during HTML parsing
- * for referring to tokens in the input HTML string.
- *
- * This class is designed for internal use by the HTML processor.
- *
- * @since 6.4.0
- *
- * @access private
- *
- * @see WP_HTML_Processor
- */
-class WP_HTML_Token {
 	/**
-	 * Name of bookmark corresponding to source of token in input HTML string.
+	 * Core class used by the HTML processor during HTML parsing
+	 * for referring to tokens in the input HTML string.
 	 *
-	 * Having a bookmark name does not imply that the token still exists. It
-	 * may be that the source token and underlying bookmark was wiped out by
-	 * some modification to the source HTML.
+	 * This class is designed for internal use by the HTML processor.
 	 *
 	 * @since 6.4.0
 	 *
-	 * @var string
+	 * @access private
+	 *
+	 * @see WP_HTML_Processor
 	 */
-	public $bookmark_name = null;
+	class WP_HTML_Token {
+		/**
+		 * Name of bookmark corresponding to source of token in input HTML string.
+		 *
+		 * Having a bookmark name does not imply that the token still exists. It
+		 * may be that the source token and underlying bookmark was wiped out by
+		 * some modification to the source HTML.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @var string
+		 */
+		public $bookmark_name = null;
 
-	/**
-	 * Name of node; lowercase names such as "marker" are not HTML elements.
-	 *
-	 * For HTML elements/tags this value should come from WP_HTML_Processor::get_tag().
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see WP_HTML_Processor::get_tag()
-	 *
-	 * @var string
-	 */
-	public $node_name = null;
+		/**
+		 * Name of node; lowercase names such as "marker" are not HTML elements.
+		 *
+		 * For HTML elements/tags this value should come from WP_HTML_Processor::get_tag().
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see WP_HTML_Processor::get_tag()
+		 *
+		 * @var string
+		 */
+		public $node_name = null;
 
-	/**
-	 * Whether node contains the self-closing flag.
-	 *
-	 * A node may have a self-closing flag when it shouldn't. This value
-	 * only reports if the flag is present in the original HTML.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#self-closing-flag
-	 *
-	 * @var bool
-	 */
-	public $has_self_closing_flag = false;
+		/**
+		 * Whether node contains the self-closing flag.
+		 *
+		 * A node may have a self-closing flag when it shouldn't. This value
+		 * only reports if the flag is present in the original HTML.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @see https://html.spec.whatwg.org/#self-closing-flag
+		 *
+		 * @var bool
+		 */
+		public $has_self_closing_flag = false;
 
-	/**
-	 * Called when token is garbage-collected or otherwise destroyed.
-	 *
-	 * @var callable|null
-	 */
-	public $on_destroy = null;
+		/**
+		 * Called when token is garbage-collected or otherwise destroyed.
+		 *
+		 * @var callable|null
+		 */
+		public $on_destroy = null;
 
-	/**
-	 * Constructor - creates a reference to a token in some external HTML string.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param string   $bookmark_name         Name of bookmark corresponding to location in HTML where token is found.
-	 * @param string   $node_name             Name of node token represents; if uppercase, an HTML element; if lowercase, a special value like "marker".
-	 * @param bool     $has_self_closing_flag Whether the source token contains the self-closing flag, regardless of whether it's valid.
-	 * @param callable $on_destroy            Function to call when destroying token, useful for releasing the bookmark.
-	 */
-	public function __construct( $bookmark_name, $node_name, $has_self_closing_flag, $on_destroy = null ) {
-		$this->bookmark_name         = $bookmark_name;
-		$this->node_name             = $node_name;
-		$this->has_self_closing_flag = $has_self_closing_flag;
-		$this->on_destroy            = $on_destroy;
-	}
+		/**
+		 * Constructor - creates a reference to a token in some external HTML string.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param string   $bookmark_name         Name of bookmark corresponding to location in HTML where token is found.
+		 * @param string   $node_name             Name of node token represents; if uppercase, an HTML element; if lowercase, a special value like "marker".
+		 * @param bool     $has_self_closing_flag Whether the source token contains the self-closing flag, regardless of whether it's valid.
+		 * @param callable $on_destroy            Function to call when destroying token, useful for releasing the bookmark.
+		 */
+		public function __construct( $bookmark_name, $node_name, $has_self_closing_flag, $on_destroy = null ) {
+			$this->bookmark_name         = $bookmark_name;
+			$this->node_name             = $node_name;
+			$this->has_self_closing_flag = $has_self_closing_flag;
+			$this->on_destroy            = $on_destroy;
+		}
 
-	/**
-	 * Destructor.
-	 *
-	 * @since 6.4.0
-	 */
-	public function __destruct() {
-		if ( is_callable( $this->on_destroy ) ) {
-			call_user_func( $this->on_destroy, $this->bookmark_name );
+		/**
+		 * Destructor.
+		 *
+		 * @since 6.4.0
+		 */
+		public function __destruct() {
+			if ( is_callable( $this->on_destroy ) ) {
+				call_user_func( $this->on_destroy, $this->bookmark_name );
+			}
 		}
 	}
 }

--- a/lib/compat/wordpress-6.4/html-api/class-wp-html-unsupported-exception.php
+++ b/lib/compat/wordpress-6.4/html-api/class-wp-html-unsupported-exception.php
@@ -7,29 +7,28 @@
  * @since 6.4.0
  */
 
-if ( class_exists( 'WP_HTML_Unsupported_Exception' ) ) {
-	return;
-}
+if ( ! class_exists( 'WP_HTML_Unsupported_Exception' ) ) {
 
-/**
- * Core class used by the HTML processor during HTML parsing
- * for indicating that a given operation is unsupported.
- *
- * This class is designed for internal use by the HTML processor.
- *
- * The HTML API aims to operate in compliance with the HTML5
- * specification, but does not implement the full specification.
- * In cases where it lacks support it should not cause breakage
- * or unexpected behavior. In the cases where it recognizes that
- * it cannot proceed, this class is used to abort from any
- * operation and signify that the given HTML cannot be processed.
- *
- * @since 6.4.0
- *
- * @access private
- *
- * @see WP_HTML_Processor
- */
-class WP_HTML_Unsupported_Exception extends Exception {
+	/**
+	 * Core class used by the HTML processor during HTML parsing
+	 * for indicating that a given operation is unsupported.
+	 *
+	 * This class is designed for internal use by the HTML processor.
+	 *
+	 * The HTML API aims to operate in compliance with the HTML5
+	 * specification, but does not implement the full specification.
+	 * In cases where it lacks support it should not cause breakage
+	 * or unexpected behavior. In the cases where it recognizes that
+	 * it cannot proceed, this class is used to abort from any
+	 * operation and signify that the given HTML cannot be processed.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @access private
+	 *
+	 * @see WP_HTML_Processor
+	 */
+	class WP_HTML_Unsupported_Exception extends Exception {
 
+	}
 }

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -9,189 +9,188 @@
  * @since 6.5.0
  */
 
-if ( class_exists( 'WP_Block_Bindings_Registry' ) ) {
-	return;
-}
-
-/**
- * Class used for interacting with block bindings sources.
- *
- *  @since 6.5.0
- */
-final class WP_Block_Bindings_Registry {
-	/**
-	 * Holds the registered block bindings sources, keyed by source identifier.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @var array
-	 */
-	private $sources = array();
+if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 
 	/**
-	 * Container for the main instance of the class.
+	 * Class used for interacting with block bindings sources.
 	 *
-	 * @since 6.5.0
-	 * @var WP_Block_Bindings_Registry|null
+	 *  @since 6.5.0
 	 */
-	private static $instance = null;
+	final class WP_Block_Bindings_Registry {
+		/**
+		 * Holds the registered block bindings sources, keyed by source identifier.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var array
+		 */
+		private $sources = array();
 
-	/**
-	 * Registers a new block bindings source.
-	 *
-	 * Sources are used to override block's original attributes with a value
-	 * coming from the source. Once a source is registered, it can be used by a
-	 * block by setting its `metadata.bindings` attribute to a value that refers
-	 * to the source.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string   $source_name       The name of the source.
-	 * @param array    $source_properties {
-	 *     The array of arguments that are used to register a source.
-	 *
-	 *     @type string   $label              The label of the source.
-	 *     @type callback $get_value_callback A callback executed when the source is processed during block rendering.
-	 *                                        The callback should have the following signature:
-	 *
-	 *                                        `function ($source_args, $block_instance,$attribute_name): mixed`
-	 *                                            - @param array    $source_args    Array containing source arguments
-	 *                                                                              used to look up the override value,
-	 *                                                                              i.e. {"key": "foo"}.
-	 *                                            - @param WP_Block $block_instance The block instance.
-	 *                                            - @param string   $attribute_name The name of an attribute .
-	 *                                        The callback has a mixed return type; it may return a string to override
-	 *                                        the block's original value, null, false to remove an attribute, etc.
-	 * }
-	 * @return array|false Source when the registration was successful, or `false` on failure.
-	 */
-	public function register( $source_name, array $source_properties ) {
-		if ( ! is_string( $source_name ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Block bindings source name must be a string.' ),
-				'6.5.0'
+		/**
+		 * Container for the main instance of the class.
+		 *
+		 * @since 6.5.0
+		 * @var WP_Block_Bindings_Registry|null
+		 */
+		private static $instance = null;
+
+		/**
+		 * Registers a new block bindings source.
+		 *
+		 * Sources are used to override block's original attributes with a value
+		 * coming from the source. Once a source is registered, it can be used by a
+		 * block by setting its `metadata.bindings` attribute to a value that refers
+		 * to the source.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string   $source_name       The name of the source.
+		 * @param array    $source_properties {
+		 *     The array of arguments that are used to register a source.
+		 *
+		 *     @type string   $label              The label of the source.
+		 *     @type callback $get_value_callback A callback executed when the source is processed during block rendering.
+		 *                                        The callback should have the following signature:
+		 *
+		 *                                        `function ($source_args, $block_instance,$attribute_name): mixed`
+		 *                                            - @param array    $source_args    Array containing source arguments
+		 *                                                                              used to look up the override value,
+		 *                                                                              i.e. {"key": "foo"}.
+		 *                                            - @param WP_Block $block_instance The block instance.
+		 *                                            - @param string   $attribute_name The name of an attribute .
+		 *                                        The callback has a mixed return type; it may return a string to override
+		 *                                        the block's original value, null, false to remove an attribute, etc.
+		 * }
+		 * @return array|false Source when the registration was successful, or `false` on failure.
+		 */
+		public function register( $source_name, array $source_properties ) {
+			if ( ! is_string( $source_name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Block bindings source name must be a string.' ),
+					'6.5.0'
+				);
+				return false;
+			}
+
+			if ( preg_match( '/[A-Z]+/', $source_name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Block bindings source names must not contain uppercase characters.' ),
+					'6.5.0'
+				);
+				return false;
+			}
+
+			$name_matcher = '/^[a-z0-9-]+\/[a-z0-9-]+$/';
+			if ( ! preg_match( $name_matcher, $source_name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Block bindings source names must contain a namespace prefix. Example: my-plugin/my-custom-source' ),
+					'6.5.0'
+				);
+				return false;
+			}
+
+			if ( $this->is_registered( $source_name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Block bindings source name. */
+					sprintf( __( 'Block bindings sources "%s" already registered.' ), $source_name ),
+					'6.5.0'
+				);
+				return false;
+			}
+
+			$source = array_merge(
+				array( 'name' => $source_name ),
+				$source_properties
 			);
-			return false;
+
+			$this->sources[ $source_name ] = $source;
+
+			return $source;
 		}
 
-		if ( preg_match( '/[A-Z]+/', $source_name ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Block bindings source names must not contain uppercase characters.' ),
-				'6.5.0'
-			);
-			return false;
+		/**
+		 * Unregisters a block bindings source.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string $source_name Block bindings source name including namespace.
+		 * @return array|false The unregistred block bindings source on success and `false` otherwise.
+		 */
+		public function unregister( $source_name ) {
+			if ( ! $this->is_registered( $source_name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Block bindings source name. */
+					sprintf( __( 'Block bindings "%s" not found.' ), $source_name ),
+					'6.5.0'
+				);
+				return false;
+			}
+
+			$unregistered_source = $this->sources[ $source_name ];
+			unset( $this->sources[ $source_name ] );
+
+			return $unregistered_source;
 		}
 
-		$name_matcher = '/^[a-z0-9-]+\/[a-z0-9-]+$/';
-		if ( ! preg_match( $name_matcher, $source_name ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Block bindings source names must contain a namespace prefix. Example: my-plugin/my-custom-source' ),
-				'6.5.0'
-			);
-			return false;
+		/**
+		 * Retrieves the list of all registered block bindings sources.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array The array of registered sources.
+		 */
+		public function get_all_registered() {
+			return $this->sources;
 		}
 
-		if ( $this->is_registered( $source_name ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				/* translators: %s: Block bindings source name. */
-				sprintf( __( 'Block bindings sources "%s" already registered.' ), $source_name ),
-				'6.5.0'
-			);
-			return false;
+		/**
+		 * Retrieves a registered block bindings source.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string $source_name The name of the source.
+		 * @return array|null The registered block bindings source, or `null` if it is not registered.
+		 */
+		public function get_registered( $source_name ) {
+			if ( ! $this->is_registered( $source_name ) ) {
+				return null;
+			}
+
+			return $this->sources[ $source_name ];
 		}
 
-		$source = array_merge(
-			array( 'name' => $source_name ),
-			$source_properties
-		);
-
-		$this->sources[ $source_name ] = $source;
-
-		return $source;
-	}
-
-	/**
-	 * Unregisters a block bindings source.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string $source_name Block bindings source name including namespace.
-	 * @return array|false The unregistred block bindings source on success and `false` otherwise.
-	 */
-	public function unregister( $source_name ) {
-		if ( ! $this->is_registered( $source_name ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				/* translators: %s: Block bindings source name. */
-				sprintf( __( 'Block bindings "%s" not found.' ), $source_name ),
-				'6.5.0'
-			);
-			return false;
+		/**
+		 * Checks if a block bindings source is registered.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string $source_name The name of the source.
+		 * @return bool `true` if the block bindings source is registered, `false` otherwise.
+		 */
+		public function is_registered( $source_name ) {
+			return isset( $this->sources[ $source_name ] );
 		}
 
-		$unregistered_source = $this->sources[ $source_name ];
-		unset( $this->sources[ $source_name ] );
+		/**
+		 * Utility method to retrieve the main instance of the class.
+		 *
+		 * The instance will be created if it does not exist yet.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return WP_Block_Bindings_Registry The main instance.
+		 */
+		public static function get_instance() {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
 
-		return $unregistered_source;
-	}
-
-	/**
-	 * Retrieves the list of all registered block bindings sources.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array The array of registered sources.
-	 */
-	public function get_all_registered() {
-		return $this->sources;
-	}
-
-	/**
-	 * Retrieves a registered block bindings source.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string $source_name The name of the source.
-	 * @return array|null The registered block bindings source, or `null` if it is not registered.
-	 */
-	public function get_registered( $source_name ) {
-		if ( ! $this->is_registered( $source_name ) ) {
-			return null;
+			return self::$instance;
 		}
-
-		return $this->sources[ $source_name ];
-	}
-
-	/**
-	 * Checks if a block bindings source is registered.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string $source_name The name of the source.
-	 * @return bool `true` if the block bindings source is registered, `false` otherwise.
-	 */
-	public function is_registered( $source_name ) {
-		return isset( $this->sources[ $source_name ] );
-	}
-
-	/**
-	 * Utility method to retrieve the main instance of the class.
-	 *
-	 * The instance will be created if it does not exist yet.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return WP_Block_Bindings_Registry The main instance.
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
 	}
 }

--- a/lib/experimental/class--wp-editors.php
+++ b/lib/experimental/class--wp-editors.php
@@ -8,24 +8,23 @@
 
 // phpcs:disable PEAR.NamingConventions.ValidClassName.StartWithCapital
 
-if ( class_exists( '_WP_Editors' ) ) {
-	return;
-}
-
-/**
- * Placeholder class.
- * Used to disable loading of TinyMCE assets.
- *
- * @access public
- */
-final class _WP_Editors {
-	/**
-	 * Necessary to ensure no additional TinyMCE assets are enqueued.
-	 */
-	public static function enqueue_default_editor() {}
+if ( ! class_exists( '_WP_Editors' ) ) {
 
 	/**
-	 * Necessary for wp admin dashboard.
+	 * Placeholder class.
+	 * Used to disable loading of TinyMCE assets.
+	 *
+	 * @access public
 	 */
-	public static function editor() {}
+	final class _WP_Editors {
+		/**
+		 * Necessary to ensure no additional TinyMCE assets are enqueued.
+		 */
+		public static function enqueue_default_editor() {}
+
+		/**
+		 * Necessary for wp admin dashboard.
+		 */
+		public static function editor() {}
+	}
 }

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -6,317 +6,316 @@
  * @subpackage REST_API
  */
 
-if ( class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
-	return;
-}
-
-/**
- * Core class used to retrieve the block editor settings via the REST API.
- *
- * @see WP_REST_Controller
- */
-class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
-	/**
-	 * Constructs the controller.
-	 */
-	public function __construct() {
-		$this->namespace = 'wp-block-editor/v1';
-		$this->rest_base = 'settings';
-	}
+if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 
 	/**
-	 * Registers the necessary REST API routes.
+	 * Core class used to retrieve the block editor settings via the REST API.
+	 *
+	 * @see WP_REST_Controller
 	 */
-	public function register_routes() {
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base,
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-	}
-
-	/**
-	 * Checks whether a given request has permission to read block editor settings
-	 *
-	 * @since 5.8.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 *
-	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
-	 */
-	public function get_items_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( current_user_can( 'edit_posts' ) ) {
-			return true;
+	class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
+		/**
+		 * Constructs the controller.
+		 */
+		public function __construct() {
+			$this->namespace = 'wp-block-editor/v1';
+			$this->rest_base = 'settings';
 		}
 
-		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
-			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+		/**
+		 * Registers the necessary REST API routes.
+		 */
+		public function register_routes() {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
+				array(
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_items' ),
+						'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					),
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
+			);
+		}
+
+		/**
+		 * Checks whether a given request has permission to read block editor settings
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 *
+		 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
+		 */
+		public function get_items_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			if ( current_user_can( 'edit_posts' ) ) {
 				return true;
 			}
+
+			foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+				if ( current_user_can( $post_type->cap->edit_posts ) ) {
+					return true;
+				}
+			}
+
+			return new WP_Error(
+				'rest_cannot_read_block_editor_settings',
+				__( 'Sorry, you are not allowed to read the block editor settings.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
 		}
 
-		return new WP_Error(
-			'rest_cannot_read_block_editor_settings',
-			__( 'Sorry, you are not allowed to read the block editor settings.', 'gutenberg' ),
-			array( 'status' => rest_authorization_required_code() )
-		);
-	}
+		/**
+		 * Returns the block editor's settings
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 *
+		 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+		 */
+		public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis
+			switch ( $request['context'] ) {
+				case 'post-editor':
+				default:
+					$editor_context_name = 'core/edit-post';
+					break;
+				case 'widgets-editor':
+					$editor_context_name = 'core/edit-widgets';
+					break;
+				case 'site-editor':
+					$editor_context_name = 'core/edit-site';
+					break;
+				case 'mobile':
+					$editor_context_name = 'core/mobile';
+					break;
+			}
 
-	/**
-	 * Returns the block editor's settings
-	 *
-	 * @since 5.8.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 *
-	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
-	 */
-	public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis
-		switch ( $request['context'] ) {
-			case 'post-editor':
-			default:
-				$editor_context_name = 'core/edit-post';
-				break;
-			case 'widgets-editor':
-				$editor_context_name = 'core/edit-widgets';
-				break;
-			case 'site-editor':
-				$editor_context_name = 'core/edit-site';
-				break;
-			case 'mobile':
-				$editor_context_name = 'core/mobile';
-				break;
+			$editor_context = new WP_Block_Editor_Context( array( 'name' => $editor_context_name ) );
+			$settings       = get_block_editor_settings( array(), $editor_context );
+
+			return rest_ensure_response( $settings );
 		}
 
-		$editor_context = new WP_Block_Editor_Context( array( 'name' => $editor_context_name ) );
-		$settings       = get_block_editor_settings( array(), $editor_context );
+		/**
+		 * Retrieves the block editor's settings schema, conforming to JSON Schema.
+		 *
+		 * @since 5.8.0
+		 *
+		 * @return array Item schema data.
+		 */
+		public function get_item_schema() {
+			if ( $this->schema ) {
+				return $this->add_additional_fields_schema( $this->schema );
+			}
 
-		return rest_ensure_response( $settings );
-	}
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'block-editor-settings-item',
+				'type'       => 'object',
+				'properties' => array(
+					'__unstableEnableFullSiteEditingBlocks'  => array(
+						'description' => __( 'Enables experimental Site Editor blocks', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
 
-	/**
-	 * Retrieves the block editor's settings schema, conforming to JSON Schema.
-	 *
-	 * @since 5.8.0
-	 *
-	 * @return array Item schema data.
-	 */
-	public function get_item_schema() {
-		if ( $this->schema ) {
+					'styles'                                 => array(
+						'description' => __( 'Editor styles', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'supportsTemplateMode'                   => array(
+						'description' => __( 'Indicates whether the current theme supports block-based templates.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'supportsLayout'                         => array(
+						'description' => __( 'Enable/disable layouts support in container blocks.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'widgetTypesToHideFromLegacyWidgetBlock' => array(
+						'description' => __( 'Widget types to hide from Legacy Widget block.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'__experimentalFeatures'                 => array(
+						'description' => __( 'Settings consolidated from core, theme, and user origins.', 'gutenberg' ),
+						'type'        => 'object',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor', 'mobile' ),
+					),
+
+					'__experimentalStyles'                   => array(
+						'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
+						'type'        => 'object',
+						'context'     => array( 'mobile' ),
+					),
+
+					'__experimentalEnableQuoteBlockV2'       => array(
+						'description' => __( 'Whether the V2 of the quote block that uses inner blocks should be enabled.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'mobile' ),
+					),
+
+					'__experimentalEnableListBlockV2'        => array(
+						'description' => __( 'Whether the V2 of the list block that uses inner blocks should be enabled.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'mobile' ),
+					),
+
+					'alignWide'                              => array(
+						'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'allowedBlockTypes'                      => array(
+						'description' => __( 'List of allowed block types.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'allowedMimeTypes'                       => array(
+						'description' => __( 'List of allowed mime types and file extensions.', 'gutenberg' ),
+						'type'        => 'object',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'blockCategories'                        => array(
+						'description' => __( 'Returns all the categories for block types that will be shown in the block editor.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'blockInspectorTabs'                     => array(
+						'description' => __( 'Block inspector tab display overrides.', 'gutenberg' ),
+						'type'        => 'object',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'disableCustomColors'                    => array(
+						'description' => __( 'Disables custom colors.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'disableCustomFontSizes'                 => array(
+						'description' => __( 'Disables custom font size.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'disableCustomGradients'                 => array(
+						'description' => __( 'Disables custom font size.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'disableLayoutStyles'                    => array(
+						'description' => __( 'Disables output of layout styles.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'enableCustomLineHeight'                 => array(
+						'description' => __( 'Enables custom line height.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'enableCustomSpacing'                    => array(
+						'description' => __( 'Enables custom spacing.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'enableCustomUnits'                      => array(
+						'description' => __( 'Enables custom units.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'isRTL'                                  => array(
+						'description' => __( 'Determines whether the current locale is right-to-left (RTL).', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'imageDefaultSize'                       => array(
+						'description' => __( 'Default size for images.', 'gutenberg' ),
+						'type'        => 'string',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'imageDimensions'                        => array(
+						'description' => __( 'Available image dimensions.', 'gutenberg' ),
+						'type'        => 'object',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'imageEditing'                           => array(
+						'description' => __( 'Determines whether the image editing feature is enabled.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'imageSizes'                             => array(
+						'description' => __( 'Available image sizes.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'maxUploadFileSize'                      => array(
+						'description' => __( 'Maximum upload size in bytes allowed for the site.', 'gutenberg' ),
+						'type'        => 'number',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'colors'                                 => array(
+						'description' => __( 'Active theme color palette.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'fontSizes'                              => array(
+						'description' => __( 'Active theme font sizes.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+
+					'gradients'                              => array(
+						'description' => __( 'Active theme gradients.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+					'spacingSizes'                           => array(
+						'description' => __( 'Active theme spacing sizes.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+					'spacingScale'                           => array(
+						'description' => __( 'Active theme spacing scale.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+					'disableCustomSpacingSizes'              => array(
+						'description' => __( 'Disables custom spacing sizes.', 'gutenberg' ),
+						'type'        => 'boolean',
+						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					),
+				),
+			);
+
+			$this->schema = $schema;
+
 			return $this->add_additional_fields_schema( $this->schema );
 		}
-
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'block-editor-settings-item',
-			'type'       => 'object',
-			'properties' => array(
-				'__unstableEnableFullSiteEditingBlocks'  => array(
-					'description' => __( 'Enables experimental Site Editor blocks', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'styles'                                 => array(
-					'description' => __( 'Editor styles', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'supportsTemplateMode'                   => array(
-					'description' => __( 'Indicates whether the current theme supports block-based templates.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'supportsLayout'                         => array(
-					'description' => __( 'Enable/disable layouts support in container blocks.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'widgetTypesToHideFromLegacyWidgetBlock' => array(
-					'description' => __( 'Widget types to hide from Legacy Widget block.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'__experimentalFeatures'                 => array(
-					'description' => __( 'Settings consolidated from core, theme, and user origins.', 'gutenberg' ),
-					'type'        => 'object',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor', 'mobile' ),
-				),
-
-				'__experimentalStyles'                   => array(
-					'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
-					'type'        => 'object',
-					'context'     => array( 'mobile' ),
-				),
-
-				'__experimentalEnableQuoteBlockV2'       => array(
-					'description' => __( 'Whether the V2 of the quote block that uses inner blocks should be enabled.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'mobile' ),
-				),
-
-				'__experimentalEnableListBlockV2'        => array(
-					'description' => __( 'Whether the V2 of the list block that uses inner blocks should be enabled.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'mobile' ),
-				),
-
-				'alignWide'                              => array(
-					'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'allowedBlockTypes'                      => array(
-					'description' => __( 'List of allowed block types.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'allowedMimeTypes'                       => array(
-					'description' => __( 'List of allowed mime types and file extensions.', 'gutenberg' ),
-					'type'        => 'object',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'blockCategories'                        => array(
-					'description' => __( 'Returns all the categories for block types that will be shown in the block editor.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'blockInspectorTabs'                     => array(
-					'description' => __( 'Block inspector tab display overrides.', 'gutenberg' ),
-					'type'        => 'object',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'disableCustomColors'                    => array(
-					'description' => __( 'Disables custom colors.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'disableCustomFontSizes'                 => array(
-					'description' => __( 'Disables custom font size.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'disableCustomGradients'                 => array(
-					'description' => __( 'Disables custom font size.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'disableLayoutStyles'                    => array(
-					'description' => __( 'Disables output of layout styles.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'enableCustomLineHeight'                 => array(
-					'description' => __( 'Enables custom line height.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'enableCustomSpacing'                    => array(
-					'description' => __( 'Enables custom spacing.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'enableCustomUnits'                      => array(
-					'description' => __( 'Enables custom units.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'isRTL'                                  => array(
-					'description' => __( 'Determines whether the current locale is right-to-left (RTL).', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'imageDefaultSize'                       => array(
-					'description' => __( 'Default size for images.', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'imageDimensions'                        => array(
-					'description' => __( 'Available image dimensions.', 'gutenberg' ),
-					'type'        => 'object',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'imageEditing'                           => array(
-					'description' => __( 'Determines whether the image editing feature is enabled.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'imageSizes'                             => array(
-					'description' => __( 'Available image sizes.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'maxUploadFileSize'                      => array(
-					'description' => __( 'Maximum upload size in bytes allowed for the site.', 'gutenberg' ),
-					'type'        => 'number',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'colors'                                 => array(
-					'description' => __( 'Active theme color palette.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'fontSizes'                              => array(
-					'description' => __( 'Active theme font sizes.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-
-				'gradients'                              => array(
-					'description' => __( 'Active theme gradients.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-				'spacingSizes'                           => array(
-					'description' => __( 'Active theme spacing sizes.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-				'spacingScale'                           => array(
-					'description' => __( 'Active theme spacing scale.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-				'disableCustomSpacingSizes'              => array(
-					'description' => __( 'Disables custom spacing sizes.', 'gutenberg' ),
-					'type'        => 'boolean',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
-				),
-			),
-		);
-
-		$this->schema = $schema;
-
-		return $this->add_additional_fields_schema( $this->schema );
 	}
 }

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -116,25 +116,25 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 				'title'      => 'block-editor-settings-item',
 				'type'       => 'object',
 				'properties' => array(
-					'__unstableEnableFullSiteEditingBlocks'  => array(
+					'__unstableEnableFullSiteEditingBlocks' => array(
 						'description' => __( 'Enables experimental Site Editor blocks', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'styles'                                 => array(
+					'styles'                           => array(
 						'description' => __( 'Editor styles', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'supportsTemplateMode'                   => array(
+					'supportsTemplateMode'             => array(
 						'description' => __( 'Indicates whether the current theme supports block-based templates.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'supportsLayout'                         => array(
+					'supportsLayout'                   => array(
 						'description' => __( 'Enable/disable layouts support in container blocks.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
@@ -146,166 +146,166 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'__experimentalFeatures'                 => array(
+					'__experimentalFeatures'           => array(
 						'description' => __( 'Settings consolidated from core, theme, and user origins.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor', 'mobile' ),
 					),
 
-					'__experimentalStyles'                   => array(
+					'__experimentalStyles'             => array(
 						'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'mobile' ),
 					),
 
-					'__experimentalEnableQuoteBlockV2'       => array(
+					'__experimentalEnableQuoteBlockV2' => array(
 						'description' => __( 'Whether the V2 of the quote block that uses inner blocks should be enabled.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'mobile' ),
 					),
 
-					'__experimentalEnableListBlockV2'        => array(
+					'__experimentalEnableListBlockV2'  => array(
 						'description' => __( 'Whether the V2 of the list block that uses inner blocks should be enabled.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'mobile' ),
 					),
 
-					'alignWide'                              => array(
+					'alignWide'                        => array(
 						'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'allowedBlockTypes'                      => array(
+					'allowedBlockTypes'                => array(
 						'description' => __( 'List of allowed block types.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'allowedMimeTypes'                       => array(
+					'allowedMimeTypes'                 => array(
 						'description' => __( 'List of allowed mime types and file extensions.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'blockCategories'                        => array(
+					'blockCategories'                  => array(
 						'description' => __( 'Returns all the categories for block types that will be shown in the block editor.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'blockInspectorTabs'                     => array(
+					'blockInspectorTabs'               => array(
 						'description' => __( 'Block inspector tab display overrides.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'disableCustomColors'                    => array(
+					'disableCustomColors'              => array(
 						'description' => __( 'Disables custom colors.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'disableCustomFontSizes'                 => array(
+					'disableCustomFontSizes'           => array(
 						'description' => __( 'Disables custom font size.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'disableCustomGradients'                 => array(
+					'disableCustomGradients'           => array(
 						'description' => __( 'Disables custom font size.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'disableLayoutStyles'                    => array(
+					'disableLayoutStyles'              => array(
 						'description' => __( 'Disables output of layout styles.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'enableCustomLineHeight'                 => array(
+					'enableCustomLineHeight'           => array(
 						'description' => __( 'Enables custom line height.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'enableCustomSpacing'                    => array(
+					'enableCustomSpacing'              => array(
 						'description' => __( 'Enables custom spacing.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'enableCustomUnits'                      => array(
+					'enableCustomUnits'                => array(
 						'description' => __( 'Enables custom units.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'isRTL'                                  => array(
+					'isRTL'                            => array(
 						'description' => __( 'Determines whether the current locale is right-to-left (RTL).', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'imageDefaultSize'                       => array(
+					'imageDefaultSize'                 => array(
 						'description' => __( 'Default size for images.', 'gutenberg' ),
 						'type'        => 'string',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'imageDimensions'                        => array(
+					'imageDimensions'                  => array(
 						'description' => __( 'Available image dimensions.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'imageEditing'                           => array(
+					'imageEditing'                     => array(
 						'description' => __( 'Determines whether the image editing feature is enabled.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'imageSizes'                             => array(
+					'imageSizes'                       => array(
 						'description' => __( 'Available image sizes.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'maxUploadFileSize'                      => array(
+					'maxUploadFileSize'                => array(
 						'description' => __( 'Maximum upload size in bytes allowed for the site.', 'gutenberg' ),
 						'type'        => 'number',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'colors'                                 => array(
+					'colors'                           => array(
 						'description' => __( 'Active theme color palette.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'fontSizes'                              => array(
+					'fontSizes'                        => array(
 						'description' => __( 'Active theme font sizes.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
 
-					'gradients'                              => array(
+					'gradients'                        => array(
 						'description' => __( 'Active theme gradients.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
-					'spacingSizes'                           => array(
+					'spacingSizes'                     => array(
 						'description' => __( 'Active theme spacing sizes.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
-					'spacingScale'                           => array(
+					'spacingScale'                     => array(
 						'description' => __( 'Active theme spacing scale.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 					),
-					'disableCustomSpacingSizes'              => array(
+					'disableCustomSpacingSizes'        => array(
 						'description' => __( 'Disables custom spacing sizes.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),

--- a/lib/experimental/class-wp-rest-customizer-nonces.php
+++ b/lib/experimental/class-wp-rest-customizer-nonces.php
@@ -5,71 +5,70 @@
  * @package gutenberg
  */
 
-if ( class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
-	return;
-}
-
-/**
- * Class that returns the customizer "save" nonce that's required for the
- * batch save operation using the customizer API endpoint.
- */
-class WP_Rest_Customizer_Nonces extends WP_REST_Controller {
+if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
 
 	/**
-	 * Constructor.
+	 * Class that returns the customizer "save" nonce that's required for the
+	 * batch save operation using the customizer API endpoint.
 	 */
-	public function __construct() {
-		$this->namespace = '__experimental';
-		$this->rest_base = 'customizer-nonces';
-	}
+	class WP_Rest_Customizer_Nonces extends WP_REST_Controller {
 
-	/**
-	 * Registers the necessary REST API routes.
-	 *
-	 * @access public
-	 */
-	public function register_routes() {
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/get-save-nonce',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_save_nonce' ),
-					'permission_callback' => array( $this, 'permissions_check' ),
-					'args'                => $this->get_collection_params(),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-	}
-
-	/**
-	 * Checks if a given request has access to read menu items if they have access to edit them.
-	 *
-	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
-	 */
-	public function permissions_check() {
-		$post_type = get_post_type_object( 'nav_menu_item' );
-		if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
-			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to edit posts in this post type.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->namespace = '__experimental';
+			$this->rest_base = 'customizer-nonces';
 		}
-		return true;
-	}
 
-	/**
-	 * Returns the nonce required to request the customizer API endpoint.
-	 *
-	 * @access public
-	 */
-	public function get_save_nonce() {
-		require_once ABSPATH . 'wp-includes/class-wp-customize-manager.php';
-		$wp_customize = new WP_Customize_Manager();
-		$nonce        = wp_create_nonce( 'save-customize_' . $wp_customize->get_stylesheet() );
-		return array(
-			'success'    => true,
-			'nonce'      => $nonce,
-			'stylesheet' => $wp_customize->get_stylesheet(),
-		);
+		/**
+		 * Registers the necessary REST API routes.
+		 *
+		 * @access public
+		 */
+		public function register_routes() {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base . '/get-save-nonce',
+				array(
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_save_nonce' ),
+						'permission_callback' => array( $this, 'permissions_check' ),
+						'args'                => $this->get_collection_params(),
+					),
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
+			);
+		}
+
+		/**
+		 * Checks if a given request has access to read menu items if they have access to edit them.
+		 *
+		 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+		 */
+		public function permissions_check() {
+			$post_type = get_post_type_object( 'nav_menu_item' );
+			if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
+				return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to edit posts in this post type.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+			return true;
+		}
+
+		/**
+		 * Returns the nonce required to request the customizer API endpoint.
+		 *
+		 * @access public
+		 */
+		public function get_save_nonce() {
+			require_once ABSPATH . 'wp-includes/class-wp-customize-manager.php';
+			$wp_customize = new WP_Customize_Manager();
+			$nonce        = wp_create_nonce( 'save-customize_' . $wp_customize->get_stylesheet() );
+			return array(
+				'success'    => true,
+				'nonce'      => $nonce,
+				'stylesheet' => $wp_customize->get_stylesheet(),
+			);
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts-provider-local.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts-provider-local.php
@@ -7,40 +7,39 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Fonts_Provider_Local' ) ) {
-	return;
-}
-
-/**
- * A core bundled provider for generating `@font-face` styles
- * from locally-hosted font files.
- *
- * @since X.X.X
- * @deprecated 16.3.0 Providers are not supported.
- *                    Local provider is in WP_Font_Face.
- */
-class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
+if ( ! class_exists( 'WP_Fonts_Provider_Local' ) ) {
 
 	/**
-	 * The provider's unique ID.
+	 * A core bundled provider for generating `@font-face` styles
+	 * from locally-hosted font files.
 	 *
 	 * @since X.X.X
-	 * @deprecated 16.3.0
-	 *
-	 * @var string
+	 * @deprecated 16.3.0 Providers are not supported.
+	 *                    Local provider is in WP_Font_Face.
 	 */
-	protected $id = 'local';
+	class WP_Fonts_Provider_Local extends WP_Fonts_Provider {
 
-	/**
-	 * Gets the `@font-face` CSS styles for locally-hosted font files.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Get styles is not supported.
-	 *
-	 * @return string Empty string.
-	 */
-	public function get_css() {
-		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
-		return '';
+		/**
+		 * The provider's unique ID.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 *
+		 * @var string
+		 */
+		protected $id = 'local';
+
+		/**
+		 * Gets the `@font-face` CSS styles for locally-hosted font files.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Get styles is not supported.
+		 *
+		 * @return string Empty string.
+		 */
+		public function get_css() {
+			_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+			return '';
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts-provider.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts-provider.php
@@ -9,90 +9,89 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Fonts_Provider' ) ) {
-	return;
-}
-
-/**
- * Abstract class for Fonts API providers.
- *
- * @since X.X.X
- * @deprecated 16.3.0 Custom providers are not supported.
- */
-abstract class WP_Fonts_Provider {
+if ( ! class_exists( 'WP_Fonts_Provider' ) ) {
 
 	/**
-	 * The provider's unique ID.
+	 * Abstract class for Fonts API providers.
 	 *
 	 * @since X.X.X
-	 * @deprecated 16.3.0
-	 *
-	 * @var string
+	 * @deprecated 16.3.0 Custom providers are not supported.
 	 */
-	protected $id = '';
+	abstract class WP_Fonts_Provider {
 
-	/**
-	 * Fonts to be processed.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0
-	 *
-	 * @var array[]
-	 */
-	protected $fonts = array();
+		/**
+		 * The provider's unique ID.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 *
+		 * @var string
+		 */
+		protected $id = '';
 
-	/**
-	 * Array of Font-face style tag's attribute(s)
-	 * where the key is the attribute name and the
-	 * value is its value.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0
-	 *
-	 * @var string[]
-	 */
-	protected $style_tag_atts = array();
+		/**
+		 * Fonts to be processed.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 *
+		 * @var array[]
+		 */
+		protected $fonts = array();
 
-	/**
-	 * Sets this provider's fonts property.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Set is not supported.
-	 */
-	public function set_fonts() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+		/**
+		 * Array of Font-face style tag's attribute(s)
+		 * where the key is the attribute name and the
+		 * value is its value.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 *
+		 * @var string[]
+		 */
+		protected $style_tag_atts = array();
 
-	/**
-	 * Prints the generated styles.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Use wp_print_font_faces() instead.
-	 */
-	public function print_styles() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0', 'wp_print_font_faces' );
-	}
+		/**
+		 * Sets this provider's fonts property.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Set is not supported.
+		 */
+		public function set_fonts() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Gets the `@font-face` CSS for the provider's fonts.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0
-	 *
-	 * @return string The `@font-face` CSS.
-	 */
-	abstract public function get_css();
+		/**
+		 * Prints the generated styles.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Use wp_print_font_faces() instead.
+		 */
+		public function print_styles() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0', 'wp_print_font_faces' );
+		}
 
-	/**
-	 * Gets the `<style>` element for wrapping the `@font-face` CSS.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Get style element is not supported.
-	 *
-	 * @return string Empty string.
-	 */
-	protected function get_style_element() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return '';
+		/**
+		 * Gets the `@font-face` CSS for the provider's fonts.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 *
+		 * @return string The `@font-face` CSS.
+		 */
+		abstract public function get_css();
+
+		/**
+		 * Gets the `<style>` element for wrapping the `@font-face` CSS.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Get style element is not supported.
+		 *
+		 * @return string Empty string.
+		 */
+		protected function get_style_element() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return '';
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts-resolver.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts-resolver.php
@@ -7,58 +7,57 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Fonts_Resolver' ) ) {
-	return;
-}
-
-/**
- * The Fonts API Resolver abstracts the processing of different data sources
- * (such as theme.json and global styles) for font interactions with the API.
- *
- * This class is for internal core usage and is not supposed to be used by
- * extenders (plugins and/or themes).
- *
- * @access private
- *
- * @since X.X.X
- * @deprecated 16.3.0 Fonts API is not supported.
- */
-class WP_Fonts_Resolver {
+if ( ! class_exists( 'WP_Fonts_Resolver' ) ) {
 
 	/**
-	 * Enqueues user-selected fonts via global styles.
+	 * The Fonts API Resolver abstracts the processing of different data sources
+	 * (such as theme.json and global styles) for font interactions with the API.
+	 *
+	 * This class is for internal core usage and is not supposed to be used by
+	 * extenders (plugins and/or themes).
+	 *
+	 * @access private
 	 *
 	 * @since X.X.X
-	 * @deprecated 16.3.0 Enqueue is not supported.
-	 *
-	 * @return array Empty array.
+	 * @deprecated 16.3.0 Fonts API is not supported.
 	 */
-	public static function enqueue_user_selected_fonts() {
-		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
-		return array();
-	}
+	class WP_Fonts_Resolver {
 
-	/**
-	 * Register fonts defined in theme.json.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Register is not supported.
-	 */
-	public static function register_fonts_from_theme_json() {
-		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
-	}
+		/**
+		 * Enqueues user-selected fonts via global styles.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Enqueue is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public static function enqueue_user_selected_fonts() {
+			_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+			return array();
+		}
 
-	/**
-	 * Add missing fonts to the global styles.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Adding fonts into theme.json theme data layer is not supported.
-	 *
-	 * @param WP_Theme_JSON_Gutenberg|WP_Theme_JSON $data The global styles.
-	 * @return WP_Theme_JSON_Gutenberg|WP_Theme_JSON Unchanged global styles.
-	 */
-	public static function add_missing_fonts_to_theme_json( $data ) {
-		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
-		return $data;
+		/**
+		 * Register fonts defined in theme.json.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Register is not supported.
+		 */
+		public static function register_fonts_from_theme_json() {
+			_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+		}
+
+		/**
+		 * Add missing fonts to the global styles.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Adding fonts into theme.json theme data layer is not supported.
+		 *
+		 * @param WP_Theme_JSON_Gutenberg|WP_Theme_JSON $data The global styles.
+		 * @return WP_Theme_JSON_Gutenberg|WP_Theme_JSON Unchanged global styles.
+		 */
+		public static function add_missing_fonts_to_theme_json( $data ) {
+			_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+			return $data;
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts-utils.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts-utils.php
@@ -7,68 +7,67 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Fonts_Utils' ) ) {
-	return;
-}
-
-/**
- * Utility helpers for the Fonts API.
- *
- * @since X.X.X
- * @deprecated 16.3.0 Fonts API is not supported.
- */
-class WP_Fonts_Utils {
+if ( ! class_exists( 'WP_Fonts_Utils' ) ) {
 
 	/**
-	 * Converts the given font family into a handle.
+	 * Utility helpers for the Fonts API.
 	 *
 	 * @since X.X.X
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @return null
+	 * @deprecated 16.3.0 Fonts API is not supported.
 	 */
-	public static function convert_font_family_into_handle() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return null;
-	}
+	class WP_Fonts_Utils {
 
-	/**
-	 * Converts the given variation and its font-family into a handle.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @return null
-	 */
-	public static function convert_variation_into_handle() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return null;
-	}
+		/**
+		 * Converts the given font family into a handle.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @return null
+		 */
+		public static function convert_font_family_into_handle() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return null;
+		}
 
-	/**
-	 * Gets the font family from the variation.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @return null Null.
-	 */
-	public static function get_font_family_from_variation() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return null;
-	}
+		/**
+		 * Converts the given variation and its font-family into a handle.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @return null
+		 */
+		public static function convert_variation_into_handle() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return null;
+		}
 
-	/**
-	 * Checks if the given input is defined, i.e. meaning is a non-empty string.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0
-	 *
-	 * @param string $input The input to check.
-	 * @return bool True when non-empty string. Else false.
-	 */
-	public static function is_defined( $input ) {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return ( is_string( $input ) && ! empty( $input ) );
+		/**
+		 * Gets the font family from the variation.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @return null Null.
+		 */
+		public static function get_font_family_from_variation() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return null;
+		}
+
+		/**
+		 * Checks if the given input is defined, i.e. meaning is a non-empty string.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 *
+		 * @param string $input The input to check.
+		 * @return bool True when non-empty string. Else false.
+		 */
+		public static function is_defined( $input ) {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return ( is_string( $input ) && ! empty( $input ) );
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-fonts.php
@@ -7,193 +7,192 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Fonts' ) ) {
-	return;
-}
-
-/**
- * Class WP_Fonts
- *
- * @since X.X.X
- * @deprecated 16.3.0 Fonts API is not supported.
- */
-class WP_Fonts extends WP_Dependencies {
+if ( ! class_exists( 'WP_Fonts' ) ) {
 
 	/**
-	 * Registered "origin", indicating the font is registered in the API.
+	 * Class WP_Fonts
 	 *
 	 * @since X.X.X
-	 * @deprecated 16.3.0
-	 *
-	 * @var string
+	 * @deprecated 16.3.0 Fonts API is not supported.
 	 */
-	const REGISTERED_ORIGIN = 'gutenberg_wp_fonts_api';
+	class WP_Fonts extends WP_Dependencies {
 
-	/**
-	 * Constructor.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0
-	 */
-	public function __construct() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+		/**
+		 * Registered "origin", indicating the font is registered in the API.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 *
+		 * @var string
+		 */
+		const REGISTERED_ORIGIN = 'gutenberg_wp_fonts_api';
 
-	/**
-	 * Get the list of registered providers.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Providers are not supported.
-	 */
-	public function get_providers() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+		/**
+		 * Constructor.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 */
+		public function __construct() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Register a provider.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Providers are not supported.
-	 *
-	 * @return bool False.
-	 */
-	public function register_provider() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return false;
-	}
+		/**
+		 * Get the list of registered providers.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Providers are not supported.
+		 */
+		public function get_providers() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Get the list of all registered font family handles.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Register is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_registered_font_families() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
-	}
+		/**
+		 * Register a provider.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Providers are not supported.
+		 *
+		 * @return bool False.
+		 */
+		public function register_provider() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return false;
+		}
 
-	/**
-	 * Get the list of all registered font families and their variations.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Register is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_registered() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
-	}
+		/**
+		 * Get the list of all registered font family handles.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Register is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_registered_font_families() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 
-	/**
-	 * Get the list of enqueued font families and their variations.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Enqueue is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_enqueued() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
-	}
+		/**
+		 * Get the list of all registered font families and their variations.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Register is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_registered() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 
-	/**
-	 * Registers a font family.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Add is not supported.
-	 *
-	 * @return null Null.
-	 */
-	public function add_font_family() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return null;
-	}
+		/**
+		 * Get the list of enqueued font families and their variations.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Enqueue is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_enqueued() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 
-	/**
-	 * Removes a font family and all registered variations.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Remove is not supported.
-	 */
-	public function remove_font_family() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+		/**
+		 * Registers a font family.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Add is not supported.
+		 *
+		 * @return null Null.
+		 */
+		public function add_font_family() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return null;
+		}
 
-	/**
-	 * Add a variation to an existing family or register family if none exists.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Add is not supported.
-	 *
-	 * @return null Null.
-	 */
-	public function add_variation() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return null;
-	}
+		/**
+		 * Removes a font family and all registered variations.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Remove is not supported.
+		 */
+		public function remove_font_family() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Removes a variation.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Remove is not supported.
-	 */
-	public function remove_variation() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+		/**
+		 * Add a variation to an existing family or register family if none exists.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Add is not supported.
+		 *
+		 * @return null Null.
+		 */
+		public function add_variation() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return null;
+		}
 
-	/**
-	 * Processes the items and dependencies.
-	 *
-	 * Processes the items passed to it or the queue, and their dependencies.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Processing items and dependencies is not supported.
-	 *
-	 * @param string|string[]|bool $handles Optional. Items to be processed: queue (false),
-	 *                                      single item (string), or multiple items (array of strings).
-	 *                                      Default false.
-	 * @param int|false            $group   Optional. Group level: level (int), no group (false).
-	 *
-	 * @return array Empty array.
-	 */
-	public function do_items( $handles = false, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
-	}
+		/**
+		 * Removes a variation.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Remove is not supported.
+		 */
+		public function remove_variation() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Invokes each provider to process and print its styles.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Process and print provider styles is not supported.
-	 *
-	 * @see WP_Dependencies::do_item()
-	 *
-	 * @param string    $provider_id The provider to process.
-	 * @param int|false $group       Not used.
-	 * @return bool False.
-	 */
-	public function do_item( $provider_id, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return false;
-	}
+		/**
+		 * Processes the items and dependencies.
+		 *
+		 * Processes the items passed to it or the queue, and their dependencies.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Processing items and dependencies is not supported.
+		 *
+		 * @param string|string[]|bool $handles Optional. Items to be processed: queue (false),
+		 *                                      single item (string), or multiple items (array of strings).
+		 *                                      Default false.
+		 * @param int|false            $group   Optional. Group level: level (int), no group (false).
+		 *
+		 * @return array Empty array.
+		 */
+		public function do_items( $handles = false, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 
-	/**
-	 * Converts the font family and its variations into theme.json structural format.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Convert is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function to_theme_json() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
+		/**
+		 * Invokes each provider to process and print its styles.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Process and print provider styles is not supported.
+		 *
+		 * @see WP_Dependencies::do_item()
+		 *
+		 * @param string    $provider_id The provider to process.
+		 * @param int|false $group       Not used.
+		 * @return bool False.
+		 */
+		public function do_item( $provider_id, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return false;
+		}
+
+		/**
+		 * Converts the font family and its variations into theme.json structural format.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Convert is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function to_theme_json() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-web-fonts.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-web-fonts.php
@@ -7,184 +7,183 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Web_Fonts' ) ) {
-	return;
-}
-
-/**
- * Class WP_Web_Fonts
- *
- * @since 14.9.1
- * @deprecated 15.1 Use WP_Fonts instead.
- * @deprecated 16.3.0 Fonts API is not supported.
- */
-class WP_Web_Fonts extends WP_Webfonts {
+if ( ! class_exists( 'WP_Web_Fonts' ) ) {
 
 	/**
-	 * Constructor.
+	 * Class WP_Web_Fonts
 	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0
+	 * @since 14.9.1
+	 * @deprecated 15.1 Use WP_Fonts instead.
+	 * @deprecated 16.3.0 Fonts API is not supported.
 	 */
-	public function __construct() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+	class WP_Web_Fonts extends WP_Webfonts {
 
-	/**
-	 * Get the list of registered providers.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Providers are not supported.
-	 */
-	public function get_providers() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+		/**
+		 * Constructor.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 */
+		public function __construct() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Register a provider.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Providers are not supported.
-	 *
-	 * @return bool False.
-	 */
-	public function register_provider() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return false;
-	}
+		/**
+		 * Get the list of registered providers.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Providers are not supported.
+		 */
+		public function get_providers() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Get the list of all registered font family handles.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Register is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_registered_font_families() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
-	}
+		/**
+		 * Register a provider.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Providers are not supported.
+		 *
+		 * @return bool False.
+		 */
+		public function register_provider() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return false;
+		}
 
-	/**
-	 * Get the list of all registered font families and their variations.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Register is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_registered() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
-	}
+		/**
+		 * Get the list of all registered font family handles.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Register is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_registered_font_families() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 
-	/**
-	 * Get the list of enqueued font families and their variations.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Enqueue is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_enqueued() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
-	}
+		/**
+		 * Get the list of all registered font families and their variations.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Register is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_registered() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 
-	/**
-	 * Registers a font family.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Add is not supported.
-	 *
-	 * @return null Null.
-	 */
-	public function add_font_family() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return null;
-	}
+		/**
+		 * Get the list of enqueued font families and their variations.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Enqueue is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_enqueued() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 
-	/**
-	 * Removes a font family and all registered variations.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Remove is not supported.
-	 */
-	public function remove_font_family() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+		/**
+		 * Registers a font family.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Add is not supported.
+		 *
+		 * @return null Null.
+		 */
+		public function add_font_family() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return null;
+		}
 
-	/**
-	 * Add a variation to an existing family or register family if none exists.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Add is not supported.
-	 *
-	 * @return null Null.
-	 */
-	public function add_variation() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return null;
-	}
+		/**
+		 * Removes a font family and all registered variations.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Remove is not supported.
+		 */
+		public function remove_font_family() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Removes a variation.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Remove is not supported.
-	 */
-	public function remove_variation() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+		/**
+		 * Add a variation to an existing family or register family if none exists.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Add is not supported.
+		 *
+		 * @return null Null.
+		 */
+		public function add_variation() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return null;
+		}
 
-	/**
-	 * Processes the items and dependencies.
-	 *
-	 * Processes the items passed to it or the queue, and their dependencies.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Processing items and dependencies is not supported.
-	 *
-	 * @param string|string[]|bool $handles Optional. Items to be processed: queue (false),
-	 *                                      single item (string), or multiple items (array of strings).
-	 *                                      Default false.
-	 * @param int|false            $group   Optional. Group level: level (int), no group (false).
-	 *
-	 * @return array Empty array.
-	 */
-	public function do_items( $handles = false, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
-	}
+		/**
+		 * Removes a variation.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Remove is not supported.
+		 */
+		public function remove_variation() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Invokes each provider to process and print its styles.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Process and print provider styles is not supported.
-	 *
-	 * @see WP_Dependencies::do_item()
-	 *
-	 * @param string    $provider_id The provider to process.
-	 * @param int|false $group       Not used.
-	 * @return bool False.
-	 */
-	public function do_item( $provider_id, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return false;
-	}
+		/**
+		 * Processes the items and dependencies.
+		 *
+		 * Processes the items passed to it or the queue, and their dependencies.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Processing items and dependencies is not supported.
+		 *
+		 * @param string|string[]|bool $handles Optional. Items to be processed: queue (false),
+		 *                                      single item (string), or multiple items (array of strings).
+		 *                                      Default false.
+		 * @param int|false            $group   Optional. Group level: level (int), no group (false).
+		 *
+		 * @return array Empty array.
+		 */
+		public function do_items( $handles = false, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 
-	/**
-	 * Converts the font family and its variations into theme.json structural format.
-	 *
-	 * @since X.X.X
-	 * @deprecated 16.3.0 Convert is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function to_theme_json() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return array();
+		/**
+		 * Invokes each provider to process and print its styles.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Process and print provider styles is not supported.
+		 *
+		 * @see WP_Dependencies::do_item()
+		 *
+		 * @param string    $provider_id The provider to process.
+		 * @param int|false $group       Not used.
+		 * @return bool False.
+		 */
+		public function do_item( $provider_id, $group = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return false;
+		}
+
+		/**
+		 * Converts the font family and its variations into theme.json structural format.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Convert is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function to_theme_json() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return array();
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-webfonts-provider-local.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-webfonts-provider-local.php
@@ -14,52 +14,51 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Webfonts_Provider_Local' ) ) {
-	return;
-}
-
-/**
- * A deprecated core bundled provider for generating `@font-face` styles
- * from locally-hosted font files.
- *
- * BACKPORT NOTE: Do not backport this file to Core.
- *
- * @since X.X.X
- * @deprecated 15.1 Use `WP_Fonts_Provider_Local` instead.
- * @deprecated 16.3.0 Providers are not supported.
- *                    Local provider is in WP_Font_Face.
- */
-class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
+if ( ! class_exists( 'WP_Webfonts_Provider_Local' ) ) {
 
 	/**
-	 * The provider's unique ID.
+	 * A deprecated core bundled provider for generating `@font-face` styles
+	 * from locally-hosted font files.
 	 *
-	 * @since 6.0.0
-	 * @deprecated 16.3.0
-	 *
-	 * @var string
-	 */
-	protected $id = 'local';
-
-	/**
-	 * Constructor.
-	 *
-	 * @since 6.1.0
-	 */
-	public function __construct() {
-		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
-	}
-
-	/**
-	 * Gets the `@font-face` CSS styles for locally-hosted font files.
+	 * BACKPORT NOTE: Do not backport this file to Core.
 	 *
 	 * @since X.X.X
-	 * @deprecated 16.3.0 Get styles is not supported.
-	 *
-	 * @return string Empty string.
+	 * @deprecated 15.1 Use `WP_Fonts_Provider_Local` instead.
+	 * @deprecated 16.3.0 Providers are not supported.
+	 *                    Local provider is in WP_Font_Face.
 	 */
-	public function get_css() {
-		_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
-		return '';
+	class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
+
+		/**
+		 * The provider's unique ID.
+		 *
+		 * @since 6.0.0
+		 * @deprecated 16.3.0
+		 *
+		 * @var string
+		 */
+		protected $id = 'local';
+
+		/**
+		 * Constructor.
+		 *
+		 * @since 6.1.0
+		 */
+		public function __construct() {
+			_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+		}
+
+		/**
+		 * Gets the `@font-face` CSS styles for locally-hosted font files.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0 Get styles is not supported.
+		 *
+		 * @return string Empty string.
+		 */
+		public function get_css() {
+			_deprecated_function( __FUNCTION__, 'Gutenberg 16.3' );
+			return '';
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-webfonts-provider.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-webfonts-provider.php
@@ -14,40 +14,39 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Webfonts_Provider' ) ) {
-	return;
-}
-
-/**
- * Deprecated abstract class for Fonts API providers.
- *
- * BACKPORT NOTE: Do not backport this file to Core.
- *
- * @since X.X.X
- * @deprecated 15.1 Use `WP_Fonts_Provider` instead.
- * @deprecated 16.3.0 Custom providers are not supported.
- */
-abstract class WP_Webfonts_Provider extends WP_Fonts_Provider {
+if ( ! class_exists( 'WP_Webfonts_Provider' ) ) {
 
 	/**
-	 * Fonts to be processed.
+	 * Deprecated abstract class for Fonts API providers.
+	 *
+	 * BACKPORT NOTE: Do not backport this file to Core.
 	 *
 	 * @since X.X.X
-	 * @deprecated 15.1 Use WP_Fonts_Provider::$fonts property instead.
-	 * @deprecated 16.3.0
-	 *
-	 * @var array[]
+	 * @deprecated 15.1 Use `WP_Fonts_Provider` instead.
+	 * @deprecated 16.3.0 Custom providers are not supported.
 	 */
-	protected $webfonts = array();
+	abstract class WP_Webfonts_Provider extends WP_Fonts_Provider {
 
-	/**
-	 * Sets this provider's fonts property.
-	 *
-	 * @since X.X.X
-	 * @deprecated GB 15.1 Use WP_Fonts_Provider::set_fonts() instead.
-	 * @deprecated 16.3.0 Set is not supported.
-	 */
-	public function set_webfonts() {
-		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+		/**
+		 * Fonts to be processed.
+		 *
+		 * @since X.X.X
+		 * @deprecated 15.1 Use WP_Fonts_Provider::$fonts property instead.
+		 * @deprecated 16.3.0
+		 *
+		 * @var array[]
+		 */
+		protected $webfonts = array();
+
+		/**
+		 * Sets this provider's fonts property.
+		 *
+		 * @since X.X.X
+		 * @deprecated GB 15.1 Use WP_Fonts_Provider::set_fonts() instead.
+		 * @deprecated 16.3.0 Set is not supported.
+		 */
+		public function set_webfonts() {
+			_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-webfonts-utils.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-webfonts-utils.php
@@ -10,73 +10,72 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Webfonts_Utils' ) ) {
-	return;
-}
-
-/**
- * Utility helpers for the Webfonts API.
- *
- * @since X.X.X
- * @deprecated 15.1 Use WP_Fonts_Utils instead.
- * @deprecated 16.3.0 Webfonts API is not supported.
- */
-class WP_Webfonts_Utils {
+if ( ! class_exists( 'WP_Webfonts_Utils' ) ) {
 
 	/**
-	 * Converts the given font family into a handle.
+	 * Utility helpers for the Webfonts API.
 	 *
 	 * @since X.X.X
-	 * @deprecated 15.1 Use WP_Fonts_Utils::convert_font_family_into_handle() instead.
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @return null
+	 * @deprecated 15.1 Use WP_Fonts_Utils instead.
+	 * @deprecated 16.3.0 Webfonts API is not supported.
 	 */
-	public static function convert_font_family_into_handle() {
-		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
-		return null;
-	}
+	class WP_Webfonts_Utils {
 
-	/**
-	 * Converts the given variation and its font-family into a handle.
-	 *
-	 * @since X.X.X
-	 * @deprecated 15.1 Use WP_Fonts_Utils::convert_variation_into_handle() instead.
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @return null
-	 */
-	public static function convert_variation_into_handle() {
-		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
-		return null;
-	}
+		/**
+		 * Converts the given font family into a handle.
+		 *
+		 * @since X.X.X
+		 * @deprecated 15.1 Use WP_Fonts_Utils::convert_font_family_into_handle() instead.
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @return null
+		 */
+		public static function convert_font_family_into_handle() {
+			_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+			return null;
+		}
 
-	/**
-	 * Gets the font family from the variation.
-	 *
-	 * @since X.X.X
-	 * @deprecated 15.1 Use WP_Fonts_Utils::get_font_family_from_variation() instead.
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @return null
-	 */
-	public static function get_font_family_from_variation() {
-		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
-		return null;
-	}
+		/**
+		 * Converts the given variation and its font-family into a handle.
+		 *
+		 * @since X.X.X
+		 * @deprecated 15.1 Use WP_Fonts_Utils::convert_variation_into_handle() instead.
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @return null
+		 */
+		public static function convert_variation_into_handle() {
+			_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+			return null;
+		}
 
-	/**
-	 * Checks if the given input is defined, i.e. meaning is a non-empty string.
-	 *
-	 * @since X.X.X
-	 * @deprecated 15.1 Use WP_Fonts_Utils::is_defined() instead.
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @param string $input The input to check.
-	 * @return bool True when non-empty string. Else false.
-	 */
-	public static function is_defined( $input ) {
-		_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
-		return ( is_string( $input ) && ! empty( $input ) );
+		/**
+		 * Gets the font family from the variation.
+		 *
+		 * @since X.X.X
+		 * @deprecated 15.1 Use WP_Fonts_Utils::get_font_family_from_variation() instead.
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @return null
+		 */
+		public static function get_font_family_from_variation() {
+			_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+			return null;
+		}
+
+		/**
+		 * Checks if the given input is defined, i.e. meaning is a non-empty string.
+		 *
+		 * @since X.X.X
+		 * @deprecated 15.1 Use WP_Fonts_Utils::is_defined() instead.
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @param string $input The input to check.
+		 * @return bool True when non-empty string. Else false.
+		 */
+		public static function is_defined( $input ) {
+			_deprecated_function( __METHOD__, 'Gutenberg 15.1' );
+			return ( is_string( $input ) && ! empty( $input ) );
+		}
 	}
 }

--- a/lib/experimental/fonts/font-face/bc-layer/class-wp-webfonts.php
+++ b/lib/experimental/fonts/font-face/bc-layer/class-wp-webfonts.php
@@ -12,135 +12,134 @@
  * @since      X.X.X
  */
 
-if ( class_exists( 'WP_Webfonts' ) ) {
-	return;
-}
-
-/**
- * Class WP_Webfonts
- *
- * @since X.X.X
- * @deprecated 15.1 Use WP_Fonts instead.
- * @deprecated 16.3.0 Fonts API is not supported.
- */
-class WP_Webfonts {
+if ( ! class_exists( 'WP_Webfonts' ) ) {
 
 	/**
-	 * Constructor.
+	 * Class WP_Webfonts
 	 *
 	 * @since X.X.X
-	 * @deprecated 16.3.0
+	 * @deprecated 15.1 Use WP_Fonts instead.
+	 * @deprecated 16.3.0 Fonts API is not supported.
 	 */
-	public function __construct() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-	}
+	class WP_Webfonts {
 
-	/**
-	 * Gets the font slug.
-	 *
-	 * @since X.X.X
-	 * @deprecated Use WP_Fonts_Utils::convert_font_family_into_handle() or WP_Fonts_Utils::get_font_family_from_variation().
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @return false False.
-	 */
-	public static function get_font_slug() {
-		_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
-		return false;
-	}
+		/**
+		 * Constructor.
+		 *
+		 * @since X.X.X
+		 * @deprecated 16.3.0
+		 */
+		public function __construct() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+		}
 
-	/**
-	 * Initializes the API.
-	 *
-	 * @since 6.0.0
-	 * @deprecated 14.9.1 Use wp_fonts().
-	 */
-	public static function init() {
-		_deprecated_function( __METHOD__, 'GB 14.9.1', 'wp_fonts()' );
-	}
+		/**
+		 * Gets the font slug.
+		 *
+		 * @since X.X.X
+		 * @deprecated Use WP_Fonts_Utils::convert_font_family_into_handle() or WP_Fonts_Utils::get_font_family_from_variation().
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @return false False.
+		 */
+		public static function get_font_slug() {
+			_deprecated_function( __METHOD__, 'Gutenberg 16.3.0' );
+			return false;
+		}
 
-	/**
-	 * Get the list of all registered font family handles.
-	 *
-	 * @since X.X.X
-	 * @deprecated GB 15.8.0 Use wp_fonts()->get_registered_font_families().
-	 * @deprecated 16.3.0 Register is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_registered_font_families() {
-		_deprecated_function( __METHOD__, 'Gutenberg 15.8.0' );
-		return array();
-	}
+		/**
+		 * Initializes the API.
+		 *
+		 * @since 6.0.0
+		 * @deprecated 14.9.1 Use wp_fonts().
+		 */
+		public static function init() {
+			_deprecated_function( __METHOD__, 'GB 14.9.1', 'wp_fonts()' );
+		}
 
-	/**
-	 * Gets the list of registered fonts.
-	 *
-	 * @since 6.0.0
-	 * @deprecated 14.9.1 Use wp_fonts()->get_registered().
-	 * @deprecated 16.3.0 Register is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_registered_webfonts() {
-		_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
+		/**
+		 * Get the list of all registered font family handles.
+		 *
+		 * @since X.X.X
+		 * @deprecated GB 15.8.0 Use wp_fonts()->get_registered_font_families().
+		 * @deprecated 16.3.0 Register is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_registered_font_families() {
+			_deprecated_function( __METHOD__, 'Gutenberg 15.8.0' );
+			return array();
+		}
 
-		return array();
-	}
+		/**
+		 * Gets the list of registered fonts.
+		 *
+		 * @since 6.0.0
+		 * @deprecated 14.9.1 Use wp_fonts()->get_registered().
+		 * @deprecated 16.3.0 Register is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_registered_webfonts() {
+			_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
 
-	/**
-	 * Gets the list of enqueued fonts.
-	 *
-	 * @since 6.0.0
-	 * @deprecated 14.9.1 Use wp_fonts()->get_enqueued().
-	 * @deprecated 16.3.0 Enqueue is not supported.
-	 *
-	 * @return array Empty array.
-	 */
-	public function get_enqueued_webfonts() {
-		_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
-		return array();
-	}
+			return array();
+		}
 
-	/**
-	 * Gets the list of all fonts.
-	 *
-	 * @since X.X.X
-	 * @deprecated GB 14.9.1 Use wp_fonts()->get_registered().
-	 * @deprecated 16.3.0 This method is not supported.
-	 *
-	 * @return array[]
-	 */
-	public function get_all_webfonts() {
-		_deprecated_function( __METHOD__, 'Gutenberg 14.9.1', 'wp_fonts()->get_registered()' );
-		return array();
-	}
+		/**
+		 * Gets the list of enqueued fonts.
+		 *
+		 * @since 6.0.0
+		 * @deprecated 14.9.1 Use wp_fonts()->get_enqueued().
+		 * @deprecated 16.3.0 Enqueue is not supported.
+		 *
+		 * @return array Empty array.
+		 */
+		public function get_enqueued_webfonts() {
+			_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
+			return array();
+		}
 
-	/**
-	 * Registers a webfont.
-	 *
-	 * @since 6.0.0
-	 * @deprecated GB 14.9.1 Use wp_register_fonts().
-	 * @deprecated 16.3.0 Register is not supported.
-	 *
-	 * @return bool False.
-	 */
-	public function register_webfont() {
-		_deprecated_function( __METHOD__, 'GB 14.9.1', 'wp_register_fonts()' );
-		return false;
-	}
+		/**
+		 * Gets the list of all fonts.
+		 *
+		 * @since X.X.X
+		 * @deprecated GB 14.9.1 Use wp_fonts()->get_registered().
+		 * @deprecated 16.3.0 This method is not supported.
+		 *
+		 * @return array[]
+		 */
+		public function get_all_webfonts() {
+			_deprecated_function( __METHOD__, 'Gutenberg 14.9.1', 'wp_fonts()->get_registered()' );
+			return array();
+		}
 
-	/**
-	 * Enqueue a font-family that has been already registered.
-	 *
-	 * @since XX.X
-	 * @deprecated 14.9.1 Use wp_enqueue_fonts().
-	 * @deprecated 16.3.0 Register is not supported.
-	 *
-	 * @return bool False.
-	 */
-	public function enqueue_webfont() {
-		_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
-		return false;
+		/**
+		 * Registers a webfont.
+		 *
+		 * @since 6.0.0
+		 * @deprecated GB 14.9.1 Use wp_register_fonts().
+		 * @deprecated 16.3.0 Register is not supported.
+		 *
+		 * @return bool False.
+		 */
+		public function register_webfont() {
+			_deprecated_function( __METHOD__, 'GB 14.9.1', 'wp_register_fonts()' );
+			return false;
+		}
+
+		/**
+		 * Enqueue a font-family that has been already registered.
+		 *
+		 * @since XX.X
+		 * @deprecated 14.9.1 Use wp_enqueue_fonts().
+		 * @deprecated 16.3.0 Register is not supported.
+		 *
+		 * @return bool False.
+		 */
+		public function enqueue_webfont() {
+			_deprecated_function( __METHOD__, 'Gutenberg 14.9.1' );
+			return false;
+		}
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-font-collection.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-collection.php
@@ -9,224 +9,223 @@
  * @since      6.5.0
  */
 
-if ( class_exists( 'WP_Font_Collection' ) ) {
-	return;
-}
-
-/**
- * Font Collection class.
- *
- * @since 6.5.0
- */
-class WP_Font_Collection {
+if ( ! class_exists( 'WP_Font_Collection' ) ) {
 
 	/**
-	 * The unique slug for the font collection.
+	 * Font Collection class.
 	 *
 	 * @since 6.5.0
-	 *
-	 * @var string
 	 */
-	public $slug;
+	class WP_Font_Collection {
 
-	/**
-	 * The name of the font collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @var string
-	 */
-	public $name;
+		/**
+		 * The unique slug for the font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var string
+		 */
+		public $slug;
 
-	/**
-	 * Description of the font collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @var string
-	 */
-	public $description;
+		/**
+		 * The name of the font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var string
+		 */
+		public $name;
 
-	/**
-	 * Source of the font collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @var string
-	 */
-	public $src;
+		/**
+		 * Description of the font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var string
+		 */
+		public $description;
 
-	/**
-	 * Array of font families in the collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @var array
-	 */
-	public $font_families;
+		/**
+		 * Source of the font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var string
+		 */
+		public $src;
 
-	/**
-	 * Categories associated with the font collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @var array
-	 */
-	public $categories;
+		/**
+		 * Array of font families in the collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var array
+		 */
+		public $font_families;
+
+		/**
+		 * Categories associated with the font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var array
+		 */
+		public $categories;
 
 
-	/**
-	 * WP_Font_Collection constructor.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param array $config Font collection config options. {
-	 *      @type string $slug        The font collection's unique slug.
-	 *      @type string $name        The font collection's name.
-	 *      @type string $description The font collection's description.
-	 *      @type string $src         The font collection's source.
-	 *      @type array  $font_families An array of font families in the font collection.
-	 *      @type array  $categories The font collection's categories.
-	 *  }
-	 */
-	public function __construct( $config ) {
-		$this->is_config_valid( $config );
+		/**
+		 * WP_Font_Collection constructor.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array $config Font collection config options. {
+		 *      @type string $slug        The font collection's unique slug.
+		 *      @type string $name        The font collection's name.
+		 *      @type string $description The font collection's description.
+		 *      @type string $src         The font collection's source.
+		 *      @type array  $font_families An array of font families in the font collection.
+		 *      @type array  $categories The font collection's categories.
+		 *  }
+		 */
+		public function __construct( $config ) {
+			$this->is_config_valid( $config );
 
-		$this->slug          = isset( $config['slug'] ) ? $config['slug'] : '';
-		$this->name          = isset( $config['name'] ) ? $config['name'] : '';
-		$this->description   = isset( $config['description'] ) ? $config['description'] : '';
-		$this->src           = isset( $config['src'] ) ? $config['src'] : '';
-		$this->font_families = isset( $config['font_families'] ) ? $config['font_families'] : array();
-		$this->categories    = isset( $config['categories'] ) ? $config['categories'] : array();
-	}
-
-	/**
-	 * Checks if the font collection config is valid.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param array $config Font collection config options. {
-	 *      @type string $slug        The font collection's unique slug.
-	 *      @type string $name        The font collection's name.
-	 *      @type string $description The font collection's description.
-	 *      @type string $src         The font collection's source.
-	 *      @type array  $font_families An array of font families in the font collection.
-	 *      @type array  $categories The font collection's categories.
-	 *  }
-	 * @return bool True if the font collection config is valid and false otherwise.
-	 */
-	public static function is_config_valid( $config ) {
-		if ( empty( $config ) || ! is_array( $config ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Font Collection config options are required as a non-empty array.', 'gutenberg' ), '6.5.0' );
-			return false;
+			$this->slug          = isset( $config['slug'] ) ? $config['slug'] : '';
+			$this->name          = isset( $config['name'] ) ? $config['name'] : '';
+			$this->description   = isset( $config['description'] ) ? $config['description'] : '';
+			$this->src           = isset( $config['src'] ) ? $config['src'] : '';
+			$this->font_families = isset( $config['font_families'] ) ? $config['font_families'] : array();
+			$this->categories    = isset( $config['categories'] ) ? $config['categories'] : array();
 		}
 
-		$required_keys = array( 'slug', 'name' );
-		foreach ( $required_keys as $key ) {
-			if ( empty( $config[ $key ] ) ) {
+		/**
+		 * Checks if the font collection config is valid.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array $config Font collection config options. {
+		 *      @type string $slug        The font collection's unique slug.
+		 *      @type string $name        The font collection's name.
+		 *      @type string $description The font collection's description.
+		 *      @type string $src         The font collection's source.
+		 *      @type array  $font_families An array of font families in the font collection.
+		 *      @type array  $categories The font collection's categories.
+		 *  }
+		 * @return bool True if the font collection config is valid and false otherwise.
+		 */
+		public static function is_config_valid( $config ) {
+			if ( empty( $config ) || ! is_array( $config ) ) {
+				_doing_it_wrong( __METHOD__, __( 'Font Collection config options are required as a non-empty array.', 'gutenberg' ), '6.5.0' );
+				return false;
+			}
+
+			$required_keys = array( 'slug', 'name' );
+			foreach ( $required_keys as $key ) {
+				if ( empty( $config[ $key ] ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						// translators: %s: Font collection config key.
+						sprintf( __( 'Font Collection config %s is required as a non-empty string.', 'gutenberg' ), $key ),
+						'6.5.0'
+					);
+					return false;
+				}
+			}
+
+			if (
+				( empty( $config['src'] ) && empty( $config['font_families'] ) ) ||
+				( ! empty( $config['src'] ) && ! empty( $config['font_families'] ) )
+			) {
 				_doing_it_wrong(
 					__METHOD__,
-					// translators: %s: Font collection config key.
-					sprintf( __( 'Font Collection config %s is required as a non-empty string.', 'gutenberg' ), $key ),
+					sprintf(
+						/* translators: %1$s: src, %2$s: font_families */
+						__( 'Font Collection config "%1$s" option OR "%2$s" option is required.', 'gutenberg' ),
+						'src',
+						'font_families'
+					),
 					'6.5.0'
 				);
 				return false;
 			}
+
+			return true;
 		}
 
-		if (
-			( empty( $config['src'] ) && empty( $config['font_families'] ) ) ||
-			( ! empty( $config['src'] ) && ! empty( $config['font_families'] ) )
-		) {
-			_doing_it_wrong(
-				__METHOD__,
-				sprintf(
-					/* translators: %1$s: src, %2$s: font_families */
-					__( 'Font Collection config "%1$s" option OR "%2$s" option is required.', 'gutenberg' ),
-					'src',
-					'font_families'
-				),
-				'6.5.0'
+		/**
+		 * Gets the font collection content.
+		 *
+		 * Load the font collection data from the src if it is not already loaded.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array|WP_Error {
+		 *     An array of font collection contents.
+		 *
+		 *     @type array $font_families      The font collection's font families.
+		 *     @type string $categories        The font collection's categories.
+		 * }
+		 *
+		 * A WP_Error object if there was an error loading the font collection data.
+		 */
+		public function get_content() {
+			// If the font families are not loaded, and the src is not empty, load the data from the src.
+			if ( empty( $this->font_families ) && ! empty( $this->src ) ) {
+				$data = $this->load_contents_from_src();
+				if ( is_wp_error( $data ) ) {
+					return $data;
+				}
+			}
+
+			return array(
+				'font_families' => $this->font_families,
+				'categories'    => $this->categories,
 			);
-			return false;
 		}
 
-		return true;
-	}
+		/**
+		 * Loads the font collection data from the src.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array|WP_Error An array containing the list of font families in font-collection.json format on success,
+		 *                        else an instance of WP_Error on failure.
+		 */
+		private function load_contents_from_src() {
+			// If the src is a URL, fetch the data from the URL.
+			if ( preg_match( '#^https?://#', $this->src ) ) {
+				if ( ! wp_http_validate_url( $this->src ) ) {
+					return new WP_Error( 'font_collection_read_error', __( 'Invalid URL for Font Collection data.', 'gutenberg' ) );
+				}
 
-	/**
-	 * Gets the font collection content.
-	 *
-	 * Load the font collection data from the src if it is not already loaded.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array|WP_Error {
-	 *     An array of font collection contents.
-	 *
-	 *     @type array $font_families      The font collection's font families.
-	 *     @type string $categories        The font collection's categories.
-	 * }
-	 *
-	 * A WP_Error object if there was an error loading the font collection data.
-	 */
-	public function get_content() {
-		// If the font families are not loaded, and the src is not empty, load the data from the src.
-		if ( empty( $this->font_families ) && ! empty( $this->src ) ) {
-			$data = $this->load_contents_from_src();
-			if ( is_wp_error( $data ) ) {
-				return $data;
+				$response = wp_remote_get( $this->src );
+				if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+					return new WP_Error( 'font_collection_read_error', __( 'Error fetching the Font Collection data from a URL.', 'gutenberg' ) );
+				}
+
+				$data = json_decode( wp_remote_retrieve_body( $response ), true );
+				if ( empty( $data ) ) {
+					return new WP_Error( 'font_collection_read_error', __( 'Error decoding the Font Collection data from the REST response JSON.', 'gutenberg' ) );
+				}
+				// If the src is a file path, read the data from the file.
+			} else {
+				if ( ! file_exists( $this->src ) ) {
+					return new WP_Error( 'font_collection_read_error', __( 'Font Collection data JSON file does not exist.', 'gutenberg' ) );
+				}
+				$data = wp_json_file_decode( $this->src, array( 'associative' => true ) );
+				if ( empty( $data ) ) {
+					return new WP_Error( 'font_collection_read_error', __( 'Error reading the Font Collection data JSON file contents.', 'gutenberg' ) );
+				}
 			}
+
+			if ( empty( $data['font_families'] ) ) {
+				return new WP_Error( 'font_collection_contents_error', __( 'Font Collection data JSON file does not contain font families.', 'gutenberg' ) );
+			}
+
+			$this->font_families = $data['font_families'];
+			$this->categories    = $data['categories'] ?? array();
+
+			return $data;
 		}
-
-		return array(
-			'font_families' => $this->font_families,
-			'categories'    => $this->categories,
-		);
-	}
-
-	/**
-	 * Loads the font collection data from the src.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array|WP_Error An array containing the list of font families in font-collection.json format on success,
-	 *                        else an instance of WP_Error on failure.
-	 */
-	private function load_contents_from_src() {
-		// If the src is a URL, fetch the data from the URL.
-		if ( preg_match( '#^https?://#', $this->src ) ) {
-			if ( ! wp_http_validate_url( $this->src ) ) {
-				return new WP_Error( 'font_collection_read_error', __( 'Invalid URL for Font Collection data.', 'gutenberg' ) );
-			}
-
-			$response = wp_remote_get( $this->src );
-			if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-				return new WP_Error( 'font_collection_read_error', __( 'Error fetching the Font Collection data from a URL.', 'gutenberg' ) );
-			}
-
-			$data = json_decode( wp_remote_retrieve_body( $response ), true );
-			if ( empty( $data ) ) {
-				return new WP_Error( 'font_collection_read_error', __( 'Error decoding the Font Collection data from the REST response JSON.', 'gutenberg' ) );
-			}
-			// If the src is a file path, read the data from the file.
-		} else {
-			if ( ! file_exists( $this->src ) ) {
-				return new WP_Error( 'font_collection_read_error', __( 'Font Collection data JSON file does not exist.', 'gutenberg' ) );
-			}
-			$data = wp_json_file_decode( $this->src, array( 'associative' => true ) );
-			if ( empty( $data ) ) {
-				return new WP_Error( 'font_collection_read_error', __( 'Error reading the Font Collection data JSON file contents.', 'gutenberg' ) );
-			}
-		}
-
-		if ( empty( $data['font_families'] ) ) {
-			return new WP_Error( 'font_collection_contents_error', __( 'Font Collection data JSON file does not contain font families.', 'gutenberg' ) );
-		}
-
-		$this->font_families = $data['font_families'];
-		$this->categories    = $data['categories'] ?? array();
-
-		return $data;
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-font-library.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-library.php
@@ -9,154 +9,153 @@
  * @since      6.5.0
  */
 
-if ( class_exists( 'WP_Font_Library' ) ) {
-	return;
-}
-
-/**
- * Font Library class.
- *
- * @since 6.5.0
- */
-class WP_Font_Library {
+if ( ! class_exists( 'WP_Font_Library' ) ) {
 
 	/**
-	 * Provide the expected mime-type value for font files per-PHP release. Due to differences in the values returned these values differ between PHP versions.
-	 *
-	 * This is necessary until a collection of valid mime-types per-file extension can be provided to 'upload_mimes' filter.
+	 * Font Library class.
 	 *
 	 * @since 6.5.0
-	 *
-	 * @param array $php_version_id The version of PHP to provide mime types for. The default is the current PHP version.
-	 *
-	 * @return Array A collection of mime types keyed by file extension.
 	 */
-	public static function get_expected_font_mime_types_per_php_version( $php_version_id = PHP_VERSION_ID ) {
+	class WP_Font_Library {
 
-		$php_7_ttf_mime_type = $php_version_id >= 70300 ? 'application/font-sfnt' : 'application/x-font-ttf';
+		/**
+		 * Provide the expected mime-type value for font files per-PHP release. Due to differences in the values returned these values differ between PHP versions.
+		 *
+		 * This is necessary until a collection of valid mime-types per-file extension can be provided to 'upload_mimes' filter.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array $php_version_id The version of PHP to provide mime types for. The default is the current PHP version.
+		 *
+		 * @return Array A collection of mime types keyed by file extension.
+		 */
+		public static function get_expected_font_mime_types_per_php_version( $php_version_id = PHP_VERSION_ID ) {
 
-		return array(
-			'otf'   => 'application/vnd.ms-opentype',
-			'ttf'   => $php_version_id >= 70400 ? 'font/sfnt' : $php_7_ttf_mime_type,
-			'woff'  => $php_version_id >= 80100 ? 'font/woff' : 'application/font-woff',
-			'woff2' => $php_version_id >= 80100 ? 'font/woff2' : 'application/font-woff2',
-		);
-	}
+			$php_7_ttf_mime_type = $php_version_id >= 70300 ? 'application/font-sfnt' : 'application/x-font-ttf';
 
-	/**
-	 * Font collections.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @var array
-	 */
-	private static $collections = array();
-
-	/**
-	 * Register a new font collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param array $config Font collection config options.
-	 *                      See {@see wp_register_font_collection()} for the supported fields.
-	 * @return WP_Font_Collection|WP_Error A font collection is it was registered successfully and a WP_Error otherwise.
-	 */
-	public static function register_font_collection( $config ) {
-		if ( ! WP_Font_Collection::is_config_valid( $config ) ) {
-			$error_message = __( 'Font collection config is invalid.', 'gutenberg' );
-			return new WP_Error( 'font_collection_registration_error', $error_message );
-		}
-
-		$new_collection = new WP_Font_Collection( $config );
-
-		if ( self::is_collection_registered( $new_collection->slug ) ) {
-			$error_message = sprintf(
-				/* translators: %s: Font collection slug. */
-				__( 'Font collection with slug: "%s" is already registered.', 'gutenberg' ),
-				$config['slug']
+			return array(
+				'otf'   => 'application/vnd.ms-opentype',
+				'ttf'   => $php_version_id >= 70400 ? 'font/sfnt' : $php_7_ttf_mime_type,
+				'woff'  => $php_version_id >= 80100 ? 'font/woff' : 'application/font-woff',
+				'woff2' => $php_version_id >= 80100 ? 'font/woff2' : 'application/font-woff2',
 			);
-			_doing_it_wrong(
-				__METHOD__,
-				$error_message,
-				'6.5.0'
-			);
-			return new WP_Error( 'font_collection_registration_error', $error_message );
 		}
-		self::$collections[ $new_collection->slug ] = $new_collection;
-		return $new_collection;
-	}
 
-	/**
-	 * Unregisters a previously registered font collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string $collection_slug Font collection slug.
-	 * @return bool True if the font collection was unregistered successfully and false otherwise.
-	 */
-	public static function unregister_font_collection( $slug ) {
-		if ( ! self::is_collection_registered( $slug ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				/* translators: %s: Font collection slug. */
-				sprintf( __( 'Font collection "%s" not found.', 'default' ), $slug ),
-				'6.5.0'
-			);
-			return false;
+		/**
+		 * Font collections.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var array
+		 */
+		private static $collections = array();
+
+		/**
+		 * Register a new font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array $config Font collection config options.
+		 *                      See {@see wp_register_font_collection()} for the supported fields.
+		 * @return WP_Font_Collection|WP_Error A font collection is it was registered successfully and a WP_Error otherwise.
+		 */
+		public static function register_font_collection( $config ) {
+			if ( ! WP_Font_Collection::is_config_valid( $config ) ) {
+				$error_message = __( 'Font collection config is invalid.', 'gutenberg' );
+				return new WP_Error( 'font_collection_registration_error', $error_message );
+			}
+
+			$new_collection = new WP_Font_Collection( $config );
+
+			if ( self::is_collection_registered( $new_collection->slug ) ) {
+				$error_message = sprintf(
+					/* translators: %s: Font collection slug. */
+					__( 'Font collection with slug: "%s" is already registered.', 'gutenberg' ),
+					$config['slug']
+				);
+				_doing_it_wrong(
+					__METHOD__,
+					$error_message,
+					'6.5.0'
+				);
+				return new WP_Error( 'font_collection_registration_error', $error_message );
+			}
+			self::$collections[ $new_collection->slug ] = $new_collection;
+			return $new_collection;
 		}
-		unset( self::$collections[ $slug ] );
-		return true;
-	}
 
-	/**
-	 * Checks if a font collection is registered.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string $slug Font collection slug.
-	 * @return bool True if the font collection is registered and false otherwise.
-	 */
-	private static function is_collection_registered( $slug ) {
-		return array_key_exists( $slug, self::$collections );
-	}
-
-	/**
-	 * Gets all the font collections available.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array List of font collections.
-	 */
-	public static function get_font_collections() {
-		return self::$collections;
-	}
-
-	/**
-	 * Gets a font collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string $slug Font collection slug.
-	 * @return array List of font collections.
-	 */
-	public static function get_font_collection( $slug ) {
-		if ( array_key_exists( $slug, self::$collections ) ) {
-			return self::$collections[ $slug ];
+		/**
+		 * Unregisters a previously registered font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string $collection_slug Font collection slug.
+		 * @return bool True if the font collection was unregistered successfully and false otherwise.
+		 */
+		public static function unregister_font_collection( $slug ) {
+			if ( ! self::is_collection_registered( $slug ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Font collection slug. */
+					sprintf( __( 'Font collection "%s" not found.', 'default' ), $slug ),
+					'6.5.0'
+				);
+				return false;
+			}
+			unset( self::$collections[ $slug ] );
+			return true;
 		}
-		return new WP_Error( 'font_collection_not_found', 'Font collection not found.' );
-	}
+
+		/**
+		 * Checks if a font collection is registered.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string $slug Font collection slug.
+		 * @return bool True if the font collection is registered and false otherwise.
+		 */
+		private static function is_collection_registered( $slug ) {
+			return array_key_exists( $slug, self::$collections );
+		}
+
+		/**
+		 * Gets all the font collections available.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array List of font collections.
+		 */
+		public static function get_font_collections() {
+			return self::$collections;
+		}
+
+		/**
+		 * Gets a font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string $slug Font collection slug.
+		 * @return array List of font collections.
+		 */
+		public static function get_font_collection( $slug ) {
+			if ( array_key_exists( $slug, self::$collections ) ) {
+				return self::$collections[ $slug ];
+			}
+			return new WP_Error( 'font_collection_not_found', 'Font collection not found.' );
+		}
 
 
 
-	/**
-	 * Sets the allowed mime types for fonts.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param array $mime_types List of allowed mime types.
-	 * @return array Modified upload directory.
-	 */
-	public static function set_allowed_mime_types( $mime_types ) {
-		return array_merge( $mime_types, self::get_expected_font_mime_types_per_php_version() );
+		/**
+		 * Sets the allowed mime types for fonts.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array $mime_types List of allowed mime types.
+		 * @return array Modified upload directory.
+		 */
+		public static function set_allowed_mime_types( $mime_types ) {
+			return array_merge( $mime_types, self::get_expected_font_mime_types_per_php_version() );
+		}
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-font-utils.php
+++ b/lib/experimental/fonts/font-library/class-wp-font-utils.php
@@ -9,130 +9,129 @@
  * @since      6.5.0
  */
 
-if ( class_exists( 'WP_Font_Utils' ) ) {
-	return;
-}
+if ( ! class_exists( 'WP_Font_Utils' ) ) {
 
-/**
- * A class of utilities for working with the Font Library.
- *
- * These utilities may change or be removed in the future and are intended for internal use only.
- *
- * @since 6.5.0
- * @access private
- */
-class WP_Font_Utils {
 	/**
-	 * Format font family names with surrounding quotes when the name contains a space.
+	 * A class of utilities for working with the Font Library.
+	 *
+	 * These utilities may change or be removed in the future and are intended for internal use only.
 	 *
 	 * @since 6.5.0
 	 * @access private
-	 *
-	 * @param string $font_family Font family attribute.
-	 * @return string The formatted font family attribute.
 	 */
-	public static function format_font_family( $font_family ) {
-		if ( $font_family ) {
-			$font_families         = explode( ',', $font_family );
-			$wrapped_font_families = array_map(
-				function ( $family ) {
-					$trimmed = trim( $family );
-					if ( ! empty( $trimmed ) && strpos( $trimmed, ' ' ) !== false && strpos( $trimmed, "'" ) === false && strpos( $trimmed, '"' ) === false ) {
-							return '"' . $trimmed . '"';
-					}
-					return $trimmed;
-				},
-				$font_families
-			);
+	class WP_Font_Utils {
+		/**
+		 * Format font family names with surrounding quotes when the name contains a space.
+		 *
+		 * @since 6.5.0
+		 * @access private
+		 *
+		 * @param string $font_family Font family attribute.
+		 * @return string The formatted font family attribute.
+		 */
+		public static function format_font_family( $font_family ) {
+			if ( $font_family ) {
+				$font_families         = explode( ',', $font_family );
+				$wrapped_font_families = array_map(
+					function ( $family ) {
+						$trimmed = trim( $family );
+						if ( ! empty( $trimmed ) && strpos( $trimmed, ' ' ) !== false && strpos( $trimmed, "'" ) === false && strpos( $trimmed, '"' ) === false ) {
+								return '"' . $trimmed . '"';
+						}
+						return $trimmed;
+					},
+					$font_families
+				);
 
-			if ( count( $wrapped_font_families ) === 1 ) {
-				$font_family = $wrapped_font_families[0];
-			} else {
-				$font_family = implode( ', ', $wrapped_font_families );
+				if ( count( $wrapped_font_families ) === 1 ) {
+					$font_family = $wrapped_font_families[0];
+				} else {
+					$font_family = implode( ', ', $wrapped_font_families );
+				}
 			}
+
+			return $font_family;
 		}
 
-		return $font_family;
-	}
+		/**
+		 * Generates a slug from font face properties, e.g. `open sans;normal;400;100%;U+0-10FFFF`
+		 *
+		 * Used for comparison with other font faces in the same family, to prevent duplicates
+		 * that would both match according the CSS font matching spec. Uses only simple case-insensitive
+		 * matching for fontFamily and unicodeRange, so does not handle overlapping font-family lists or
+		 * unicode ranges.
+		 *
+		 * @since 6.5.0
+		 * @access private
+		 *
+		 * @link https://drafts.csswg.org/css-fonts/#font-style-matching
+		 *
+		 * @param array $settings {
+		 *     Font face settings.
+		 *
+		 *     @type string $fontFamily   Font family name.
+		 *     @type string $fontStyle    Optional font style, defaults to 'normal'.
+		 *     @type string $fontWeight   Optional font weight, defaults to 400.
+		 *     @type string $fontStretch  Optional font stretch, defaults to '100%'.
+		 *     @type string $unicodeRange Optional unicode range, defaults to 'U+0-10FFFF'.
+		 * }
+		 * @return string Font face slug.
+		 */
+		public static function get_font_face_slug( $settings ) {
+			$settings = wp_parse_args(
+				$settings,
+				array(
+					'fontFamily'   => '',
+					'fontStyle'    => 'normal',
+					'fontWeight'   => '400',
+					'fontStretch'  => '100%',
+					'unicodeRange' => 'U+0-10FFFF',
+				)
+			);
 
-	/**
-	 * Generates a slug from font face properties, e.g. `open sans;normal;400;100%;U+0-10FFFF`
-	 *
-	 * Used for comparison with other font faces in the same family, to prevent duplicates
-	 * that would both match according the CSS font matching spec. Uses only simple case-insensitive
-	 * matching for fontFamily and unicodeRange, so does not handle overlapping font-family lists or
-	 * unicode ranges.
-	 *
-	 * @since 6.5.0
-	 * @access private
-	 *
-	 * @link https://drafts.csswg.org/css-fonts/#font-style-matching
-	 *
-	 * @param array $settings {
-	 *     Font face settings.
-	 *
-	 *     @type string $fontFamily   Font family name.
-	 *     @type string $fontStyle    Optional font style, defaults to 'normal'.
-	 *     @type string $fontWeight   Optional font weight, defaults to 400.
-	 *     @type string $fontStretch  Optional font stretch, defaults to '100%'.
-	 *     @type string $unicodeRange Optional unicode range, defaults to 'U+0-10FFFF'.
-	 * }
-	 * @return string Font face slug.
-	 */
-	public static function get_font_face_slug( $settings ) {
-		$settings = wp_parse_args(
-			$settings,
-			array(
-				'fontFamily'   => '',
-				'fontStyle'    => 'normal',
-				'fontWeight'   => '400',
-				'fontStretch'  => '100%',
-				'unicodeRange' => 'U+0-10FFFF',
-			)
-		);
+			// Convert all values to lowercase for comparison.
+			// Font family names may use multibyte characters.
+			$font_family   = mb_strtolower( $settings['fontFamily'] );
+			$font_style    = strtolower( $settings['fontStyle'] );
+			$font_weight   = strtolower( $settings['fontWeight'] );
+			$font_stretch  = strtolower( $settings['fontStretch'] );
+			$unicode_range = strtoupper( $settings['unicodeRange'] );
 
-		// Convert all values to lowercase for comparison.
-		// Font family names may use multibyte characters.
-		$font_family   = mb_strtolower( $settings['fontFamily'] );
-		$font_style    = strtolower( $settings['fontStyle'] );
-		$font_weight   = strtolower( $settings['fontWeight'] );
-		$font_stretch  = strtolower( $settings['fontStretch'] );
-		$unicode_range = strtoupper( $settings['unicodeRange'] );
+			// Convert weight keywords to numeric strings.
+			$font_weight = str_replace( 'normal', '400', $font_weight );
+			$font_weight = str_replace( 'bold', '700', $font_weight );
 
-		// Convert weight keywords to numeric strings.
-		$font_weight = str_replace( 'normal', '400', $font_weight );
-		$font_weight = str_replace( 'bold', '700', $font_weight );
+			// Convert stretch keywords to numeric strings.
+			$font_stretch_map = array(
+				'ultra-condensed' => '50%',
+				'extra-condensed' => '62.5%',
+				'condensed'       => '75%',
+				'semi-condensed'  => '87.5%',
+				'normal'          => '100%',
+				'semi-expanded'   => '112.5%',
+				'expanded'        => '125%',
+				'extra-expanded'  => '150%',
+				'ultra-expanded'  => '200%',
+			);
+			$font_stretch     = str_replace( array_keys( $font_stretch_map ), array_values( $font_stretch_map ), $font_stretch );
 
-		// Convert stretch keywords to numeric strings.
-		$font_stretch_map = array(
-			'ultra-condensed' => '50%',
-			'extra-condensed' => '62.5%',
-			'condensed'       => '75%',
-			'semi-condensed'  => '87.5%',
-			'normal'          => '100%',
-			'semi-expanded'   => '112.5%',
-			'expanded'        => '125%',
-			'extra-expanded'  => '150%',
-			'ultra-expanded'  => '200%',
-		);
-		$font_stretch     = str_replace( array_keys( $font_stretch_map ), array_values( $font_stretch_map ), $font_stretch );
+			$slug_elements = array( $font_family, $font_style, $font_weight, $font_stretch, $unicode_range );
 
-		$slug_elements = array( $font_family, $font_style, $font_weight, $font_stretch, $unicode_range );
+			$slug_elements = array_map(
+				function ( $elem ) {
+					// Remove quotes to normalize font-family names, and ';' to use as a separator.
+					$elem = trim( str_replace( array( '"', "'", ';' ), '', $elem ) );
 
-		$slug_elements = array_map(
-			function ( $elem ) {
-				// Remove quotes to normalize font-family names, and ';' to use as a separator.
-				$elem = trim( str_replace( array( '"', "'", ';' ), '', $elem ) );
+					// Normalize comma separated lists by removing whitespace in between items,
+					// but keep whitespace within items (e.g. "Open Sans" and "OpenSans" are different fonts).
+					// CSS spec for whitespace includes: U+000A LINE FEED, U+0009 CHARACTER TABULATION, or U+0020 SPACE,
+					// which by default are all matched by \s in PHP.
+					return preg_replace( '/,\s+/', ',', $elem );
+				},
+				$slug_elements
+			);
 
-				// Normalize comma separated lists by removing whitespace in between items,
-				// but keep whitespace within items (e.g. "Open Sans" and "OpenSans" are different fonts).
-				// CSS spec for whitespace includes: U+000A LINE FEED, U+0009 CHARACTER TABULATION, or U+0020 SPACE,
-				// which by default are all matched by \s in PHP.
-				return preg_replace( '/,\s+/', ',', $elem );
-			},
-			$slug_elements
-		);
-
-		return join( ';', $slug_elements );
+			return join( ';', $slug_elements );
+		}
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-collections-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-collections-controller.php
@@ -9,331 +9,330 @@
  * @since      6.5.0
  */
 
-if ( class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
-	return;
-}
-
-/**
- * Font Library Controller class.
- *
- * @since 6.5.0
- */
-class WP_REST_Font_Collections_Controller extends WP_REST_Controller {
+if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 
 	/**
-	 * Constructor.
+	 * Font Library Controller class.
 	 *
 	 * @since 6.5.0
 	 */
-	public function __construct() {
-		$this->rest_base = 'font-collections';
-		$this->namespace = 'wp/v2';
-	}
+	class WP_REST_Font_Collections_Controller extends WP_REST_Controller {
 
-	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @since 6.5.0
-	 */
-	public function register_routes() {
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base,
-			array(
+		/**
+		 * Constructor.
+		 *
+		 * @since 6.5.0
+		 */
+		public function __construct() {
+			$this->rest_base = 'font-collections';
+			$this->namespace = 'wp/v2';
+		}
+
+		/**
+		 * Registers the routes for the objects of the controller.
+		 *
+		 * @since 6.5.0
+		 */
+		public function register_routes() {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
 				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-					'args'                => $this->get_collection_params(),
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_items' ),
+						'permission_callback' => array( $this, 'get_items_permissions_check' ),
+						'args'                => $this->get_collection_params(),
 
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/(?P<slug>[\/\w-]+)',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-					'args'                => array(
-						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 					),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-	}
-
-	/**
-	 * Gets the font collections available.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function get_items( $request ) {
-		$collections_all = WP_Font_Library::get_font_collections();
-
-		$page        = $request['page'];
-		$per_page    = $request['per_page'];
-		$total_items = count( $collections_all );
-		$max_pages   = ceil( $total_items / $per_page );
-
-		if ( $page > $max_pages && $total_items > 0 ) {
-			return new WP_Error(
-				'rest_post_invalid_page_number',
-				__( 'The page number requested is larger than the number of pages available.', 'default' ),
-				array( 'status' => 400 )
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
 			);
-		}
 
-		$collections_page = array_slice( $collections_all, ( $page - 1 ) * $per_page, $per_page );
-
-		$items = array();
-		foreach ( $collections_page as $collection ) {
-			$item = $this->prepare_item_for_response( $collection, $request );
-			if ( is_wp_error( $item ) ) {
-				return $item;
-			}
-			$item    = $this->prepare_response_for_collection( $item );
-			$items[] = $item;
-		}
-
-		$response = rest_ensure_response( $items );
-
-		$response->header( 'X-WP-Total', (int) $total_items );
-		$response->header( 'X-WP-TotalPages', (int) $max_pages );
-
-		$request_params = $request->get_query_params();
-		$collection_url = rest_url( $this->namespace . '/' . $this->rest_base );
-		$base           = add_query_arg( urlencode_deep( $request_params ), $collection_url );
-
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
-	}
-
-	/**
-	 * Gets a font collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function get_item( $request ) {
-		$slug       = $request->get_param( 'slug' );
-		$collection = WP_Font_Library::get_font_collection( $slug );
-
-		// If the collection doesn't exist returns a 404.
-		if ( is_wp_error( $collection ) ) {
-			$collection->add_data( array( 'status' => 404 ) );
-			return $collection;
-		}
-
-		$item = $this->prepare_item_for_response( $collection, $request );
-
-		if ( is_wp_error( $item ) ) {
-			return $item;
-		}
-
-		return $item;
-	}
-
-	/*
-	* Prepare a single collection output for response.
-	*
-	* @since 6.5.0
-	*
-	* @param WP_Font_Collection $collection Collection object.
-	* @param WP_REST_Request    $request    Request object.
-	* @return array|WP_Error
-	*/
-	public function prepare_item_for_response( $collection, $request ) {
-		$fields = $this->get_fields_for_response( $request );
-		$item   = array();
-
-		$config_fields = array( 'slug', 'name', 'description' );
-		foreach ( $config_fields as $field ) {
-			if ( in_array( $field, $fields, true ) ) {
-				$item[ $field ] = $collection->$field;
-			}
-		}
-
-		$data_fields = array( 'font_families', 'categories' );
-		if ( in_array( 'font_families', $fields, true ) || in_array( 'categories', $fields, true ) ) {
-			$content = $collection->get_content();
-
-			// If there was an error getting the collection data, return the error.
-			if ( is_wp_error( $content ) ) {
-				$content->add_data( array( 'status' => 500 ) );
-				return $content;
-			}
-
-			foreach ( $data_fields as $field ) {
-				if ( in_array( $field, $fields, true ) ) {
-					$item[ $field ] = $content[ $field ];
-				}
-			}
-		}
-
-		$response = rest_ensure_response( $item );
-
-		if ( rest_is_field_included( '_links', $fields ) ) {
-			$links = $this->prepare_links( $collection );
-			$response->add_links( $links );
-		}
-
-		$context        = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$response->data = $this->add_additional_fields_to_object( $response->data, $request );
-		$response->data = $this->filter_response_by_context( $response->data, $context );
-
-		/**
-		 * Filters a font collection returned from the REST API.
-		 *
-		 * Allows modification of the font collection right before it is returned.
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param WP_REST_Response $response The response object.
-		 * @param WP_Font_Collection $collection  The Font Collection object.
-		 * @param WP_REST_Request  $request  Request used to generate the response.
-		 */
-		return apply_filters( 'rest_prepare_font_collection', $response, $collection, $request );
-	}
-
-	/**
-	 * Retrieves the font collection's schema, conforming to JSON Schema.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array Item schema data.
-	 */
-	public function get_item_schema() {
-		if ( $this->schema ) {
-			return $this->add_additional_fields_schema( $this->schema );
-		}
-
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'font-collection',
-			'type'       => 'object',
-			'properties' => array(
-				'slug'          => array(
-					'description' => __( 'Unique identifier for the font collection.', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit', 'embed' ),
-					'readonly'    => true,
-				),
-				'name'          => array(
-					'description' => __( 'The name for the font collection.', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'description'   => array(
-					'description' => __( 'The description for the font collection.', 'gutenberg' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'font_families' => array(
-					'description' => __( 'The font families for the font collection.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'categories'    => array(
-					'description' => __( 'The categories for the font collection.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-			),
-		);
-
-		$this->schema = $schema;
-
-		return $this->add_additional_fields_schema( $this->schema );
-	}
-
-	/**
-	 * Prepares links for the request.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_Font_Collection $collection Font collection data
-	 * @return array Links for the given font collection.
-	 */
-	protected function prepare_links( $collection ) {
-		$links = array(
-			'self'       => array(
-				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $collection->slug ) ),
-			),
-			'collection' => array(
-				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
-			),
-		);
-		return $links;
-	}
-
-	/**
-	 * Retrieves the search params for the font collections.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array Collection parameters.
-	 */
-	public function get_collection_params() {
-		$query_params = parent::get_collection_params();
-
-		$query_params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
-
-		unset( $query_params['search'] );
-
-		/**
-		 * Filters REST API collection parameters for the font collections controller.
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param array $query_params JSON Schema-formatted collection parameters.
-		 */
-		return apply_filters( 'rest_font_collections_collection_params', $query_params );
-	}
-
-	/**
-	 * Checks whether the user has permissions to use the Fonts Collections.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return true|WP_Error True if the request has write access for the item, WP_Error object otherwise.
-	 */
-	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			return new WP_Error(
-				'rest_cannot_read',
-				__( 'Sorry, you are not allowed to use the Font Library on this site.', 'gutenberg' ),
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base . '/(?P<slug>[\/\w-]+)',
 				array(
-					'status' => rest_authorization_required_code(),
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_item' ),
+						'permission_callback' => array( $this, 'get_items_permissions_check' ),
+						'args'                => array(
+							'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+						),
+					),
+					'schema' => array( $this, 'get_public_item_schema' ),
 				)
 			);
 		}
-		return true;
+
+		/**
+		 * Gets the font collections available.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function get_items( $request ) {
+			$collections_all = WP_Font_Library::get_font_collections();
+
+			$page        = $request['page'];
+			$per_page    = $request['per_page'];
+			$total_items = count( $collections_all );
+			$max_pages   = ceil( $total_items / $per_page );
+
+			if ( $page > $max_pages && $total_items > 0 ) {
+				return new WP_Error(
+					'rest_post_invalid_page_number',
+					__( 'The page number requested is larger than the number of pages available.', 'default' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$collections_page = array_slice( $collections_all, ( $page - 1 ) * $per_page, $per_page );
+
+			$items = array();
+			foreach ( $collections_page as $collection ) {
+				$item = $this->prepare_item_for_response( $collection, $request );
+				if ( is_wp_error( $item ) ) {
+					return $item;
+				}
+				$item    = $this->prepare_response_for_collection( $item );
+				$items[] = $item;
+			}
+
+			$response = rest_ensure_response( $items );
+
+			$response->header( 'X-WP-Total', (int) $total_items );
+			$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+			$request_params = $request->get_query_params();
+			$collection_url = rest_url( $this->namespace . '/' . $this->rest_base );
+			$base           = add_query_arg( urlencode_deep( $request_params ), $collection_url );
+
+			if ( $page > 1 ) {
+				$prev_page = $page - 1;
+
+				if ( $prev_page > $max_pages ) {
+					$prev_page = $max_pages;
+				}
+
+				$prev_link = add_query_arg( 'page', $prev_page, $base );
+				$response->link_header( 'prev', $prev_link );
+			}
+			if ( $max_pages > $page ) {
+				$next_page = $page + 1;
+				$next_link = add_query_arg( 'page', $next_page, $base );
+
+				$response->link_header( 'next', $next_link );
+			}
+
+			return $response;
+		}
+
+		/**
+		 * Gets a font collection.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function get_item( $request ) {
+			$slug       = $request->get_param( 'slug' );
+			$collection = WP_Font_Library::get_font_collection( $slug );
+
+			// If the collection doesn't exist returns a 404.
+			if ( is_wp_error( $collection ) ) {
+				$collection->add_data( array( 'status' => 404 ) );
+				return $collection;
+			}
+
+			$item = $this->prepare_item_for_response( $collection, $request );
+
+			if ( is_wp_error( $item ) ) {
+				return $item;
+			}
+
+			return $item;
+		}
+
+		/*
+		* Prepare a single collection output for response.
+		*
+		* @since 6.5.0
+		*
+		* @param WP_Font_Collection $collection Collection object.
+		* @param WP_REST_Request    $request    Request object.
+		* @return array|WP_Error
+		*/
+		public function prepare_item_for_response( $collection, $request ) {
+			$fields = $this->get_fields_for_response( $request );
+			$item   = array();
+
+			$config_fields = array( 'slug', 'name', 'description' );
+			foreach ( $config_fields as $field ) {
+				if ( in_array( $field, $fields, true ) ) {
+					$item[ $field ] = $collection->$field;
+				}
+			}
+
+			$data_fields = array( 'font_families', 'categories' );
+			if ( in_array( 'font_families', $fields, true ) || in_array( 'categories', $fields, true ) ) {
+				$content = $collection->get_content();
+
+				// If there was an error getting the collection data, return the error.
+				if ( is_wp_error( $content ) ) {
+					$content->add_data( array( 'status' => 500 ) );
+					return $content;
+				}
+
+				foreach ( $data_fields as $field ) {
+					if ( in_array( $field, $fields, true ) ) {
+						$item[ $field ] = $content[ $field ];
+					}
+				}
+			}
+
+			$response = rest_ensure_response( $item );
+
+			if ( rest_is_field_included( '_links', $fields ) ) {
+				$links = $this->prepare_links( $collection );
+				$response->add_links( $links );
+			}
+
+			$context        = ! empty( $request['context'] ) ? $request['context'] : 'view';
+			$response->data = $this->add_additional_fields_to_object( $response->data, $request );
+			$response->data = $this->filter_response_by_context( $response->data, $context );
+
+			/**
+			 * Filters a font collection returned from the REST API.
+			 *
+			 * Allows modification of the font collection right before it is returned.
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param WP_REST_Response $response The response object.
+			 * @param WP_Font_Collection $collection  The Font Collection object.
+			 * @param WP_REST_Request  $request  Request used to generate the response.
+			 */
+			return apply_filters( 'rest_prepare_font_collection', $response, $collection, $request );
+		}
+
+		/**
+		 * Retrieves the font collection's schema, conforming to JSON Schema.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array Item schema data.
+		 */
+		public function get_item_schema() {
+			if ( $this->schema ) {
+				return $this->add_additional_fields_schema( $this->schema );
+			}
+
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'font-collection',
+				'type'       => 'object',
+				'properties' => array(
+					'slug'          => array(
+						'description' => __( 'Unique identifier for the font collection.', 'gutenberg' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit', 'embed' ),
+						'readonly'    => true,
+					),
+					'name'          => array(
+						'description' => __( 'The name for the font collection.', 'gutenberg' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+					'description'   => array(
+						'description' => __( 'The description for the font collection.', 'gutenberg' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+					'font_families' => array(
+						'description' => __( 'The font families for the font collection.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+					'categories'    => array(
+						'description' => __( 'The categories for the font collection.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+				),
+			);
+
+			$this->schema = $schema;
+
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		/**
+		 * Prepares links for the request.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_Font_Collection $collection Font collection data
+		 * @return array Links for the given font collection.
+		 */
+		protected function prepare_links( $collection ) {
+			$links = array(
+				'self'       => array(
+					'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $collection->slug ) ),
+				),
+				'collection' => array(
+					'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+				),
+			);
+			return $links;
+		}
+
+		/**
+		 * Retrieves the search params for the font collections.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array Collection parameters.
+		 */
+		public function get_collection_params() {
+			$query_params = parent::get_collection_params();
+
+			$query_params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
+
+			unset( $query_params['search'] );
+
+			/**
+			 * Filters REST API collection parameters for the font collections controller.
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param array $query_params JSON Schema-formatted collection parameters.
+			 */
+			return apply_filters( 'rest_font_collections_collection_params', $query_params );
+		}
+
+		/**
+		 * Checks whether the user has permissions to use the Fonts Collections.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return true|WP_Error True if the request has write access for the item, WP_Error object otherwise.
+		 */
+		public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+			if ( ! current_user_can( 'edit_theme_options' ) ) {
+				return new WP_Error(
+					'rest_cannot_read',
+					__( 'Sorry, you are not allowed to use the Font Library on this site.', 'gutenberg' ),
+					array(
+						'status' => rest_authorization_required_code(),
+					)
+				);
+			}
+			return true;
+		}
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-faces-controller.php
@@ -7,841 +7,840 @@
  * @since 6.5.0
  */
 
-if ( class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
-	return;
-}
-
-/**
- * Class to access font faces through the REST API.
- */
-class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
-	/**
-	 * Whether the controller supports batching.
-	 *
-	 * @since 6.5.0
-	 * @var false
-	 */
-	protected $allow_batch = false;
+if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 
 	/**
-	 * Registers the routes for posts.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @see register_rest_route()
+	 * Class to access font faces through the REST API.
 	 */
-	public function register_routes() {
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base,
-			array(
-				'args'   => array(
-					'font_family_id' => array(
-						'description' => __( 'The ID for the parent font family of the font face.', 'gutenberg' ),
-						'type'        => 'integer',
-						'required'    => true,
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-					'args'                => $this->get_collection_params(),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'create_item' ),
-					'permission_callback' => array( $this, 'create_item_permissions_check' ),
-					'args'                => $this->get_create_params(),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
+	class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
+		/**
+		 * Whether the controller supports batching.
+		 *
+		 * @since 6.5.0
+		 * @var false
+		 */
+		protected $allow_batch = false;
 
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\d]+)',
-			array(
-				'args'   => array(
-					'font_family_id' => array(
-						'description' => __( 'The ID for the parent font family of the font face.', 'gutenberg' ),
-						'type'        => 'integer',
-						'required'    => true,
-					),
-					'id'             => array(
-						'description' => __( 'Unique identifier for the font face.', 'gutenberg' ),
-						'type'        => 'integer',
-						'required'    => true,
-					),
-				),
+		/**
+		 * Registers the routes for posts.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @see register_rest_route()
+		 */
+		public function register_routes() {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
 				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'get_item_permissions_check' ),
-					'args'                => array(
-						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $this, 'delete_item' ),
-					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
-					'args'                => array(
-						'force' => array(
-							'type'        => 'boolean',
-							'default'     => false,
-							'description' => __( 'Whether to bypass Trash and force deletion.', 'default' ),
+					'args'   => array(
+						'font_family_id' => array(
+							'description' => __( 'The ID for the parent font family of the font face.', 'gutenberg' ),
+							'type'        => 'integer',
+							'required'    => true,
 						),
 					),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-	}
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_items' ),
+						'permission_callback' => array( $this, 'get_items_permissions_check' ),
+						'args'                => $this->get_collection_params(),
+					),
+					array(
+						'methods'             => WP_REST_Server::CREATABLE,
+						'callback'            => array( $this, 'create_item' ),
+						'permission_callback' => array( $this, 'create_item_permissions_check' ),
+						'args'                => $this->get_create_params(),
+					),
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
+			);
 
-	/**
-	 * Checks if a given request has access to font faces.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
-	 */
-	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- required by parent class
-		$post_type = get_post_type_object( $this->post_type );
-
-		if ( ! current_user_can( $post_type->cap->read ) ) {
-			return new WP_Error(
-				'rest_cannot_read',
-				__( 'Sorry, you are not allowed to access font faces.', 'gutenberg' ),
-				array( 'status' => rest_authorization_required_code() )
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base . '/(?P<id>[\d]+)',
+				array(
+					'args'   => array(
+						'font_family_id' => array(
+							'description' => __( 'The ID for the parent font family of the font face.', 'gutenberg' ),
+							'type'        => 'integer',
+							'required'    => true,
+						),
+						'id'             => array(
+							'description' => __( 'Unique identifier for the font face.', 'gutenberg' ),
+							'type'        => 'integer',
+							'required'    => true,
+						),
+					),
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_item' ),
+						'permission_callback' => array( $this, 'get_item_permissions_check' ),
+						'args'                => array(
+							'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+						),
+					),
+					array(
+						'methods'             => WP_REST_Server::DELETABLE,
+						'callback'            => array( $this, 'delete_item' ),
+						'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+						'args'                => array(
+							'force' => array(
+								'type'        => 'boolean',
+								'default'     => false,
+								'description' => __( 'Whether to bypass Trash and force deletion.', 'default' ),
+							),
+						),
+					),
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
 			);
 		}
 
-		return true;
-	}
+		/**
+		 * Checks if a given request has access to font faces.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+		 */
+		public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- required by parent class
+			$post_type = get_post_type_object( $this->post_type );
 
-	/**
-	 * Checks if a given request has access to a font face.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
-	 */
-	public function get_item_permissions_check( $request ) {
-		$post = $this->get_post( $request['id'] );
-		if ( is_wp_error( $post ) ) {
-			return $post;
+			if ( ! current_user_can( $post_type->cap->read ) ) {
+				return new WP_Error(
+					'rest_cannot_read',
+					__( 'Sorry, you are not allowed to access font faces.', 'gutenberg' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+
+			return true;
 		}
 
-		if ( ! current_user_can( 'read_post', $post->ID ) ) {
-			return new WP_Error(
-				'rest_cannot_read',
-				__( 'Sorry, you are not allowed to access this font face.', 'gutenberg' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
+		/**
+		 * Checks if a given request has access to a font face.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+		 */
+		public function get_item_permissions_check( $request ) {
+			$post = $this->get_post( $request['id'] );
+			if ( is_wp_error( $post ) ) {
+				return $post;
+			}
+
+			if ( ! current_user_can( 'read_post', $post->ID ) ) {
+				return new WP_Error(
+					'rest_cannot_read',
+					__( 'Sorry, you are not allowed to access this font face.', 'gutenberg' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+
+			return true;
 		}
 
-		return true;
-	}
+		/**
+		 * Validates settings when creating a font face.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string          $value   Encoded JSON string of font face settings.
+		 * @param WP_REST_Request $request Request object.
+		 * @return false|WP_Error True if the settings are valid, otherwise a WP_Error object.
+		 */
+		public function validate_create_font_face_settings( $value, $request ) {
+			$settings = json_decode( $value, true );
 
-	/**
-	 * Validates settings when creating a font face.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string          $value   Encoded JSON string of font face settings.
-	 * @param WP_REST_Request $request Request object.
-	 * @return false|WP_Error True if the settings are valid, otherwise a WP_Error object.
-	 */
-	public function validate_create_font_face_settings( $value, $request ) {
-		$settings = json_decode( $value, true );
-
-		// Check settings string is valid JSON.
-		if ( null === $settings ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				__( 'font_face_settings parameter must be a valid JSON string.', 'gutenberg' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		// Check that the font face settings match the theme.json schema.
-		$schema             = $this->get_item_schema()['properties']['font_face_settings'];
-		$has_valid_settings = rest_validate_value_from_schema( $settings, $schema, 'font_face_settings' );
-
-		if ( is_wp_error( $has_valid_settings ) ) {
-			$has_valid_settings->add_data( array( 'status' => 400 ) );
-			return $has_valid_settings;
-		}
-
-		// Check that none of the required settings are empty values.
-		$required = $schema['required'];
-		foreach ( $required as $key ) {
-			if ( isset( $settings[ $key ] ) && ! $settings[ $key ] ) {
+			// Check settings string is valid JSON.
+			if ( null === $settings ) {
 				return new WP_Error(
 					'rest_invalid_param',
-					/* translators: %s: Font family setting key. */
-					sprintf( __( 'font_face_setting[%s] cannot be empty.', 'gutenberg' ), $key ),
+					__( 'font_face_settings parameter must be a valid JSON string.', 'gutenberg' ),
 					array( 'status' => 400 )
 				);
 			}
-		}
 
-		$srcs = is_array( $settings['src'] ) ? $settings['src'] : array( $settings['src'] );
+			// Check that the font face settings match the theme.json schema.
+			$schema             = $this->get_item_schema()['properties']['font_face_settings'];
+			$has_valid_settings = rest_validate_value_from_schema( $settings, $schema, 'font_face_settings' );
 
-		// Check that srcs are non-empty strings.
-		$filtered_src = array_filter( array_filter( $srcs, 'is_string' ) );
-		if ( empty( $filtered_src ) ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				__( 'font_face_settings[src] values must be non-empty strings.', 'gutenberg' ),
-				array( 'status' => 400 )
-			);
-		}
+			if ( is_wp_error( $has_valid_settings ) ) {
+				$has_valid_settings->add_data( array( 'status' => 400 ) );
+				return $has_valid_settings;
+			}
 
-		// Check that each file in the request references a src in the settings.
-		$files = $request->get_file_params();
-		foreach ( array_keys( $files ) as $file ) {
-			if ( ! in_array( $file, $srcs, true ) ) {
+			// Check that none of the required settings are empty values.
+			$required = $schema['required'];
+			foreach ( $required as $key ) {
+				if ( isset( $settings[ $key ] ) && ! $settings[ $key ] ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						/* translators: %s: Font family setting key. */
+						sprintf( __( 'font_face_setting[%s] cannot be empty.', 'gutenberg' ), $key ),
+						array( 'status' => 400 )
+					);
+				}
+			}
+
+			$srcs = is_array( $settings['src'] ) ? $settings['src'] : array( $settings['src'] );
+
+			// Check that srcs are non-empty strings.
+			$filtered_src = array_filter( array_filter( $srcs, 'is_string' ) );
+			if ( empty( $filtered_src ) ) {
 				return new WP_Error(
 					'rest_invalid_param',
-					// translators: %s: File key (e.g. `file-0`) in the request data.
-					sprintf( __( 'File %1$s must be used in font_face_settings[src].', 'gutenberg' ), $file ),
+					__( 'font_face_settings[src] values must be non-empty strings.', 'gutenberg' ),
 					array( 'status' => 400 )
 				);
 			}
-		}
 
-		return true;
-	}
-
-	/**
-	 * Sanitizes the font face settings when creating a font face.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string          $value   Encoded JSON string of font face settings.
-	 * @param WP_REST_Request $request Request object.
-	 * @return array                   Decoded array of font face settings.
-	 */
-	public function sanitize_font_face_settings( $value ) {
-		// Settings arrive as stringified JSON, since this is a multipart/form-data request.
-		$settings = json_decode( $value, true );
-
-		if ( isset( $settings['fontFamily'] ) ) {
-			$settings['fontFamily'] = WP_Font_Utils::format_font_family( $settings['fontFamily'] );
-		}
-
-		return $settings;
-	}
-
-	/**
-	 * Retrieves a collection of font faces within the parent font family.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function get_items( $request ) {
-		$font_family = $this->get_parent_font_family_post( $request['font_family_id'] );
-		if ( is_wp_error( $font_family ) ) {
-			return $font_family;
-		}
-
-		return parent::get_items( $request );
-	}
-
-	/**
-	 * Retrieves a single font face within the parent font family.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function get_item( $request ) {
-		$post = $this->get_post( $request['id'] );
-		if ( is_wp_error( $post ) ) {
-			return $post;
-		}
-
-		// Check that the font face has a valid parent font family.
-		$font_family = $this->get_parent_font_family_post( $request['font_family_id'] );
-		if ( is_wp_error( $font_family ) ) {
-			return $font_family;
-		}
-
-		if ( (int) $font_family->ID !== (int) $post->post_parent ) {
-			return new WP_Error(
-				'rest_font_face_parent_id_mismatch',
-				/* translators: %d: A post id. */
-				sprintf( __( 'The font face does not belong to the specified font family with id of "%d"', 'gutenberg' ), $font_family->ID ),
-				array( 'status' => 404 )
-			);
-		}
-
-		return parent::get_item( $request );
-	}
-
-	/**
-	 * Creates a font face for the parent font family.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function create_item( $request ) {
-		$font_family = $this->get_parent_font_family_post( $request['font_family_id'] );
-		if ( is_wp_error( $font_family ) ) {
-			return $font_family;
-		}
-
-		// Settings have already been decoded by ::sanitize_font_face_settings().
-		$settings    = $request->get_param( 'font_face_settings' );
-		$file_params = $request->get_file_params();
-
-		// Check that the necessary font face properties are unique.
-		$query = new WP_Query(
-			array(
-				'post_type'              => $this->post_type,
-				'posts_per_page'         => 1,
-				'title'                  => WP_Font_Utils::get_font_face_slug( $settings ),
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-			)
-		);
-		if ( ! empty( $query->get_posts() ) ) {
-			return new WP_Error(
-				'rest_duplicate_font_face',
-				__( 'A font face matching those settings already exists.', 'gutenberg' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		// Move the uploaded font asset from the temp folder to the fonts directory.
-		if ( ! function_exists( 'wp_handle_upload' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		$srcs           = is_string( $settings['src'] ) ? array( $settings['src'] ) : $settings['src'];
-		$processed_srcs = array();
-		$font_file_meta = array();
-
-		foreach ( $srcs as $src ) {
-			// If src not a file reference, use it as is.
-			if ( ! isset( $file_params[ $src ] ) ) {
-				$processed_srcs[] = $src;
-				continue;
+			// Check that each file in the request references a src in the settings.
+			$files = $request->get_file_params();
+			foreach ( array_keys( $files ) as $file ) {
+				if ( ! in_array( $file, $srcs, true ) ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						// translators: %s: File key (e.g. `file-0`) in the request data.
+						sprintf( __( 'File %1$s must be used in font_face_settings[src].', 'gutenberg' ), $file ),
+						array( 'status' => 400 )
+					);
+				}
 			}
 
-			$file      = $file_params[ $src ];
-			$font_file = $this->handle_font_file_upload( $file );
-			if ( is_wp_error( $font_file ) ) {
-				return $font_file;
-			}
-
-			$processed_srcs[] = $font_file['url'];
-			$font_file_meta[] = $this->relative_fonts_path( $font_file['file'] );
+			return true;
 		}
 
-		// Store the updated settings for prepare_item_for_database to use.
-		$settings['src'] = count( $processed_srcs ) === 1 ? $processed_srcs[0] : $processed_srcs;
-		$request->set_param( 'font_face_settings', $settings );
+		/**
+		 * Sanitizes the font face settings when creating a font face.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string          $value   Encoded JSON string of font face settings.
+		 * @param WP_REST_Request $request Request object.
+		 * @return array                   Decoded array of font face settings.
+		 */
+		public function sanitize_font_face_settings( $value ) {
+			// Settings arrive as stringified JSON, since this is a multipart/form-data request.
+			$settings = json_decode( $value, true );
 
-		// Ensure that $settings data is slashed, so values with quotes are escaped.
-		// WP_REST_Posts_Controller::create_item uses wp_slash() on the post_content.
-		$font_face_post = parent::create_item( $request );
+			if ( isset( $settings['fontFamily'] ) ) {
+				$settings['fontFamily'] = WP_Font_Utils::format_font_family( $settings['fontFamily'] );
+			}
 
-		if ( is_wp_error( $font_face_post ) ) {
+			return $settings;
+		}
+
+		/**
+		 * Retrieves a collection of font faces within the parent font family.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function get_items( $request ) {
+			$font_family = $this->get_parent_font_family_post( $request['font_family_id'] );
+			if ( is_wp_error( $font_family ) ) {
+				return $font_family;
+			}
+
+			return parent::get_items( $request );
+		}
+
+		/**
+		 * Retrieves a single font face within the parent font family.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function get_item( $request ) {
+			$post = $this->get_post( $request['id'] );
+			if ( is_wp_error( $post ) ) {
+				return $post;
+			}
+
+			// Check that the font face has a valid parent font family.
+			$font_family = $this->get_parent_font_family_post( $request['font_family_id'] );
+			if ( is_wp_error( $font_family ) ) {
+				return $font_family;
+			}
+
+			if ( (int) $font_family->ID !== (int) $post->post_parent ) {
+				return new WP_Error(
+					'rest_font_face_parent_id_mismatch',
+					/* translators: %d: A post id. */
+					sprintf( __( 'The font face does not belong to the specified font family with id of "%d"', 'gutenberg' ), $font_family->ID ),
+					array( 'status' => 404 )
+				);
+			}
+
+			return parent::get_item( $request );
+		}
+
+		/**
+		 * Creates a font face for the parent font family.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function create_item( $request ) {
+			$font_family = $this->get_parent_font_family_post( $request['font_family_id'] );
+			if ( is_wp_error( $font_family ) ) {
+				return $font_family;
+			}
+
+			// Settings have already been decoded by ::sanitize_font_face_settings().
+			$settings    = $request->get_param( 'font_face_settings' );
+			$file_params = $request->get_file_params();
+
+			// Check that the necessary font face properties are unique.
+			$query = new WP_Query(
+				array(
+					'post_type'              => $this->post_type,
+					'posts_per_page'         => 1,
+					'title'                  => WP_Font_Utils::get_font_face_slug( $settings ),
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				)
+			);
+			if ( ! empty( $query->get_posts() ) ) {
+				return new WP_Error(
+					'rest_duplicate_font_face',
+					__( 'A font face matching those settings already exists.', 'gutenberg' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			// Move the uploaded font asset from the temp folder to the fonts directory.
+			if ( ! function_exists( 'wp_handle_upload' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+			}
+
+			$srcs           = is_string( $settings['src'] ) ? array( $settings['src'] ) : $settings['src'];
+			$processed_srcs = array();
+			$font_file_meta = array();
+
+			foreach ( $srcs as $src ) {
+				// If src not a file reference, use it as is.
+				if ( ! isset( $file_params[ $src ] ) ) {
+					$processed_srcs[] = $src;
+					continue;
+				}
+
+				$file      = $file_params[ $src ];
+				$font_file = $this->handle_font_file_upload( $file );
+				if ( is_wp_error( $font_file ) ) {
+					return $font_file;
+				}
+
+				$processed_srcs[] = $font_file['url'];
+				$font_file_meta[] = $this->relative_fonts_path( $font_file['file'] );
+			}
+
+			// Store the updated settings for prepare_item_for_database to use.
+			$settings['src'] = count( $processed_srcs ) === 1 ? $processed_srcs[0] : $processed_srcs;
+			$request->set_param( 'font_face_settings', $settings );
+
+			// Ensure that $settings data is slashed, so values with quotes are escaped.
+			// WP_REST_Posts_Controller::create_item uses wp_slash() on the post_content.
+			$font_face_post = parent::create_item( $request );
+
+			if ( is_wp_error( $font_face_post ) ) {
+				return $font_face_post;
+			}
+
+			$font_face_id = $font_face_post->data['id'];
+
+			foreach ( $font_file_meta as $font_file_path ) {
+				add_post_meta( $font_face_id, '_wp_font_face_file', $font_file_path );
+			}
+
 			return $font_face_post;
 		}
 
-		$font_face_id = $font_face_post->data['id'];
-
-		foreach ( $font_file_meta as $font_file_path ) {
-			add_post_meta( $font_face_id, '_wp_font_face_file', $font_file_path );
-		}
-
-		return $font_face_post;
-	}
-
-	/**
-	 * Deletes a single font face.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function delete_item( $request ) {
-		$post = $this->get_post( $request['id'] );
-		if ( is_wp_error( $post ) ) {
-			return $post;
-		}
-
-		$font_family = $this->get_parent_font_family_post( $request['font_family_id'] );
-		if ( is_wp_error( $font_family ) ) {
-			return $font_family;
-		}
-
-		if ( (int) $font_family->ID !== (int) $post->post_parent ) {
-			return new WP_Error(
-				'rest_font_face_parent_id_mismatch',
-				/* translators: %d: A post id. */
-				sprintf( __( 'The font face does not belong to the specified font family with id of "%d"', 'gutenberg' ), $font_family->ID ),
-				array( 'status' => 404 )
-			);
-		}
-
-		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
-
-		// We don't support trashing for font faces.
-		if ( ! $force ) {
-			return new WP_Error(
-				'rest_trash_not_supported',
-				/* translators: %s: force=true */
-				sprintf( __( "Font faces do not support trashing. Set '%s' to delete.", 'gutenberg' ), 'force=true' ),
-				array( 'status' => 501 )
-			);
-		}
-
-		return parent::delete_item( $request );
-	}
-
-	/**
-	 * Prepares a single font face output for response.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_Post         $item    Post object.
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response object.
-	 */
-	public function prepare_item_for_response( $item, $request ) {
-		$fields = $this->get_fields_for_response( $request );
-		$data   = array();
-
-		if ( rest_is_field_included( 'id', $fields ) ) {
-			$data['id'] = $item->ID;
-		}
-		if ( rest_is_field_included( 'theme_json_version', $fields ) ) {
-			$data['theme_json_version'] = 2;
-		}
-
-		if ( rest_is_field_included( 'parent', $fields ) ) {
-			$data['parent'] = $item->post_parent;
-		}
-
-		if ( rest_is_field_included( 'font_face_settings', $fields ) ) {
-			$data['font_face_settings'] = $this->get_settings_from_post( $item );
-		}
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		$response = rest_ensure_response( $data );
-
-		if ( rest_is_field_included( '_links', $fields ) || rest_is_field_included( '_embedded', $fields ) ) {
-			$links = $this->prepare_links( $item );
-			$response->add_links( $links );
-		}
-
 		/**
-		 * Filters the font face data for a REST API response.
+		 * Deletes a single font face.
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param WP_REST_Response $response The response object.
-		 * @param WP_Post          $post     Font face post object.
-		 * @param WP_REST_Request  $request  Request object.
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 		 */
-		return apply_filters( 'rest_prepare_wp_font_face', $response, $item, $request );
-	}
+		public function delete_item( $request ) {
+			$post = $this->get_post( $request['id'] );
+			if ( is_wp_error( $post ) ) {
+				return $post;
+			}
 
-	/**
-	 * Retrieves the post's schema, conforming to JSON Schema.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array Item schema data.
-	 */
-	public function get_item_schema() {
-		if ( $this->schema ) {
+			$font_family = $this->get_parent_font_family_post( $request['font_family_id'] );
+			if ( is_wp_error( $font_family ) ) {
+				return $font_family;
+			}
+
+			if ( (int) $font_family->ID !== (int) $post->post_parent ) {
+				return new WP_Error(
+					'rest_font_face_parent_id_mismatch',
+					/* translators: %d: A post id. */
+					sprintf( __( 'The font face does not belong to the specified font family with id of "%d"', 'gutenberg' ), $font_family->ID ),
+					array( 'status' => 404 )
+				);
+			}
+
+			$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+
+			// We don't support trashing for font faces.
+			if ( ! $force ) {
+				return new WP_Error(
+					'rest_trash_not_supported',
+					/* translators: %s: force=true */
+					sprintf( __( "Font faces do not support trashing. Set '%s' to delete.", 'gutenberg' ), 'force=true' ),
+					array( 'status' => 501 )
+				);
+			}
+
+			return parent::delete_item( $request );
+		}
+
+		/**
+		 * Prepares a single font face output for response.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_Post         $item    Post object.
+		 * @param WP_REST_Request $request Request object.
+		 * @return WP_REST_Response Response object.
+		 */
+		public function prepare_item_for_response( $item, $request ) {
+			$fields = $this->get_fields_for_response( $request );
+			$data   = array();
+
+			if ( rest_is_field_included( 'id', $fields ) ) {
+				$data['id'] = $item->ID;
+			}
+			if ( rest_is_field_included( 'theme_json_version', $fields ) ) {
+				$data['theme_json_version'] = 2;
+			}
+
+			if ( rest_is_field_included( 'parent', $fields ) ) {
+				$data['parent'] = $item->post_parent;
+			}
+
+			if ( rest_is_field_included( 'font_face_settings', $fields ) ) {
+				$data['font_face_settings'] = $this->get_settings_from_post( $item );
+			}
+
+			$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+			$data    = $this->add_additional_fields_to_object( $data, $request );
+			$data    = $this->filter_response_by_context( $data, $context );
+
+			$response = rest_ensure_response( $data );
+
+			if ( rest_is_field_included( '_links', $fields ) || rest_is_field_included( '_embedded', $fields ) ) {
+				$links = $this->prepare_links( $item );
+				$response->add_links( $links );
+			}
+
+			/**
+			 * Filters the font face data for a REST API response.
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param WP_REST_Response $response The response object.
+			 * @param WP_Post          $post     Font face post object.
+			 * @param WP_REST_Request  $request  Request object.
+			 */
+			return apply_filters( 'rest_prepare_wp_font_face', $response, $item, $request );
+		}
+
+		/**
+		 * Retrieves the post's schema, conforming to JSON Schema.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array Item schema data.
+		 */
+		public function get_item_schema() {
+			if ( $this->schema ) {
+				return $this->add_additional_fields_schema( $this->schema );
+			}
+
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => $this->post_type,
+				'type'       => 'object',
+				// Base properties for every Post.
+				'properties' => array(
+					'id'                 => array(
+						'description' => __( 'Unique identifier for the post.', 'default' ),
+						'type'        => 'integer',
+						'context'     => array( 'view', 'edit', 'embed' ),
+						'readonly'    => true,
+					),
+					'theme_json_version' => array(
+						'description' => __( 'Version of the theme.json schema used for the typography settings.', 'gutenberg' ),
+						'type'        => 'integer',
+						'default'     => 2,
+						'minimum'     => 2,
+						'maximum'     => 2,
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+					'parent'             => array(
+						'description' => __( 'The ID for the parent font family of the font face.', 'gutenberg' ),
+						'type'        => 'integer',
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+					// Font face settings come directly from theme.json schema
+					// See https://schemas.wp.org/trunk/theme.json
+					'font_face_settings' => array(
+						'description'          => __( 'font-face declaration in theme.json format.', 'gutenberg' ),
+						'type'                 => 'object',
+						'context'              => array( 'view', 'edit', 'embed' ),
+						'properties'           => array(
+							'fontFamily'            => array(
+								'description' => __( 'CSS font-family value.', 'gutenberg' ),
+								'type'        => 'string',
+								'default'     => '',
+							),
+							'fontStyle'             => array(
+								'description' => __( 'CSS font-style value.', 'gutenberg' ),
+								'type'        => 'string',
+								'default'     => 'normal',
+							),
+							'fontWeight'            => array(
+								'description' => __( 'List of available font weights, separated by a space.', 'gutenberg' ),
+								'default'     => '400',
+								// Changed from `oneOf` to avoid errors from loose type checking.
+								// e.g. a fontWeight of "400" validates as both a string and an integer due to is_numeric check.
+								'type'        => array( 'string', 'integer' ),
+							),
+							'fontDisplay'           => array(
+								'description' => __( 'CSS font-display value.', 'gutenberg' ),
+								'type'        => 'string',
+								'default'     => 'fallback',
+								'enum'        => array(
+									'auto',
+									'block',
+									'fallback',
+									'swap',
+									'optional',
+								),
+							),
+							'src'                   => array(
+								'description' => __( 'Paths or URLs to the font files.', 'gutenberg' ),
+								// Changed from `oneOf` to `anyOf` due to rest_sanitize_array converting a string into an array.
+								'anyOf'       => array(
+									array(
+										'type' => 'string',
+									),
+									array(
+										'type'  => 'array',
+										'items' => array(
+											'type' => 'string',
+										),
+									),
+								),
+								'default'     => array(),
+							),
+							'fontStretch'           => array(
+								'description' => __( 'CSS font-stretch value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'ascentOverride'        => array(
+								'description' => __( 'CSS ascent-override value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'descentOverride'       => array(
+								'description' => __( 'CSS descent-override value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'fontVariant'           => array(
+								'description' => __( 'CSS font-variant value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'fontFeatureSettings'   => array(
+								'description' => __( 'CSS font-feature-settings value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'fontVariationSettings' => array(
+								'description' => __( 'CSS font-variation-settings value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'lineGapOverride'       => array(
+								'description' => __( 'CSS line-gap-override value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'sizeAdjust'            => array(
+								'description' => __( 'CSS size-adjust value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'unicodeRange'          => array(
+								'description' => __( 'CSS unicode-range value.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+							'preview'               => array(
+								'description' => __( 'URL to a preview image of the font face.', 'gutenberg' ),
+								'type'        => 'string',
+							),
+						),
+						'required'             => array( 'fontFamily', 'src' ),
+						'additionalProperties' => false,
+					),
+				),
+			);
+
+			$this->schema = $schema;
+
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => $this->post_type,
-			'type'       => 'object',
-			// Base properties for every Post.
-			'properties' => array(
-				'id'                 => array(
-					'description' => __( 'Unique identifier for the post.', 'default' ),
-					'type'        => 'integer',
-					'context'     => array( 'view', 'edit', 'embed' ),
-					'readonly'    => true,
-				),
-				'theme_json_version' => array(
-					'description' => __( 'Version of the theme.json schema used for the typography settings.', 'gutenberg' ),
-					'type'        => 'integer',
-					'default'     => 2,
-					'minimum'     => 2,
-					'maximum'     => 2,
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'parent'             => array(
-					'description' => __( 'The ID for the parent font family of the font face.', 'gutenberg' ),
-					'type'        => 'integer',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				// Font face settings come directly from theme.json schema
-				// See https://schemas.wp.org/trunk/theme.json
-				'font_face_settings' => array(
-					'description'          => __( 'font-face declaration in theme.json format.', 'gutenberg' ),
-					'type'                 => 'object',
-					'context'              => array( 'view', 'edit', 'embed' ),
-					'properties'           => array(
-						'fontFamily'            => array(
-							'description' => __( 'CSS font-family value.', 'gutenberg' ),
-							'type'        => 'string',
-							'default'     => '',
-						),
-						'fontStyle'             => array(
-							'description' => __( 'CSS font-style value.', 'gutenberg' ),
-							'type'        => 'string',
-							'default'     => 'normal',
-						),
-						'fontWeight'            => array(
-							'description' => __( 'List of available font weights, separated by a space.', 'gutenberg' ),
-							'default'     => '400',
-							// Changed from `oneOf` to avoid errors from loose type checking.
-							// e.g. a fontWeight of "400" validates as both a string and an integer due to is_numeric check.
-							'type'        => array( 'string', 'integer' ),
-						),
-						'fontDisplay'           => array(
-							'description' => __( 'CSS font-display value.', 'gutenberg' ),
-							'type'        => 'string',
-							'default'     => 'fallback',
-							'enum'        => array(
-								'auto',
-								'block',
-								'fallback',
-								'swap',
-								'optional',
-							),
-						),
-						'src'                   => array(
-							'description' => __( 'Paths or URLs to the font files.', 'gutenberg' ),
-							// Changed from `oneOf` to `anyOf` due to rest_sanitize_array converting a string into an array.
-							'anyOf'       => array(
-								array(
-									'type' => 'string',
-								),
-								array(
-									'type'  => 'array',
-									'items' => array(
-										'type' => 'string',
-									),
-								),
-							),
-							'default'     => array(),
-						),
-						'fontStretch'           => array(
-							'description' => __( 'CSS font-stretch value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'ascentOverride'        => array(
-							'description' => __( 'CSS ascent-override value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'descentOverride'       => array(
-							'description' => __( 'CSS descent-override value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'fontVariant'           => array(
-							'description' => __( 'CSS font-variant value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'fontFeatureSettings'   => array(
-							'description' => __( 'CSS font-feature-settings value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'fontVariationSettings' => array(
-							'description' => __( 'CSS font-variation-settings value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'lineGapOverride'       => array(
-							'description' => __( 'CSS line-gap-override value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'sizeAdjust'            => array(
-							'description' => __( 'CSS size-adjust value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'unicodeRange'          => array(
-							'description' => __( 'CSS unicode-range value.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-						'preview'               => array(
-							'description' => __( 'URL to a preview image of the font face.', 'gutenberg' ),
-							'type'        => 'string',
-						),
-					),
-					'required'             => array( 'fontFamily', 'src' ),
-					'additionalProperties' => false,
-				),
-			),
-		);
-
-		$this->schema = $schema;
-
-		return $this->add_additional_fields_schema( $this->schema );
-	}
-
-	/**
-	 * Retrieves the query params for the font face collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array Collection parameters.
-	 */
-	public function get_collection_params() {
-		$query_params = parent::get_collection_params();
-
-		// Remove unneeded params.
-		unset( $query_params['after'] );
-		unset( $query_params['modified_after'] );
-		unset( $query_params['before'] );
-		unset( $query_params['modified_before'] );
-		unset( $query_params['search'] );
-		unset( $query_params['search_columns'] );
-		unset( $query_params['slug'] );
-		unset( $query_params['status'] );
-
-		$query_params['orderby']['default'] = 'id';
-		$query_params['orderby']['enum']    = array( 'id', 'include' );
-
 		/**
-		 * Filters collection parameters for the font face controller.
+		 * Retrieves the query params for the font face collection.
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param array $query_params JSON Schema-formatted collection parameters.
+		 * @return array Collection parameters.
 		 */
-		return apply_filters( 'rest_wp_font_face_collection_params', $query_params );
-	}
+		public function get_collection_params() {
+			$query_params = parent::get_collection_params();
 
-	/**
-	 * Get the params used when creating a new font face.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array Font face create arguments.
-	 */
-	public function get_create_params() {
-		$properties = $this->get_item_schema()['properties'];
-		return array(
-			'theme_json_version' => $properties['theme_json_version'],
-			// When creating, font_face_settings is stringified JSON, to work with multipart/form-data used
-			// when uploading font files.
-			'font_face_settings' => array(
-				'description'       => __( 'font-face declaration in theme.json format, encoded as a string.', 'gutenberg' ),
-				'type'              => 'string',
-				'required'          => true,
-				'validate_callback' => array( $this, 'validate_create_font_face_settings' ),
-				'sanitize_callback' => array( $this, 'sanitize_font_face_settings' ),
-			),
-		);
-	}
+			// Remove unneeded params.
+			unset( $query_params['after'] );
+			unset( $query_params['modified_after'] );
+			unset( $query_params['before'] );
+			unset( $query_params['modified_before'] );
+			unset( $query_params['search'] );
+			unset( $query_params['search_columns'] );
+			unset( $query_params['slug'] );
+			unset( $query_params['status'] );
 
-	/**
-	 * Get the parent font family, if the ID is valid.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param int $font_family_id Supplied ID.
-	 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
-	 */
-	protected function get_parent_font_family_post( $font_family_id ) {
-		$error = new WP_Error(
-			'rest_post_invalid_parent',
-			__( 'Invalid post parent ID.', 'default' ),
-			array( 'status' => 404 )
-		);
+			$query_params['orderby']['default'] = 'id';
+			$query_params['orderby']['enum']    = array( 'id', 'include' );
 
-		if ( (int) $font_family_id <= 0 ) {
-			return $error;
+			/**
+			 * Filters collection parameters for the font face controller.
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param array $query_params JSON Schema-formatted collection parameters.
+			 */
+			return apply_filters( 'rest_wp_font_face_collection_params', $query_params );
 		}
 
-		$font_family_post = get_post( (int) $font_family_id );
-
-		if ( empty( $font_family_post ) || empty( $font_family_post->ID )
-		|| 'wp_font_family' !== $font_family_post->post_type
-		) {
-			return $error;
-		}
-
-		return $font_family_post;
-	}
-
-	/**
-	 * Prepares links for the request.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_Post $post Post object.
-	 * @return array Links for the given post.
-	 */
-	protected function prepare_links( $post ) {
-		// Entity meta.
-		$links = array(
-			'self'       => array(
-				'href' => rest_url( $this->namespace . '/font-families/' . $post->post_parent . '/font-faces/' . $post->ID ),
-			),
-			'collection' => array(
-				'href' => rest_url( $this->namespace . '/font-families/' . $post->post_parent . '/font-faces' ),
-			),
-			'parent'     => array(
-				'href' => rest_url( $this->namespace . '/font-families/' . $post->post_parent ),
-			),
-		);
-
-		return $links;
-	}
-
-	/**
-	 * Prepares a single font face post for creation.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return stdClass|WP_Error Post object or WP_Error.
-	 */
-	protected function prepare_item_for_database( $request ) {
-		$prepared_post = new stdClass();
-
-		// Settings have already been decoded by ::sanitize_font_face_settings().
-		$settings = $request->get_param( 'font_face_settings' );
-
-		// Store this "slug" as the post_title rather than post_name, since it uses the fontFamily setting,
-		// which may contain multibyte characters.
-		$title = WP_Font_Utils::get_font_face_slug( $settings );
-
-		$prepared_post->post_type    = $this->post_type;
-		$prepared_post->post_parent  = $request['font_family_id'];
-		$prepared_post->post_status  = 'publish';
-		$prepared_post->post_title   = $title;
-		$prepared_post->post_name    = sanitize_title( $title );
-		$prepared_post->post_content = wp_json_encode( $settings );
-
-		return $prepared_post;
-	}
-
-	/**
-	 * Handles the upload of a font file using wp_handle_upload().
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param array $file Single file item from $_FILES.
-	 * @return array Array containing uploaded file attributes on success, or error on failure.
-	 */
-	protected function handle_font_file_upload( $file ) {
-		add_filter( 'upload_mimes', array( 'WP_Font_Library', 'set_allowed_mime_types' ) );
-		add_filter( 'upload_dir', 'wp_get_font_dir' );
-
-		$overrides = array(
-			'upload_error_handler' => array( $this, 'handle_font_file_upload_error' ),
-			// Arbitrary string to avoid the is_uploaded_file() check applied
-			// when using 'wp_handle_upload'.
-			'action'               => 'wp_handle_font_upload',
-			// Not testing a form submission.
-			'test_form'            => false,
-			// Seems mime type for files that are not images cannot be tested.
-			// See wp_check_filetype_and_ext().
-			'test_type'            => true,
-			// Only allow uploading font files for this request.
-			'mimes'                => WP_Font_Library::get_expected_font_mime_types_per_php_version(),
-		);
-
-		$uploaded_file = wp_handle_upload( $file, $overrides );
-
-		remove_filter( 'upload_dir', 'wp_get_font_dir' );
-		remove_filter( 'upload_mimes', array( 'WP_Font_Library', 'set_allowed_mime_types' ) );
-
-		return $uploaded_file;
-	}
-
-	/**
-	 * Handles file upload error.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param array  $file    File upload data.
-	 * @param string $message Error message from wp_handle_upload().
-	 * @return WP_Error WP_Error object.
-	 */
-	public function handle_font_file_upload_error( $file, $message ) {
-		$status = 500;
-		$code   = 'rest_font_upload_unknown_error';
-
-		if ( __( 'Sorry, you are not allowed to upload this file type.', 'default' ) === $message ) {
-			$status = 400;
-			$code   = 'rest_font_upload_invalid_file_type';
-		}
-
-		return new WP_Error( $code, $message, array( 'status' => $status ) );
-	}
-
-	/**
-	* Returns relative path to an uploaded font file.
-	*
-	* The path is relative to the current fonts dir.
-	*
-	* @since 6.5.0
-	* @access private
-	*
-	* @param string $path Full path to the file.
-	* @return string Relative path on success, unchanged path on failure.
-	*/
-	protected function relative_fonts_path( $path ) {
-		$new_path = $path;
-
-		$fonts_dir = wp_get_font_dir();
-		if ( str_starts_with( $new_path, $fonts_dir['path'] ) ) {
-			$new_path = str_replace( $fonts_dir, '', $new_path );
-			$new_path = ltrim( $new_path, '/' );
-		}
-
-		return $new_path;
-	}
-
-	/**
-	 * Gets the font face's settings from the post.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_Post $post Font face post object.
-	 * @return array Font face settings array.
-	 */
-	protected function get_settings_from_post( $post ) {
-		$settings   = json_decode( $post->post_content, true );
-		$properties = $this->get_item_schema()['properties']['font_face_settings']['properties'];
-
-		// Provide required, empty settings if needed.
-		if ( null === $settings ) {
-			$settings = array(
-				'fontFamily' => '',
-				'src'        => array(),
+		/**
+		 * Get the params used when creating a new font face.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array Font face create arguments.
+		 */
+		public function get_create_params() {
+			$properties = $this->get_item_schema()['properties'];
+			return array(
+				'theme_json_version' => $properties['theme_json_version'],
+				// When creating, font_face_settings is stringified JSON, to work with multipart/form-data used
+				// when uploading font files.
+				'font_face_settings' => array(
+					'description'       => __( 'font-face declaration in theme.json format, encoded as a string.', 'gutenberg' ),
+					'type'              => 'string',
+					'required'          => true,
+					'validate_callback' => array( $this, 'validate_create_font_face_settings' ),
+					'sanitize_callback' => array( $this, 'sanitize_font_face_settings' ),
+				),
 			);
 		}
 
-		// Only return the properties defined in the schema.
-		return array_intersect_key( $settings, $properties );
+		/**
+		 * Get the parent font family, if the ID is valid.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param int $font_family_id Supplied ID.
+		 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
+		 */
+		protected function get_parent_font_family_post( $font_family_id ) {
+			$error = new WP_Error(
+				'rest_post_invalid_parent',
+				__( 'Invalid post parent ID.', 'default' ),
+				array( 'status' => 404 )
+			);
+
+			if ( (int) $font_family_id <= 0 ) {
+				return $error;
+			}
+
+			$font_family_post = get_post( (int) $font_family_id );
+
+			if ( empty( $font_family_post ) || empty( $font_family_post->ID )
+			|| 'wp_font_family' !== $font_family_post->post_type
+			) {
+				return $error;
+			}
+
+			return $font_family_post;
+		}
+
+		/**
+		 * Prepares links for the request.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_Post $post Post object.
+		 * @return array Links for the given post.
+		 */
+		protected function prepare_links( $post ) {
+			// Entity meta.
+			$links = array(
+				'self'       => array(
+					'href' => rest_url( $this->namespace . '/font-families/' . $post->post_parent . '/font-faces/' . $post->ID ),
+				),
+				'collection' => array(
+					'href' => rest_url( $this->namespace . '/font-families/' . $post->post_parent . '/font-faces' ),
+				),
+				'parent'     => array(
+					'href' => rest_url( $this->namespace . '/font-families/' . $post->post_parent ),
+				),
+			);
+
+			return $links;
+		}
+
+		/**
+		 * Prepares a single font face post for creation.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Request object.
+		 * @return stdClass|WP_Error Post object or WP_Error.
+		 */
+		protected function prepare_item_for_database( $request ) {
+			$prepared_post = new stdClass();
+
+			// Settings have already been decoded by ::sanitize_font_face_settings().
+			$settings = $request->get_param( 'font_face_settings' );
+
+			// Store this "slug" as the post_title rather than post_name, since it uses the fontFamily setting,
+			// which may contain multibyte characters.
+			$title = WP_Font_Utils::get_font_face_slug( $settings );
+
+			$prepared_post->post_type    = $this->post_type;
+			$prepared_post->post_parent  = $request['font_family_id'];
+			$prepared_post->post_status  = 'publish';
+			$prepared_post->post_title   = $title;
+			$prepared_post->post_name    = sanitize_title( $title );
+			$prepared_post->post_content = wp_json_encode( $settings );
+
+			return $prepared_post;
+		}
+
+		/**
+		 * Handles the upload of a font file using wp_handle_upload().
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array $file Single file item from $_FILES.
+		 * @return array Array containing uploaded file attributes on success, or error on failure.
+		 */
+		protected function handle_font_file_upload( $file ) {
+			add_filter( 'upload_mimes', array( 'WP_Font_Library', 'set_allowed_mime_types' ) );
+			add_filter( 'upload_dir', 'wp_get_font_dir' );
+
+			$overrides = array(
+				'upload_error_handler' => array( $this, 'handle_font_file_upload_error' ),
+				// Arbitrary string to avoid the is_uploaded_file() check applied
+				// when using 'wp_handle_upload'.
+				'action'               => 'wp_handle_font_upload',
+				// Not testing a form submission.
+				'test_form'            => false,
+				// Seems mime type for files that are not images cannot be tested.
+				// See wp_check_filetype_and_ext().
+				'test_type'            => true,
+				// Only allow uploading font files for this request.
+				'mimes'                => WP_Font_Library::get_expected_font_mime_types_per_php_version(),
+			);
+
+			$uploaded_file = wp_handle_upload( $file, $overrides );
+
+			remove_filter( 'upload_dir', 'wp_get_font_dir' );
+			remove_filter( 'upload_mimes', array( 'WP_Font_Library', 'set_allowed_mime_types' ) );
+
+			return $uploaded_file;
+		}
+
+		/**
+		 * Handles file upload error.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array  $file    File upload data.
+		 * @param string $message Error message from wp_handle_upload().
+		 * @return WP_Error WP_Error object.
+		 */
+		public function handle_font_file_upload_error( $file, $message ) {
+			$status = 500;
+			$code   = 'rest_font_upload_unknown_error';
+
+			if ( __( 'Sorry, you are not allowed to upload this file type.', 'default' ) === $message ) {
+				$status = 400;
+				$code   = 'rest_font_upload_invalid_file_type';
+			}
+
+			return new WP_Error( $code, $message, array( 'status' => $status ) );
+		}
+
+		/**
+		* Returns relative path to an uploaded font file.
+		*
+		* The path is relative to the current fonts dir.
+		*
+		* @since 6.5.0
+		* @access private
+		*
+		* @param string $path Full path to the file.
+		* @return string Relative path on success, unchanged path on failure.
+		*/
+		protected function relative_fonts_path( $path ) {
+			$new_path = $path;
+
+			$fonts_dir = wp_get_font_dir();
+			if ( str_starts_with( $new_path, $fonts_dir['path'] ) ) {
+				$new_path = str_replace( $fonts_dir, '', $new_path );
+				$new_path = ltrim( $new_path, '/' );
+			}
+
+			return $new_path;
+		}
+
+		/**
+		 * Gets the font face's settings from the post.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_Post $post Font face post object.
+		 * @return array Font face settings array.
+		 */
+		protected function get_settings_from_post( $post ) {
+			$settings   = json_decode( $post->post_content, true );
+			$properties = $this->get_item_schema()['properties']['font_face_settings']['properties'];
+
+			// Provide required, empty settings if needed.
+			if ( null === $settings ) {
+				$settings = array(
+					'fontFamily' => '',
+					'src'        => array(),
+				);
+			}
+
+			// Only return the properties defined in the schema.
+			return array_intersect_key( $settings, $properties );
+		}
 	}
 }

--- a/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
+++ b/lib/experimental/fonts/font-library/class-wp-rest-font-families-controller.php
@@ -7,518 +7,517 @@
  * @since 6.5.0
  */
 
-if ( class_exists( 'WP_REST_Font_Families_Controller' ) ) {
-	return;
-}
+if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 
-/**
- * Font Families Controller class.
- *
- * @since 6.5.0
- */
-class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	/**
-	 * Whether the controller supports batching.
+	 * Font Families Controller class.
 	 *
 	 * @since 6.5.0
-	 * @var false
 	 */
-	protected $allow_batch = false;
-
-	/**
-	 * Checks if a given request has access to font families.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
-	 */
-	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- required by parent class
-		$post_type = get_post_type_object( $this->post_type );
-
-		if ( ! current_user_can( $post_type->cap->read ) ) {
-			return new WP_Error(
-				'rest_cannot_read',
-				__( 'Sorry, you are not allowed to access font families.', 'gutenberg' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		return true;
-	}
-
-	/**
-	 * Checks if a given request has access to a font family.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
-	 */
-	public function get_item_permissions_check( $request ) {
-		$post = $this->get_post( $request['id'] );
-		if ( is_wp_error( $post ) ) {
-			return $post;
-		}
-
-		if ( ! current_user_can( 'read_post', $post->ID ) ) {
-			return new WP_Error(
-				'rest_cannot_read',
-				__( 'Sorry, you are not allowed to access this font family.', 'gutenberg' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		return true;
-	}
-
-	/**
-	 * Validates settings when creating or updating a font family.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string          $value   Encoded JSON string of font family settings.
-	 * @param WP_REST_Request $request Request object.
-	 * @return false|WP_Error True if the settings are valid, otherwise a WP_Error object.
-	 */
-	public function validate_font_family_settings( $value, $request ) {
-		$settings = json_decode( $value, true );
-
-		// Check settings string is valid JSON.
-		if ( null === $settings ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				__( 'font_family_settings parameter must be a valid JSON string.', 'gutenberg' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		$schema   = $this->get_item_schema()['properties']['font_family_settings'];
-		$required = $schema['required'];
-
-		if ( isset( $request['id'] ) ) {
-			// Allow sending individual properties if we are updating an existing font family.
-			unset( $schema['required'] );
-
-			// But don't allow updating the slug, since it is used as a unique identifier.
-			if ( isset( $settings['slug'] ) ) {
-				return new WP_Error(
-					'rest_invalid_param',
-					__( 'font_family_settings[slug] cannot be updated.', 'gutenberg' ),
-					array( 'status' => 400 )
-				);
-			}
-		}
-
-		// Check that the font face settings match the theme.json schema.
-		$has_valid_settings = rest_validate_value_from_schema( $settings, $schema, 'font_family_settings' );
-
-		if ( is_wp_error( $has_valid_settings ) ) {
-			$has_valid_settings->add_data( array( 'status' => 400 ) );
-			return $has_valid_settings;
-		}
-
-		// Check that none of the required settings are empty values.
-		foreach ( $required as $key ) {
-			if ( isset( $settings[ $key ] ) && ! $settings[ $key ] ) {
-				return new WP_Error(
-					'rest_invalid_param',
-					/* translators: %s: Font family setting key. */
-					sprintf( __( 'font_family_settings[%s] cannot be empty.', 'gutenberg' ), $key ),
-					array( 'status' => 400 )
-				);
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Sanitizes the font family settings when creating or updating a font family.
-	 *
-	* @since 6.5.0
-	 *
-	 * @param string          $value   Encoded JSON string of font family settings.
-	 * @param WP_REST_Request $request Request object.
-	 * @return array                   Decoded array font family settings.
-	 */
-	public function sanitize_font_family_settings( $value ) {
-		$settings = json_decode( $value, true );
-
-		if ( isset( $settings['fontFamily'] ) ) {
-			$settings['fontFamily'] = WP_Font_Utils::format_font_family( $settings['fontFamily'] );
-		}
-
-		// Provide default for preview, if not provided.
-		if ( ! isset( $settings['preview'] ) ) {
-			$settings['preview'] = '';
-		}
-
-		return $settings;
-	}
-
-	/**
-	 * Creates a single font family.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function create_item( $request ) {
-		$settings = $request->get_param( 'font_family_settings' );
-
-		// Check that the font family slug is unique.
-		$query = new WP_Query(
-			array(
-				'post_type'              => $this->post_type,
-				'posts_per_page'         => 1,
-				'name'                   => $settings['slug'],
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-			)
-		);
-		if ( ! empty( $query->get_posts() ) ) {
-			return new WP_Error(
-				'rest_duplicate_font_family',
-				/* translators: %s: Font family slug. */
-				sprintf( __( 'A font family with slug "%s" already exists.', 'gutenberg' ), $settings['slug'] ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return parent::create_item( $request );
-	}
-
-	/**
-	 * Deletes a single font family.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function delete_item( $request ) {
-		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
-
-		// We don't support trashing for font families.
-		if ( ! $force ) {
-			return new WP_Error(
-				'rest_trash_not_supported',
-				/* translators: %s: force=true */
-				sprintf( __( "Font faces do not support trashing. Set '%s' to delete.", 'gutenberg' ), 'force=true' ),
-				array( 'status' => 501 )
-			);
-		}
-
-		return parent::delete_item( $request );
-	}
-
-	/**
-	 * Prepares a single font family output for response.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_Post         $item    Post object.
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response object.
-	 */
-	public function prepare_item_for_response( $item, $request ) {
-		$fields = $this->get_fields_for_response( $request );
-		$data   = array();
-
-		if ( rest_is_field_included( 'id', $fields ) ) {
-			$data['id'] = $item->ID;
-		}
-
-		if ( rest_is_field_included( 'theme_json_version', $fields ) ) {
-			$data['theme_json_version'] = 2;
-		}
-
-		if ( rest_is_field_included( 'font_faces', $fields ) ) {
-			$data['font_faces'] = $this->get_font_face_ids( $item->ID );
-		}
-
-		if ( rest_is_field_included( 'font_family_settings', $fields ) ) {
-			$data['font_family_settings'] = $this->get_settings_from_post( $item );
-		}
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		$response = rest_ensure_response( $data );
-
-		if ( rest_is_field_included( '_links', $fields ) ) {
-			$links = $this->prepare_links( $item );
-			$response->add_links( $links );
-		}
+	class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
+		/**
+		 * Whether the controller supports batching.
+		 *
+		 * @since 6.5.0
+		 * @var false
+		 */
+		protected $allow_batch = false;
 
 		/**
-		 * Filters the font family data for a REST API response.
+		 * Checks if a given request has access to font families.
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param WP_REST_Response $response The response object.
-		 * @param WP_Post          $post     Font family post object.
-		 * @param WP_REST_Request  $request  Request object.
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 		 */
-		return apply_filters( 'rest_prepare_wp_font_family', $response, $item, $request );
-	}
+		public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- required by parent class
+			$post_type = get_post_type_object( $this->post_type );
+
+			if ( ! current_user_can( $post_type->cap->read ) ) {
+				return new WP_Error(
+					'rest_cannot_read',
+					__( 'Sorry, you are not allowed to access font families.', 'gutenberg' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+
+			return true;
+		}
 
 		/**
-	 * Retrieves the post's schema, conforming to JSON Schema.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array Item schema data.
-	 */
-	public function get_item_schema() {
-		if ( $this->schema ) {
+		 * Checks if a given request has access to a font family.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+		 */
+		public function get_item_permissions_check( $request ) {
+			$post = $this->get_post( $request['id'] );
+			if ( is_wp_error( $post ) ) {
+				return $post;
+			}
+
+			if ( ! current_user_can( 'read_post', $post->ID ) ) {
+				return new WP_Error(
+					'rest_cannot_read',
+					__( 'Sorry, you are not allowed to access this font family.', 'gutenberg' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+
+			return true;
+		}
+
+		/**
+		 * Validates settings when creating or updating a font family.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string          $value   Encoded JSON string of font family settings.
+		 * @param WP_REST_Request $request Request object.
+		 * @return false|WP_Error True if the settings are valid, otherwise a WP_Error object.
+		 */
+		public function validate_font_family_settings( $value, $request ) {
+			$settings = json_decode( $value, true );
+
+			// Check settings string is valid JSON.
+			if ( null === $settings ) {
+				return new WP_Error(
+					'rest_invalid_param',
+					__( 'font_family_settings parameter must be a valid JSON string.', 'gutenberg' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$schema   = $this->get_item_schema()['properties']['font_family_settings'];
+			$required = $schema['required'];
+
+			if ( isset( $request['id'] ) ) {
+				// Allow sending individual properties if we are updating an existing font family.
+				unset( $schema['required'] );
+
+				// But don't allow updating the slug, since it is used as a unique identifier.
+				if ( isset( $settings['slug'] ) ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						__( 'font_family_settings[slug] cannot be updated.', 'gutenberg' ),
+						array( 'status' => 400 )
+					);
+				}
+			}
+
+			// Check that the font face settings match the theme.json schema.
+			$has_valid_settings = rest_validate_value_from_schema( $settings, $schema, 'font_family_settings' );
+
+			if ( is_wp_error( $has_valid_settings ) ) {
+				$has_valid_settings->add_data( array( 'status' => 400 ) );
+				return $has_valid_settings;
+			}
+
+			// Check that none of the required settings are empty values.
+			foreach ( $required as $key ) {
+				if ( isset( $settings[ $key ] ) && ! $settings[ $key ] ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						/* translators: %s: Font family setting key. */
+						sprintf( __( 'font_family_settings[%s] cannot be empty.', 'gutenberg' ), $key ),
+						array( 'status' => 400 )
+					);
+				}
+			}
+
+			return true;
+		}
+
+		/**
+		 * Sanitizes the font family settings when creating or updating a font family.
+		 *
+		* @since 6.5.0
+		*
+		* @param string          $value   Encoded JSON string of font family settings.
+		* @param WP_REST_Request $request Request object.
+		* @return array                   Decoded array font family settings.
+		*/
+		public function sanitize_font_family_settings( $value ) {
+			$settings = json_decode( $value, true );
+
+			if ( isset( $settings['fontFamily'] ) ) {
+				$settings['fontFamily'] = WP_Font_Utils::format_font_family( $settings['fontFamily'] );
+			}
+
+			// Provide default for preview, if not provided.
+			if ( ! isset( $settings['preview'] ) ) {
+				$settings['preview'] = '';
+			}
+
+			return $settings;
+		}
+
+		/**
+		 * Creates a single font family.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function create_item( $request ) {
+			$settings = $request->get_param( 'font_family_settings' );
+
+			// Check that the font family slug is unique.
+			$query = new WP_Query(
+				array(
+					'post_type'              => $this->post_type,
+					'posts_per_page'         => 1,
+					'name'                   => $settings['slug'],
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				)
+			);
+			if ( ! empty( $query->get_posts() ) ) {
+				return new WP_Error(
+					'rest_duplicate_font_family',
+					/* translators: %s: Font family slug. */
+					sprintf( __( 'A font family with slug "%s" already exists.', 'gutenberg' ), $settings['slug'] ),
+					array( 'status' => 400 )
+				);
+			}
+
+			return parent::create_item( $request );
+		}
+
+		/**
+		 * Deletes a single font family.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function delete_item( $request ) {
+			$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+
+			// We don't support trashing for font families.
+			if ( ! $force ) {
+				return new WP_Error(
+					'rest_trash_not_supported',
+					/* translators: %s: force=true */
+					sprintf( __( "Font faces do not support trashing. Set '%s' to delete.", 'gutenberg' ), 'force=true' ),
+					array( 'status' => 501 )
+				);
+			}
+
+			return parent::delete_item( $request );
+		}
+
+		/**
+		 * Prepares a single font family output for response.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_Post         $item    Post object.
+		 * @param WP_REST_Request $request Request object.
+		 * @return WP_REST_Response Response object.
+		 */
+		public function prepare_item_for_response( $item, $request ) {
+			$fields = $this->get_fields_for_response( $request );
+			$data   = array();
+
+			if ( rest_is_field_included( 'id', $fields ) ) {
+				$data['id'] = $item->ID;
+			}
+
+			if ( rest_is_field_included( 'theme_json_version', $fields ) ) {
+				$data['theme_json_version'] = 2;
+			}
+
+			if ( rest_is_field_included( 'font_faces', $fields ) ) {
+				$data['font_faces'] = $this->get_font_face_ids( $item->ID );
+			}
+
+			if ( rest_is_field_included( 'font_family_settings', $fields ) ) {
+				$data['font_family_settings'] = $this->get_settings_from_post( $item );
+			}
+
+			$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+			$data    = $this->add_additional_fields_to_object( $data, $request );
+			$data    = $this->filter_response_by_context( $data, $context );
+
+			$response = rest_ensure_response( $data );
+
+			if ( rest_is_field_included( '_links', $fields ) ) {
+				$links = $this->prepare_links( $item );
+				$response->add_links( $links );
+			}
+
+			/**
+			 * Filters the font family data for a REST API response.
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param WP_REST_Response $response The response object.
+			 * @param WP_Post          $post     Font family post object.
+			 * @param WP_REST_Request  $request  Request object.
+			 */
+			return apply_filters( 'rest_prepare_wp_font_family', $response, $item, $request );
+		}
+
+			/**
+		 * Retrieves the post's schema, conforming to JSON Schema.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array Item schema data.
+		 */
+		public function get_item_schema() {
+			if ( $this->schema ) {
+				return $this->add_additional_fields_schema( $this->schema );
+			}
+
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => $this->post_type,
+				'type'       => 'object',
+				// Base properties for every Post.
+				'properties' => array(
+					'id'                   => array(
+						'description' => __( 'Unique identifier for the post.', 'default' ),
+						'type'        => 'integer',
+						'context'     => array( 'view', 'edit', 'embed' ),
+						'readonly'    => true,
+					),
+					'theme_json_version'   => array(
+						'description' => __( 'Version of the theme.json schema used for the typography settings.', 'gutenberg' ),
+						'type'        => 'integer',
+						'default'     => 2,
+						'minimum'     => 2,
+						'maximum'     => 2,
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+					'font_faces'           => array(
+						'description' => __( 'The IDs of the child font faces in the font family.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'view', 'edit', 'embed' ),
+						'items'       => array(
+							'type' => 'integer',
+						),
+					),
+					// Font family settings come directly from theme.json schema
+					// See https://schemas.wp.org/trunk/theme.json
+					'font_family_settings' => array(
+						'description'          => __( 'font-face declaration in theme.json format.', 'gutenberg' ),
+						'type'                 => 'object',
+						'context'              => array( 'view', 'edit', 'embed' ),
+						'properties'           => array(
+							'name'       => array(
+								'description' => 'Name of the font family preset, translatable.',
+								'type'        => 'string',
+							),
+							'slug'       => array(
+								'description' => 'Kebab-case unique identifier for the font family preset.',
+								'type'        => 'string',
+							),
+							'fontFamily' => array(
+								'description' => 'CSS font-family value.',
+								'type'        => 'string',
+							),
+							'preview'    => array(
+								'description' => 'URL to a preview image of the font family.',
+								'type'        => 'string',
+							),
+						),
+						'required'             => array( 'name', 'slug', 'fontFamily' ),
+						'additionalProperties' => false,
+					),
+				),
+			);
+
+			$this->schema = $schema;
+
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => $this->post_type,
-			'type'       => 'object',
-			// Base properties for every Post.
-			'properties' => array(
-				'id'                   => array(
-					'description' => __( 'Unique identifier for the post.', 'default' ),
-					'type'        => 'integer',
-					'context'     => array( 'view', 'edit', 'embed' ),
-					'readonly'    => true,
-				),
-				'theme_json_version'   => array(
-					'description' => __( 'Version of the theme.json schema used for the typography settings.', 'gutenberg' ),
-					'type'        => 'integer',
-					'default'     => 2,
-					'minimum'     => 2,
-					'maximum'     => 2,
-					'context'     => array( 'view', 'edit', 'embed' ),
-				),
-				'font_faces'           => array(
-					'description' => __( 'The IDs of the child font faces in the font family.', 'gutenberg' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit', 'embed' ),
-					'items'       => array(
-						'type' => 'integer',
-					),
-				),
-				// Font family settings come directly from theme.json schema
-				// See https://schemas.wp.org/trunk/theme.json
-				'font_family_settings' => array(
-					'description'          => __( 'font-face declaration in theme.json format.', 'gutenberg' ),
-					'type'                 => 'object',
-					'context'              => array( 'view', 'edit', 'embed' ),
-					'properties'           => array(
-						'name'       => array(
-							'description' => 'Name of the font family preset, translatable.',
-							'type'        => 'string',
-						),
-						'slug'       => array(
-							'description' => 'Kebab-case unique identifier for the font family preset.',
-							'type'        => 'string',
-						),
-						'fontFamily' => array(
-							'description' => 'CSS font-family value.',
-							'type'        => 'string',
-						),
-						'preview'    => array(
-							'description' => 'URL to a preview image of the font family.',
-							'type'        => 'string',
-						),
-					),
-					'required'             => array( 'name', 'slug', 'fontFamily' ),
-					'additionalProperties' => false,
-				),
-			),
-		);
-
-		$this->schema = $schema;
-
-		return $this->add_additional_fields_schema( $this->schema );
-	}
-
-	/**
-	 * Retrieves the query params for the font family collection.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array Collection parameters.
-	 */
-	public function get_collection_params() {
-		$query_params = parent::get_collection_params();
-
-		// Remove unneeded params.
-		unset( $query_params['after'] );
-		unset( $query_params['modified_after'] );
-		unset( $query_params['before'] );
-		unset( $query_params['modified_before'] );
-		unset( $query_params['search'] );
-		unset( $query_params['search_columns'] );
-		unset( $query_params['status'] );
-
-		$query_params['orderby']['default'] = 'id';
-		$query_params['orderby']['enum']    = array( 'id', 'include' );
-
 		/**
-		 * Filters collection parameters for the font family controller.
+		 * Retrieves the query params for the font family collection.
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param array $query_params JSON Schema-formatted collection parameters.
+		 * @return array Collection parameters.
 		 */
-		return apply_filters( 'rest_wp_font_family_collection_params', $query_params );
-	}
+		public function get_collection_params() {
+			$query_params = parent::get_collection_params();
 
-	/**
-	 * Get the arguments used when creating or updating a font family.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return array Font family create/edit arguments.
-	 */
-	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
-		if ( WP_REST_Server::CREATABLE === $method || WP_REST_Server::EDITABLE === $method ) {
-			$properties = $this->get_item_schema()['properties'];
-			return array(
-				'theme_json_version'   => $properties['theme_json_version'],
-				// When creating or updating, font_family_settings is stringified JSON, to work with multipart/form-data.
-				// Font families don't currently support file uploads, but may accept preview files in the future.
-				'font_family_settings' => array(
-					'description'       => __( 'font-family declaration in theme.json format, encoded as a string.', 'gutenberg' ),
-					'type'              => 'string',
-					'required'          => true,
-					'validate_callback' => array( $this, 'validate_font_family_settings' ),
-					'sanitize_callback' => array( $this, 'sanitize_font_family_settings' ),
-				),
-			);
+			// Remove unneeded params.
+			unset( $query_params['after'] );
+			unset( $query_params['modified_after'] );
+			unset( $query_params['before'] );
+			unset( $query_params['modified_before'] );
+			unset( $query_params['search'] );
+			unset( $query_params['search_columns'] );
+			unset( $query_params['status'] );
+
+			$query_params['orderby']['default'] = 'id';
+			$query_params['orderby']['enum']    = array( 'id', 'include' );
+
+			/**
+			 * Filters collection parameters for the font family controller.
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param array $query_params JSON Schema-formatted collection parameters.
+			 */
+			return apply_filters( 'rest_wp_font_family_collection_params', $query_params );
 		}
 
-		return parent::get_endpoint_args_for_item_schema( $method );
-	}
-
-	/**
-	 * Get the child font face post IDs.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param int $font_family_id Font family post ID.
-	 * @return int[] Array of child font face post IDs.
-	 * .
-	 */
-	protected function get_font_face_ids( $font_family_id ) {
-		$query = new WP_Query(
-			array(
-				'fields'                 => 'ids',
-				'post_parent'            => $font_family_id,
-				'post_type'              => 'wp_font_face',
-				'posts_per_page'         => 99,
-				'order'                  => 'ASC',
-				'orderby'                => 'id',
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-			)
-		);
-
-		return $query->get_posts();
-	}
-
-	/**
-	 * Prepares font family links for the request.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_Post $post Post object.
-	 * @return array Links for the given post.
-	 */
-	protected function prepare_links( $post ) {
-		// Entity meta.
-		$links = parent::prepare_links( $post );
-
-		return array(
-			'self'       => $links['self'],
-			'collection' => $links['collection'],
-			'font_faces' => $this->prepare_font_face_links( $post->ID ),
-		);
-	}
-
-	/**
-	 * Prepares child font face links for the request.
-	 *
-	 * @param int $font_family_id Font family post ID.
-	 * @return array Links for the child font face posts.
-	 */
-	protected function prepare_font_face_links( $font_family_id ) {
-		$font_face_ids = $this->get_font_face_ids( $font_family_id );
-		$links         = array();
-		foreach ( $font_face_ids as $font_face_id ) {
-			$links[] = array(
-				'embeddable' => true,
-				'href'       => rest_url( $this->namespace . '/' . $this->rest_base . '/' . $font_family_id . '/font-faces/' . $font_face_id ),
-			);
-		}
-		return $links;
-	}
-
-	/**
-	 * Prepares a single font family post for create or update.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return stdClass|WP_Error Post object or WP_Error.
-	 */
-	protected function prepare_item_for_database( $request ) {
-		$prepared_post = new stdClass();
-		// Settings have already been decoded by ::sanitize_font_family_settings().
-		$settings = $request->get_param( 'font_family_settings' );
-
-		// This is an update and we merge with the existing font family.
-		if ( isset( $request['id'] ) ) {
-			$existing_post = $this->get_post( $request['id'] );
-			if ( is_wp_error( $existing_post ) ) {
-				return $existing_post;
+		/**
+		 * Get the arguments used when creating or updating a font family.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array Font family create/edit arguments.
+		 */
+		public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
+			if ( WP_REST_Server::CREATABLE === $method || WP_REST_Server::EDITABLE === $method ) {
+				$properties = $this->get_item_schema()['properties'];
+				return array(
+					'theme_json_version'   => $properties['theme_json_version'],
+					// When creating or updating, font_family_settings is stringified JSON, to work with multipart/form-data.
+					// Font families don't currently support file uploads, but may accept preview files in the future.
+					'font_family_settings' => array(
+						'description'       => __( 'font-family declaration in theme.json format, encoded as a string.', 'gutenberg' ),
+						'type'              => 'string',
+						'required'          => true,
+						'validate_callback' => array( $this, 'validate_font_family_settings' ),
+						'sanitize_callback' => array( $this, 'sanitize_font_family_settings' ),
+					),
+				);
 			}
 
-			$prepared_post->ID = $existing_post->ID;
-			$existing_settings = $this->get_settings_from_post( $existing_post );
-			$settings          = array_merge( $existing_settings, $settings );
+			return parent::get_endpoint_args_for_item_schema( $method );
 		}
 
-		$prepared_post->post_type   = $this->post_type;
-		$prepared_post->post_status = 'publish';
-		$prepared_post->post_title  = $settings['name'];
-		$prepared_post->post_name   = sanitize_title( $settings['slug'] );
+		/**
+		 * Get the child font face post IDs.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param int $font_family_id Font family post ID.
+		 * @return int[] Array of child font face post IDs.
+		 * .
+		 */
+		protected function get_font_face_ids( $font_family_id ) {
+			$query = new WP_Query(
+				array(
+					'fields'                 => 'ids',
+					'post_parent'            => $font_family_id,
+					'post_type'              => 'wp_font_face',
+					'posts_per_page'         => 99,
+					'order'                  => 'ASC',
+					'orderby'                => 'id',
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				)
+			);
 
-		// Remove duplicate information from settings.
-		unset( $settings['name'] );
-		unset( $settings['slug'] );
+			return $query->get_posts();
+		}
 
-		$prepared_post->post_content = wp_json_encode( $settings );
+		/**
+		 * Prepares font family links for the request.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_Post $post Post object.
+		 * @return array Links for the given post.
+		 */
+		protected function prepare_links( $post ) {
+			// Entity meta.
+			$links = parent::prepare_links( $post );
 
-		return $prepared_post;
-	}
+			return array(
+				'self'       => $links['self'],
+				'collection' => $links['collection'],
+				'font_faces' => $this->prepare_font_face_links( $post->ID ),
+			);
+		}
 
-	/**
-	 * Gets the font family's settings from the post.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param WP_Post $post Font family post object.
-	 * @return array Font family settings array.
-	 */
-	protected function get_settings_from_post( $post ) {
-		$settings_json = json_decode( $post->post_content, true );
+		/**
+		 * Prepares child font face links for the request.
+		 *
+		 * @param int $font_family_id Font family post ID.
+		 * @return array Links for the child font face posts.
+		 */
+		protected function prepare_font_face_links( $font_family_id ) {
+			$font_face_ids = $this->get_font_face_ids( $font_family_id );
+			$links         = array();
+			foreach ( $font_face_ids as $font_face_id ) {
+				$links[] = array(
+					'embeddable' => true,
+					'href'       => rest_url( $this->namespace . '/' . $this->rest_base . '/' . $font_family_id . '/font-faces/' . $font_face_id ),
+				);
+			}
+			return $links;
+		}
 
-		// Default to empty strings if the settings are missing.
-		return array(
-			'name'       => isset( $post->post_title ) && $post->post_title ? $post->post_title : '',
-			'slug'       => isset( $post->post_name ) && $post->post_name ? $post->post_name : '',
-			'fontFamily' => isset( $settings_json['fontFamily'] ) && $settings_json['fontFamily'] ? $settings_json['fontFamily'] : '',
-			'preview'    => isset( $settings_json['preview'] ) && $settings_json['preview'] ? $settings_json['preview'] : '',
-		);
+		/**
+		 * Prepares a single font family post for create or update.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_REST_Request $request Request object.
+		 * @return stdClass|WP_Error Post object or WP_Error.
+		 */
+		protected function prepare_item_for_database( $request ) {
+			$prepared_post = new stdClass();
+			// Settings have already been decoded by ::sanitize_font_family_settings().
+			$settings = $request->get_param( 'font_family_settings' );
+
+			// This is an update and we merge with the existing font family.
+			if ( isset( $request['id'] ) ) {
+				$existing_post = $this->get_post( $request['id'] );
+				if ( is_wp_error( $existing_post ) ) {
+					return $existing_post;
+				}
+
+				$prepared_post->ID = $existing_post->ID;
+				$existing_settings = $this->get_settings_from_post( $existing_post );
+				$settings          = array_merge( $existing_settings, $settings );
+			}
+
+			$prepared_post->post_type   = $this->post_type;
+			$prepared_post->post_status = 'publish';
+			$prepared_post->post_title  = $settings['name'];
+			$prepared_post->post_name   = sanitize_title( $settings['slug'] );
+
+			// Remove duplicate information from settings.
+			unset( $settings['name'] );
+			unset( $settings['slug'] );
+
+			$prepared_post->post_content = wp_json_encode( $settings );
+
+			return $prepared_post;
+		}
+
+		/**
+		 * Gets the font family's settings from the post.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_Post $post Font family post object.
+		 * @return array Font family settings array.
+		 */
+		protected function get_settings_from_post( $post ) {
+			$settings_json = json_decode( $post->post_content, true );
+
+			// Default to empty strings if the settings are missing.
+			return array(
+				'name'       => isset( $post->post_title ) && $post->post_title ? $post->post_title : '',
+				'slug'       => isset( $post->post_name ) && $post->post_name ? $post->post_name : '',
+				'fontFamily' => isset( $settings_json['fontFamily'] ) && $settings_json['fontFamily'] ? $settings_json['fontFamily'] : '',
+				'preview'    => isset( $settings_json['preview'] ) && $settings_json['preview'] ? $settings_json['preview'] : '',
+			);
+		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -7,163 +7,162 @@
  * @package Gutenberg
  */
 
-if ( class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
-	return;
-}
-
-/**
- * Holds, sanitizes, processes and prints CSS declarations for the Style Engine.
- *
- * @access private
- */
-class WP_Style_Engine_CSS_Declarations {
-	/**
-	 * An array of CSS declarations (property => value pairs).
-	 *
-	 * @var array
-	 */
-	protected $declarations = array();
+if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 
 	/**
-	 * Constructor for this object.
+	 * Holds, sanitizes, processes and prints CSS declarations for the Style Engine.
 	 *
-	 * If a `$declarations` array is passed, it will be used to populate
-	 * the initial $declarations prop of the object by calling add_declarations().
-	 *
-	 * @param string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+	 * @access private
 	 */
-	public function __construct( $declarations = array() ) {
-		$this->add_declarations( $declarations );
-	}
+	class WP_Style_Engine_CSS_Declarations {
+		/**
+		 * An array of CSS declarations (property => value pairs).
+		 *
+		 * @var array
+		 */
+		protected $declarations = array();
 
-	/**
-	 * Adds a single declaration.
-	 *
-	 * @param string $property The CSS property.
-	 * @param string $value    The CSS value.
-	 *
-	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
-	 */
-	public function add_declaration( $property, $value ) {
-		// Sanitizes the property.
-		$property = $this->sanitize_property( $property );
-		// Bails early if the property is empty.
-		if ( empty( $property ) ) {
-			return $this;
+		/**
+		 * Constructor for this object.
+		 *
+		 * If a `$declarations` array is passed, it will be used to populate
+		 * the initial $declarations prop of the object by calling add_declarations().
+		 *
+		 * @param string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 */
+		public function __construct( $declarations = array() ) {
+			$this->add_declarations( $declarations );
 		}
 
-		// Trims the value. If empty, bail early.
-		$value = trim( $value );
-		if ( '' === $value ) {
-			return $this;
-		}
-
-		// Adds the declaration property/value pair.
-		$this->declarations[ $property ] = $value;
-
-		return $this;
-	}
-
-	/**
-	 * Removes a single declaration.
-	 *
-	 * @param string $property The CSS property.
-	 *
-	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
-	 */
-	public function remove_declaration( $property ) {
-		unset( $this->declarations[ $property ] );
-		return $this;
-	}
-
-	/**
-	 * Adds multiple declarations.
-	 *
-	 * @param array $declarations An array of declarations.
-	 *
-	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
-	 */
-	public function add_declarations( $declarations ) {
-		foreach ( $declarations as $property => $value ) {
-			$this->add_declaration( $property, $value );
-		}
-		return $this;
-	}
-
-	/**
-	 * Removes multiple declarations.
-	 *
-	 * @param array $properties An array of properties.
-	 *
-	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
-	 */
-	public function remove_declarations( $properties = array() ) {
-		foreach ( $properties as $property ) {
-			$this->remove_declaration( $property );
-		}
-		return $this;
-	}
-
-	/**
-	 * Gets the declarations array.
-	 *
-	 * @return array
-	 */
-	public function get_declarations() {
-		return $this->declarations;
-	}
-
-	/**
-	 * Filters a CSS property + value pair.
-	 *
-	 * @param string $property The CSS property.
-	 * @param string $value    The value to be filtered.
-	 * @param string $spacer   The spacer between the colon and the value. Defaults to an empty string.
-	 *
-	 * @return string The filtered declaration or an empty string.
-	 */
-	protected static function filter_declaration( $property, $value, $spacer = '' ) {
-		$filtered_value = wp_strip_all_tags( $value, true );
-
-		if ( '' !== $filtered_value ) {
-			return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
-		}
-		return '';
-	}
-
-	/**
-	 * Filters and compiles the CSS declarations.
-	 *
-	 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
-	 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
-	 *
-	 * @return string The CSS declarations.
-	 */
-	public function get_declarations_string( $should_prettify = false, $indent_count = 0 ) {
-		$declarations_array  = $this->get_declarations();
-		$declarations_output = '';
-		$indent              = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
-		$suffix              = $should_prettify ? ' ' : '';
-		$suffix              = $should_prettify && $indent_count > 0 ? "\n" : $suffix;
-		$spacer              = $should_prettify ? ' ' : '';
-
-		foreach ( $declarations_array as $property => $value ) {
-			$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
-			if ( $filtered_declaration ) {
-				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
+		/**
+		 * Adds a single declaration.
+		 *
+		 * @param string $property The CSS property.
+		 * @param string $value    The CSS value.
+		 *
+		 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
+		 */
+		public function add_declaration( $property, $value ) {
+			// Sanitizes the property.
+			$property = $this->sanitize_property( $property );
+			// Bails early if the property is empty.
+			if ( empty( $property ) ) {
+				return $this;
 			}
-		}
-		return rtrim( $declarations_output );
-	}
 
-	/**
-	 * Sanitizes property names.
-	 *
-	 * @param string $property The CSS property.
-	 *
-	 * @return string The sanitized property name.
-	 */
-	protected function sanitize_property( $property ) {
-		return sanitize_key( $property );
+			// Trims the value. If empty, bail early.
+			$value = trim( $value );
+			if ( '' === $value ) {
+				return $this;
+			}
+
+			// Adds the declaration property/value pair.
+			$this->declarations[ $property ] = $value;
+
+			return $this;
+		}
+
+		/**
+		 * Removes a single declaration.
+		 *
+		 * @param string $property The CSS property.
+		 *
+		 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
+		 */
+		public function remove_declaration( $property ) {
+			unset( $this->declarations[ $property ] );
+			return $this;
+		}
+
+		/**
+		 * Adds multiple declarations.
+		 *
+		 * @param array $declarations An array of declarations.
+		 *
+		 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
+		 */
+		public function add_declarations( $declarations ) {
+			foreach ( $declarations as $property => $value ) {
+				$this->add_declaration( $property, $value );
+			}
+			return $this;
+		}
+
+		/**
+		 * Removes multiple declarations.
+		 *
+		 * @param array $properties An array of properties.
+		 *
+		 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
+		 */
+		public function remove_declarations( $properties = array() ) {
+			foreach ( $properties as $property ) {
+				$this->remove_declaration( $property );
+			}
+			return $this;
+		}
+
+		/**
+		 * Gets the declarations array.
+		 *
+		 * @return array
+		 */
+		public function get_declarations() {
+			return $this->declarations;
+		}
+
+		/**
+		 * Filters a CSS property + value pair.
+		 *
+		 * @param string $property The CSS property.
+		 * @param string $value    The value to be filtered.
+		 * @param string $spacer   The spacer between the colon and the value. Defaults to an empty string.
+		 *
+		 * @return string The filtered declaration or an empty string.
+		 */
+		protected static function filter_declaration( $property, $value, $spacer = '' ) {
+			$filtered_value = wp_strip_all_tags( $value, true );
+
+			if ( '' !== $filtered_value ) {
+				return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
+			}
+			return '';
+		}
+
+		/**
+		 * Filters and compiles the CSS declarations.
+		 *
+		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
+		 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+		 *
+		 * @return string The CSS declarations.
+		 */
+		public function get_declarations_string( $should_prettify = false, $indent_count = 0 ) {
+			$declarations_array  = $this->get_declarations();
+			$declarations_output = '';
+			$indent              = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
+			$suffix              = $should_prettify ? ' ' : '';
+			$suffix              = $should_prettify && $indent_count > 0 ? "\n" : $suffix;
+			$spacer              = $should_prettify ? ' ' : '';
+
+			foreach ( $declarations_array as $property => $value ) {
+				$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
+				if ( $filtered_declaration ) {
+					$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
+				}
+			}
+			return rtrim( $declarations_output );
+		}
+
+		/**
+		 * Sanitizes property names.
+		 *
+		 * @param string $property The CSS property.
+		 *
+		 * @return string The sanitized property name.
+		 */
+		protected function sanitize_property( $property ) {
+			return sanitize_key( $property );
+		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -7,121 +7,120 @@
  * @package Gutenberg
  */
 
-if ( class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
-	return;
-}
-
-/**
- * Holds, sanitizes, processes and prints CSS declarations for the Style Engine.
- *
- * @access private
- */
-class WP_Style_Engine_CSS_Rule {
+if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 
 	/**
-	 * The selector.
+	 * Holds, sanitizes, processes and prints CSS declarations for the Style Engine.
 	 *
-	 * @var string
+	 * @access private
 	 */
-	protected $selector;
+	class WP_Style_Engine_CSS_Rule {
 
-	/**
-	 * The selector declarations.
-	 *
-	 * Contains a WP_Style_Engine_CSS_Declarations object.
-	 *
-	 * @var WP_Style_Engine_CSS_Declarations
-	 */
-	protected $declarations;
+		/**
+		 * The selector.
+		 *
+		 * @var string
+		 */
+		protected $selector;
 
-	/**
-	 * Constructor
-	 *
-	 * @param string                                    $selector     The CSS selector.
-	 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
-	 *                                                                or a WP_Style_Engine_CSS_Declarations object.
-	 */
-	public function __construct( $selector = '', $declarations = array() ) {
-		$this->set_selector( $selector );
-		$this->add_declarations( $declarations );
-	}
+		/**
+		 * The selector declarations.
+		 *
+		 * Contains a WP_Style_Engine_CSS_Declarations object.
+		 *
+		 * @var WP_Style_Engine_CSS_Declarations
+		 */
+		protected $declarations;
 
-	/**
-	 * Sets the selector.
-	 *
-	 * @param string $selector The CSS selector.
-	 *
-	 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
-	 */
-	public function set_selector( $selector ) {
-		$this->selector = $selector;
-		return $this;
-	}
+		/**
+		 * Constructor
+		 *
+		 * @param string                                    $selector     The CSS selector.
+		 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
+		 *                                                                or a WP_Style_Engine_CSS_Declarations object.
+		 */
+		public function __construct( $selector = '', $declarations = array() ) {
+			$this->set_selector( $selector );
+			$this->add_declarations( $declarations );
+		}
 
-	/**
-	 * Sets the declarations.
-	 *
-	 * @param array|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
-	 *                                                             or a WP_Style_Engine_CSS_Declarations object.
-	 *
-	 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
-	 */
-	public function add_declarations( $declarations ) {
-		$is_declarations_object = ! is_array( $declarations );
-		$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
+		/**
+		 * Sets the selector.
+		 *
+		 * @param string $selector The CSS selector.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
+		 */
+		public function set_selector( $selector ) {
+			$this->selector = $selector;
+			return $this;
+		}
 
-		if ( null === $this->declarations ) {
-			if ( $is_declarations_object ) {
-				$this->declarations = $declarations;
-				return $this;
+		/**
+		 * Sets the declarations.
+		 *
+		 * @param array|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
+		 *                                                             or a WP_Style_Engine_CSS_Declarations object.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
+		 */
+		public function add_declarations( $declarations ) {
+			$is_declarations_object = ! is_array( $declarations );
+			$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
+
+			if ( null === $this->declarations ) {
+				if ( $is_declarations_object ) {
+					$this->declarations = $declarations;
+					return $this;
+				}
+				$this->declarations = new WP_Style_Engine_CSS_Declarations( $declarations_array );
 			}
-			$this->declarations = new WP_Style_Engine_CSS_Declarations( $declarations_array );
-		}
-		$this->declarations->add_declarations( $declarations_array );
+			$this->declarations->add_declarations( $declarations_array );
 
-		return $this;
-	}
-
-	/**
-	 * Gets the declarations object.
-	 *
-	 * @return WP_Style_Engine_CSS_Declarations The declarations object.
-	 */
-	public function get_declarations() {
-		return $this->declarations;
-	}
-
-	/**
-	 * Gets the full selector.
-	 *
-	 * @return string
-	 */
-	public function get_selector() {
-		return $this->selector;
-	}
-
-	/**
-	 * Gets the CSS.
-	 *
-	 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
-	 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
-	 *
-	 * @return string
-	 */
-	public function get_css( $should_prettify = false, $indent_count = 0 ) {
-		$rule_indent         = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
-		$declarations_indent = $should_prettify ? $indent_count + 1 : 0;
-		$suffix              = $should_prettify ? "\n" : '';
-		$spacer              = $should_prettify ? ' ' : '';
-		// Trims any multiple selectors strings.
-		$selector         = $should_prettify ? implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) ) : $this->get_selector();
-		$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector ) : $selector;
-		$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
-
-		if ( empty( $css_declarations ) ) {
-			return '';
+			return $this;
 		}
 
-		return "{$rule_indent}{$selector}{$spacer}{{$suffix}{$css_declarations}{$suffix}{$rule_indent}}";
+		/**
+		 * Gets the declarations object.
+		 *
+		 * @return WP_Style_Engine_CSS_Declarations The declarations object.
+		 */
+		public function get_declarations() {
+			return $this->declarations;
+		}
+
+		/**
+		 * Gets the full selector.
+		 *
+		 * @return string
+		 */
+		public function get_selector() {
+			return $this->selector;
+		}
+
+		/**
+		 * Gets the CSS.
+		 *
+		 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
+		 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+		 *
+		 * @return string
+		 */
+		public function get_css( $should_prettify = false, $indent_count = 0 ) {
+			$rule_indent         = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
+			$declarations_indent = $should_prettify ? $indent_count + 1 : 0;
+			$suffix              = $should_prettify ? "\n" : '';
+			$spacer              = $should_prettify ? ' ' : '';
+			// Trims any multiple selectors strings.
+			$selector         = $should_prettify ? implode( ',', array_map( 'trim', explode( ',', $this->get_selector() ) ) ) : $this->get_selector();
+			$selector         = $should_prettify ? str_replace( array( ',' ), ",\n", $selector ) : $selector;
+			$css_declarations = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
+
+			if ( empty( $css_declarations ) ) {
+				return '';
+			}
+
+			return "{$rule_indent}{$selector}{$spacer}{{$suffix}{$css_declarations}{$suffix}{$rule_indent}}";
+		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -7,138 +7,137 @@
  * @package Gutenberg
  */
 
-if ( class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
-	return;
-}
-
-/**
- * Holds, sanitizes, processes and prints CSS declarations for the Style Engine.
- *
- * @access private
- */
-class WP_Style_Engine_CSS_Rules_Store {
+if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 
 	/**
-	 * An array of named WP_Style_Engine_CSS_Rules_Store objects.
+	 * Holds, sanitizes, processes and prints CSS declarations for the Style Engine.
 	 *
-	 * @static
-	 *
-	 * @var WP_Style_Engine_CSS_Rules_Store[]
+	 * @access private
 	 */
-	protected static $stores = array();
+	class WP_Style_Engine_CSS_Rules_Store {
 
-	/**
-	 * The store name.
-	 *
-	 * @var string
-	 */
-	protected $name = '';
+		/**
+		 * An array of named WP_Style_Engine_CSS_Rules_Store objects.
+		 *
+		 * @static
+		 *
+		 * @var WP_Style_Engine_CSS_Rules_Store[]
+		 */
+		protected static $stores = array();
 
-	/**
-	 * An array of CSS Rules objects assigned to the store.
-	 *
-	 * @var WP_Style_Engine_CSS_Rule[]
-	 */
-	protected $rules = array();
+		/**
+		 * The store name.
+		 *
+		 * @var string
+		 */
+		protected $name = '';
 
-	/**
-	 * Gets an instance of the store.
-	 *
-	 * @param string $store_name The name of the store.
-	 *
-	 * @return WP_Style_Engine_CSS_Rules_Store|void
-	 */
-	public static function get_store( $store_name = 'default' ) {
-		if ( ! is_string( $store_name ) || empty( $store_name ) ) {
-			return;
-		}
-		if ( ! isset( static::$stores[ $store_name ] ) ) {
-			static::$stores[ $store_name ] = new static();
-			// Set the store name.
-			static::$stores[ $store_name ]->set_name( $store_name );
-		}
-		return static::$stores[ $store_name ];
-	}
+		/**
+		 * An array of CSS Rules objects assigned to the store.
+		 *
+		 * @var WP_Style_Engine_CSS_Rule[]
+		 */
+		protected $rules = array();
 
-	/**
-	 * Gets an array of all available stores.
-	 *
-	 * @return WP_Style_Engine_CSS_Rules_Store[]
-	 */
-	public static function get_stores() {
-		return static::$stores;
-	}
-
-	/**
-	 * Clears all stores from static::$stores.
-	 *
-	 * @return void
-	 */
-	public static function remove_all_stores() {
-		static::$stores = array();
-	}
-
-	/**
-	 * Sets the store name.
-	 *
-	 * @param string $name The store name.
-	 *
-	 * @return void
-	 */
-	public function set_name( $name ) {
-		$this->name = $name;
-	}
-
-	/**
-	 * Gets the store name.
-	 *
-	 * @return string
-	 */
-	public function get_name() {
-		return $this->name;
-	}
-
-	/**
-	 * Gets an array of all rules.
-	 *
-	 * @return WP_Style_Engine_CSS_Rule[]
-	 */
-	public function get_all_rules() {
-		return $this->rules;
-	}
-
-	/**
-	 * Gets a WP_Style_Engine_CSS_Rule object by its selector.
-	 * If the rule does not exist, it will be created.
-	 *
-	 * @param string $selector The CSS selector.
-	 *
-	 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
-	 */
-	public function add_rule( $selector ) {
-		$selector = trim( $selector );
-
-		// Bail early if there is no selector.
-		if ( empty( $selector ) ) {
-			return;
+		/**
+		 * Gets an instance of the store.
+		 *
+		 * @param string $store_name The name of the store.
+		 *
+		 * @return WP_Style_Engine_CSS_Rules_Store|void
+		 */
+		public static function get_store( $store_name = 'default' ) {
+			if ( ! is_string( $store_name ) || empty( $store_name ) ) {
+				return;
+			}
+			if ( ! isset( static::$stores[ $store_name ] ) ) {
+				static::$stores[ $store_name ] = new static();
+				// Set the store name.
+				static::$stores[ $store_name ]->set_name( $store_name );
+			}
+			return static::$stores[ $store_name ];
 		}
 
-		// Create the rule if it doesn't exist.
-		if ( empty( $this->rules[ $selector ] ) ) {
-			$this->rules[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
+		/**
+		 * Gets an array of all available stores.
+		 *
+		 * @return WP_Style_Engine_CSS_Rules_Store[]
+		 */
+		public static function get_stores() {
+			return static::$stores;
 		}
 
-		return $this->rules[ $selector ];
-	}
+		/**
+		 * Clears all stores from static::$stores.
+		 *
+		 * @return void
+		 */
+		public static function remove_all_stores() {
+			static::$stores = array();
+		}
 
-	/**
-	 * Removes a selector from the store.
-	 *
-	 * @param string $selector The CSS selector.
-	 *
-	 * @return void
-	 */
-	public function remove_rule( $selector ) {
-		unset( $this->rules[ $selector ] );
+		/**
+		 * Sets the store name.
+		 *
+		 * @param string $name The store name.
+		 *
+		 * @return void
+		 */
+		public function set_name( $name ) {
+			$this->name = $name;
+		}
+
+		/**
+		 * Gets the store name.
+		 *
+		 * @return string
+		 */
+		public function get_name() {
+			return $this->name;
+		}
+
+		/**
+		 * Gets an array of all rules.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule[]
+		 */
+		public function get_all_rules() {
+			return $this->rules;
+		}
+
+		/**
+		 * Gets a WP_Style_Engine_CSS_Rule object by its selector.
+		 * If the rule does not exist, it will be created.
+		 *
+		 * @param string $selector The CSS selector.
+		 *
+		 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
+		 */
+		public function add_rule( $selector ) {
+			$selector = trim( $selector );
+
+			// Bail early if there is no selector.
+			if ( empty( $selector ) ) {
+				return;
+			}
+
+			// Create the rule if it doesn't exist.
+			if ( empty( $this->rules[ $selector ] ) ) {
+				$this->rules[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
+			}
+
+			return $this->rules[ $selector ];
+		}
+
+		/**
+		 * Removes a selector from the store.
+		 *
+		 * @param string $selector The CSS selector.
+		 *
+		 * @return void
+		 */
+		public function remove_rule( $selector ) {
+			unset( $this->rules[ $selector ] );
+		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -7,151 +7,150 @@
  * @package Gutenberg
  */
 
-if ( class_exists( 'WP_Style_Engine_Processor' ) ) {
-	return;
-}
-
-/**
- * Compiles styles from stores or collection of CSS rules.
- *
- * @access private
- */
-class WP_Style_Engine_Processor {
+if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 
 	/**
-	 * A collection of Style Engine Store objects.
+	 * Compiles styles from stores or collection of CSS rules.
 	 *
-	 * @var WP_Style_Engine_CSS_Rules_Store[]
+	 * @access private
 	 */
-	protected $stores = array();
+	class WP_Style_Engine_Processor {
 
-	/**
-	 * The set of CSS rules that this processor will work on.
-	 *
-	 * @var WP_Style_Engine_CSS_Rule[]
-	 */
-	protected $css_rules = array();
+		/**
+		 * A collection of Style Engine Store objects.
+		 *
+		 * @var WP_Style_Engine_CSS_Rules_Store[]
+		 */
+		protected $stores = array();
 
-	/**
-	 * Add a store to the processor.
-	 *
-	 * @param WP_Style_Engine_CSS_Rules_Store $store The store to add.
-	 *
-	 * @return WP_Style_Engine_Processor Returns the object to allow chaining methods.
-	 */
-	public function add_store( $store ) {
-		if ( ! $store instanceof WP_Style_Engine_CSS_Rules_Store ) {
-			_doing_it_wrong(
-				__METHOD__,
-				__( '$store must be an instance of WP_Style_Engine_CSS_Rules_Store', 'default' ),
-				'6.1.0'
-			);
+		/**
+		 * The set of CSS rules that this processor will work on.
+		 *
+		 * @var WP_Style_Engine_CSS_Rule[]
+		 */
+		protected $css_rules = array();
+
+		/**
+		 * Add a store to the processor.
+		 *
+		 * @param WP_Style_Engine_CSS_Rules_Store $store The store to add.
+		 *
+		 * @return WP_Style_Engine_Processor Returns the object to allow chaining methods.
+		 */
+		public function add_store( $store ) {
+			if ( ! $store instanceof WP_Style_Engine_CSS_Rules_Store ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( '$store must be an instance of WP_Style_Engine_CSS_Rules_Store', 'default' ),
+					'6.1.0'
+				);
+				return $this;
+			}
+
+			$this->stores[ $store->get_name() ] = $store;
+
 			return $this;
 		}
 
-		$this->stores[ $store->get_name() ] = $store;
-
-		return $this;
-	}
-
-	/**
-	 * Adds rules to be processed.
-	 *
-	 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[] $css_rules A single, or an array of, WP_Style_Engine_CSS_Rule objects from a store or otherwise.
-	 *
-	 * @return WP_Style_Engine_Processor Returns the object to allow chaining methods.
-	 */
-	public function add_rules( $css_rules ) {
-		if ( ! is_array( $css_rules ) ) {
-			$css_rules = array( $css_rules );
-		}
-
-		foreach ( $css_rules as $rule ) {
-			$selector = $rule->get_selector();
-			if ( isset( $this->css_rules[ $selector ] ) ) {
-				$this->css_rules[ $selector ]->add_declarations( $rule->get_declarations() );
-				continue;
-			}
-			$this->css_rules[ $rule->get_selector() ] = $rule;
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Get the CSS rules as a string.
-	 *
-	 * Since 6.4.0 Optimization is no longer the default.
-	 *
-	 * @param array $options   {
-	 *     Optional. An array of options. Default empty array.
-	 *
-	 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
-	 *     @type bool $prettify Whether to add new lines and indents to output. Default is to inherit the value of the global constant `SCRIPT_DEBUG`, if it is defined.
-	 * }
-	 *
-	 * @return string The computed CSS.
-	 */
-	public function get_css( $options = array() ) {
-		$defaults = array(
-			'optimize' => false,
-			'prettify' => SCRIPT_DEBUG,
-		);
-		$options  = wp_parse_args( $options, $defaults );
-
-		// If we have stores, get the rules from them.
-		foreach ( $this->stores as $store ) {
-			$this->add_rules( $store->get_all_rules() );
-		}
-
-		// Combine CSS selectors that have identical declarations.
-		if ( true === $options['optimize'] ) {
-			$this->combine_rules_selectors();
-		}
-
-		// Build the CSS.
-		$css = '';
-		foreach ( $this->css_rules as $rule ) {
-			$css .= $rule->get_css( $options['prettify'] );
-			$css .= $options['prettify'] ? "\n" : '';
-		}
-		return $css;
-	}
-
-	/**
-	 * Combines selectors from the rules store when they have the same styles.
-	 *
-	 * @return void
-	 */
-	private function combine_rules_selectors() {
-		// Build an array of selectors along with the JSON-ified styles to make comparisons easier.
-		$selectors_json = array();
-		foreach ( $this->css_rules as $rule ) {
-			$declarations = $rule->get_declarations()->get_declarations();
-			ksort( $declarations );
-			$selectors_json[ $rule->get_selector() ] = wp_json_encode( $declarations );
-		}
-
-		// Combine selectors that have the same styles.
-		foreach ( $selectors_json as $selector => $json ) {
-			// Get selectors that use the same styles.
-			$duplicates = array_keys( $selectors_json, $json, true );
-			// Skip if there are no duplicates.
-			if ( 1 >= count( $duplicates ) ) {
-				continue;
+		/**
+		 * Adds rules to be processed.
+		 *
+		 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[] $css_rules A single, or an array of, WP_Style_Engine_CSS_Rule objects from a store or otherwise.
+		 *
+		 * @return WP_Style_Engine_Processor Returns the object to allow chaining methods.
+		 */
+		public function add_rules( $css_rules ) {
+			if ( ! is_array( $css_rules ) ) {
+				$css_rules = array( $css_rules );
 			}
 
-			$declarations = $this->css_rules[ $selector ]->get_declarations();
-
-			foreach ( $duplicates as $key ) {
-				// Unset the duplicates from the $selectors_json array to avoid looping through them as well.
-				unset( $selectors_json[ $key ] );
-				// Remove the rules from the rules collection.
-				unset( $this->css_rules[ $key ] );
+			foreach ( $css_rules as $rule ) {
+				$selector = $rule->get_selector();
+				if ( isset( $this->css_rules[ $selector ] ) ) {
+					$this->css_rules[ $selector ]->add_declarations( $rule->get_declarations() );
+					continue;
+				}
+				$this->css_rules[ $rule->get_selector() ] = $rule;
 			}
-			// Create a new rule with the combined selectors.
-			$duplicate_selectors                     = implode( ',', $duplicates );
-			$this->css_rules[ $duplicate_selectors ] = new WP_Style_Engine_CSS_Rule( $duplicate_selectors, $declarations );
+
+			return $this;
+		}
+
+		/**
+		 * Get the CSS rules as a string.
+		 *
+		 * Since 6.4.0 Optimization is no longer the default.
+		 *
+		 * @param array $options   {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+		 *     @type bool $prettify Whether to add new lines and indents to output. Default is to inherit the value of the global constant `SCRIPT_DEBUG`, if it is defined.
+		 * }
+		 *
+		 * @return string The computed CSS.
+		 */
+		public function get_css( $options = array() ) {
+			$defaults = array(
+				'optimize' => false,
+				'prettify' => SCRIPT_DEBUG,
+			);
+			$options  = wp_parse_args( $options, $defaults );
+
+			// If we have stores, get the rules from them.
+			foreach ( $this->stores as $store ) {
+				$this->add_rules( $store->get_all_rules() );
+			}
+
+			// Combine CSS selectors that have identical declarations.
+			if ( true === $options['optimize'] ) {
+				$this->combine_rules_selectors();
+			}
+
+			// Build the CSS.
+			$css = '';
+			foreach ( $this->css_rules as $rule ) {
+				$css .= $rule->get_css( $options['prettify'] );
+				$css .= $options['prettify'] ? "\n" : '';
+			}
+			return $css;
+		}
+
+		/**
+		 * Combines selectors from the rules store when they have the same styles.
+		 *
+		 * @return void
+		 */
+		private function combine_rules_selectors() {
+			// Build an array of selectors along with the JSON-ified styles to make comparisons easier.
+			$selectors_json = array();
+			foreach ( $this->css_rules as $rule ) {
+				$declarations = $rule->get_declarations()->get_declarations();
+				ksort( $declarations );
+				$selectors_json[ $rule->get_selector() ] = wp_json_encode( $declarations );
+			}
+
+			// Combine selectors that have the same styles.
+			foreach ( $selectors_json as $selector => $json ) {
+				// Get selectors that use the same styles.
+				$duplicates = array_keys( $selectors_json, $json, true );
+				// Skip if there are no duplicates.
+				if ( 1 >= count( $duplicates ) ) {
+					continue;
+				}
+
+				$declarations = $this->css_rules[ $selector ]->get_declarations();
+
+				foreach ( $duplicates as $key ) {
+					// Unset the duplicates from the $selectors_json array to avoid looping through them as well.
+					unset( $selectors_json[ $key ] );
+					// Remove the rules from the rules collection.
+					unset( $this->css_rules[ $key ] );
+				}
+				// Create a new rule with the combined selectors.
+				$duplicate_selectors                     = implode( ',', $duplicates );
+				$this->css_rules[ $duplicate_selectors ] = new WP_Style_Engine_CSS_Rule( $duplicate_selectors, $declarations );
+			}
 		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -7,658 +7,657 @@
  * @package Gutenberg
  */
 
-if ( class_exists( 'WP_Style_Engine' ) ) {
-	return;
-}
+if ( ! class_exists( 'WP_Style_Engine' ) ) {
 
-/**
- * Class WP_Style_Engine.
- *
- * The Style Engine aims to provide a consistent API for rendering styling for blocks across both client-side and server-side applications.
- *
- * This class is for internal Core usage and is not supposed to be used by extenders (plugins and/or themes).
- * This class is final and should not be extended.
- * This is a low-level API that may need to do breaking changes. Please, use wp_style_engine_get_styles instead.
- *
- * @access private
- */
-final class WP_Style_Engine {
 	/**
-	 * Style definitions that contain the instructions to parse/output valid Gutenberg styles from a block's attributes.
+	 * Class WP_Style_Engine.
 	 *
-	 * For every style definition, the following properties are valid:
+	 * The Style Engine aims to provide a consistent API for rendering styling for blocks across both client-side and server-side applications.
 	 *
-	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
-	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
-	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
-	 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values.
-	 *                     The key should be the CSS property name that matches the second element of the preset string value,
-	 *                     i.e., "color" in var:preset|color|somePresetSlug. The value is a CSS var pattern (e.g. `--wp--preset--color--$slug`),
-	 *                     whose `$slug` fragment will be replaced with the preset slug, which is the third element of the preset string value,
-	 *                     i.e., `somePresetSlug` in var:preset|color|somePresetSlug.
-	 *  - property_keys => (array) array of keys whose values represent a valid CSS property, e.g., "margin" or "border".
-	 *  - path          => (array) a path that accesses the corresponding style value in the block style object.
-	 *  - value_func    => (string) the name of a function to generate a CSS definition array for a particular style object. The output of this function should be `array( "$property" => "$value", ... )`.
+	 * This class is for internal Core usage and is not supposed to be used by extenders (plugins and/or themes).
+	 * This class is final and should not be extended.
+	 * This is a low-level API that may need to do breaking changes. Please, use wp_style_engine_get_styles instead.
 	 *
-	 * @var array
+	 * @access private
 	 */
-	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
-		'background' => array(
-			'backgroundImage'    => array(
-				'property_keys' => array(
-					'default' => 'background-image',
-				),
-				'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
-				'path'          => array( 'background', 'backgroundImage' ),
-			),
-			'backgroundPosition' => array(
-				'property_keys' => array(
-					'default' => 'background-position',
-				),
-				'path'          => array( 'background', 'backgroundPosition' ),
-			),
-			'backgroundRepeat'   => array(
-				'property_keys' => array(
-					'default' => 'background-repeat',
-				),
-				'path'          => array( 'background', 'backgroundRepeat' ),
-			),
-			'backgroundSize'     => array(
-				'property_keys' => array(
-					'default' => 'background-size',
-				),
-				'path'          => array( 'background', 'backgroundSize' ),
-			),
-		),
-		'color'      => array(
-			'text'       => array(
-				'property_keys' => array(
-					'default' => 'color',
-				),
-				'path'          => array( 'color', 'text' ),
-				'css_vars'      => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-				'classnames'    => array(
-					'has-text-color'  => true,
-					'has-$slug-color' => 'color',
-				),
-			),
+	final class WP_Style_Engine {
+		/**
+		 * Style definitions that contain the instructions to parse/output valid Gutenberg styles from a block's attributes.
+		 *
+		 * For every style definition, the following properties are valid:
+		 *
+		 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
+		 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
+		 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
+		 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values.
+		 *                     The key should be the CSS property name that matches the second element of the preset string value,
+		 *                     i.e., "color" in var:preset|color|somePresetSlug. The value is a CSS var pattern (e.g. `--wp--preset--color--$slug`),
+		 *                     whose `$slug` fragment will be replaced with the preset slug, which is the third element of the preset string value,
+		 *                     i.e., `somePresetSlug` in var:preset|color|somePresetSlug.
+		 *  - property_keys => (array) array of keys whose values represent a valid CSS property, e.g., "margin" or "border".
+		 *  - path          => (array) a path that accesses the corresponding style value in the block style object.
+		 *  - value_func    => (string) the name of a function to generate a CSS definition array for a particular style object. The output of this function should be `array( "$property" => "$value", ... )`.
+		 *
+		 * @var array
+		 */
+		const BLOCK_STYLE_DEFINITIONS_METADATA = array(
 			'background' => array(
-				'property_keys' => array(
-					'default' => 'background-color',
+				'backgroundImage'    => array(
+					'property_keys' => array(
+						'default' => 'background-image',
+					),
+					'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
+					'path'          => array( 'background', 'backgroundImage' ),
 				),
-				'path'          => array( 'color', 'background' ),
-				'css_vars'      => array(
-					'color' => '--wp--preset--color--$slug',
+				'backgroundPosition' => array(
+					'property_keys' => array(
+						'default' => 'background-position',
+					),
+					'path'          => array( 'background', 'backgroundPosition' ),
 				),
-				'classnames'    => array(
-					'has-background'             => true,
-					'has-$slug-background-color' => 'color',
+				'backgroundRepeat'   => array(
+					'property_keys' => array(
+						'default' => 'background-repeat',
+					),
+					'path'          => array( 'background', 'backgroundRepeat' ),
 				),
-			),
-			'gradient'   => array(
-				'property_keys' => array(
-					'default' => 'background',
-				),
-				'css_vars'      => array(
-					'gradient' => '--wp--preset--gradient--$slug',
-				),
-				'path'          => array( 'color', 'gradient' ),
-				'classnames'    => array(
-					'has-background'                => true,
-					'has-$slug-gradient-background' => 'gradient',
-				),
-			),
-		),
-		'border'     => array(
-			'color'  => array(
-				'property_keys' => array(
-					'default'    => 'border-color',
-					'individual' => 'border-%s-color',
-				),
-				'path'          => array( 'border', 'color' ),
-				'classnames'    => array(
-					'has-border-color'       => true,
-					'has-$slug-border-color' => 'color',
+				'backgroundSize'     => array(
+					'property_keys' => array(
+						'default' => 'background-size',
+					),
+					'path'          => array( 'background', 'backgroundSize' ),
 				),
 			),
-			'radius' => array(
-				'property_keys' => array(
-					'default'    => 'border-radius',
-					'individual' => 'border-%s-radius',
+			'color'      => array(
+				'text'       => array(
+					'property_keys' => array(
+						'default' => 'color',
+					),
+					'path'          => array( 'color', 'text' ),
+					'css_vars'      => array(
+						'color' => '--wp--preset--color--$slug',
+					),
+					'classnames'    => array(
+						'has-text-color'  => true,
+						'has-$slug-color' => 'color',
+					),
 				),
-				'path'          => array( 'border', 'radius' ),
-			),
-			'style'  => array(
-				'property_keys' => array(
-					'default'    => 'border-style',
-					'individual' => 'border-%s-style',
+				'background' => array(
+					'property_keys' => array(
+						'default' => 'background-color',
+					),
+					'path'          => array( 'color', 'background' ),
+					'css_vars'      => array(
+						'color' => '--wp--preset--color--$slug',
+					),
+					'classnames'    => array(
+						'has-background'             => true,
+						'has-$slug-background-color' => 'color',
+					),
 				),
-				'path'          => array( 'border', 'style' ),
-			),
-			'width'  => array(
-				'property_keys' => array(
-					'default'    => 'border-width',
-					'individual' => 'border-%s-width',
-				),
-				'path'          => array( 'border', 'width' ),
-			),
-			'top'    => array(
-				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
-				'path'       => array( 'border', 'top' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'right'  => array(
-				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
-				'path'       => array( 'border', 'right' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'bottom' => array(
-				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
-				'path'       => array( 'border', 'bottom' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'left'   => array(
-				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
-				'path'       => array( 'border', 'left' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
+				'gradient'   => array(
+					'property_keys' => array(
+						'default' => 'background',
+					),
+					'css_vars'      => array(
+						'gradient' => '--wp--preset--gradient--$slug',
+					),
+					'path'          => array( 'color', 'gradient' ),
+					'classnames'    => array(
+						'has-background'                => true,
+						'has-$slug-gradient-background' => 'gradient',
+					),
 				),
 			),
-		),
-		'shadow'     => array(
-			'shadow' => array(
-				'property_keys' => array(
-					'default' => 'box-shadow',
+			'border'     => array(
+				'color'  => array(
+					'property_keys' => array(
+						'default'    => 'border-color',
+						'individual' => 'border-%s-color',
+					),
+					'path'          => array( 'border', 'color' ),
+					'classnames'    => array(
+						'has-border-color'       => true,
+						'has-$slug-border-color' => 'color',
+					),
 				),
-				'path'          => array( 'shadow' ),
-				'css_vars'      => array(
-					'shadow' => '--wp--preset--shadow--$slug',
+				'radius' => array(
+					'property_keys' => array(
+						'default'    => 'border-radius',
+						'individual' => 'border-%s-radius',
+					),
+					'path'          => array( 'border', 'radius' ),
 				),
-			),
-		),
-		'dimensions' => array(
-			'aspectRatio' => array(
-				'property_keys' => array(
-					'default' => 'aspect-ratio',
+				'style'  => array(
+					'property_keys' => array(
+						'default'    => 'border-style',
+						'individual' => 'border-%s-style',
+					),
+					'path'          => array( 'border', 'style' ),
 				),
-				'path'          => array( 'dimensions', 'aspectRatio' ),
-				'classnames'    => array(
-					'has-aspect-ratio' => true,
+				'width'  => array(
+					'property_keys' => array(
+						'default'    => 'border-width',
+						'individual' => 'border-%s-width',
+					),
+					'path'          => array( 'border', 'width' ),
 				),
-			),
-			'minHeight'   => array(
-				'property_keys' => array(
-					'default' => 'min-height',
+				'top'    => array(
+					'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+					'path'       => array( 'border', 'top' ),
+					'css_vars'   => array(
+						'color' => '--wp--preset--color--$slug',
+					),
 				),
-				'path'          => array( 'dimensions', 'minHeight' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
+				'right'  => array(
+					'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+					'path'       => array( 'border', 'right' ),
+					'css_vars'   => array(
+						'color' => '--wp--preset--color--$slug',
+					),
 				),
-			),
-		),
-		'spacing'    => array(
-			'padding' => array(
-				'property_keys' => array(
-					'default'    => 'padding',
-					'individual' => 'padding-%s',
+				'bottom' => array(
+					'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+					'path'       => array( 'border', 'bottom' ),
+					'css_vars'   => array(
+						'color' => '--wp--preset--color--$slug',
+					),
 				),
-				'path'          => array( 'spacing', 'padding' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
-				),
-			),
-			'margin'  => array(
-				'property_keys' => array(
-					'default'    => 'margin',
-					'individual' => 'margin-%s',
-				),
-				'path'          => array( 'spacing', 'margin' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
-				),
-			),
-		),
-		'typography' => array(
-			'fontSize'       => array(
-				'property_keys' => array(
-					'default' => 'font-size',
-				),
-				'css_vars'      => array(
-					'font-size' => '--wp--preset--font-size--$slug',
-				),
-				'path'          => array( 'typography', 'fontSize' ),
-				'classnames'    => array(
-					'has-$slug-font-size' => 'font-size',
+				'left'   => array(
+					'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+					'path'       => array( 'border', 'left' ),
+					'css_vars'   => array(
+						'color' => '--wp--preset--color--$slug',
+					),
 				),
 			),
-			'fontFamily'     => array(
-				'property_keys' => array(
-					'default' => 'font-family',
-				),
-				'css_vars'      => array(
-					'font-family' => '--wp--preset--font-family--$slug',
-				),
-				'path'          => array( 'typography', 'fontFamily' ),
-				'classnames'    => array(
-					'has-$slug-font-family' => 'font-family',
+			'shadow'     => array(
+				'shadow' => array(
+					'property_keys' => array(
+						'default' => 'box-shadow',
+					),
+					'path'          => array( 'shadow' ),
+					'css_vars'      => array(
+						'shadow' => '--wp--preset--shadow--$slug',
+					),
 				),
 			),
-			'fontStyle'      => array(
-				'property_keys' => array(
-					'default' => 'font-style',
+			'dimensions' => array(
+				'aspectRatio' => array(
+					'property_keys' => array(
+						'default' => 'aspect-ratio',
+					),
+					'path'          => array( 'dimensions', 'aspectRatio' ),
+					'classnames'    => array(
+						'has-aspect-ratio' => true,
+					),
 				),
-				'path'          => array( 'typography', 'fontStyle' ),
-			),
-			'fontWeight'     => array(
-				'property_keys' => array(
-					'default' => 'font-weight',
+				'minHeight'   => array(
+					'property_keys' => array(
+						'default' => 'min-height',
+					),
+					'path'          => array( 'dimensions', 'minHeight' ),
+					'css_vars'      => array(
+						'spacing' => '--wp--preset--spacing--$slug',
+					),
 				),
-				'path'          => array( 'typography', 'fontWeight' ),
 			),
-			'lineHeight'     => array(
-				'property_keys' => array(
-					'default' => 'line-height',
+			'spacing'    => array(
+				'padding' => array(
+					'property_keys' => array(
+						'default'    => 'padding',
+						'individual' => 'padding-%s',
+					),
+					'path'          => array( 'spacing', 'padding' ),
+					'css_vars'      => array(
+						'spacing' => '--wp--preset--spacing--$slug',
+					),
 				),
-				'path'          => array( 'typography', 'lineHeight' ),
-			),
-			'textColumns'    => array(
-				'property_keys' => array(
-					'default' => 'column-count',
+				'margin'  => array(
+					'property_keys' => array(
+						'default'    => 'margin',
+						'individual' => 'margin-%s',
+					),
+					'path'          => array( 'spacing', 'margin' ),
+					'css_vars'      => array(
+						'spacing' => '--wp--preset--spacing--$slug',
+					),
 				),
-				'path'          => array( 'typography', 'textColumns' ),
 			),
-			'textDecoration' => array(
-				'property_keys' => array(
-					'default' => 'text-decoration',
+			'typography' => array(
+				'fontSize'       => array(
+					'property_keys' => array(
+						'default' => 'font-size',
+					),
+					'css_vars'      => array(
+						'font-size' => '--wp--preset--font-size--$slug',
+					),
+					'path'          => array( 'typography', 'fontSize' ),
+					'classnames'    => array(
+						'has-$slug-font-size' => 'font-size',
+					),
 				),
-				'path'          => array( 'typography', 'textDecoration' ),
-			),
-			'textTransform'  => array(
-				'property_keys' => array(
-					'default' => 'text-transform',
+				'fontFamily'     => array(
+					'property_keys' => array(
+						'default' => 'font-family',
+					),
+					'css_vars'      => array(
+						'font-family' => '--wp--preset--font-family--$slug',
+					),
+					'path'          => array( 'typography', 'fontFamily' ),
+					'classnames'    => array(
+						'has-$slug-font-family' => 'font-family',
+					),
 				),
-				'path'          => array( 'typography', 'textTransform' ),
-			),
-			'letterSpacing'  => array(
-				'property_keys' => array(
-					'default' => 'letter-spacing',
+				'fontStyle'      => array(
+					'property_keys' => array(
+						'default' => 'font-style',
+					),
+					'path'          => array( 'typography', 'fontStyle' ),
 				),
-				'path'          => array( 'typography', 'letterSpacing' ),
-			),
-			'writingMode'    => array(
-				'property_keys' => array(
-					'default' => 'writing-mode',
+				'fontWeight'     => array(
+					'property_keys' => array(
+						'default' => 'font-weight',
+					),
+					'path'          => array( 'typography', 'fontWeight' ),
 				),
-				'path'          => array( 'typography', 'writingMode' ),
+				'lineHeight'     => array(
+					'property_keys' => array(
+						'default' => 'line-height',
+					),
+					'path'          => array( 'typography', 'lineHeight' ),
+				),
+				'textColumns'    => array(
+					'property_keys' => array(
+						'default' => 'column-count',
+					),
+					'path'          => array( 'typography', 'textColumns' ),
+				),
+				'textDecoration' => array(
+					'property_keys' => array(
+						'default' => 'text-decoration',
+					),
+					'path'          => array( 'typography', 'textDecoration' ),
+				),
+				'textTransform'  => array(
+					'property_keys' => array(
+						'default' => 'text-transform',
+					),
+					'path'          => array( 'typography', 'textTransform' ),
+				),
+				'letterSpacing'  => array(
+					'property_keys' => array(
+						'default' => 'letter-spacing',
+					),
+					'path'          => array( 'typography', 'letterSpacing' ),
+				),
+				'writingMode'    => array(
+					'property_keys' => array(
+						'default' => 'writing-mode',
+					),
+					'path'          => array( 'typography', 'writingMode' ),
+				),
 			),
-		),
-	);
-
-	/**
-	 * Util: Extracts the slug in kebab case from a preset string, e.g., "heavenly-blue" from 'var:preset|color|heavenlyBlue'.
-	 *
-	 * @param string $style_value  A single CSS preset value.
-	 * @param string $property_key The CSS property that is the second element of the preset string. Used for matching.
-	 *
-	 * @return string The slug, or empty string if not found.
-	 */
-	protected static function get_slug_from_preset_value( $style_value, $property_key ) {
-		if ( is_string( $style_value ) && is_string( $property_key ) && str_contains( $style_value, "var:preset|{$property_key}|" ) ) {
-			$index_to_splice = strrpos( $style_value, '|' ) + 1;
-			return _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
-		}
-		return '';
-	}
-
-	/**
-	 * Util: Generates a CSS var string, e.g., var(--wp--preset--color--background) from a preset string such as `var:preset|space|50`.
-	 *
-	 * @param string   $style_value  A single CSS preset value.
-	 * @param string[] $css_vars     An associate array of CSS var patterns used to generate the var string.
-	 *
-	 * @return string The css var, or an empty string if no match for slug found.
-	 */
-	protected static function get_css_var_value( $style_value, $css_vars ) {
-		foreach ( $css_vars as  $property_key => $css_var_pattern ) {
-			$slug = static::get_slug_from_preset_value( $style_value, $property_key );
-			if ( static::is_valid_style_value( $slug ) ) {
-				$var = strtr(
-					$css_var_pattern,
-					array( '$slug' => $slug )
-				);
-				return "var($var)";
-			}
-		}
-		return '';
-	}
-
-	/**
-	 * Util: Checks whether an incoming block style value is valid.
-	 *
-	 * @param string? $style_value  A single css preset value.
-	 *
-	 * @return bool
-	 */
-	protected static function is_valid_style_value( $style_value ) {
-		return '0' === $style_value || ! empty( $style_value );
-	}
-
-	/**
-	 * Stores a CSS rule using the provided CSS selector and CSS declarations.
-	 *
-	 * @param string   $store_name       A valid store key.
-	 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
-	 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-	 *
-	 * @return void.
-	 */
-	public static function store_css_rule( $store_name, $css_selector, $css_declarations ) {
-		if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
-			return;
-		}
-		static::get_store( $store_name )->add_rule( $css_selector )->add_declarations( $css_declarations );
-	}
-
-	/**
-	 * Returns a store by store key.
-	 *
-	 * @param string $store_name A store key.
-	 *
-	 * @return WP_Style_Engine_CSS_Rules_Store
-	 */
-	public static function get_store( $store_name ) {
-		return WP_Style_Engine_CSS_Rules_Store::get_store( $store_name );
-	}
-
-	/**
-	 * Returns classnames and CSS based on the values in a styles object.
-	 * Return values are parsed based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
-	 *
-	 * @since 6.1.0
-	 *
-	 * @param array $block_styles The style object.
-	 * @param array $options      {
-	 *     Optional. An array of options. Default empty array.
-	 *
-	 *     @type bool        $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
-	 *     @type string      $selector                   Optional. When a selector is passed, the value of `$css` in the return value will comprise a full CSS rule `$selector { ...$css_declarations }`,
-	 *                                                   otherwise, the value will be a concatenated string of CSS declarations.
-	 * }
-	 *
-	 * @return array {
-	 *     @type string   $classnames   Classnames separated by a space.
-	 *     @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-	 * }
-	 */
-	public static function parse_block_styles( $block_styles, $options ) {
-		$parsed_styles = array(
-			'classnames'   => array(),
-			'declarations' => array(),
 		);
-		if ( empty( $block_styles ) || ! is_array( $block_styles ) ) {
-			return $parsed_styles;
-		}
 
-		// Collect CSS and classnames.
-		foreach ( static::BLOCK_STYLE_DEFINITIONS_METADATA as $definition_group_key => $definition_group_style ) {
-			if ( empty( $block_styles[ $definition_group_key ] ) ) {
-				continue;
-			}
-			foreach ( $definition_group_style as $style_definition ) {
-				$style_value = _wp_array_get( $block_styles, $style_definition['path'], null );
-
-				if ( ! static::is_valid_style_value( $style_value ) ) {
-					continue;
-				}
-
-				$parsed_styles['classnames']   = array_merge( $parsed_styles['classnames'], static::get_classnames( $style_value, $style_definition ) );
-				$parsed_styles['declarations'] = array_merge( $parsed_styles['declarations'], static::get_css_declarations( $style_value, $style_definition, $options ) );
-			}
-		}
-
-		return $parsed_styles;
-	}
-
-	/**
-	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., '`var:preset|<PRESET_TYPE>|<PRESET_SLUG>`'.
-	 *
-	 * @param array $style_value      A single raw style value or css preset property from the $block_styles array.
-	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 *
-	 * @return array|string[] An array of CSS classnames, or empty array.
-	 */
-	protected static function get_classnames( $style_value, $style_definition ) {
-		if ( empty( $style_value ) ) {
-			return array();
-		}
-
-		$classnames = array();
-		if ( ! empty( $style_definition['classnames'] ) ) {
-			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
-				if ( true === $property_key ) {
-					$classnames[] = $classname;
-				}
-
-				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
-
-				if ( $slug ) {
-					/*
-					 * Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
-					 * One day, if there are no stored schemata, we could allow custom patterns or
-					 * generate classnames based on other properties
-					 * such as a path or a value or a prefix passed in options.
-					 */
-					$classnames[] = strtr( $classname, array( '$slug' => $slug ) );
-				}
-			}
-		}
-
-		return $classnames;
-	}
-
-	/**
-	 * Returns an array of CSS declarations based on valid block style values.
-	 *
-	 * @since 6.1.0
-	 *
-	 * @param array $style_value      A single raw style value from $block_styles array.
-	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * @param array $options          {
-	 *     Optional. An array of options. Default empty array.
-	 *
-	 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
-	 * }
-	 *
-	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-	 */
-	protected static function get_css_declarations( $style_value, $style_definition, $options = array() ) {
-		if ( isset( $style_definition['value_func'] ) && is_callable( $style_definition['value_func'] ) ) {
-			return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $options );
-		}
-
-		$css_declarations     = array();
-		$style_property_keys  = $style_definition['property_keys'];
-		$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
-
-		/*
-		 * Build CSS var values from `var:preset|<PRESET_TYPE>|<PRESET_SLUG>` values, e.g, `var(--wp--css--rule-slug )`.
-		 * Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
+		/**
+		 * Util: Extracts the slug in kebab case from a preset string, e.g., "heavenly-blue" from 'var:preset|color|heavenlyBlue'.
+		 *
+		 * @param string $style_value  A single CSS preset value.
+		 * @param string $property_key The CSS property that is the second element of the preset string. Used for matching.
+		 *
+		 * @return string The slug, or empty string if not found.
 		 */
-		if ( is_string( $style_value ) && str_contains( $style_value, 'var:' ) ) {
-			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
-				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
-				if ( static::is_valid_style_value( $css_var ) ) {
-					$css_declarations[ $style_property_keys['default'] ] = $css_var;
-				}
+		protected static function get_slug_from_preset_value( $style_value, $property_key ) {
+			if ( is_string( $style_value ) && is_string( $property_key ) && str_contains( $style_value, "var:preset|{$property_key}|" ) ) {
+				$index_to_splice = strrpos( $style_value, '|' ) + 1;
+				return _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
 			}
-			return $css_declarations;
-		}
-
-		/*
-		 * Default rule builder.
-		 * If the input contains an array, assume box model-like properties
-		 * for styles such as margins and padding.
-		 */
-		if ( is_array( $style_value ) ) {
-			// Bail out early if the `'individual'` property is not defined.
-			if ( ! isset( $style_property_keys['individual'] ) ) {
-				return $css_declarations;
-			}
-
-			foreach ( $style_value as $key => $value ) {
-				if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
-					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
-				}
-
-				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
-
-				if ( $individual_property && static::is_valid_style_value( $value ) ) {
-					$css_declarations[ $individual_property ] = $value;
-				}
-			}
-
-			return $css_declarations;
-		}
-
-		$css_declarations[ $style_property_keys['default'] ] = $style_value;
-		return $css_declarations;
-	}
-
-	/**
-	 * Style value parser that returns a CSS definition array comprising style properties
-	 * that have keys representing individual style properties, otherwise known as longhand CSS properties.
-	 * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
-	 * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
-	 * "border-image-{outset|source|width|repeat|slice}: {value};"
-	 *
-	 * @param array $style_value                    A single raw style value from $block_styles array.
-	 * @param array $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA representing an individual property of a CSS property, e.g., 'top' in 'border-top'.
-	 * @param array $options                        {
-	 *     Optional. An array of options. Default empty array.
-	 *
-	 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
-	 * }
-	 *
-	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-	 */
-	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
-		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
-			return array();
-		}
-
-		/*
-		 * The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
-		 * We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
-		 * The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
-		 */
-		$definition_group_key    = $individual_property_definition['path'][0];
-		$individual_property_key = $individual_property_definition['path'][1];
-		$should_skip_css_vars    = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
-		$css_declarations        = array();
-
-		foreach ( $style_value as $css_property => $value ) {
-			if ( empty( $value ) ) {
-				continue;
-			}
-
-			// Build a path to the individual rules in definitions.
-			$style_definition_path = array( $definition_group_key, $css_property );
-			$style_definition      = _wp_array_get( static::BLOCK_STYLE_DEFINITIONS_METADATA, $style_definition_path, null );
-
-			if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
-				// Set a CSS var if there is a valid preset value.
-				if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
-					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
-				}
-				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
-				$css_declarations[ $individual_css_property ] = $value;
-			}
-		}
-		return $css_declarations;
-	}
-
-	/**
-	 * Style value parser that constructs a CSS definition array comprising a single CSS property and value.
-	 * If the provided value is an array containing a `url` property, the function will return a CSS definition array
-	 * with a single property and value, with `url` escaped and injected into a CSS `url()` function,
-	 * e.g., array( 'background-image' => "url( '...' )" ).
-	 *
-	 * @param array $style_value      A single raw style value from $block_styles array.
-	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 *
-	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-	 */
-	protected static function get_url_or_value_css_declaration( $style_value, $style_definition ) {
-		if ( empty( $style_value ) ) {
-			return array();
-		}
-
-		$css_declarations = array();
-
-		if ( isset( $style_definition['property_keys']['default'] ) ) {
-			$value = null;
-
-			if ( ! empty( $style_value['url'] ) ) {
-				$value = "url('" . $style_value['url'] . "')";
-			} elseif ( is_string( $style_value ) ) {
-				$value = $style_value;
-			}
-
-			if ( null !== $value ) {
-				$css_declarations[ $style_definition['property_keys']['default'] ] = $value;
-			}
-		}
-
-		return $css_declarations;
-	}
-
-	/**
-	 * Returns compiled CSS from css_declarations.
-	 *
-	 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-	 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
-	 *
-	 * @return string A compiled CSS string.
-	 */
-	public static function compile_css( $css_declarations, $css_selector ) {
-		if ( empty( $css_declarations ) || ! is_array( $css_declarations ) ) {
 			return '';
 		}
 
-		// Return an entire rule if there is a selector.
-		if ( $css_selector ) {
-			$css_rule = new WP_Style_Engine_CSS_Rule( $css_selector, $css_declarations );
-			return $css_rule->get_css();
+		/**
+		 * Util: Generates a CSS var string, e.g., var(--wp--preset--color--background) from a preset string such as `var:preset|space|50`.
+		 *
+		 * @param string   $style_value  A single CSS preset value.
+		 * @param string[] $css_vars     An associate array of CSS var patterns used to generate the var string.
+		 *
+		 * @return string The css var, or an empty string if no match for slug found.
+		 */
+		protected static function get_css_var_value( $style_value, $css_vars ) {
+			foreach ( $css_vars as  $property_key => $css_var_pattern ) {
+				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+				if ( static::is_valid_style_value( $slug ) ) {
+					$var = strtr(
+						$css_var_pattern,
+						array( '$slug' => $slug )
+					);
+					return "var($var)";
+				}
+			}
+			return '';
 		}
 
-		$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
-		return $css_declarations->get_declarations_string();
-	}
+		/**
+		 * Util: Checks whether an incoming block style value is valid.
+		 *
+		 * @param string? $style_value  A single css preset value.
+		 *
+		 * @return bool
+		 */
+		protected static function is_valid_style_value( $style_value ) {
+			return '0' === $style_value || ! empty( $style_value );
+		}
 
-	/**
-	 * Returns a compiled stylesheet from stored CSS rules.
-	 *
-	 * @param WP_Style_Engine_CSS_Rule[] $css_rules An array of WP_Style_Engine_CSS_Rule objects from a store or otherwise.
-	 * @param array                      $options   {
-	 *     Optional. An array of options. Default empty array.
-	 *
-	 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
-	 *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
-	 * }
-	 *
-	 * @return string A compiled stylesheet from stored CSS rules.
-	 */
-	public static function compile_stylesheet_from_css_rules( $css_rules, $options = array() ) {
-		$processor = new WP_Style_Engine_Processor();
-		$processor->add_rules( $css_rules );
-		return $processor->get_css( $options );
+		/**
+		 * Stores a CSS rule using the provided CSS selector and CSS declarations.
+		 *
+		 * @param string   $store_name       A valid store key.
+		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+		 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 *
+		 * @return void.
+		 */
+		public static function store_css_rule( $store_name, $css_selector, $css_declarations ) {
+			if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
+				return;
+			}
+			static::get_store( $store_name )->add_rule( $css_selector )->add_declarations( $css_declarations );
+		}
+
+		/**
+		 * Returns a store by store key.
+		 *
+		 * @param string $store_name A store key.
+		 *
+		 * @return WP_Style_Engine_CSS_Rules_Store
+		 */
+		public static function get_store( $store_name ) {
+			return WP_Style_Engine_CSS_Rules_Store::get_store( $store_name );
+		}
+
+		/**
+		 * Returns classnames and CSS based on the values in a styles object.
+		 * Return values are parsed based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
+		 *
+		 * @since 6.1.0
+		 *
+		 * @param array $block_styles The style object.
+		 * @param array $options      {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool        $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+		 *     @type string      $selector                   Optional. When a selector is passed, the value of `$css` in the return value will comprise a full CSS rule `$selector { ...$css_declarations }`,
+		 *                                                   otherwise, the value will be a concatenated string of CSS declarations.
+		 * }
+		 *
+		 * @return array {
+		 *     @type string   $classnames   Classnames separated by a space.
+		 *     @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 * }
+		 */
+		public static function parse_block_styles( $block_styles, $options ) {
+			$parsed_styles = array(
+				'classnames'   => array(),
+				'declarations' => array(),
+			);
+			if ( empty( $block_styles ) || ! is_array( $block_styles ) ) {
+				return $parsed_styles;
+			}
+
+			// Collect CSS and classnames.
+			foreach ( static::BLOCK_STYLE_DEFINITIONS_METADATA as $definition_group_key => $definition_group_style ) {
+				if ( empty( $block_styles[ $definition_group_key ] ) ) {
+					continue;
+				}
+				foreach ( $definition_group_style as $style_definition ) {
+					$style_value = _wp_array_get( $block_styles, $style_definition['path'], null );
+
+					if ( ! static::is_valid_style_value( $style_value ) ) {
+						continue;
+					}
+
+					$parsed_styles['classnames']   = array_merge( $parsed_styles['classnames'], static::get_classnames( $style_value, $style_definition ) );
+					$parsed_styles['declarations'] = array_merge( $parsed_styles['declarations'], static::get_css_declarations( $style_value, $style_definition, $options ) );
+				}
+			}
+
+			return $parsed_styles;
+		}
+
+		/**
+		 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., '`var:preset|<PRESET_TYPE>|<PRESET_SLUG>`'.
+		 *
+		 * @param array $style_value      A single raw style value or css preset property from the $block_styles array.
+		 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+		 *
+		 * @return array|string[] An array of CSS classnames, or empty array.
+		 */
+		protected static function get_classnames( $style_value, $style_definition ) {
+			if ( empty( $style_value ) ) {
+				return array();
+			}
+
+			$classnames = array();
+			if ( ! empty( $style_definition['classnames'] ) ) {
+				foreach ( $style_definition['classnames'] as $classname => $property_key ) {
+					if ( true === $property_key ) {
+						$classnames[] = $classname;
+					}
+
+					$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+
+					if ( $slug ) {
+						/*
+						* Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
+						* One day, if there are no stored schemata, we could allow custom patterns or
+						* generate classnames based on other properties
+						* such as a path or a value or a prefix passed in options.
+						*/
+						$classnames[] = strtr( $classname, array( '$slug' => $slug ) );
+					}
+				}
+			}
+
+			return $classnames;
+		}
+
+		/**
+		 * Returns an array of CSS declarations based on valid block style values.
+		 *
+		 * @since 6.1.0
+		 *
+		 * @param array $style_value      A single raw style value from $block_styles array.
+		 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+		 * @param array $options          {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+		 * }
+		 *
+		 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 */
+		protected static function get_css_declarations( $style_value, $style_definition, $options = array() ) {
+			if ( isset( $style_definition['value_func'] ) && is_callable( $style_definition['value_func'] ) ) {
+				return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $options );
+			}
+
+			$css_declarations     = array();
+			$style_property_keys  = $style_definition['property_keys'];
+			$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
+
+			/*
+			* Build CSS var values from `var:preset|<PRESET_TYPE>|<PRESET_SLUG>` values, e.g, `var(--wp--css--rule-slug )`.
+			* Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
+			*/
+			if ( is_string( $style_value ) && str_contains( $style_value, 'var:' ) ) {
+				if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
+					$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
+					if ( static::is_valid_style_value( $css_var ) ) {
+						$css_declarations[ $style_property_keys['default'] ] = $css_var;
+					}
+				}
+				return $css_declarations;
+			}
+
+			/*
+			* Default rule builder.
+			* If the input contains an array, assume box model-like properties
+			* for styles such as margins and padding.
+			*/
+			if ( is_array( $style_value ) ) {
+				// Bail out early if the `'individual'` property is not defined.
+				if ( ! isset( $style_property_keys['individual'] ) ) {
+					return $css_declarations;
+				}
+
+				foreach ( $style_value as $key => $value ) {
+					if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
+						$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
+					}
+
+					$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
+
+					if ( $individual_property && static::is_valid_style_value( $value ) ) {
+						$css_declarations[ $individual_property ] = $value;
+					}
+				}
+
+				return $css_declarations;
+			}
+
+			$css_declarations[ $style_property_keys['default'] ] = $style_value;
+			return $css_declarations;
+		}
+
+		/**
+		 * Style value parser that returns a CSS definition array comprising style properties
+		 * that have keys representing individual style properties, otherwise known as longhand CSS properties.
+		 * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
+		 * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
+		 * "border-image-{outset|source|width|repeat|slice}: {value};"
+		 *
+		 * @param array $style_value                    A single raw style value from $block_styles array.
+		 * @param array $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA representing an individual property of a CSS property, e.g., 'top' in 'border-top'.
+		 * @param array $options                        {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+		 * }
+		 *
+		 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 */
+		protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
+			if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
+				return array();
+			}
+
+			/*
+			* The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
+			* We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
+			* The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
+			*/
+			$definition_group_key    = $individual_property_definition['path'][0];
+			$individual_property_key = $individual_property_definition['path'][1];
+			$should_skip_css_vars    = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
+			$css_declarations        = array();
+
+			foreach ( $style_value as $css_property => $value ) {
+				if ( empty( $value ) ) {
+					continue;
+				}
+
+				// Build a path to the individual rules in definitions.
+				$style_definition_path = array( $definition_group_key, $css_property );
+				$style_definition      = _wp_array_get( static::BLOCK_STYLE_DEFINITIONS_METADATA, $style_definition_path, null );
+
+				if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
+					// Set a CSS var if there is a valid preset value.
+					if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
+						$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
+					}
+					$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
+					$css_declarations[ $individual_css_property ] = $value;
+				}
+			}
+			return $css_declarations;
+		}
+
+		/**
+		 * Style value parser that constructs a CSS definition array comprising a single CSS property and value.
+		 * If the provided value is an array containing a `url` property, the function will return a CSS definition array
+		 * with a single property and value, with `url` escaped and injected into a CSS `url()` function,
+		 * e.g., array( 'background-image' => "url( '...' )" ).
+		 *
+		 * @param array $style_value      A single raw style value from $block_styles array.
+		 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+		 *
+		 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 */
+		protected static function get_url_or_value_css_declaration( $style_value, $style_definition ) {
+			if ( empty( $style_value ) ) {
+				return array();
+			}
+
+			$css_declarations = array();
+
+			if ( isset( $style_definition['property_keys']['default'] ) ) {
+				$value = null;
+
+				if ( ! empty( $style_value['url'] ) ) {
+					$value = "url('" . $style_value['url'] . "')";
+				} elseif ( is_string( $style_value ) ) {
+					$value = $style_value;
+				}
+
+				if ( null !== $value ) {
+					$css_declarations[ $style_definition['property_keys']['default'] ] = $value;
+				}
+			}
+
+			return $css_declarations;
+		}
+
+		/**
+		 * Returns compiled CSS from css_declarations.
+		 *
+		 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+		 *
+		 * @return string A compiled CSS string.
+		 */
+		public static function compile_css( $css_declarations, $css_selector ) {
+			if ( empty( $css_declarations ) || ! is_array( $css_declarations ) ) {
+				return '';
+			}
+
+			// Return an entire rule if there is a selector.
+			if ( $css_selector ) {
+				$css_rule = new WP_Style_Engine_CSS_Rule( $css_selector, $css_declarations );
+				return $css_rule->get_css();
+			}
+
+			$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
+			return $css_declarations->get_declarations_string();
+		}
+
+		/**
+		 * Returns a compiled stylesheet from stored CSS rules.
+		 *
+		 * @param WP_Style_Engine_CSS_Rule[] $css_rules An array of WP_Style_Engine_CSS_Rule objects from a store or otherwise.
+		 * @param array                      $options   {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+		 *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+		 * }
+		 *
+		 * @return string A compiled stylesheet from stored CSS rules.
+		 */
+		public static function compile_stylesheet_from_css_rules( $css_rules, $options = array() ) {
+			$processor = new WP_Style_Engine_Processor();
+			$processor->add_rules( $css_rules );
+			return $processor->get_css( $options );
+		}
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,6 +93,7 @@
 			</property>
 			<property name="classesWhiteList" type="array">
 				<element value="/^Gutenberg.+/"/>
+				<element value="/^.+_Gutenberg/"/>
 			</property>
 		</properties>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,7 +93,7 @@
 			</property>
 			<property name="classesWhiteList" type="array">
 				<element value="/^Gutenberg.+/"/>
-				<element value="/^.+_Gutenberg/"/>
+				<element value="/^.+_Gutenberg$/"/>
 			</property>
 		</properties>
 	</rule>

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
@@ -182,13 +182,13 @@ final class GuardedFunctionAndClassNamesSniff implements Sniff {
 		$result               = preg_match( $regexp, $content );
 
 		if ( 1 === $result ) {
-			$incorrect_guarded_error_message = sprintf(
+			$notProperlyGuardedErrorMessage = sprintf(
 				'The class "%s" is not properly guarded against redeclaration. Please ensure the entire class body is wrapped within an "if ( ! class_exists( \'%s\' ) ) {" statement.',
 				$className,
 				$className
 			);
 
-			$phpcsFile->addError( $incorrect_guarded_error_message, $classToken, 'ClassNotProperlyGuardedAgainstRedeclaration' );
+			$phpcsFile->addError( $notProperlyGuardedErrorMessage, $classToken, 'ClassNotProperlyGuardedAgainstRedeclaration' );
 			return;
 		}
 

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
@@ -165,6 +165,13 @@ final class GuardedFunctionAndClassNamesSniff implements Sniff {
 			$regexp               = sprintf( '/if\s*\(\s*!\s*class_exists\s*\(\s*(\'|")%s(\'|")/', preg_quote( $className, '/' ) );
 			$result               = preg_match( $regexp, $content );
 			if ( 1 === $result ) {
+				$incorrect_guarded_error_message = sprintf(
+					'The class "%s" is not properly guarded against redeclaration. Please ensure the entire class body is wrapped within an "if ( ! class_exists( \'%s\' )) {" statement.',
+					$className,
+					$className
+				);
+
+				$phpcsFile->addError( $incorrect_guarded_error_message, $classToken, 'ClassIncorrectlyGuardedAgainstRedeclaration' );
 				return;
 			}
 		}

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
@@ -165,13 +165,6 @@ final class GuardedFunctionAndClassNamesSniff implements Sniff {
 			$regexp               = sprintf( '/if\s*\(\s*!\s*class_exists\s*\(\s*(\'|")%s(\'|")/', preg_quote( $className, '/' ) );
 			$result               = preg_match( $regexp, $content );
 			if ( 1 === $result ) {
-				$incorrect_guarded_error_message = sprintf(
-					'The class "%s" is not properly guarded against redeclaration. Please ensure the entire class body is wrapped within an "if ( ! class_exists( \'%s\' ) ) {" statement.',
-					$className,
-					$className
-				);
-
-				$phpcsFile->addError( $incorrect_guarded_error_message, $classToken, 'ClassNotProperlyGuardedAgainstRedeclaration' );
 				return;
 			}
 		}
@@ -189,10 +182,14 @@ final class GuardedFunctionAndClassNamesSniff implements Sniff {
 		$result               = preg_match( $regexp, $content );
 
 		if ( 1 === $result ) {
-			$returnToken = $phpcsFile->findNext( T_RETURN, $previousIfToken, $endOfPreviousIfToken );
-			if ( false !== $returnToken ) {
-				return;
-			}
+			$incorrect_guarded_error_message = sprintf(
+				'The class "%s" is not properly guarded against redeclaration. Please ensure the entire class body is wrapped within an "if ( ! class_exists( \'%s\' ) ) {" statement.',
+				$className,
+				$className
+			);
+
+			$phpcsFile->addError( $incorrect_guarded_error_message, $classToken, 'ClassNotProperlyGuardedAgainstRedeclaration' );
+			return;
 		}
 
 		$phpcsFile->addError( $errorMessage, $classToken, 'ClassNotGuardedAgainstRedeclaration' );

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
@@ -166,7 +166,7 @@ final class GuardedFunctionAndClassNamesSniff implements Sniff {
 			$result               = preg_match( $regexp, $content );
 			if ( 1 === $result ) {
 				$incorrect_guarded_error_message = sprintf(
-					'The class "%s" is not properly guarded against redeclaration. Please ensure the entire class body is wrapped within an "if ( ! class_exists( \'%s\' )) {" statement.',
+					'The class "%s" is not properly guarded against redeclaration. Please ensure the entire class body is wrapped within an "if ( ! class_exists( \'%s\' ) ) {" statement.',
 					$className,
 					$className
 				);

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
@@ -133,7 +133,7 @@ final class GuardedFunctionAndClassNamesSniff implements Sniff {
 
 	/**
 	 * Classes should be wrapped with !function_exists() to avoid fatal errors.
-	 *
+	 * E.g.:
 	 * if ( ! class_exists( 'WP_Navigation' ) ) {
 	 *    class WP_Navigation { ... }
 	 * }

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
@@ -171,7 +171,7 @@ final class GuardedFunctionAndClassNamesSniff implements Sniff {
 					$className
 				);
 
-				$phpcsFile->addError( $incorrect_guarded_error_message, $classToken, 'ClassIncorrectlyGuardedAgainstRedeclaration' );
+				$phpcsFile->addError( $incorrect_guarded_error_message, $classToken, 'ClassNotProperlyGuardedAgainstRedeclaration' );
 				return;
 			}
 		}

--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/GuardedFunctionAndClassNamesSniff.php
@@ -133,12 +133,6 @@ final class GuardedFunctionAndClassNamesSniff implements Sniff {
 
 	/**
 	 * Classes should be wrapped with !function_exists() to avoid fatal errors.
-	 * E.g.:
-	 * if ( class_exists( 'WP_Navigation' ) ) {
-	 *     return;
-	 * }
-	 *
-	 * Alternatively:
 	 *
 	 * if ( ! class_exists( 'WP_Navigation' ) ) {
 	 *    class WP_Navigation { ... }

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/CodeAnalysis/ForbiddenFunctionsAndClassesUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/CodeAnalysis/ForbiddenFunctionsAndClassesUnitTest.php
@@ -87,7 +87,7 @@ final class ForbiddenFunctionsAndClassesUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Prepares the environment before executing tests. Specifically, sets prefixes for the
-	 * ValidBlockLibraryFunctionName sniff.This is needed since AbstractSniffUnitTest class
+	 * ForbiddenFunctionsAndClassesSniff sniff.This is needed since AbstractSniffUnitTest class
 	 * doesn't apply sniff properties from the Gutenberg/ruleset.xml file.
 	 *
 	 * @param string $filename The name of the file being tested.

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/CodeAnalysis/GuardedFunctionAndClassNamesUnitTest.inc
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/CodeAnalysis/GuardedFunctionAndClassNamesUnitTest.inc
@@ -24,3 +24,19 @@ if ( ! function_exists( 'quux' ) ) {
 
 function blarg() {
 }
+
+class Gutenberg_Class {
+
+}
+
+class Class_Gutenberg {
+}
+
+class Class_Gutenberg_With_Some_Postifx {
+}
+
+function gutenberg_function() {
+}
+
+function _gutenberg_function() {
+}

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/CodeAnalysis/GuardedFunctionAndClassNamesUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/CodeAnalysis/GuardedFunctionAndClassNamesUnitTest.php
@@ -9,12 +9,22 @@
 
 namespace GutenbergCS\Gutenberg\Tests\CodeAnalysis;
 
+use GutenbergCS\Gutenberg\Sniffs\CodeAnalysis\GuardedFunctionAndClassNamesSniff;
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Ruleset;
 
 /**
  * Unit test class for the GuardedFunctionAndClassNames sniff.
  */
 final class GuardedFunctionAndClassNamesUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Holds the original Ruleset instance.
+	 *
+	 * @var Ruleset
+	 */
+	private static $original_ruleset;
 
 	/**
 	 * Returns the lines where errors should occur.
@@ -23,8 +33,10 @@ final class GuardedFunctionAndClassNamesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
+			7  => 1,
 			17 => 1,
 			25 => 1,
+			35 => 1,
 		);
 	}
 
@@ -35,5 +47,60 @@ final class GuardedFunctionAndClassNamesUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getWarningList() {
 		return array();
+	}
+
+	/**
+	 *
+	 * This method resets the 'Gutenberg' ruleset in the $GLOBALS['PHP_CODESNIFFER_RULESETS']
+	 * to its original state.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		$GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] = self::$original_ruleset;
+		self::$original_ruleset                           = null;
+	}
+
+
+	/**
+	 * Prepares the environment before executing tests. Specifically, sets prefixes for the
+	 * GuardedFunctionAndClassNames sniff.This is needed since AbstractSniffUnitTest class
+	 * doesn't apply sniff properties from the Gutenberg/ruleset.xml file.
+	 *
+	 * @param string $filename The name of the file being tested.
+	 * @param Config $config   The config data for the run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues( $filename, $config ) {
+		parent::setCliValues( $filename, $config );
+
+		if ( ! isset( $GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] )
+			|| ( ! $GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] instanceof Ruleset )
+		) {
+			throw new \RuntimeException( 'Cannot set ruleset parameters required for this test.' );
+		}
+
+		// Backup the original Ruleset instance.
+		self::$original_ruleset = $GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'];
+
+		$current_ruleset                                  = clone self::$original_ruleset;
+		$GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] = $current_ruleset;
+
+		if ( ! isset( $current_ruleset->sniffs[ GuardedFunctionAndClassNamesSniff::class ] )
+			|| ( ! $current_ruleset->sniffs[ GuardedFunctionAndClassNamesSniff::class ] instanceof GuardedFunctionAndClassNamesSniff )
+		) {
+			throw new \RuntimeException( 'Cannot set ruleset parameters required for this test.' );
+		}
+
+		$sniff                     = $current_ruleset->sniffs[ GuardedFunctionAndClassNamesSniff::class ];
+		$sniff->functionsWhiteList = array(
+			'/^_?gutenberg.+/',
+		);
+
+		$sniff->classesWhiteList = array(
+			'/^Gutenberg.+/',
+			'/^.+_Gutenberg$/',
+		);
 	}
 }


### PR DESCRIPTION
## What?

As we've seen recently class_exists + early returns is not enough to prevent against classes duplication properly. It actually depends on the php version and sometimes PHP scans the classes before running the code which results in php fatal errors.

This PR updates our code to avoid these.

## Why?

We're merging more and more code into Core and this will help us prevent fatal errors.

## How?

I just inverted the condition, I wanted to update our PHPCS rule to not consider the early return as a correct fix but failed to do so. I'll leave that for @anton-vlasenko either here or as a follow-up. 

## Testing Instructions

There's no functional change in this PR, also consider checking the diff with the "whitespace" option enabled.