### PR TITLE
Block Bindings: Add block bindings e2e tests

### DIFF
--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -17,6 +17,7 @@ function gutenberg_test_block_bindings_register_custom_fields() {
 		array(
 			'show_in_rest' => true,
 			'type'         => 'string',
+			'single'       => true,
 			'default'      => 'Value of the text_custom_field',
 		)
 	);
@@ -27,7 +28,8 @@ function gutenberg_test_block_bindings_register_custom_fields() {
 		array(
 			'show_in_rest' => true,
 			'type'         => 'string',
-			'default'      => 'https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg',
+			'single'       => true,
+			'default'      => '',
 		)
 	);
 }

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Block Bindings
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-block-bindings
+ */
+
+/**
+* Register custom fields.
+*/
+function gutenberg_test_block_bindings_register_custom_fields() {
+	register_meta(
+		'post',
+		'text_custom_field',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'default'      => 'Value of the text_custom_field',
+		)
+	);
+	// TODO: Change url.
+	register_meta(
+		'post',
+		'url_custom_field',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'default'      => 'https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg',
+		)
+	);
+}
+add_action( 'init', 'gutenberg_test_block_bindings_register_custom_fields' );

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -201,382 +201,394 @@ test.describe( 'Block bindings - Template context', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	// Paragraph block tests.
-	test( 'Paragraph - should show the value of the custom field', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( contentBindingParagraphBlock );
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
+	test.describe( 'Paragraph', () => {
+		test( 'Should show the value of the custom field', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( contentBindingParagraphBlock );
+			const paragraphBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+			const paragraphContent = await paragraphBlock.textContent();
+			expect( paragraphContent ).toBe( textCustomFieldKey );
 		} );
-		const paragraphContent = await paragraphBlock.textContent();
-		expect( paragraphContent ).toBe( textCustomFieldKey );
+
+		test( 'Should lock the appropriate controls', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( contentBindingParagraphBlock );
+			const paragraphBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+			await paragraphBlock.click();
+
+			// Alignment controls exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: alignName,
+				} )
+			).toBeVisible();
+
+			// Format controls don't exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: boldName,
+				} )
+			).toBeHidden();
+
+			// Paragraph is not editable.
+			const isContentEditable =
+				await paragraphBlock.getAttribute( 'contenteditable' );
+			expect( isContentEditable ).toBe( 'false' );
+		} );
 	} );
 
-	test( 'Paragraph - should lock the appropriate controls', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( contentBindingParagraphBlock );
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
+	test.describe( 'Heading', () => {
+		test( 'Should show the value of the custom field', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( contentBindingHeadingBlock );
+			const headingBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Heading',
+			} );
+			const headingContent = await headingBlock.textContent();
+			expect( headingContent ).toBe( textCustomFieldKey );
 		} );
-		await paragraphBlock.click();
 
-		// Alignment controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: alignName,
-			} )
-		).toBeVisible();
+		test( 'Should lock the appropriate controls', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( contentBindingHeadingBlock );
+			const headingBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Heading',
+			} );
+			await headingBlock.click();
 
-		// Format controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeHidden();
+			// Alignment controls exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: alignName,
+				} )
+			).toBeVisible();
 
-		// Paragraph is not editable.
-		const isContentEditable =
-			await paragraphBlock.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
+			// Format controls don't exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: boldName,
+				} )
+			).toBeHidden();
+
+			// Heading is not editable.
+			const isContentEditable =
+				await headingBlock.getAttribute( 'contenteditable' );
+			expect( isContentEditable ).toBe( 'false' );
+		} );
 	} );
 
-	// Heading block tests.
-	test( 'Heading - should show the value of the custom field', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( contentBindingHeadingBlock );
-		const headingBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Heading',
+	test.describe( 'Button', () => {
+		test( 'Should show the value of the custom field when text is bound', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( textBindingButtonBlock );
+			const buttonBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Button',
+				exact: true,
+			} );
+			const buttonText = await buttonBlock.textContent();
+			expect( buttonText ).toBe( textCustomFieldKey );
 		} );
-		const headingContent = await headingBlock.textContent();
-		expect( headingContent ).toBe( textCustomFieldKey );
+
+		test( 'Should lock text controls when text is bound', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( textBindingButtonBlock );
+			const buttonBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Button',
+				exact: true,
+			} );
+			await buttonBlock.click();
+
+			// Alignment controls exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: alignName,
+				} )
+			).toBeVisible();
+
+			// Format controls don't exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: boldName,
+				} )
+			).toBeHidden();
+
+			// Button is not editable.
+			const isContentEditable = await buttonBlock
+				.locator( 'div' )
+				.getAttribute( 'contenteditable' );
+			expect( isContentEditable ).toBe( 'false' );
+
+			// Link controls exist.
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Unlink' } )
+			).toBeVisible();
+		} );
+
+		test( 'Should lock url controls when url is bound', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( urlBindingButtonBlock );
+			const buttonBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Button',
+				exact: true,
+			} );
+			await buttonBlock.click();
+
+			// Format controls exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: boldName,
+				} )
+			).toBeVisible();
+
+			// Button is editable.
+			const isContentEditable = await buttonBlock
+				.locator( 'div' )
+				.getAttribute( 'contenteditable' );
+			expect( isContentEditable ).toBe( 'true' );
+
+			// Link controls don't exist.
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Link' } )
+			).toBeHidden();
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Unlink' } )
+			).toBeHidden();
+		} );
+
+		test( 'Should lock url and text controls when both are bound', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( multipleBindingsButtonBlock );
+			const buttonBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Button',
+				exact: true,
+			} );
+			await buttonBlock.click();
+
+			// Alignment controls are visible.
+			await expect(
+				page.getByRole( 'button', {
+					name: alignName,
+				} )
+			).toBeVisible();
+
+			// Format controls don't exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: boldName,
+				} )
+			).toBeHidden();
+
+			// Button is not editable.
+			const isContentEditable = await buttonBlock
+				.locator( 'div' )
+				.getAttribute( 'contenteditable' );
+			expect( isContentEditable ).toBe( 'false' );
+
+			// Link controls don't exist.
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Link' } )
+			).toBeHidden();
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Unlink' } )
+			).toBeHidden();
+		} );
 	} );
 
-	test( 'Heading - should lock the appropriate controls', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( contentBindingHeadingBlock );
-		const headingBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Heading',
+	test.describe( 'Image', () => {
+		test( 'Should show the upload form when url is not bound', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( { name: 'core/image' } );
+			const imageBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Image',
+			} );
+			await imageBlock.click();
+			await expect(
+				imageBlock.getByRole( 'button', { name: 'Upload' } )
+			).toBeVisible();
 		} );
-		await headingBlock.click();
 
-		// Alignment controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: alignName,
-			} )
-		).toBeVisible();
-
-		// Format controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeHidden();
-
-		// Heading is not editable.
-		const isContentEditable =
-			await headingBlock.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
-	} );
-
-	// Button block tests.
-	test( 'Button - should show the value of the custom field when text is bound', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( textBindingButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
+		test( 'Should NOT show the upload form when url is bound', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( urlBindingImageBlock );
+			const imageBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Image',
+			} );
+			await imageBlock.click();
+			await expect(
+				imageBlock.getByRole( 'button', { name: 'Upload' } )
+			).toBeHidden();
 		} );
-		const buttonText = await buttonBlock.textContent();
-		expect( buttonText ).toBe( textCustomFieldKey );
-	} );
 
-	test( 'Button - should lock text controls when text is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( textBindingButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
+		test( 'Should lock url controls when url is bound', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( urlBindingImageBlock );
+			const imageBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Image',
+			} );
+			await imageBlock.click();
+
+			// Replace controls don't exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: imageReplaceName,
+				} )
+			).toBeHidden();
+
+			// Image placeholder doesn't show the upload button.
+			await expect(
+				imageBlock.getByRole( 'button', { name: 'Upload' } )
+			).toBeHidden();
+
+			// Alt textarea is enabled and with the original value.
+			await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+			const altValue = await page
+				.getByLabel( imageAltLabel )
+				.inputValue();
+			expect( altValue ).toBe( 'a' );
+
+			// Title input is enabled and with the original value.
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+			const titleValue = await page
+				.getByLabel( imageTitleLabel )
+				.inputValue();
+			expect( titleValue ).toBe( 't' );
 		} );
-		await buttonBlock.click();
 
-		// Alignment controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: alignName,
-			} )
-		).toBeVisible();
+		test( 'Should disable alt textarea when alt is bound', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( altBindingImageBlock );
+			const imageBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Image',
+			} );
+			await imageBlock.click();
 
-		// Format controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeHidden();
+			// Replace controls exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: imageReplaceName,
+				} )
+			).toBeVisible();
 
-		// Button is not editable.
-		const isContentEditable = await buttonBlock
-			.locator( 'div' )
-			.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
+			// Alt textarea is disabled and with the custom field value.
+			await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+			const altValue = await page
+				.getByLabel( imageAltLabel )
+				.inputValue();
+			expect( altValue ).toBe( textCustomFieldKey );
 
-		// Link controls exist.
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Unlink' } )
-		).toBeVisible();
-	} );
-
-	test( 'Button - should lock url controls when url is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( urlBindingButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
+			// Title input is enabled and with the original value.
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+			const titleValue = await page
+				.getByLabel( imageTitleLabel )
+				.inputValue();
+			expect( titleValue ).toBe( 't' );
 		} );
-		await buttonBlock.click();
 
-		// Format controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeVisible();
+		test( 'Should disable title input when title is bound', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( titleBindingImageBlock );
+			const imageBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Image',
+			} );
+			await imageBlock.click();
 
-		// Button is editable.
-		const isContentEditable = await buttonBlock
-			.locator( 'div' )
-			.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'true' );
+			// Replace controls exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: imageReplaceName,
+				} )
+			).toBeVisible();
 
-		// Link controls don't exist.
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Link' } )
-		).toBeHidden();
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Unlink' } )
-		).toBeHidden();
-	} );
+			// Alt textarea is enabled and with the original value.
+			await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+			const altValue = await page
+				.getByLabel( imageAltLabel )
+				.inputValue();
+			expect( altValue ).toBe( 'a' );
 
-	test( 'Button - should lock url and text controls when both are bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( multipleBindingsButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
+			// Title input is disabled and with the custom field value.
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
+			const titleValue = await page
+				.getByLabel( imageTitleLabel )
+				.inputValue();
+			expect( titleValue ).toBe( textCustomFieldKey );
 		} );
-		await buttonBlock.click();
 
-		// Alignment controls are visible.
-		await expect(
-			page.getByRole( 'button', {
-				name: alignName,
-			} )
-		).toBeVisible();
+		test( 'Multiple bindings should lock the appropriate controls', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( multipleBindingsImageBlock );
+			const imageBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Image',
+			} );
+			await imageBlock.click();
 
-		// Format controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeHidden();
+			// Replace controls don't exist.
+			await expect(
+				page.getByRole( 'button', {
+					name: imageReplaceName,
+				} )
+			).toBeHidden();
 
-		// Button is not editable.
-		const isContentEditable = await buttonBlock
-			.locator( 'div' )
-			.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
+			// Image placeholder doesn't show the upload button.
+			await expect(
+				imageBlock.getByRole( 'button', { name: 'Upload' } )
+			).toBeHidden();
 
-		// Link controls don't exist.
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Link' } )
-		).toBeHidden();
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Unlink' } )
-		).toBeHidden();
-	} );
+			// Alt textarea is disabled and with the custom field value.
+			await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+			const altValue = await page
+				.getByLabel( imageAltLabel )
+				.inputValue();
+			expect( altValue ).toBe( textCustomFieldKey );
 
-	// Image block tests.
-	test( 'Image - should show the upload form when url is not bound', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( { name: 'core/image' } );
-		const imageBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
+			// Title input is enabled and with the original value.
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+			const titleValue = await page
+				.getByLabel( imageTitleLabel )
+				.inputValue();
+			expect( titleValue ).toBe( 't' );
 		} );
-		await imageBlock.click();
-		await expect(
-			imageBlock.getByRole( 'button', { name: 'Upload' } )
-		).toBeVisible();
-	} );
-
-	test( 'Image - should NOT show the upload form when url is bound', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( urlBindingImageBlock );
-		const imageBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-		await imageBlock.click();
-		await expect(
-			imageBlock.getByRole( 'button', { name: 'Upload' } )
-		).toBeHidden();
-	} );
-
-	test( 'Image - should lock url controls when url is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( urlBindingImageBlock );
-		const imageBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-		await imageBlock.click();
-
-		// Replace controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: imageReplaceName,
-			} )
-		).toBeHidden();
-
-		// Image placeholder doesn't show the upload button.
-		await expect(
-			imageBlock.getByRole( 'button', { name: 'Upload' } )
-		).toBeHidden();
-
-		// Alt textarea is enabled and with the original value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( 'a' );
-
-		// Title input is enabled and with the original value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( 't' );
-	} );
-
-	test( 'Image - should disable alt textarea when alt is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( altBindingImageBlock );
-		const imageBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-		await imageBlock.click();
-
-		// Replace controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: imageReplaceName,
-			} )
-		).toBeVisible();
-
-		// Alt textarea is disabled and with the custom field value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( textCustomFieldKey );
-
-		// Title input is enabled and with the original value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( 't' );
-	} );
-
-	test( 'Image - should disable title input when title is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( titleBindingImageBlock );
-		const imageBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-		await imageBlock.click();
-
-		// Replace controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: imageReplaceName,
-			} )
-		).toBeVisible();
-
-		// Alt textarea is enabled and with the original value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( 'a' );
-
-		// Title input is disabled and with the custom field value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( textCustomFieldKey );
-	} );
-
-	test( 'Image - multiple bindings should lock the appropriate controls', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( multipleBindingsImageBlock );
-		const imageBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-		await imageBlock.click();
-
-		// Replace controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: imageReplaceName,
-			} )
-		).toBeHidden();
-
-		// Image placeholder doesn't show the upload button.
-		await expect(
-			imageBlock.getByRole( 'button', { name: 'Upload' } )
-		).toBeHidden();
-
-		// Alt textarea is disabled and with the custom field value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( textCustomFieldKey );
-
-		// Title input is enabled and with the original value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( 't' );
 	} );
 } );
 
