### PR TITLE
Template editing: update fullscreen WP back functionality

### DIFF
--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -33,7 +33,7 @@ const ListViewBlockContents = forwardRef(
 		},
 		ref
 	) => {
-		const { clientId } = block;
+		const clientId = block?.clientId;
 
 		const { blockMovingClientId, selectedBlockInBlockEditor } = useSelect(
 			( select ) => {
@@ -49,6 +49,10 @@ const ListViewBlockContents = forwardRef(
 
 		const { AdditionalBlockContent, insertedBlock, setInsertedBlock } =
 			useListViewContext();
+
+		if ( ! clientId ) {
+			return null;
+		}
 
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -33,7 +33,7 @@ const ListViewBlockContents = forwardRef(
 		},
 		ref
 	) => {
-		const clientId = block?.clientId;
+		const { clientId } = block;
 
 		const { blockMovingClientId, selectedBlockInBlockEditor } = useSelect(
 			( select ) => {
@@ -49,10 +49,6 @@ const ListViewBlockContents = forwardRef(
 
 		const { AdditionalBlockContent, insertedBlock, setInsertedBlock } =
 			useListViewContext();
-
-		if ( ! clientId ) {
-			return null;
-		}
 
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -33,7 +33,7 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 				select( coreStore );
 			const siteData =
 				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
-			const { getEditPostTypeProps } = getEditorSettings();
+			const { editPostTypeProps } = getEditorSettings();
 
 			return {
 				isActive: isFeatureActive( 'fullscreenMode' ),
@@ -42,7 +42,7 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 					'__unstableBase',
 					undefined,
 				] ),
-				postType: getPostType( getEditPostTypeProps()?.postType ),
+				postType: getPostType( editPostTypeProps?.postType ),
 				siteIconUrl: siteData.site_icon_url,
 			};
 		},

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -18,7 +18,6 @@ import { wordpress } from '@wordpress/icons';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useReducedMotion } from '@wordpress/compose';
-import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -26,16 +25,15 @@ import { useCallback } from '@wordpress/element';
 import { store as editPostStore } from '../../../store';
 
 function FullscreenModeClose( { showTooltip, icon, href } ) {
-	const { isActive, isRequestingSiteIcon, postType, siteIconUrl, goBack } =
-		useSelect( ( select ) => {
-			const { getCurrentPostType, getEditorSettings } =
-				select( editorStore );
+	const { isActive, isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
+		( select ) => {
+			const { getEditorSettings } = select( editorStore );
 			const { isFeatureActive } = select( editPostStore );
 			const { getEntityRecord, getPostType, isResolving } =
 				select( coreStore );
 			const siteData =
 				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
-			const _goBack = getEditorSettings()?.goBack;
+			const { getEditPostTypeProps } = getEditorSettings();
 
 			return {
 				isActive: isFeatureActive( 'fullscreenMode' ),
@@ -44,22 +42,14 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 					'__unstableBase',
 					undefined,
 				] ),
-				postType: getPostType( getCurrentPostType() ),
+				postType: getPostType( getEditPostTypeProps()?.postType ),
 				siteIconUrl: siteData.site_icon_url,
-				goBack: typeof _goBack === 'function' ? _goBack : undefined,
 			};
-		}, [] );
+		},
+		[]
+	);
 
 	const disableMotion = useReducedMotion();
-	const onClick = useCallback(
-		( event ) => {
-			if ( goBack ) {
-				event.preventDefault();
-				goBack();
-			}
-		},
-		[ goBack ]
-	);
 
 	if ( ! isActive || ! postType ) {
 		return null;
@@ -105,19 +95,15 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 			post_type: postType.slug,
 		} );
 
-	const buttonLabel =
-		! goBack && postType?.labels?.view_items
-			? postType?.labels?.view_items
-			: __( 'Back' );
+	const buttonLabel = postType?.labels?.view_items ?? __( 'Back' );
 
 	return (
 		<motion.div whileHover="expand">
 			<Button
 				className={ classes }
-				href={ ! goBack ? buttonHref : undefined }
+				href={ buttonHref }
 				label={ buttonLabel }
 				showTooltip={ showTooltip }
-				onClick={ onClick }
 			>
 				{ buttonIcon }
 			</Button>

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -24,17 +24,16 @@ import { useReducedMotion } from '@wordpress/compose';
  */
 import { store as editPostStore } from '../../../store';
 
-function FullscreenModeClose( { showTooltip, icon, href } ) {
+function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 	const { isActive, isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
 		( select ) => {
-			const { getEditorSettings } = select( editorStore );
+			const { getCurrentPostType } = select( editorStore );
 			const { isFeatureActive } = select( editPostStore );
 			const { getEntityRecord, getPostType, isResolving } =
 				select( coreStore );
 			const siteData =
 				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
-			const { editPostTypeProps } = getEditorSettings();
-
+			const _postType = initialPost?.type || getCurrentPostType();
 			return {
 				isActive: isFeatureActive( 'fullscreenMode' ),
 				isRequestingSiteIcon: isResolving( 'getEntityRecord', [
@@ -42,7 +41,7 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 					'__unstableBase',
 					undefined,
 				] ),
-				postType: getPostType( editPostTypeProps?.postType ),
+				postType: getPostType( _postType ),
 				siteIconUrl: siteData.site_icon_url,
 			};
 		},

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
@@ -15,8 +15,7 @@ import FullscreenModeClose from '../';
 
 jest.mock( '@wordpress/data/src/components/use-select', () => {
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
+	return jest.fn();
 } );
 
 jest.mock( '@wordpress/core-data' );
@@ -28,13 +27,14 @@ describe( 'FullscreenModeClose', () => {
 				return cb( () => ( {
 					isResolving: () => false,
 					isFeatureActive: () => true,
-					getCurrentPostType: () => {},
 					getPostType: () => true,
 					getEntityRecord: () => ( {
 						site_icon_url: 'https://fakeUrl.com',
 					} ),
 					getEditorSettings: () => ( {
-						goBack: undefined,
+						getEditPostTypeProps: () => ( {
+							postType: 'post',
+						} ),
 					} ),
 				} ) );
 			} );
@@ -50,13 +50,14 @@ describe( 'FullscreenModeClose', () => {
 				return cb( () => ( {
 					isResolving: () => false,
 					isFeatureActive: () => true,
-					getCurrentPostType: () => {},
 					getPostType: () => true,
 					getEntityRecord: () => ( {
 						site_icon_url: '',
 					} ),
 					getEditorSettings: () => ( {
-						goBack: undefined,
+						getEditPostTypeProps: () => ( {
+							postType: 'post',
+						} ),
 					} ),
 				} ) );
 			} );
@@ -75,12 +76,11 @@ describe( 'FullscreenModeClose', () => {
 				return cb( () => ( {
 					isResolving: () => false,
 					isFeatureActive: () => true,
-					getCurrentPostType: () => {},
 					getPostType: () => {
 						return {
-							slug: 'post',
+							slug: 'page',
 							labels: {
-								view_items: 'View Posts',
+								view_items: 'View Pages',
 							},
 						};
 					},
@@ -88,49 +88,19 @@ describe( 'FullscreenModeClose', () => {
 						site_icon_url: '',
 					} ),
 					getEditorSettings: () => ( {
-						goBack: undefined,
+						getEditPostTypeProps: () => ( {
+							postType: 'page',
+						} ),
 					} ),
 				} ) );
 			} );
 
 			render( <FullscreenModeClose /> );
 
-			const button = screen.getByLabelText( 'View Posts' );
+			const button = screen.getByLabelText( 'View Pages' );
 			expect( button.href ).toBe(
-				'http://localhost/edit.php?post_type=post'
+				'http://localhost/edit.php?post_type=page'
 			);
-		} );
-
-		it( 'should add correct click handler where goBack function exists', () => {
-			const goBack = jest.fn();
-			useSelect.mockImplementation( ( cb ) => {
-				return cb( () => ( {
-					isResolving: () => false,
-					isFeatureActive: () => true,
-					getCurrentPostType: () => {},
-					getPostType: () => {
-						return {
-							slug: 'post',
-							labels: {
-								view_items: 'View Posts',
-							},
-						};
-					},
-					getEntityRecord: () => ( {
-						site_icon_url: '',
-					} ),
-					getEditorSettings: () => ( {
-						goBack,
-					} ),
-				} ) );
-			} );
-
-			render( <FullscreenModeClose /> );
-
-			const button = screen.getByLabelText( 'Back' );
-			expect( button.href ).toBeUndefined();
-			button.click();
-			expect( goBack ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
@@ -32,9 +32,9 @@ describe( 'FullscreenModeClose', () => {
 						site_icon_url: 'https://fakeUrl.com',
 					} ),
 					getEditorSettings: () => ( {
-						getEditPostTypeProps: () => ( {
+						editPostTypeProps: {
 							postType: 'post',
-						} ),
+						},
 					} ),
 				} ) );
 			} );
