### PR TITLE
Enable dynamic import transform for React Native tests

### DIFF
--- a/test/native/babel.config.js
+++ b/test/native/babel.config.js
@@ -13,6 +13,7 @@ module.exports = ( api ) => {
 			],
 			'react-native-reanimated/plugin',
 			'@babel/plugin-proposal-export-namespace-from',
+			'@babel/plugin-transform-dynamic-import',
 		],
 		overrides: [
 			{


### PR DESCRIPTION
Adds the `plugin-transform-dynamic-import` transform to Babel config for React Native tests. This is needed when Gutenberg code starts using dynamic `import()` statements. Then they need to be transpiled, because otherwise Node.js interprets them natively, and expects the imported modules to be ESM `.mjs` files. But they are not, they are regular JS files. Jest tests are failing.

More info in https://github.com/WordPress/gutenberg/pull/55585#issuecomment-1851788919. Affects only tests, not the production React Native code.