### PR TITLE
Flaky Test: Fix "directives inside islands should not be hydrated twice"

### DIFF
--- a/test/e2e/specs/interactivity/tovdom-islands.spec.ts
+++ b/test/e2e/specs/interactivity/tovdom-islands.spec.ts
@@ -44,7 +44,7 @@ test.describe( 'toVdom - islands', () => {
 	} ) => {
 		const el = page.getByTestId( 'island inside another island' );
 		const templates = el.locator( 'template' );
-		expect( await templates.count() ).toEqual( 1 );
+		await expect( templates ).toHaveCount( 1 );
 	} );
 
 	test( 'islands inside inner blocks of isolated islands should be hydrated', async ( {


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/58332.

The fix was originally included in https://github.com/WordPress/gutenberg/pull/58377, but as that PR still needs more iteration, I cherry-picked the fix here.