@@ -55,9 +55,9 @@ describe( 'FullscreenModeClose', () => {
 						site_icon_url: '',
 					} ),
 					getEditorSettings: () => ( {
-						getEditPostTypeProps: () => ( {
+						editPostTypeProps: {
 							postType: 'post',
-						} ),
+						},
 					} ),
 				} ) );
 			} );
@@ -88,9 +88,9 @@ describe( 'FullscreenModeClose', () => {
 						site_icon_url: '',
 					} ),
 					getEditorSettings: () => ( {
-						getEditPostTypeProps: () => ( {
+						editPostTypeProps: {
 							postType: 'page',
-						} ),
+						},
 					} ),
 				} ) );
 			} );

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
@@ -33,11 +33,13 @@ describe( 'FullscreenModeClose', () => {
 					getEntityRecord: () => ( {
 						site_icon_url: 'https://fakeUrl.com',
 					} ),
+					getEditorSettings: () => ( {
+						goBack: undefined,
+					} ),
 				} ) );
 			} );
 
 			render( <FullscreenModeClose /> );
-
 			const siteIcon = screen.getByAltText( 'Site Icon' );
 
 			expect( siteIcon ).toBeVisible();
@@ -53,6 +55,9 @@ describe( 'FullscreenModeClose', () => {
 					getEntityRecord: () => ( {
 						site_icon_url: '',
 					} ),
+					getEditorSettings: () => ( {
+						goBack: undefined,
+					} ),
 				} ) );
 			} );
 
