### PR TITLE
Show borders for disabled secondary buttons.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+
 ### Enhancements
 
+-   `Button`: Update secondary variant to show the border even in a disabled state. ([#58606](https://github.com/WordPress/gutenberg/pull/58606)).
 -   `ConfirmDialog`: Add `__next40pxDefaultSize` to buttons ([#58421](https://github.com/WordPress/gutenberg/pull/58421)).
 -   `SnackbarList`: Allow limiting the number of maximum visible Snackbars ([#58559](https://github.com/WordPress/gutenberg/pull/58559)).
 -   `Snackbar`: Update the warning message ([#58591](https://github.com/WordPress/gutenberg/pull/58591)).

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -129,11 +129,6 @@
 			background: transparent;
 			transform: none;
 			opacity: 1;
-
-			&:not(:focus) {
-				box-shadow: none;
-				outline: none;
-			}
 		}
 	}
 
@@ -150,6 +145,12 @@
 
 		&:hover:not(:disabled, [aria-disabled="true"]) {
 			box-shadow: inset 0 0 0 $border-width $components-color-accent-darker-10;
+		}
+
+		&:disabled:not(:focus),
+		&[aria-disabled="true"]:not(:focus),
+		&[aria-disabled="true"]:hover:not(:focus) {
+			box-shadow: inset 0 0 0 $border-width $gray-300;
 		}
 	}
 
@@ -177,6 +178,15 @@
 		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.
 		p + & {
 			margin-left: -($grid-unit-15 * 0.5);
+		}
+
+		&:disabled,
+		&[aria-disabled="true"],
+		&[aria-disabled="true"]:hover {
+			&:not(:focus) {
+				box-shadow: none;
+				outline: none;
+			}
 		}
 	}
 


### PR DESCRIPTION
## What?

Secondary buttons have outlines. But not when disabled. This is causing the component to be less reliable in such sitautions, as evident by it floating a bit for the "Switch to draft" button:

![before, unsaved](https://github.com/WordPress/gutenberg/assets/1204802/14ded5a8-904d-4ec4-938d-a63fd213d8ae)

![before, saved](https://github.com/WordPress/gutenberg/assets/1204802/49cab725-fbeb-47f8-ad50-f45d369e5d15)

![before, published](https://github.com/WordPress/gutenberg/assets/1204802/d019c2f5-451b-4988-9918-4fc36a59af1d)

This PR changes the CSS so that the secondary button always has a border, even when disabled:
![after, unsaved](https://github.com/WordPress/gutenberg/assets/1204802/30181edd-7c9d-45a4-a632-63a24d84e552)

![after, saved](https://github.com/WordPress/gutenberg/assets/1204802/92f0d445-5e3a-49aa-8f09-172e159013a4)

![focus style](https://github.com/WordPress/gutenberg/assets/1204802/6415fcec-589e-4035-ac8c-af22f0fb077e)

## Testing Instructions

* Open the post editor
* Observe the disabled "Switch to draft" button
* Tab to it, observe it has a focus style.
