### PR TITLE
Font Library: simplify font collection schema

### DIFF
--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -4,7 +4,7 @@
 	"type": "object",
 	"definitions": {
 		"fontFace": {
-			"description": "Font face theme.json settings, with added preview key.",
+			"description": "Font face theme.json settings, with added preview property.",
 			"type": "object",
 			"properties": {
 				"preview": {
@@ -119,7 +119,7 @@
 				"type": "object",
 				"properties": {
 					"font_family_settings": {
-						"description": "Font family theme.json settings, with added preview key.",
+						"description": "Font family theme.json settings, with added preview property.",
 						"type": "object",
 						"properties": {
 							"name": {
@@ -139,7 +139,7 @@
 								"description": "URL to a preview image of the font family."
 							},
 							"fontFace": {
-								"description": "Array of font-face declarations.",
+								"description": "Array of font-face definitions.",
 								"type": "array",
 								"items": {
 									"allOf": [

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -4,7 +4,7 @@
 	"type": "object",
 	"definitions": {
 		"fontFace": {
-			"description": "Font face settings. The same as theme.json but with the preview key",
+			"description": "Font face theme.json settings, with added preview key.",
 			"type": "object",
 			"properties": {
 				"preview": {
@@ -114,12 +114,12 @@
 		},
 		"font_families": {
 			"type": "array",
-			"description": "Array of font families ready to be installed",
+			"description": "Array of font families ready to be installed.",
 			"items": {
 				"type": "object",
 				"properties": {
 					"font_family_settings": {
-						"description": "Font family settings similar to theme.json but without fontFace key.",
+						"description": "Font family theme.json settings, with added preview key.",
 						"type": "object",
 						"properties": {
 							"name": {
@@ -154,7 +154,7 @@
 					},
 					"categories": {
 						"type": "array",
-						"description": "Array of category slugs",
+						"description": "Array of category slugs.",
 						"items": {
 							"type": "string"
 						}
@@ -166,7 +166,7 @@
 		},
 		"categories": {
 			"type": "array",
-			"description": "Array of category objects",
+			"description": "Array of category objects.",
 			"items": {
 				"type": "object",
 				"properties": {

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -2,6 +2,99 @@
 	"title": "JSON schema for WordPress Font Collections",
 	"$schema": "http://json-schema.org/draft-04/schema#",
 	"type": "object",
+	"definitions": {
+		"fontFace": {
+			"description": "Font face settings. The same as theme.json but with the preview key",
+			"type": "object",
+			"properties": {
+				"preview": {
+					"description": "URL to a preview image of the font",
+					"type": "string"
+				},
+				"fontFamily": {
+					"description": "CSS font-family value.",
+					"type": "string",
+					"default": ""
+				},
+				"fontStyle": {
+					"description": "CSS font-style value.",
+					"type": "string",
+					"default": "normal"
+				},
+				"fontWeight": {
+					"description": "List of available font weights, separated by a space.",
+					"default": "400",
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "integer"
+						}
+					]
+				},
+				"fontDisplay": {
+					"description": "CSS font-display value.",
+					"type": "string",
+					"default": "fallback",
+					"enum": [ "auto", "block", "fallback", "swap", "optional" ]
+				},
+				"src": {
+					"description": "Paths or URLs to the font files.",
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
+					],
+					"default": []
+				},
+				"fontStretch": {
+					"description": "CSS font-stretch value.",
+					"type": "string"
+				},
+				"ascentOverride": {
+					"description": "CSS ascent-override value.",
+					"type": "string"
+				},
+				"descentOverride": {
+					"description": "CSS descent-override value.",
+					"type": "string"
+				},
+				"fontVariant": {
+					"description": "CSS font-variant value.",
+					"type": "string"
+				},
+				"fontFeatureSettings": {
+					"description": "CSS font-feature-settings value.",
+					"type": "string"
+				},
+				"fontVariationSettings": {
+					"description": "CSS font-variation-settings value.",
+					"type": "string"
+				},
+				"lineGapOverride": {
+					"description": "CSS line-gap-override value.",
+					"type": "string"
+				},
+				"sizeAdjust": {
+					"description": "CSS size-adjust value.",
+					"type": "string"
+				},
+				"unicodeRange": {
+					"description": "CSS unicode-range value.",
+					"type": "string"
+				}
+			},
+			"required": [ "fontFamily", "src" ],
+			"additionalProperties": false
+		}
+	},
 	"properties": {
 		"$schema": {
 			"description": "JSON schema URI for font-collection.json.",
@@ -40,30 +133,24 @@
 							"fontFamily": {
 								"description": "CSS font-family value.",
 								"type": "string"
-							}
-						},
-						"additionalProperties": false
-					},
-					"font_faces": {
-						"description": "Array of font-face declarations.",
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"preview": {
-									"type": "string",
-									"description": "URL to a preview image of the font face"
-								},
-								"font_face_settings": {
-									"description": "Font face settings as in theme.json",
+							},
+							"preview": {
+								"type": "string",
+								"description": "URL to a preview image of the font family"
+							},
+							"fontFace": {
+								"description": "Array of font-face declarations.",
+								"type": "array",
+								"items": {
 									"allOf": [
 										{
-											"$ref": "./theme.json#/definitions/fontFace"
+											"$ref": "#/definitions/fontFace"
 										}
 									]
 								}
 							}
-						}
+						},
+						"additionalProperties": false
 					},
 					"categories": {
 						"type": "array",
@@ -71,10 +158,6 @@
 						"items": {
 							"type": "string"
 						}
-					},
-					"preview": {
-						"type": "string",
-						"description": "URL to a preview image of the font family"
 					}
 				},
 				"required": [ "font_family_settings" ],

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -8,7 +8,7 @@
 			"type": "object",
 			"properties": {
 				"preview": {
-					"description": "URL to a preview image of the font",
+					"description": "URL to a preview image of the font.",
 					"type": "string"
 				},
 				"fontFamily": {
@@ -136,7 +136,7 @@
 							},
 							"preview": {
 								"type": "string",
-								"description": "URL to a preview image of the font family"
+								"description": "URL to a preview image of the font family."
 							},
 							"fontFace": {
 								"description": "Array of font-face declarations.",


### PR DESCRIPTION
## What?
Simplify the `font-collection.json` schema.

## Why?
[After removing the not needed `preview` key](https://github.com/WordPress/gutenberg/pull/58395) from the `theme.json` schema, we a[dded some complexity to the `font-collection.json` ](https://github.com/WordPress/gutenberg/pull/58413)schema that was revealed as unnecessary and promoting more complex code down the line, so in this PR, we are reverting part of the complexity added.

## How?
Simplify the `font-collection.json` schema to make it look like `theme.json` font families but with the `preview` key.

## Testing Instructions
Create a JSON file in vscode or other editor with JSON Schema validation and autocomplete.
Add this content to the file:

```json
{
    "$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/ed06197dc046f77a38d290182c632c7d20af7d71/schemas/json/font-collection.json",
    "name": "My Font Collection",
    "slug": "my-font-collection",
    "description": "A collection of my favorite fonts",
    "font_families": [
        {
            "font_family_settings": {
                "fontFamily": "Roboto",
                "name": "Roboto",
                "slug": "roboto",
                "fontFace": [
                    {
                        "fontFamily": "Roboto",
                        "fontStyle": "normal",
                        "fontWeight": "400",
                        "src": "https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Mu4mxP.ttf",
                        "preview": "https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Mu4mxP.ttf"
                    }
                ]
            },
            "categories": [
                "sans-serif"
            ]
        }
    ],
    "categories": [
        {
            "name": "Sans serif",
            "slug": "sans-serif"
        }
    ]
}
```
You should not see any validation error.
If you add keys not present in the schema you should see validation errors.
