### PR TITLE
Block Library: Rename variation build methods

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -375,12 +375,11 @@ function block_core_navigation_link_unregister_variation( $name ) {
 }
 
 /**
- * Register the navigation link block.
  * Returns an array of variations for the navigation link block.
  *
  * @return array
  */
-function build_navigation_link_block_variations() {
+function block_core_navigation_link_build_variations() {
 	// This will only handle post types and taxonomies registered until this point (init on priority 9).
 	// See action hooks below for other post types and taxonomies.
 	// See https://github.com/WordPress/gutenberg/issues/53826 for details.
@@ -429,7 +428,7 @@ function register_block_core_navigation_link() {
 		__DIR__ . '/navigation-link',
 		array(
 			'render_callback'    => 'render_block_core_navigation_link',
-			'variation_callback' => 'build_navigation_link_block_variations',
+			'variation_callback' => 'block_core_navigation_link_build_variations',
 		)
 	);
 }

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -63,7 +63,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
  *
  * @return array The available variations for the block.
  */
-function build_post_term_block_variations() {
+function block_core_post_terms_build_variations() {
 	$taxonomies = get_taxonomies(
 		array(
 			'publicly_queryable' => true,
@@ -116,7 +116,7 @@ function register_block_core_post_terms() {
 		__DIR__ . '/post-terms',
 		array(
 			'render_callback'    => 'render_block_core_post_terms',
-			'variation_callback' => 'build_post_term_block_variations',
+			'variation_callback' => 'block_core_post_terms_build_variations',
 		)
 	);
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -122,8 +122,6 @@
 				<element value="apply_block_core_search_border_style"/>
 				<element value="apply_block_core_search_border_styles"/>
 				<element value="build_dropdown_script_block_core_categories"/>
-				<element value="build_navigation_link_block_variations"/>
-				<element value="build_post_term_block_variations"/>
 				<element value="build_template_part_block_area_variations"/>
 				<element value="build_template_part_block_instance_variations"/>
 				<element value="build_template_part_block_variations"/>


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/56952#discussion_r1472111718.

PR renames new variation build methods to follow coding standards.

## Testing Instructions
1. Open a post or page.
2. Ron following snippets in DevTools Console - `wp.blocks.getBlockType('core/post-terms')` and `wp.blocks.getBlockType('core/navigation-link')`
3. Ensure that the block object returned has variations.

### Testing Instructions for Keyboard
Same.