### PR TITLE
Block Bindings: Add block context needed for bindings in PHP

### DIFF
--- a/lib/compat/wordpress-6.5/block-bindings/block-bindings.php
+++ b/lib/compat/wordpress-6.5/block-bindings/block-bindings.php
@@ -25,18 +25,19 @@
  * @param array  $source_properties {
  *     The array of arguments that are used to register a source.
  *
- *     @type string   $label              The label of the source.
- *     @type callback $get_value_callback A callback executed when the source is processed during block rendering.
- *                                        The callback should have the following signature:
+ *     @type string   $label                   The label of the source.
+ *     @type callback $get_value_callback      A callback executed when the source is processed during block rendering.
+ *                                             The callback should have the following signature:
  *
- *                                        `function ($source_args, $block_instance,$attribute_name): mixed`
- *                                            - @param array    $source_args    Array containing source arguments
- *                                                                              used to look up the override value,
- *                                                                              i.e. {"key": "foo"}.
- *                                            - @param WP_Block $block_instance The block instance.
- *                                            - @param string   $attribute_name The name of an attribute .
- *                                        The callback has a mixed return type; it may return a string to override
- *                                        the block's original value, null, false to remove an attribute, etc.
+ *                                             `function ($source_args, $block_instance,$attribute_name): mixed`
+ *                                                 - @param array    $source_args    Array containing source arguments
+ *                                                                                   used to look up the override value,
+ *                                                                                   i.e. {"key": "foo"}.
+ *                                                 - @param WP_Block $block_instance The block instance.
+ *                                                 - @param string   $attribute_name The name of an attribute .
+ *                                             The callback has a mixed return type; it may return a string to override
+ *                                             the block's original value, null, false to remove an attribute, etc.
+ *     @type array    $uses_context (optional) Array of values to add to block `uses_context` needed by the source.
  * }
  * @return WP_Block_Bindings_Source|false Source when the registration was successful, or `false` on failure.
  */

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -109,14 +109,14 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 			if ( $this->is_registered( $source_name ) ) {
 				_doing_it_wrong(
 					__METHOD__,
-					/* translators: %s: Block bindings source name. */
+					// translators: %s: Block bindings source name.
 					sprintf( __( 'Block bindings source "%s" already registered.' ), $source_name ),
 					'6.5.0'
 				);
 				return false;
 			}
 