@@ -597,51 +609,51 @@ test.describe( 'Block bindings - Post/page context', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	// Paragraph block tests.
-	test( 'Paragraph - should show the value of the custom field when exists', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( contentBindingParagraphBlock );
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
+	test.describe( 'Paragraph', () => {
+		test( 'Should show the value of the custom field when exists', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( contentBindingParagraphBlock );
+			const paragraphBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+			const paragraphContent = await paragraphBlock.textContent();
+			expect( paragraphContent ).toBe( textCustomFieldValue );
+			// Paragraph is not editable.
+			const isContentEditable =
+				await paragraphBlock.getAttribute( 'contenteditable' );
+			expect( isContentEditable ).toBe( 'false' );
 		} );
-		const paragraphContent = await paragraphBlock.textContent();
-		expect( paragraphContent ).toBe( textCustomFieldValue );
-		// Paragraph is not editable.
-		const isContentEditable =
-			await paragraphBlock.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
-	} );
 
-	test( "Paragraph - should show the value of the key when custom field doesn't exists", async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: {
-				content: 'p',
-				metadata: {
-					bindings: {
-						content: {
-							source: 'core/post-meta',
-							args: { key: 'non_existing_custom_field' },
+		test( "Should show the value of the key when custom field doesn't exists", async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'p',
+					metadata: {
+						bindings: {
+							content: {
+								source: 'core/post-meta',
+								args: { key: 'non_existing_custom_field' },
+							},
 						},
 					},
 				},
-			},
+			} );
+			const paragraphBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+			const paragraphContent = await paragraphBlock.textContent();
+			expect( paragraphContent ).toBe( 'non_existing_custom_field' );
+			// Paragraph is not editable.
+			const isContentEditable =
+				await paragraphBlock.getAttribute( 'contenteditable' );
+			expect( isContentEditable ).toBe( 'false' );
 		} );
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
-		} );
-		const paragraphContent = await paragraphBlock.textContent();
-		expect( paragraphContent ).toBe( 'non_existing_custom_field' );
-		// Paragraph is not editable.
-		const isContentEditable =
-			await paragraphBlock.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
 	} );
 
-	// Heading block tests.
 	test( 'Heading - should show the value of the custom field', async ( {
 		editor,
 	} ) => {
@@ -657,7 +669,6 @@ test.describe( 'Block bindings - Post/page context', () => {
 		expect( isContentEditable ).toBe( 'false' );
 	} );
 
-	// Button block tests.
 	test( 'Button - should show the value of the custom field when text is bound', async ( {
 		editor,
 	} ) => {
@@ -677,94 +688,99 @@ test.describe( 'Block bindings - Post/page context', () => {
 		expect( isContentEditable ).toBe( 'false' );
 	} );
 
-	// Image block tests.
-	test( 'Image - should show the value of the custom field when url is bound', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( urlBindingImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( urlCustomFieldValue );
-	} );
+	test.describe( 'Image', () => {
+		test( 'Should show the value of the custom field when url is bound', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( urlBindingImageBlock );
+			const imageBlockImg = editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Image',
+				} )
+				.locator( 'img' );
+			const imageSrc = await imageBlockImg.getAttribute( 'src' );
+			expect( imageSrc ).toBe( urlCustomFieldValue );
+		} );
 
-	test( 'Image - should show value of the custom field in the alt textarea when alt is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( altBindingImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		await imageBlockImg.click();
+		test( 'Should show value of the custom field in the alt textarea when alt is bound', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( altBindingImageBlock );
+			const imageBlockImg = editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Image',
+				} )
+				.locator( 'img' );
+			await imageBlockImg.click();
 
-		// Image src is the placeholder.
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( imagePlaceholder );
+			// Image src is the placeholder.
+			const imageSrc = await imageBlockImg.getAttribute( 'src' );
+			expect( imageSrc ).toBe( imagePlaceholder );
 
-		// Alt textarea is disabled and with the custom field value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( textCustomFieldValue );
-	} );
+			// Alt textarea is disabled and with the custom field value.
+			await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+			const altValue = await page
+				.getByLabel( imageAltLabel )
+				.inputValue();
+			expect( altValue ).toBe( textCustomFieldValue );
+		} );
 
-	test( 'Image - should show value of the custom field in the title input when title is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( titleBindingImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		await imageBlockImg.click();
+		test( 'Should show value of the custom field in the title input when title is bound', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( titleBindingImageBlock );
+			const imageBlockImg = editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Image',
+				} )
+				.locator( 'img' );
+			await imageBlockImg.click();
 
-		// Image src is the placeholder.
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( imagePlaceholder );
+			// Image src is the placeholder.
+			const imageSrc = await imageBlockImg.getAttribute( 'src' );
+			expect( imageSrc ).toBe( imagePlaceholder );
 
-		// Title input is disabled and with the custom field value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( textCustomFieldValue );
-	} );
+			// Title input is disabled and with the custom field value.
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
+			const titleValue = await page
+				.getByLabel( imageTitleLabel )
+				.inputValue();
+			expect( titleValue ).toBe( textCustomFieldValue );
+		} );
 
-	test( 'Image - multiple bindings should show the value of the custom fields', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( multipleBindingsImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		await imageBlockImg.click();
+		test( 'Multiple bindings should show the value of the custom fields', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( multipleBindingsImageBlock );
+			const imageBlockImg = editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Image',
+				} )
+				.locator( 'img' );
+			await imageBlockImg.click();
 
-		// Image src is the custom field value.
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( urlCustomFieldValue );
+			// Image src is the custom field value.
+			const imageSrc = await imageBlockImg.getAttribute( 'src' );
+			expect( imageSrc ).toBe( urlCustomFieldValue );
 
-		// Alt textarea is disabled and with the custom field value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( textCustomFieldValue );
+			// Alt textarea is disabled and with the custom field value.
+			await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+			const altValue = await page
+				.getByLabel( imageAltLabel )
+				.inputValue();
+			expect( altValue ).toBe( textCustomFieldValue );
 
-		// Title input is enabled and with the original value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( 't' );
+			// Title input is enabled and with the original value.
+			await page.getByRole( 'button', { name: 'Advanced' } ).click();
+			await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+			const titleValue = await page
+				.getByLabel( imageTitleLabel )
+				.inputValue();
+			expect( titleValue ).toBe( 't' );
+		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -186,6 +186,7 @@ const imageTitleLabel = 'Title attribute';
 test.describe( 'Block bindings - Template context', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
 	} );
 
 	test.beforeEach( async ( { admin, editor } ) => {
@@ -199,6 +200,7 @@ test.describe( 'Block bindings - Template context', () => {
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
 	} );
 
 	test.describe( 'Paragraph', () => {
@@ -245,7 +247,7 @@ test.describe( 'Block bindings - Template context', () => {
 	} );
 
 	test.describe( 'Heading', () => {
-		test( 'Should show the value of the custom field', async ( {
+		test( 'Should show the key of the custom field', async ( {
 			editor,
 		} ) => {
 			await editor.insertBlock( contentBindingHeadingBlock );
@@ -288,7 +290,7 @@ test.describe( 'Block bindings - Template context', () => {
 	} );
 
 	test.describe( 'Button', () => {
-		test( 'Should show the value of the custom field when text is bound', async ( {
+		test( 'Should show the key of the custom field when text is bound', async ( {
 			editor,
 		} ) => {
 			await editor.insertBlock( textBindingButtonBlock );
@@ -595,6 +597,7 @@ test.describe( 'Block bindings - Template context', () => {
 test.describe( 'Block bindings - Post/page context', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
 	} );
 
 	test.beforeEach( async ( { admin } ) => {
@@ -607,6 +610,7 @@ test.describe( 'Block bindings - Post/page context', () => {
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
 	} );
 
 	test.describe( 'Paragraph', () => {

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1,0 +1,580 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const textCustomFieldValue = 'Value of the text_custom_field';
+// TODO: Replace with test images.
+const urlCustomFieldValue =
+	'https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg';
+const imagePlaceholder =
+	'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg';
+
+// Shared variables
+const alignName = 'Align text';
+const boldName = 'Bold';
+// Paragraph block.
+const contentBindingParagraphBlock = {
+	name: 'core/paragraph',
+	attributes: {
+		content: 'p',
+		metadata: {
+			bindings: {
+				content: {
+					source: 'core/post-meta',
+					args: { key: 'text_custom_field' },
+				},
+			},
+		},
+	},
+};
+// Heading block.
+const contentBindingHeadingBlock = {
+	name: 'core/heading',
+	attributes: {
+		content: 'h',
+		metadata: {
+			bindings: {
+				content: {
+					source: 'core/post-meta',
+					args: { key: 'text_custom_field' },
+				},
+			},
+		},
+	},
+};
+// Button blocks.
+const textBindingButtonBlock = {
+	name: 'core/buttons',
+	innerBlocks: [
+		{
+			name: 'core/button',
+			attributes: {
+				text: 'b',
+				url: 'https://www.wordpress.org/',
+				metadata: {
+					bindings: {
+						text: {
+							source: 'core/post-meta',
+							args: { key: 'text_custom_field' },
+						},
+					},
+				},
+			},
+		},
+	],
+};
+const urlBindingButtonBlock = {
+	name: 'core/buttons',
+	innerBlocks: [
+		{
+			name: 'core/button',
+			attributes: {
+				text: 'b',
+				url: 'https://www.wordpress.org/',
+				metadata: {
+					bindings: {
+						url: {
+							source: 'core/post-meta',
+							args: { key: 'url_custom_field' },
+						},
+					},
+				},
+			},
+		},
+	],
+};
+const multipleBindingsButtonBlock = {
+	name: 'core/buttons',
+	innerBlocks: [
+		{
+			name: 'core/button',
+			attributes: {
+				text: 'b',
+				url: 'https://www.wordpress.org/',
+				metadata: {
+					bindings: {
+						text: {
+							source: 'core/post-meta',
+							args: { key: 'text_custom_field' },
+						},
+						url: {
+							source: 'core/post-meta',
+							args: { key: 'url_custom_field' },
+						},
+					},
+				},
+			},
+		},
+	],
+};
+// Image blocks.
+const urlBindingImageBlock = {
+	name: 'core/image',
+	attributes: {
+		url: imagePlaceholder,
+		alt: 'a',
+		title: 't',
+		metadata: {
+			bindings: {
+				url: {
+					source: 'core/post-meta',
+					args: { key: 'url_custom_field' },
+				},
+			},
+		},
+	},
+};
+const altBindingImageBlock = {
+	name: 'core/image',
+	attributes: {
+		url: imagePlaceholder,
+		alt: 'a',
+		title: 't',
+		metadata: {
+			bindings: {
+				alt: {
+					source: 'core/post-meta',
+					args: { key: 'text_custom_field' },
+				},
+			},
+		},
+	},
+};
+const titleBindingImageBlock = {
+	name: 'core/image',
+	attributes: {
+		url: imagePlaceholder,
+		alt: 'a',
+		title: 't',
+		metadata: {
+			bindings: {
+				title: {
+					source: 'core/post-meta',
+					args: { key: 'text_custom_field' },
+				},
+			},
+		},
+	},
+};
+const multipleBindingsImageBlock = {
+	name: 'core/image',
+	attributes: {
+		url: imagePlaceholder,
+		alt: 'a',
+		title: 't',
+		metadata: {
+			bindings: {
+				url: {
+					source: 'core/post-meta',
+					args: { key: 'url_custom_field' },
+				},
+				alt: {
+					source: 'core/post-meta',
+					args: { key: 'text_custom_field' },
+				},
+			},
+		},
+	},
+};
+// Image variables.
+const imageReplaceName = 'Replace';
+const imageAltLabel = 'Alternative text';
+const imageTitleLabel = 'Title attribute';
+
+test.describe( 'Block bindings - Page context', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	// Paragraph block tests.
+	test( 'Paragraph - should show the value of the custom field', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( contentBindingParagraphBlock );
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const paragraphContent = await paragraphBlock.textContent();
+		expect( paragraphContent ).toBe( textCustomFieldValue );
+	} );
+
+	test( 'Paragraph - should lock the appropriate controls', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( contentBindingParagraphBlock );
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		await paragraphBlock.click();
+
+		// Alignment controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: alignName,
+			} )
+		).toBeVisible();
+
+		// Format controls don't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeHidden();
+
+		// Paragraph is not editable.
+		const isContentEditable =
+			await paragraphBlock.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+	} );
+
+	// Heading block tests.
+	test( 'Heading - should show the value of the custom field', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( contentBindingHeadingBlock );
+		const headingBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Heading',
+		} );
+		const headingContent = await headingBlock.textContent();
+		expect( headingContent ).toBe( textCustomFieldValue );
+	} );
+
+	test( 'Heading - should lock the appropriate controls', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( contentBindingHeadingBlock );
+		const headingBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Heading',
+		} );
+		await headingBlock.click();
+
+		// Alignment controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: alignName,
+			} )
+		).toBeVisible();
+
+		// Format controls don't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeHidden();
+
+		// Heading is not editable.
+		const isContentEditable =
+			await headingBlock.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+	} );
+
+	// Button block tests.
+	test( 'Button - should show the value of the custom field when text is bound', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( textBindingButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		const buttonText = await buttonBlock.textContent();
+		expect( buttonText ).toBe( textCustomFieldValue );
+	} );
+
+	test( 'Button - should lock text controls when text is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( textBindingButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		await buttonBlock.click();
+
+		// Alignment controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: alignName,
+			} )
+		).toBeVisible();
+
+		// Format controls don't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeHidden();
+
+		// Button is not editable.
+		const isContentEditable = await buttonBlock
+			.locator( 'div' )
+			.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+
+		// Link controls exist.
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Unlink' } )
+		).toBeVisible();
+	} );
+
+	test( 'Button - should lock url controls when url is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( urlBindingButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		await buttonBlock.click();
+
+		// Format controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeVisible();
+
+		// Button is editable.
+		const isContentEditable = await buttonBlock
+			.locator( 'div' )
+			.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'true' );
+
+		// Link controls doesn't exist.
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Link' } )
+		).toBeHidden();
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Unlink' } )
+		).toBeHidden();
+	} );
+
+	test( 'Button - should lock url and text controls when both are bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( multipleBindingsButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		await buttonBlock.click();
+
+		// Alignment controls are visible.
+		await expect(
+			page.getByRole( 'button', {
+				name: alignName,
+			} )
+		).toBeVisible();
+
+		// Format controls don't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeHidden();
+
+		// Button is not editable.
+		const isContentEditable = await buttonBlock
+			.locator( 'div' )
+			.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+
+		// Link controls doesn't exist.
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Link' } )
+		).toBeHidden();
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Unlink' } )
+		).toBeHidden();
+	} );
+
+	// Image block tests.
+	test( 'Image - should show the value of the custom field when url is bound', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( urlBindingImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( urlCustomFieldValue );
+	} );
+
+	test( 'Image - should lock url controls when url is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( urlBindingImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		await imageBlockImg.click();
+
+		// Replace controls doesn't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: imageReplaceName,
+			} )
+		).toBeHidden();
+
+		// Image src is the custom field value.
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( urlCustomFieldValue );
+
+		// Alt textarea is enabled and with the original value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( 'a' );
+
+		// Title input is enabled and with the original value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( 't' );
+	} );
+
+	test( 'Image - should disable alt textarea when alt is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( altBindingImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		await imageBlockImg.click();
+
+		// Replace controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: imageReplaceName,
+			} )
+		).toBeVisible();
+
+		// Image src is the placeholder.
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( imagePlaceholder );
+
+		// Alt textarea is disabled and with the custom field value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( textCustomFieldValue );
+
+		// Title input is enabled and with the original value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( 't' );
+	} );
+
+	test( 'Image - should disable title input when title is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( titleBindingImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		await imageBlockImg.click();
+
+		// Replace controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: imageReplaceName,
+			} )
+		).toBeVisible();
+
+		// Image src is the placeholder.
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( imagePlaceholder );
+
+		// Alt textarea is enabled and with the original value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( 'a' );
+
+		// Title input is disabled and with the custom field value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( textCustomFieldValue );
+	} );
+
+	test( 'Image - multiple bindings should lock the appropriate controls', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( multipleBindingsImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		await imageBlockImg.click();
+
+		// Replace controls doesn't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: imageReplaceName,
+			} )
+		).toBeHidden();
+
+		// Image src is the custom field value.
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( urlCustomFieldValue );
+
+		// Alt textarea is disabled and with the custom field value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( textCustomFieldValue );
+
+		// Title input is enabled and with the original value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( 't' );
+	} );
+} );

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -201,7 +201,7 @@ test.describe( 'Block bindings - Post/page context', () => {
 	} );
 
 	// Paragraph block tests.
