### PR TITLE
MediaReplaceFlow: restore popover width

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	.block-editor-link-control {
-		width: 200px; // Hardcoded width avoids resizing of control when switching between preview/edit.
+		width: 300px; // Hardcoded width avoids resizing of control when switching between preview/edit.
 
 		.block-editor-url-input {
 			padding: 0; // Cancel unnecessary default 1px padding in this case.


### PR DESCRIPTION
Part of #58593

## What?

This PR changes the width of the link control inside the `MediaReplaceFlow` component back from 200px to 300px.
This allows you to remove unintended scrollbars.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/df08db01-1761-4dbf-b32c-1b6850203447) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/ad4544d9-6d5c-4e92-ab98-526032a30a47) |


## Why?

This width was changed in #57608. #57608 focuses on improving the link UI, so this width change should be unintentional.

## Testing Instructions

- Insert an Image block.
- Upload media.
- Click "Replace" on the block toolbar.
- Scrollbars should not be visible.
- It should not affect the width of Link UI, which was improved in #57608.