### PR TITLE
Font Library: Use Button's API to disable footer buttons

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -298,11 +298,10 @@ function Footer( { handleInstall, isDisabled } ) {
 		<Flex justify="flex-end">
 			<Button
 				variant="primary"
-				onClick={
-					isDisabled || isInstalling ? undefined : handleInstall
-				}
+				onClick={ handleInstall }
 				isBusy={ isInstalling }
-				aria-disabled={ isDisabled || isInstalling }
+				disabled={ isDisabled || isInstalling }
+				__experimentalIsFocusable
 			>
 				{ __( 'Install' ) }
 			</Button>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -186,11 +186,10 @@ function Footer( { shouldDisplayDeleteButton, handleUninstallClick } ) {
 				) }
 			</div>
 			<Button
-				aria-disabled={ ! fontFamiliesHasChanges }
 				variant="primary"
-				onClick={
-					fontFamiliesHasChanges ? saveFontFamilies : undefined
-				}
+				onClick={ saveFontFamilies }
+				disabled={ ! fontFamiliesHasChanges }
+				__experimentalIsFocusable
 			>
 				{ __( 'Update' ) }
 			</Button>


### PR DESCRIPTION
Follow up: #58364
See this comment: https://github.com/WordPress/gutenberg/pull/58364#issuecomment-1919313818

## What?

This PR uses the `__experimentalIsFocusable` and `disabled` props to disable the footer buttons of the font library.

## Why?

It makes more sense to use the component's API rather than using custom props.

## How?

I also removed the conditional statement in the `onClick` prop. Even in the whole project, when using `__experimentalIsFocusable` and `disabled`, such conditional statements seem to be used very little.

I would appreciate any advice on whether this change makes sense.

## Testing Instructions

Please refer to the "Testing Instructions for Keyboard" section of #58364 to confirm that it still works as expected.