### PR TITLE
Pattern overrides: Update overrides attribute data structure and rename it to `content`

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -42,7 +42,7 @@ Reuse this design across your site. ([Source](https://github.com/WordPress/guten
 -	**Name:** core/block
 -	**Category:** reusable
 -	**Supports:** interactivity (clientNavigation), ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
--	**Attributes:** overrides, ref
+-	**Attributes:** content, ref
 
 ## Button
 

--- a/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
+++ b/lib/compat/wordpress-6.5/block-bindings/sources/pattern.php
@@ -9,7 +9,7 @@ function gutenberg_block_bindings_pattern_overrides_callback( $source_attrs, $bl
 		return null;
 	}
 	$block_id = $block_instance->attributes['metadata']['id'];
-	return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, $attribute_name ), null );
+	return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, 'values', $attribute_name ), null );
 }
 
 function gutenberg_register_block_bindings_pattern_overrides_source() {

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -11,7 +11,7 @@
 		"ref": {
 			"type": "number"
 		},
-		"overrides": {
+		"content": {
 			"type": "object"
 		}
 	},

--- a/packages/block-library/src/block/deprecated.js
+++ b/packages/block-library/src/block/deprecated.js
@@ -1,0 +1,57 @@
+// v1: Migrate and rename the `overrides` attribute to the `content` attribute.
+const v1 = {
+	attributes: {
+		ref: {
+			type: 'number',
+		},
+		overrides: {
+			type: 'object',
+		},
+	},
+	supports: {
+		customClassName: false,
+		html: false,
+		inserter: false,
+		renaming: false,
+	},
+	// Force this deprecation to run whenever there's an `overrides` object.
+	isEligible( { overrides } ) {
+		return !! overrides;
+	},
+	/*
+	 * Old attribute format:
+	 * overrides: {
+	 *     // An key is an id that represents a block.
+	 *     // The values are the attribute values of the block.
+	 *     "V98q_x": { content: 'dwefwefwefwe' }
+	 * }
+	 *
+	 * New attribute format:
+	 * content: {
+	 *     "V98q_x": {
+	 * 	   		// The attribute values are now stored as a 'values' sub-property.
+	 *         values: { content: 'dwefwefwefwe' },
+	 * 	       // ... additional metadata, like the block name can be stored here.
+	 *     }
+	 * }
+	 *
+	 */
+	migrate( attributes ) {
+		const { overrides, ...retainedAttributes } = attributes;
+
+		const content = {};
+
+		Object.keys( overrides ).forEach( ( id ) => {
+			content[ id ] = {
+				values: overrides[ id ],
+			};
+		} );
+
+		return {
+			...retainedAttributes,
+			content,
+		};
+	},
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -144,7 +144,7 @@ function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
 		for ( const attributeKey of attributes ) {
 			if (
 				block.attributes[ attributeKey ] !==
-				defaultValues[ blockId ][ attributeKey ]
+				defaultValues[ blockId ].values[ attributeKey ]
 			) {
 				content[ blockId ] ??= { values: {} };
 				// TODO: We need a way to represent `undefined` in the serialized overrides.

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -182,8 +182,13 @@ export default function ReusableBlockEdit( {
 		ref
 	);
 	const isMissing = hasResolved && ! record;
-	const initialOverrides = useRef( content );
-	const defaultValuesRef = useRef( {} );
+
+	// The initial value of the `content` attribute.
+	const initialContent = useRef( content );
+
+	// The default content values from the original pattern for overridable attributes.
+	// Set by the `applyInitialContentValuesToInnerBlocks` function.
+	const defaultContent = useRef( {} );
 
 	const {
 		replaceInnerBlocks,
@@ -244,9 +249,8 @@ export default function ReusableBlockEdit( {
 
 	// Apply the initial overrides from the pattern block to the inner blocks.
 	useEffect( () => {
-		defaultValuesRef.current = {};
+		defaultContent.current = {};
 		const editingMode = getBlockEditingMode( patternClientId );
-		// Replace the contents of the blocks with the overrides.
 		registry.batch( () => {
 			setBlockEditingMode( patternClientId, 'default' );
 			syncDerivedUpdates( () => {
@@ -254,8 +258,8 @@ export default function ReusableBlockEdit( {
 					patternClientId,
 					applyInitialContentValuesToInnerBlocks(
 						initialBlocks,
-						initialOverrides.current,
-						defaultValuesRef.current
+						initialContent.current,
+						defaultContent.current
 					)
 				);
 			} );
@@ -307,7 +311,7 @@ export default function ReusableBlockEdit( {
 					setAttributes( {
 						content: getContentValuesFromInnerBlocks(
 							blocks,
-							defaultValuesRef.current
+							defaultContent.current
 						),
 					} );
 				} );
@@ -320,7 +324,7 @@ export default function ReusableBlockEdit( {
 		editOriginalProps.onClick( event );
 	};
 
-	const resetOverrides = () => {
+	const resetContent = () => {
 		if ( content ) {
 			replaceInnerBlocks( patternClientId, initialBlocks );
 		}
@@ -371,7 +375,7 @@ export default function ReusableBlockEdit( {
 				<BlockControls>
 					<ToolbarGroup>
 						<ToolbarButton
-							onClick={ resetOverrides }
+							onClick={ resetContent }
 							disabled={ ! content }
 							__experimentalIsFocusable
 						>

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -117,9 +117,9 @@ function applyInitialContentValuesToInnerBlocks(
 			defaultValues[ blockId ].values[ attributeKey ] =
 				block.attributes[ attributeKey ];
 
-			if ( content[ blockId ]?.values?.[ attributeKey ] !== undefined ) {
-				newAttributes[ attributeKey ] =
-					content[ blockId ]?.values?.[ attributeKey ];
+			const contentValues = content[ blockId ]?.values;
+			if ( contentValues?.[ attributeKey ] !== undefined ) {
+				newAttributes[ attributeKey ] = contentValues[ attributeKey ];
 			}
 		}
 		return {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -113,8 +113,8 @@ function applyInitialContentValuesToInnerBlocks(
 		const attributes = getOverridableAttributes( block );
 		const newAttributes = { ...block.attributes };
 		for ( const attributeKey of attributes ) {
-			defaultValues[ blockId ] ??= { values: {} };
-			defaultValues[ blockId ].values[ attributeKey ] =
+			defaultValues[ blockId ] ??= {};
+			defaultValues[ blockId ][ attributeKey ] =
 				block.attributes[ attributeKey ];
 
 			const contentValues = content[ blockId ]?.values;
@@ -144,7 +144,7 @@ function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
 		for ( const attributeKey of attributes ) {
 			if (
 				block.attributes[ attributeKey ] !==
-				defaultValues[ blockId ].values[ attributeKey ]
+				defaultValues[ blockId ][ attributeKey ]
 			) {
 				content[ blockId ] ??= { values: {} };
 				// TODO: We need a way to represent `undefined` in the serialized overrides.

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -131,7 +131,7 @@ function applyInitialContentValuesToInnerBlocks(
 }
 
 function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
-	/** @type {Record<string, { values: Record<string, unknown>> }} */
+	/** @type {Record<string, { values: Record<string, unknown>}>} */
 	const content = {};
 	for ( const block of blocks ) {
 		Object.assign(

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -131,7 +131,7 @@ function applyInitialContentValuesToInnerBlocks(
 }
 
 function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
-	/** @type {Record<string, Record<string, unknown>>} */
+	/** @type {Record<string, { values: Record<string, unknown>> }} */
 	const content = {};
 	for ( const block of blocks ) {
 		Object.assign(

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -9,12 +9,14 @@ import { symbol as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 
 export { metadata, name };
 
 export const settings = {
+	deprecated,
 	edit,
 	icon,
 };

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -170,9 +170,11 @@ test.describe( 'Pattern Overrides', () => {
 					name: 'core/block',
 					attributes: {
 						ref: patternId,
-						overrides: {
+						content: {
 							[ editableParagraphId ]: {
-								content: 'I would word it this way',
+								values: {
+									content: 'I would word it this way',
+								},
 							},
 						},
 					},
@@ -181,9 +183,11 @@ test.describe( 'Pattern Overrides', () => {
 					name: 'core/block',
 					attributes: {
 						ref: patternId,
-						overrides: {
+						content: {
 							[ editableParagraphId ]: {
-								content: 'This one is different',
+								values: {
+									content: 'This one is different',
+								},
 							},
 						},
 					},


### PR DESCRIPTION
## What?
Part of #53705

Updates the pattern block's `overrides` attribute data structure and renames it to `content`.

This branch intends to maintain full backwards compatible with the previous `overrides` attribute.

The old attribute data structure:
```js
overrides: {
    // An key is an id that represents a block.
    // The values are the attribute values of the block.
    // This format doesn't provide anywhere to add additional properties
    // that aren't block ids or content values.
    "V98q_x": { content: 'dwefwefwefwe' }
 }
 ```
	 
The new attribute data structure:
```js
content: {
    "V98q_x": {
        // The attribute values are now stored as a 'values' sub-property.
      	// In future, if we want to use a patch system, the `values` property
	// can be dropped and replaced with a `patch` property or similar.
	values: { content: 'dwefwefwefwe' },
	// ... additional metadata, like the block name can be stored here.
    }
}
```

## Why?
This new format should prove more flexible for the future.

It allows storing additional metadata for each block, like the block name. (see [the discussion in the tracking issue for more information](https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1911583913))

It also supports the possibility of moving to different formats in the future, like the patch format that was explored but ultimately reverted - [Use a patch format and support linkTarget of core/button for Pattern Overrides](https://github.com/WordPress/gutenberg/pull/58165#top).

## How?
- Adds a deprecation with migration to the pattern block that migrates from the old format/name to the new
- Updates the block's edit function to use the new naming and format
- Updates the block's server render callback to use new format and adds some back compat in case the old format/name is still present.

## Testing Instructions
1. Checkout `trunk`
2. Create some patterns with overrides, insert them into a post, set some override values, save.
3. Checkout this branch
4. Preview the post, everything should render correctly (except the heading block as there's a separate bug in trunk)
5. Change the content values in the patterns
6. Preview the post again, everything should still render correctly (and still except the heading block)
