### PR TITLE
Navigation: Fix performance regression

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -71,8 +71,8 @@ class WP_Navigation_Block_Renderer {
 			return static::$has_submenus;
 		}
 
-		foreach( $inner_blocks as $inner_block ) {
-			if ( "core/navigation-submenu" === $inner_block->name ) {
+		foreach ( $inner_blocks as $inner_block ) {
+			if ( 'core/navigation-submenu' === $inner_block->name ) {
 				static::$has_submenus = true;
 				return static::$has_submenus;
 			}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -63,7 +63,7 @@ class WP_Navigation_Block_Renderer {
 	/**
 	 * Returns whether or not a navigation has a submenu.
 	 *
-	 * @param array $inner_blocks An array of inner blocks.
+	 * @param WP_Block_List $inner_blocks The list of inner blocks.
 	 * @return bool Returns whether or not a navigation has a submenu and also sets the member variable.
 	 */
 	private static function has_submenus( $inner_blocks ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -85,10 +85,9 @@ class WP_Navigation_Block_Renderer {
 	 * Determine whether the navigation blocks is interactive.
 	 *
 	 * @param array         $attributes   The block attributes.
-	 * @param WP_Block_List $inner_blocks The list of inner blocks.
 	 * @return bool Returns whether or not to load the view script.
 	 */
-	private static function is_interactive( $attributes, $inner_blocks ) {
+	private static function is_interactive( $attributes ) {
 		$has_submenus       = static::$has_submenus;
 		$is_responsive_menu = static::is_responsive( $attributes );
 		return ( $has_submenus && ( $attributes['openSubmenusOnClick'] || $attributes['showSubmenuIcon'] ) ) || $is_responsive_menu;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -63,7 +63,7 @@ class WP_Navigation_Block_Renderer {
 	/**
 	 * Returns whether or not a navigation has a submenu.
 	 *
-	 * //@param WP_Block_List $inner_blocks The list of inner blocks.
+	 * @param string $inner_blocks_content_rendered A rendered inner block.
 	 * @return bool Returns whether or not a navigation has a submenu.
 	 */
 	private static function has_submenus( $inner_blocks_content_rendered ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -130,6 +130,9 @@ class WP_Navigation_Block_Renderer {
 	 * @return string Returns the html for the inner blocks of the navigation block.
 	 */
 	private static function get_inner_blocks_html( $attributes, $inner_blocks ) {
+		$has_submenus   = static::has_submenus( $inner_blocks );
+		$is_interactive = static::is_interactive( $attributes, $inner_blocks );
+
 		$style                = static::get_styles( $attributes );
 		$class                = static::get_classes( $attributes );
 		$container_attributes = get_block_wrapper_attributes(
@@ -166,8 +169,6 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		// Add directives to the submenu if needed.
-		$has_submenus   = static::has_submenus( $inner_blocks );
-		$is_interactive = static::is_interactive( $attributes, $inner_blocks );
 		if ( $has_submenus && $is_interactive ) {
 			$tags              = new WP_HTML_Tag_Processor( $inner_blocks_html );
 			$inner_blocks_html = block_core_navigation_add_directives_to_submenu( $tags, $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -89,7 +89,7 @@ class WP_Navigation_Block_Renderer {
 	 * @return bool Returns whether or not to load the view script.
 	 */
 	private static function is_interactive( $attributes, $inner_blocks ) {
-		$has_submenus       = static::has_submenus( $inner_blocks);
+		$has_submenus       = static::has_submenus( $inner_blocks );
 		$is_responsive_menu = static::is_responsive( $attributes );
 		return ( $has_submenus && ( $attributes['openSubmenusOnClick'] || $attributes['showSubmenuIcon'] ) ) || $is_responsive_menu;
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -112,7 +112,6 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function get_markup_for_inner_block( $inner_block ) {
 		$inner_block_content = $inner_block->render();
-
 		if ( ! empty( $inner_block_content ) ) {
 			if ( static::does_block_need_a_list_item_wrapper( $inner_block ) ) {
 				return '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
@@ -638,7 +637,6 @@ class WP_Navigation_Block_Renderer {
 		unset( $attributes['rgbTextColor'], $attributes['rgbBackgroundColor'] );
 
 		$inner_blocks = static::get_inner_blocks( $attributes, $block );
-
 		// Prevent navigation blocks referencing themselves from rendering.
 		if ( block_core_navigation_block_contains_core_navigation( $inner_blocks ) ) {
 			return '';
@@ -649,7 +647,7 @@ class WP_Navigation_Block_Renderer {
 		return sprintf(
 			'<nav %1$s>%2$s</nav>',
 			static::get_nav_wrapper_attributes( $attributes, $inner_blocks ),
-			static::get_wrapper_markup( $attributes, $inner_blocks ),
+			static::get_wrapper_markup( $attributes, $inner_blocks )
 		);
 	}
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -85,10 +85,11 @@ class WP_Navigation_Block_Renderer {
 	 * Determine whether the navigation blocks is interactive.
 	 *
 	 * @param array         $attributes   The block attributes.
+	 * @param WP_Block_List $inner_blocks The list of inner blocks.
 	 * @return bool Returns whether or not to load the view script.
 	 */
-	private static function is_interactive( $attributes ) {
-		$has_submenus       = static::$has_submenus;
+	private static function is_interactive( $attributes, $inner_blocks ) {
+		$has_submenus       = static::has_submenus( $inner_blocks);
 		$is_responsive_menu = static::is_responsive( $attributes );
 		return ( $has_submenus && ( $attributes['openSubmenusOnClick'] || $attributes['showSubmenuIcon'] ) ) || $is_responsive_menu;
 	}
@@ -165,7 +166,7 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		// Add directives to the submenu if needed.
-		$has_submenus   = static::$has_submenus;
+		$has_submenus   = static::has_submenus( $inner_blocks );
 		$is_interactive = static::is_interactive( $attributes, $inner_blocks );
 		if ( $has_submenus && $is_interactive ) {
 			$tags              = new WP_HTML_Tag_Processor( $inner_blocks_html );
@@ -636,13 +637,6 @@ class WP_Navigation_Block_Renderer {
 		unset( $attributes['rgbTextColor'], $attributes['rgbBackgroundColor'] );
 
 		$inner_blocks = static::get_inner_blocks( $attributes, $block );
-
-		// This sets the `has_submenus` member variable
-		// which is used by other functions in the class
-		// to determine whether or not a navigation has submenus.
-		// This has to be called before any other code that relies
-		// on the has_submenus member variable.
-		static::has_submenus( $inner_blocks );
 
 		// Prevent navigation blocks referencing themselves from rendering.
 		if ( block_core_navigation_block_contains_core_navigation( $inner_blocks ) ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -72,6 +72,22 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		foreach ( $inner_blocks as $inner_block ) {
+			// If this is a page list then work out if any of the pages have children.
+			if ( 'core/page-list' === $inner_block->name ) {
+				$all_pages = get_pages(
+					array(
+						'sort_column' => 'menu_order,post_title',
+						'order'       => 'asc',
+					)
+				);
+				foreach ( (array) $all_pages as $page ) {
+					if ( $page->post_parent ) {
+						static::$has_submenus = true;
+						break;
+					}
+				}
+			}
+			// If this is a navigation submenu then we know we have submenus.
 			if ( 'core/navigation-submenu' === $inner_block->name ) {
 				static::$has_submenus = true;
 				break;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -74,7 +74,7 @@ class WP_Navigation_Block_Renderer {
 		foreach ( $inner_blocks as $inner_block ) {
 			if ( 'core/navigation-submenu' === $inner_block->name ) {
 				static::$has_submenus = true;
-				return static::$has_submenus;
+				break;
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is another attempt at https://github.com/WordPress/gutenberg/pull/58506.

In https://github.com/WordPress/gutenberg/pull/55605/ we changed the navigation rendering logic so that inner_blocks were rendered multiple times. This updates that logic so that inner_blocks are only rendered once. 

## Why?
To improve performance.

## How?
Instead of calling `render` every time we want to check that a navigation has a submenu, we now save that as a member variable on the class. This means we only need to call render once for each inner block.

There should be a more performant way to determine if a navigation contains submenus.

## Testing Instructions
Check that a navigation block with submenus displays as on trunk.
