### PR TITLE
Block Hooks: Set ignoredHookedBlocks metada attr upon insertion

### DIFF
--- a/docs/reference-guides/data/data-core-blocks.md
+++ b/docs/reference-guides/data/data-core-blocks.md
@@ -504,6 +504,43 @@ _Returns_
 
 -   `string?`: Name of the block for handling the grouping of blocks.
 
+### getHookedBlockNames
+
+Returns an array with the hooked blocks for a given anchor block.
+
+_Usage_
+
+```js
+import { store as blocksStore } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const hookedBlockNames = useSelect(
+		( select ) =>
+			select( blocksStore ).getHookedBlockNames( 'core/navigation' ),
+		[]
+	);
+
+	return (
+		<ul>
+			{ hookedBlockNames &&
+				hookedBlockNames.map( ( hookedBlock ) => (
+					<li key={ hookedBlock }>{ hookedBlock }</li>
+				) ) }
+		</ul>
+	);
+};
+```
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+-   _blockName_ `string`: Anchor block type name.
+
+_Returns_
+
+-   `Array`: Array of hooked block names.
+
 ### getUnregisteredFallbackBlockName
 
 Returns the name of the block for handling unregistered blocks.

--- a/docs/reference-guides/data/data-core-blocks.md
+++ b/docs/reference-guides/data/data-core-blocks.md
@@ -504,7 +504,7 @@ _Returns_
 
 -   `string?`: Name of the block for handling the grouping of blocks.
 
-### getHookedBlockNames
+### getHookedBlocks
 
 Returns an array with the hooked blocks for a given anchor block.
 
