### PR TITLE
Font Library: Show 'Add fonts' button when there are no fonts installed

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -9,7 +9,7 @@ import {
 	Button,
 	Tooltip,
 } from '@wordpress/components';
-import { typography } from '@wordpress/icons';
+import { settings } from '@wordpress/icons';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -33,7 +33,7 @@ function FontFamilies() {
 			{ !! modalTabOpen && (
 				<FontLibraryModal
 					onRequestClose={ () => toggleModal() }
-					initialTabName={ modalTabOpen }
+					initialTabId={ modalTabOpen }
 				/>
 			) }
 
@@ -47,7 +47,7 @@ function FontFamilies() {
 									toggleModal( 'installed-fonts' )
 								}
 								aria-label={ __( 'Manage fonts' ) }
-								icon={ typography }
+								icon={ settings }
 								size={ 'small' }
 							/>
 						</Tooltip>
@@ -63,7 +63,16 @@ function FontFamilies() {
 						) ) }
 					</ItemGroup>
 				) : (
-					<>{ __( 'No fonts installed.' ) }</>
+					<>
+						{ __( 'No fonts installed.' ) }
+						<Button
+							className="edit-site-global-styles-font-families__add-fonts"
+							variant="secondary"
+							onClick={ () => toggleModal( 'upload-fonts' ) }
+						>
+							{ __( 'Add fonts' ) }
+						</Button>
+					</>
 				) }
 			</VStack>
 		</>

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -46,6 +46,10 @@
 	color: $gray-700;
 }
 
+.edit-site-global-styles-font-families__add-fonts {
+	justify-content: center;
+}
+
 .edit-site-global-styles-screen-colors {
 	margin: $grid-unit-20;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update the Typography panel in Global Styles to show an 'Add fonts' button when there are no fonts installed. Also switches the `typography` icon to `settings` which better matches other Global Styles panels.

## Why?
Implements the suggestions made in https://github.com/WordPress/gutenberg/issues/55179#issuecomment-1915558985 and https://github.com/WordPress/gutenberg/issues/55179#issuecomment-1921896400.

## Testing Instructions
1. Activate a theme that has fonts e.g. TT4.
1. Navigate to the site editor and open Global Styles.
1. Navigate to Typography. You should see the installed fonts listed and no 'Add fonts' button.
1. Activate a theme that has no fonts e.g. Emptytheme.
1. Navigate to the site editor and open Global Styles.
1. Navigate to Typography. You should see 'No fonts installed.' with an 'Add fonts' button underneath.

## Screenshots or screencast 

<img width="288" alt="Screenshot 2024-02-02 at 10 39 47" src="https://github.com/WordPress/gutenberg/assets/612155/3524460c-db1e-422d-b707-52485fd5acce">
<img width="290" alt="Screenshot 2024-02-02 at 10 40 04" src="https://github.com/WordPress/gutenberg/assets/612155/57b6dfdf-0add-4d28-a1fd-8211f1b70313">
