### PR TITLE
Fix image link preset suggestions arrow key navigation

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -5,11 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
 import {
 	ToolbarButton,
+	NavigableMenu,
 	Button,
 	MenuItem,
 	ToggleControl,
 	TextControl,
-	MenuGroup,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import {
@@ -257,7 +257,7 @@ const ImageURLInputUI = ( {
 					}
 					additionalControls={
 						showLinkEditor && (
-							<MenuGroup>
+							<NavigableMenu>
 								{ getLinkDestinations().map( ( link ) => (
 									<MenuItem
 										key={ link.linkDestination }
@@ -295,7 +295,7 @@ const ImageURLInputUI = ( {
 										{ __( 'Expand on click' ) }
 									</MenuItem>
 								) }
-							</MenuGroup>
+							</NavigableMenu>
 						)
 					}
 				>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/58495
<!-- In a few words, what is the PR actually doing? -->

When adding a link to an image, the initial view of the UI shows some preset suggestions:

1. Link to image file
2. Link to attachment page
3. And the recently added 'Expand on click'


In this [PR](https://github.com/WordPress/gutenberg/pull/57608/files#diff-c6070dd5f3e12e9df7a71d0ec209063b8e64be12b9ae651120b024ed035bee53R260) the `NavigableMenu` component was replaced with a `MenuGroup`, which broke the arrow key navigation. I don't see any reason for that change, but @artemiomorales would be good to confirm or explain why is needed and take action accordingly.


### Step-by-step reproduction instructions

- Add an Image block
- In the block toolbar, click the 'Insert link' button.
- Initial focus is set on the input field.
- Press the Tab key until you reach the first menu item
- Press the Down or Up arrow keys and observe they move focus through the menu items.
