### PR TITLE
Data views: Fix double scrollbar in grid layout

### DIFF
--- a/packages/edit-site/src/components/page/style.scss
+++ b/packages/edit-site/src/components/page/style.scss
@@ -27,7 +27,6 @@
 .edit-site-page-content {
 	height: 100%;
 	display: flex;
-	overflow: auto;
 	flex-flow: column;
 	position: relative;
 	z-index: z-index(".edit-site-page-content");


### PR DESCRIPTION
Fixes #58535

## What?

This PR fixes double scrollbars that occur in the dataview grid layout.

### Before

![image](https://github.com/WordPress/gutenberg/assets/54422211/fa068c69-228a-4025-b0b3-938d360f6e6d)

### After

![image](https://github.com/WordPress/gutenberg/assets/54422211/00e7ef6a-e04f-41ae-8f9e-73d5e701b15b)

## Why?

It seems like an unnecessary `overflow: auto` is having an effect.

## How?

This style has been added in [#53207](https://github.com/WordPress/gutenberg/pull/53207/files#diff-faf245a8ddb49305b5d7b7c5ce3ca8b5c5a973a0feaed2112fa3d8a87366a981R37) to fix the snackbar. However, it currently appears that the problem does not occur without this style. Maybe it's because the content area was wrapped in a new element (`.edit-site-layout__area`).

## Testing Instructions

- Create enough Templates, Template Parts, Patterns, Pages so that the content can be scrolled.
- Check that double scrollbars are not displayed in the grid layout.
- Make sure that it does not affect other layouts.
- Duplicate, delete, or rename any item. If you scroll through the content after the snackbar appears, the snackbar position should not change.
