### PR TITLE
Refine when Props Bot runs

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -64,7 +64,7 @@ jobs:
         if: |
             contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
             ( github.event_name == 'issue_comment' && github.event.issue.pull_request ) ||
-            github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+            github.event_name == 'pull_request_target' && github.event.action != 'labeled' && ! github.pull_request.draft && github.pull_request.state == 'open' ||
             'props-bot' == github.event.label.name
 
         steps:

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -1,10 +1,10 @@
 name: Props Bot
 
 on:
-    # This event runs anytime a PR is (re)opened, updated, or labeled.
+    # This event runs anytime a PR is (re)opened, updated, marked ready for review, or labeled.
     # GitHub does not allow filtering the `labeled` event by a specific label.
     # However, the logic below will short-circuit the workflow when the `props-bot` label is not the one being added.
-    # Note: The pull_request_target event is uesed instead of pull_request because this workflow needs permission to comment
+    # Note: The pull_request_target event is used instead of pull_request because this workflow needs permission to comment
     # on the pull request. Because this event grants extra permissions to `GITHUB_TOKEN`, any code changes within the PR
     # should be considered untrusted. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
     pull_request_target:
@@ -13,6 +13,7 @@ on:
             - synchronize
             - reopened
             - labeled
+            - ready_for_review
     # This event runs anytime a comment is added or deleted.
     # You cannot filter this event for PR comments only.
     # However, the logic below does short-circuit the workflow for issues.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This refines when Props Bot runs and leaves comments a bit.

## Why?
There are some scenarios where it's not appropriate for the bot to collect a list of contributors.

## How?
When a PR is a draft, or closed, the bot should not comment with a list of contributors.

Reported in #58576.