### PR TITLE
Block editor: reduce appender sync! subscriptions

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -39,77 +39,12 @@ function DefaultAppender( { rootClientId } ) {
 	);
 }
 
-function useAppender( rootClientId, CustomAppender ) {
-	const isVisible = useSelect(
-		( select ) => {
-			const {
-				getTemplateLock,
-				getSelectedBlockClientId,
-				__unstableGetEditorMode,
-				getBlockEditingMode,
-			} = select( blockEditorStore );
-
-			if ( ! CustomAppender ) {
-				const selectedBlockClientId = getSelectedBlockClientId();
-				const isParentSelected =
-					rootClientId === selectedBlockClientId ||
-					( ! rootClientId && ! selectedBlockClientId );
-				if ( ! isParentSelected ) {
-					return false;
-				}
-			}
-
-			if (
-				getTemplateLock( rootClientId ) ||
-				getBlockEditingMode( rootClientId ) === 'disabled' ||
-				__unstableGetEditorMode() === 'zoom-out'
-			) {
-				return false;
-			}
-
-			return true;
-		},
-		[ rootClientId, CustomAppender ]
-	);
-
-	if ( ! isVisible ) {
-		return null;
-	}
-
-	return CustomAppender ? (
-		<CustomAppender />
-	) : (
-		<DefaultAppender rootClientId={ rootClientId } />
-	);
-}
-
-function BlockListAppender( {
+export default function BlockListAppender( {
 	rootClientId,
-	renderAppender,
+	CustomAppender,
 	className,
 	tagName: TagName = 'div',
 } ) {
-	if ( renderAppender === false ) {
-		return null;
-	}
-
-	return (
-		<BlockListAppenderInner
-			rootClientId={ rootClientId }
-			renderAppender={ renderAppender }
-			className={ className }
-			tagName={ TagName }
-		/>
-	);
-}
-
-function BlockListAppenderInner( {
-	rootClientId,
-	renderAppender,
-	className,
-	tagName: TagName,
-} ) {
-	const appender = useAppender( rootClientId, renderAppender );
 	const isDragOver = useSelect(
 		( select ) => {
 			const {
@@ -129,10 +64,6 @@ function BlockListAppenderInner( {
 		},
 		[ rootClientId ]
 	);
-
-	if ( ! appender ) {
-		return null;
-	}
 
 	return (
 		<TagName
@@ -162,9 +93,11 @@ function BlockListAppenderInner( {
 			// have commonly targeted that attribute for margins.
 			data-block
 		>
-			{ appender }
+			{ CustomAppender ? (
+				<CustomAppender />
+			) : (
+				<DefaultAppender rootClientId={ rootClientId } />
+			) }
 		</TagName>
 	);
 }
-
-export default BlockListAppender;

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -155,6 +155,10 @@ function Items( {
 	__experimentalAppenderTagName,
 	layout = defaultLayout,
 } ) {
+	// Avoid passing CustomAppender to useSelect because it could be a new
+	// function on every render.
+	const hasAppender = CustomAppender !== false;
+	const hasCustomAppender = !! CustomAppender;
 	const {
 		order,
 		selectedBlocks,
@@ -181,17 +185,16 @@ function Items( {
 				temporarilyEditingAsBlocks:
 					__unstableGetTemporarilyEditingAsBlocks(),
 				shouldRenderAppender:
-					CustomAppender !== false &&
-					( CustomAppender
+					hasAppender &&
+					( hasCustomAppender
 						? ! getTemplateLock( rootClientId ) &&
-						  ! getBlockEditingMode( rootClientId ) ===
-								'disabled' &&
-						  ! __unstableGetEditorMode() === 'zoom-out'
+						  getBlockEditingMode( rootClientId ) !== 'disabled' &&
+						  __unstableGetEditorMode() !== 'zoom-out'
 						: rootClientId === selectedBlockClientId ||
 						  ( ! rootClientId && ! selectedBlockClientId ) ),
 			};
 		},
-		[ rootClientId, CustomAppender ]
+		[ rootClientId, hasAppender, hasCustomAppender ]
 	);
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes 2 block editor store subscriptions for almost each inner block list.

1. Even when no appender is rendered, there's a block editor store subscription added related to drag, which is addressed in this PR.
2. The other subscription that checks if the appender should be rendered can be moved up and combined with the Items subscription.

Both of these subscriptions were sync subscriptions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

First run type -12.5%, second run -5.2%

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
