### PR TITLE
Font Library: Change referenced tab name on Google Fonts confirmation dialog

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/google-fonts-confirm-dialog.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/google-fonts-confirm-dialog.js
@@ -34,7 +34,7 @@ function GoogleFontsConfirmDialog() {
 					<Spacer margin={ 3 } />
 					<Text as="p">
 						{ __(
-							'You can alternatively upload files directly on the Library tab.'
+							'You can alternatively upload files directly on the Upload tab.'
 						) }
 					</Text>
 					<Spacer margin={ 6 } />


### PR DESCRIPTION
Fixes the tab referenced for manual uploads to "Upload" in the Google Fonts dialog.

## What?
I changes the tab name from "Library" to "Upload".

## Why?
Users cannot upload via the referenced Library tab, but must use the Upload tab.

## How?
A string change.

## Testing Instructions
1. If you have previously granted permission for the Font Library to access Google Fonts, in your browser, delete the local storage key for `wp-font-library-google-fonts-permission` to re-enable the dialog.
2. Open the **Styles** panel in the site editor.
3. Open Typography and then the "Manage fonts" icon (the stylized "Aa" glyph above the fonts list), and click the "Install Fonts" tab.
4. The text in the second paragraph of the dialog should read: "You can alternatively upload files directly on the Upload tab."

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast
![SCR-20240201-orsw](https://github.com/WordPress/gutenberg/assets/824344/cf1988c3-1197-49df-b1e3-b9b4a5d39e01)
