### PR TITLE
Font Library REST API: sanitize font family and font face settings

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 	 */
 	class WP_Font_Utils {
 		/**
-		 * Sanitize and formats font family names.
+		 * Sanitizes and formats font family names.
 		 *
 		 * - Applies `sanitize_text_field`
 		 * - Adds surrounding quotes to names that contain spaces and are not already quoted

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -74,7 +74,6 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * @access private
 		 *
 		 * @link https://drafts.csswg.org/css-fonts/#font-style-matching
-		 * @uses sanitize_text_field()
 		 *
 		 * @param array $settings {
 		 *     Font face settings.

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 	 */
 	class WP_Font_Utils {
 		/**
-		 * Sanitize font family names.
+		 * Sanitize and formats font family names.
 		 *
 		 * - Applies `sanitize_text_field`
 		 * - Adds surrounding quotes to names that contain spaces and are not already quoted
@@ -32,8 +32,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * @see sanitize_text_field()
 		 *
 		 * @param string $font_family Font family name(s), comma-separated.
-		 *
-		 * @return string Formatted font family name(s).
+		 * @return string Sanitized and formatted font family name(s).
 		 */
 		public static function sanitize_font_family( $font_family ) {
 			if ( ! $font_family ) {
@@ -45,7 +44,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 			$wrapped_font_families = array_map(
 				function ( $family ) {
 					$trimmed = trim( $family );
-					if ( ! empty( $trimmed ) && strpos( $trimmed, ' ' ) !== false && strpos( $trimmed, "'" ) === false && strpos( $trimmed, '"' ) === false ) {
+					if ( ! empty( $trimmed ) && false !== strpos( $trimmed, ' ' ) && false === strpos( $trimmed, "'" ) && false === strpos( $trimmed, '"' ) ) {
 							return '"' . $trimmed . '"';
 					}
 					return $trimmed;

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -74,6 +74,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * @access private
 		 *
 		 * @link https://drafts.csswg.org/css-fonts/#font-style-matching
+		 * @uses sanitize_text_field()
 		 *
 		 * @param array $settings {
 		 *     Font face settings.

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -21,35 +21,42 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 	 */
 	class WP_Font_Utils {
 		/**
-		 * Format font family names.
+		 * Sanitize font family names.
 		 *
-		 * Adds surrounding quotes to font family names containing spaces and not already quoted.
+		 * - Applies `sanitize_text_field`
+		 * - Adds surrounding quotes to names that contain spaces and are not already quoted
 		 *
 		 * @since 6.5.0
 		 * @access private
 		 *
+		 * @see sanitize_text_field()
+		 *
 		 * @param string $font_family Font family name(s), comma-separated.
+		 *
 		 * @return string Formatted font family name(s).
 		 */
-		public static function format_font_family( $font_family ) {
-			if ( $font_family ) {
-				$font_families         = explode( ',', $font_family );
-				$wrapped_font_families = array_map(
-					function ( $family ) {
-						$trimmed = trim( $family );
-						if ( ! empty( $trimmed ) && strpos( $trimmed, ' ' ) !== false && strpos( $trimmed, "'" ) === false && strpos( $trimmed, '"' ) === false ) {
-								return '"' . $trimmed . '"';
-						}
-						return $trimmed;
-					},
-					$font_families
-				);
+		public static function sanitize_font_family( $font_family ) {
+			if ( ! $font_family ) {
+				return '';
+			}
 
-				if ( count( $wrapped_font_families ) === 1 ) {
-					$font_family = $wrapped_font_families[0];
-				} else {
-					$font_family = implode( ', ', $wrapped_font_families );
-				}
+			$font_family           = sanitize_text_field( $font_family );
+			$font_families         = explode( ',', $font_family );
+			$wrapped_font_families = array_map(
+				function ( $family ) {
+					$trimmed = trim( $family );
+					if ( ! empty( $trimmed ) && strpos( $trimmed, ' ' ) !== false && strpos( $trimmed, "'" ) === false && strpos( $trimmed, '"' ) === false ) {
+							return '"' . $trimmed . '"';
+					}
+					return $trimmed;
+				},
+				$font_families
+			);
+
+			if ( count( $wrapped_font_families ) === 1 ) {
+				$font_family = $wrapped_font_families[0];
+			} else {
+				$font_family = implode( ', ', $wrapped_font_families );
 			}
 
 			return $font_family;
@@ -128,7 +135,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 				$slug_elements
 			);
 
-			return join( ';', $slug_elements );
+			return sanitize_text_field( join( ';', $slug_elements ) );
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -231,7 +231,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 
 			// Sanitize settings based on callbacks in the schema.
 			foreach ( $settings as $key => $value ) {
-				$sanitize_callback = $schema[ $key ]['sanitize_callback'];
+				$sanitize_callback = $schema[ $key ]['arg_options']['sanitize_callback'];
 				$settings[ $key ]  = call_user_func( $sanitize_callback, $value );
 			}
 
@@ -509,43 +509,51 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 						'context'              => array( 'view', 'edit', 'embed' ),
 						'properties'           => array(
 							'fontFamily'            => array(
-								'description'       => __( 'CSS font-family value.', 'gutenberg' ),
-								'type'              => 'string',
-								'default'           => '',
-								'sanitize_callback' => array( 'WP_Font_Utils', 'sanitize_font_family' ),
+								'description' => __( 'CSS font-family value.', 'gutenberg' ),
+								'type'        => 'string',
+								'default'     => '',
+								'arg_options' => array(
+									'sanitize_callback' => array( 'WP_Font_Utils', 'sanitize_font_family' ),
+								),
 							),
 							'fontStyle'             => array(
-								'description'       => __( 'CSS font-style value.', 'gutenberg' ),
-								'type'              => 'string',
-								'default'           => 'normal',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS font-style value.', 'gutenberg' ),
+								'type'        => 'string',
+								'default'     => 'normal',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'fontWeight'            => array(
-								'description'       => __( 'List of available font weights, separated by a space.', 'gutenberg' ),
-								'default'           => '400',
+								'description' => __( 'List of available font weights, separated by a space.', 'gutenberg' ),
+								'default'     => '400',
 								// Changed from `oneOf` to avoid errors from loose type checking.
 								// e.g. a fontWeight of "400" validates as both a string and an integer due to is_numeric check.
-								'type'              => array( 'string', 'integer' ),
-								'sanitize_callback' => 'sanitize_text_field',
+								'type'        => array( 'string', 'integer' ),
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'fontDisplay'           => array(
-								'description'       => __( 'CSS font-display value.', 'gutenberg' ),
-								'type'              => 'string',
-								'default'           => 'fallback',
-								'enum'              => array(
+								'description' => __( 'CSS font-display value.', 'gutenberg' ),
+								'type'        => 'string',
+								'default'     => 'fallback',
+								'enum'        => array(
 									'auto',
 									'block',
 									'fallback',
 									'swap',
 									'optional',
 								),
-								'sanitize_callback' => 'sanitize_text_field',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'src'                   => array(
-								'description'       => __( 'Paths or URLs to the font files.', 'gutenberg' ),
+								'description' => __( 'Paths or URLs to the font files.', 'gutenberg' ),
 								// Changed from `oneOf` to `anyOf` due to rest_sanitize_array converting a string into an array,
 								// and causing a "matches more than one of the expected formats" error.
-								'anyOf'             => array(
+								'anyOf'       => array(
 									array(
 										'type' => 'string',
 									),
@@ -556,63 +564,85 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 										),
 									),
 								),
-								'default'           => array(),
-								'sanitize_callback' => function ( $value ) {
-									if ( is_string( $value ) ) {
-										return sanitize_text_field( $value );
-									}
-									return array_map( 'sanitize_text_field', $value );
-								},
+								'default'     => array(),
+								'arg_options' => array(
+									'sanitize_callback' => function ( $value ) {
+										if ( is_string( $value ) ) {
+											return sanitize_text_field( $value );
+										}
+										return array_map( 'sanitize_text_field', $value );
+									},
+								),
 							),
 							'fontStretch'           => array(
-								'description'       => __( 'CSS font-stretch value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS font-stretch value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'ascentOverride'        => array(
-								'description'       => __( 'CSS ascent-override value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS ascent-override value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'descentOverride'       => array(
-								'description'       => __( 'CSS descent-override value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS descent-override value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'fontVariant'           => array(
-								'description'       => __( 'CSS font-variant value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS font-variant value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'fontFeatureSettings'   => array(
-								'description'       => __( 'CSS font-feature-settings value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS font-feature-settings value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'fontVariationSettings' => array(
-								'description'       => __( 'CSS font-variation-settings value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS font-variation-settings value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'lineGapOverride'       => array(
-								'description'       => __( 'CSS line-gap-override value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS line-gap-override value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'sizeAdjust'            => array(
-								'description'       => __( 'CSS size-adjust value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS size-adjust value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'unicodeRange'          => array(
-								'description'       => __( 'CSS unicode-range value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'CSS unicode-range value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'preview'               => array(
-								'description'       => __( 'URL to a preview image of the font face.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_url',
+								'description' => __( 'URL to a preview image of the font face.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_url',
+								),
 							),
 						),
 						'required'             => array( 'fontFamily', 'src' ),
@@ -624,6 +654,26 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 			$this->schema = $schema;
 
 			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		/**
+		 * Retrieves the item's schema for display / public consumption purposes.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array Public item schema data.
+		 */
+		public function get_public_item_schema() {
+
+			$schema = parent::get_public_item_schema();
+
+			// Also remove `arg_options' from child font_family_settings properties, since the parent
+			// controller only handles the top level properties.
+			foreach ( $schema['properties']['font_face_settings']['properties'] as &$property ) {
+				unset( $property['arg_options'] );
+			}
+
+			return $schema;
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -192,6 +192,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 
 			foreach ( $srcs as $src ) {
 				// Check that each src is a non-empty string.
+				$src = ltrim( $src );
 				if ( empty( $src ) ) {
 					return new WP_Error(
 						'rest_invalid_param',
@@ -833,6 +834,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 * @return string Sanitized $src value.
 		 */
 		protected function sanitize_src( $value ) {
+			$value = ltrim( $value );
 			return false === wp_http_validate_url( $value ) ? (string) $value : sanitize_url( $value );
 		}
 

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -212,7 +212,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				}
 			}
 
-			// Check that each file in the request references a src in the settings
+			// Check that each file in the request references a src in the settings.
 			foreach ( array_keys( $files ) as $file ) {
 				if ( ! in_array( $file, $srcs, true ) ) {
 					return new WP_Error(
@@ -825,13 +825,13 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		}
 
 		/**
-		 * Sanitizes a single src value when creating a font face.
+		 * Sanitizes a single src value for a font face.
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param string $value Font face src that is a url or a key for a $_FILES item.
+		 * @param string $value Font face src that is a URL or the key for a $_FILES array item.
 		 *
-		 * @return string Sanitized $src value.
+		 * @return string Sanitized value.
 		 */
 		protected function sanitize_src( $value ) {
 			$value = ltrim( $value );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 
 			// Sanitize settings based on callbacks in the schema.
 			foreach ( $settings as $key => $value ) {
-				$sanitize_callback = $schema[ $key ]['sanitize_callback'];
+				$sanitize_callback = $schema[ $key ]['arg_options']['sanitize_callback'];
 				$settings[ $key ]  = call_user_func( $sanitize_callback, $value );
 			}
 
@@ -311,26 +311,34 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 						'context'              => array( 'view', 'edit', 'embed' ),
 						'properties'           => array(
 							'name'       => array(
-								'description'       => __( 'Name of the font family preset, translatable.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_text_field',
+								'description' => __( 'Name of the font family preset, translatable.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_text_field',
+								),
 							),
 							'slug'       => array(
-								'description'       => __( 'Kebab-case unique identifier for the font family preset.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => 'sanitize_title',
+								'description' => __( 'Kebab-case unique identifier for the font family preset.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_title',
+								),
 							),
 							'fontFamily' => array(
-								'description'       => __( 'CSS font-family value.', 'gutenberg' ),
-								'type'              => 'string',
-								'sanitize_callback' => array( 'WP_Font_Utils', 'sanitize_font_family' ),
+								'description' => __( 'CSS font-family value.', 'gutenberg' ),
+								'type'        => 'string',
+								'arg_options' => array(
+									'sanitize_callback' => array( 'WP_Font_Utils', 'sanitize_font_family' ),
+								),
 							),
 							'preview'    => array(
-								'description'       => __( 'URL to a preview image of the font family.', 'gutenberg' ),
-								'type'              => 'string',
-								'format'            => 'uri',
-								'default'           => '',
-								'sanitize_callback' => 'sanitize_url',
+								'description' => __( 'URL to a preview image of the font family.', 'gutenberg' ),
+								'type'        => 'string',
+								'format'      => 'uri',
+								'default'     => '',
+								'arg_options' => array(
+									'sanitize_callback' => 'sanitize_url',
+								),
 							),
 						),
 						'required'             => array( 'name', 'slug', 'fontFamily' ),
@@ -342,6 +350,26 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 			$this->schema = $schema;
 
 			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		/**
+		 * Retrieves the item's schema for display / public consumption purposes.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return array Public item schema data.
+		 */
+		public function get_public_item_schema() {
+
+			$schema = parent::get_public_item_schema();
+
+			// Also remove `arg_options' from child font_family_settings properties, since the parent
+			// controller only handles the top level properties.
+			foreach ( $schema['properties']['font_family_settings']['properties'] as &$property ) {
+				unset( $property['arg_options'] );
+			}
+
+			return $schema;
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -150,7 +150,7 @@ function gutenberg_register_font_collections() {
 	// TODO: update to production font collection URL.
 	wp_register_font_collection( 'google-fonts', 'https://raw.githubusercontent.com/WordPress/google-fonts-to-wordpress-collection/01aa57731575bd13f9db8d86ab80a2d74e28a1ac/releases/gutenberg-17.6/collections/google-fonts-with-preview.json' );
 }
-add_action( 'init', 'gutenberg_register_font_collections' );
+// add_action( 'init', 'gutenberg_register_font_collections' );
 
 // @core-merge: This code should probably go into Core's src/wp-includes/functions.php.
 if ( ! function_exists( 'wp_get_font_dir' ) ) {

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -150,7 +150,7 @@ function gutenberg_register_font_collections() {
 	// TODO: update to production font collection URL.
 	wp_register_font_collection( 'google-fonts', 'https://raw.githubusercontent.com/WordPress/google-fonts-to-wordpress-collection/01aa57731575bd13f9db8d86ab80a2d74e28a1ac/releases/gutenberg-17.6/collections/google-fonts-with-preview.json' );
 }
-// add_action( 'init', 'gutenberg_register_font_collections' );
+add_action( 'init', 'gutenberg_register_font_collections' );
 
 // @core-merge: This code should probably go into Core's src/wp-includes/functions.php.
 if ( ! function_exists( 'wp_get_font_dir' ) ) {

--- a/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
+++ b/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
@@ -54,6 +54,10 @@ class Tests_Fonts_WpFontUtils_SanitizeFontFamily extends WP_UnitTestCase {
 				'font_family' => ' ',
 				'expected'    => '',
 			),
+			'data_font_family_with_whitespace_tags_new_lines' => array(
+				'font_family' => "   Rock      3D</style><script>alert('XSS');</script>\n    ",
+				'expected'    => '"Rock 3D"',
+			),
 		);
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
+++ b/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test WP_Font_Utils::format_font_family().
+ * Test WP_Font_Utils::sanitize_font_family().
  *
  * @package WordPress
  * @subpackage Font Library
@@ -8,20 +8,20 @@
  * @group fonts
  * @group font-library
  *
- * @covers WP_Font_Utils::format_font_family
+ * @covers WP_Font_Utils::sanitize_font_family
  */
-class Tests_Fonts_WpFontUtils_FormatFontFamily extends WP_UnitTestCase {
+class Tests_Fonts_WpFontUtils_SanitizeFontFamily extends WP_UnitTestCase {
 
 	/**
-	 * @dataProvider data_should_format_font_family
+	 * @dataProvider data_should_sanitize_font_family
 	 *
 	 * @param string $font_family Font family to test.
 	 * @param string $expected    Expected family.
 	 */
-	public function test_should_format_font_family( $font_family, $expected ) {
+	public function test_should_sanitize_font_family( $font_family, $expected ) {
 		$this->assertSame(
 			$expected,
-			WP_Font_Utils::format_font_family(
+			WP_Font_Utils::sanitize_font_family(
 				$font_family
 			)
 		);
@@ -32,7 +32,7 @@ class Tests_Fonts_WpFontUtils_FormatFontFamily extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_should_format_font_family() {
+	public function data_should_sanitize_font_family() {
 		return array(
 			'data_families_with_spaces_and_numbers' => array(
 				'font_family' => 'Rock 3D , Open Sans,serif',

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -993,7 +993,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		foreach ( $font_face_settings_schema['properties'] as $property ) {
 			$this->assertArrayHasKey( 'arg_options', $property, 'Setting schema should have arg_options.' );
 			$this->assertArrayHasKey( 'sanitize_callback', $property['arg_options'], 'Setting schema should have a sanitize_callback.' );
-			$this->assertIsCallable( $property['arg_options']['sanitize_callback'], 'sanitize_callback should be callable.' );
+			$this->assertIsCallable( $property['arg_options']['sanitize_callback'], 'The sanitize_callback value should be callable.' );
 		}
 	}
 

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -711,12 +711,13 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$files = $this->setup_font_file_upload( array( 'woff2' ) );
 
 		wp_set_current_user( self::$admin_id );
+		$src     = 'invalid';
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
 		$request->set_param( 'theme_json_version', 2 );
 		$request->set_param(
 			'font_face_settings',
 			wp_json_encode(
-				array_merge( self::$default_settings, array( 'src' => 'invalid' ) )
+				array_merge( self::$default_settings, array( 'src' => $src ) )
 			)
 		);
 		$request->set_file_params( $files );
@@ -724,7 +725,32 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
-		$expected_message = 'File ' . array_keys( $files )[0] . ' must be used in font_face_settings[src].';
+		$expected_message = 'font_face_settings[src] value "' . $src . '" must be a valid URL or file reference.';
+		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_face_settings'];
+		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
+	}
+
+	/**
+	 * @covers WP_REST_Font_Faces_Controller::validate_create_font_face_settings
+	 */
+	public function test_create_item_missing_file_src() {
+		$files = $this->setup_font_file_upload( array( 'woff2', 'woff' ) );
+
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
+		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param(
+			'font_face_settings',
+			wp_json_encode(
+				array_merge( self::$default_settings, array( 'src' => array( array_keys( $files )[0] ) ) )
+			)
+		);
+		$request->set_file_params( $files );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
+		$expected_message = 'File ' . array_keys( $files )[1] . ' must be used in font_face_settings[src].';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_face_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
 	}

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -905,6 +905,40 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$this->assertArrayHasKey( 'font_face_settings', $properties, 'The id property should exist in the schema::properties data.' );
 	}
 
+	/**
+	 * @covers WP_REST_Font_Faces_Controller::get_item_schema
+	 */
+	public function test_get_item_schema_font_face_settings_should_all_have_sanitize_callbacks() {
+		$schema                    = ( new WP_REST_Font_Faces_Controller( 'wp_font_face' ) )->get_item_schema();
+		$font_face_settings_schema = $schema['properties']['font_face_settings'];
+
+		$this->assertArrayHasKey( 'properties', $font_face_settings_schema, 'font_face_settings schema is missing properties.' );
+		$this->assertIsArray( $font_face_settings_schema['properties'], 'font_face_settings properties should be an array.' );
+
+		// arg_options should be removed for each setting property.
+		foreach ( $font_face_settings_schema['properties'] as $property ) {
+			$this->assertArrayHasKey( 'arg_options', $property, 'Setting schema should have arg_options.' );
+			$this->assertArrayHasKey( 'sanitize_callback', $property['arg_options'], 'Setting schema should have a sanitize_callback.' );
+			$this->assertIsCallable( $property['arg_options']['sanitize_callback'], 'sanitize_callback should be callable.' );
+		}
+	}
+
+	/**
+	 * @covers WP_REST_Font_Faces_Controller::get_public_item_schema
+	 */
+	public function test_get_public_item_schema_should_not_have_arg_options() {
+		$schema                    = ( new WP_REST_Font_Faces_Controller( 'wp_font_face' ) )->get_public_item_schema();
+		$font_face_settings_schema = $schema['properties']['font_face_settings'];
+
+		$this->assertArrayHasKey( 'properties', $font_face_settings_schema, 'font_face_settings schema is missing properties.' );
+		$this->assertIsArray( $font_face_settings_schema['properties'], 'font_face_settings properties should be an array.' );
+
+		// arg_options should be removed for each setting property.
+		foreach ( $font_face_settings_schema['properties'] as $property ) {
+			$this->assertArrayNotHasKey( 'arg_options', $property, 'arg_options should be removed from the schema for each setting.' );
+		}
+	}
+
 	protected function check_font_face_data( $data, $post_id, $links ) {
 		self::$post_ids_for_cleanup[] = $post_id;
 		$post                         = get_post( $post_id );

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -970,7 +970,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		foreach ( $font_family_settings_schema['properties'] as $property ) {
 			$this->assertArrayHasKey( 'arg_options', $property, 'Setting schema should have arg_options.' );
 			$this->assertArrayHasKey( 'sanitize_callback', $property['arg_options'], 'Setting schema should have a sanitize_callback.' );
-			$this->assertIsCallable( $property['arg_options']['sanitize_callback'], 'sanitize_callback should be callable.' );
+			$this->assertIsCallable( $property['arg_options']['sanitize_callback'], 'That sanitize_callback value should be callable.' );
 		}
 	}
 

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -124,7 +124,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::register_routes
+	 * @covers WP_REST_Font_Families_Controller::register_routes
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
@@ -209,7 +209,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::get_items
+	 * @covers WP_REST_Font_Families_Controller::get_items
 	 */
 	public function test_get_items() {
 		wp_set_current_user( self::$admin_id );
@@ -226,7 +226,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::get_items
+	 * @covers WP_REST_Font_Families_Controller::get_items
 	 */
 	public function test_get_items_by_slug() {
 		$font_family = get_post( self::$font_family_id2 );
@@ -244,7 +244,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::get_items
+	 * @covers WP_REST_Font_Families_Controller::get_items
 	 */
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
@@ -259,7 +259,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::get_item
+	 * @covers WP_REST_Font_Families_Controller::get_item
 	 */
 	public function test_get_item() {
 		wp_set_current_user( self::$admin_id );
@@ -272,7 +272,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::prepare_item_for_response
+	 * @covers WP_REST_Font_Families_Controller::prepare_item_for_response
 	 */
 	public function test_get_item_embedded_font_faces() {
 		wp_set_current_user( self::$admin_id );
@@ -344,7 +344,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::get_item
+	 * @covers WP_REST_Font_Families_Controller::get_item
 	 */
 	public function test_get_item_invalid_font_family_id() {
 		wp_set_current_user( self::$admin_id );
@@ -354,7 +354,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::get_item
+	 * @covers WP_REST_Font_Families_Controller::get_item
 	 */
 	public function test_get_item_no_permission() {
 		wp_set_current_user( 0 );
@@ -369,7 +369,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::create_item
+	 * @covers WP_REST_Font_Families_Controller::create_item
 	 */
 	public function test_create_item() {
 		$settings = array_merge( self::$default_settings, array( 'slug' => 'open-sans-2' ) );
@@ -390,7 +390,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::validate_create_font_face_request
+	 * @covers WP_REST_Font_Families_Controller::validate_create_font_face_request
 	 */
 	public function test_create_item_default_theme_json_version() {
 		$settings = array_merge( self::$default_settings, array( 'slug' => 'open-sans-2' ) );
@@ -411,7 +411,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	/**
 	 * @dataProvider data_create_item_invalid_theme_json_version
 	 *
-	 * @covers WP_REST_Font_Faces_Controller::create_item
+	 * @covers WP_REST_Font_Families_Controller::create_item
 	 *
 	 * @param int $theme_json_version Version to test.
 	 */
@@ -440,7 +440,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	/**
 	 * @dataProvider data_create_item_with_default_preview
 	 *
-	 * @covers WP_REST_Font_Faces_Controller::sanitize_font_family_settings
+	 * @covers WP_REST_Font_Families_Controller::sanitize_font_family_settings
 	 *
 	 * @param array $settings Settings to test.
 	 */
@@ -484,7 +484,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	/**
 	 * @dataProvider data_create_item_invalid_settings
 	 *
-	 * @covers WP_REST_Font_Faces_Controller::validate_create_font_face_settings
+	 * @covers WP_REST_Font_Families_Controller::validate_create_font_face_settings
 	 *
 	 * @param array $settings Settings to test.
 	 */
@@ -570,7 +570,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::create_item
+	 * @covers WP_REST_Font_Families_Controller::create_item
 	 */
 	public function test_create_item_no_permission() {
 		$settings = array_merge( self::$default_settings, array( 'slug' => 'open-sans-2' ) );
@@ -714,7 +714,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	/**
 	 * @dataProvider data_update_item_invalid_settings
 	 *
-	 * @covers WP_REST_Font_Faces_Controller::update_item
+	 * @covers WP_REST_Font_Families_Controller::update_item
 	 *
 	 * @param array $settings Settings to test.
 	 */
@@ -752,7 +752,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::update_item
+	 * @covers WP_REST_Font_Families_Controller::update_item
 	 */
 	public function test_update_item_update_slug_not_allowed() {
 		wp_set_current_user( self::$admin_id );
@@ -770,7 +770,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::update_item
+	 * @covers WP_REST_Font_Families_Controller::update_item
 	 */
 	public function test_update_item_invalid_font_family_id() {
 		$settings = array_diff_key( self::$default_settings, array( 'slug' => '' ) );
@@ -783,7 +783,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::update_item
+	 * @covers WP_REST_Font_Families_Controller::update_item
 	 */
 	public function test_update_item_no_permission() {
 		$settings = array_diff_key( self::$default_settings, array( 'slug' => '' ) );
@@ -803,7 +803,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::delete_item
+	 * @covers WP_REST_Font_Families_Controller::delete_item
 	 */
 	public function test_delete_item() {
 		wp_set_current_user( self::$admin_id );
@@ -817,7 +817,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::delete_item
+	 * @covers WP_REST_Font_Families_Controller::delete_item
 	 */
 	public function test_delete_item_no_trash() {
 		wp_set_current_user( self::$admin_id );
@@ -838,7 +838,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::delete_item
+	 * @covers WP_REST_Font_Families_Controller::delete_item
 	 */
 	public function test_delete_item_invalid_font_family_id() {
 		wp_set_current_user( self::$admin_id );
@@ -848,7 +848,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::delete_item
+	 * @covers WP_REST_Font_Families_Controller::delete_item
 	 */
 	public function test_delete_item_no_permissions() {
 		$font_family_id = self::create_font_family_post();
@@ -865,7 +865,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::prepare_item_for_response
+	 * @covers WP_REST_Font_Families_Controller::prepare_item_for_response
 	 */
 	public function test_prepare_item() {
 		wp_set_current_user( self::$admin_id );
@@ -878,7 +878,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
-	 * @covers WP_REST_Font_Faces_Controller::get_item_schema
+	 * @covers WP_REST_Font_Families_Controller::get_item_schema
 	 */
 	public function test_get_item_schema() {
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/font-families' );
@@ -892,6 +892,40 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		$this->assertArrayHasKey( 'theme_json_version', $properties, 'The theme_json_version property should exist in the schema::properties data.' );
 		$this->assertArrayHasKey( 'font_faces', $properties, 'The font_faces property should exist in the schema::properties data.' );
 		$this->assertArrayHasKey( 'font_family_settings', $properties, 'The font_family_settings property should exist in the schema::properties data.' );
+	}
+
+	/**
+	 * @covers WP_REST_Font_Families_Controller::get_item_schema
+	 */
+	public function test_get_item_schema_font_family_settings_should_all_have_sanitize_callbacks() {
+		$schema                      = ( new WP_REST_Font_Families_Controller( 'wp_font_family' ) )->get_item_schema();
+		$font_family_settings_schema = $schema['properties']['font_family_settings'];
+
+		$this->assertArrayHasKey( 'properties', $font_family_settings_schema, 'font_family_settings schema is missing properties.' );
+		$this->assertIsArray( $font_family_settings_schema['properties'], 'font_family_settings properties should be an array.' );
+
+		// arg_options should be removed for each setting property.
+		foreach ( $font_family_settings_schema['properties'] as $property ) {
+			$this->assertArrayHasKey( 'arg_options', $property, 'Setting schema should have arg_options.' );
+			$this->assertArrayHasKey( 'sanitize_callback', $property['arg_options'], 'Setting schema should have a sanitize_callback.' );
+			$this->assertIsCallable( $property['arg_options']['sanitize_callback'], 'sanitize_callback should be callable.' );
+		}
+	}
+
+	/**
+	 * @covers WP_REST_Font_Families_Controller::get_public_item_schema
+	 */
+	public function test_get_public_item_schema_should_not_have_arg_options() {
+		$schema                      = ( new WP_REST_Font_Families_Controller( 'wp_font_family' ) )->get_public_item_schema();
+		$font_family_settings_schema = $schema['properties']['font_family_settings'];
+
+		$this->assertArrayHasKey( 'properties', $font_family_settings_schema, 'font_family_settings schema is missing properties.' );
+		$this->assertIsArray( $font_family_settings_schema['properties'], 'font_family_settings properties should be an array.' );
+
+		// arg_options should be removed for each setting property.
+		foreach ( $font_family_settings_schema['properties'] as $property ) {
+			$this->assertArrayNotHasKey( 'arg_options', $property, 'arg_options should be removed from the schema for each setting.' );
+		}
 	}
 
 	protected function check_font_family_data( $data, $post_id, $links ) {


### PR DESCRIPTION
## What?

Ensures font family and font face settings are sanitized when creating or updating through the REST API endpoints.

Addresses part of https://github.com/WordPress/gutenberg/issues/58464

## Why?

- Clean and normalize font family and font face settings data.
- To mitigate possible XSS attacks.

## How?

- Uses the `sanitize_callback` param for each setting in the schema, and manually calls the callback for each property because the settings are submitted as JSON string and aren't handled by normal REST API mechanisms.
- Updates `WP_Font_Utils::format_font_family` to `WP_Font_Utils::santize_font_family` and calls `sanitize_text_field` on the font family value so it is sanitized in addition to being formatted.
- Manually removes `arg_options` from the public schema of font family and font face controllers, because the parent controller doesn't handle that for child properties.
- Add phpunit tests for the above.

## Testing Instructions

- See updated unit tests.
- Try creating a font family or font face with tags, whitespace, or line breaks in the settings values and see that they are sanitized before being created.
- Check that installing from the Google Fonts collection works as expected.
