### PR TITLE
List View: unmemo recursive getEnabledClientIdsTree

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -71,6 +71,25 @@ export const isBlockSubtreeDisabled = ( state, clientId ) => {
 	return getBlockOrder( state, clientId ).every( isChildSubtreeDisabled );
 };
 
+function getEnabledClientIdsTreeUnmemoized( state, rootClientId ) {
+	const blockOrder = getBlockOrder( state, rootClientId );
+	const result = [];
+
+	for ( const clientId of blockOrder ) {
+		const innerBlocks = getEnabledClientIdsTreeUnmemoized(
+			state,
+			clientId
+		);
+		if ( getBlockEditingMode( state, clientId ) !== 'disabled' ) {
+			result.push( { clientId, innerBlocks } );
+		} else {
+			result.push( ...innerBlocks );
+		}
+	}
+
+	return result;
+}
+
 /**
  * Returns a tree of block objects with only clientID and innerBlocks set.
  * Blocks with a 'disabled' editing mode are not included.
@@ -81,19 +100,7 @@ export const isBlockSubtreeDisabled = ( state, clientId ) => {
  * @return {Object[]} Tree of block objects with only clientID and innerBlocks set.
  */
 export const getEnabledClientIdsTree = createSelector(
-	( state, rootClientId = '' ) => {
-		return getBlockOrder( state, rootClientId ).flatMap( ( clientId ) => {
-			if ( getBlockEditingMode( state, clientId ) !== 'disabled' ) {
-				return [
-					{
-						clientId,
-						innerBlocks: getEnabledClientIdsTree( state, clientId ),
-					},
-				];
-			}
-			return getEnabledClientIdsTree( state, clientId );
-		} );
-	},
+	getEnabledClientIdsTreeUnmemoized,
 	( state ) => [
 		state.blocks.order,
 		state.blockEditingModes,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This selector is currently very expensive because of the recursive calls to an memoized selector for every block. This should speed up the ListView quite a bit.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's at least 10x faster for a large post

|Before|After|
|-|-|
|<img width="541" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/b742d852-6112-427b-b533-4716f4bc4bfa">|<img width="379" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/97171462-64f0-423e-a018-b9517c327c3d">|

This is taking up ~10% of the total time it takes to render the ListView:

<img width="305" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/22e96a5b-b227-4687-8284-f50ebc6c0a7d">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
