### PR TITLE
More refinements to Props Bot run conditions.

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -54,24 +54,24 @@ jobs:
             pull-requests: write
             contents: read
         timeout-minutes: 20
+        # The job will run when pull requests are open, ready for review and:
+        #
+        # - A comment is added to the pull request.
+        # - A review is created or commented on.
+        # - The pull request is opened, synchronized, marked ready for review, or reopened.
+        # - The `props-bot` label is added to the pull request.
+        if: |
+            (
+              github.event_name == 'issue_comment' && github.event.issue.pull_request ||
+              contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
+              github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+              'props-bot' == github.event.label.name
+            ) &&
+            ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
         steps:
             - name: Gather a list of contributors
               uses: WordPress/props-bot-action@trunk
-              # The step will run when open pull requests are ready for review and:
-              #
-              # - A comment is added to the pull request.
-              # - A review is created or commented on.
-              # - The pull request is opened, synchronized, marked ready for review, or reopened.
-              # - The `props-bot` label is added to the pull request.
-              if: |
-                  (
-                    github.event_name == 'issue_comment' && github.event.issue.pull_request ||
-                    contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
-                    github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
-                    'props-bot' == github.event.label.name
-                  ) &&
-                  ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
             - name: Remove the props-bot label
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -20,7 +20,6 @@ on:
     issue_comment:
         type:
             - created
-            - deleted
     # This event will run everytime a new PR review is initially submitted.
     pull_request_review:
         types:
@@ -29,7 +28,6 @@ on:
     pull_request_review_comment:
         types:
             - created
-            - deleted
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -56,27 +54,24 @@ jobs:
             pull-requests: write
             contents: read
         timeout-minutes: 20
-        # The job should only run if:
-        #
-        # - A pull request review is created or commented on.
-        # - An issue comment is added to a pull request.
-        # - A pull request is opened, synchronized, or reopened.
-        # - The `props-bot` label is added to the pull request.
-        if: |
-            github.event_name == 'issue_comment' && github.event.issue.pull_request && ! github.issue.draft && github.issue.state == 'open' ||
-            (
-              (
-                contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
-                github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
-                'props-bot' == github.event.label.name
-              )
-              &&
-              ! github.pull_request.draft && github.pull_request.state == 'open'
-            )
 
         steps:
             - name: Gather a list of contributors
               uses: WordPress/props-bot-action@trunk
+              # The step will run when open pull requests are ready for review and:
+              #
+              # - A comment is added to the pull request.
+              # - A review is created or commented on.
+              # - The pull request is opened, synchronized, marked ready for review, or reopened.
+              # - The `props-bot` label is added to the pull request.
+              if: |
+                  (
+                    github.event_name == 'issue_comment' && github.event.issue.pull_request ||
+                    contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
+                    github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+                    'props-bot' == github.event.label.name
+                  ) &&
+                  ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
             - name: Remove the props-bot label
               uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -63,10 +63,16 @@ jobs:
         # - A pull request is opened, synchronized, or reopened.
         # - The `props-bot` label is added to the pull request.
         if: |
-            contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
-            ( github.event_name == 'issue_comment' && github.event.issue.pull_request ) ||
-            github.event_name == 'pull_request_target' && github.event.action != 'labeled' && ! github.pull_request.draft && github.pull_request.state == 'open' ||
-            'props-bot' == github.event.label.name
+            github.event_name == 'issue_comment' && github.event.issue.pull_request && ! github.issue.draft && github.issue.state == 'open' ||
+            (
+              (
+                contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
+                github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+                'props-bot' == github.event.label.name
+              )
+              &&
+              ! github.pull_request.draft && github.pull_request.state == 'open'
+            )
 
         steps:
             - name: Gather a list of contributors


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow up to #58616.

## What?
This further refines the conditions that Props Bot will run under. The previous approach only worked for the `pull_request_target` event. Now all triggering events will skip the props bot when a PR is closed, or draft.
