### PR TITLE
CustomSelect: disable `virtualFocus` to fix issue for screenreaders

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   `Tabs`: improve controlled mode focus handling and keyboard navigation ([#57696](https://github.com/WordPress/gutenberg/pull/57696)).
 -   `Tabs`: prevent internal focus from updating too early ([#58625](https://github.com/WordPress/gutenberg/pull/58625)).
 -   Expand theming support in the `COLORS` variable object ([#58097](https://github.com/WordPress/gutenberg/pull/58097)).
+-   `CustomSelect`: disable `virtualFocus` to fix issue for screenreaders ([#58585](https://github.com/WordPress/gutenberg/pull/58585))
 
 ### Enhancements
 

--- a/packages/components/src/custom-select-control-v2/index.tsx
+++ b/packages/components/src/custom-select-control-v2/index.tsx
@@ -56,6 +56,8 @@ export function CustomSelect( {
 		setValue: ( nextValue ) => onChange?.( nextValue ),
 		defaultValue,
 		value,
+		// fix for Safari bug: https://github.com/WordPress/gutenberg/issues/55023#issuecomment-1834035917
+		virtualFocus: false,
 	} );
 
 	const { value: currentValue } = store.useState();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

@afercia pointed out an issue in Safari for screenreaders, where multi-selection has incorrect announcements: 

https://github.com/WordPress/gutenberg/issues/55023#issuecomment-1833394967

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Unfortunately, it appears it still hasn't been resolved in Safari, so in preparation for the component to be utilized (#57902), we should have a working solution. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

@diegohaz shared this is a bug in Safari and a solution to use in the meantime: https://github.com/WordPress/gutenberg/issues/55023#issuecomment-1834035917

>Safari has known issues with aria-activedescendant. [It appears the issue is being addressed for combobox widgets in the upcoming version](https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-183#Accessibility:~:text=Fixed%20comboboxes%20not%20notifying%20assistive%20technologies%20when%20aria%2Dactivedescendant%20changes.%20(270182%40main)%20(117747058)). So, we can expect improvements in the near future.

>For now, the aria-activedescendant can be disabled for the Ariakit Select component by setting the [virtualFocus](https://ariakit.org/reference/select-provider#virtualfocus) prop to false. This will enable the use of the roving tabindex approach, which seems to function well on Safari.

## Testing Instructions

1. `npm run:storybook dev` 
2. While using a screen reader, open the select for the 'Multiselect' story. 
3. Ensure it announces the names of unselected items, rather than saying they are selected 

| Before  | After |
| ------------- | ------------- |
| <img width="1335" alt="Screenshot 2024-02-01 at 5 31 46 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/c5f43fdc-f1e8-4859-bd13-4c21cbb87fe2">  | <img width="1324" alt="Screenshot 2024-02-01 at 5 32 32 PM" src="https://github.com/WordPress/gutenberg/assets/35543432/e6b7cf3e-5c44-4123-95b6-3f5e6c9a91ed">  | 