@@ -517,7 +517,7 @@ import { useSelect } from '@wordpress/data';
 const ExampleComponent = () => {
 	const hookedBlockNames = useSelect(
 		( select ) =>
-			select( blocksStore ).getHookedBlockNames( 'core/navigation' ),
+			select( blocksStore ).getHookedBlocks( 'core/navigation' ),
 		[]
 	);
 

--- a/docs/reference-guides/data/data-core-blocks.md
+++ b/docs/reference-guides/data/data-core-blocks.md
@@ -506,7 +506,9 @@ _Returns_
 
 ### getHookedBlocks
 
-Returns an array with the hooked blocks for a given anchor block.
+Returns the hooked blocks for a given anchor block.
+
+Given an anchor block name, returns an object whose keys are relative positions, and whose values are arrays of block names that are hooked to the anchor block at that relative position.
 
 _Usage_
 
@@ -523,9 +525,18 @@ const ExampleComponent = () => {
 
 	return (
 		<ul>
-			{ hookedBlockNames &&
-				hookedBlockNames.map( ( hookedBlock ) => (
-					<li key={ hookedBlock }>{ hookedBlock }</li>
+			{ Object.keys( hookedBlockNames ).length &&
+				Object.keys( hookedBlockNames ).map( ( relativePosition ) => (
+					<li key={ relativePosition }>
+						{ relativePosition }>
+						<ul>
+							{ hookedBlockNames[ relativePosition ].map(
+								( hookedBlock ) => (
+									<li key={ hookedBlock }>{ hookedBlock }</li>
+								)
+							) }
+						</ul>
+					</li>
 				) ) }
 		</ul>
 	);
@@ -539,7 +550,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: Array of hooked block names.
+-   `Object`: Lists of hooked block names for each relative position.
 
 ### getUnregisteredFallbackBlockName
 

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment, useMemo } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	PanelBody,
@@ -20,17 +20,9 @@ import { store as blockEditorStore } from '../store';
 const EMPTY_OBJECT = {};
 
 function BlockHooksControlPure( { name, clientId } ) {
-	const blockTypes = useSelect(
-		( select ) => select( blocksStore ).getBlockTypes(),
-		[]
-	);
-
-	const hookedBlocksForCurrentBlock = useMemo(
-		() =>
-			blockTypes?.filter(
-				( { blockHooks } ) => blockHooks && name in blockHooks
-			),
-		[ blockTypes, name ]
+	const hookedBlocksForCurrentBlock = useSelect(
+		( select ) => select( blocksStore ).getHookedBlockNames( name ),
+		[ name ]
 	);
 
 	const { blockIndex, rootClientId, innerBlocksLength } = useSelect(

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	PanelBody,
@@ -20,9 +20,17 @@ import { store as blockEditorStore } from '../store';
 const EMPTY_OBJECT = {};
 
 function BlockHooksControlPure( { name, clientId } ) {
-	const hookedBlocksForCurrentBlock = useSelect(
-		( select ) => select( blocksStore ).getHookedBlockNames( name ),
-		[ name ]
+	const blockTypes = useSelect(
+		( select ) => select( blocksStore ).getBlockTypes(),
+		[]
+	);
+
+	const hookedBlocksForCurrentBlock = useMemo(
+		() =>
+			blockTypes?.filter(
+				( { blockHooks } ) => blockHooks && name in blockHooks
+			),
+		[ blockTypes, name ]
 	);
 
 	const { blockIndex, rootClientId, innerBlocksLength } = useSelect(

--- a/packages/block-editor/src/hooks/block-hooks.js
+++ b/packages/block-editor/src/hooks/block-hooks.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	PanelBody,
@@ -20,20 +20,17 @@ import { store as blockEditorStore } from '../store';
 const EMPTY_OBJECT = {};
 
 function BlockHooksControlPure( { name, clientId } ) {
-	const hookedBlocksForCurrentBlock = useSelect(
-		( select ) => {
-			const hookedBlocks = select( blocksStore ).getHookedBlocks( name );
-			const _hookedBlocksForCurrentBlock = {};
-			for ( const relativePosition in hookedBlocks ) {
-				_hookedBlocksForCurrentBlock[ relativePosition ] = hookedBlocks[
-					relativePosition
-				].map( ( blockName ) =>
-					select( blocksStore ).getBlockType( blockName )
-				);
-			}
-			return _hookedBlocksForCurrentBlock;
-		},
-		[ name ]
+	const blockTypes = useSelect(
+		( select ) => select( blocksStore ).getBlockTypes(),
+		[]
+	);
+
+	const hookedBlocksForCurrentBlock = useMemo(
+		() =>
+			blockTypes?.filter(
+				( { blockHooks } ) => blockHooks && name in blockHooks
+			),
+		[ blockTypes, name ]
 	);
 
 	const { blockIndex, rootClientId, innerBlocksLength } = useSelect(
@@ -55,49 +52,54 @@ function BlockHooksControlPure( { name, clientId } ) {
 			const { getBlock, getGlobalBlockCount } =
 				select( blockEditorStore );
 
-			const _hookedBlockClientIds = {};
-			for ( const relativePosition in hookedBlocksForCurrentBlock ) {
-				hookedBlocksForCurrentBlock[ relativePosition ].forEach(
-					( block ) => {
-						// If the block doesn't exist anywhere in the block tree,
-						// we know that we have to set the toggle to disabled.
-						if ( getGlobalBlockCount( block.name ) === 0 ) {
-							return;
-						}
-
-						let candidates;
-						switch ( relativePosition ) {
-							case 'before':
-							case 'after':
-								// Any of the current block's siblings (with the right block type) qualifies
-								// as a hooked block (inserted `before` or `after` the current one), as the block
-								// might've been automatically inserted and then moved around a bit by the user.
-								candidates =
-									getBlock( rootClientId )?.innerBlocks;
-								break;
-
-							case 'first_child':
-							case 'last_child':
-								// Any of the current block's child blocks (with the right block type) qualifies
-								// as a hooked first or last child block, as the block might've been automatically
-								// inserted and then moved around a bit by the user.
-								candidates = getBlock( clientId ).innerBlocks;
-								break;
-						}
-
-						const hookedBlock = candidates?.find(
-							( candidate ) => candidate.name === block.name
-						);
-
-						// If the block exists in the designated location, we consider it hooked
-						// and show the toggle as enabled.
-						if ( hookedBlock ) {
-							_hookedBlockClientIds[ block.name ] =
-								hookedBlock.clientId;
-						}
+			const _hookedBlockClientIds = hookedBlocksForCurrentBlock.reduce(
+				( clientIds, block ) => {
+					// If the block doesn't exist anywhere in the block tree,
+					// we know that we have to set the toggle to disabled.
+					if ( getGlobalBlockCount( block.name ) === 0 ) {
+						return clientIds;
 					}
-				);
-			}
+
+					const relativePosition = block?.blockHooks?.[ name ];
+					let candidates;
+
+					switch ( relativePosition ) {
+						case 'before':
+						case 'after':
+							// Any of the current block's siblings (with the right block type) qualifies
+							// as a hooked block (inserted `before` or `after` the current one), as the block
+							// might've been automatically inserted and then moved around a bit by the user.
+							candidates = getBlock( rootClientId )?.innerBlocks;
+							break;
+
+						case 'first_child':
+						case 'last_child':
+							// Any of the current block's child blocks (with the right block type) qualifies
+							// as a hooked first or last child block, as the block might've been automatically
+							// inserted and then moved around a bit by the user.
+							candidates = getBlock( clientId ).innerBlocks;
+							break;
+					}
+
+					const hookedBlock = candidates?.find(
+						( candidate ) => candidate.name === block.name
+					);
+
+					// If the block exists in the designated location, we consider it hooked
+					// and show the toggle as enabled.
+					if ( hookedBlock ) {
+						return {
+							...clientIds,
+							[ block.name ]: hookedBlock.clientId,
+						};
+					}
+
+					// If no hooked block was found in any of its designated locations,
+					// we set the toggle to disabled.
+					return clientIds;
+				},
+				{}
+			);
 
 			if ( Object.values( _hookedBlockClientIds ).length > 0 ) {
 				return _hookedBlockClientIds;
@@ -105,26 +107,27 @@ function BlockHooksControlPure( { name, clientId } ) {
 
 			return EMPTY_OBJECT;
 		},
-		[ hookedBlocksForCurrentBlock, clientId, rootClientId ]
+		[ hookedBlocksForCurrentBlock, name, clientId, rootClientId ]
 	);
 
 	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
 
-	if ( ! Object.keys( hookedBlocksForCurrentBlock ).length ) {
+	if ( ! hookedBlocksForCurrentBlock.length ) {
 		return null;
 	}
 
 	// Group by block namespace (i.e. prefix before the slash).
-	const groupedHookedBlocks = Object.values( hookedBlocksForCurrentBlock )
-		.flat()
-		.reduce( ( groups, block ) => {
+	const groupedHookedBlocks = hookedBlocksForCurrentBlock.reduce(
+		( groups, block ) => {
 			const [ namespace ] = block.name.split( '/' );
 			if ( ! groups[ namespace ] ) {
 				groups[ namespace ] = [];
 			}
 			groups[ namespace ].push( block );
 			return groups;
-		}, {} );
+		},
+		{}
+	);
 
 	const insertBlockIntoDesignatedLocation = ( block, relativePosition ) => {
 		switch ( relativePosition ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1936,9 +1936,26 @@ const buildBlockTypeItem =
 			blockType.name,
 			'inserter'
 		);
+
+		let initialAttributes = {};
+
+		const hookedBlocksForCurrentBlock = getBlockTypes()?.filter(
+			( { blockHooks } ) => blockHooks && id in blockHooks
+		);
+
+		if ( hookedBlocksForCurrentBlock?.length ) {
+			initialAttributes = {
+				metadata: {
+					ignoredHookedBlocks: hookedBlocksForCurrentBlock.map(
+						( { name } ) => name
+					),
+				},
+			};
+		}
+
 		return {
 			...blockItemBase,
-			initialAttributes: {},
+			initialAttributes,
 			description: blockType.description,
 			category: blockType.category,
 			keywords: blockType.keywords,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -10,6 +10,7 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getBlockVariations,
+	getHookedBlockNames,
 	hasBlockSupport,
 	getPossibleBlockTransformations,
 	parse,
@@ -1939,9 +1940,7 @@ const buildBlockTypeItem =
 
 		let initialAttributes = {};
 
-		const hookedBlocksForCurrentBlock = getBlockTypes()?.filter(
-			( { blockHooks } ) => blockHooks && id in blockHooks
-		);
+		const hookedBlocksForCurrentBlock = getHookedBlockNames( id );
 
 		if ( hookedBlocksForCurrentBlock?.length ) {
 			initialAttributes = {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1938,23 +1938,15 @@ const buildBlockTypeItem =
 			'inserter'
 		);
 
-		let initialAttributes = {};
-
 		const ignoredHookedBlocks = Object.values(
 			getHookedBlocks( id )
 		).flat();
 
-		if ( ignoredHookedBlocks.length ) {
-			initialAttributes = {
-				metadata: {
-					ignoredHookedBlocks,
-				},
-			};
-		}
-
 		return {
 			...blockItemBase,
-			initialAttributes,
+			initialAttributes: ignoredHookedBlocks
+				? { metadata: { ignoredHookedBlocks } }
+				: {},
 			description: blockType.description,
 			category: blockType.category,
 			keywords: blockType.keywords,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1938,9 +1938,9 @@ const buildBlockTypeItem =
 			'inserter'
 		);
 
-		const ignoredHookedBlocks = Object.values(
-			getHookedBlocks( id )
-		).flat();
+		const ignoredHookedBlocks = [
+			...new Set( Object.values( getHookedBlocks( id ) ).flat() ),
+		];
 
 		return {
 			...blockItemBase,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -10,7 +10,7 @@ import {
 	getBlockType,
 	getBlockTypes,
 	getBlockVariations,
-	getHookedBlockNames,
+	getHookedBlocks,
 	hasBlockSupport,
 	getPossibleBlockTransformations,
 	parse,
@@ -1941,7 +1941,7 @@ const buildBlockTypeItem =
 		let initialAttributes = {};
 
 		const ignoredHookedBlocks = Object.values(
-			getHookedBlockNames( id )
+			getHookedBlocks( id )
 		).flat();
 
 		if ( ignoredHookedBlocks.length ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1944,7 +1944,7 @@ const buildBlockTypeItem =
 
 		return {
 			...blockItemBase,
-			initialAttributes: ignoredHookedBlocks
+			initialAttributes: ignoredHookedBlocks.length
 				? { metadata: { ignoredHookedBlocks } }
 				: {},
 			description: blockType.description,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1940,14 +1940,14 @@ const buildBlockTypeItem =
 
 		let initialAttributes = {};
 
-		const hookedBlocksForCurrentBlock = getHookedBlockNames( id );
+		const ignoredHookedBlocks = Object.values(
+			getHookedBlockNames( id )
+		).flat();
 
-		if ( hookedBlocksForCurrentBlock?.length ) {
+		if ( ignoredHookedBlocks.length ) {
 			initialAttributes = {
 				metadata: {
-					ignoredHookedBlocks: hookedBlocksForCurrentBlock.map(
-						( { name } ) => name
-					),
+					ignoredHookedBlocks,
 				},
 			};
 		}

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -234,6 +234,18 @@ _Returns_
 
 -   `?string`: Block name.
 
+### getHookedBlockNames
+
+Returns all hooked blocks for a given anchor block.
+
+_Parameters_
+
+-   _name_ `string`: Anchor block name.
+
+_Returns_
+
+-   `Array`: List of blocks hooked to the anchor block.
+
 ### getPhrasingContentSchema
 
 Undocumented declaration.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -234,7 +234,7 @@ _Returns_
 
 -   `?string`: Block name.
 
-### getHookedBlockNames
+### getHookedBlocks
 
 Returns all hooked blocks for a given anchor block.
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -236,7 +236,9 @@ _Returns_
 
 ### getHookedBlocks
 
-Returns all hooked blocks for a given anchor block.
+Returns the hooked blocks for a given anchor block.
+
+Given an anchor block name, returns an object whose keys are relative positions, and whose values are arrays of block names that are hooked to the anchor block at that relative position.
 
 _Parameters_
 
@@ -244,7 +246,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: List of blocks hooked to the anchor block.
+-   `Object`: Lists of hooked block names for each relative position.
 
 ### getPhrasingContentSchema
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -124,7 +124,7 @@ export {
 	getBlockTypes,
 	getBlockSupport,
 	hasBlockSupport,
-	getHookedBlockNames,
+	getHookedBlocks,
 	getBlockVariations,
 	isReusableBlock,
 	isTemplatePart,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -124,6 +124,7 @@ export {
 	getBlockTypes,
 	getBlockSupport,
 	hasBlockSupport,
+	getHookedBlockNames,
 	getBlockVariations,
 	isReusableBlock,
 	isTemplatePart,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -515,6 +515,17 @@ export function getBlockTypes() {
 }
 
 /**
+ * Returns all hooked blocks for a given anchor block.
+ *
+ * @param {string} name Anchor block name.
+ *
+ * @return {Array} List of blocks hooked to the anchor block.
+ */
+export function getHookedBlockNames( name ) {
+	return select( blocksStore ).getHookedBlockNames( name );
+}
+
+/**
  * Returns the block support value for a feature, if defined.
  *
  * @param {(string|Object)} nameOrType      Block name or type object

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -557,8 +557,8 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
  *
  * @return {Array} List of blocks hooked to the anchor block.
  */
-export function getHookedBlockNames( name ) {
-	return select( blocksStore ).getHookedBlockNames( name );
+export function getHookedBlocks( name ) {
+	return select( blocksStore ).getHookedBlocks( name );
 }
 
 /**

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -515,17 +515,6 @@ export function getBlockTypes() {
 }
 
 /**
- * Returns all hooked blocks for a given anchor block.
- *
- * @param {string} name Anchor block name.
- *
- * @return {Array} List of blocks hooked to the anchor block.
- */
-export function getHookedBlockNames( name ) {
-	return select( blocksStore ).getHookedBlockNames( name );
-}
-
-/**
  * Returns the block support value for a feature, if defined.
  *
  * @param {(string|Object)} nameOrType      Block name or type object
@@ -559,6 +548,17 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
 		feature,
 		defaultSupports
 	);
+}
+
+/**
+ * Returns all hooked blocks for a given anchor block.
+ *
+ * @param {string} name Anchor block name.
+ *
+ * @return {Array} List of blocks hooked to the anchor block.
+ */
+export function getHookedBlockNames( name ) {
+	return select( blocksStore ).getHookedBlockNames( name );
 }
 
 /**

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -551,11 +551,15 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
 }
 
 /**
- * Returns all hooked blocks for a given anchor block.
+ * Returns the hooked blocks for a given anchor block.
+ *
+ * Given an anchor block name, returns an object whose keys are relative positions,
+ * and whose values are arrays of block names that are hooked to the anchor block
+ * at that relative position.
  *
  * @param {string} name Anchor block name.
  *
- * @return {Array} List of blocks hooked to the anchor block.
+ * @return {Object} Lists of hooked block names for each relative position.
  */
 export function getHookedBlocks( name ) {
 	return select( blocksStore ).getHookedBlocks( name );

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -8,7 +8,7 @@ import { renderToString } from '@wordpress/element';
  */
 import { convertLegacyBlockNameAndAttributes } from './parser/convert-legacy-block';
 import { createBlock } from './factory';
-import { getBlockType } from './registration';
+import { getBlockType, getBlockTypes } from './registration';
 
 /**
  * Checks whether a list of blocks matches a template by comparing the block names.
@@ -114,6 +114,23 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 					name,
 					normalizedAttributes
 				);
+
+			const hookedBlocksForCurrentBlock = getBlockTypes()?.filter(
+				( { blockHooks } ) => blockHooks && blockName in blockHooks
+			);
+
+			if ( hookedBlocksForCurrentBlock?.length ) {
+				const { metadata, ...otherAttributes } = blockAttributes;
+				blockAttributes = {
+					metadata: {
+						ignoredHookedBlocks: hookedBlocksForCurrentBlock.map(
+							( hookedBlock ) => hookedBlock.name
+						),
+						...blockAttributes.metadata,
+					},
+					...otherAttributes,
+				};
+			}
 
 			// If a Block is undefined at this point, use the core/missing block as
 			// a placeholder for a better user experience.

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -8,7 +8,7 @@ import { renderToString } from '@wordpress/element';
  */
 import { convertLegacyBlockNameAndAttributes } from './parser/convert-legacy-block';
 import { createBlock } from './factory';
-import { getBlockType, getBlockTypes } from './registration';
+import { getBlockType, getHookedBlockNames } from './registration';
 
 /**
  * Checks whether a list of blocks matches a template by comparing the block names.
@@ -115,11 +115,10 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 					normalizedAttributes
 				);
 
-			const hookedBlocksForCurrentBlock = getBlockTypes()?.filter(
-				( { blockHooks } ) => blockHooks && blockName in blockHooks
-			);
+			const hookedBlocksForCurrentBlock =
+				getHookedBlockNames( blockName );
 
-			if ( hookedBlocksForCurrentBlock?.length ) {
+			if ( getHookedBlockNames( blockName )?.length ) {
 				const { metadata, ...otherAttributes } = blockAttributes;
 				blockAttributes = {
 					metadata: {

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -8,7 +8,7 @@ import { renderToString } from '@wordpress/element';
  */
 import { convertLegacyBlockNameAndAttributes } from './parser/convert-legacy-block';
 import { createBlock } from './factory';
-import { getBlockType, getHookedBlockNames } from './registration';
+import { getBlockType, getHookedBlocks } from './registration';
 
 /**
  * Checks whether a list of blocks matches a template by comparing the block names.
@@ -116,7 +116,7 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 				);
 
 			const ignoredHookedBlocks = Object.values(
-				getHookedBlockNames( blockName )
+				getHookedBlocks( blockName )
 			).flat();
 
 			if ( ignoredHookedBlocks.length ) {

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -122,11 +122,23 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 			];
 
 			if ( ignoredHookedBlocks.length ) {
-				const { metadata, ...otherAttributes } = blockAttributes;
+				const { metadata = {}, ...otherAttributes } = blockAttributes;
+				const {
+					ignoredHookedBlocks: ignoredHookedBlocksFromTemplate = [],
+					...otherMetadata
+				} = metadata;
+
+				const newIgnoredHookedBlocks = [
+					...new Set( [
+						...ignoredHookedBlocks,
+						...ignoredHookedBlocksFromTemplate,
+					] ),
+				];
+
 				blockAttributes = {
 					metadata: {
-						ignoredHookedBlocks,
-						...metadata,
+						ignoredHookedBlocks: newIgnoredHookedBlocks,
+						...otherMetadata,
 					},
 					...otherAttributes,
 				};

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -126,7 +126,7 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 				blockAttributes = {
 					metadata: {
 						ignoredHookedBlocks,
-						...blockAttributes.metadata,
+						...metadata,
 					},
 					...otherAttributes,
 				};

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -115,9 +115,11 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 					normalizedAttributes
 				);
 
-			const ignoredHookedBlocks = Object.values(
-				getHookedBlocks( blockName )
-			).flat();
+			const ignoredHookedBlocks = [
+				...new Set(
+					Object.values( getHookedBlocks( blockName ) ).flat()
+				),
+			];
 
 			if ( ignoredHookedBlocks.length ) {
 				const { metadata, ...otherAttributes } = blockAttributes;

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -115,16 +115,15 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 					normalizedAttributes
 				);
 
-			const hookedBlocksForCurrentBlock =
-				getHookedBlockNames( blockName );
+			const ignoredHookedBlocks = Object.values(
+				getHookedBlockNames( blockName )
+			).flat();
 
-			if ( getHookedBlockNames( blockName )?.length ) {
+			if ( ignoredHookedBlocks.length ) {
 				const { metadata, ...otherAttributes } = blockAttributes;
 				blockAttributes = {
 					metadata: {
-						ignoredHookedBlocks: hookedBlocksForCurrentBlock.map(
-							( hookedBlock ) => hookedBlock.name
-						),
+						ignoredHookedBlocks,
 						...blockAttributes.metadata,
 					},
 					...otherAttributes,

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -168,6 +168,48 @@ describe( 'templates', () => {
 			] );
 		} );
 
+		it( 'retains previously set ignoredHookedBlocks metadata', () => {
+			registerBlockType( 'core/hooked-block', {
+				attributes: {},
+				save: noop,
+				category: 'text',
+				title: 'hooked block',
+				blockHooks: { 'core/test-block': 'after' },
+			} );
+
+			const template = [
+				[
+					'core/test-block',
+					{
+						metadata: {
+							ignoredHookedBlocks: [ 'core/other-hooked-block' ],
+						},
+					},
+				],
+				[ 'core/test-block-2' ],
+				[ 'core/test-block-2' ],
+			];
+			const blockList = [];
+
+			expect(
+				synchronizeBlocksWithTemplate( blockList, template )
+			).toMatchObject( [
+				{
+					name: 'core/test-block',
+					attributes: {
+						metadata: {
+							ignoredHookedBlocks: [
+								'core/hooked-block',
+								'core/other-hooked-block',
+							],
+						},
+					},
+				},
+				{ name: 'core/test-block-2' },
+				{ name: 'core/test-block-2' },
+			] );
+		} );
+
 		it( 'should create nested blocks', () => {
 			const template = [
 				[ 'core/test-block', {}, [ [ 'core/test-block-2' ] ] ],

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -28,7 +28,11 @@ describe( 'templates', () => {
 
 	beforeEach( () => {
 		registerBlockType( 'core/test-block', {
-			attributes: {},
+			attributes: {
+				metadata: {
+					type: 'object',
+				},
+			},
 			save: noop,
 			category: 'text',
 			title: 'test block',
@@ -127,6 +131,38 @@ describe( 'templates', () => {
 				synchronizeBlocksWithTemplate( blockList, template )
 			).toMatchObject( [
 				{ name: 'core/test-block' },
+				{ name: 'core/test-block-2' },
+				{ name: 'core/test-block-2' },
+			] );
+		} );
+
+		it( 'should set ignoredHookedBlocks metadata if a block has hooked blocks', () => {
+			registerBlockType( 'core/hooked-block', {
+				attributes: {},
+				save: noop,
+				category: 'text',
+				title: 'hooked block',
+				blockHooks: { 'core/test-block': 'after' },
+			} );
+
+			const template = [
+				[ 'core/test-block' ],
+				[ 'core/test-block-2' ],
+				[ 'core/test-block-2' ],
+			];
+			const blockList = [];
+
+			expect(
+				synchronizeBlocksWithTemplate( blockList, template )
+			).toMatchObject( [
+				{
+					name: 'core/test-block',
+					attributes: {
+						metadata: {
+							ignoredHookedBlocks: [ 'core/hooked-block' ],
+						},
+					},
+				},
 				{ name: 'core/test-block-2' },
 				{ name: 'core/test-block-2' },
 			] );

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -107,6 +107,47 @@ export function getBlockType( state, name ) {
 }
 
 /**
+ * Returns an array with the hooked blocks for a given anchor block.
+ *
+ * @param {Object} state     Data state.
+ * @param {string} blockName Anchor block type name.
+ *
+ * @example
+ * ```js
+ * import { store as blocksStore } from '@wordpress/blocks';
+ * import { useSelect } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ *     const hookedBlockNames = useSelect( ( select ) =>
+ *         select( blocksStore ).getHookedBlockNames( 'core/navigation' ),
+ *         []
+ *     );
+ *
+ *     return (
+ *         <ul>
+ *             { hookedBlockNames &&
+ *                 hookedBlockNames.map( ( hookedBlock ) => (
+ *                     <li key={ hookedBlock }>{ hookedBlock }</li>
+ *             ) ) }
+ *         </ul>
+ *     );
+ * };
+ * ```
+ *
+ * @return {Array} Array of hooked block names.
+ */
+export const getHookedBlockNames = createSelector(
+	( state, blockName ) => {
+		return getBlockTypes( state )
+			.filter(
+				( { blockHooks } ) => blockHooks && blockName in blockHooks
+			)
+			.map( ( { name } ) => name );
+	},
+	( state ) => [ state.blockTypes ]
+);
+
+/**
  * Returns block styles by block name.
  *
  * @param {Object} state Data state.

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -119,7 +119,7 @@ export function getBlockType( state, name ) {
  *
  * const ExampleComponent = () => {
  *     const hookedBlockNames = useSelect( ( select ) =>
- *         select( blocksStore ).getHookedBlockNames( 'core/navigation' ),
+ *         select( blocksStore ).getHookedBlocks( 'core/navigation' ),
  *         []
  *     );
  *
@@ -136,7 +136,7 @@ export function getBlockType( state, name ) {
  *
  * @return {Array} Array of hooked block names.
  */
-export const getHookedBlockNames = createSelector(
+export const getHookedBlocks = createSelector(
 	( state, blockName ) => {
 		const hookedBlockTypes = getBlockTypes( state ).filter(
 			( { blockHooks } ) => blockHooks && blockName in blockHooks

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -107,7 +107,11 @@ export function getBlockType( state, name ) {
 }
 
 /**
- * Returns an array with the hooked blocks for a given anchor block.
+ * Returns the hooked blocks for a given anchor block.
+ *
+ * Given an anchor block name, returns an object whose keys are relative positions,
+ * and whose values are arrays of block names that are hooked to the anchor block
+ * at that relative position.
  *
  * @param {Object} state     Data state.
  * @param {string} blockName Anchor block type name.
@@ -125,16 +129,22 @@ export function getBlockType( state, name ) {
  *
  *     return (
  *         <ul>
- *             { hookedBlockNames &&
- *                 hookedBlockNames.map( ( hookedBlock ) => (
- *                     <li key={ hookedBlock }>{ hookedBlock }</li>
+ *             { Object.keys( hookedBlockNames ).length &&
+ *                 Object.keys( hookedBlockNames ).map( ( relativePosition ) => (
+ *                     <li key={ relativePosition }>{ relativePosition }>
+ *                         <ul>
+ *                             { hookedBlockNames[ relativePosition ].map( ( hookedBlock ) => (
+ *                                 <li key={ hookedBlock }>{ hookedBlock }</li>
+ *                             ) ) }
+ *                         </ul>
+ *                     </li>
  *             ) ) }
  *         </ul>
  *     );
  * };
  * ```
  *
- * @return {Array} Array of hooked block names.
+ * @return {Object} Lists of hooked block names for each relative position.
  */
 export const getHookedBlocks = createSelector(
 	( state, blockName ) => {

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -138,11 +138,22 @@ export function getBlockType( state, name ) {
  */
 export const getHookedBlockNames = createSelector(
 	( state, blockName ) => {
-		return getBlockTypes( state )
-			.filter(
-				( { blockHooks } ) => blockHooks && blockName in blockHooks
-			)
-			.map( ( { name } ) => name );
+		const hookedBlockTypes = getBlockTypes( state ).filter(
+			( { blockHooks } ) => blockHooks && blockName in blockHooks
+		);
+
+		let hookedBlocks = {};
+		for ( const blockType of hookedBlockTypes ) {
+			const relativePosition = blockType.blockHooks[ blockName ];
+			hookedBlocks = {
+				...hookedBlocks,
+				[ relativePosition ]: [
+					...( hookedBlocks[ relativePosition ] ?? [] ),
+					blockType.name,
+				],
+			};
+		}
+		return hookedBlocks;
 	},
 	( state ) => [ state.blockTypes ]
 );

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -253,7 +253,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getChildBlockNames( state, 'otherAnchor' ) ).toHaveLength(
+			expect( getHookedBlockNames( state, 'otherAnchor' ) ).toHaveLength(
 				0
 			);
 		} );

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -230,15 +230,15 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getHookedBlockNames', () => {
-		it( 'should return an empty array if state is empty', () => {
+		it( 'should return an empty object if state is empty', () => {
 			const state = {
 				blockTypes: {},
 			};
 
-			expect( getHookedBlockNames( state, 'anchor' ) ).toHaveLength( 0 );
+			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( {} );
 		} );
 
-		it( 'should return an empty array if the anchor block is not found', () => {
+		it( 'should return an empty object if the anchor block is not found', () => {
 			const state = {
 				blockTypes: {
 					anchor: {
@@ -253,9 +253,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getHookedBlockNames( state, 'otherAnchor' ) ).toHaveLength(
-				0
-			);
+			expect( getHookedBlockNames( state, 'otherAnchor' ) ).toEqual( {} );
 		} );
 
 		it( "should return the anchor block name even if the anchor block doesn't exist", () => {
@@ -270,9 +268,9 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( [
-				'hookedBlock',
-			] );
+			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( {
+				after: [ 'hookedBlock' ],
+			} );
 		} );
 
 		it( 'should return an array with the hooked block names', () => {
@@ -296,10 +294,43 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( [
-				'hookedBlock1',
-				'hookedBlock2',
-			] );
+			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( {
+				after: [ 'hookedBlock1' ],
+				before: [ 'hookedBlock2' ],
+			} );
+		} );
+
+		it( 'should return an array with the hooked block names, even if multiple blocks are in the same relative position', () => {
+			const state = {
+				blockTypes: {
+					anchor: {
+						name: 'anchor',
+					},
+					hookedBlock1: {
+						name: 'hookedBlock1',
+						blockHooks: {
+							anchor: 'after',
+						},
+					},
+					hookedBlock2: {
+						name: 'hookedBlock2',
+						blockHooks: {
+							anchor: 'before',
+						},
+					},
+					hookedBlock3: {
+						name: 'hookedBlock3',
+						blockHooks: {
+							anchor: 'after',
+						},
+					},
+				},
+			};
+
+			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( {
+				after: [ 'hookedBlock1', 'hookedBlock3' ],
+				before: [ 'hookedBlock2' ],
+			} );
 		} );
 	} );
 

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -12,7 +12,7 @@ import {
 	getBlockVariations,
 	getDefaultBlockVariation,
 	getGroupingBlockName,
-	getHookedBlockNames,
+	getHookedBlocks,
 	isMatchingSearchTerm,
 	getCategories,
 	getActiveBlockVariation,
@@ -229,13 +229,13 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getHookedBlockNames', () => {
+	describe( 'getHookedBlocks', () => {
 		it( 'should return an empty object if state is empty', () => {
 			const state = {
 				blockTypes: {},
 			};
 
-			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( {} );
+			expect( getHookedBlocks( state, 'anchor' ) ).toEqual( {} );
 		} );
 
 		it( 'should return an empty object if the anchor block is not found', () => {
@@ -253,7 +253,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getHookedBlockNames( state, 'otherAnchor' ) ).toEqual( {} );
+			expect( getHookedBlocks( state, 'otherAnchor' ) ).toEqual( {} );
 		} );
 
 		it( "should return the anchor block name even if the anchor block doesn't exist", () => {
@@ -268,7 +268,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( {
+			expect( getHookedBlocks( state, 'anchor' ) ).toEqual( {
 				after: [ 'hookedBlock' ],
 			} );
 		} );
@@ -294,7 +294,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( {
+			expect( getHookedBlocks( state, 'anchor' ) ).toEqual( {
 				after: [ 'hookedBlock1' ],
 				before: [ 'hookedBlock2' ],
 			} );
@@ -327,7 +327,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( {
+			expect( getHookedBlocks( state, 'anchor' ) ).toEqual( {
 				after: [ 'hookedBlock1', 'hookedBlock3' ],
 				before: [ 'hookedBlock2' ],
 			} );

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	getBlockVariations,
 	getDefaultBlockVariation,
 	getGroupingBlockName,
+	getHookedBlockNames,
 	isMatchingSearchTerm,
 	getCategories,
 	getActiveBlockVariation,
@@ -224,6 +225,80 @@ describe( 'selectors', () => {
 			] );
 			expect( getChildBlockNames( state, 'parent2' ) ).toEqual( [
 				'child2',
+			] );
+		} );
+	} );
+
+	describe( 'getHookedBlockNames', () => {
+		it( 'should return an empty array if state is empty', () => {
+			const state = {
+				blockTypes: {},
+			};
+
+			expect( getHookedBlockNames( state, 'anchor' ) ).toHaveLength( 0 );
+		} );
+
+		it( 'should return an empty array if the anchor block is not found', () => {
+			const state = {
+				blockTypes: {
+					anchor: {
+						name: 'anchor',
+					},
+					hookedBlock: {
+						name: 'hookedBlock',
+						blockHooks: {
+							anchor: 'after',
+						},
+					},
+				},
+			};
+
+			expect( getChildBlockNames( state, 'otherAnchor' ) ).toHaveLength(
+				0
+			);
+		} );
+
+		it( "should return the anchor block name even if the anchor block doesn't exist", () => {
+			const state = {
+				blockTypes: {
+					hookedBlock: {
+						name: 'hookedBlock',
+						blockHooks: {
+							anchor: 'after',
+						},
+					},
+				},
+			};
+
+			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( [
+				'hookedBlock',
+			] );
+		} );
+
+		it( 'should return an array with the hooked block names', () => {
+			const state = {
+				blockTypes: {
+					anchor: {
+						name: 'anchor',
+					},
+					hookedBlock1: {
+						name: 'hookedBlock1',
+						blockHooks: {
+							anchor: 'after',
+						},
+					},
+					hookedBlock2: {
+						name: 'hookedBlock2',
+						blockHooks: {
+							anchor: 'before',
+						},
+					},
+				},
+			};
+
+			expect( getHookedBlockNames( state, 'anchor' ) ).toEqual( [
+				'hookedBlock1',
+				'hookedBlock2',
 			] );
 		} );
 	} );


### PR DESCRIPTION
## What?
Set the `metadata.ignoredHookedBlocks` attribute upon inserting a new block that has hooked blocks.

## Why?
To unblock https://github.com/WordPress/wordpress-develop/pull/5726 (see https://github.com/WordPress/wordpress-develop/pull/5712#issuecomment-1838758546).

In WP 6.5, we'll be enabling insertion of hooked blocks into modified templates/parts/patterns. This is implemented by adding a `metadata.ignoredHookedBlocks` attribute to the hooked block's anchor block upon editing.

As a consequence, upon insertion of an anchor block, this attribute also needs to be added to that newly inserted instance.

_A note on UX: It could be argued that ideally, insertion of a new anchor block should cause its hooked blocks to be inserted alongside with it. This could be a future addition but seems to be a bit more complicated to do. Regardless, the `metadata.ignoredHookedBlocks` attribute also would need to be set in that case, in order to avoid double insertion -- meaning that adding that attribute is required as a baseline anyway._

## How?

AFAICT, there are two mechanisms that set attributes for a newly inserted block:
- `buildBlockTypeItem` is used to build items that appear in the inserter; conveniently, it allows setting an `initialAttribute`.
- OTOH, blocks that _don't_ show up in the inserter but are inserted as inner blocks of another block (e.g. the Comment Template block, as a newly inserted Comments block's inner block). These blocks are typically sync'd via `synchronizeBlocksWithTemplate` from a `template` set in the container block.

Both mechanisms are modified by this PR to set the `metadata.ignoredHookedBlocks` attribute.

## Testing Instructions
- Install and activate the [latest version of the Like Button plugin](https://github.com/ockham/like-button/releases/latest).
- Use a block theme like TT3 or TT4.
- In the Site Editor, edit the Single Posts template.
- Verify that the Like Button block is inserted both below the Post Content block, and as the Comment Template block's last child.
- Insert a new instance of the Post Content block right above the footer template part.
- Switch to the Code Editor and verify that the newly inserted instance of the Post Content block has its `metadata.ignoredHookedBlocks` attribute set to include the Like Button block: `<!-- wp:post-content {"metadata":{"ignoredHookedBlocks":["ockham/like-button"]}} /-->`.
- Delete that block, and insert a new instance of the Comments block.
- Switch to the Code Editor and verified that the Comment Template block inside the new Comments block has its `metadata.ignoredHookedBlocks` attribute set to include the Like Button block: `<!-- wp:comment-template {"metadata":{"ignoredHookedBlocks":["ockham/like-button"]}} -->`

## Follow-up

Currently, only hooked blocks that were added via `block.json` will be taken into account, but not the ones added via a filter. This will be addressed by #58622.

We should then also use it the selector to compute `hookedBlocksForCurrentBlock` in `block-hooks.js` (so it'll also use the new endpoint as its source of truth). (I've tried that out in https://github.com/WordPress/gutenberg/pull/58553/commits/6f973f9859b8522306268c6a5d6740bd8eec66b8 but decided to punt for now as it'd add needless complexity for the time being.)