@@ -63,6 +68,69 @@ describe( 'FullscreenModeClose', () => {
 			).not.toBeInTheDocument();
 
 			expect( container ).toMatchSnapshot();
+		} );
+
+		it( 'should add correct href where post type exists', () => {
+			useSelect.mockImplementation( ( cb ) => {
+				return cb( () => ( {
+					isResolving: () => false,
+					isFeatureActive: () => true,
+					getCurrentPostType: () => {},
+					getPostType: () => {
+						return {
+							slug: 'post',
+							labels: {
+								view_items: 'View Posts',
+							},
+						};
+					},
+					getEntityRecord: () => ( {
+						site_icon_url: '',
+					} ),
+					getEditorSettings: () => ( {
+						goBack: undefined,
+					} ),
+				} ) );
+			} );
+
+			render( <FullscreenModeClose /> );
+
+			const button = screen.getByLabelText( 'View Posts' );
+			expect( button.href ).toBe(
+				'http://localhost/edit.php?post_type=post'
+			);
+		} );
+
+		it( 'should add correct click handler where goBack function exists', () => {
+			const goBack = jest.fn();
+			useSelect.mockImplementation( ( cb ) => {
+				return cb( () => ( {
+					isResolving: () => false,
+					isFeatureActive: () => true,
+					getCurrentPostType: () => {},
+					getPostType: () => {
+						return {
+							slug: 'post',
+							labels: {
+								view_items: 'View Posts',
+							},
+						};
+					},
+					getEntityRecord: () => ( {
+						site_icon_url: '',
+					} ),
+					getEditorSettings: () => ( {
+						goBack,
+					} ),
+				} ) );
+			} );
+
+			render( <FullscreenModeClose /> );
+
+			const button = screen.getByLabelText( 'Back' );
+			expect( button.href ).toBeUndefined();
+			button.click();
+			expect( goBack ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
@@ -31,11 +31,7 @@ describe( 'FullscreenModeClose', () => {
 					getEntityRecord: () => ( {
 						site_icon_url: 'https://fakeUrl.com',
 					} ),
-					getEditorSettings: () => ( {
-						editPostTypeProps: {
-							postType: 'post',
-						},
-					} ),
+					getCurrentPostType: () => 'post',
 				} ) );
 			} );
 
@@ -54,11 +50,7 @@ describe( 'FullscreenModeClose', () => {
 					getEntityRecord: () => ( {
 						site_icon_url: '',
 					} ),
-					getEditorSettings: () => ( {
-						editPostTypeProps: {
-							postType: 'post',
-						},
-					} ),
+					getCurrentPostType: () => 'post',
 				} ) );
 			} );
 
@@ -71,7 +63,7 @@ describe( 'FullscreenModeClose', () => {
 			expect( container ).toMatchSnapshot();
 		} );
 
