### PR TITLE
Media Replace Flow: Vertically align the URL

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -177,7 +177,7 @@ $block-editor-link-control-number-of-actions: 1;
 	.block-editor-link-control__search-item-header {
 		display: block;
 		flex-direction: row;
-		align-items: flex-start;
+		align-items: center;
 		margin-right: $grid-unit-10;
 		gap: $grid-unit-10;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Vertically aligns the URL inside LinkControl, when it's used in the MediaReplaceFlow component.

## Why?
This stops the UI from looking broken when there is a missing title. Fixes #58593.

## How?
CSS

## Testing Instructions
1. Create a post and add an image block, an audio block and a video block
2. Add media to each block
3. Click on "Replace" in the block toolbar
4. Confirm that you see the URL vertically aligned

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="480" alt="Screenshot 2024-02-08 at 23 29 08" src="https://github.com/WordPress/gutenberg/assets/275961/1af671ce-c467-4d21-9deb-ea0b3b401b0b">
<img width="360" alt="Screenshot 2024-02-08 at 23 29 01" src="https://github.com/WordPress/gutenberg/assets/275961/00d5c664-9c8e-43ab-9953-a6b6a6837342">
<img width="388" alt="Screenshot 2024-02-08 at 23 28 10" src="https://github.com/WordPress/gutenberg/assets/275961/6cbc779d-6143-4452-adf0-50415c64d144">
<img width="379" alt="Screenshot 2024-02-08 at 23 28 01" src="https://github.com/WordPress/gutenberg/assets/275961/b1aecf30-a4cf-4c16-b052-2912587140f2">

