### PR TITLE
Navigation: minimize the number of innerblocks renders

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -39,6 +39,16 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static $seen_menu_names = array();
 
+	private static function get_inner_blocks_content( $inner_blocks ) {
+		static $inner_blocks_content = array();
+		if ( empty( $inner_blocks_content ) ) {
+			foreach ( $inner_blocks as $inner_block ) {
+				array_push( $inner_blocks_content, $inner_block->render() );
+			}
+		}
+		return $inner_blocks_content;
+	}
+
 	/**
 	 * Returns whether or not this is responsive navigation.
 	 *
@@ -61,9 +71,9 @@ class WP_Navigation_Block_Renderer {
 	 * @return bool Returns whether or not a navigation has a submenu.
 	 */
 	private static function has_submenus( $inner_blocks ) {
-		foreach ( $inner_blocks as $inner_block ) {
-			$inner_block_content = $inner_block->render();
-			$p                   = new WP_HTML_Tag_Processor( $inner_block_content );
+		$inner_blocks_content = static::get_inner_blocks_content( $inner_blocks );
+		foreach ( $inner_blocks_content as $inner_block_content ) {
+			$p = new WP_HTML_Tag_Processor( $inner_block_content );
 			if ( $p->next_tag(
 				array(
 					'name'       => 'LI',


### PR DESCRIPTION
**NOT TO MERGE.**

## What?

This PR is an experiment to minimize the number of `$inner_blocks` renders in the navigation block.

## Why?

The [initial package update for 6.5](https://github.com/WordPress/wordpress-develop/pull/5922) took a performance hit. Part of it was due to the navigation block render refactor at https://github.com/WordPress/gutenberg/pull/55605. That PR increased from 1 to 6 the number of times its inner blocks rendered, causing a cascade of other updates, degrading performance.

| | Before Update | After update | This PR |
| --- | --- | --- | --- |
| Total time (ms) | 2 117 | 2 517 | 2 227 |
| render_block_core_navigation (ms) | 106 | 334 | 160 |
| # calls to `WP_Block->render` | 410 | 415 | 411 |

See also some kcachegrind visualizations:

| Before | After | This PR |
| --- | --- | --- |
| <img width="1509" alt="Captura de ecrã 2024-01-31, às 16 20 46" src="https://github.com/WordPress/gutenberg/assets/583546/ff31676f-211c-4569-9de1-354483889665"> | <img width="1509" alt="Captura de ecrã 2024-01-31, às 16 21 23" src="https://github.com/WordPress/gutenberg/assets/583546/0a6035a9-8c3a-4916-899c-b5f25f9fa6f8"> | <img width="1509" alt="Captura de ecrã 2024-01-31, às 16 21 48" src="https://github.com/WordPress/gutenberg/assets/583546/7f43e232-0cf3-4545-b3d4-4255807a7435"> |

I'm also sharing the [cachegrind-logs.zip](https://github.com/WordPress/gutenberg/files/14113479/cachegrind-logs.zip) for people to inspect by their own. [qcachegrind](https://formulae.brew.sh/formula/qcachegrind) (macos) or [kcachegrind](https://kcachegrind.sourceforge.net/html/Home.html) (linux) can be used to open and inspect the files (see images in table).

## How?

TBD.

The test case here just demonstrate how this is an issue, but it's not the proper implementation.

## Testing Instructions

TBD.

The performance tests in Gutenberg won't report any performance impact, the same https://github.com/WordPress/gutenberg/pull/55605 didn't. The reason is that the test data doesn't cover the navigation block appropriately. The core performance tests cover more ground for the navigation block.

These changes are ported to core via the `@wordpress/block-library` package. How can we test the changes in this PR in core?