### PR TITLE
Navigation: Update the fallback block list to avoid a PHP Warning

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -968,7 +968,9 @@ function block_core_navigation_block_contains_core_navigation( $inner_blocks ) {
 function block_core_navigation_get_fallback_blocks() {
 	$page_list_fallback = array(
 		array(
-			'blockName' => 'core/page-list',
+			'blockName'    => 'core/page-list',
+			'innerContent' => array(),
+			'attrs'        => array(),
 		),
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR avoids PHP Warnings in `traverse_and_serialize_block()` which expects that `innerContent` and `attrs` are set.

I'm unsure if this is the proper place for the fix, or if the above function needs updating to properly handle a `$block` variable of `[ 'blockName' => 'core/block-name' ]` without the before mentioned parameters. I can see reasons for both.

Based on https://github.com/WordPress/gutenberg/blob/b859f54ccf1ae1c8d1296ddf93f23c614cb2d240/packages/block-library/src/navigation/index.php#L1376-L1381 this probably belongs here, but perhaps it should also be setting `innerBlocks` too like that?

It appears this was recently introduced with #57754 cc @tjcafferkey 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Note: These warnings are on wordpress.org/showcase with Gutenberg 17.x, warning weren't present on 16.8

The code as-is, causes the following notices on WordPress Trunk:
```
WARNING: wp-includes/blocks.php:1114 - Undefined array key "innerContent"
require('wp-blog-header.php'), require_once('wp-includes/template-loader.php'), include('wp-includes/template-canvas.php'), get_the_block_template_html, do_blocks, render_block, WP_Block->render, render_block_core_template_part, do_blocks, render_block, WP_Block->render, render_block_core_pattern, do_blocks, render_block, WP_Block->render, WP_Block->render, render_block_core_navigation, WP_Navigation_Block_Renderer::render, WP_Navigation_Block_Renderer::get_inner_blocks, WP_Navigation_Block_Renderer::get_inner_blocks_from_fallback, block_core_navigation_get_fallback_blocks, block_core_navigation_insert_hooked_blocks, traverse_and_serialize_block, traverse_and_serialize_block

WARNING: wp-includes/blocks.php:1114 - foreach() argument must be of type array|object, null given
require('wp-blog-header.php'), require_once('wp-includes/template-loader.php'), include('wp-includes/template-canvas.php'), get_the_block_template_html, do_blocks, render_block, WP_Block->render, render_block_core_template_part, do_blocks, render_block, WP_Block->render, render_block_core_pattern, do_blocks, render_block, WP_Block->render, WP_Block->render, render_block_core_navigation, WP_Navigation_Block_Renderer::render, WP_Navigation_Block_Renderer::get_inner_blocks, WP_Navigation_Block_Renderer::get_inner_blocks_from_fallback, block_core_navigation_get_fallback_blocks, block_core_navigation_insert_hooked_blocks, traverse_and_serialize_block, traverse_and_serialize_block

WARNING: wp-includes/blocks.php:1149 - Undefined array key "attrs"
require('wp-blog-header.php'), require_once('wp-includes/template-loader.php'), include('wp-includes/template-canvas.php'), get_the_block_template_html, do_blocks, render_block, WP_Block->render, render_block_core_template_part, do_blocks, render_block, WP_Block->render, render_block_core_pattern, do_blocks, render_block, WP_Block->render, WP_Block->render, render_block_core_navigation, WP_Navigation_Block_Renderer::render, WP_Navigation_Block_Renderer::get_inner_blocks, WP_Navigation_Block_Renderer::get_inner_blocks_from_fallback, block_core_navigation_get_fallback_blocks, block_core_navigation_insert_hooked_blocks, traverse_and_serialize_block, traverse_and_serialize_block

```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Sets the missing array indexes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Unknown. It's triggered on wordpress.org/showcase, I'm assuming that a navigation menu block is used without a fallback menu present.

