### PR TITLE
Allow placing Query pagination inside groups and other containers

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -722,7 +722,6 @@ Displays a paginated navigation to next/previous set of posts, when applicable. 
 
 -	**Name:** core/query-pagination
 -	**Category:** theme
--	**Parent:** core/query
 -	**Supports:** align, color (background, gradients, link, text), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** paginationArrow, showLabel
 

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -4,7 +4,7 @@
 	"name": "core/query-pagination",
 	"title": "Pagination",
 	"category": "theme",
-	"parent": [ "core/query" ],
+	"ancestor": [ "core/query" ],
 	"allowedBlocks": [
 		"core/query-pagination-previous",
 		"core/query-pagination-numbers",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The query pagination block has a `parent` attribute in block.json which limits its placement to be a direct child of the query loop.
This PR changes parent to ancestor so that the query pagination works when placed in:
- Template parts inside the query loop.
- Patterns inside the query loop

**Partial** fix for https://github.com/WordPress/gutenberg/issues/38684
Ideally, it should also be possible to insert or move the query pagination block to a template part, when that template part is placed inside the query loop, this PR does not solve that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it is limited to be placed directly in the query loop, it limits its design choices, but it also makes translating the labels more difficult.
To make these labels translatable, you would have to place the whole query inside a block pattern:
```
<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In block.json, parent is changed to ancestor.

## Testing Instructions

On your WordPress installation, make sure that you have enough posts to enable pagination on archives.

Download and install Twenty Twenty-Three.
In the themes patterns folder, create a new pattern with a file called pagination.php.
Add this code, and save.

```
<?php
/**
 * Title: Pagination
 * Slug: twentytwentythree/pagination
 * Categories: query
 * Keywords: pagination
 */
?>
<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
	<!-- wp:query-pagination-previous {"label":"Pattern Newer Posts"} /-->
	<!-- wp:query-pagination-next {"label":"Pattern test Older Posts"} /-->
<!-- /wp:query-pagination -->
```

In the parts folder, create a new file called pagination.html.
Add this code:
<!-- wp:pattern {"slug":"twentytwentythree/pagination"} /-->

Open home.html.
Add the following code inside the query loop, but outside the post template:
<!-- wp:pattern {"slug":"twentytwentythree/pagination"} /-->
<!-- wp:template-part {"slug":"pagination"} /-->

Go to the Site editor and open then home template. Reset customizations.
Confirm that the pagination blocks are in the template.
View the front of the site, confirm that the pagination blocks are visible and that the pagination works. The results should be correct no matter which of the 3 sets of pagination blocks that are used.
