### PR TITLE
Update Font Library REST API code to align with Core standards

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -298,17 +298,17 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 		 * @return true|WP_Error True if the request has write access for the item, WP_Error object otherwise.
 		 */
 		public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
-			if ( ! current_user_can( 'edit_theme_options' ) ) {
-				return new WP_Error(
-					'rest_cannot_read',
-					__( 'Sorry, you are not allowed to use the Font Library on this site.', 'gutenberg' ),
-					array(
-						'status' => rest_authorization_required_code(),
-					)
-				);
+			if ( current_user_can( 'edit_theme_options' ) ) {
+				return true;
 			}
-			return true;
+
+			return new WP_Error(
+				'rest_cannot_read',
+				__( 'Sorry, you are not allowed to use the Font Library on this site.', 'gutenberg' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
 		}
 	}
 }

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -157,15 +157,15 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 			return $item;
 		}
 
-		/*
-		* Prepare a single collection output for response.
-		*
-		* @since 6.5.0
-		*
-		* @param WP_Font_Collection $collection Collection object.
-		* @param WP_REST_Request    $request    Request object.
-		* @return array|WP_Error
-		*/
+		/**
+		 * Prepare a single collection output for response.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param WP_Font_Collection $collection Collection object.
+		 * @param WP_REST_Request    $request    Request object.
+		 * @return array|WP_Error
+		 */
 		public function prepare_item_for_response( $collection, $request ) {
 			$fields = $this->get_fields_for_response( $request );
 			$item   = array();

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 			if ( $page > $max_pages && $total_items > 0 ) {
 				return new WP_Error(
 					'rest_post_invalid_page_number',
-					__( 'The page number requested is larger than the number of pages available.', 'default' ),
+					__( 'The page number requested is larger than the number of pages available.' ),
 					array( 'status' => 400 )
 				);
 			}
@@ -148,24 +148,18 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 				return $collection;
 			}
 
-			$item = $this->prepare_item_for_response( $collection, $request );
-
-			if ( is_wp_error( $item ) ) {
-				return $item;
-			}
-
-			return $item;
+			return $this->prepare_item_for_response( $collection, $request );
 		}
 
 		/**
-		 * Prepare a single collection output for response.
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param WP_Font_Collection $collection Collection object.
-		 * @param WP_REST_Request    $request    Request object.
-		 * @return array|WP_Error
-		 */
+		* Prepare a single collection output for response.
+		*
+		* @since 6.5.0
+		*
+		* @param WP_Font_Collection $collection Collection object.
+		* @param WP_REST_Request    $request    Request object.
+		* @return WP_REST_Response Response object.
+		*/
 		public function prepare_item_for_response( $collection, $request ) {
 			$fields = $this->get_fields_for_response( $request );
 			$item   = array();
@@ -195,9 +189,9 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 			 *
 			 * @since 6.5.0
 			 *
-			 * @param WP_REST_Response $response The response object.
+			 * @param WP_REST_Response   $response    The response object.
 			 * @param WP_Font_Collection $collection  The Font Collection object.
-			 * @param WP_REST_Request  $request  Request used to generate the response.
+			 * @param WP_REST_Request    $request     Request used to generate the response.
 			 */
 			return apply_filters( 'rest_prepare_font_collection', $response, $collection, $request );
 		}
@@ -262,7 +256,7 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 		 * @return array Links for the given font collection.
 		 */
 		protected function prepare_links( $collection ) {
-			$links = array(
+			return array(
 				'self'       => array(
 					'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $collection->slug ) ),
 				),
@@ -270,7 +264,6 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 					'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
 				),
 			);
-			return $links;
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 *
 		 * @param string          $value   Encoded JSON string of font face settings.
 		 * @param WP_REST_Request $request Request object.
-		 * @return false|WP_Error True if the settings are valid, otherwise a WP_Error object.
+		 * @return true|WP_Error True if the settings are valid, otherwise a WP_Error object.
 		 */
 		public function validate_create_font_face_settings( $value, $request ) {
 			$settings = json_decode( $value, true );
@@ -698,7 +698,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 */
 		protected function prepare_links( $post ) {
 			// Entity meta.
-			$links = array(
+			return array(
 				'self'       => array(
 					'href' => rest_url( $this->namespace . '/font-families/' . $post->post_parent . '/font-faces/' . $post->ID ),
 				),
@@ -709,8 +709,6 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 					'href' => rest_url( $this->namespace . '/font-families/' . $post->post_parent ),
 				),
 			);
-
-			return $links;
 		}
 
 		/**
@@ -788,7 +786,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 			$status = 500;
 			$code   = 'rest_font_upload_unknown_error';
 
-			if ( __( 'Sorry, you are not allowed to upload this file type.', 'default' ) === $message ) {
+			if ( __( 'Sorry, you are not allowed to upload this file type.' ) === $message ) {
 				$status = 400;
 				$code   = 'rest_font_upload_invalid_file_type';
 			}
@@ -799,7 +797,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		/**
 		* Returns relative path to an uploaded font file.
 		*
-		* The path is relative to the current fonts dir.
+		* The path is relative to the current fonts directory.
 		*
 		* @since 6.5.0
 		* @access private

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -405,7 +405,6 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 		 *
 		 * @param int $font_family_id Font family post ID.
 		 * @return int[] Array of child font face post IDs.
-		 * .
 		 */
 		protected function get_font_face_ids( $font_family_id ) {
 			$query = new WP_Query(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Aligns the Font Library **REST API** code with Core PHP standards.

See https://github.com/WordPress/gutenberg/issues/55277#issuecomment-1923550684

Co-authored-by: getdave <get_dave@git.wordpress.org>
Co-authored-by: anton-vlasenko <antonvlasenko@git.wordpress.org>
Co-authored-by: pbking <pbking@git.wordpress.org>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
