### PR TITLE
Support button's link settings for Pattern Overrides

### DIFF
--- a/lib/compat/wordpress-6.5/blocks.php
+++ b/lib/compat/wordpress-6.5/blocks.php
@@ -163,7 +163,7 @@ function gutenberg_process_block_bindings( $block_content, $block, $block_instan
 		'core/paragraph' => array( 'content' ),
 		'core/heading'   => array( 'content' ),
 		'core/image'     => array( 'url', 'title', 'alt' ),
-		'core/button'    => array( 'url', 'text' ),
+		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 	);
 
 	// If the block doesn't have the bindings property or isn't one of the allowed block types, return.

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -147,10 +147,13 @@ function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
 				defaultValues[ blockId ][ attributeKey ]
 			) {
 				content[ blockId ] ??= { values: {} };
-				// TODO: We need a way to represent `undefined` in the serialized overrides.
-				// Also see: https://github.com/WordPress/gutenberg/pull/57249#discussion_r1452987871
 				content[ blockId ].values[ attributeKey ] =
-					block.attributes[ attributeKey ];
+					block.attributes[ attributeKey ] === undefined
+						? // TODO: We use an empty string to represent undefined for now until
+						  // we support a richer format for overrides and the block binding API.
+						  // Currently only the `linkTarget` attribute of `core/button` is affected.
+						  ''
+						: block.attributes[ attributeKey ];
 			}
 		}
 	}

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -27,6 +27,8 @@ export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 	'core/button': {
 		text: __( 'Text' ),
 		url: __( 'URL' ),
+		linkTarget: __( 'Link Target' ),
+		rel: __( 'Link Relationship' ),
 	},
 	'core/image': {
 		url: __( 'URL' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #53705. Support both `linkTarget` and `rel` of `core/button` for Pattern Overrides.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
These attributes are editable in the UI but not saved in the overrides.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use an empty string to represent `undefined` for now until the block binding API supports a richer format.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Added an e2e test.

1. Create a pattern with a button block and toggle the "Allow instance overrides" in the advanced block settings.
2. Set a link to the button and check the "Open in new tab" and "Mark as nofollow" checkboxes.
3. Insert the pattern in a post.
4. Override the link settings and try different combinations.
5. Check the saved post on the frontend as well.

## Screenshots or screencast <!-- if applicable -->