-			/* Validate that the source properties contain the label */
+			// Validate that the source properties contain the label.
 			if ( ! isset( $source_properties['label'] ) ) {
 				_doing_it_wrong(
 					__METHOD__,
@@ -126,7 +126,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 				return false;
 			}
 
-			/* Validate that the source properties contain the get_value_callback */
+			// Validate that the source properties contain the get_value_callback.
 			if ( ! isset( $source_properties['get_value_callback'] ) ) {
 				_doing_it_wrong(
 					__METHOD__,
@@ -136,7 +136,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 				return false;
 			}
 
-			/* Validate that the get_value_callback is a valid callback */
+			// Validate that the get_value_callback is a valid callback.
 			if ( ! is_callable( $source_properties['get_value_callback'] ) ) {
 				_doing_it_wrong(
 					__METHOD__,
@@ -212,7 +212,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 			if ( ! $this->is_registered( $source_name ) ) {
 				_doing_it_wrong(
 					__METHOD__,
-					/* translators: %s: Block bindings source name. */
+					// translators: %s: Block bindings source name.
 					sprintf( __( 'Block binding "%s" not found.' ), $source_name ),
 					'6.5.0'
 				);

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -139,6 +139,25 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 
 			$this->sources[ $source_name ] = $source;
 
+			// Add `uses_context` defined by block bindings sources.
+			add_filter(
+				'register_block_type_args',
+				function ( $args, $block_name ) use ( $source ) {
+					$allowed_blocks = $this->allowed_blocks;
+
+					if ( empty( $allowed_blocks[ $block_name ] ) || empty( $source->uses_context ) ) {
+						return $args;
+					}
+					$original_use_context = isset( $args['uses_context'] ) ? $args['uses_context'] : array();
+					// Use array_values to reset the array keys.
+					$args['uses_context'] = array_values( array_unique( array_merge( $original_use_context, $source->uses_context ) ) );
+
+					return $args;
+				},
+				10,
+				2
+			);
+
 			return $source;
 		}
 

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -184,9 +184,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 				add_filter(
 					'register_block_type_args',
 					function ( $args, $block_name ) use ( $source ) {
-						$supported_blocks = $this->supported_blocks;
-
-						if ( empty( $supported_blocks[ $block_name ] ) || empty( $source->uses_context ) ) {
+						if ( ! in_array( $block_name, $this->supported_blocks, true ) || empty( $source->uses_context ) ) {
 							return $args;
 						}
 						$original_use_context = isset( $args['uses_context'] ) ? $args['uses_context'] : array();

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -184,9 +184,9 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 				add_filter(
 					'register_block_type_args',
 					function ( $args, $block_name ) use ( $source ) {
-						$allowed_blocks = $this->allowed_blocks;
+						$supported_blocks = $this->supported_blocks;
 
-						if ( empty( $allowed_blocks[ $block_name ] ) || empty( $source->uses_context ) ) {
+						if ( empty( $supported_blocks[ $block_name ] ) || empty( $source->uses_context ) ) {
 							return $args;
 						}
 						$original_use_context = isset( $args['uses_context'] ) ? $args['uses_context'] : array();

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -33,6 +33,18 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 		private static $instance = null;
 
 		/**
+		 * Supported source properties that can be passed to the registered source.
+		 *
+		 * @since 6.5.0
+		 * @var array
+		 */
+		private $allowed_source_properties = array(
+			'label',
+			'get_value_callback',
+			'uses_context',
+		);
+
+		/**
 		 * Supported blocks that can use the block bindings API.
 		 *
 		 * @since 6.5.0
@@ -109,7 +121,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 			if ( $this->is_registered( $source_name ) ) {
 				_doing_it_wrong(
 					__METHOD__,
-					// translators: %s: Block bindings source name.
+					/* translators: %s: Block bindings source name. */
 					sprintf( __( 'Block bindings source "%s" already registered.' ), $source_name ),
 					'6.5.0'
 				);
@@ -156,6 +168,16 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 				return false;
 			}
 
+			// Validate that the source properties contain only allowed properties.
+			if ( ! empty( array_diff( array_keys( $source_properties ), $this->allowed_source_properties ) ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'The $source_properties array contains invalid properties.' ),
+					'6.5.0'
+				);
+				return false;
+			}
+
 			$source = new WP_Block_Bindings_Source(
 				$source_name,
 				$source_properties
@@ -173,9 +195,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 							return $uses_context;
 						}
 						// Use array_values to reset the array keys.
-						$merged_uses_context = array_values( array_unique( array_merge( $uses_context, $source->uses_context ) ) );
-
-						return $merged_uses_context;
+						return array_values( array_unique( array_merge( $uses_context, $source->uses_context ) ) );
 					},
 					10,
 					2
@@ -212,7 +232,7 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 			if ( ! $this->is_registered( $source_name ) ) {
 				_doing_it_wrong(
 					__METHOD__,
-					// translators: %s: Block bindings source name.
+					/* translators: %s: Block bindings source name. */
 					sprintf( __( 'Block binding "%s" not found.' ), $source_name ),
 					'6.5.0'
 				);

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -61,19 +61,19 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 		 * @param array    $source_properties {
 		 *     The array of arguments that are used to register a source.
 		 *
-		 *     @type string   $label                  The label of the source.
-		 *     @type callback $get_value_callback     A callback executed when the source is processed during block rendering.
-		 *                                            The callback should have the following signature:
+		 *     @type string   $label                   The label of the source.
+		 *     @type callback $get_value_callback      A callback executed when the source is processed during block rendering.
+		 *                                             The callback should have the following signature:
 		 *
-		 *                                            `function ($source_args, $block_instance,$attribute_name): mixed`
-		 *                                                - @param array    $source_args    Array containing source arguments
-		 *                                                                                  used to look up the override value,
-		 *                                                                                  i.e. {"key": "foo"}.
-		 *                                                - @param WP_Block $block_instance The block instance.
-		 *                                                - @param string   $attribute_name The name of the target attribute.
-		 *                                            The callback has a mixed return type; it may return a string to override
-		 *                                            the block's original value, null, false to remove an attribute, etc.
-		 *     @type array   $uses_context (optional) Array of values to add to block `uses_context` needed by the source.
+		 *                                             `function ($source_args, $block_instance,$attribute_name): mixed`
+		 *                                                 - @param array    $source_args    Array containing source arguments
+		 *                                                                                   used to look up the override value,
+		 *                                                                                   i.e. {"key": "foo"}.
+		 *                                                 - @param WP_Block $block_instance The block instance.
+		 *                                                 - @param string   $attribute_name The name of the target attribute.
+		 *                                             The callback has a mixed return type; it may return a string to override
+		 *                                             the block's original value, null, false to remove an attribute, etc.
+		 *     @type array    $uses_context (optional) Array of values to add to block `uses_context` needed by the source.
 		 * }
 		 * @return WP_Block_Bindings_Source|false Source when the registration was successful, or `false` on failure.
 		 */

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-registry.php
@@ -186,37 +186,21 @@ if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 			$this->sources[ $source_name ] = $source;
 
 			// Add `uses_context` defined by block bindings sources.
-			// If `get_uses_context` exists (from WP 6.5), use its filter because it is more reliable.
-			if ( method_exists( 'WP_Block_Type', 'get_uses_context' ) ) {
-				add_filter(
-					'get_block_type_uses_context',
-					function ( $uses_context, $block_type ) use ( $source ) {
-						if ( ! in_array( $block_type->name, $this->supported_blocks, true ) || empty( $source->uses_context ) ) {
-							return $uses_context;
-						}
-						// Use array_values to reset the array keys.
-						return array_values( array_unique( array_merge( $uses_context, $source->uses_context ) ) );
-					},
-					10,
-					2
-				);
-			} else {
-				add_filter(
-					'register_block_type_args',
-					function ( $args, $block_name ) use ( $source ) {
-						if ( ! in_array( $block_name, $this->supported_blocks, true ) || empty( $source->uses_context ) ) {
-							return $args;
-						}
-						$original_use_context = isset( $args['uses_context'] ) ? $args['uses_context'] : array();
-						// Use array_values to reset the array keys.
-						$args['uses_context'] = array_values( array_unique( array_merge( $original_use_context, $source->uses_context ) ) );
-
+			add_filter(
+				'register_block_type_args',
+				function ( $args, $block_name ) use ( $source ) {
+					if ( ! in_array( $block_name, $this->supported_blocks, true ) || empty( $source->uses_context ) ) {
 						return $args;
-					},
-					10,
-					2
-				);
-			}
+					}
+					$original_use_context = isset( $args['uses_context'] ) ? $args['uses_context'] : array();
+					// Use array_values to reset the array keys.
+					$args['uses_context'] = array_values( array_unique( array_merge( $original_use_context, $source->uses_context ) ) );
+
+					return $args;
+				},
+				10,
+				2
+			);
 			return $source;
 		}
 

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-source.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-source.php
@@ -47,6 +47,14 @@ if ( ! class_exists( 'WP_Block_Bindings_Source' ) ) {
 		private $get_value_callback;
 
 		/**
+		 * The context added to the blocks needed by the source.
+		 *
+		 * @since 6.5.0
+		 * @var array|null
+		 */
+		public $uses_context = null;
+
+		/**
 		 * Constructor.
 		 *
 		 * Do not use this constructor directly. Instead, use the
@@ -61,6 +69,9 @@ if ( ! class_exists( 'WP_Block_Bindings_Source' ) ) {
 			$this->name               = $name;
 			$this->label              = $source_properties['label'];
 			$this->get_value_callback = $source_properties['get_value_callback'];
+			if ( isset( $source_properties['uses_context'] ) ) {
+				$this->uses_context = $source_properties['uses_context'];
+			}
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-source.php
+++ b/lib/compat/wordpress-6.5/block-bindings/class-wp-block-bindings-source.php
@@ -66,11 +66,9 @@ if ( ! class_exists( 'WP_Block_Bindings_Source' ) ) {
 		 * @param array  $source_properties  The properties of the source.
 		 */
 		public function __construct( string $name, array $source_properties ) {
-			$this->name               = $name;
-			$this->label              = $source_properties['label'];
-			$this->get_value_callback = $source_properties['get_value_callback'];
-			if ( isset( $source_properties['uses_context'] ) ) {
-				$this->uses_context = $source_properties['uses_context'];
+			$this->name = $name;
+			foreach ( $source_properties as $property_name => $property_value ) {
+				$this->$property_name = $property_value;
 			}
 		}
 

--- a/lib/compat/wordpress-6.5/block-bindings/pattern-overrides.php
+++ b/lib/compat/wordpress-6.5/block-bindings/pattern-overrides.php
@@ -35,6 +35,7 @@ function gutenberg_register_block_bindings_pattern_overrides_source() {
 		array(
 			'label'              => _x( 'Pattern Overrides', 'block bindings source' ),
 			'get_value_callback' => 'gutenberg_block_bindings_pattern_overrides_callback',
+			'uses_context'       => array( 'pattern/overrides' ),
 		)
 	);
 }

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -12,7 +12,7 @@
  *                           Example: array( "key" => "foo" ).
  * @return mixed The value computed for the source.
  */
-function gutenberg_block_bindings_post_meta_callback( $source_attrs ) {
+function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_instance ) {
 	if ( ! isset( $source_attrs['key'] ) ) {
 		return null;
 	}
@@ -21,8 +21,7 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs ) {
 	if ( isset( $source_attrs['postId'] ) ) {
 		$post_id = $source_attrs['postId'];
 	} else {
-		// I tried using $block_instance->context['postId'] but it wasn't available in the image block.
-		$post_id = get_the_ID();
+		$post_id = isset( $block_instance->context['postId'] ) ? $block_instance->context['postId'] : get_the_ID();
 	}
 
 	// If a post isn't public, we need to prevent unauthorized users from accessing the post meta.

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -17,13 +17,7 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 		return null;
 	}
 
-	// Use the postId attribute if available
-	if ( isset( $source_attrs['postId'] ) ) {
-		$post_id = $source_attrs['postId'];
-	} else {
-		$post_id = isset( $block_instance->context['postId'] ) ? $block_instance->context['postId'] : get_the_ID();
-	}
-
+	$post_id = isset( $block_instance->context['postId'] );
 	// If a post isn't public, we need to prevent unauthorized users from accessing the post meta.
 	$post = get_post( $post_id );
 	if ( ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) || post_password_required( $post ) ) {

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -8,8 +8,9 @@
 /**
  * Gets value for Post Meta source.
  *
- * @param array $source_args Array containing source arguments used to look up the override value.
- *                           Example: array( "key" => "foo" ).
+ * @param array    $source_args    Array containing source arguments used to look up the override value.
+ *                                 Example: array( "key" => "foo" ).
+ * @param WP_Block $block_instance The block instance.
  * @return mixed The value computed for the source.
  */
 function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_instance ) {

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -17,7 +17,7 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 		return null;
 	}
 
-	$post_id = isset( $block_instance->context['postId'] );
+	$post_id = $block_instance->context['postId'];
 	// If a post isn't public, we need to prevent unauthorized users from accessing the post meta.
 	$post = get_post( $post_id );
 	if ( ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) || post_password_required( $post ) ) {

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -17,6 +17,9 @@ function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_inst
 		return null;
 	}
 
+	if ( ! isset( $block_instance->context['postId'] ) ) {
+		return null;
+	}
 	$post_id = $block_instance->context['postId'];
 	// If a post isn't public, we need to prevent unauthorized users from accessing the post meta.
 	$post = get_post( $post_id );
@@ -40,6 +43,7 @@ function gutenberg_register_block_bindings_post_meta_source() {
 		array(
 			'label'              => _x( 'Post Meta', 'block bindings source' ),
 			'get_value_callback' => 'gutenberg_block_bindings_post_meta_callback',
+			'uses_context'       => array( 'postId', 'postType' ),
 		)
 	);
 }

--- a/lib/compat/wordpress-6.5/block-bindings/post-meta.php
+++ b/lib/compat/wordpress-6.5/block-bindings/post-meta.php
@@ -13,11 +13,11 @@
  * @return mixed The value computed for the source.
  */
 function gutenberg_block_bindings_post_meta_callback( $source_attrs, $block_instance ) {
-	if ( ! isset( $source_attrs['key'] ) ) {
+	if ( empty( $source_attrs['key'] ) ) {
 		return null;
 	}
 
-	if ( ! isset( $block_instance->context['postId'] ) ) {
+	if ( empty( $block_instance->context['postId'] ) ) {
 		return null;
 	}
 	$post_id = $block_instance->context['postId'];

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -157,18 +157,16 @@ function gutenberg_block_bindings_replace_html( $block_content, $block_name, str
 	 * @param WP_Block $block_instance The block instance.
 	 */
 function gutenberg_process_block_bindings( $block_content, $parsed_block, $block_instance ) {
-	// Allowed blocks that support block bindings.
-	// TODO: Look for a mechanism to opt-in for this. Maybe adding a property to block attributes?
-	$allowed_blocks = array(
+	$supported_block_attrs = array(
 		'core/paragraph' => array( 'content' ),
 		'core/heading'   => array( 'content' ),
 		'core/image'     => array( 'url', 'title', 'alt' ),
 		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 	);
 
-	// If the block doesn't have the bindings property or isn't one of the allowed block types, return.
+	// If the block doesn't have the bindings property or isn't one of the supported block types, return.
 	if (
-		! isset( $allowed_blocks[ $block_instance->name ] ) ||
+		! isset( $supported_block_attrs[ $block_instance->name ] ) ||
 		empty( $parsed_block['attrs']['metadata']['bindings'] ) ||
 		! is_array( $parsed_block['attrs']['metadata']['bindings'] )
 	) {
@@ -192,8 +190,8 @@ function gutenberg_process_block_bindings( $block_content, $parsed_block, $block
 
 	$modified_block_content = $block_content;
 	foreach ( $parsed_block['attrs']['metadata']['bindings'] as $attribute_name => $block_binding ) {
-		// If the attribute is not in the allowed list, process next attribute.
-		if ( ! in_array( $attribute_name, $allowed_blocks[ $block_instance->name ], true ) ) {
+		// If the attribute is not in the supported list, process next attribute.
+		if ( ! in_array( $attribute_name, $supported_block_attrs[ $block_instance->name ], true ) ) {
 			continue;
 		}
 		// If no source is provided, or that source is not registered, process next attribute.

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -219,38 +219,3 @@ function gutenberg_process_block_bindings( $block_content, $parsed_block, $block
 }
 
 add_filter( 'render_block', 'gutenberg_process_block_bindings', 20, 3 );
-
-/**
- * Add `postId` and `postType` context to blocks that can use block bindings.
- *
- * @param string $args Array of arguments for registering a block type.
- * @param string $block_name The name of the block to process.
- * @return array The modified arguments for registering a block type.
- */
-function gutenberg_add_context_for_block_bindings( $args, $block_name ) {
-	$allowed_blocks = array(
-		'core/paragraph' => array( 'content' ),
-		'core/heading'   => array( 'content' ),
-		'core/image'     => array( 'url', 'title', 'alt' ),
-		'core/button'    => array( 'url', 'text' ),
-	);
-
-	if ( ! isset( $allowed_blocks[ $block_name ] ) ) {
-		return $args;
-	}
-	if ( ! isset( $args['uses_context'] ) ) {
-		$args['uses_context'] = array( 'postId', 'postType' );
-	} else {
-		// Check if 'postId' exists in 'uses_context' and add it if it doesn't.
-		if ( ! in_array( 'postId', $args['uses_context'], true ) ) {
-			$args['uses_context'][] = 'postId';
-		}
-		// Check if 'postType' exists in 'uses_context' and add it if it doesn't.
-		if ( ! in_array( 'postType', $args['uses_context'], true ) ) {
-			$args['uses_context'][] = 'postType';
-		}
-	}
-
-	return $args;
-}
-add_filter( 'register_block_type_args', 'gutenberg_add_context_for_block_bindings', 10, 2 );

--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -219,3 +219,38 @@ function gutenberg_process_block_bindings( $block_content, $parsed_block, $block
 }
 
 add_filter( 'render_block', 'gutenberg_process_block_bindings', 20, 3 );
+
+/**
+ * Add `postId` and `postType` context to blocks that can use block bindings.
+ *
+ * @param string $args Array of arguments for registering a block type.
+ * @param string $block_name The name of the block to process.
+ * @return array The modified arguments for registering a block type.
+ */
+function gutenberg_add_context_for_block_bindings( $args, $block_name ) {
+	$allowed_blocks = array(
+		'core/paragraph' => array( 'content' ),
+		'core/heading'   => array( 'content' ),
+		'core/image'     => array( 'url', 'title', 'alt' ),
+		'core/button'    => array( 'url', 'text' ),
+	);
+
+	if ( ! isset( $allowed_blocks[ $block_name ] ) ) {
+		return $args;
+	}
+	if ( ! isset( $args['uses_context'] ) ) {
+		$args['uses_context'] = array( 'postId', 'postType' );
+	} else {
+		// Check if 'postId' exists in 'uses_context' and add it if it doesn't.
+		if ( ! in_array( 'postId', $args['uses_context'], true ) ) {
+			$args['uses_context'][] = 'postId';
+		}
+		// Check if 'postType' exists in 'uses_context' and add it if it doesn't.
+		if ( ! in_array( 'postType', $args['uses_context'], true ) ) {
+			$args['uses_context'][] = 'postType';
+		}
+	}
+
+	return $args;
+}
+add_filter( 'register_block_type_args', 'gutenberg_add_context_for_block_bindings', 10, 2 );

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -112,24 +112,3 @@ addFilter(
 	'core/editor/custom-sources-backwards-compatibility/shim-attribute-source',
 	shimAttributeSource
 );
-
-// Add the context to all blocks.
-addFilter(
-	'blocks.registerBlockType',
-	'core/block-bindings-ui',
-	( settings, name ) => {
-		if ( ! ( name in BLOCK_BINDINGS_ALLOWED_BLOCKS ) ) {
-			return settings;
-		}
-		const contextItems = [ 'postId', 'postType', 'queryId' ];
-		const usesContextArray = settings.usesContext;
-		const oldUsesContextArray = new Set( usesContextArray );
-		contextItems.forEach( ( item ) => {
-			if ( ! oldUsesContextArray.has( item ) ) {
-				usesContextArray.push( item );
-			}
-		} );
-		settings.usesContext = usesContextArray;
-		return settings;
-	}
-);

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -8,7 +8,6 @@
 	"description": "Prompt visitors to take action with a button-style link.",
 	"keywords": [ "link" ],
 	"textdomain": "default",
-	"usesContext": [ "pattern/overrides" ],
 	"attributes": {
 		"tagName": {
 			"type": "string",

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -7,7 +7,6 @@
 	"description": "Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.",
 	"keywords": [ "title", "subtitle" ],
 	"textdomain": "default",
-	"usesContext": [ "pattern/overrides" ],
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -4,12 +4,7 @@
 	"name": "core/image",
 	"title": "Image",
 	"category": "media",
-	"usesContext": [
-		"allowResize",
-		"imageCrop",
-		"fixedHeight",
-		"pattern/overrides"
-	],
+	"usesContext": [ "allowResize", "imageCrop", "fixedHeight" ],
 	"description": "Insert an image to make a visual statement.",
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -7,7 +7,7 @@
 	"description": "Start with the basic building block of all narrative.",
 	"keywords": [ "text" ],
 	"textdomain": "default",
-	"usesContext": [ "postId", "pattern/overrides" ],
+	"usesContext": [ "postId" ],
 	"attributes": {
 		"align": {
 			"type": "string"


### PR DESCRIPTION
## What?
EDIT: I created other pull request to handle this in wordpress-develop: [link](https://github.com/WordPress/wordpress-develop/pull/6079). I'm using this PR to adapt Gutenberg to those changes.

Tests are expected to fail until the core pull request is merged.

## Why?
If the core PR gets merged, we need to adapt the existing sources.

## How?
* Using the new `uses_context` argument in the sources.
* Remove the old editor hook because it is not needed anymore.
* Remove the `pattern/overrides` definition in `block.json` because now it is handled by the new approach.

## Testing Instructions
1. Register a custom field in your site. You can use a code snippet like this:
```
register_meta(
	'post',
	'url_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg',
	)
);
```

2. Go to a page and insert an image block connected to the custom field.
```
<!-- wp:image {"id":134,"sizeSlug":"large","linkDestination":"none","metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"url_custom_field"}},"alt":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<figure class="wp-block-image size-large"><img src="https://wpmovies.dev/wp-content/uploads/2023/04/goncharov-poster-original-1-682x1024.jpeg" alt="Content of the page_text_custom_field" class="wp-image-134" title="Content of the PAGE text custom field"/></figure>
<!-- /wp:image -->
```
3. Check that the value of the custom field is shown in the editor.
4. Save the page.
5. Go to the frontend and check that the value of the custom field is shown there as well.