### PR TITLE
Components: Allow limiting the number of maximum visible Snackbars

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `ConfirmDialog`: Add `__next40pxDefaultSize` to buttons ([#58421](https://github.com/WordPress/gutenberg/pull/58421)).
+-   `SnackbarList`: Allow limiting the number of maximum visible Snackbars ([#58559](https://github.com/WordPress/gutenberg/pull/58559)).
 
 ### Bug Fix
 

--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -62,12 +62,14 @@ const SNACKBAR_VARIANTS = {
  */
 export function SnackbarList( {
 	notices,
+	maxVisible,
 	className,
 	children,
 	onRemove,
 }: WordPressComponentProps< SnackbarListProps, 'div' > ) {
 	const listRef = useRef< HTMLDivElement | null >( null );
 	const isReducedMotion = useReducedMotion();
+	const visibleNotices = maxVisible ? notices.slice( -maxVisible ) : notices;
 	className = classnames( 'components-snackbar-list', className );
 	const removeNotice =
 		( notice: SnackbarListProps[ 'notices' ][ number ] ) => () =>
@@ -76,7 +78,7 @@ export function SnackbarList( {
 		<div className={ className } tabIndex={ -1 } ref={ listRef }>
 			{ children }
 			<AnimatePresence>
-				{ notices.map( ( notice ) => {
+				{ visibleNotices.map( ( notice ) => {
 					const { content, ...restNotice } = notice;
 
 					return (

--- a/packages/components/src/snackbar/types.ts
+++ b/packages/components/src/snackbar/types.ts
@@ -38,6 +38,7 @@ export type SnackbarListProps = {
 			content: string;
 		}
 	>;
+	maxVisible?: number;
 	onRemove: ( id: string ) => void;
 	children?: NoticeChildren | Array< NoticeChildren >;
 };

--- a/packages/edit-widgets/src/components/notices/index.js
+++ b/packages/edit-widgets/src/components/notices/index.js
@@ -36,6 +36,7 @@ function Notices() {
 			/>
 			<SnackbarList
 				notices={ snackbarNotices }
+				maxVisible={ 3 }
 				className="edit-widgets-notices__snackbar"
 				onRemove={ removeNotice }
 			/>

--- a/packages/editor/src/components/editor-snackbars/index.js
+++ b/packages/editor/src/components/editor-snackbars/index.js
@@ -18,6 +18,7 @@ export default function EditorSnackbars() {
 	return (
 		<SnackbarList
 			notices={ snackbarNotices }
+			maxVisible={ 3 }
 			className="components-editor-notices__snackbar"
 			onRemove={ removeNotice }
 		/>


### PR DESCRIPTION
## What?
Resolves #53201.

PR updates the `SnackbarList` component to allow limiting the number of maximum visible Snackbars.

## Why?
Reduces noise in the editors.

## How?
Introduces new `maxVisible` property and sets it to `3` for post and site editors.

## Testing Instructions
1. Open a post or page.
2. Insert a block.
3. Trigger a lot of snackbar notices. Copying a block can do that.
4. Confirm that only a fixed number (3) of snackbars are visible.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/1e90ffc6-0312-4bca-9ac2-97adbe8a3afb

