### PR TITLE
ListView: render options only for selected/visible block

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -392,31 +392,34 @@ function ListViewBlock( {
 					aria-selected={ !! isSelected }
 					ref={ settingsRef }
 				>
-					{ ( { ref, tabIndex, onFocus } ) => (
-						<BlockSettingsMenu
-							clientIds={ dropdownClientIds }
-							block={ block }
-							icon={ moreVertical }
-							label={ settingsAriaLabel }
-							popoverProps={ {
-								anchor: settingsPopoverAnchor, // Used to position the settings at the cursor on right-click.
-							} }
-							toggleProps={ {
-								ref,
-								className: 'block-editor-list-view-block__menu',
-								tabIndex,
-								onClick: clearSettingsAnchorRect,
-								onFocus,
-							} }
-							disableOpenOnArrowDown
-							expand={ expand }
-							expandedState={ expandedState }
-							setInsertedBlock={ setInsertedBlock }
-							__experimentalSelectBlock={
-								updateFocusAndSelection
-							}
-						/>
-					) }
+					{ isHovered || isFirstSelectedBlock
+						? ( { ref, tabIndex, onFocus } ) => (
+								<BlockSettingsMenu
+									clientIds={ dropdownClientIds }
+									block={ block }
+									icon={ moreVertical }
+									label={ settingsAriaLabel }
+									popoverProps={ {
+										anchor: settingsPopoverAnchor, // Used to position the settings at the cursor on right-click.
+									} }
+									toggleProps={ {
+										ref,
+										className:
+											'block-editor-list-view-block__menu',
+										tabIndex,
+										onClick: clearSettingsAnchorRect,
+										onFocus,
+									} }
+									disableOpenOnArrowDown
+									expand={ expand }
+									expandedState={ expandedState }
+									setInsertedBlock={ setInsertedBlock }
+									__experimentalSelectBlock={
+										updateFocusAndSelection
+									}
+								/>
+						  )
+						: null }
 				</TreeGridCell>
 			) }
 		</ListViewLeaf>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -80,19 +80,25 @@ function ListViewBlock( {
 	const blockTitle =
 		blockInformation?.name || blockInformation?.title || __( 'Untitled' );
 
-	const { block, blockName, blockEditingMode } = useSelect(
+	const selected = useSelect(
 		( select ) => {
-			const { getBlock, getBlockName, getBlockEditingMode } =
-				select( blockEditorStore );
+			const {
+				getBlock,
+				getBlockName,
+				getBlockEditingMode,
+				hasMultiSelection,
+			} = select( blockEditorStore );
 
 			return {
 				block: getBlock( clientId ),
 				blockName: getBlockName( clientId ),
 				blockEditingMode: getBlockEditingMode( clientId ),
+				hasMultiSelection: hasMultiSelection(),
 			};
 		},
 		[ clientId ]
 	);
+	const { block, blockName, blockEditingMode, hasMultiSelection } = selected;
 	const allowRightClickOverrides = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings().allowRightClickOverrides,
@@ -392,7 +398,11 @@ function ListViewBlock( {
 					aria-selected={ !! isSelected }
 					ref={ settingsRef }
 				>
-					{ isHovered || isFirstSelectedBlock
+					{ (
+						hasMultiSelection
+							? isFirstSelectedBlock
+							: isSelected || isHovered
+					)
 						? ( { ref, tabIndex, onFocus } ) => (
 								<BlockSettingsMenu
 									clientIds={ dropdownClientIds }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a performance improvement as much as a bug fix.

When rendering the items in the list view, only show the options button when it is needed: when the block is selected or when the it is hovered. In the editor, this would be a bit like rendering a toolbar for every block even if it's not selected/needed.

It also removes the button for all the subsequent items when multi-selecting.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In all other cases it's not visible anyway, so we spend time rendering components that are not even on visible.

|Before|After|
|-|-|
|<img width="417" alt="image" src="https://github.com/WordPress/gutenberg/assets/4710635/a01fa773-6eb4-4cb7-a3af-bd4710c76e1e">|<img width="360" alt="Screenshot 2024-02-01 at 10 20 46" src="https://github.com/WordPress/gutenberg/assets/4710635/1820d8ab-a4d1-4781-bd26-8f94402757a5">|

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
