### PR TITLE
CheckboxControl: Change alignment

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -364,6 +364,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 	.components-base-control__field {
 		display: flex; // don't allow label to wrap under checkbox.
+		align-items: center;
 
 		.components-checkbox-control__label {
 			color: $gray-900;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58563

## What?
<!-- In a few words, what is the PR actually doing? -->
Very tiny PR: The vertical alignment of checkboxes and labels in the URL input UI could be slighly improved by using flexbox align-items.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Flexbox handles vertical alignment nicely and it should be used for that whenever possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Set `align-items: center` on the flex container.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue https://github.com/WordPress/gutenberg/issues/58563
- Observe vertical alignment of checkboxes and their labels has improved. Note: it's like a 1 pixel difference.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before and after:

![Screenshot 2024-02-01 at 14 16 03](https://github.com/WordPress/gutenberg/assets/1682452/4cd10a09-2c78-4073-af24-761bde1bb021)

