### PR TITLE
Try: Fix lightbox URL popover position.

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -298,6 +298,7 @@ const ImageURLInputUI = ( {
 							</MenuGroup>
 						)
 					}
+					offset={ 13 }
 				>
 					{ ( ! url || isEditingLink ) && ! lightboxEnabled && (
 						<>

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -1,3 +1,7 @@
+.block-editor-url-popover {
+	margin-top: $grid-unit-15 + $border-width;
+}
+
 .block-editor-url-popover__additional-controls {
 	border-top: $border-width solid $gray-900;
 	padding: $grid-unit-10 $grid-unit-10;

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -1,7 +1,3 @@
-.block-editor-url-popover {
-	margin-top: $grid-unit-15 + $border-width;
-}
-
 .block-editor-url-popover__additional-controls {
 	border-top: $border-width solid $gray-900;
 	padding: $grid-unit-10 $grid-unit-10;


### PR DESCRIPTION
## What?

The UI to untoggle the lightbox was recently vastly improved, moving to the toolbar. But the position is incorrect:

![before](https://github.com/WordPress/gutenberg/assets/1204802/03c014e2-c6c8-4dda-a597-1fdfdfe101bf)

Like other toolbar dropdowns, the popover itself should be moved down 12px:

![other dropdown](https://github.com/WordPress/gutenberg/assets/1204802/35ddfe2a-e395-43d0-adad-57d1eb3aae84)

This PR implements a hack to make it appear the same:

![after](https://github.com/WordPress/gutenberg/assets/1204802/bad2b810-8c62-4baf-bbcd-030633920cf6)

It's not clear to me if we want to land this hack as is, so marking as draft. From a glance it seems the `Dropdown` component automatically adds these 12px, rather than relying on margin, whereas since this URL dialog is not using that component, it positions itself at the bottom of the URL button itself. 

What's the best fix here?
