### PR TITLE
Mobile Release v1.112.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55551,7 +55551,7 @@
 		},
 		"packages/react-native-aztec": {
 			"name": "@wordpress/react-native-aztec",
-			"version": "1.111.2",
+			"version": "1.112.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "file:../element",
@@ -55564,7 +55564,7 @@
 		},
 		"packages/react-native-bridge": {
 			"name": "@wordpress/react-native-bridge",
-			"version": "1.111.2",
+			"version": "1.112.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/react-native-aztec": "file:../react-native-aztec"
@@ -55575,7 +55575,7 @@
 		},
 		"packages/react-native-editor": {
 			"name": "@wordpress/react-native-editor",
-			"version": "1.111.2",
+			"version": "1.112.0",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.111.2",
+	"version": "1.112.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.111.2",
+	"version": "1.112.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,8 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+
+## 1.112.0
 -   [*] [internal] Upgrade React Native to version 0.71.15 [#57667]
 
 ## 1.111.2

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,6 +13,8 @@ For each user feature we should also add a importance categorization label  to i
 
 ## 1.112.0
 -   [*] [internal] Upgrade React Native to version 0.71.15 [#57667]
+-   [**] Prevent images from temporarily disappearing when uploading media [#57869]
+-   [**] Fix crash occurring on large post on Android [#58266]
 
 ## 1.111.2
 -   [*] [internal] Remove `mediaFilesCollectionBlock` initial prop [#58140]
@@ -25,7 +27,6 @@ For each user feature we should also add a importance categorization label  to i
 -   [**] Image block media uploads display a custom error message when there is no internet connection [#56937]
 -   [*] Fix missing custom color indicator for custom gradients [#57605]
 -   [**] Display a notice when a network connection unavailable [#56934]
--   [**] Prevent images from temporarily disappearing when uploading media [#57869]
 
 ## 1.110.1
 -   [**] Fix crash when RichText values are not defined [#58088]

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.71.15)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Gutenberg (1.111.2):
+  - Gutenberg (1.112.0):
     - React-Core (= 0.71.15)
     - React-CoreModules (= 0.71.15)
     - React-RCTImage (= 0.71.15)
@@ -429,7 +429,7 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - RNTAztecView (1.111.2):
+  - RNTAztecView (1.112.0):
     - React-Core
     - WordPress-Aztec-iOS (= 1.19.9)
   - SDWebImage (5.11.1):
@@ -617,7 +617,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 8f5ee005451bf28f6a3ae995914b2f04b3584122
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Gutenberg: 0bcdba988e55a27b78422d2f6b6fec1868b8e5bb
+  Gutenberg: fad00864ab916e9f7778e5493c1a7f3bd9316eb4
   hermes-engine: 04437e4291ede4af0c76c25e7efd0eacb8fd25e5
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
@@ -662,7 +662,7 @@ SPEC CHECKSUMS:
   RNReanimated: d4f363f4987ae0ade3e36ff81c94e68261bf4b8d
   RNScreens: 68fd1060f57dd1023880bf4c05d74784b5392789
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
-  RNTAztecView: 129120dde150fce9554f28272321310aa18a0d82
+  RNTAztecView: 74c676c87e4a9db79104fcdad9624c1e5c02fe15
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.111.2",
+	"version": "1.112.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Release 1.112.0 of the react-native-editor and Gutenberg-Mobile.

- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6597
- https://github.com/wordpress-mobile/WordPress-Android/pull/20093
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22513

