### PR TITLE
Block editor canvas: use focusMode instead of editorPadding

### DIFF
--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -2,12 +2,5 @@ iframe[name="editor-canvas"] {
 	width: 100%;
 	height: 100%;
 	display: block;
-}
-
-iframe[name="editor-canvas"]:not(.has-editor-padding) {
 	background-color: $white;
-}
-
-iframe[name="editor-canvas"].has-editor-padding {
-	padding: $grid-unit-30 $grid-unit-30 0;
 }

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -31,11 +31,14 @@ export default function VisualEditor( { styles } ) {
 		isBlockBasedTheme,
 		hasV3BlocksOnly,
 		isEditingTemplate,
+		isEditingPattern,
 	} = useSelect( ( select ) => {
 		const { isFeatureActive } = select( editPostStore );
-		const { getEditorSettings, getRenderingMode } = select( editorStore );
+		const { getEditorSettings, getRenderingMode, getCurrentPostType } =
+			select( editorStore );
 		const { getBlockTypes } = select( blocksStore );
 		const editorSettings = getEditorSettings();
+		const currentPostType = getCurrentPostType();
 
 		return {
 			isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
@@ -44,8 +47,8 @@ export default function VisualEditor( { styles } ) {
 			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
 				return type.apiVersion >= 3;
 			} ),
-			isEditingTemplate:
-				select( editorStore ).getCurrentPostType() === 'wp_template',
+			isEditingPattern: currentPostType === 'wp_block',
+			isEditingTemplate: currentPostType === 'wp_template',
 		};
 	}, [] );
 	const hasMetaBoxes = useSelect(
@@ -83,6 +86,7 @@ export default function VisualEditor( { styles } ) {
 		<div
 			className={ classnames( 'edit-post-visual-editor', {
 				'has-inline-canvas': ! isToBeIframed,
+				'is-focus-mode': isEditingPattern || isEditingTemplate,
 			} ) }
 		>
 			<EditorCanvas
@@ -91,6 +95,13 @@ export default function VisualEditor( { styles } ) {
 				// We should auto-focus the canvas (title) on load.
 				// eslint-disable-next-line jsx-a11y/no-autofocus
 				autoFocus={ ! isWelcomeGuideVisible }
+				iframeProps={ {
+					style: {
+						background: isEditingPattern
+							? 'transparent'
+							: undefined,
+					},
+				} }
 			/>
 		</div>
 	);

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -95,13 +95,6 @@ export default function VisualEditor( { styles } ) {
 				// We should auto-focus the canvas (title) on load.
 				// eslint-disable-next-line jsx-a11y/no-autofocus
 				autoFocus={ ! isWelcomeGuideVisible }
-				iframeProps={ {
-					style: {
-						background: isEditingPattern
-							? 'transparent'
-							: undefined,
-					},
-				} }
 			/>
 		</div>
 	);

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -36,6 +36,12 @@
 	// as align-items: stretch is inherited by default.Additionally due to older browser's flex height
 	// interpretation, any percentage value is likely going to cause issues, such as metaboxes overlapping.
 	// See also https://www.w3.org/TR/CSS22/visudet.html#the-height-property.
+
+	// Matches `.is-focus-mode` padding in
+	// packages/edit-site/src/components/block-editor/style.scss.
+	&.is-focus-mode {
+		padding: $grid-unit-60;
+	}
 }
 
 .edit-post-visual-editor__content-area {

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -40,7 +40,7 @@
 	// Matches `.is-focus-mode` padding in
 	// packages/edit-site/src/components/block-editor/style.scss.
 	&.is-focus-mode {
-		padding: $grid-unit-60;
+		padding: $grid-unit-30;
 	}
 }
 

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -26,14 +26,6 @@
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;
 
-	// Controls height of editor and editor canvas container (style book, global styles revisions previews etc.)
-	iframe {
-		display: block;
-		width: 100%;
-		height: 100%;
-		background: $white;
-	}
-
 	.edit-site-visual-editor__editor-canvas {
 		&.is-focused {
 			outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -326,7 +326,6 @@ function EditorCanvas( {
 				style: {
 					...iframeProps?.style,
 					...deviceStyles,
-					border: showEditorPadding ? undefined : 0,
 				},
 			} }
 		>

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -331,6 +331,7 @@ function EditorCanvas( {
 				style: {
 					...iframeProps?.style,
 					...deviceStyles,
+					border: showEditorPadding ? undefined : 0,
 				},
 			} }
 		>

--- a/packages/editor/src/components/editor-canvas/index.js
+++ b/packages/editor/src/components/editor-canvas/index.js
@@ -103,7 +103,6 @@ function EditorCanvas( {
 		wrapperBlockName,
 		wrapperUniqueId,
 		deviceType,
-		showEditorPadding,
 		isDesignPostType,
 	} = useSelect( ( select ) => {
 		const {
@@ -152,8 +151,6 @@ function EditorCanvas( {
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			deviceType: getDeviceType(),
-			showEditorPadding:
-				!! editorSettings.onNavigateToPreviousEntityRecord,
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -324,9 +321,7 @@ function EditorCanvas( {
 			styles={ styles }
 			height="100%"
 			iframeProps={ {
-				className: classnames( 'editor-canvas__iframe', {
-					'has-editor-padding': showEditorPadding,
-				} ),
+				className: 'editor-canvas__iframe',
 				...iframeProps,
 				style: {
 					...iframeProps?.style,


### PR DESCRIPTION
## What?
Follow up to https://github.com/WordPress/gutenberg/pull/57631

This PR ensures that the iframe background is always white regardless of whether it has "padding". 

## Why?
Normally, the iframe has a white background.

When editing a template in the post editor, the iframe receives a classname of `.has-editor-padding` - this class is excluded from receiving the white background via the `not()` selector.

Here's the post editor in trunk:

https://github.com/WordPress/gutenberg/assets/6458278/4c04d509-69c4-4ab8-91bf-12a681a5d4fe




## How?

This PR tries to harmonize the editor canvas `.is-focus-mode` between site and post editors. 

By "harmonize", I mean use the same approach by driving the padding via a classname `is-focus-mode` on the edit-${site/post}-layout element, not centralize the code. 

The latter is difficult because the site editor has "modes", such as edit and view, which also affect the styles.


## Testing Instructions
1. I've tested this in 2022 2023 and 2024 WP themes.
2. Open the post editor and edit the post's template
3. The background should be white
4. Check test instructions for https://github.com/WordPress/gutenberg/pull/57631
5. Also edit a page template in the site editor, check for regressions

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Post editor editing post template


<img width="1076" alt="Screenshot 2024-02-01 at 12 16 26 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/2cd51f64-c029-46a8-ae0a-17181b2d58f2">

### Post editor editing original synched pattern


<img width="1065" alt="Screenshot 2024-02-01 at 12 16 44 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/485adf88-b53f-4fb5-8a0c-a9ad8c5f3d83">

### Site editor editing page template

<img width="1057" alt="Screenshot 2024-02-01 at 12 17 09 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/1b560361-0b63-4873-949d-763b4d212970">