-		it( 'should add correct href where post type exists', () => {
+		it( 'should add correct href using post type from initialPost props', () => {
 			useSelect.mockImplementation( ( cb ) => {
 				return cb( () => ( {
 					isResolving: () => false,
@@ -87,15 +79,11 @@ describe( 'FullscreenModeClose', () => {
 					getEntityRecord: () => ( {
 						site_icon_url: '',
 					} ),
-					getEditorSettings: () => ( {
-						editPostTypeProps: {
-							postType: 'page',
-						},
-					} ),
+					getCurrentPostType: () => 'post',
 				} ) );
 			} );
 
-			render( <FullscreenModeClose /> );
+			render( <FullscreenModeClose initialPost={ { type: 'page' } } /> );
 
 			const button = screen.getByLabelText( 'View Pages' );
 			expect( button.href ).toBe(

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -55,7 +55,7 @@ const slideX = {
 	hover: { x: 0, transition: { type: 'tween', delay: 0.2 } },
 };
 
-function Header( { setEntitiesSavedStatesCallback } ) {
+function Header( { setEntitiesSavedStatesCallback, initialPost } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const blockToolbarRef = useRef();
@@ -101,7 +101,10 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 					variants={ slideX }
 					transition={ { type: 'tween', delay: 0.8 } }
 				>
-					<FullscreenModeClose showTooltip />
+					<FullscreenModeClose
+						showTooltip
+						initialPost={ initialPost }
+					/>
 				</motion.div>
 			</MainDashboardButton.Slot>
 			<motion.div

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -131,7 +131,7 @@ function useEditorStyles() {
 	] );
 }
 
-function Layout() {
+function Layout( { initialPost } ) {
 	useCommands();
 	useCommonCommands();
 	useBlockCommands();
@@ -304,6 +304,7 @@ function Layout() {
 						setEntitiesSavedStatesCallback={
 							setEntitiesSavedStatesCallback
 						}
+						initialPost={ initialPost }
 					/>
 				}
 				editorNotices={ <EditorNotices /> }

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -32,10 +32,8 @@ function Editor( {
 	initialEdits,
 	...props
 } ) {
-	const { currentPost, getPostLinkProps, goBack } = usePostHistory(
-		initialPostId,
-		initialPostType
-	);
+	const { currentPost, getPostLinkProps, getEditPostTypeProps, goBack } =
+		usePostHistory( initialPostId, initialPostType );
 
 	const { hasInlineToolbar, post, preferredStyleVariations, template } =
 		useSelect(
@@ -80,10 +78,11 @@ function Editor( {
 	const defaultRenderingMode =
 		currentPost.postType === 'wp_template' ? 'all' : 'post-only';
 
-	const editorSettings = useMemo( () => {
-		const result = {
+	const editorSettings = useMemo(
+		() => ( {
 			...settings,
 			getPostLinkProps,
+			getEditPostTypeProps,
 			goBack,
 			defaultRenderingMode,
 			__experimentalPreferredStyleVariations: {
@@ -91,17 +90,18 @@ function Editor( {
 				onChange: updatePreferredStyleVariations,
 			},
 			hasInlineToolbar,
-		};
-		return result;
-	}, [
-		settings,
-		hasInlineToolbar,
-		preferredStyleVariations,
-		updatePreferredStyleVariations,
-		getPostLinkProps,
-		goBack,
-		defaultRenderingMode,
-	] );
+		} ),
+		[
+			settings,
+			hasInlineToolbar,
+			preferredStyleVariations,
+			updatePreferredStyleVariations,
+			getPostLinkProps,
+			getEditPostTypeProps,
+			goBack,
+			defaultRenderingMode,
+		]
+	);
 
 	if ( ! post ) {
 		return null;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -32,7 +32,7 @@ function Editor( {
 	initialEdits,
 	...props
 } ) {
-	const { currentPost, getPostLinkProps, getEditPostTypeProps, goBack } =
+	const { currentPost, getPostLinkProps, editPostTypeProps, goBack } =
 		usePostHistory( initialPostId, initialPostType );
 
 	const { hasInlineToolbar, post, preferredStyleVariations, template } =
@@ -82,7 +82,7 @@ function Editor( {
 		() => ( {
 			...settings,
 			getPostLinkProps,
-			getEditPostTypeProps,
+			editPostTypeProps,
 			goBack,
 			defaultRenderingMode,
 			__experimentalPreferredStyleVariations: {
@@ -97,7 +97,7 @@ function Editor( {
 			preferredStyleVariations,
 			updatePreferredStyleVariations,
 			getPostLinkProps,
-			getEditPostTypeProps,
+			editPostTypeProps,
 			goBack,
 			defaultRenderingMode,
 		]

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -32,7 +32,7 @@ function Editor( {
 	initialEdits,
 	...props
 } ) {
-	const { currentPost, getPostLinkProps, editPostTypeProps, goBack } =
+	const { currentPost, getPostLinkProps, initialPost, goBack } =
 		usePostHistory( initialPostId, initialPostType );
 
 	const { hasInlineToolbar, post, preferredStyleVariations, template } =
@@ -82,7 +82,6 @@ function Editor( {
 		() => ( {
 			...settings,
 			getPostLinkProps,
-			editPostTypeProps,
 			goBack,
 			defaultRenderingMode,
 			__experimentalPreferredStyleVariations: {
@@ -97,7 +96,6 @@ function Editor( {
 			preferredStyleVariations,
 			updatePreferredStyleVariations,
 			getPostLinkProps,
-			editPostTypeProps,
 			goBack,
 			defaultRenderingMode,
 		]
@@ -120,7 +118,7 @@ function Editor( {
 				<ErrorBoundary>
 					<CommandMenu />
 					<EditorInitialization postId={ currentPost.postId } />
-					<Layout />
+					<Layout initialPost={ initialPost } />
 				</ErrorBoundary>
 				<PostLockedModal />
 			</ExperimentalEditorProvider>

--- a/packages/edit-post/src/hooks/use-post-history.js
+++ b/packages/edit-post/src/hooks/use-post-history.js
@@ -35,6 +35,13 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 		[ { postId: initialPostId, postType: initialPostType } ]
 	);
 
+	const getEditPostTypeProps = useCallback( () => {
+		return {
+			postType: initialPostType,
+			postId: initialPostId,
+		};
+	}, [ initialPostType, initialPostId ] );
+
 	const getPostLinkProps = useCallback( ( params ) => {
 		const currentArgs = getQueryArgs( window.location.href );
 		const currentUrlWithoutArgs = removeQueryArgs(
@@ -68,6 +75,7 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 	return {
 		currentPost,
 		getPostLinkProps,
+		getEditPostTypeProps,
 		goBack: postHistory.length > 1 ? goBack : undefined,
 	};
 }

--- a/packages/edit-post/src/hooks/use-post-history.js
+++ b/packages/edit-post/src/hooks/use-post-history.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useReducer } from '@wordpress/element';
+import { useCallback, useReducer, useMemo } from '@wordpress/element';
 import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 
 /**
@@ -35,7 +35,7 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 		[ { postId: initialPostId, postType: initialPostType } ]
 	);
 
-	const getEditPostTypeProps = useCallback( () => {
+	const editPostTypeProps = useMemo( () => {
 		return {
 			postType: initialPostType,
 			postId: initialPostId,
@@ -75,7 +75,7 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 	return {
 		currentPost,
 		getPostLinkProps,
-		getEditPostTypeProps,
+		editPostTypeProps,
 		goBack: postHistory.length > 1 ? goBack : undefined,
 	};
 }

--- a/packages/edit-post/src/hooks/use-post-history.js
+++ b/packages/edit-post/src/hooks/use-post-history.js
@@ -35,10 +35,10 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 		[ { postId: initialPostId, postType: initialPostType } ]
 	);
 
-	const editPostTypeProps = useMemo( () => {
+	const initialPost = useMemo( () => {
 		return {
-			postType: initialPostType,
-			postId: initialPostId,
+			type: initialPostType,
+			id: initialPostId,
 		};
 	}, [ initialPostType, initialPostId ] );
 
@@ -75,7 +75,7 @@ export default function usePostHistory( initialPostId, initialPostType ) {
 	return {
 		currentPost,
 		getPostLinkProps,
-		editPostTypeProps,
+		initialPost,
 		goBack: postHistory.length > 1 ? goBack : undefined,
 	};
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and how?
This PR:

1. ~~checks for a clientId in the list view to fix a bug in template editing mode where no block is selected~~ https://github.com/WordPress/gutenberg/pull/58533 will take care of this
2. adds an object `editPostTypeProps` to the post editor settings that stores the initial post type and post id.


## Why?
1. ~~In the site and post editors, when editing a page/post template with the list view open, clicking back to the page triggers `Uncaught TypeError: Cannot destructure property 'clientId' of 'block' as it is null. at block-contents.js:36:1` and the editor crashes.~~
2. When editing a post/page template in the post editor the the current post type flips to `wp_template`, creating a link in the fullscreen WordPress logo of `/wp-admin/edit.php?post_type=wp_template` - this page is inaccessible. What we want is the _original_ post details.



https://github.com/WordPress/gutenberg/assets/6458278/573d609b-664f-4159-b897-a4f2e4e77427




## Testing Instructions

1. Open the post editor in Fullscreen mode
2. Edit the post template
3. Click the WP logo
4. You should exit the editor and return to the posts list.
5. Repeat steps 2-6 with a page.
6. For good measure check the site editor too.
7. Have a tea. You deserve it!
