### PR TITLE
Background image support: add background position controls

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -60,13 +60,17 @@ export function hasBackgroundImageValue( style ) {
 
 /**
  * Checks if there is a current value in the background size block support
- * attributes.
+ * attributes. Background size values include background size as well
+ * as background position.
  *
  * @param {Object} style Style attribute.
  * @return {boolean}     Whether or not the block has a background size value set.
  */
 export function hasBackgroundSizeValue( style ) {
-	return style?.background?.backgroundSize !== undefined;
+	return (
+		style?.background?.backgroundPosition !== undefined ||
+		style?.background?.backgroundSize !== undefined
+	);
 }
 
 /**
@@ -131,6 +135,7 @@ function resetBackgroundSize( style = {}, setAttributes ) {
 			...style,
 			background: {
 				...style?.background,
+				backgroundPosition: undefined,
 				backgroundRepeat: undefined,
 				backgroundSize: undefined,
 			},
@@ -368,60 +373,22 @@ function backgroundSizeHelpText( value ) {
 	return __( 'Set a fixed width.' );
 }
 
-const coordsToBackgroundPosition = ( value ) => {
-	if ( ! value ) {
+export const coordsToBackgroundPosition = ( value ) => {
+	if ( ! value || isNaN( value.x ) || isNaN( value.y ) ) {
 		return undefined;
-	}
-
-	if ( value.x === 0 && value.y === 0 ) {
-		return 'left top';
-	}
-
-	if ( value.x === 0 && value.y === 1 ) {
-		return 'left bottom';
-	}
-
-	if ( value.x === 1 && value.y === 0 ) {
-		return 'right top';
-	}
-
-	if ( value.x === 1 && value.y === 1 ) {
-		return 'right bottom';
-	}
-
-	if ( value.x === 0.5 && value.y === 0.5 ) {
-		return 'center';
 	}
 
 	return `${ value.x * 100 }% ${ value.y * 100 }%`;
 };
 
-const backgroundPositionToCoords = ( value ) => {
+export const backgroundPositionToCoords = ( value ) => {
 	if ( ! value ) {
-		return { x: 0.5, y: 0.5 };
+		return { x: undefined, y: undefined };
 	}
 
-	if ( value === 'left top' ) {
-		return { x: 0, y: 0 };
-	}
-
-	if ( value === 'left bottom' ) {
-		return { x: 0, y: 1 };
-	}
-
-	if ( value === 'right top' ) {
-		return { x: 1, y: 0 };
-	}
-
-	if ( value === 'right bottom' ) {
-		return { x: 1, y: 1 };
-	}
-
-	if ( value === 'center' ) {
-		return { x: 0.5, y: 0.5 };
-	}
-
-	const [ x, y ] = value.split( ' ' ).map( ( v ) => parseFloat( v ) / 100 );
+	let [ x, y ] = value.split( ' ' ).map( ( v ) => parseFloat( v ) / 100 );
+	x = isNaN( x ) ? undefined : x;
+	y = isNaN( y ) ? x : y;
 
 	return { x, y };
 };
@@ -545,7 +512,7 @@ function BackgroundSizePanelItem( {
 			<FocalPointPicker
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
-				label={ __( 'Focal point' ) }
+				label={ __( 'Position' ) }
 				url={ style?.background?.backgroundImage?.url }
 				value={ backgroundPositionToCoords(
 					style?.background?.backgroundPosition

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -18,6 +18,7 @@ import {
 	__experimentalVStack as VStack,
 	DropZone,
 	FlexItem,
+	FocalPointPicker,
 	MenuItem,
 	VisuallyHidden,
 	__experimentalItemGroup as ItemGroup,
@@ -367,6 +368,64 @@ function backgroundSizeHelpText( value ) {
 	return __( 'Set a fixed width.' );
 }
 
+const coordsToBackgroundPosition = ( value ) => {
+	if ( ! value ) {
+		return undefined;
+	}
+
+	if ( value.x === 0 && value.y === 0 ) {
+		return 'left top';
+	}
+
+	if ( value.x === 0 && value.y === 1 ) {
+		return 'left bottom';
+	}
+
+	if ( value.x === 1 && value.y === 0 ) {
+		return 'right top';
+	}
+
+	if ( value.x === 1 && value.y === 1 ) {
+		return 'right bottom';
+	}
+
+	if ( value.x === 0.5 && value.y === 0.5 ) {
+		return 'center';
+	}
+
+	return `${ value.x * 100 }% ${ value.y * 100 }%`;
+};
+
+const backgroundPositionToCoords = ( value ) => {
+	if ( ! value ) {
+		return { x: 0.5, y: 0.5 };
+	}
+
+	if ( value === 'left top' ) {
+		return { x: 0, y: 0 };
+	}
+
+	if ( value === 'left bottom' ) {
+		return { x: 0, y: 1 };
+	}
+
+	if ( value === 'right top' ) {
+		return { x: 1, y: 0 };
+	}
+
+	if ( value === 'right bottom' ) {
+		return { x: 1, y: 1 };
+	}
+
+	if ( value === 'center' ) {
+		return { x: 0.5, y: 0.5 };
+	}
+
+	const [ x, y ] = value.split( ' ' ).map( ( v ) => parseFloat( v ) / 100 );
+
+	return { x, y };
+};
+
 function BackgroundSizePanelItem( {
 	clientId,
 	isShownByDefault,
@@ -446,6 +505,18 @@ function BackgroundSizePanelItem( {
 		} );
 	};
 
+	const updateBackgroundPosition = ( next ) => {
+		setAttributes( {
+			style: cleanEmptyObject( {
+				...style,
+				background: {
+					...style?.background,
+					backgroundPosition: coordsToBackgroundPosition( next ),
+				},
+			} ),
+		} );
+	};
+
 	const toggleIsRepeated = () => {
 		setAttributes( {
 			style: cleanEmptyObject( {
@@ -471,6 +542,16 @@ function BackgroundSizePanelItem( {
 			resetAllFilter={ resetAllFilter }
 			panelId={ clientId }
 		>
+			<FocalPointPicker
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ __( 'Focal point' ) }
+				url={ style?.background?.backgroundImage?.url }
+				value={ backgroundPositionToCoords(
+					style?.background?.backgroundPosition
+				) }
+				onChange={ updateBackgroundPosition }
+			/>
 			<ToggleGroupControl
 				__nextHasNoMarginBottom
 				size={ '__unstable-large' }

--- a/packages/block-editor/src/hooks/test/background.js
+++ b/packages/block-editor/src/hooks/test/background.js
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+
+import {
+	backgroundPositionToCoords,
+	coordsToBackgroundPosition,
+} from '../background';
+
+describe( 'backgroundPositionToCoords', () => {
+	it( 'should return the correct coordinates for a percentage value using 2-value syntax', () => {
+		expect( backgroundPositionToCoords( '25% 75%' ) ).toEqual( {
+			x: 0.25,
+			y: 0.75,
+		} );
+	} );
+
+	it( 'should return the correct coordinates for a percentage using 1-value syntax', () => {
+		expect( backgroundPositionToCoords( '50%' ) ).toEqual( {
+			x: 0.5,
+			y: 0.5,
+		} );
+	} );
+
+	it( 'should return undefined coords in given an empty value', () => {
+		expect( backgroundPositionToCoords( '' ) ).toEqual( {
+			x: undefined,
+			y: undefined,
+		} );
+	} );
+
+	it( 'should return undefined coords in given a string that cannot be converted', () => {
+		expect( backgroundPositionToCoords( 'apples' ) ).toEqual( {
+			x: undefined,
+			y: undefined,
+		} );
+	} );
+} );
+
+describe( 'coordsToBackgroundPosition', () => {
+	it( 'should return the correct background position for a set of coordinates', () => {
+		expect( coordsToBackgroundPosition( { x: 0.25, y: 0.75 } ) ).toBe(
+			'25% 75%'
+		);
+	} );
+
+	it( 'should return undefined if no coordinates are provided', () => {
+		expect( coordsToBackgroundPosition( {} ) ).toBeUndefined();
+	} );
+} );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fix
 
+-   `FocalPointPicker`: Allow `PointerCircle` to render in a default centered position when x and y coordinates are undefined ([#58592](https://github.com/WordPress/gutenberg/pull/58592)).
 -   `DateTime`: Add a timezone offset value for display purposes. ([#56682](https://github.com/WordPress/gutenberg/pull/56682)).
 -   `Placeholder`: Fix Placeholder component padding when body text font size is changed ([#58323](https://github.com/WordPress/gutenberg/pull/58323)).
 -   `Placeholder`: Fix Global Styles typography settings bleeding into placeholder component ([#58303](https://github.com/WordPress/gutenberg/pull/58303)).

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -217,8 +217,8 @@ export function FocalPointPicker( {
 	};
 
 	const focalPointPosition = {
-		left: x * bounds.width,
-		top: y * bounds.height,
+		left: x !== undefined ? x * bounds.width : 0.5 * bounds.width,
+		top: y !== undefined ? y * bounds.height : 0.5 * bounds.height,
 	};
 
 	const classes = classnames(

--- a/packages/style-engine/src/styles/background/index.ts
+++ b/packages/style-engine/src/styles/background/index.ts
@@ -52,6 +52,18 @@ const backgroundRepeat = {
 	},
 };
 
+const backgroundPosition = {
+	name: 'backgroundRepeat',
+	generate: ( style: Style, options: StyleOptions ) => {
+		return generateRule(
+			style,
+			options,
+			[ 'background', 'backgroundPosition' ],
+			'backgroundPosition'
+		);
+	},
+};
+
 const backgroundSize = {
 	name: 'backgroundSize',
 	generate: ( style: Style, options: StyleOptions ) => {
@@ -89,4 +101,9 @@ const backgroundSize = {
 	},
 };
 
-export default [ backgroundImage, backgroundRepeat, backgroundSize ];
+export default [
+	backgroundImage,
+	backgroundRepeat,
+	backgroundPosition,
+	backgroundSize,
+];

--- a/packages/style-engine/src/styles/background/index.ts
+++ b/packages/style-engine/src/styles/background/index.ts
@@ -40,18 +40,6 @@ const backgroundImage = {
 	},
 };
 
-const backgroundRepeat = {
-	name: 'backgroundRepeat',
-	generate: ( style: Style, options: StyleOptions ) => {
-		return generateRule(
-			style,
-			options,
-			[ 'background', 'backgroundRepeat' ],
-			'backgroundRepeat'
-		);
-	},
-};
-
 const backgroundPosition = {
 	name: 'backgroundRepeat',
 	generate: ( style: Style, options: StyleOptions ) => {
@@ -60,6 +48,18 @@ const backgroundPosition = {
 			options,
 			[ 'background', 'backgroundPosition' ],
 			'backgroundPosition'
+		);
+	},
+};
+
+const backgroundRepeat = {
+	name: 'backgroundRepeat',
+	generate: ( style: Style, options: StyleOptions ) => {
+		return generateRule(
+			style,
+			options,
+			[ 'background', 'backgroundRepeat' ],
+			'backgroundRepeat'
 		);
 	},
 };
@@ -103,7 +103,7 @@ const backgroundSize = {
 
 export default [
 	backgroundImage,
-	backgroundRepeat,
 	backgroundPosition,
+	backgroundRepeat,
 	backgroundSize,
 ];

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -229,6 +229,7 @@ describe( 'getCSSRules', () => {
 							source: 'file',
 							url: 'https://example.com/image.jpg',
 						},
+						backgroundPosition: '50% 50%',
 						backgroundRepeat: 'no-repeat',
 						backgroundSize: '300px',
 					},
@@ -383,6 +384,11 @@ describe( 'getCSSRules', () => {
 				selector: '.some-selector',
 				key: 'backgroundImage',
 				value: "url( 'https://example.com/image.jpg' )",
+			},
+			{
+				selector: '.some-selector',
+				key: 'backgroundPosition',
+				value: '50% 50%',
 			},
 			{
 				selector: '.some-selector',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of: https://github.com/WordPress/gutenberg/issues/54336

Try adding background position controls to the background image block support used by the Group block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

So that folks can choose a focal point / background position within the set background image. This offers a lot more flexiblity to using `Contain` or `Fixed` sizes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Re-use the `FocalPointPicker` component and map coords to a real `backgroundPosition` CSS value.

## To-do

For now, I mostly wanted to gather feedback to see if this feels viable for 6.5. Before a final review, I'll need to tidy up:

* [x] Tidy up coords mapping
* [x] Fix up reset behaviour
* [x] Add unit tests for style engine JS changes

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Group block to a post
2. Add a background image to it
3. In the ellipsis menu, enable Background Size
4. You should now also see the same Focal Point picker as used in the Cover block
5. Try adjusting the Focal Point (note that _realtime_ updates to the style output haven't been done yet — so the update happens when you release the mouse cursor)

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/14988353/8f40f7a8-e84e-43e9-956b-98cc1c93a1b5