### PR TITLE
Components: Fix the Snackbar auto-dismissal timers

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   `Placeholder`: Fix Placeholder component padding when body text font size is changed ([#58323](https://github.com/WordPress/gutenberg/pull/58323)).
 -   `Placeholder`: Fix Global Styles typography settings bleeding into placeholder component ([#58303](https://github.com/WordPress/gutenberg/pull/58303)).
 -   `PaletteEdit`: Fix palette item accessibility in details view ([#58214](https://github.com/WordPress/gutenberg/pull/58214)).
+-   `Snackbar`: Fix the auto-dismissal timers ([#58604](https://github.com/WordPress/gutenberg/pull/58604)).
 
 ### Experimental
 

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -88,8 +88,8 @@ function UnforwardedSnackbar(
 
 	useSpokenMessage( spokenMessage, politeness );
 
-	// Only set up the timeout dismiss if we're not explicitly dismissing.
 	useEffect( () => {
+		// Only set up the timeout dismiss if we're not explicitly dismissing.
 		const timeoutHandle = setTimeout( () => {
 			if ( ! explicitDismiss ) {
 				onDismiss?.();
@@ -98,7 +98,10 @@ function UnforwardedSnackbar(
 		}, NOTICE_TIMEOUT );
 
 		return () => clearTimeout( timeoutHandle );
-	}, [ onDismiss, onRemove, explicitDismiss ] );
+		// The `onDismiss/onRemove` can have unstable references,
+		// trigger side-effect cleanup, and reset timers.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ explicitDismiss ] );
 
 	const classes = classnames( className, 'components-snackbar', {
 		'components-snackbar-explicit-dismiss': !! explicitDismiss,


### PR DESCRIPTION
## What?
Resolves #58594.

PR removes `onDismiss/onRemove` callbacks from side-effect dependencies to avoid resetting timers on re-render.

## Why?
See #58594.

## Testing Instructions
1. Open a post or page.
2. Insert a block.
3. Trigger a few snackbar notices. Copying a block can do that.

### Expected behavior

_Let's assume there is a one-second difference between message triggers._

```
Message 1 - 10s
Message 2 - 10s + 1s
Message 3 - 10s + 2s
```

## Screenshots or screencast <!-- if applicable -->
