### PR TITLE
WIP, Follow up: Query pagination in patterns

### DIFF
--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -16,9 +16,5 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "queryId", "query" ],
-	"providesContext": {
-		"query": "query",
-		"queryId": "queryId"
-	}
+	"usesContext": [ "queryId", "query" ]
 }

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -15,5 +15,10 @@
 		"slug": {
 			"type": "string"
 		}
+	},
+	"usesContext": [ "queryId", "query" ],
+	"providesContext": {
+		"query": "query",
+		"queryId": "queryId"
 	}
 }

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -25,7 +25,8 @@
 	"usesContext": [ "queryId", "query" ],
 	"providesContext": {
 		"paginationArrow": "paginationArrow",
-		"showLabel": "showLabel"
+		"showLabel": "showLabel",
+		"query": "query"
 	},
 	"supports": {
 		"align": true,

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -25,9 +25,7 @@
 	"usesContext": [ "queryId", "query" ],
 	"providesContext": {
 		"paginationArrow": "paginationArrow",
-		"showLabel": "showLabel",
-		"query": "query",
-		"queryId": "queryId"
+		"showLabel": "showLabel"
 	},
 	"supports": {
 		"align": true,

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -26,7 +26,8 @@
 	"providesContext": {
 		"paginationArrow": "paginationArrow",
 		"showLabel": "showLabel",
-		"query": "query"
+		"query": "query",
+		"queryId": "queryId"
 	},
 	"supports": {
 		"align": true,


### PR DESCRIPTION
Add query to providesContext.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a follow up to https://github.com/WordPress/gutenberg/pull/58602 which I merged to hastily.

When a query pagination block is placed inside a pattern that is inside a query loop, the next and previous page links were incorrect: `?query-page=2`
The expected link is `page/2/` or `?query-ID_HERE-page=2`

**Blocker:** The path only works once the content or template has been saved, so it does not work right now if the pattern is in a theme template.

## Testing Instructions
See https://github.com/WordPress/gutenberg/pull/58602
