### PR TITLE
Fix nested pattern overrides and disable editing inner pattern

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -33,6 +33,7 @@ import { parse, cloneBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import { name as blockName } from './index';
 import { unlock } from '../lock-unlock';
 
 const { useLayoutClasses } = unlock( blockEditorPrivateApis );
@@ -134,6 +135,7 @@ function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
 	/** @type {Record<string, { values: Record<string, unknown>}>} */
 	const content = {};
 	for ( const block of blocks ) {
+		if ( block.name === blockName ) continue;
 		Object.assign(
 			content,
 			getContentValuesFromInnerBlocks( block.innerBlocks, defaultValues )
@@ -166,7 +168,13 @@ function setBlockEditMode( setEditMode, blocks, mode ) {
 			mode ||
 			( hasOverridableAttributes( block ) ? 'contentOnly' : 'disabled' );
 		setEditMode( block.clientId, editMode );
-		setBlockEditMode( setEditMode, block.innerBlocks, mode );
+
+		setBlockEditMode(
+			setEditMode,
+			block.innerBlocks,
+			// Disable editing for nested patterns.
+			block.name === blockName ? 'disabled' : mode
+		);
 	} );
 }
 
@@ -200,15 +208,12 @@ export default function ReusableBlockEdit( {
 	} = useDispatch( blockEditorStore );
 	const { syncDerivedUpdates } = unlock( useDispatch( blockEditorStore ) );
 
-	const { innerBlocks, userCanEdit, getBlockEditingMode, getPostLinkProps } =
+	const { innerBlocks, userCanEdit, getPostLinkProps, editingMode } =
 		useSelect(
 			( select ) => {
 				const { canUser } = select( coreStore );
-				const {
-					getBlocks,
-					getBlockEditingMode: editingMode,
-					getSettings,
-				} = select( blockEditorStore );
+				const { getBlocks, getSettings, getBlockEditingMode } =
+					select( blockEditorStore );
 				const blocks = getBlocks( patternClientId );
 				const canEdit = canUser( 'update', 'blocks', ref );
 
@@ -216,8 +221,8 @@ export default function ReusableBlockEdit( {
 				return {
 					innerBlocks: blocks,
 					userCanEdit: canEdit,
-					getBlockEditingMode: editingMode,
 					getPostLinkProps: getSettings().getPostLinkProps,
+					editingMode: getBlockEditingMode( patternClientId ),
 				};
 			},
 			[ patternClientId, ref ]
@@ -230,10 +235,15 @@ export default function ReusableBlockEdit( {
 		  } )
 		: {};
 
-	useEffect(
-		() => setBlockEditMode( setBlockEditingMode, innerBlocks ),
-		[ innerBlocks, setBlockEditingMode ]
-	);
+	// Sync the editing mode of the pattern block with the inner blocks.
+	useEffect( () => {
+		setBlockEditMode(
+			setBlockEditingMode,
+			innerBlocks,
+			// Disable editing if the pattern itself is disabled.
+			editingMode === 'disabled' ? 'disabled' : undefined
+		);
+	}, [ editingMode, innerBlocks, setBlockEditingMode ] );
 
 	const canOverrideBlocks = useMemo(
 		() => hasOverridableBlocks( innerBlocks ),
@@ -253,7 +263,9 @@ export default function ReusableBlockEdit( {
 	// Apply the initial overrides from the pattern block to the inner blocks.
 	useEffect( () => {
 		defaultContent.current = {};
-		const editingMode = getBlockEditingMode( patternClientId );
+		const { getBlockEditingMode } = registry.select( blockEditorStore );
+		const originalEditingMode = getBlockEditingMode( patternClientId );
+		// Replace the contents of the blocks with the overrides.
 		registry.batch( () => {
 			setBlockEditingMode( patternClientId, 'default' );
 			syncDerivedUpdates( () => {
@@ -266,7 +278,7 @@ export default function ReusableBlockEdit( {
 					)
 				);
 			} );
-			setBlockEditingMode( patternClientId, editingMode );
+			setBlockEditingMode( patternClientId, originalEditingMode );
 		} );
 	}, [
 		__unstableMarkNextChangeAsNotPersistent,
@@ -274,7 +286,6 @@ export default function ReusableBlockEdit( {
 		initialBlocks,
 		replaceInnerBlocks,
 		registry,
-		getBlockEditingMode,
 		setBlockEditingMode,
 		syncDerivedUpdates,
 	] );
@@ -323,7 +334,6 @@ export default function ReusableBlockEdit( {
 	}, [ syncDerivedUpdates, patternClientId, registry, setAttributes ] );
 
 	const handleEditOriginal = ( event ) => {
-		setBlockEditMode( setBlockEditingMode, innerBlocks, 'default' );
 		editOriginalProps.onClick( event );
 	};
 

--- a/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-blocks.ts
@@ -29,11 +29,28 @@ export async function getBlocks(
 
 	return await this.page.evaluate(
 		( [ _full, _clientId ] ) => {
+			// Serialize serializable attributes of blocks.
+			function serializeAttributes(
+				attributes: Record< string, unknown >
+			) {
+				return Object.fromEntries(
+					Object.entries( attributes ).map( ( [ key, value ] ) => {
+						// Serialize RichTextData to string.
+						if (
+							value instanceof window.wp.richText.RichTextData
+						) {
+							return [ key, ( value as string ).toString() ];
+						}
+						return [ key, value ];
+					} )
+				);
+			}
+
 			// Remove other unpredictable properties like clientId from blocks for testing purposes.
 			function recursivelyTransformBlocks( blocks: Block[] ): Block[] {
 				return blocks.map( ( block ) => ( {
 					name: block.name,
-					attributes: block.attributes,
+					attributes: serializeAttributes( block.attributes ),
 					innerBlocks: recursivelyTransformBlocks(
 						block.innerBlocks
 					),

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -374,4 +374,123 @@ test.describe( 'Pattern Overrides', () => {
 		await expect( buttonLink ).toHaveAttribute( 'target', '' );
 		await expect( buttonLink ).toHaveAttribute( 'rel', /^\s*nofollow\s*$/ );
 	} );
+
+	test( 'disables editing of nested patterns', async ( {
+		page,
+		admin,
+		requestUtils,
+		editor,
+	} ) => {
+		const paragraphId = 'paragraph-id';
+		const headingId = 'heading-id';
+		const innerPattern = await requestUtils.createBlock( {
+			title: 'Inner Pattern',
+			content: `<!-- wp:paragraph {"metadata":{"id":"${ paragraphId }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+<p>Inner paragraph</p>
+<!-- /wp:paragraph -->`,
+			status: 'publish',
+		} );
+		const outerPattern = await requestUtils.createBlock( {
+			title: 'Outer Pattern',
+			content: `<!-- wp:heading {"metadata":{"id":"${ headingId }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+<h2 class="wp-block-heading">Outer heading</h2>
+<!-- /wp:heading -->
+<!-- wp:block {"ref":${ innerPattern.id },"overrides":{"${ paragraphId }":{"content":"Inner paragraph (edited)"}}} /-->`,
+			status: 'publish',
+		} );
+
+		await admin.createNewPost();
+
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: { ref: outerPattern.id },
+		} );
+
+		// Make an edit to the outer pattern heading.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Heading' } )
+			.fill( 'Outer heading (edited)' );
+
+		const postId = await editor.publishPost();
+
+		// Check it renders correctly.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/block',
+				attributes: {
+					ref: outerPattern.id,
+					content: {
+						[ headingId ]: {
+							values: { content: 'Outer heading (edited)' },
+						},
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'core/heading',
+						attributes: { content: 'Outer heading (edited)' },
+					},
+					{
+						name: 'core/block',
+						attributes: {
+							ref: innerPattern.id,
+							content: {
+								[ paragraphId ]: {
+									values: {
+										content: 'Inner paragraph (edited)',
+									},
+								},
+							},
+						},
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								attributes: {
+									content: 'Inner paragraph (edited)',
+								},
+							},
+						],
+					},
+				],
+			},
+		] );
+
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+				includeHidden: true,
+			} ),
+			'The inner paragraph should not be editable'
+		).toHaveAttribute( 'inert', 'true' );
+
+		// Edit the outer pattern.
+		await editor.selectBlocks(
+			editor.canvas
+				.getByRole( 'document', { name: 'Block: Pattern' } )
+				.first()
+		);
+		await editor.showBlockToolbar();
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'link', { name: 'Edit original' } )
+			.click();
+
+		// The inner paragraph should be editable in the pattern focus mode.
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} ),
+			'The inner paragraph should not be editable'
+		).not.toHaveAttribute( 'inert', 'true' );
+
+		// Visit the post on the frontend.
+		await page.goto( `/?p=${ postId }` );
+
+		await expect( page.getByRole( 'heading', { level: 2 } ) ).toHaveText(
+			'Outer heading (edited)'
+		);
+		await expect(
+			page.getByText( 'Inner paragraph (edited)' )
+		).toBeVisible();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Alternative to https://github.com/WordPress/gutenberg/pull/58359. Fix https://github.com/WordPress/gutenberg/issues/58291.

This PR does a few things:

1. Fix the error when editing patterns with nested inner patterns.
2. Disable editing the inner pattern even with overrides.
3. Refactor the logic a bit.
4. Disable editing the pattern with overrides if the pattern instance itself is disabled.

The first two are the same with #58359. This PR also fixes the fourth but it's just a nice-to-have.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To prevent unexpected broken page. See #58291.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just some small refactorings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Added an e2e test.

1. Follow the instructions in https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1882305331 to create two synced patterns with overrides.
2. The "outer" pattern should include the "inner" pattern.
3. Insert the outer pattern in a post.
4. The overridable part in the outer pattern should be editable.
5. The overridable part in the inner pattern should not be editable.
6. Editing the outer pattern should be able to edit the overridable part of the inner pattern.

## Screenshots or screencast <!-- if applicable -->