-	test( 'Paragraph - should show the value of the custom field', async ( {
+	test( 'Paragraph - should show the value of the custom field when exists', async ( {
 		editor,
 	} ) => {
 		await editor.insertBlock( contentBindingParagraphBlock );
@@ -210,6 +210,30 @@ test.describe( 'Block bindings - Post/page context', () => {
 		} );
 		const paragraphContent = await paragraphBlock.textContent();
 		expect( paragraphContent ).toBe( textCustomFieldValue );
+	} );
+
+	test( "Paragraph - should show the value of the key when custom field doesn't exists", async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'p',
+				metadata: {
+					bindings: {
+						content: {
+							source: 'core/post-meta',
+							args: { key: 'non_existing_custom_field' },
+						},
+					},
+				},
+			},
+		} );
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const paragraphContent = await paragraphBlock.textContent();
+		expect( paragraphContent ).toBe( 'non_existing_custom_field' );
 	} );
 
 	test( 'Paragraph - should lock the appropriate controls', async ( {

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -7,118 +7,125 @@ const path = require( 'path' );
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-const textCustomFieldValue = 'Value of the text_custom_field';
-const textCustomFieldKey = 'text_custom_field';
-// Shared variables
-const alignName = 'Align text';
-const boldName = 'Bold';
-// Paragraph block.
-const contentBindingParagraphBlock = {
-	name: 'core/paragraph',
-	attributes: {
-		content: 'p',
-		metadata: {
-			bindings: {
-				content: {
-					source: 'core/post-meta',
-					args: { key: 'text_custom_field' },
-				},
-			},
-		},
-	},
-};
-// Heading block.
-const contentBindingHeadingBlock = {
-	name: 'core/heading',
-	attributes: {
-		content: 'h',
-		metadata: {
-			bindings: {
-				content: {
-					source: 'core/post-meta',
-					args: { key: 'text_custom_field' },
-				},
-			},
-		},
-	},
-};
-// Button blocks.
-const textBindingButtonBlock = {
-	name: 'core/buttons',
-	innerBlocks: [
-		{
-			name: 'core/button',
-			attributes: {
-				text: 'b',
-				url: 'https://www.wordpress.org/',
-				metadata: {
-					bindings: {
-						text: {
-							source: 'core/post-meta',
-							args: { key: 'text_custom_field' },
-						},
-					},
-				},
-			},
-		},
-	],
-};
-const urlBindingButtonBlock = {
-	name: 'core/buttons',
-	innerBlocks: [
-		{
-			name: 'core/button',
-			attributes: {
-				text: 'b',
-				url: 'https://www.wordpress.org/',
-				metadata: {
-					bindings: {
-						url: {
-							source: 'core/post-meta',
-							args: { key: 'url_custom_field' },
-						},
-					},
-				},
-			},
-		},
-	],
-};
-const multipleBindingsButtonBlock = {
-	name: 'core/buttons',
-	innerBlocks: [
-		{
-			name: 'core/button',
-			attributes: {
-				text: 'b',
-				url: 'https://www.wordpress.org/',
-				metadata: {
-					bindings: {
-						text: {
-							source: 'core/post-meta',
-							args: { key: 'text_custom_field' },
-						},
-						url: {
-							source: 'core/post-meta',
-							args: { key: 'url_custom_field' },
-						},
-					},
-				},
-			},
-		},
-	],
-};
-// Image blocks.
-let urlBindingImageBlock;
-let altBindingImageBlock;
-let titleBindingImageBlock;
-let multipleBindingsImageBlock;
-// Image variables.
-const imageReplaceName = 'Replace';
-const imageAltLabel = 'Alternative text';
-const imageTitleLabel = 'Title attribute';
-
 test.describe( 'Block bindings', () => {
-	let placeholderSrc;
+	const variables = {
+		customFields: {
+			textValue: 'Value of the text_custom_field',
+			textKey: 'text_custom_field',
+			urlValue: '',
+			urlKey: 'url_custom_field',
+		},
+		labels: {
+			align: 'Align text',
+			bold: 'Bold',
+			imageReplace: 'Replace',
+			imageAlt: 'Alternative text',
+			imageTitle: 'Title attribute',
+		},
+		blocks: {
+			paragraph: {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'p',
+					metadata: {
+						bindings: {
+							content: {
+								source: 'core/post-meta',
+								args: { key: 'text_custom_field' },
+							},
+						},
+					},
+				},
+			},
+			heading: {
+				name: 'core/heading',
+				attributes: {
+					content: 'h',
+					metadata: {
+						bindings: {
+							content: {
+								source: 'core/post-meta',
+								args: { key: 'text_custom_field' },
+							},
+						},
+					},
+				},
+			},
+			buttons: {
+				textOnly: {
+					name: 'core/buttons',
+					innerBlocks: [
+						{
+							name: 'core/button',
+							attributes: {
+								text: 'b',
+								url: 'https://www.wordpress.org/',
+								metadata: {
+									bindings: {
+										text: {
+											source: 'core/post-meta',
+											args: { key: 'text_custom_field' },
+										},
+									},
+								},
+							},
+						},
+					],
+				},
+				urlOnly: {
+					name: 'core/buttons',
+					innerBlocks: [
+						{
+							name: 'core/button',
+							attributes: {
+								text: 'b',
+								url: 'https://www.wordpress.org/',
+								metadata: {
+									bindings: {
+										url: {
+											source: 'core/post-meta',
+											args: { key: 'url_custom_field' },
+										},
+									},
+								},
+							},
+						},
+					],
+				},
+				multipleAttrs: {
+					name: 'core/buttons',
+					innerBlocks: [
+						{
+							name: 'core/button',
+							attributes: {
+								text: 'b',
+								url: 'https://www.wordpress.org/',
+								metadata: {
+									bindings: {
+										text: {
+											source: 'core/post-meta',
+											args: { key: 'text_custom_field' },
+										},
+										url: {
+											source: 'core/post-meta',
+											args: { key: 'url_custom_field' },
+										},
+									},
+								},
+							},
+						},
+					],
+				},
+			},
+			images: {
+				urlOnly: {},
+				altOnly: {},
+				titleOnly: {},
+				multipleAttrs: {},
+			},
+		},
+		placeholderSrc: '',
+	};
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
@@ -126,12 +133,12 @@ test.describe( 'Block bindings', () => {
 		const placeholderMedia = await requestUtils.uploadMedia(
 			path.join( './test/e2e/assets', '10x10_e2e_test_image_z9T8jK.png' )
 		);
-		placeholderSrc = placeholderMedia.source_url;
+		variables.placeholderSrc = placeholderMedia.source_url;
 		// Init image blocks.
-		urlBindingImageBlock = {
+		variables.blocks.images.urlOnly = {
 			name: 'core/image',
 			attributes: {
-				url: placeholderSrc,
+				url: variables.placeholderSrc,
 				alt: 'default alt value',
 				title: 'default title value',
 				metadata: {
@@ -144,10 +151,10 @@ test.describe( 'Block bindings', () => {
 				},
 			},
 		};
-		altBindingImageBlock = {
+		variables.blocks.images.altOnly = {
 			name: 'core/image',
 			attributes: {
-				url: placeholderSrc,
+				url: variables.placeholderSrc,
 				alt: 'default alt value',
 				title: 'default title value',
 				metadata: {
@@ -160,10 +167,10 @@ test.describe( 'Block bindings', () => {
 				},
 			},
 		};
-		titleBindingImageBlock = {
+		variables.blocks.images.titleOnly = {
 			name: 'core/image',
 			attributes: {
-				url: placeholderSrc,
+				url: variables.placeholderSrc,
 				alt: 'default alt value',
 				title: 'default title value',
 				metadata: {
@@ -176,10 +183,10 @@ test.describe( 'Block bindings', () => {
 				},
 			},
 		};
-		multipleBindingsImageBlock = {
+		variables.blocks.images.multipleAttrs = {
 			name: 'core/image',
 			attributes: {
-				url: placeholderSrc,
+				url: variables.placeholderSrc,
 				alt: 'default alt value',
 				title: 'default title value',
 				metadata: {
@@ -222,19 +229,21 @@ test.describe( 'Block bindings', () => {
 			test( 'Should show the value of the custom field', async ( {
 				editor,
 			} ) => {
-				await editor.insertBlock( contentBindingParagraphBlock );
+				await editor.insertBlock( variables.blocks.paragraph );
 				const paragraphBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Paragraph',
 				} );
 				const paragraphContent = await paragraphBlock.textContent();
-				expect( paragraphContent ).toBe( textCustomFieldKey );
+				expect( paragraphContent ).toBe(
+					variables.customFields.textKey
+				);
 			} );
 
 			test( 'Should lock the appropriate controls', async ( {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( contentBindingParagraphBlock );
+				await editor.insertBlock( variables.blocks.paragraph );
 				const paragraphBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Paragraph',
 				} );
@@ -243,14 +252,14 @@ test.describe( 'Block bindings', () => {
 				// Alignment controls exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: alignName,
+						name: variables.labels.align,
 					} )
 				).toBeVisible();
 
 				// Format controls don't exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: boldName,
+						name: variables.labels.bold,
 					} )
 				).toBeHidden();
 
@@ -265,19 +274,19 @@ test.describe( 'Block bindings', () => {
 			test( 'Should show the key of the custom field', async ( {
 				editor,
 			} ) => {
-				await editor.insertBlock( contentBindingHeadingBlock );
+				await editor.insertBlock( variables.blocks.heading );
 				const headingBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Heading',
 				} );
 				const headingContent = await headingBlock.textContent();
-				expect( headingContent ).toBe( textCustomFieldKey );
+				expect( headingContent ).toBe( variables.customFields.textKey );
 			} );
 
 			test( 'Should lock the appropriate controls', async ( {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( contentBindingHeadingBlock );
+				await editor.insertBlock( variables.blocks.heading );
 				const headingBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Heading',
 				} );
@@ -286,14 +295,14 @@ test.describe( 'Block bindings', () => {
 				// Alignment controls exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: alignName,
+						name: variables.labels.align,
 					} )
 				).toBeVisible();
 
 				// Format controls don't exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: boldName,
+						name: variables.labels.bold,
 					} )
 				).toBeHidden();
 
@@ -308,20 +317,20 @@ test.describe( 'Block bindings', () => {
 			test( 'Should show the key of the custom field when text is bound', async ( {
 				editor,
 			} ) => {
-				await editor.insertBlock( textBindingButtonBlock );
+				await editor.insertBlock( variables.blocks.buttons.textOnly );
 				const buttonBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Button',
 					exact: true,
 				} );
 				const buttonText = await buttonBlock.textContent();
-				expect( buttonText ).toBe( textCustomFieldKey );
+				expect( buttonText ).toBe( variables.customFields.textKey );
 			} );
 
 			test( 'Should lock text controls when text is bound', async ( {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( textBindingButtonBlock );
+				await editor.insertBlock( variables.blocks.buttons.textOnly );
 				const buttonBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Button',
 					exact: true,
@@ -331,14 +340,14 @@ test.describe( 'Block bindings', () => {
 				// Alignment controls exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: alignName,
+						name: variables.labels.align,
 					} )
 				).toBeVisible();
 
 				// Format controls don't exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: boldName,
+						name: variables.labels.bold,
 					} )
 				).toBeHidden();
 
@@ -360,7 +369,7 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( urlBindingButtonBlock );
+				await editor.insertBlock( variables.blocks.buttons.urlOnly );
 				const buttonBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Button',
 					exact: true,
@@ -370,7 +379,7 @@ test.describe( 'Block bindings', () => {
 				// Format controls exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: boldName,
+						name: variables.labels.bold,
 					} )
 				).toBeVisible();
 
@@ -397,7 +406,9 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( multipleBindingsButtonBlock );
+				await editor.insertBlock(
+					variables.blocks.buttons.multipleAttrs
+				);
 				const buttonBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Button',
 					exact: true,
@@ -407,14 +418,14 @@ test.describe( 'Block bindings', () => {
 				// Alignment controls are visible.
 				await expect(
 					page.getByRole( 'button', {
-						name: alignName,
+						name: variables.labels.align,
 					} )
 				).toBeVisible();
 
 				// Format controls don't exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: boldName,
+						name: variables.labels.bold,
 					} )
 				).toBeHidden();
 
@@ -455,7 +466,7 @@ test.describe( 'Block bindings', () => {
 			test( 'Should NOT show the upload form when url is bound', async ( {
 				editor,
 			} ) => {
-				await editor.insertBlock( urlBindingImageBlock );
+				await editor.insertBlock( variables.blocks.images.urlOnly );
 				const imageBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Image',
 				} );
@@ -469,7 +480,7 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( urlBindingImageBlock );
+				await editor.insertBlock( variables.blocks.images.urlOnly );
 				const imageBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Image',
 				} );
@@ -478,7 +489,7 @@ test.describe( 'Block bindings', () => {
 				// Replace controls don't exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: imageReplaceName,
+						name: variables.labels.imageReplace,
 					} )
 				).toBeHidden();
 
@@ -488,19 +499,21 @@ test.describe( 'Block bindings', () => {
 				).toBeHidden();
 
 				// Alt textarea is enabled and with the original value.
-				await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+				await expect(
+					page.getByLabel( variables.labels.imageAlt )
+				).toBeEnabled();
 				const altValue = await page
-					.getByLabel( imageAltLabel )
+					.getByLabel( variables.labels.imageAlt )
 					.inputValue();
 				expect( altValue ).toBe( 'default alt value' );
 
 				// Title input is enabled and with the original value.
 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
 				await expect(
-					page.getByLabel( imageTitleLabel )
+					page.getByLabel( variables.labels.imageTitle )
 				).toBeEnabled();
 				const titleValue = await page
-					.getByLabel( imageTitleLabel )
+					.getByLabel( variables.labels.imageTitle )
 					.inputValue();
 				expect( titleValue ).toBe( 'default title value' );
 			} );
@@ -509,7 +522,7 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( altBindingImageBlock );
+				await editor.insertBlock( variables.blocks.images.altOnly );
 				const imageBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Image',
 				} );
@@ -518,24 +531,26 @@ test.describe( 'Block bindings', () => {
 				// Replace controls exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: imageReplaceName,
+						name: variables.labels.imageReplace,
 					} )
 				).toBeVisible();
 
 				// Alt textarea is disabled and with the custom field value.
-				await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+				await expect(
+					page.getByLabel( variables.labels.imageAlt )
+				).toBeDisabled();
 				const altValue = await page
-					.getByLabel( imageAltLabel )
+					.getByLabel( variables.labels.imageAlt )
 					.inputValue();
-				expect( altValue ).toBe( textCustomFieldKey );
+				expect( altValue ).toBe( variables.customFields.textKey );
 
 				// Title input is enabled and with the original value.
 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
 				await expect(
-					page.getByLabel( imageTitleLabel )
+					page.getByLabel( variables.labels.imageTitle )
 				).toBeEnabled();
 				const titleValue = await page
-					.getByLabel( imageTitleLabel )
+					.getByLabel( variables.labels.imageTitle )
 					.inputValue();
 				expect( titleValue ).toBe( 'default title value' );
 			} );
@@ -544,7 +559,7 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( titleBindingImageBlock );
+				await editor.insertBlock( variables.blocks.images.titleOnly );
 				const imageBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Image',
 				} );
@@ -553,33 +568,37 @@ test.describe( 'Block bindings', () => {
 				// Replace controls exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: imageReplaceName,
+						name: variables.labels.imageReplace,
 					} )
 				).toBeVisible();
 
 				// Alt textarea is enabled and with the original value.
