### PR TITLE
Patterns: Allow the override id to be changed

### DIFF
--- a/packages/patterns/src/components/partial-syncing-controls.js
+++ b/packages/patterns/src/components/partial-syncing-controls.js
@@ -7,7 +7,12 @@ import { nanoid } from 'nanoid';
  * WordPress dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
-import { BaseControl, CheckboxControl } from '@wordpress/components';
+import {
+	BaseControl,
+	CheckboxControl,
+	TextControl,
+	PanelBody,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -83,6 +88,9 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 			},
 		} );
 	}
+	const hasOverrides = attributeSources.some(
+		( source ) => source === 'core/pattern-overrides'
+	);
 
 	return (
 		<InspectorControls group="advanced">
@@ -93,13 +101,33 @@ function PartialSyncingControls( { name, attributes, setAttributes } ) {
 				<CheckboxControl
 					__nextHasNoMarginBottom
 					label={ __( 'Allow instance overrides' ) }
-					checked={ attributeSources.some(
-						( source ) => source === 'core/pattern-overrides'
-					) }
+					checked={ hasOverrides }
 					onChange={ ( isChecked ) => {
 						updateBindings( isChecked );
 					} }
 				/>
+				{ hasOverrides && (
+					<PanelBody
+						className="block-editor-block-inspector__advanced"
+						title={ __( 'Override settings' ) }
+						initialOpen={ false }
+					>
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Override id' ) }
+							value={ attributes.metadata?.id || '' }
+							onChange={ ( newId ) => {
+								setAttributes( {
+									metadata: {
+										...attributes.metadata,
+										id: newId,
+									},
+								} );
+							} }
+						/>
+					</PanelBody>
+				) }
 			</BaseControl>
 		</InspectorControls>
 	);


### PR DESCRIPTION
## What?
Makes the new pattern override id editable.

## Why?
There has been [some discussion](https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1911583913) about how pattern overrides can be set up in order to allow content to be easily switched between similar patterns, and how the current random ids do not allow for this. 

There have been suggestions of reusing the existing block meta `name` property, but this adds a mental overhead to uses to know that these have to be unique across all blocks in the pattern, and also these names appear in, and are editable from, the list view, so a risk of users renaming for visual reasons without an understanding of the impact of the pattern override data.

## How?
This PR aims to solve this problem by setting the default id as random so your average user does not have to worry about it, and there is no potential conflict/impact with changes to block name. 

For theme authors, etc. that wish to set up patterns that can shuffle content, etc. in future iterations of this feature the id value can be overridden either in the editor UX or the pattern code with a more meaningful unique string, eg. `recipe-title`.

## Testing Instructions

- Add a new synced pattern and set `Allow instance overrides`
- Expand the `Override settings` and check that a random id is assigned
- Try changing the id to a meaningful label, eg. `recipe-title` and check that this id is set in the pattern attributes content and that the pattern overrides work as expected in a post

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/54ffcc11-1932-46fb-a3de-0e8b04f9e4be

