### PR TITLE
InnerBlocks: don't get layout block setting if no blocks

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -201,6 +201,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				__unstableHasActiveBlockOverlayActive,
 				getBlockEditingMode,
 				getBlockSettings,
+				getBlockCount,
 			} = unlock( select( blockEditorStore ) );
 			const { hasBlockSupport, getBlockType } = select( blocksStore );
 			const blockName = getBlockName( clientId );
@@ -208,7 +209,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				__unstableGetEditorMode() === 'navigation';
 			const blockEditingMode = getBlockEditingMode( clientId );
 			const parentClientId = getBlockRootClientId( clientId );
-			const [ defaultLayout ] = getBlockSettings( clientId, 'layout' );
 			return {
 				__experimentalCaptureToolbars: hasBlockSupport(
 					blockName,
@@ -228,7 +228,10 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 					blockEditingMode !== 'default' ||
 					__unstableHasActiveBlockOverlayActive( clientId ) ||
 					__unstableIsWithinBlockOverlay( clientId ),
-				defaultLayout,
+				defaultLayout:
+					getBlockCount( clientId ) === 0
+						? null
+						: getBlockSettings( clientId, 'layout' )[ 0 ],
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This setting feeds into a layout provider that is eventually consumed by blocks. It doesn't make sense to calculate it if there's no inner blocks (such as empty nested lists in list items, which each list item has).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's the most expensive selector in this component.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