-				await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+				await expect(
+					page.getByLabel( variables.labels.imageAlt )
+				).toBeEnabled();
 				const altValue = await page
-					.getByLabel( imageAltLabel )
+					.getByLabel( variables.labels.imageAlt )
 					.inputValue();
 				expect( altValue ).toBe( 'default alt value' );
 
 				// Title input is disabled and with the custom field value.
 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
 				await expect(
-					page.getByLabel( imageTitleLabel )
+					page.getByLabel( variables.labels.imageTitle )
 				).toBeDisabled();
 				const titleValue = await page
-					.getByLabel( imageTitleLabel )
+					.getByLabel( variables.labels.imageTitle )
 					.inputValue();
-				expect( titleValue ).toBe( textCustomFieldKey );
+				expect( titleValue ).toBe( variables.customFields.textKey );
 			} );
 
 			test( 'Multiple bindings should lock the appropriate controls', async ( {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( multipleBindingsImageBlock );
+				await editor.insertBlock(
+					variables.blocks.images.multipleAttrs
+				);
 				const imageBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Image',
 				} );
@@ -588,7 +607,7 @@ test.describe( 'Block bindings', () => {
 				// Replace controls don't exist.
 				await expect(
 					page.getByRole( 'button', {
-						name: imageReplaceName,
+						name: variables.labels.imageReplace,
 					} )
 				).toBeHidden();
 
@@ -598,19 +617,21 @@ test.describe( 'Block bindings', () => {
 				).toBeHidden();
 
 				// Alt textarea is disabled and with the custom field value.
-				await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+				await expect(
+					page.getByLabel( variables.labels.imageAlt )
+				).toBeDisabled();
 				const altValue = await page
-					.getByLabel( imageAltLabel )
+					.getByLabel( variables.labels.imageAlt )
 					.inputValue();
-				expect( altValue ).toBe( textCustomFieldKey );
+				expect( altValue ).toBe( variables.customFields.textKey );
 
 				// Title input is enabled and with the original value.
 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
 				await expect(
-					page.getByLabel( imageTitleLabel )
+					page.getByLabel( variables.labels.imageTitle )
 				).toBeEnabled();
 				const titleValue = await page
-					.getByLabel( imageTitleLabel )
+					.getByLabel( variables.labels.imageTitle )
 					.inputValue();
 				expect( titleValue ).toBe( 'default title value' );
 			} );
@@ -625,12 +646,14 @@ test.describe( 'Block bindings', () => {
 			test( 'Should show the value of the custom field when exists', async ( {
 				editor,
 			} ) => {
-				await editor.insertBlock( contentBindingParagraphBlock );
+				await editor.insertBlock( variables.blocks.paragraph );
 				const paragraphBlock = editor.canvas.getByRole( 'document', {
 					name: 'Block: Paragraph',
 				} );
 				const paragraphContent = await paragraphBlock.textContent();
-				expect( paragraphContent ).toBe( textCustomFieldValue );
+				expect( paragraphContent ).toBe(
+					variables.customFields.textValue
+				);
 				// Paragraph is not editable.
 				const isContentEditable =
 					await paragraphBlock.getAttribute( 'contenteditable' );
@@ -669,12 +692,12 @@ test.describe( 'Block bindings', () => {
 		test( 'Heading - should show the value of the custom field', async ( {
 			editor,
 		} ) => {
-			await editor.insertBlock( contentBindingHeadingBlock );
+			await editor.insertBlock( variables.blocks.heading );
 			const headingBlock = editor.canvas.getByRole( 'document', {
 				name: 'Block: Heading',
 			} );
 			const headingContent = await headingBlock.textContent();
-			expect( headingContent ).toBe( textCustomFieldValue );
+			expect( headingContent ).toBe( variables.customFields.textValue );
 			// Heading is not editable.
 			const isContentEditable =
 				await headingBlock.getAttribute( 'contenteditable' );
@@ -684,14 +707,14 @@ test.describe( 'Block bindings', () => {
 		test( 'Button - should show the value of the custom field when text is bound', async ( {
 			editor,
 		} ) => {
-			await editor.insertBlock( textBindingButtonBlock );
+			await editor.insertBlock( variables.blocks.buttons.textOnly );
 			const buttonBlock = editor.canvas.getByRole( 'document', {
 				name: 'Block: Button',
 				exact: true,
 			} );
 			await buttonBlock.click();
 			const buttonText = await buttonBlock.textContent();
-			expect( buttonText ).toBe( textCustomFieldValue );
+			expect( buttonText ).toBe( variables.customFields.textValue );
 
 			// Button is not editable.
 			const isContentEditable = await buttonBlock
@@ -728,7 +751,7 @@ test.describe( 'Block bindings', () => {
 			test( 'Should show the value of the custom field when url is bound', async ( {
 				editor,
 			} ) => {
-				await editor.insertBlock( urlBindingImageBlock );
+				await editor.insertBlock( variables.blocks.images.urlOnly );
 				const imageBlockImg = editor.canvas
 					.getByRole( 'document', {
 						name: 'Block: Image',
@@ -742,7 +765,7 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( altBindingImageBlock );
+				await editor.insertBlock( variables.blocks.images.altOnly );
 				const imageBlockImg = editor.canvas
 					.getByRole( 'document', {
 						name: 'Block: Image',
@@ -752,21 +775,23 @@ test.describe( 'Block bindings', () => {
 
 				// Image src is the placeholder.
 				const imageSrc = await imageBlockImg.getAttribute( 'src' );
-				expect( imageSrc ).toBe( placeholderSrc );
+				expect( imageSrc ).toBe( variables.placeholderSrc );
 
 				// Alt textarea is disabled and with the custom field value.
-				await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+				await expect(
+					page.getByLabel( variables.labels.imageAlt )
+				).toBeDisabled();
 				const altValue = await page
-					.getByLabel( imageAltLabel )
+					.getByLabel( variables.labels.imageAlt )
 					.inputValue();
-				expect( altValue ).toBe( textCustomFieldValue );
+				expect( altValue ).toBe( variables.customFields.textValue );
 			} );
 
 			test( 'Should show value of the custom field in the title input when title is bound', async ( {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( titleBindingImageBlock );
+				await editor.insertBlock( variables.blocks.images.titleOnly );
 				const imageBlockImg = editor.canvas
 					.getByRole( 'document', {
 						name: 'Block: Image',
@@ -776,24 +801,26 @@ test.describe( 'Block bindings', () => {
 
 				// Image src is the placeholder.
 				const imageSrc = await imageBlockImg.getAttribute( 'src' );
-				expect( imageSrc ).toBe( placeholderSrc );
+				expect( imageSrc ).toBe( variables.placeholderSrc );
 
 				// Title input is disabled and with the custom field value.
 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
 				await expect(
-					page.getByLabel( imageTitleLabel )
+					page.getByLabel( variables.labels.imageTitle )
 				).toBeDisabled();
 				const titleValue = await page
-					.getByLabel( imageTitleLabel )
+					.getByLabel( variables.labels.imageTitle )
 					.inputValue();
-				expect( titleValue ).toBe( textCustomFieldValue );
+				expect( titleValue ).toBe( variables.customFields.textValue );
 			} );
 
 			test( 'Multiple bindings should show the value of the custom fields', async ( {
 				editor,
 				page,
 			} ) => {
-				await editor.insertBlock( multipleBindingsImageBlock );
+				await editor.insertBlock(
+					variables.blocks.images.multipleAttrs
+				);
 				const imageBlockImg = editor.canvas
 					.getByRole( 'document', {
 						name: 'Block: Image',
@@ -806,19 +833,21 @@ test.describe( 'Block bindings', () => {
 				expect( imageSrc ).toBe( customFieldSrc );
 
 				// Alt textarea is disabled and with the custom field value.
-				await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+				await expect(
+					page.getByLabel( variables.labels.imageAlt )
+				).toBeDisabled();
 				const altValue = await page
-					.getByLabel( imageAltLabel )
+					.getByLabel( variables.labels.imageAlt )
 					.inputValue();
-				expect( altValue ).toBe( textCustomFieldValue );
+				expect( altValue ).toBe( variables.customFields.textValue );
 
 				// Title input is enabled and with the original value.
 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
 				await expect(
-					page.getByLabel( imageTitleLabel )
+					page.getByLabel( variables.labels.imageTitle )
 				).toBeEnabled();
 				const titleValue = await page
-					.getByLabel( imageTitleLabel )
+					.getByLabel( variables.labels.imageTitle )
 					.inputValue();
 				expect( titleValue ).toBe( 'default title value' );
 			} );

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -4,6 +4,7 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const textCustomFieldValue = 'Value of the text_custom_field';
+const textCustomFieldKey = 'text_custom_field';
 // TODO: Replace with test images.
 const urlCustomFieldValue =
 	'https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg';
@@ -182,7 +183,7 @@ const imageReplaceName = 'Replace';
 const imageAltLabel = 'Alternative text';
 const imageTitleLabel = 'Title attribute';
 
-test.describe( 'Block bindings - Page context', () => {
+test.describe( 'Block bindings - Post/page context', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 	} );
@@ -568,6 +569,403 @@ test.describe( 'Block bindings - Page context', () => {
 		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
 		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
 		expect( altValue ).toBe( textCustomFieldValue );
+
+		// Title input is enabled and with the original value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( 't' );
+	} );
+} );
+
+test.describe( 'Block bindings - Template context', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//index',
+			postType: 'wp_template',
+		} );
+		await editor.canvas.locator( 'body' ).click();
+		await editor.openDocumentSettingsSidebar();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	// Paragraph block tests.
+	test( 'Paragraph - should show the value of the custom field', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( contentBindingParagraphBlock );
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const paragraphContent = await paragraphBlock.textContent();
+		expect( paragraphContent ).toBe( textCustomFieldKey );
+	} );
+
+	test( 'Paragraph - should lock the appropriate controls', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( contentBindingParagraphBlock );
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		await paragraphBlock.click();
+
+		// Alignment controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: alignName,
+			} )
+		).toBeVisible();
+
+		// Format controls don't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeHidden();
+
+		// Paragraph is not editable.
+		const isContentEditable =
+			await paragraphBlock.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+	} );
+
+	// Heading block tests.
+	test( 'Heading - should show the value of the custom field', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( contentBindingHeadingBlock );
+		const headingBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Heading',
+		} );
+		const headingContent = await headingBlock.textContent();
+		expect( headingContent ).toBe( textCustomFieldKey );
+	} );
+
+	test( 'Heading - should lock the appropriate controls', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( contentBindingHeadingBlock );
+		const headingBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Heading',
+		} );
+		await headingBlock.click();
+
+		// Alignment controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: alignName,
+			} )
+		).toBeVisible();
+
+		// Format controls don't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeHidden();
+
+		// Heading is not editable.
+		const isContentEditable =
+			await headingBlock.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+	} );
+
+	// Button block tests.
+	test( 'Button - should show the value of the custom field when text is bound', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( textBindingButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		const buttonText = await buttonBlock.textContent();
+		expect( buttonText ).toBe( textCustomFieldKey );
+	} );
+
+	test( 'Button - should lock text controls when text is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( textBindingButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		await buttonBlock.click();
+
+		// Alignment controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: alignName,
+			} )
+		).toBeVisible();
+
+		// Format controls don't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeHidden();
+
+		// Button is not editable.
+		const isContentEditable = await buttonBlock
+			.locator( 'div' )
+			.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+
+		// Link controls exist.
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Unlink' } )
+		).toBeVisible();
+	} );
+
+	test( 'Button - should lock url controls when url is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( urlBindingButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		await buttonBlock.click();
+
+		// Format controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeVisible();
+
+		// Button is editable.
+		const isContentEditable = await buttonBlock
+			.locator( 'div' )
+			.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'true' );
+
+		// Link controls doesn't exist.
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Link' } )
+		).toBeHidden();
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Unlink' } )
+		).toBeHidden();
+	} );
+
+	test( 'Button - should lock url and text controls when both are bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( multipleBindingsButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		await buttonBlock.click();
+
+		// Alignment controls are visible.
+		await expect(
+			page.getByRole( 'button', {
+				name: alignName,
+			} )
+		).toBeVisible();
+
+		// Format controls don't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: boldName,
+			} )
+		).toBeHidden();
+
+		// Button is not editable.
+		const isContentEditable = await buttonBlock
+			.locator( 'div' )
+			.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+
+		// Link controls doesn't exist.
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Link' } )
+		).toBeHidden();
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Unlink' } )
+		).toBeHidden();
+	} );
+
+	// Image block tests.
+	test( 'Image - should show the upload form when url is not bound', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		await imageBlock.click();
+		await expect(
+			imageBlock.getByRole( 'button', { name: 'Upload' } )
+		).toBeVisible();
+	} );
+
+	test( 'Image - should NOT show the upload form when url is bound', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( urlBindingImageBlock );
+		const imageBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		await imageBlock.click();
+		await expect(
+			imageBlock.getByRole( 'button', { name: 'Upload' } )
+		).toBeHidden();
+	} );
+
+	test( 'Image - should lock url controls when url is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( urlBindingImageBlock );
+		const imageBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		await imageBlock.click();
+
+		// Replace controls doesn't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: imageReplaceName,
+			} )
+		).toBeHidden();
+
+		// Image placeholder doesn't show the upload button.
+		await expect(
+			imageBlock.getByRole( 'button', { name: 'Upload' } )
+		).toBeHidden();
+
+		// Alt textarea is enabled and with the original value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( 'a' );
+
+		// Title input is enabled and with the original value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( 't' );
+	} );
+
+	test( 'Image - should disable alt textarea when alt is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( altBindingImageBlock );
+		const imageBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		await imageBlock.click();
+
+		// Replace controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: imageReplaceName,
+			} )
+		).toBeVisible();
+
+		// Alt textarea is disabled and with the custom field value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( textCustomFieldKey );
+
+		// Title input is enabled and with the original value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( 't' );
+	} );
+
+	test( 'Image - should disable title input when title is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( titleBindingImageBlock );
+		const imageBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		await imageBlock.click();
+
+		// Replace controls exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: imageReplaceName,
+			} )
+		).toBeVisible();
+
+		// Alt textarea is enabled and with the original value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( 'a' );
+
+		// Title input is disabled and with the custom field value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( textCustomFieldKey );
+	} );
+
+	test( 'Image - multiple bindings should lock the appropriate controls', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( multipleBindingsImageBlock );
+		const imageBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		await imageBlock.click();
+
+		// Replace controls doesn't exist.
+		await expect(
+			page.getByRole( 'button', {
+				name: imageReplaceName,
+			} )
+		).toBeHidden();
+
+		// Image placeholder doesn't show the upload button.
+		await expect(
+			imageBlock.getByRole( 'button', { name: 'Upload' } )
+		).toBeHidden();
+
+		// Alt textarea is disabled and with the custom field value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( textCustomFieldKey );
 
 		// Title input is enabled and with the original value.
 		await page.getByRole( 'button', { name: 'Advanced' } ).click();

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -132,8 +132,8 @@ test.describe( 'Block bindings', () => {
 			name: 'core/image',
 			attributes: {
 				url: placeholderSrc,
-				alt: 'a',
-				title: 't',
+				alt: 'default alt value',
+				title: 'default title value',
 				metadata: {
 					bindings: {
 						url: {
@@ -148,8 +148,8 @@ test.describe( 'Block bindings', () => {
 			name: 'core/image',
 			attributes: {
 				url: placeholderSrc,
-				alt: 'a',
-				title: 't',
+				alt: 'default alt value',
+				title: 'default title value',
 				metadata: {
 					bindings: {
 						alt: {
@@ -164,8 +164,8 @@ test.describe( 'Block bindings', () => {
 			name: 'core/image',
 			attributes: {
 				url: placeholderSrc,
-				alt: 'a',
-				title: 't',
+				alt: 'default alt value',
+				title: 'default title value',
 				metadata: {
 					bindings: {
 						title: {
@@ -180,8 +180,8 @@ test.describe( 'Block bindings', () => {
 			name: 'core/image',
 			attributes: {
 				url: placeholderSrc,
-				alt: 'a',
-				title: 't',
+				alt: 'default alt value',
+				title: 'default title value',
 				metadata: {
 					bindings: {
 						url: {
@@ -492,7 +492,7 @@ test.describe( 'Block bindings', () => {
 				const altValue = await page
 					.getByLabel( imageAltLabel )
 					.inputValue();
-				expect( altValue ).toBe( 'a' );
+				expect( altValue ).toBe( 'default alt value' );
 
 				// Title input is enabled and with the original value.
 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
@@ -502,7 +502,7 @@ test.describe( 'Block bindings', () => {
 				const titleValue = await page
 					.getByLabel( imageTitleLabel )
 					.inputValue();
-				expect( titleValue ).toBe( 't' );
+				expect( titleValue ).toBe( 'default title value' );
 			} );
 
 			test( 'Should disable alt textarea when alt is bound', async ( {
@@ -537,7 +537,7 @@ test.describe( 'Block bindings', () => {
 				const titleValue = await page
 					.getByLabel( imageTitleLabel )
 					.inputValue();
-				expect( titleValue ).toBe( 't' );
+				expect( titleValue ).toBe( 'default title value' );
 			} );
 
 			test( 'Should disable title input when title is bound', async ( {
@@ -562,7 +562,7 @@ test.describe( 'Block bindings', () => {
 				const altValue = await page
 					.getByLabel( imageAltLabel )
 					.inputValue();
-				expect( altValue ).toBe( 'a' );
+				expect( altValue ).toBe( 'default alt value' );
 
 				// Title input is disabled and with the custom field value.
 				await page.getByRole( 'button', { name: 'Advanced' } ).click();
@@ -612,7 +612,7 @@ test.describe( 'Block bindings', () => {
 				const titleValue = await page
 					.getByLabel( imageTitleLabel )
 					.inputValue();
-				expect( titleValue ).toBe( 't' );
+				expect( titleValue ).toBe( 'default title value' );
 			} );
 		} );
 	} );
@@ -820,7 +820,7 @@ test.describe( 'Block bindings', () => {
 				const titleValue = await page
 					.getByLabel( imageTitleLabel )
 					.inputValue();
-				expect( titleValue ).toBe( 't' );
+				expect( titleValue ).toBe( 'default title value' );
 			} );
 		} );
 	} );

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -183,427 +183,6 @@ const imageReplaceName = 'Replace';
 const imageAltLabel = 'Alternative text';
 const imageTitleLabel = 'Title attribute';
 
-test.describe( 'Block bindings - Post/page context', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'emptytheme' );
-	} );
-
-	test.beforeEach( async ( { admin } ) => {
-		await admin.createNewPost();
-	} );
-
-	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts();
-	} );
-
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
-	// Paragraph block tests.
-	test( 'Paragraph - should show the value of the custom field when exists', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( contentBindingParagraphBlock );
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
-		} );
-		const paragraphContent = await paragraphBlock.textContent();
-		expect( paragraphContent ).toBe( textCustomFieldValue );
-	} );
-
-	test( "Paragraph - should show the value of the key when custom field doesn't exists", async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: {
-				content: 'p',
-				metadata: {
-					bindings: {
-						content: {
-							source: 'core/post-meta',
-							args: { key: 'non_existing_custom_field' },
-						},
-					},
-				},
-			},
-		} );
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
-		} );
-		const paragraphContent = await paragraphBlock.textContent();
-		expect( paragraphContent ).toBe( 'non_existing_custom_field' );
-	} );
-
-	test( 'Paragraph - should lock the appropriate controls', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( contentBindingParagraphBlock );
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
-		} );
-		await paragraphBlock.click();
-
-		// Alignment controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: alignName,
-			} )
-		).toBeVisible();
-
-		// Format controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeHidden();
-
-		// Paragraph is not editable.
-		const isContentEditable =
-			await paragraphBlock.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
-	} );
-
-	// Heading block tests.
-	test( 'Heading - should show the value of the custom field', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( contentBindingHeadingBlock );
-		const headingBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Heading',
-		} );
-		const headingContent = await headingBlock.textContent();
-		expect( headingContent ).toBe( textCustomFieldValue );
-	} );
-
-	test( 'Heading - should lock the appropriate controls', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( contentBindingHeadingBlock );
-		const headingBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Heading',
-		} );
-		await headingBlock.click();
-
-		// Alignment controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: alignName,
-			} )
-		).toBeVisible();
-
-		// Format controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeHidden();
-
-		// Heading is not editable.
-		const isContentEditable =
-			await headingBlock.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
-	} );
-
-	// Button block tests.
-	test( 'Button - should show the value of the custom field when text is bound', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( textBindingButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
-		} );
-		const buttonText = await buttonBlock.textContent();
-		expect( buttonText ).toBe( textCustomFieldValue );
-	} );
-
-	test( 'Button - should lock text controls when text is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( textBindingButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
-		} );
-		await buttonBlock.click();
-
-		// Alignment controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: alignName,
-			} )
-		).toBeVisible();
-
-		// Format controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeHidden();
-
-		// Button is not editable.
-		const isContentEditable = await buttonBlock
-			.locator( 'div' )
-			.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
-
-		// Link controls exist.
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Unlink' } )
-		).toBeVisible();
-	} );
-
-	test( 'Button - should lock url controls when url is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( urlBindingButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
-		} );
-		await buttonBlock.click();
-
-		// Format controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeVisible();
-
-		// Button is editable.
-		const isContentEditable = await buttonBlock
-			.locator( 'div' )
-			.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'true' );
-
-		// Link controls don't exist.
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Link' } )
-		).toBeHidden();
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Unlink' } )
-		).toBeHidden();
-	} );
-
-	test( 'Button - should lock url and text controls when both are bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( multipleBindingsButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
-		} );
-		await buttonBlock.click();
-
-		// Alignment controls are visible.
-		await expect(
-			page.getByRole( 'button', {
-				name: alignName,
-			} )
-		).toBeVisible();
-
-		// Format controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: boldName,
-			} )
-		).toBeHidden();
-
-		// Button is not editable.
-		const isContentEditable = await buttonBlock
-			.locator( 'div' )
-			.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
-
-		// Link controls don't exist.
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Link' } )
-		).toBeHidden();
-		await expect(
-			page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Unlink' } )
-		).toBeHidden();
-	} );
-
-	// Image block tests.
-	test( 'Image - should show the value of the custom field when url is bound', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( urlBindingImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( urlCustomFieldValue );
-	} );
-
-	test( 'Image - should lock url controls when url is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( urlBindingImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		await imageBlockImg.click();
-
-		// Replace controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: imageReplaceName,
-			} )
-		).toBeHidden();
-
-		// Image src is the custom field value.
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( urlCustomFieldValue );
-
-		// Alt textarea is enabled and with the original value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( 'a' );
-
-		// Title input is enabled and with the original value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( 't' );
-	} );
-
-	test( 'Image - should disable alt textarea when alt is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( altBindingImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		await imageBlockImg.click();
-
-		// Replace controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: imageReplaceName,
-			} )
-		).toBeVisible();
-
-		// Image src is the placeholder.
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( imagePlaceholder );
-
-		// Alt textarea is disabled and with the custom field value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( textCustomFieldValue );
-
-		// Title input is enabled and with the original value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( 't' );
-	} );
-
-	test( 'Image - should disable title input when title is bound', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( titleBindingImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		await imageBlockImg.click();
-
-		// Replace controls exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: imageReplaceName,
-			} )
-		).toBeVisible();
-
-		// Image src is the placeholder.
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( imagePlaceholder );
-
-		// Alt textarea is enabled and with the original value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( 'a' );
-
-		// Title input is disabled and with the custom field value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( textCustomFieldValue );
-	} );
-
-	test( 'Image - multiple bindings should lock the appropriate controls', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( multipleBindingsImageBlock );
-		const imageBlockImg = editor.canvas
-			.getByRole( 'document', {
-				name: 'Block: Image',
-			} )
-			.locator( 'img' );
-		await imageBlockImg.click();
-
-		// Replace controls don't exist.
-		await expect(
-			page.getByRole( 'button', {
-				name: imageReplaceName,
-			} )
-		).toBeHidden();
-
-		// Image src is the custom field value.
-		const imageSrc = await imageBlockImg.getAttribute( 'src' );
-		expect( imageSrc ).toBe( urlCustomFieldValue );
-
-		// Alt textarea is disabled and with the custom field value.
-		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
-		expect( altValue ).toBe( textCustomFieldValue );
-
-		// Title input is enabled and with the original value.
-		await page.getByRole( 'button', { name: 'Advanced' } ).click();
-		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-		const titleValue = await page
-			.getByLabel( imageTitleLabel )
-			.inputValue();
-		expect( titleValue ).toBe( 't' );
-	} );
-} );
-
 test.describe( 'Block bindings - Template context', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
@@ -990,6 +569,195 @@ test.describe( 'Block bindings - Template context', () => {
 		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
 		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
 		expect( altValue ).toBe( textCustomFieldKey );
+
+		// Title input is enabled and with the original value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( 't' );
+	} );
+} );
+
+test.describe( 'Block bindings - Post/page context', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	// Paragraph block tests.
+	test( 'Paragraph - should show the value of the custom field when exists', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( contentBindingParagraphBlock );
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const paragraphContent = await paragraphBlock.textContent();
+		expect( paragraphContent ).toBe( textCustomFieldValue );
+		// Paragraph is not editable.
+		const isContentEditable =
+			await paragraphBlock.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+	} );
+
+	test( "Paragraph - should show the value of the key when custom field doesn't exists", async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'p',
+				metadata: {
+					bindings: {
+						content: {
+							source: 'core/post-meta',
+							args: { key: 'non_existing_custom_field' },
+						},
+					},
+				},
+			},
+		} );
+		const paragraphBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const paragraphContent = await paragraphBlock.textContent();
+		expect( paragraphContent ).toBe( 'non_existing_custom_field' );
+		// Paragraph is not editable.
+		const isContentEditable =
+			await paragraphBlock.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+	} );
+
+	// Heading block tests.
+	test( 'Heading - should show the value of the custom field', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( contentBindingHeadingBlock );
+		const headingBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Heading',
+		} );
+		const headingContent = await headingBlock.textContent();
+		expect( headingContent ).toBe( textCustomFieldValue );
+		// Heading is not editable.
+		const isContentEditable =
+			await headingBlock.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+	} );
+
+	// Button block tests.
+	test( 'Button - should show the value of the custom field when text is bound', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( textBindingButtonBlock );
+		const buttonBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		await buttonBlock.click();
+		const buttonText = await buttonBlock.textContent();
+		expect( buttonText ).toBe( textCustomFieldValue );
+
+		// Button is not editable.
+		const isContentEditable = await buttonBlock
+			.locator( 'div' )
+			.getAttribute( 'contenteditable' );
+		expect( isContentEditable ).toBe( 'false' );
+	} );
+
+	// Image block tests.
+	test( 'Image - should show the value of the custom field when url is bound', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( urlBindingImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( urlCustomFieldValue );
+	} );
+
+	test( 'Image - should show value of the custom field in the alt textarea when alt is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( altBindingImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		await imageBlockImg.click();
+
+		// Image src is the placeholder.
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( imagePlaceholder );
+
+		// Alt textarea is disabled and with the custom field value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( textCustomFieldValue );
+	} );
+
+	test( 'Image - should show value of the custom field in the title input when title is bound', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( titleBindingImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		await imageBlockImg.click();
+
+		// Image src is the placeholder.
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( imagePlaceholder );
+
+		// Title input is disabled and with the custom field value.
+		await page.getByRole( 'button', { name: 'Advanced' } ).click();
+		await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
+		const titleValue = await page
+			.getByLabel( imageTitleLabel )
+			.inputValue();
+		expect( titleValue ).toBe( textCustomFieldValue );
+	} );
+
+	test( 'Image - multiple bindings should show the value of the custom fields', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( multipleBindingsImageBlock );
+		const imageBlockImg = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Image',
+			} )
+			.locator( 'img' );
+		await imageBlockImg.click();
+
+		// Image src is the custom field value.
+		const imageSrc = await imageBlockImg.getAttribute( 'src' );
+		expect( imageSrc ).toBe( urlCustomFieldValue );
+
+		// Alt textarea is disabled and with the custom field value.
+		await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+		const altValue = await page.getByLabel( imageAltLabel ).inputValue();
+		expect( altValue ).toBe( textCustomFieldValue );
 
 		// Title input is enabled and with the original value.
 		await page.getByRole( 'button', { name: 'Advanced' } ).click();

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -384,7 +384,7 @@ test.describe( 'Block bindings - Post/page context', () => {
 			.getAttribute( 'contenteditable' );
 		expect( isContentEditable ).toBe( 'true' );
 
-		// Link controls doesn't exist.
+		// Link controls don't exist.
 		await expect(
 			page
 				.getByRole( 'toolbar', { name: 'Block tools' } )
@@ -428,7 +428,7 @@ test.describe( 'Block bindings - Post/page context', () => {
 			.getAttribute( 'contenteditable' );
 		expect( isContentEditable ).toBe( 'false' );
 
-		// Link controls doesn't exist.
+		// Link controls don't exist.
 		await expect(
 			page
 				.getByRole( 'toolbar', { name: 'Block tools' } )
@@ -467,7 +467,7 @@ test.describe( 'Block bindings - Post/page context', () => {
 			.locator( 'img' );
 		await imageBlockImg.click();
 
-		// Replace controls doesn't exist.
+		// Replace controls don't exist.
 		await expect(
 			page.getByRole( 'button', {
 				name: imageReplaceName,
@@ -578,7 +578,7 @@ test.describe( 'Block bindings - Post/page context', () => {
 			.locator( 'img' );
 		await imageBlockImg.click();
 
-		// Replace controls doesn't exist.
+		// Replace controls don't exist.
 		await expect(
 			page.getByRole( 'button', {
 				name: imageReplaceName,
@@ -782,7 +782,7 @@ test.describe( 'Block bindings - Template context', () => {
 			.getAttribute( 'contenteditable' );
 		expect( isContentEditable ).toBe( 'true' );
 
-		// Link controls doesn't exist.
+		// Link controls don't exist.
 		await expect(
 			page
 				.getByRole( 'toolbar', { name: 'Block tools' } )
@@ -826,7 +826,7 @@ test.describe( 'Block bindings - Template context', () => {
 			.getAttribute( 'contenteditable' );
 		expect( isContentEditable ).toBe( 'false' );
 
-		// Link controls doesn't exist.
+		// Link controls don't exist.
 		await expect(
 			page
 				.getByRole( 'toolbar', { name: 'Block tools' } )
@@ -876,7 +876,7 @@ test.describe( 'Block bindings - Template context', () => {
 		} );
 		await imageBlock.click();
 
-		// Replace controls doesn't exist.
+		// Replace controls don't exist.
 		await expect(
 			page.getByRole( 'button', {
 				name: imageReplaceName,
@@ -974,7 +974,7 @@ test.describe( 'Block bindings - Template context', () => {
 		} );
 		await imageBlock.click();
 
-		// Replace controls doesn't exist.
+		// Replace controls don't exist.
 		await expect(
 			page.getByRole( 'button', {
 				name: imageReplaceName,

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1,16 +1,14 @@
 /**
+ * External dependencies
+ */
+const path = require( 'path' );
+/**
  * WordPress dependencies
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const textCustomFieldValue = 'Value of the text_custom_field';
 const textCustomFieldKey = 'text_custom_field';
-// TODO: Replace with test images.
-const urlCustomFieldValue =
-	'https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg';
-const imagePlaceholder =
-	'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg';
-
 // Shared variables
 const alignName = 'Align text';
 const boldName = 'Bold';
@@ -110,498 +108,94 @@ const multipleBindingsButtonBlock = {
 	],
 };
 // Image blocks.
-const urlBindingImageBlock = {
-	name: 'core/image',
-	attributes: {
-		url: imagePlaceholder,
-		alt: 'a',
-		title: 't',
-		metadata: {
-			bindings: {
-				url: {
-					source: 'core/post-meta',
-					args: { key: 'url_custom_field' },
-				},
-			},
-		},
-	},
-};
-const altBindingImageBlock = {
-	name: 'core/image',
-	attributes: {
-		url: imagePlaceholder,
-		alt: 'a',
-		title: 't',
-		metadata: {
-			bindings: {
-				alt: {
-					source: 'core/post-meta',
-					args: { key: 'text_custom_field' },
-				},
-			},
-		},
-	},
-};
-const titleBindingImageBlock = {
-	name: 'core/image',
-	attributes: {
-		url: imagePlaceholder,
-		alt: 'a',
-		title: 't',
-		metadata: {
-			bindings: {
-				title: {
-					source: 'core/post-meta',
-					args: { key: 'text_custom_field' },
-				},
-			},
-		},
-	},
-};
-const multipleBindingsImageBlock = {
-	name: 'core/image',
-	attributes: {
-		url: imagePlaceholder,
-		alt: 'a',
-		title: 't',
-		metadata: {
-			bindings: {
-				url: {
-					source: 'core/post-meta',
-					args: { key: 'url_custom_field' },
-				},
-				alt: {
-					source: 'core/post-meta',
-					args: { key: 'text_custom_field' },
-				},
-			},
-		},
-	},
-};
+let urlBindingImageBlock;
+let altBindingImageBlock;
+let titleBindingImageBlock;
+let multipleBindingsImageBlock;
 // Image variables.
 const imageReplaceName = 'Replace';
 const imageAltLabel = 'Alternative text';
 const imageTitleLabel = 'Title attribute';
 
-test.describe( 'Block bindings - Template context', () => {
+test.describe( 'Block bindings', () => {
+	let placeholderSrc;
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
-	} );
-
-	test.beforeEach( async ( { admin, editor } ) => {
-		await admin.visitSiteEditor( {
-			postId: 'emptytheme//index',
-			postType: 'wp_template',
-		} );
-		await editor.canvas.locator( 'body' ).click();
-		await editor.openDocumentSettingsSidebar();
-	} );
-
-	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
-		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
-	} );
-
-	test.describe( 'Paragraph', () => {
-		test( 'Should show the value of the custom field', async ( {
-			editor,
-		} ) => {
-			await editor.insertBlock( contentBindingParagraphBlock );
-			const paragraphBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Paragraph',
-			} );
-			const paragraphContent = await paragraphBlock.textContent();
-			expect( paragraphContent ).toBe( textCustomFieldKey );
-		} );
-
-		test( 'Should lock the appropriate controls', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( contentBindingParagraphBlock );
-			const paragraphBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Paragraph',
-			} );
-			await paragraphBlock.click();
-
-			// Alignment controls exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: alignName,
-				} )
-			).toBeVisible();
-
-			// Format controls don't exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: boldName,
-				} )
-			).toBeHidden();
-
-			// Paragraph is not editable.
-			const isContentEditable =
-				await paragraphBlock.getAttribute( 'contenteditable' );
-			expect( isContentEditable ).toBe( 'false' );
-		} );
-	} );
-
-	test.describe( 'Heading', () => {
-		test( 'Should show the key of the custom field', async ( {
-			editor,
-		} ) => {
-			await editor.insertBlock( contentBindingHeadingBlock );
-			const headingBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Heading',
-			} );
-			const headingContent = await headingBlock.textContent();
-			expect( headingContent ).toBe( textCustomFieldKey );
-		} );
-
-		test( 'Should lock the appropriate controls', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( contentBindingHeadingBlock );
-			const headingBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Heading',
-			} );
-			await headingBlock.click();
-
-			// Alignment controls exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: alignName,
-				} )
-			).toBeVisible();
-
-			// Format controls don't exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: boldName,
-				} )
-			).toBeHidden();
-
-			// Heading is not editable.
-			const isContentEditable =
-				await headingBlock.getAttribute( 'contenteditable' );
-			expect( isContentEditable ).toBe( 'false' );
-		} );
-	} );
-
-	test.describe( 'Button', () => {
-		test( 'Should show the key of the custom field when text is bound', async ( {
-			editor,
-		} ) => {
-			await editor.insertBlock( textBindingButtonBlock );
-			const buttonBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Button',
-				exact: true,
-			} );
-			const buttonText = await buttonBlock.textContent();
-			expect( buttonText ).toBe( textCustomFieldKey );
-		} );
-
-		test( 'Should lock text controls when text is bound', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( textBindingButtonBlock );
-			const buttonBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Button',
-				exact: true,
-			} );
-			await buttonBlock.click();
-
-			// Alignment controls exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: alignName,
-				} )
-			).toBeVisible();
-
-			// Format controls don't exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: boldName,
-				} )
-			).toBeHidden();
-
-			// Button is not editable.
-			const isContentEditable = await buttonBlock
-				.locator( 'div' )
-				.getAttribute( 'contenteditable' );
-			expect( isContentEditable ).toBe( 'false' );
-
-			// Link controls exist.
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Unlink' } )
-			).toBeVisible();
-		} );
-
-		test( 'Should lock url controls when url is bound', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( urlBindingButtonBlock );
-			const buttonBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Button',
-				exact: true,
-			} );
-			await buttonBlock.click();
-
-			// Format controls exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: boldName,
-				} )
-			).toBeVisible();
-
-			// Button is editable.
-			const isContentEditable = await buttonBlock
-				.locator( 'div' )
-				.getAttribute( 'contenteditable' );
-			expect( isContentEditable ).toBe( 'true' );
-
-			// Link controls don't exist.
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Link' } )
-			).toBeHidden();
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Unlink' } )
-			).toBeHidden();
-		} );
-
-		test( 'Should lock url and text controls when both are bound', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( multipleBindingsButtonBlock );
-			const buttonBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Button',
-				exact: true,
-			} );
-			await buttonBlock.click();
-
-			// Alignment controls are visible.
-			await expect(
-				page.getByRole( 'button', {
-					name: alignName,
-				} )
-			).toBeVisible();
-
-			// Format controls don't exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: boldName,
-				} )
-			).toBeHidden();
-
-			// Button is not editable.
-			const isContentEditable = await buttonBlock
-				.locator( 'div' )
-				.getAttribute( 'contenteditable' );
-			expect( isContentEditable ).toBe( 'false' );
-
-			// Link controls don't exist.
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Link' } )
-			).toBeHidden();
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Unlink' } )
-			).toBeHidden();
-		} );
-	} );
-
-	test.describe( 'Image', () => {
-		test( 'Should show the upload form when url is not bound', async ( {
-			editor,
-		} ) => {
-			await editor.insertBlock( { name: 'core/image' } );
-			const imageBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Image',
-			} );
-			await imageBlock.click();
-			await expect(
-				imageBlock.getByRole( 'button', { name: 'Upload' } )
-			).toBeVisible();
-		} );
-
-		test( 'Should NOT show the upload form when url is bound', async ( {
-			editor,
-		} ) => {
-			await editor.insertBlock( urlBindingImageBlock );
-			const imageBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Image',
-			} );
-			await imageBlock.click();
-			await expect(
-				imageBlock.getByRole( 'button', { name: 'Upload' } )
-			).toBeHidden();
-		} );
-
-		test( 'Should lock url controls when url is bound', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( urlBindingImageBlock );
-			const imageBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Image',
-			} );
-			await imageBlock.click();
-
-			// Replace controls don't exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: imageReplaceName,
-				} )
-			).toBeHidden();
-
-			// Image placeholder doesn't show the upload button.
-			await expect(
-				imageBlock.getByRole( 'button', { name: 'Upload' } )
-			).toBeHidden();
-
-			// Alt textarea is enabled and with the original value.
-			await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
-			const altValue = await page
-				.getByLabel( imageAltLabel )
-				.inputValue();
-			expect( altValue ).toBe( 'a' );
-
-			// Title input is enabled and with the original value.
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-			const titleValue = await page
-				.getByLabel( imageTitleLabel )
-				.inputValue();
-			expect( titleValue ).toBe( 't' );
-		} );
-
-		test( 'Should disable alt textarea when alt is bound', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( altBindingImageBlock );
-			const imageBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Image',
-			} );
-			await imageBlock.click();
-
-			// Replace controls exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: imageReplaceName,
-				} )
-			).toBeVisible();
-
-			// Alt textarea is disabled and with the custom field value.
-			await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-			const altValue = await page
-				.getByLabel( imageAltLabel )
-				.inputValue();
-			expect( altValue ).toBe( textCustomFieldKey );
-
-			// Title input is enabled and with the original value.
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-			const titleValue = await page
-				.getByLabel( imageTitleLabel )
-				.inputValue();
-			expect( titleValue ).toBe( 't' );
-		} );
-
-		test( 'Should disable title input when title is bound', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( titleBindingImageBlock );
-			const imageBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Image',
-			} );
-			await imageBlock.click();
-
-			// Replace controls exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: imageReplaceName,
-				} )
-			).toBeVisible();
-
-			// Alt textarea is enabled and with the original value.
-			await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
-			const altValue = await page
-				.getByLabel( imageAltLabel )
-				.inputValue();
-			expect( altValue ).toBe( 'a' );
-
-			// Title input is disabled and with the custom field value.
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
-			const titleValue = await page
-				.getByLabel( imageTitleLabel )
-				.inputValue();
-			expect( titleValue ).toBe( textCustomFieldKey );
-		} );
-
-		test( 'Multiple bindings should lock the appropriate controls', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( multipleBindingsImageBlock );
-			const imageBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Image',
-			} );
-			await imageBlock.click();
-
-			// Replace controls don't exist.
-			await expect(
-				page.getByRole( 'button', {
-					name: imageReplaceName,
-				} )
-			).toBeHidden();
-
-			// Image placeholder doesn't show the upload button.
-			await expect(
-				imageBlock.getByRole( 'button', { name: 'Upload' } )
-			).toBeHidden();
-
-			// Alt textarea is disabled and with the custom field value.
-			await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-			const altValue = await page
-				.getByLabel( imageAltLabel )
-				.inputValue();
-			expect( altValue ).toBe( textCustomFieldKey );
-
-			// Title input is enabled and with the original value.
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-			const titleValue = await page
-				.getByLabel( imageTitleLabel )
-				.inputValue();
-			expect( titleValue ).toBe( 't' );
-		} );
-	} );
-} );
-
-test.describe( 'Block bindings - Post/page context', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'emptytheme' );
-		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
-	} );
-
-	test.beforeEach( async ( { admin } ) => {
-		await admin.createNewPost();
+		await requestUtils.deleteAllMedia();
+		const placeholderMedia = await requestUtils.uploadMedia(
+			path.join( './test/e2e/assets', '10x10_e2e_test_image_z9T8jK.png' )
+		);
+		placeholderSrc = placeholderMedia.source_url;
+		// Init image blocks.
+		urlBindingImageBlock = {
+			name: 'core/image',
+			attributes: {
+				url: placeholderSrc,
+				alt: 'a',
+				title: 't',
+				metadata: {
+					bindings: {
+						url: {
+							source: 'core/post-meta',
+							args: { key: 'url_custom_field' },
+						},
+					},
+				},
+			},
+		};
+		altBindingImageBlock = {
+			name: 'core/image',
+			attributes: {
+				url: placeholderSrc,
+				alt: 'a',
+				title: 't',
+				metadata: {
+					bindings: {
+						alt: {
+							source: 'core/post-meta',
+							args: { key: 'text_custom_field' },
+						},
+					},
+				},
+			},
+		};
+		titleBindingImageBlock = {
+			name: 'core/image',
+			attributes: {
+				url: placeholderSrc,
+				alt: 'a',
+				title: 't',
+				metadata: {
+					bindings: {
+						title: {
+							source: 'core/post-meta',
+							args: { key: 'text_custom_field' },
+						},
+					},
+				},
+			},
+		};
+		multipleBindingsImageBlock = {
+			name: 'core/image',
+			attributes: {
+				url: placeholderSrc,
+				alt: 'a',
+				title: 't',
+				metadata: {
+					bindings: {
+						url: {
+							source: 'core/post-meta',
+							args: { key: 'url_custom_field' },
+						},
+						alt: {
+							source: 'core/post-meta',
+							args: { key: 'text_custom_field' },
+						},
+					},
+				},
+			},
+		};
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
@@ -609,182 +203,625 @@ test.describe( 'Block bindings - Post/page context', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
 		await requestUtils.activateTheme( 'twentytwentyone' );
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
 	} );
 
-	test.describe( 'Paragraph', () => {
-		test( 'Should show the value of the custom field when exists', async ( {
-			editor,
-		} ) => {
-			await editor.insertBlock( contentBindingParagraphBlock );
-			const paragraphBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Paragraph',
+	test.describe( 'Template context', () => {
+		test.beforeEach( async ( { admin, editor } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//index',
+				postType: 'wp_template',
 			} );
-			const paragraphContent = await paragraphBlock.textContent();
-			expect( paragraphContent ).toBe( textCustomFieldValue );
-			// Paragraph is not editable.
-			const isContentEditable =
-				await paragraphBlock.getAttribute( 'contenteditable' );
-			expect( isContentEditable ).toBe( 'false' );
+			await editor.canvas.locator( 'body' ).click();
+			await editor.openDocumentSettingsSidebar();
 		} );
 
-		test( "Should show the value of the key when custom field doesn't exists", async ( {
-			editor,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: {
-					content: 'p',
-					metadata: {
-						bindings: {
-							content: {
-								source: 'core/post-meta',
-								args: { key: 'non_existing_custom_field' },
+		test.describe( 'Paragraph', () => {
+			test( 'Should show the value of the custom field', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( contentBindingParagraphBlock );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+				const paragraphContent = await paragraphBlock.textContent();
+				expect( paragraphContent ).toBe( textCustomFieldKey );
+			} );
+
+			test( 'Should lock the appropriate controls', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( contentBindingParagraphBlock );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+				await paragraphBlock.click();
+
+				// Alignment controls exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: alignName,
+					} )
+				).toBeVisible();
+
+				// Format controls don't exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: boldName,
+					} )
+				).toBeHidden();
+
+				// Paragraph is not editable.
+				const isContentEditable =
+					await paragraphBlock.getAttribute( 'contenteditable' );
+				expect( isContentEditable ).toBe( 'false' );
+			} );
+		} );
+
+		test.describe( 'Heading', () => {
+			test( 'Should show the key of the custom field', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( contentBindingHeadingBlock );
+				const headingBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Heading',
+				} );
+				const headingContent = await headingBlock.textContent();
+				expect( headingContent ).toBe( textCustomFieldKey );
+			} );
+
+			test( 'Should lock the appropriate controls', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( contentBindingHeadingBlock );
+				const headingBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Heading',
+				} );
+				await headingBlock.click();
+
+				// Alignment controls exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: alignName,
+					} )
+				).toBeVisible();
+
+				// Format controls don't exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: boldName,
+					} )
+				).toBeHidden();
+
+				// Heading is not editable.
+				const isContentEditable =
+					await headingBlock.getAttribute( 'contenteditable' );
+				expect( isContentEditable ).toBe( 'false' );
+			} );
+		} );
+
+		test.describe( 'Button', () => {
+			test( 'Should show the key of the custom field when text is bound', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( textBindingButtonBlock );
+				const buttonBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Button',
+					exact: true,
+				} );
+				const buttonText = await buttonBlock.textContent();
+				expect( buttonText ).toBe( textCustomFieldKey );
+			} );
+
+			test( 'Should lock text controls when text is bound', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( textBindingButtonBlock );
+				const buttonBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Button',
+					exact: true,
+				} );
+				await buttonBlock.click();
+
+				// Alignment controls exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: alignName,
+					} )
+				).toBeVisible();
+
+				// Format controls don't exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: boldName,
+					} )
+				).toBeHidden();
+
+				// Button is not editable.
+				const isContentEditable = await buttonBlock
+					.locator( 'div' )
+					.getAttribute( 'contenteditable' );
+				expect( isContentEditable ).toBe( 'false' );
+
+				// Link controls exist.
+				await expect(
+					page
+						.getByRole( 'toolbar', { name: 'Block tools' } )
+						.getByRole( 'button', { name: 'Unlink' } )
+				).toBeVisible();
+			} );
+
+			test( 'Should lock url controls when url is bound', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( urlBindingButtonBlock );
+				const buttonBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Button',
+					exact: true,
+				} );
+				await buttonBlock.click();
+
+				// Format controls exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: boldName,
+					} )
+				).toBeVisible();
+
+				// Button is editable.
+				const isContentEditable = await buttonBlock
+					.locator( 'div' )
+					.getAttribute( 'contenteditable' );
+				expect( isContentEditable ).toBe( 'true' );
+
+				// Link controls don't exist.
+				await expect(
+					page
+						.getByRole( 'toolbar', { name: 'Block tools' } )
+						.getByRole( 'button', { name: 'Link' } )
+				).toBeHidden();
+				await expect(
+					page
+						.getByRole( 'toolbar', { name: 'Block tools' } )
+						.getByRole( 'button', { name: 'Unlink' } )
+				).toBeHidden();
+			} );
+
+			test( 'Should lock url and text controls when both are bound', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( multipleBindingsButtonBlock );
+				const buttonBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Button',
+					exact: true,
+				} );
+				await buttonBlock.click();
+
+				// Alignment controls are visible.
+				await expect(
+					page.getByRole( 'button', {
+						name: alignName,
+					} )
+				).toBeVisible();
+
+				// Format controls don't exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: boldName,
+					} )
+				).toBeHidden();
+
+				// Button is not editable.
+				const isContentEditable = await buttonBlock
+					.locator( 'div' )
+					.getAttribute( 'contenteditable' );
+				expect( isContentEditable ).toBe( 'false' );
+
+				// Link controls don't exist.
+				await expect(
+					page
+						.getByRole( 'toolbar', { name: 'Block tools' } )
+						.getByRole( 'button', { name: 'Link' } )
+				).toBeHidden();
+				await expect(
+					page
+						.getByRole( 'toolbar', { name: 'Block tools' } )
+						.getByRole( 'button', { name: 'Unlink' } )
+				).toBeHidden();
+			} );
+		} );
+
+		test.describe( 'Image', () => {
+			test( 'Should show the upload form when url is not bound', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( { name: 'core/image' } );
+				const imageBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Image',
+				} );
+				await imageBlock.click();
+				await expect(
+					imageBlock.getByRole( 'button', { name: 'Upload' } )
+				).toBeVisible();
+			} );
+
+			test( 'Should NOT show the upload form when url is bound', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( urlBindingImageBlock );
+				const imageBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Image',
+				} );
+				await imageBlock.click();
+				await expect(
+					imageBlock.getByRole( 'button', { name: 'Upload' } )
+				).toBeHidden();
+			} );
+
+			test( 'Should lock url controls when url is bound', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( urlBindingImageBlock );
+				const imageBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Image',
+				} );
+				await imageBlock.click();
+
+				// Replace controls don't exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: imageReplaceName,
+					} )
+				).toBeHidden();
+
+				// Image placeholder doesn't show the upload button.
+				await expect(
+					imageBlock.getByRole( 'button', { name: 'Upload' } )
+				).toBeHidden();
+
+				// Alt textarea is enabled and with the original value.
+				await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+				const altValue = await page
+					.getByLabel( imageAltLabel )
+					.inputValue();
+				expect( altValue ).toBe( 'a' );
+
+				// Title input is enabled and with the original value.
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				await expect(
+					page.getByLabel( imageTitleLabel )
+				).toBeEnabled();
+				const titleValue = await page
+					.getByLabel( imageTitleLabel )
+					.inputValue();
+				expect( titleValue ).toBe( 't' );
+			} );
+
+			test( 'Should disable alt textarea when alt is bound', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( altBindingImageBlock );
+				const imageBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Image',
+				} );
+				await imageBlock.click();
+
+				// Replace controls exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: imageReplaceName,
+					} )
+				).toBeVisible();
+
+				// Alt textarea is disabled and with the custom field value.
+				await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+				const altValue = await page
+					.getByLabel( imageAltLabel )
+					.inputValue();
+				expect( altValue ).toBe( textCustomFieldKey );
+
+				// Title input is enabled and with the original value.
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				await expect(
+					page.getByLabel( imageTitleLabel )
+				).toBeEnabled();
+				const titleValue = await page
+					.getByLabel( imageTitleLabel )
+					.inputValue();
+				expect( titleValue ).toBe( 't' );
+			} );
+
+			test( 'Should disable title input when title is bound', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( titleBindingImageBlock );
+				const imageBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Image',
+				} );
+				await imageBlock.click();
+
+				// Replace controls exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: imageReplaceName,
+					} )
+				).toBeVisible();
+
+				// Alt textarea is enabled and with the original value.
+				await expect( page.getByLabel( imageAltLabel ) ).toBeEnabled();
+				const altValue = await page
+					.getByLabel( imageAltLabel )
+					.inputValue();
+				expect( altValue ).toBe( 'a' );
+
+				// Title input is disabled and with the custom field value.
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				await expect(
+					page.getByLabel( imageTitleLabel )
+				).toBeDisabled();
+				const titleValue = await page
+					.getByLabel( imageTitleLabel )
+					.inputValue();
+				expect( titleValue ).toBe( textCustomFieldKey );
+			} );
+
+			test( 'Multiple bindings should lock the appropriate controls', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( multipleBindingsImageBlock );
+				const imageBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Image',
+				} );
+				await imageBlock.click();
+
+				// Replace controls don't exist.
+				await expect(
+					page.getByRole( 'button', {
+						name: imageReplaceName,
+					} )
+				).toBeHidden();
+
+				// Image placeholder doesn't show the upload button.
+				await expect(
+					imageBlock.getByRole( 'button', { name: 'Upload' } )
+				).toBeHidden();
+
+				// Alt textarea is disabled and with the custom field value.
+				await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+				const altValue = await page
+					.getByLabel( imageAltLabel )
+					.inputValue();
+				expect( altValue ).toBe( textCustomFieldKey );
+
+				// Title input is enabled and with the original value.
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				await expect(
+					page.getByLabel( imageTitleLabel )
+				).toBeEnabled();
+				const titleValue = await page
+					.getByLabel( imageTitleLabel )
+					.inputValue();
+				expect( titleValue ).toBe( 't' );
+			} );
+		} );
+	} );
+
+	test.describe( 'Post/page context', () => {
+		test.beforeEach( async ( { admin } ) => {
+			await admin.createNewPost( { title: 'Test bindings' } );
+		} );
+		test.describe( 'Paragraph', () => {
+			test( 'Should show the value of the custom field when exists', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( contentBindingParagraphBlock );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+				const paragraphContent = await paragraphBlock.textContent();
+				expect( paragraphContent ).toBe( textCustomFieldValue );
+				// Paragraph is not editable.
+				const isContentEditable =
+					await paragraphBlock.getAttribute( 'contenteditable' );
+				expect( isContentEditable ).toBe( 'false' );
+			} );
+
+			test( "Should show the value of the key when custom field doesn't exists", async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						content: 'p',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: { key: 'non_existing_custom_field' },
+								},
 							},
 						},
 					},
-				},
+				} );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+				const paragraphContent = await paragraphBlock.textContent();
+				expect( paragraphContent ).toBe( 'non_existing_custom_field' );
+				// Paragraph is not editable.
+				const isContentEditable =
+					await paragraphBlock.getAttribute( 'contenteditable' );
+				expect( isContentEditable ).toBe( 'false' );
 			} );
-			const paragraphBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Paragraph',
+		} );
+
+		test( 'Heading - should show the value of the custom field', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( contentBindingHeadingBlock );
+			const headingBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Heading',
 			} );
-			const paragraphContent = await paragraphBlock.textContent();
-			expect( paragraphContent ).toBe( 'non_existing_custom_field' );
-			// Paragraph is not editable.
+			const headingContent = await headingBlock.textContent();
+			expect( headingContent ).toBe( textCustomFieldValue );
+			// Heading is not editable.
 			const isContentEditable =
-				await paragraphBlock.getAttribute( 'contenteditable' );
+				await headingBlock.getAttribute( 'contenteditable' );
 			expect( isContentEditable ).toBe( 'false' );
 		} );
-	} );
 
-	test( 'Heading - should show the value of the custom field', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( contentBindingHeadingBlock );
-		const headingBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Heading',
-		} );
-		const headingContent = await headingBlock.textContent();
-		expect( headingContent ).toBe( textCustomFieldValue );
-		// Heading is not editable.
-		const isContentEditable =
-			await headingBlock.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
-	} );
-
-	test( 'Button - should show the value of the custom field when text is bound', async ( {
-		editor,
-	} ) => {
-		await editor.insertBlock( textBindingButtonBlock );
-		const buttonBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Button',
-			exact: true,
-		} );
-		await buttonBlock.click();
-		const buttonText = await buttonBlock.textContent();
-		expect( buttonText ).toBe( textCustomFieldValue );
-
-		// Button is not editable.
-		const isContentEditable = await buttonBlock
-			.locator( 'div' )
-			.getAttribute( 'contenteditable' );
-		expect( isContentEditable ).toBe( 'false' );
-	} );
-
-	test.describe( 'Image', () => {
-		test( 'Should show the value of the custom field when url is bound', async ( {
+		test( 'Button - should show the value of the custom field when text is bound', async ( {
 			editor,
 		} ) => {
-			await editor.insertBlock( urlBindingImageBlock );
-			const imageBlockImg = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Image',
-				} )
-				.locator( 'img' );
-			const imageSrc = await imageBlockImg.getAttribute( 'src' );
-			expect( imageSrc ).toBe( urlCustomFieldValue );
+			await editor.insertBlock( textBindingButtonBlock );
+			const buttonBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Button',
+				exact: true,
+			} );
+			await buttonBlock.click();
+			const buttonText = await buttonBlock.textContent();
+			expect( buttonText ).toBe( textCustomFieldValue );
+
+			// Button is not editable.
+			const isContentEditable = await buttonBlock
+				.locator( 'div' )
+				.getAttribute( 'contenteditable' );
+			expect( isContentEditable ).toBe( 'false' );
 		} );
 
-		test( 'Should show value of the custom field in the alt textarea when alt is bound', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( altBindingImageBlock );
-			const imageBlockImg = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Image',
-				} )
-				.locator( 'img' );
-			await imageBlockImg.click();
+		test.describe( 'Image', () => {
+			let customFieldSrc;
+			test.beforeAll( async ( { requestUtils } ) => {
+				const customFieldMedia = await requestUtils.uploadMedia(
+					path.join(
+						'./test/e2e/assets',
+						'1024x768_e2e_test_image_size.jpeg'
+					)
+				);
+				customFieldSrc = customFieldMedia.source_url;
+			} );
 
-			// Image src is the placeholder.
-			const imageSrc = await imageBlockImg.getAttribute( 'src' );
-			expect( imageSrc ).toBe( imagePlaceholder );
+			test.beforeEach( async ( { editor, page, requestUtils } ) => {
+				const postId = await editor.publishPost();
+				await requestUtils.rest( {
+					method: 'POST',
+					path: '/wp/v2/posts/' + postId,
+					data: {
+						meta: {
+							url_custom_field: customFieldSrc,
+						},
+					},
+				} );
+				await page.reload();
+			} );
+			test( 'Should show the value of the custom field when url is bound', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( urlBindingImageBlock );
+				const imageBlockImg = editor.canvas
+					.getByRole( 'document', {
+						name: 'Block: Image',
+					} )
+					.locator( 'img' );
+				const imageSrc = await imageBlockImg.getAttribute( 'src' );
+				expect( imageSrc ).toBe( customFieldSrc );
+			} );
 
-			// Alt textarea is disabled and with the custom field value.
-			await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-			const altValue = await page
-				.getByLabel( imageAltLabel )
-				.inputValue();
-			expect( altValue ).toBe( textCustomFieldValue );
-		} );
+			test( 'Should show value of the custom field in the alt textarea when alt is bound', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( altBindingImageBlock );
+				const imageBlockImg = editor.canvas
+					.getByRole( 'document', {
+						name: 'Block: Image',
+					} )
+					.locator( 'img' );
+				await imageBlockImg.click();
 
-		test( 'Should show value of the custom field in the title input when title is bound', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( titleBindingImageBlock );
-			const imageBlockImg = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Image',
-				} )
-				.locator( 'img' );
-			await imageBlockImg.click();
+				// Image src is the placeholder.
+				const imageSrc = await imageBlockImg.getAttribute( 'src' );
+				expect( imageSrc ).toBe( placeholderSrc );
 
-			// Image src is the placeholder.
-			const imageSrc = await imageBlockImg.getAttribute( 'src' );
-			expect( imageSrc ).toBe( imagePlaceholder );
+				// Alt textarea is disabled and with the custom field value.
+				await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+				const altValue = await page
+					.getByLabel( imageAltLabel )
+					.inputValue();
+				expect( altValue ).toBe( textCustomFieldValue );
+			} );
 
-			// Title input is disabled and with the custom field value.
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			await expect( page.getByLabel( imageTitleLabel ) ).toBeDisabled();
-			const titleValue = await page
-				.getByLabel( imageTitleLabel )
-				.inputValue();
-			expect( titleValue ).toBe( textCustomFieldValue );
-		} );
+			test( 'Should show value of the custom field in the title input when title is bound', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( titleBindingImageBlock );
+				const imageBlockImg = editor.canvas
+					.getByRole( 'document', {
+						name: 'Block: Image',
+					} )
+					.locator( 'img' );
+				await imageBlockImg.click();
 
-		test( 'Multiple bindings should show the value of the custom fields', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( multipleBindingsImageBlock );
-			const imageBlockImg = editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Image',
-				} )
-				.locator( 'img' );
-			await imageBlockImg.click();
+				// Image src is the placeholder.
+				const imageSrc = await imageBlockImg.getAttribute( 'src' );
+				expect( imageSrc ).toBe( placeholderSrc );
 
-			// Image src is the custom field value.
-			const imageSrc = await imageBlockImg.getAttribute( 'src' );
-			expect( imageSrc ).toBe( urlCustomFieldValue );
+				// Title input is disabled and with the custom field value.
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				await expect(
+					page.getByLabel( imageTitleLabel )
+				).toBeDisabled();
+				const titleValue = await page
+					.getByLabel( imageTitleLabel )
+					.inputValue();
+				expect( titleValue ).toBe( textCustomFieldValue );
+			} );
 
-			// Alt textarea is disabled and with the custom field value.
-			await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
-			const altValue = await page
-				.getByLabel( imageAltLabel )
-				.inputValue();
-			expect( altValue ).toBe( textCustomFieldValue );
+			test( 'Multiple bindings should show the value of the custom fields', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.insertBlock( multipleBindingsImageBlock );
+				const imageBlockImg = editor.canvas
+					.getByRole( 'document', {
+						name: 'Block: Image',
+					} )
+					.locator( 'img' );
+				await imageBlockImg.click();
 
-			// Title input is enabled and with the original value.
-			await page.getByRole( 'button', { name: 'Advanced' } ).click();
-			await expect( page.getByLabel( imageTitleLabel ) ).toBeEnabled();
-			const titleValue = await page
-				.getByLabel( imageTitleLabel )
-				.inputValue();
-			expect( titleValue ).toBe( 't' );
+				// Image src is the custom field value.
+				const imageSrc = await imageBlockImg.getAttribute( 'src' );
+				expect( imageSrc ).toBe( customFieldSrc );
+
+				// Alt textarea is disabled and with the custom field value.
+				await expect( page.getByLabel( imageAltLabel ) ).toBeDisabled();
+				const altValue = await page
+					.getByLabel( imageAltLabel )
+					.inputValue();
+				expect( altValue ).toBe( textCustomFieldValue );
+
+				// Title input is enabled and with the original value.
+				await page.getByRole( 'button', { name: 'Advanced' } ).click();
+				await expect(
+					page.getByLabel( imageTitleLabel )
+				).toBeEnabled();
+				const titleValue = await page
+					.getByLabel( imageTitleLabel )
+					.inputValue();
+				expect( titleValue ).toBe( 't' );
+			} );
 		} );
 	} );
 } );

--- a/test/emptytheme/functions.php
+++ b/test/emptytheme/functions.php
@@ -30,3 +30,32 @@ if ( ! function_exists( 'emptytheme_scripts' ) ) :
 	}
 	add_action( 'wp_enqueue_scripts', 'emptytheme_scripts' );
 endif;
+
+if ( ! function_exists( 'emptytheme_register_custom_fields' ) ) :
+	/**
+	 * Register custom fields.
+	 */
+	function emptytheme_register_custom_fields() {
+		register_meta(
+			'post',
+			'text_custom_field',
+			array(
+				'show_in_rest' => true,
+				'type'         => 'string',
+				'default'	   => 'Value of the text_custom_field',
+			)
+		);
+		// TODO: Change url.
+		register_meta(
+			'post',
+			'url_custom_field',
+			array(
+				'show_in_rest' => true,
+				'type'         => 'string',
+				'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg',
+			)
+		);
+	}
+	add_action( 'init', 'emptytheme_register_custom_fields' );
+endif;
+

--- a/test/emptytheme/functions.php
+++ b/test/emptytheme/functions.php
@@ -30,32 +30,3 @@ if ( ! function_exists( 'emptytheme_scripts' ) ) :
 	}
 	add_action( 'wp_enqueue_scripts', 'emptytheme_scripts' );
 endif;
-
-if ( ! function_exists( 'emptytheme_register_custom_fields' ) ) :
-	/**
-	 * Register custom fields.
-	 */
-	function emptytheme_register_custom_fields() {
-		register_meta(
-			'post',
-			'text_custom_field',
-			array(
-				'show_in_rest' => true,
-				'type'         => 'string',
-				'default'	   => 'Value of the text_custom_field',
-			)
-		);
-		// TODO: Change url.
-		register_meta(
-			'post',
-			'url_custom_field',
-			array(
-				'show_in_rest' => true,
-				'type'         => 'string',
-				'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/03/3bhkrj58Vtu7enYsRolD1fZdja1-683x1024.jpg',
-			)
-		);
-	}
-	add_action( 'init', 'emptytheme_register_custom_fields' );
-endif;
-


### PR DESCRIPTION
## What?
Adding e2e tests for the editor experience of the block bindings. These are the tests I've added so far:

### Template context

**1 - Paragraph**
When the content is connected:
* Show the value of the key.
* Lock the format controls.
* Becomes non-editable.
* Other controls like alignment are enabled.

**2 - Heading**
When the content is connected:
* Show the value of the key.
* Lock the format controls.
* Becomes non-editable.

**3 - Button**
When only the text is connected:
* Show the value of the key.
* Lock the format controls.
* Becomes non-editable.
* Link controls exist.
* Other controls like alignment are enabled.

When only the URL is connected:
* Format controls exist.
* Button is editable.
* Link controls don't exist.

When both are connected:
* Lock the format controls.
* Becomes non-editable.
* Link controls don't exist.
* Other controls like alignment are enabled.

**4 - Image**
When non-bindings are defined:
* It shows the form to upload an image.

When only the URL is bound:
* It doesn't show the form to upload an image.
* URL controls don't exist.
* Alt textarea is enabled and with the original value.
* Title input is enabled and with the original value.

When only the ALT is bound:
* URL controls exist.
* It shows the original value of the image.
* Alt textarea is disabled and with the key value.
* Title input is enabled and with the original value.

When only the TITLE is bound:
* URL controls exist.
* It shows the original value of the image.
* Alt textarea input is enabled and with the original value.
* Title input is disabled and with the key value.

When UTL and ALT are connected, but not the TITLE:
* It doesn't show the form to upload an image.
* URL controls don't exist.
* Alt textarea is disabled and with the value of the key.
* Title input is enabled and with the original value.

### Post/page context

**1 - Paragraph**
When the content is connected:
* Show the value of the custom field if it exists.
* Show the value of the key if the custom field doesn't exist.
* Becomes non-editable.

**2 - Heading**
When the content is connected:
* Show the value of the custom field if it exists.
* Becomes non-editable.

**3 - Button**
When only the text is connected:
* Show the value of the custom field if it exists.
* Becomes non-editable.

**4 - Image**
When only the URL is bound:
* It shows the value of the custom field.

When only the ALT is bound:
* It shows the original value of the image.
* Alt textarea is disabled and with the custom field value.

When only the TITLE is bound:
* It shows the original value of the image.
* Title input is disabled and with the custom field value.

When UTL and ALT are connected, but not the TITLE:
* It shows the value of the custom field.
* Alt textarea is disabled and with the value of the custom field.
* Title input is enabled and with the original value.


## Why?
Right now, they don't exist, and the testing has to be done manually.

## How?
Using the existing e2e mechanisms. I had to create a PHP plugin to register a couple of custom fields to be used.

The tests follow this structure:

* Block Bindings group
    * Template context
        * Paragraph
        * Heading
        * Button
        * Image
    * Post/page context
        * Paragraph
        * Heading
        * Button
        * Image

It is important to note that, depending on the level, I'm doing different `beforeAll`, beforeEach`, `afterEach`, `afterAll`. Let me try to summarize that:

### Block bindings group

**Before All**
* Activate `emptytheme`
* Activate `gutenberg-test-block-bindings` plugin, which register the custom fields.
* Delete all media to have a fresh site.
* Upload the image that is gonna be used for the image placeholder and initialize the variables.

**Before Each**
Nothing

**After Each**

* Delete posts we create.

**After All**
* Delete all media.
* Activate the previous theme.
* Deactivate the testing plugin.

### Template context group

**Before Each**
* Visit the site editor, click the body, and open the sidebar.

### Post/page context group

**Before Each**
* Create a new post name "Test Bindings".

### Image > Post/page context group

I'm doing this here because it is only used in this case and we avoid uploading an unnecessary image.

**Before All**
* Upload the image that will be used for the custom field.

**Before Each**
* Publish the post to get the `postId`.
* Update the value of the `url_custom_field` through the REST API.
* Reload the page to apply the changes.

Hope that makes sense. Let me know what you think.
