### PR TITLE
Update: Footnotes support for custom post types to be support based.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -563,12 +563,8 @@ add_filter(
  *
  */
 function _gutenberg_register_footnotes_meta_field() {
-	$post_types = get_post_types(
-		array(
-			'show_in_rest' => true,
-			'public'       => true,
-		)
-	);
+	$post_types = get_post_types( array( 'show_in_rest' => true ) );
+	$post_types = array_filter( $post_types, 'is_post_type_viewable' );
 	foreach ( $post_types as $post_type ) {
 		// Only register the meta field if the post type supports the editor, custom fields, and revisions.
 		if ( post_type_supports( $post_type, 'editor' ) && post_type_supports( $post_type, 'custom-fields' ) && post_type_supports( $post_type, 'revisions' ) && post_type_supports( $post_type, 'footnotes' ) ) {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -530,9 +530,11 @@ add_action( 'set_current_user', '_gutenberg_footnotes_kses_init' );
 add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtered_html_on_import_filter', 999 );
 
 /**
- * Filters the arguments for registering a post type adding the footnotes support by default.
+ * Filters the arguments for registering a post type adding the footnotes
+ * support by default.
  *
  * @access private
+ * @internal
  *
  * @param array  $args      Array of arguments for registering a post type.
  *                          See the register_post_type() function for accepted arguments.
@@ -540,7 +542,12 @@ add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtere
 function _gutenberg_add_footnotes_post_type_support( $args ) {
 	if ( ! empty( $args['supports'] ) ) {
 		$supports = &$args['supports'];
-		if ( in_array( 'editor', $supports, true ) && in_array( 'custom-fields', $supports, true ) && in_array( 'revisions', $supports, true ) && ! in_array( 'footnotes', $supports, true ) ) {
+		if (
+			in_array( 'editor', $supports, true ) &&
+			in_array( 'custom-fields', $supports, true ) &&
+			in_array( 'revisions', $supports, true ) &&
+			! in_array( 'footnotes', $supports, true )
+		) {
 			$supports[] = 'footnotes';
 		}
 	}
@@ -548,9 +555,7 @@ function _gutenberg_add_footnotes_post_type_support( $args ) {
 	return $args;
 }
 
-/**
- * Adds the footnotes support to the post type by default.
- */
+// Adds the footnotes support to the post type by default.
 add_filter(
 	'register_post_type_args',
 	'_gutenberg_add_footnotes_post_type_support'
@@ -559,15 +564,21 @@ add_filter(
 /**
  * Registers the footnotes meta field for post types that support it.
  *
+ * @access private
  * @internal
- *
  */
 function _gutenberg_register_footnotes_meta_field() {
 	$post_types = get_post_types( array( 'show_in_rest' => true ) );
 	$post_types = array_filter( $post_types, 'is_post_type_viewable' );
 	foreach ( $post_types as $post_type ) {
-		// Only register the meta field if the post type supports the editor, custom fields, and revisions.
-		if ( post_type_supports( $post_type, 'editor' ) && post_type_supports( $post_type, 'custom-fields' ) && post_type_supports( $post_type, 'revisions' ) && post_type_supports( $post_type, 'footnotes' ) ) {
+		// Only register the meta field if the post type supports the editor,
+		// custom fields, and revisions.
+		if (
+			post_type_supports( $post_type, 'editor' ) &&
+			post_type_supports( $post_type, 'custom-fields' ) &&
+			post_type_supports( $post_type, 'revisions' ) &&
+			post_type_supports( $post_type, 'footnotes' )
+		) {
 			$post_type_meta_keys = get_registered_meta_keys( 'post', $post_type );
 			if ( ! isset( $post_type_meta_keys['footnotes'] ) ) {
 				register_post_meta(

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -68,27 +68,6 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
  * @since 6.3.0
  */
 function register_block_core_footnotes() {
-	$post_types = get_post_types(
-		array(
-			'show_in_rest' => true,
-			'public'       => true,
-		)
-	);
-	foreach ( $post_types as $post_type ) {
-		// Only register the meta field if the post type supports the editor, custom fields, and revisions.
-		if ( post_type_supports( $post_type, 'editor' ) && post_type_supports( $post_type, 'custom-fields' ) && post_type_supports( $post_type, 'revisions' ) ) {
-			register_post_meta(
-				$post_type,
-				'footnotes',
-				array(
-					'show_in_rest'      => true,
-					'single'            => true,
-					'type'              => 'string',
-					'revisions_enabled' => true,
-				)
-			);
-		}
-	}
 	register_block_type_from_metadata(
 		__DIR__ . '/footnotes',
 		array(


### PR DESCRIPTION
Update to https://github.com/WordPress/gutenberg/pull/57353.
Fixes: https://github.com/WordPress/gutenberg/issues/58341
Alternative to https://github.com/WordPress/gutenberg/pull/58343.

Follows @mcsf suggestion in https://github.com/WordPress/gutenberg/pull/57353#issuecomment-1904090852 and makes footnotes have their own supports key.
By default, every post that meets footnotes requirements has support for footnotes.
Developers can now remove footnotes support with:
```
remove_post_type_support( 'my_type', 'footnotes' );
```

cc: @mcsf, @peterwilsoncc, @ellatrix 

## Testing

Added the following post type:
```

function cptui_register_my_cpts_testfootnotes() {

	/**
	 * Post Type: Test foot notes.
	 */

	$labels = [
		"name" => esc_html__( "Test foot notes", "twentytwentyfour" ),
		"singular_name" => esc_html__( "Test foot note", "twentytwentyfour" ),
	];

	$args = [
		"label" => esc_html__( "Test foot notes", "twentytwentyfour" ),
		"labels" => $labels,
		"description" => "",
		"public" => true,
		"publicly_queryable" => true,
		"show_ui" => true,
		"show_in_rest" => true,
		"rest_base" => "",
		"rest_controller_class" => "WP_REST_Posts_Controller",
		"rest_namespace" => "wp/v2",
		"has_archive" => false,
		"show_in_menu" => true,
		"show_in_nav_menus" => true,
		"delete_with_user" => false,
		"exclude_from_search" => false,
		"capability_type" => "post",
		"map_meta_cap" => true,
		"hierarchical" => false,
		"can_export" => false,
		"rewrite" => [ "slug" => "testfootnotes", "with_front" => true ],
		"query_var" => true,
		"supports" => [ "title", "editor", "thumbnail", "custom-fields", "revisions" ],
		"show_in_graphql" => false,
	];

	register_post_type( "testfootnotes", $args );
}

add_action( 'init', 'cptui_register_my_cpts_testfootnotes' );
```

I have confirmed that the footnotes are functioning correctly on the specified post type.

Furthermore, I have removed the "custom-fields" support from the post type and confirmed that the footnotes are no longer available on the post type.

In addition, I have verified that `remove_post_type_support( 'page', 'footnotes' );` successfully removes footnotes support from pages.

