### PR TITLE
CustomSelect: add tests for new features

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,7 +25,7 @@
 -   `Tabs`: improve controlled mode focus handling and keyboard navigation ([#57696](https://github.com/WordPress/gutenberg/pull/57696)).
 -   `Tabs`: prevent internal focus from updating too early ([#58625](https://github.com/WordPress/gutenberg/pull/58625)).
 -   Expand theming support in the `COLORS` variable object ([#58097](https://github.com/WordPress/gutenberg/pull/58097)).
--   `CustomSelect`: disable `virtualFocus` to fix issue for screenreaders ([#58585](https://github.com/WordPress/gutenberg/pull/58585))
+-   `CustomSelect`: disable `virtualFocus` to fix issue for screenreaders ([#58585](https://github.com/WordPress/gutenberg/pull/58585)).
 
 ### Enhancements
 
@@ -35,6 +35,7 @@
 
 -   `Composite`: Removing Reakit `Composite` implementation ([#58620](https://github.com/WordPress/gutenberg/pull/58620)).
 -   Removing Reakit as a dependency of the components package ([#58631](https://github.com/WordPress/gutenberg/pull/58631)).
+-   `CustomSelect`: add unit tests ([#58583](https://github.com/WordPress/gutenberg/pull/58583)).
 
 ## 25.16.0 (2024-01-24)
 

--- a/packages/components/src/custom-select-control-v2/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/test/index.tsx
@@ -1,0 +1,176 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import { CustomSelect, CustomSelectItem } from '..';
+
+describe( 'CustomSelect', () => {
+	it( 'Should be able to select multiple items when provided an array', async () => {
+		const user = userEvent.setup();
+
+		const defaultValues = [
+			'incandescent glow',
+			'ultraviolet morning light',
+		];
+
+		render(
+			<CustomSelect defaultValue={ defaultValues } label="Multi-select">
+				{ [
+					'aurora borealis green',
+					'flamingo pink sunrise',
+					'incandescent glow',
+					'rose blush',
+					'ultraviolet morning light',
+				].map( ( item ) => (
+					<CustomSelectItem key={ item } value={ item }>
+						{ item }
+					</CustomSelectItem>
+				) ) }
+			</CustomSelect>
+		);
+
+		const currentSelectedItem = screen.getByRole( 'combobox', {
+			expanded: false,
+		} );
+
+		expect( currentSelectedItem ).toHaveTextContent(
+			`${ defaultValues.length } items selected`
+		);
+
+		await user.click( currentSelectedItem );
+
+		expect( screen.getByRole( 'listbox' ) ).toHaveAttribute(
+			'aria-multiselectable'
+		);
+
+		defaultValues.map( ( value ) =>
+			expect(
+				screen.getByRole( 'option', { name: value, selected: true } )
+			).toBeVisible()
+		);
+
+		const nextSelection = screen.getByRole( 'option', {
+			name: 'rose blush',
+		} );
+
+		await user.click( nextSelection );
+
+		expect( nextSelection ).toHaveAttribute( 'aria-selected' );
+
+		expect( currentSelectedItem ).toHaveTextContent(
+			`${ defaultValues.length + 1 } items selected`
+		);
+	} );
+
+	it( 'Should be able to deselect items when provided an array', async () => {
+		const user = userEvent.setup();
+
+		const defaultValues = [
+			'aurora borealis green',
+			'incandescent glow',
+			'key lime green',
+			'rose blush',
+			'ultraviolet morning light',
+		];
+
+		render(
+			<CustomSelect defaultValue={ defaultValues } label="Multi-select">
+				{ defaultValues.map( ( item ) => (
+					<CustomSelectItem key={ item } value={ item }>
+						{ item }
+					</CustomSelectItem>
+				) ) }
+			</CustomSelect>
+		);
+
+		const currentSelectedItem = screen.getByRole( 'combobox', {
+			expanded: false,
+		} );
+
+		expect( currentSelectedItem ).toHaveTextContent(
+			`${ defaultValues.length } items selected`
+		);
+
+		await user.click( currentSelectedItem );
+
+		expect( screen.getByRole( 'listbox' ) ).toHaveAttribute(
+			'aria-multiselectable'
+		);
+
+		defaultValues.map( ( option ) =>
+			expect(
+				screen.getByRole( 'option', { name: option, selected: true } )
+			).toBeVisible()
+		);
+
+		const nextSelection = [
+			'aurora borealis green',
+			'rose blush',
+			'incandescent glow',
+		];
+
+		for ( let i = 0; i < nextSelection.length; i++ ) {
+			await user.click(
+				screen.getByRole( 'option', { name: nextSelection[ i ] } )
+			);
+
+			expect(
+				screen.getByRole( 'option', {
+					name: nextSelection[ i ],
+					selected: false,
+				} )
+			).toBeVisible();
+		}
+
+		expect( currentSelectedItem ).toHaveTextContent(
+			`${ defaultValues.length - nextSelection.length } items selected`
+		);
+	} );
+
+	it( 'Should show rendered content as selected value when using `renderControlledValue`', async () => {
+		const user = userEvent.setup();
+
+		const renderControlledValue = ( value: string | string[] ) => {
+			return (
+				<>
+					<img src={ `${ value }.jpg` } alt={ value as string } />
+					<span>{ value }</span>
+				</>
+			);
+		};
+
+		render(
+			<CustomSelect
+				label="Rendered"
+				renderSelectedValue={ renderControlledValue }
+			>
+				<CustomSelectItem value="april-29">
+					{ renderControlledValue( 'april-29' ) }
+				</CustomSelectItem>
+				<CustomSelectItem value="july-9">
+					{ renderControlledValue( 'july-9' ) }
+				</CustomSelectItem>
+			</CustomSelect>
+		);
+
+		const currentSelectedItem = screen.getByRole( 'combobox', {
+			expanded: false,
+		} );
+
+		expect( currentSelectedItem ).toBeVisible();
+
+		expect( screen.getByRole( 'img', { name: 'april-29' } ) ).toBeVisible();
+
+		expect(
+			screen.queryByRole( 'img', { name: 'july-9' } )
+		).not.toBeInTheDocument();
+
+		await user.click( currentSelectedItem );
+
+		expect( screen.getByRole( 'img', { name: 'july-9' } ) ).toBeVisible();
+	} );
+} );

--- a/packages/components/src/custom-select-control-v2/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/test/index.tsx
@@ -179,12 +179,7 @@ describe.each( [
 		const user = userEvent.setup();
 
 		const renderValue = ( value: string | string[] ) => {
-			return (
-				<>
-					<img src={ `${ value }.jpg` } alt={ value as string } />
-					<span>{ value }</span>
-				</>
-			);
+			return <img src={ `${ value }.jpg` } alt={ value as string } />;
 		};
 
 		render(
@@ -217,5 +212,8 @@ describe.each( [
 
 		// expect that the other image is only visible after opening popover with options
 		expect( screen.getByRole( 'img', { name: 'july-9' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'option', { name: 'july-9' } )
+		).toBeVisible();
 	} );
 } );

--- a/packages/components/src/custom-select-control-v2/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/test/index.tsx
@@ -5,145 +5,174 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { CustomSelect, CustomSelectItem } from '..';
+import type { CustomSelectProps } from '../types';
 
-describe( 'CustomSelect', () => {
-	it( 'Should be able to select multiple items when provided an array', async () => {
-		const user = userEvent.setup();
-		const onChangeMock = jest.fn();
+const ControlledCustomSelect = ( props: CustomSelectProps ) => {
+	const [ value, setValue ] = useState< string | string[] >();
+	return (
+		<CustomSelect
+			{ ...props }
+			onChange={ ( nextValue ) => {
+				setValue( nextValue );
+				props.onChange?.( nextValue );
+			} }
+			value={ value }
+		/>
+	);
+};
 
-		// initial selection as defaultValue
-		const defaultValues = [
-			'incandescent glow',
-			'ultraviolet morning light',
-		];
+describe.each( [
+	[ 'uncontrolled', CustomSelect ],
+	[ 'controlled', ControlledCustomSelect ],
+] )( 'CustomSelect %s', ( ...modeAndComponent ) => {
+	const [ , Component ] = modeAndComponent;
 
-		render(
-			<CustomSelect
-				defaultValue={ defaultValues }
-				onChange={ onChangeMock }
-				label="Multi-select"
-			>
-				{ [
-					'aurora borealis green',
-					'flamingo pink sunrise',
-					'incandescent glow',
-					'rose blush',
-					'ultraviolet morning light',
-				].map( ( item ) => (
-					<CustomSelectItem key={ item } value={ item }>
-						{ item }
-					</CustomSelectItem>
-				) ) }
-			</CustomSelect>
-		);
+	describe( 'Multiple selection', () => {
+		it( 'Should be able to select multiple items when provided an array', async () => {
+			const user = userEvent.setup();
+			const onChangeMock = jest.fn();
 
-		const currentSelectedItem = screen.getByRole( 'combobox', {
-			expanded: false,
-		} );
+			// initial selection as defaultValue
+			const defaultValues = [
+				'incandescent glow',
+				'ultraviolet morning light',
+			];
 
-		// ensure more than one item is selected due to defaultValues
-		expect( currentSelectedItem ).toHaveTextContent(
-			`${ defaultValues.length } items selected`
-		);
+			render(
+				<Component
+					defaultValue={ defaultValues }
+					onChange={ onChangeMock }
+					label="Multi-select"
+				>
+					{ [
+						'aurora borealis green',
+						'flamingo pink sunrise',
+						'incandescent glow',
+						'rose blush',
+						'ultraviolet morning light',
+					].map( ( item ) => (
+						<CustomSelectItem key={ item } value={ item }>
+							{ item }
+						</CustomSelectItem>
+					) ) }
+				</Component>
+			);
 
-		await user.click( currentSelectedItem );
+			const currentSelectedItem = screen.getByRole( 'combobox', {
+				expanded: false,
+			} );
 
-		expect( screen.getByRole( 'listbox' ) ).toHaveAttribute(
-			'aria-multiselectable'
-		);
+			// ensure more than one item is selected due to defaultValues
+			expect( currentSelectedItem ).toHaveTextContent(
+				`${ defaultValues.length } items selected`
+			);
 
-		// ensure defaultValues are selected in list of items
-		defaultValues.forEach( ( value ) =>
-			expect(
-				screen.getByRole( 'option', {
-					name: value,
-					selected: true,
-				} )
-			).toBeVisible()
-		);
+			await user.click( currentSelectedItem );
 
-		// name of next selection
-		const nextSelectionName = 'rose blush';
+			expect( screen.getByRole( 'listbox' ) ).toHaveAttribute(
+				'aria-multiselectable'
+			);
 
-		// element for next selection
-		const nextSelection = screen.getByRole( 'option', {
-			name: nextSelectionName,
-		} );
-
-		// click next selection to add another item to current selection
-		await user.click( nextSelection );
-
-		// updated array containing defaultValues + the item just selected
-		const updatedSelection = defaultValues.concat( nextSelectionName );
-
-		expect( onChangeMock ).toHaveBeenCalledWith( updatedSelection );
-
-		expect( nextSelection ).toHaveAttribute( 'aria-selected' );
-
-		// expect increased array length for current selection
-		expect( currentSelectedItem ).toHaveTextContent(
-			`${ updatedSelection.length } items selected`
-		);
-	} );
-
-	it( 'Should be able to deselect items when provided an array', async () => {
-		const user = userEvent.setup();
-
-		// initial selection as defaultValue
-		const defaultValues = [
-			'aurora borealis green',
-			'incandescent glow',
-			'key lime green',
-			'rose blush',
-			'ultraviolet morning light',
-		];
-
-		render(
-			<CustomSelect defaultValue={ defaultValues } label="Multi-select">
-				{ defaultValues.map( ( item ) => (
-					<CustomSelectItem key={ item } value={ item }>
-						{ item }
-					</CustomSelectItem>
-				) ) }
-			</CustomSelect>
-		);
-
-		const currentSelectedItem = screen.getByRole( 'combobox', {
-			expanded: false,
-		} );
-
-		await user.click( currentSelectedItem );
-
-		// Array containing items to deselect
-		const nextSelection = [
-			'aurora borealis green',
-			'rose blush',
-			'incandescent glow',
-		];
-
-		// Deselect some items by clicking them to ensure that changes
-		// are reflected correctly
-		await Promise.all(
-			nextSelection.map( async ( value ) => {
-				await user.click(
-					screen.getByRole( 'option', { name: value } )
-				);
+			// ensure defaultValues are selected in list of items
+			defaultValues.forEach( ( value ) =>
 				expect(
 					screen.getByRole( 'option', {
 						name: value,
-						selected: false,
+						selected: true,
 					} )
-				).toBeVisible();
-			} )
-		);
+				).toBeVisible()
+			);
 
-		// expect different array length from defaultValues due to deselecting items
-		expect( currentSelectedItem ).toHaveTextContent(
-			`${ defaultValues.length - nextSelection.length } items selected`
-		);
+			// name of next selection
+			const nextSelectionName = 'rose blush';
+
+			// element for next selection
+			const nextSelection = screen.getByRole( 'option', {
+				name: nextSelectionName,
+			} );
+
+			// click next selection to add another item to current selection
+			await user.click( nextSelection );
+
+			// updated array containing defaultValues + the item just selected
+			const updatedSelection = defaultValues.concat( nextSelectionName );
+
+			expect( onChangeMock ).toHaveBeenCalledWith( updatedSelection );
+
+			expect( nextSelection ).toHaveAttribute( 'aria-selected' );
+
+			// expect increased array length for current selection
+			expect( currentSelectedItem ).toHaveTextContent(
+				`${ updatedSelection.length } items selected`
+			);
+		} );
+
+		it( 'Should be able to deselect items when provided an array', async () => {
+			const user = userEvent.setup();
+
+			// initial selection as defaultValue
+			const defaultValues = [
+				'aurora borealis green',
+				'incandescent glow',
+				'key lime green',
+				'rose blush',
+				'ultraviolet morning light',
+			];
+
+			render(
+				<Component defaultValue={ defaultValues } label="Multi-select">
+					{ defaultValues.map( ( item ) => (
+						<CustomSelectItem key={ item } value={ item }>
+							{ item }
+						</CustomSelectItem>
+					) ) }
+				</Component>
+			);
+
+			const currentSelectedItem = screen.getByRole( 'combobox', {
+				expanded: false,
+			} );
+
+			await user.click( currentSelectedItem );
+
+			// Array containing items to deselect
+			const nextSelection = [
+				'aurora borealis green',
+				'rose blush',
+				'incandescent glow',
+			];
+
+			// Deselect some items by clicking them to ensure that changes
+			// are reflected correctly
+			await Promise.all(
+				nextSelection.map( async ( value ) => {
+					await user.click(
+						screen.getByRole( 'option', { name: value } )
+					);
+					expect(
+						screen.getByRole( 'option', {
+							name: value,
+							selected: false,
+						} )
+					).toBeVisible();
+				} )
+			);
+
+			// expect different array length from defaultValues due to deselecting items
+			expect( currentSelectedItem ).toHaveTextContent(
+				`${
+					defaultValues.length - nextSelection.length
+				} items selected`
+			);
+		} );
 	} );
 
 	it( 'Should allow rendering a custom value when using `renderSelectedValue`', async () => {
@@ -159,14 +188,14 @@ describe( 'CustomSelect', () => {
 		};
 
 		render(
-			<CustomSelect label="Rendered" renderSelectedValue={ renderValue }>
+			<Component label="Rendered" renderSelectedValue={ renderValue }>
 				<CustomSelectItem value="april-29">
 					{ renderValue( 'april-29' ) }
 				</CustomSelectItem>
 				<CustomSelectItem value="july-9">
 					{ renderValue( 'july-9' ) }
 				</CustomSelectItem>
-			</CustomSelect>
+			</Component>
 		);
 
 		const currentSelectedItem = screen.getByRole( 'combobox', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I planned to add additional tests for the new component once #57902 is merged. However, I think it would be good to do this before for additional checks that the new features continue to work. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To ensure new features work as intended and future changes like the legacy adapter don't break these features. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding tests for features that aren't included in `CustomSelectControl` (which will be included in this component's tests, after merging #57902). 

> [!NOTE]
> [We were hoping](https://github.com/WordPress/gutenberg/pull/56575#discussion_r1411936918) with the ariakit version we could improve tests so instead of `toHaveTextContent` we would assert `toHaveValue`. However, there isn't a `value` attribute since it's not an HTML input. We could consider adding a data attribute if that would be better than checking the option's text content. 

## Testing Instructions
`npm run:test packages/components/src/custom-select-control-v2/test/index.tsx`


