### PR TITLE
Temporarily Disable Font Library Editor UI outside of Gutenberg Plugin 

### DIFF
--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -27,7 +27,9 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 
 	richEditingEnabled: true,
 	codeEditingEnabled: true,
-	fontLibraryEnabled: true,
+	// Whilst the Font Library PHP code is the process of being merge to Core,
+	// we need to disable it for non-Plugin envionrments.
+	fontLibraryEnabled: process.env.IS_GUTENBERG_PLUGIN ? true : false,
 	enableCustomFields: undefined,
 	defaultRenderingMode: 'post-only',
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Disables Font Library within the editor outside of the Gutenberg Plugin.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The "view" code for the Font Library within the editor will be included in WP Core. However, the PHP code which supports this is going to be merge _incrementally_. Therefore we should temporarily disable the UI until the PHP code is fully landed in Core for the WP 6.5 Beta.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Sets the editor setting conditionally based on whether we are running in the Gutenberg Plugin.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open Site Editor
- Toggle Global Styles panel (top right)
- Click Typography
- See Fonts Library available
- Invert the conditional in `packages/editor/src/store/defaults.js` 
- Repeat the test above and see that Font Library is _not_ available in the UI.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
