### PR TITLE
Drag and drop: Allow dragging from inserter or desktop to template parts

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -524,7 +524,7 @@ function BlockListBlockProvider( props ) {
 				__unstableIsFullySelected,
 				__unstableSelectionHasUnmergeableBlock,
 				isBlockBeingDragged,
-				isDraggingBlocks,
+				isDragging,
 				hasBlockMovingClientId,
 				canInsertBlockType,
 				__unstableHasActiveBlockOverlayActive,
@@ -602,7 +602,7 @@ function BlockListBlockProvider( props ) {
 				isOutlineEnabled: outlineMode,
 				hasOverlay:
 					__unstableHasActiveBlockOverlayActive( clientId ) &&
-					! isDraggingBlocks(),
+					! isDragging(),
 				initialPosition:
 					_isSelected && __unstableGetEditorMode() === 'edit'
 						? getSelectedBlocksInitialCaretPosition()

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -199,7 +199,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getBlockRootClientId,
 				getBlockEditingMode,
 				getBlockSettings,
-				isDraggingBlocks,
+				isDragging,
 			} = unlock( select( blockEditorStore ) );
 			const { hasBlockSupport, getBlockType } = select( blocksStore );
 			const blockName = getBlockName( clientId );
@@ -219,7 +219,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 					! isBlockSelected( clientId ) &&
 					! hasSelectedInnerBlock( clientId, true ) &&
 					enableClickThrough &&
-					! isDraggingBlocks(),
+					! isDragging(),
 				name: blockName,
 				blockType: getBlockType( blockName ),
 				parentLock: getTemplateLock( parentClientId ),

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -7,12 +7,15 @@ import {
 	serialize,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+
 /**
  * Internal dependencies
  */
 import BlockDraggableChip from '../block-draggable/draggable-chip';
 import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const InserterDraggableBlocks = ( {
 	isEnabled,
@@ -36,11 +39,16 @@ const InserterDraggableBlocks = ( {
 		[ blocks ]
 	);
 
+	const { startDragging, stopDragging } = unlock(
+		useDispatch( blockEditorStore )
+	);
+
 	return (
 		<Draggable
 			__experimentalTransferDataType="wp-blocks"
 			transferData={ transferData }
 			onDragStart={ ( event ) => {
+				startDragging();
 				const parsedBlocks =
 					pattern?.type === INSERTER_PATTERN_TYPES.user &&
 					pattern?.syncStatus !== 'unsynced'
@@ -50,6 +58,9 @@ const InserterDraggableBlocks = ( {
 					'text/html',
 					serialize( parsedBlocks )
 				);
+			} }
+			onDragEnd={ () => {
+				stopDragging();
 			} }
 			__experimentalDragComponent={
 				<BlockDraggableChip

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -332,6 +332,8 @@ export default function useBlockDropZone( {
 		useCallback(
 			( event, ownerDocument ) => {
 				if ( ! isDragging() ) {
+					// When dragging from the desktop, no drag start event is fired.
+					// So, ensure that the drag state is set when the user drags over a drop zone.
 					startDragging();
 				}
 				const allowedBlocks = getAllowedBlocks( targetRootClientId );

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -370,3 +370,25 @@ export function registerBlockBindingsSource( source ) {
 		lockAttributesEditing: source.lockAttributesEditing,
 	};
 }
+
+/**
+ * Returns an action object used in signalling that the user has begun to drag.
+ *
+ * @return {Object} Action object.
+ */
+export function startDragging() {
+	return {
+		type: 'START_DRAGGING',
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the user has stopped dragging.
+ *
+ * @return {Object} Action object.
+ */
+export function stopDragging() {
+	return {
+		type: 'STOP_DRAGGING',
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -344,3 +344,14 @@ export function getAllBlockBindingsSources( state ) {
 export function getBlockBindingsSource( state, sourceName ) {
 	return state.blockBindingsSources[ sourceName ];
 }
+
+/**
+ * Returns true if the user is dragging, or false otherwise.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether user is dragging.
+ */
+export function isDragging( state ) {
+	return !! state.isDragging;
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -346,7 +346,9 @@ export function getBlockBindingsSource( state, sourceName ) {
 }
 
 /**
- * Returns true if the user is dragging, or false otherwise.
+ * Returns true if the user is dragging anything, or false otherwise. It is possible for a
+ * user to be dragging data from outside of the editor, so this selector is separate from
+ * the `isDraggingBlocks` selector which only returns true if the user is dragging blocks.
  *
  * @param {Object} state Global application state.
  *

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -353,5 +353,5 @@ export function getBlockBindingsSource( state, sourceName ) {
  * @return {boolean} Whether user is dragging.
  */
 export function isDragging( state ) {
-	return !! state.isDragging;
+	return state.isDragging;
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1247,6 +1247,27 @@ export function isTyping( state = false, action ) {
 }
 
 /**
+ * Reducer returning dragging state. It is possible for a user to be dragging
+ * data from outside of the editor, so this state is separate from `draggedBlocks`.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function isDragging( state = false, action ) {
+	switch ( action.type ) {
+		case 'START_DRAGGING':
+			return true;
+
+		case 'STOP_DRAGGING':
+			return false;
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning dragged block client id.
  *
  * @param {string[]} state  Current state.
@@ -2048,6 +2069,7 @@ function blockPatterns( state = [], action ) {
 
 const combinedReducers = combineReducers( {
 	blocks,
+	isDragging,
 	isTyping,
 	isBlockInterfaceHidden,
 	draggedBlocks,

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -6,6 +6,8 @@ import {
 	showBlockInterface,
 	__experimentalUpdateSettings,
 	setOpenedBlockSettingsMenu,
+	startDragging,
+	stopDragging,
 } from '../private-actions';
 
 describe( 'private actions', () => {
@@ -92,6 +94,22 @@ describe( 'private actions', () => {
 			expect( setOpenedBlockSettingsMenu( 'abcd' ) ).toEqual( {
 				clientId: 'abcd',
 				type: 'SET_OPENED_BLOCK_SETTINGS_MENU',
+			} );
+		} );
+	} );
+
+	describe( 'startDragging', () => {
+		it( 'should return the START_DRAGGING action', () => {
+			expect( startDragging() ).toEqual( {
+				type: 'START_DRAGGING',
+			} );
+		} );
+	} );
+
+	describe( 'stopDragging', () => {
+		it( 'should return the STOP_DRAGGING action', () => {
+			expect( stopDragging() ).toEqual( {
+				type: 'STOP_DRAGGING',
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -7,6 +7,7 @@ import {
 	isBlockSubtreeDisabled,
 	getEnabledClientIdsTree,
 	getEnabledBlockParents,
+	isDragging,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 
@@ -475,6 +476,24 @@ describe( 'private selectors', () => {
 				'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
 				'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
 			] );
+		} );
+	} );
+
+	describe( 'isDragging', () => {
+		it( 'should return true if the dragging state is true', () => {
+			const state = {
+				isDragging: true,
+			};
+
+			expect( isDragging( state ) ).toBe( true );
+		} );
+
+		it( 'should return false if the dragging state is false', () => {
+			const state = {
+				isDragging: false,
+			};
+
+			expect( isDragging( state ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -21,6 +21,7 @@ import {
 	blocks,
 	isBlockInterfaceHidden,
 	isTyping,
+	isDragging,
 	draggedBlocks,
 	selection,
 	initialPosition,
@@ -2439,6 +2440,24 @@ describe( 'state', () => {
 		it( 'should set the typing flag to false', () => {
 			const state = isTyping( false, {
 				type: 'STOP_TYPING',
+			} );
+
+			expect( state ).toBe( false );
+		} );
+	} );
+
+	describe( 'isDragging', () => {
+		it( 'should set the dragging flag to true', () => {
+			const state = isDragging( false, {
+				type: 'START_DRAGGING',
+			} );
+
+			expect( state ).toBe( true );
+		} );
+
+		it( 'should set the dragging flag to false', () => {
+			const state = isDragging( true, {
+				type: 'STOP_DRAGGING',
 			} );
 
 			expect( state ).toBe( false );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follows on from #58423 and fixes #56182

Allow dragging from the block inserter into template parts, and allow dragging from the desktop to template parts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As flagged by @annezazu in testing (see: https://github.com/WordPress/gutenberg/issues/56182#issuecomment-1922298812), when dragging from the block inserter (or from the desktop) the behaviour to allow dragging into template parts isn't in place — the overlay still prevents the dragging from happening. It turns out, there are places where `isDraggingBlocks` is insufficient to detect whether the user is dragging. In both cases (dragging from the inserter or from the desktop) there is no "block" being dragged as it hasn't been created yet.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add some additional state in the block editor to track when dragging starts and when it ends. This is a generic boolean, rather than storing any data about blocks being dragged.

When starting to drag from the inserter, and in the throttled drag handler in the editor's drop zones, we set this state to `true`. When the drag ends, we set it to `false`.

Then, use this state to skip adding the block overlay while a user is dragging. The result should be that we can now drag into the template part, but if a user goes to click on a block within the template part, as on trunk, they'll first select the template part, before clicking again to select further within it.

***Note:*** This PR does add additional state to the block editor store — unfortunately due to how dragging from the desktop works and that mouse events are not fired when dragging over the window, I couldn't work out a way to implement this without the additional state. Hopefully, it's fairly simple state, though 🤞

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a template (without the Header being selected) open up the block inserter and drag a paragraph block somewhere within the Header template part. With this PR applied, this should be possible.
2. Again, with a block elsewhere in the template selected (i.e. don't have the Header selected), drag a file from the desktop on to the Header template part. With this PR applied, this should be possible.
3. Double-check that dragging and dropping otherwise works as on trunk in the post and site editors.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Dragging from the inserter

https://github.com/WordPress/gutenberg/assets/14988353/dc64cd48-2be6-471c-8e94-e273617821b4

### Dragging from the desktop

https://github.com/WordPress/gutenberg/assets/14988353/820e014c-2832-4c3a-b3e5-3f4b1e73b126