### PR TITLE
Block Hooks: Try to make insertion into Navigation block work on WP 6.4

### DIFF
--- a/lib/compat/wordpress-6.5/block-hooks.php
+++ b/lib/compat/wordpress-6.5/block-hooks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Block hooks compatiiility layer.
+ * Block hooks compatibility layer.
  *
  * @package gutenberg
  */

--- a/lib/compat/wordpress-6.5/block-hooks.php
+++ b/lib/compat/wordpress-6.5/block-hooks.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Block hooks compatiiility layer.
+ *
+ * @package gutenberg
+ */
+
+function respect_ignored_hooked_blocks_post_meta_on_wp_navigation_post ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+	// Only apply this filter if $context is a wp_navigation post object.
+	if ( ! $context instanceof WP_Post || 'wp_navigation' !== $context->post_type ) {
+		return $hooked_block_types;
+	}
+
+	// Only apply this filter if the anchor block is a Navigation block.
+	if (
+		'core/navigation' !== $anchor_block_type || (
+			'first_child' !== $relative_position &&
+			'last_child' !== $relative_position
+		)
+	) {
+		return $hooked_block_types;
+	}
+
+	$ignored_hooked_blocks = get_post_meta( $context->ID, '_wp_ignored_hooked_blocks', true );
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$ignored_hooked_blocks = json_decode( $ignored_hooked_blocks, true );
+	}
+
+	if ( ! isset( $ignored_hooked_blocks ) || ! is_array( $ignored_hooked_blocks ) ) {
+		$ignored_hooked_blocks = array();
+	}
+
+	$hooked_block_types = array_diff( $hooked_block_types, $ignored_hooked_blocks );
+
+	// FIXME. The problem is that we don't have any way of telling if this is being invoked
+	// upon read or write access. As a consequence, we're always writing the post meta, even
+	// if we're only reading. That means that the ignoredHookedBlocks meta will be set
+	// when first loading the frontend, and will cause hooked blocks to be omitted when loading
+	// it for the second time :(
+	$ignored_hooked_blocks = array_merge( $ignored_hooked_blocks, $hooked_block_types );
+	update_post_meta( $context->ID, '_wp_ignored_hooked_blocks', json_encode( $ignored_hooked_blocks ) );
+
+	return $hooked_block_types;
+}
+
+if ( version_compare( get_bloginfo( 'version' ), '6.5', '<' ) ) {
+	add_filter( 'hooked_block_types', 'respect_ignored_hooked_blocks_post_meta_on_wp_navigation_post', 10, 4 );
+}

--- a/lib/compat/wordpress-6.5/block-hooks.php
+++ b/lib/compat/wordpress-6.5/block-hooks.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-function respect_ignored_hooked_blocks_post_meta_on_wp_navigation_post ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+function respect_ignored_hooked_blocks_post_meta_on_wp_navigation_post( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
 	// Only apply this filter if $context is a wp_navigation post object.
 	if ( ! $context instanceof WP_Post || 'wp_navigation' !== $context->post_type ) {
 		return $hooked_block_types;

--- a/lib/load.php
+++ b/lib/load.php
@@ -105,6 +105,7 @@ require __DIR__ . '/compat/wordpress-6.4/kses.php';
 
 // WordPress 6.5 compat.
 require __DIR__ . '/compat/wordpress-6.5/blocks.php';
+require __DIR__ . '/compat/wordpress-6.5/block-hooks.php';
 require __DIR__ . '/compat/wordpress-6.5/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.5/kses.php';
 require __DIR__ . '/compat/wordpress-6.5/interactivity-api/class-wp-interactivity-api.php';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -192,7 +192,7 @@ class WP_Navigation_Block_Renderer {
 			// it encounters whitespace. This code strips it.
 			$blocks = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
 
-			if ( function_exists( 'get_hooked_block_markup' ) ) {
+			if ( function_exists( 'get_hooked_blocks' ) ) {
 				// Run Block Hooks algorithm to inject hooked blocks.
 				$markup         = block_core_navigation_insert_hooked_blocks( $blocks, $navigation_post );
 				$root_nav_block = parse_blocks( $markup )[0];
@@ -987,7 +987,7 @@ function block_core_navigation_get_fallback_blocks() {
 		// In this case default to the (Page List) fallback.
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 
-		if ( function_exists( 'get_hooked_block_markup' ) ) {
+		if ( function_exists( 'get_hooked_blocks' ) ) {
 			// Run Block Hooks algorithm to inject hooked blocks.
 			// We have to run it here because we need the post ID of the Navigation block to track ignored hooked blocks.
 			$markup = block_core_navigation_insert_hooked_blocks( $fallback_blocks, $navigation_post );
@@ -1413,9 +1413,9 @@ function block_core_navigation_update_ignore_hooked_blocks_meta( $post ) {
 	}
 }
 
-// Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
-// that are not present in Gutenberg's WP 6.5 compatibility layer.
-if ( function_exists( 'get_hooked_block_markup' ) ) {
+// Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.4
+// that are not present in Gutenberg's WP 6.4 compatibility layer.
+if ( function_exists( 'get_hooked_blocks' ) ) {
 	add_action( 'rest_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta', 10, 3 );
 }
 
@@ -1445,8 +1445,8 @@ function block_core_navigation_insert_hooked_blocks_into_rest_response( $respons
 	return $response;
 }
 
-// Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
-// that are not present in Gutenberg's WP 6.5 compatibility layer.
-if ( function_exists( 'get_hooked_block_markup' ) ) {
+// Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.4
+// that are not present in Gutenberg's WP 6.4 compatibility layer.
+if ( function_exists( 'get_hooked_blocks' ) ) {
 	add_filter( 'rest_prepare_wp_navigation', 'block_core_navigation_insert_hooked_blocks_into_rest_response', 10, 3 );
 }


### PR DESCRIPTION
## What?
Try to make hooked blocks insertion into Navigation block work on WP 6.4.

## Why?
We had to disable this on WP 6.4 and below, as some required functionality is missing there. That means that the feature is currently only working when running the GB plugin on Core `trunk`.

## How?
_Not great._ I thought I could get this to work by clever usage of the `hooked_block_types` filter, but it doesn't really look like it:

https://github.com/WordPress/gutenberg/compare/add/block-hooks-6-5-compat-layer-for-nav-block?expand=1#diff-5369312b3be3a2f9a55c7cc974336247b6e79105e869f241f99e64e2ea1ac756R35-R39

## Testing Instructions
TBD, but basically: Test on WP 6.4, and on `trunk`.