### PR TITLE
Editor: Limit visible Snackbars from the consumers

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Enhancements
 
 -   `ConfirmDialog`: Add `__next40pxDefaultSize` to buttons ([#58421](https://github.com/WordPress/gutenberg/pull/58421)).
--   `SnackbarList`: Allow limiting the number of maximum visible Snackbars ([#58559](https://github.com/WordPress/gutenberg/pull/58559)).
 -   `Snackbar`: Update the warning message ([#58591](https://github.com/WordPress/gutenberg/pull/58591)).
 
 ### Bug Fix

--- a/packages/components/src/snackbar/list.tsx
+++ b/packages/components/src/snackbar/list.tsx
@@ -62,14 +62,12 @@ const SNACKBAR_VARIANTS = {
  */
 export function SnackbarList( {
 	notices,
-	maxVisible,
 	className,
 	children,
 	onRemove,
 }: WordPressComponentProps< SnackbarListProps, 'div' > ) {
 	const listRef = useRef< HTMLDivElement | null >( null );
 	const isReducedMotion = useReducedMotion();
-	const visibleNotices = maxVisible ? notices.slice( -maxVisible ) : notices;
 	className = classnames( 'components-snackbar-list', className );
 	const removeNotice =
 		( notice: SnackbarListProps[ 'notices' ][ number ] ) => () =>
@@ -78,7 +76,7 @@ export function SnackbarList( {
 		<div className={ className } tabIndex={ -1 } ref={ listRef }>
 			{ children }
 			<AnimatePresence>
-				{ visibleNotices.map( ( notice ) => {
+				{ notices.map( ( notice ) => {
 					const { content, ...restNotice } = notice;
 
 					return (

--- a/packages/components/src/snackbar/types.ts
+++ b/packages/components/src/snackbar/types.ts
@@ -38,7 +38,6 @@ export type SnackbarListProps = {
 			content: string;
 		}
 	>;
-	maxVisible?: number;
 	onRemove: ( id: string ) => void;
 	children?: NoticeChildren | Array< NoticeChildren >;
 };

--- a/packages/edit-widgets/src/components/notices/index.js
+++ b/packages/edit-widgets/src/components/notices/index.js
@@ -5,6 +5,9 @@ import { NoticeList, SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
+// Last three notices. Slices from the tail end of the list.
+const MAX_VISIBLE_NOTICES = -3;
+
 function Notices() {
 	const { removeNotice } = useDispatch( noticesStore );
 	const { notices } = useSelect( ( select ) => {
@@ -19,9 +22,9 @@ function Notices() {
 	const nonDismissibleNotices = notices.filter(
 		( { isDismissible, type } ) => ! isDismissible && type === 'default'
 	);
-	const snackbarNotices = notices.filter(
-		( { type } ) => type === 'snackbar'
-	);
+	const snackbarNotices = notices
+		.filter( ( { type } ) => type === 'snackbar' )
+		.slice( MAX_VISIBLE_NOTICES );
 
 	return (
 		<>
@@ -36,7 +39,6 @@ function Notices() {
 			/>
 			<SnackbarList
 				notices={ snackbarNotices }
-				maxVisible={ 3 }
 				className="edit-widgets-notices__snackbar"
 				onRemove={ removeNotice }
 			/>

--- a/packages/editor/src/components/editor-snackbars/index.js
+++ b/packages/editor/src/components/editor-snackbars/index.js
@@ -5,20 +5,22 @@ import { SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
+// Last three notices. Slices from the tail end of the list.
+const MAX_VISIBLE_NOTICES = -3;
+
 export default function EditorSnackbars() {
 	const notices = useSelect(
 		( select ) => select( noticesStore ).getNotices(),
 		[]
 	);
 	const { removeNotice } = useDispatch( noticesStore );
-	const snackbarNotices = notices.filter(
-		( { type } ) => type === 'snackbar'
-	);
+	const snackbarNotices = notices
+		.filter( ( { type } ) => type === 'snackbar' )
+		.slice( MAX_VISIBLE_NOTICES );
 
 	return (
 		<SnackbarList
 			notices={ snackbarNotices }
-			maxVisible={ 3 }
 			className="components-editor-notices__snackbar"
 			onRemove={ removeNotice }
 		/>


### PR DESCRIPTION
## What?
This is a follow-up to #58559.

PR uses the consumers to modify the list of `Snackbars`  rendered by `SnackbarList`.

## Testing Instructions
1. Open a post or page.
2. Insert a block.
3. Trigger a lot of snackbar notices. Copying a block can do that.
4. Confirm that only a fixed number (3) of snackbars are visible.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/1e90ffc6-0312-4bca-9ac2-97adbe8a3afb