### PR TITLE
Fix font library unit tests nit-picks [round 2]

### DIFF
--- a/phpunit/tests/fonts/font-library/fontFamilyBackwardsCompatibility.php
+++ b/phpunit/tests/fonts/font-library/fontFamilyBackwardsCompatibility.php
@@ -11,7 +11,7 @@
  * @group font-library
  */
 class Tests_Font_Family_Backwards_Compatibility extends WP_UnitTestCase {
-	private $post_ids_to_delete = array();
+	private $post_ids_to_delete;
 
 	public function set_up() {
 		parent::set_up();

--- a/phpunit/tests/fonts/font-library/wpFontCollection/loadFromJson.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/loadFromJson.php
@@ -105,7 +105,7 @@ class Tests_Fonts_WpFontCollection_loadFromJson extends WP_UnitTestCase {
 		}
 
 		return array(
-			'body'     => json_encode( self::$mock_collection_data ),
+			'body'     => wp_json_encode( self::$mock_collection_data ),
 			'response' => array(
 				'code' => 200,
 			),
@@ -122,7 +122,7 @@ class Tests_Fonts_WpFontCollection_loadFromJson extends WP_UnitTestCase {
 		unset( $mock_collection_data['slug'] );
 
 		return array(
-			'body'     => json_encode( $mock_collection_data ),
+			'body'     => wp_json_encode( $mock_collection_data ),
 			'response' => array(
 				'code' => 200,
 			),

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollections.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollections.php
@@ -26,7 +26,7 @@ class Tests_Fonts_WpFontLibrary_GetFontCollections extends WP_Font_Library_UnitT
 		WP_Font_Library::register_font_collection( 'my-font-collection', $my_font_collection_config );
 
 		$font_collections = WP_Font_Library::get_font_collections();
-		$this->assertNotEmpty( $font_collections, 'Sould return an array of font collections.' );
+		$this->assertNotEmpty( $font_collections, 'Should return an array of font collections.' );
 		$this->assertCount( 1, $font_collections, 'Should return an array with one font collection.' );
 		$this->assertArrayHasKey( 'my-font-collection', $font_collections, 'The array should have the key of the registered font collection id.' );
 		$this->assertInstanceOf( 'WP_Font_Collection', $font_collections['my-font-collection'], 'The value of the array $font_collections[id] should be an instance of WP_Font_Collection class.' );

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/unregisterFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/unregisterFontCollection.php
@@ -33,7 +33,7 @@ class Tests_Fonts_WpFontLibrary_UnregisterFontCollection extends WP_Font_Library
 	}
 
 	public function unregister_non_existing_collection() {
-		// Unregisters non existing font collection.
+		// Unregisters non-existing font collection.
 		WP_Font_Library::unregister_font_collection( 'non-existing-collection' );
 		$collections = WP_Font_Library::get_font_collections();
 		$this->assertEmpty( $collections, 'Should not be registered collections.' );

--- a/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
@@ -107,11 +107,11 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 
 		wp_set_current_user( 0 );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_read', $response );
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 401, 'Response code should be 401 for non-authenticated users.' );
 
 		wp_set_current_user( self::$editor_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_read', $response );
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 403, 'Response code should be 403 for users without the right permissions.' );
 	}
 
 	/**

--- a/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
@@ -49,8 +49,8 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 		$this->assertCount( 1, $routes['/wp/v2/font-collections'], 'Rest server has not the collections path initialized.' );
 		$this->assertCount( 1, $routes['/wp/v2/font-collections/(?P<slug>[\/\w-]+)'], 'Rest server has not the collection path initialized.' );
 
-		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections'][0]['methods'], 'Rest server has not the GET method for collections intialized.' );
-		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections/(?P<slug>[\/\w-]+)'][0]['methods'], 'Rest server has not the GET method for collection intialized.' );
+		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections'][0]['methods'], 'Rest server has not the GET method for collections initialized.' );
+		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections/(?P<slug>[\/\w-]+)'][0]['methods'], 'Rest server has not the GET method for collection initialized.' );
 	}
 
 	/**
@@ -107,11 +107,11 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 
 		wp_set_current_user( 0 );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_read', $response, 401, 'Response code should be 401 for non-authenticated users.' );
+		$this->assertErrorResponse( 'rest_cannot_read', $response );
 
 		wp_set_current_user( self::$editor_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_read', $response, 403, 'Response code should be 403 for users without the right permissions.' );
+		$this->assertErrorResponse( 'rest_cannot_read', $response );
 	}
 
 	/**

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -810,11 +810,11 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		// Attempt trashing.
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces/' . $font_face_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501, 'The response should return an error for "rest_trash_not_supported" with 501 status.' );
+		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501 );
 
 		$request->set_param( 'force', 'false' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501, 'When "force" is false, the response should return an error for "rest_trash_not_supported" with 501 status.' );
+		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501 );
 
 		// Ensure the post still exists.
 		$post = get_post( $font_face_id );

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -568,7 +568,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_duplicate_font_face', $response );
+		$this->assertErrorResponse( 'rest_duplicate_font_face', $response, 400, 'The response should return an error for "rest_duplicate_font_face" with 400 status.' );
 		$expected_message = 'A font face matching those settings already exists.';
 		$message          = $response->as_error()->get_error_messages()[0];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
@@ -698,7 +698,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
 		$expected_message = 'font_face_settings parameter must be a valid JSON string.';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_face_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
@@ -723,7 +723,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
 		$expected_message = 'File ' . array_keys( $files )[0] . ' must be used in font_face_settings[src].';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_face_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
@@ -810,11 +810,11 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		// Attempt trashing.
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces/' . $font_face_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501 );
+		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501, 'The response should return an error for "rest_trash_not_supported" with 501 status.' );
 
 		$request->set_param( 'force', 'false' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501 );
+		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501, 'When "force" is false, the response should return an error for "rest_trash_not_supported" with 501 status.' );
 
 		// Ensure the post still exists.
 		$post = get_post( $font_face_id );
@@ -852,7 +852,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/font-families/' . self::$other_font_family_id . '/font-faces/' . self::$font_face_id1 );
 		$request->set_param( 'force', true );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_font_face_parent_id_mismatch', $response );
+		$this->assertErrorResponse( 'rest_font_face_parent_id_mismatch', $response, 404, 'The response should return an error for "rest_font_face_parent_id_mismatch" with 404 status.' );
 
 		$expected_message = 'The font face does not belong to the specified font family with id of "' . self::$other_font_family_id . '"';
 		$this->assertSame( $expected_message, $response->as_error()->get_error_messages()[0], 'The message must contain the correct parent ID.' );
@@ -867,12 +867,12 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( 0 );
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces/' . $font_face_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_delete', $response );
+		$this->assertErrorResponse( 'rest_cannot_delete', $response, 401, 'The response should return an error for "rest_cannot_delete" with 401 status for an invalid user.' );
 
 		wp_set_current_user( self::$editor_id );
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces/' . $font_face_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_delete', $response );
+		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403, 'The response should return an error for "rest_cannot_delete" with 403 status for a user without permission.' );
 	}
 
 	/**

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -386,12 +386,12 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$settings = $data['font_face_settings'];
 		unset( $settings['src'] );
 		$this->assertSame(
-			$settings,
 			array(
 				'fontFamily' => '"Open Sans"',
 				'fontWeight' => '200',
 				'fontStyle'  => 'normal',
 			),
+			$settings,
 			'The font_face_settings data should match the expected data.'
 		);
 
@@ -568,7 +568,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_duplicate_font_face', $response, 400, 'The response should return an error for "rest_duplicate_font_face" with 400 status.' );
+		$this->assertErrorResponse( 'rest_duplicate_font_face', $response );
 		$expected_message = 'A font face matching those settings already exists.';
 		$message          = $response->as_error()->get_error_messages()[0];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
@@ -698,7 +698,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
+		$this->assertErrorResponse( 'rest_invalid_param', $response );
 		$expected_message = 'font_face_settings parameter must be a valid JSON string.';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_face_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
@@ -723,21 +723,21 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
+		$this->assertErrorResponse( 'rest_invalid_param', $response );
 		$expected_message = 'File ' . array_keys( $files )[0] . ' must be used in font_face_settings[src].';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_face_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
 	}
 
 	/**
-	 * @dataProvider data_create_item_santize_font_family
+	 * @dataProvider data_create_item_sanitize_font_family
 	 *
 	 * @covers WP_REST_Font_Face_Controller::sanitize_font_face_settings
 	 *
 	 * @param string $font_family_setting Setting to test.
 	 * @param string $expected            Expected result.
 	 */
-	public function test_create_item_santize_font_family( $font_family_setting, $expected ) {
+	public function test_create_item_sanitize_font_family( $font_family_setting, $expected ) {
 		$settings = array_merge( self::$default_settings, array( 'fontFamily' => $font_family_setting ) );
 
 		wp_set_current_user( self::$admin_id );
@@ -755,7 +755,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 	 *
 	 * @return array
 	 */
-	public function data_create_item_santize_font_family() {
+	public function data_create_item_sanitize_font_family() {
 		return array(
 			'multiword font with integer' => array(
 				'font_family_setting' => 'Libre Barcode 128 Text',
@@ -852,7 +852,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/font-families/' . self::$other_font_family_id . '/font-faces/' . self::$font_face_id1 );
 		$request->set_param( 'force', true );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_font_face_parent_id_mismatch', $response, 404, 'The response should return an error for "rest_font_face_parent_id_mismatch" with 404 status.' );
+		$this->assertErrorResponse( 'rest_font_face_parent_id_mismatch', $response );
 
 		$expected_message = 'The font face does not belong to the specified font family with id of "' . self::$other_font_family_id . '"';
 		$this->assertSame( $expected_message, $response->as_error()->get_error_messages()[0], 'The message must contain the correct parent ID.' );
@@ -867,12 +867,12 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( 0 );
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces/' . $font_face_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_delete', $response, 401, 'The response should return an error for "rest_cannot_delete" with 401 status for an invalid user.' );
+		$this->assertErrorResponse( 'rest_cannot_delete', $response );
 
 		wp_set_current_user( self::$editor_id );
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces/' . $font_face_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403, 'The response should return an error for "rest_cannot_delete" with 403 status for a user without permission.' );
+		$this->assertErrorResponse( 'rest_cannot_delete', $response );
 	}
 
 	/**
@@ -930,11 +930,11 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$this->assertSame( $expected, $links['parent'][0]['href'], 'The links for a parent URL from the response data should match the parent\'s REST endpoint.' );
 	}
 
-	protected function check_file_meta( $font_face_id, $srcs ) {
+	protected function check_file_meta( $font_face_id, $src_attributes ) {
 		$file_meta = get_post_meta( $font_face_id, '_wp_font_face_file' );
 
-		foreach ( $srcs as $src ) {
-			$file_name = basename( $src );
+		foreach ( $src_attributes as $src_attribute ) {
+			$file_name = basename( $src_attribute );
 			$this->assertContains( $file_name, $file_meta, 'The uploaded font file path should be saved in the post meta.' );
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the Font Library's PHPUnit tests to comply with the [WordPress Core Test coding standards](https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/) and practices.

Follow-up from https://github.com/WordPress/gutenberg/pull/58502.

WP_Test_REST_TestCase::assertErrorResponse() doesn't adhere to the coding standards, so I've created a Trac ticket to address that as well: https://core.trac.wordpress.org/ticket/60426.


## Why?
To prepare the test suite for Core sync / merge, as these changes will get flagged in review. By fixing them now, it can help to reduce the review time and change requests at Core merge time.

## How?
- [x] Removed the assignment of an empty array to `$post_ids_to_delete` in the `Tests_Font_Family_Backwards_Compatibility` class, as it's unnecessary.
- [x] Replaced `json_encode` with `wp_json_encode` in the `mock_request` method within the `wpFontCollection/loadFromJson.php` file to ensure consistent JSON encoding.
- [x] Replaced `json_encode` with `wp_json_encode` in the `mock_request_missing_slug` method within the `wpFontCollection/loadFromJson.php` file to ensure consistent JSON encoding.
- [x] Updated the assertion message in the `test_should_get_mock_font_collection` method in the `wpFontLibrary/getFontCollections.php` file to fix a typo in the word "Should."
- [x] Updated a comment in the `unregister_non_existing_collection` method in the `wpFontLibrary/unregisterFontCollection.php` file to fix a typo by changing "non existing" to "non-existing."
- [x] Corrected assertion message in the `test_register_routes` method in the `wpRestFontCollectionsController.php` file by adding a missing "initialized" to "intialized."
- [x] Corrected assertion message in the `test_register_routes` method in the `wpRestFontCollectionsController.php` file by adding a missing "initialized" to "intialized."
- [x] Corrected assertion message in the `test_register_routes` method in the `wpRestFontCollectionsController.php` file by adding a missing "initialized" to "intialized."
- [x] Updated the method name from `test_create_item_santize_font_family` to `test_create_item_sanitize_font_family` in the `wpRestFontFacesController.php` file to fix a typo.
- [x] Updated the method name from `data_create_item_santize_font_family` to `data_create_item_sanitize_font_family` in the `wpRestFontFacesController.php` file to fix a typo.
- [x] Updated the method name from `test_create_item_santize_font_family` to `test_create_item_sanitize_font_family` in the `wpRestFontFacesController.php` file to fix a typo.
- [x] Updated the method name from `data_create_item_santize_font_family` to `data_create_item_sanitize_font_family` in the `wpRestFontFacesController.php` file to fix a typo.
- [x] Updated variable names in the `check_file_meta` method in the `wpRestFontFacesController.php` file to more accurately reflect their purpose by changing `$srcs` to `$src_attributes`.
- [x] Updated variable names in the `check_file_meta` method in the `wpRestFontFacesController.php` file to more accurately reflect their purpose by changing `$srcs` to `$src_attributes`.

## Testing Instructions
All PHPUnit tests and test code linting checks should still pass.

### Testing Instructions for Keyboard

