### PR TITLE
ListView: reduce subs per item

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -78,15 +78,13 @@ function ParentSelectorMenuItem( { parentClientId, parentBlockType } ) {
 }
 
 export function BlockSettingsDropdown( {
-	block,
+	currentClientId,
 	clientIds,
 	__experimentalSelectBlock,
 	children,
 	__unstableDisplayLocation,
 	...props
 } ) {
-	// Get the client id of the current block for this menu, if one is set.
-	const currentClientId = block?.clientId;
 	const blockClientIds = Array.isArray( clientIds )
 		? clientIds
 		: [ clientIds ];

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -22,7 +22,7 @@ const ListViewBlockContents = forwardRef(
 		{
 			onClick,
 			onToggleExpanded,
-			block,
+			clientId,
 			isSelected,
 			position,
 			siblingBlockCount,
@@ -33,8 +33,6 @@ const ListViewBlockContents = forwardRef(
 		},
 		ref
 	) => {
-		const { clientId } = block;
-
 		const { blockMovingClientId, selectedBlockInBlockEditor } = useSelect(
 			( select ) => {
 				const { hasBlockMovingClientId, getSelectedBlockClientId } =
@@ -69,7 +67,7 @@ const ListViewBlockContents = forwardRef(
 			<>
 				{ AdditionalBlockContent && (
 					<AdditionalBlockContent
-						block={ block }
+						clientId={ clientId }
 						insertedBlock={ insertedBlock }
 						setInsertedBlock={ setInsertedBlock }
 					/>
@@ -83,7 +81,7 @@ const ListViewBlockContents = forwardRef(
 						<ListViewBlockSelectButton
 							ref={ ref }
 							className={ className }
-							block={ block }
+							clientId={ clientId }
 							onClick={ onClick }
 							onToggleExpanded={ onToggleExpanded }
 							isSelected={ isSelected }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -36,7 +36,7 @@ import { useListViewContext } from './context';
 function ListViewBlockSelectButton(
 	{
 		className,
-		block: { clientId },
+		clientId,
 		onClick,
 		onContextMenu,
 		onMouseDown,

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -34,13 +34,17 @@ const BLOCKS_WITH_LINK_UI_SUPPORT = [
 ];
 const { PrivateListView } = unlock( blockEditorPrivateApis );
 
-function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
+function AdditionalBlockContent( {
+	clientId,
+	insertedBlock,
+	setInsertedBlock,
+} ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const supportsLinkControls = BLOCKS_WITH_LINK_UI_SUPPORT?.includes(
 		insertedBlock?.name
 	);
-	const blockWasJustInserted = insertedBlock?.clientId === block.clientId;
+	const blockWasJustInserted = insertedBlock?.clientId === clientId;
 	const showLinkControls = supportsLinkControls && blockWasJustInserted;
 
 	if ( ! showLinkControls ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A couple of things:

* Remove the `getBlock` selector, it's only needed for the clientId.
* Combine 4 block editor store subscriptions into one.
* To do that, avoid using `useBlockDisplayInformation`. This is a terrible way to get information, because you cannot specify the information you need. We should use store selectors instead. If the store selectors are awkward, we should create better store selectors. In this case we're only using it to get the block title and whether it's a synced block.
* Same thing with `useBlockLock`, we don't need all the info there, and we create a separate subscription. Let's create better selectors if it's too verbose.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We're currently retrieving unnecessary information from the store. Also every block editor store store subscription slows down load but especially typing (in this case typing with the list view open).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
