### PR TITLE
Block Hooks: Add controller to expose hooked blocks for a given anchor block

### DIFF
--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -140,7 +140,7 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 					? $hooked_block_types[ $anchor_block_type ][ $position ]
 					: array();
 
-				$hooked_block_types_by_anchor_block[ $anchor_block_type ][ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_by_anchor_block_position, $position, $block_type->name, $context );
+				$hooked_block_types_by_anchor_block[ $anchor_block_type ][ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_by_anchor_block_position, $position, $anchor_block_type, $context );
 			}
 		}
 

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Hooked_Blocks_Controller class.
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 6.5.0
+ */
+
+/**
+ * Core class used to access hooked blocks via the REST API.
+ *
+ * @since 6.5.0
+ *
+ */
+class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
+	/**
+	 * Constructs the controller.
+	 *
+	 * @since 6.5.0
+	 */
+	public function __construct() {
+		$this->namespace = 'wp/v2';
+		$this->rest_base = 'hooked-blocks';
+		$this->block_registry = WP_Block_Type_Registry::get_instance();
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @since 6.5.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<namespace>[a-zA-Z0-9_-]+)/(?P<name>[a-zA-Z0-9_-]+)',
+			array(
+				'args'   => array(
+					'name'      => array(
+						'description' => __( 'Block name.' ),
+						'type'        => 'string',
+					),
+					'namespace' => array(
+						'description' => __( 'Block namespace.' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks whether a given request has permission to read hooked block type.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		return $this->check_read_permission();
+	}
+
+	/**
+	 * Retrieves all hooked block types, depending on user and anchor block context.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		$data = array();
+
+		// TODO: Set context based on the request.
+		$context = null;
+
+		$hooked_block_types = get_hooked_blocks();
+		foreach( $hooked_block_types as $anchor_block_type => $hooked_block_types_for_anchor_block ) {
+			foreach( $hooked_block_types_for_anchor_block as $relative_position => $hooked_block_types ) {
+				$hooked_block_types_for_anchor_block[ $relative_position ] =
+					apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
+			}
+			$hooked_block_types[ $anchor_block_type ] = $hooked_block_types_for_anchor_block;
+		}
+
+		// Retrieve the list of registered collection query parameters.
+		$registered = $this->get_collection_params();
+		$namespace  = '';
+		if ( isset( $registered['namespace'] ) && ! empty( $request['namespace'] ) ) {
+			$namespace = $request['namespace'];
+		}
+
+		foreach ( $hooked_block_types as $anchor_block_type => $hooked_block_types_for_anchor_block ) {
+			if ( $namespace ) {
+				list ( $block_namespace ) = explode( '/', $anchor_block_type );
+
+				if ( $namespace !== $block_namespace ) {
+					continue;
+				}
+			}
+			$data[ $anchor_block_type ] = $this->prepare_response_for_collection( $hooked_block_types_for_anchor_block );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Checks if a given request has access to read a hooked block type.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		$check = $this->check_read_permission();
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+		$block_name = sprintf( '%s/%s', $request['namespace'], $request['name'] );
+		$block_type = $this->get_block( $block_name );
+		if ( is_wp_error( $block_type ) ) {
+			return $block_type;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether a given hooked block type should be visible.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return true|WP_Error True if the block type is visible, WP_Error otherwise.
+	 */
+	protected function check_read_permission() {
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				return true;
+			}
+		}
+
+		return new WP_Error( 'rest_block_type_cannot_view', __( 'Sorry, you are not allowed to manage block types.' ), array( 'status' => rest_authorization_required_code() ) );
+	}
+
+	/**
+	 * Get the block, if the name is valid.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param string $name Block name.
+	 * @return WP_Block_Type|WP_Error Block type object if name is valid, WP_Error otherwise.
+	 */
+	protected function get_block( $name ) {
+		$block_type = $this->block_registry->get_registered( $name );
+		if ( empty( $block_type ) ) {
+			return new WP_Error( 'rest_block_type_invalid', __( 'Invalid block type.' ), array( 'status' => 404 ) );
+		}
+
+		return $block_type;
+	}
+
+	/**
+	 * Retrieves hooked blocks for a specific anchor block type.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+		$block_name = sprintf( '%s/%s', $request['namespace'], $request['name'] );
+		$block_type = $this->get_block( $block_name );
+		if ( is_wp_error( $block_type ) ) {
+			return $block_type;
+		}
+
+		$all_hooked_block_types              = get_hooked_blocks();
+		$hooked_block_types_for_anchor_block = isset( $all_hooked_block_types[ $block_name ] )
+			? $all_hooked_block_types[ $block_name ]
+			: array();
+
+		// TODO: Set context based on the request.
+		$context = null;
+
+		foreach( $hooked_block_types_for_anchor_block as $relative_position => $hooked_block_types ) {
+			$hooked_block_types_for_anchor_block[ $relative_position ] = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $block_name, $context );
+		}
+
+		$data = $this->prepare_item_for_response( $hooked_block_types_for_anchor_block, $request );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepares a hooked blocks array for serialization.
+	 *
+	 * @since 6.50
+	 *
+	 * @param array           $item    Block type data.
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response Block type data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		// TODO: Filter?
+		$response = rest_ensure_response( $item );
+		return $response;
+	}
+
+	/**
+	 * Retrieves the query params for the hooked blocks collection.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		return array(
+			'context'   => $this->get_context_param( array( 'default' => 'view' ) ),
+			'entity'    => array(
+				'description' => __( 'Entity type to get hooked blocks for.' ),
+				'type'        => 'string',
+			),
+			'id'        => array(
+				'description' => __( 'Entity ID to get hooked blocks for.' ),
+				//'type'        => 'integer', // TODO: Can be an integer, but also a string(?) (template IDs?)
+			)
+		);
+	}
+}

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -373,24 +373,19 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 			return new WP_Error( 'rest_hooked_blocks_invalid_entity_context', __( 'Invalid entity.' ), array( 'status' => 404 ) );
 		}
 
+		// Suppress all hooked blocks getting inserted into the context.
+		add_filter( 'hooked_block_types', '__return_empty_array', 99999, 0 );
+
 		if ( ( 'wp_template' === $entity_type || 'wp_template_part' === $entity_type ) && ! empty( $id ) ) {
-			$suppress_all_hooked_blocks_filter = function() {
-				return array();
-			};
-			add_filter( 'hooked_block_types', $suppress_all_hooked_blocks_filter, 99999, 0 );
 			$context = get_block_template( $id, $entity_type );
-			remove_filter( 'hooked_block_types', $suppress_all_hooked_blocks_filter, 99999 );
-			if ( is_wp_error( $context ) ) {
-				return $context;
-			}
 		}
 
 		if ( 'wp_navigation' === $entity_type && ! empty( $id ) ) {
 			$context = get_post( (int) $id );
-			if ( is_wp_error( $context ) ) {
-				return $context;
-			}
 		}
+
+		// Remove the filter to allow hooked blocks to be inserted for all purposes.
+		remove_filter( 'hooked_block_types', '__return_empty_array', 99999 );
 
 		return $context;
 	}

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -208,6 +208,24 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		// TODO: Set context based on the request.
 		$context = null;
 
+		// Retrieve the list of registered collection query parameters.
+		$registered = $this->get_collection_params();
+		$entity     = '';
+		if ( isset( $registered['entity'] ) && ! empty( $request['entity'] ) ) {
+			$entity = $request['entity'];
+		}
+		if ( isset( $registered['id'] ) && ! empty( $request['id'] ) ) {
+			$id = $request['id'];
+		}
+
+		// TODO: Validate entity and ID.
+		if ( 'template' === $entity && is_string( $id ) ) {
+			$context = get_block_template( $id ); // TODO: How do we determine $template_type arg (template or part)?
+			if ( is_wp_error( $context ) ) {
+				return $context;
+			}
+		}
+
 		foreach( $hooked_block_types_for_anchor_block as $relative_position => $hooked_block_types ) {
 			$hooked_block_types_for_anchor_block[ $relative_position ] = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $block_name, $context );
 		}

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -233,7 +233,12 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		}
 
 		foreach ( $this->position_types as $position ) {
-			$hooked_block_types_for_anchor_block[ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_for_anchor_block[ $position ], $position, $block_name, $context );
+			// Making sure that we always pass an array to the filter.
+			$positioned_hooked_block_types = isset( $hooked_block_types_for_anchor_block[ $position ] )
+				? $hooked_block_types_for_anchor_block[ $position ]
+				: array();
+
+			$hooked_block_types_for_anchor_block[ $position ] = apply_filters( 'hooked_block_types', $positioned_hooked_block_types, $position, $block_name, $context );
 		}
 
 		// Filter non-empty arrays.

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -64,6 +64,20 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/(?P<namespace>[a-zA-Z0-9_-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/(?P<namespace>[a-zA-Z0-9_-]+)/(?P<name>[a-zA-Z0-9_-]+)',
 			array(
 				'args'   => array(
@@ -113,6 +127,7 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		// Retrieve the list of registered collection query parameters.
 		$registered = $this->get_collection_params();
 		$entity     = '';
+		$id         = null;
 		$namespace  = '';
 		if ( isset( $registered['entity'] ) && ! empty( $request['entity'] ) ) {
 			$entity = $request['entity'];

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -134,13 +134,13 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		$block_types                        = WP_Block_Type_Registry::get_instance()->get_all_registered();
 		$hooked_block_types                 = get_hooked_blocks();
 		$hooked_block_types_by_anchor_block = array();
-		foreach ( $block_types as $block_type ) {
+		foreach ( $block_types as $anchor_block_type ) {
 			foreach ( $this->position_types as $position ) {
-				$hooked_block_types_by_anchor_block_position = isset( $hooked_block_types[ $block_type->name ][ $position ] )
-					? $hooked_block_types[ $block_type->name ][ $position ]
+				$hooked_block_types_by_anchor_block_position = isset( $hooked_block_types[ $anchor_block_type->name ][ $position ] )
+					? $hooked_block_types[ $anchor_block_type->name ][ $position ]
 					: array();
 
-				$hooked_block_types_by_anchor_block[ $block_type->name ][ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_by_anchor_block_position, $position, $block_type->name, $context );
+				$hooked_block_types_by_anchor_block[ $anchor_block_type->name ][ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_by_anchor_block_position, $position, $block_type->name, $context );
 			}
 		}
 

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -332,13 +332,13 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 			'type'       => 'array',
 			'properties' => array(
 				'block_name' => array(
-					'description' => __( 'Block namespace.' ),
+					'description' => __( 'Block name.' ),
 					'type'        => array( 'array' ),
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
-						'position_key' => array(
-							'description' => __( 'Positive key' ),
+						'relative_position' => array(
+							'description' => __( 'Relative position.' ),
 							'type'        => 'array',
 							'readonly'    => true,
 							'context'     => array( 'view', 'edit' ),

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -129,8 +129,9 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 			return $context;
 		}
 
-		$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
-
+		// We need to get all registered block types and loop over each of them for the filter.
+		// TODO: Look into whether we can optimize get_hooked_blocks() to return filtered results as well.
+		$block_types                        = WP_Block_Type_Registry::get_instance()->get_all_registered();
 		$hooked_block_types                 = get_hooked_blocks();
 		$hooked_block_types_by_anchor_block = array();
 		foreach ( $block_types as $block_type ) {

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -136,15 +136,11 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		$hooked_block_types_by_anchor_block = array();
 		foreach ( $block_types as $block_type ) {
 			foreach ( $this->position_types as $position ) {
-				$hooked_block_types_for_anchor_block = isset( $hooked_block_types[ $block_type->name ][ $position ] )
+				$hooked_block_types_by_anchor_block_position = isset( $hooked_block_types[ $block_type->name ][ $position ] )
 					? $hooked_block_types[ $block_type->name ][ $position ]
 					: array();
 
-				$positioned_hooked_block_types = isset( $hooked_block_types[ $position ] )
-					? $hooked_block_types[ $position ]
-					: array();
-
-				$hooked_block_types_by_anchor_block[ $block_type->name ][ $position ] = apply_filters( 'hooked_block_types', $positioned_hooked_block_types, $position, $block_type->name, $context );
+				$hooked_block_types_by_anchor_block[ $block_type->name ][ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_by_anchor_block_position, $position, $block_type->name, $context );
 			}
 		}
 

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -374,7 +374,12 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		}
 
 		if ( ( 'wp_template' === $entity_type || 'wp_template_part' === $entity_type ) && ! empty( $id ) ) {
+			$suppress_all_hooked_blocks_filter = function() {
+				return array();
+			};
+			add_filter( 'hooked_block_types', $suppress_all_hooked_blocks_filter, 99999, 0 );
 			$context = get_block_template( $id, $entity_type );
+			remove_filter( 'hooked_block_types', $suppress_all_hooked_blocks_filter, 99999 );
 			if ( is_wp_error( $context ) ) {
 				return $context;
 			}

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -222,6 +222,7 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		// Retrieve the list of registered collection query parameters.
 		$registered = $this->get_collection_params();
 		$entity     = '';
+		$id         = null;
 		if ( isset( $registered['entity'] ) && ! empty( $request['entity'] ) ) {
 			$entity = $request['entity'];
 		}

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -147,7 +147,7 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 
 		// We need to get all registered block types and loop over each of them for the filter.
 		// TODO: Look into whether we can optimize get_hooked_blocks() to return filtered results as well.
-		$block_types                        = WP_Block_Type_Registry::get_instance()->get_all_registered();
+		$block_types                        = $this->block_registry->get_all_registered();
 		$hooked_block_types_by_anchor_block = array();
 
 		foreach ( array_column( $block_types, 'name' ) as $anchor_block_name ) {

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -312,7 +312,7 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => $this->post_type,
+			'title'      => 'hooked_blocks',
 			'type'       => 'array',
 			'properties' => array(
 				'block_name' => array(

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -368,20 +368,22 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 	 * @return WP_Block_Template|WP_Post|null Context object if name is valid, WP_Error otherwise.
 	 */
 	protected function get_context( $entity, $id ) {
-		$entity_type = in_array( $entity, $this->valid_entity_types, true ) ? $entity : null;
+		if ( ! $entity && ! $id ) {
+			return null; // No context specified.
+		}
 
-		if ( ! $entity_type || ! $id ) {
+		if ( ! in_array( $entity, $this->valid_entity_types, true ) ) {
 			return new WP_Error( 'rest_hooked_blocks_invalid_entity_context', __( 'Invalid entity.' ), array( 'status' => 404 ) );
 		}
 
 		// Suppress all hooked blocks getting inserted into the context.
 		add_filter( 'hooked_block_types', '__return_empty_array', 99999, 0 );
 
-		if ( ( 'wp_template' === $entity_type || 'wp_template_part' === $entity_type ) && ! empty( $id ) ) {
-			$context = get_block_template( $id, $entity_type );
+		if ( ( 'wp_template' === $entity || 'wp_template_part' === $entity ) && ! empty( $id ) ) {
+			$context = get_block_template( $id, $entity );
 		}
 
-		if ( 'wp_navigation' === $entity_type && ! empty( $id ) ) {
+		if ( 'wp_navigation' === $entity && ! empty( $id ) ) {
 			$context = get_post( (int) $id );
 		}
 

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -302,6 +302,48 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		);
 	}
 
+	/**
+	 * Retrieves the hooked blocks schema, conforming to JSON Schema.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->post_type,
+			'type'       => 'array',
+			'properties' => array(
+				'block_name' => array(
+					'description' => __( 'Block namespace.' ),
+					'type'        => array( 'array' ),
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'position_key' => array(
+							'description' => __( 'Positive key' ),
+							'type'        => 'array',
+							'readonly'    => true,
+							'context'     => array( 'view', 'edit' ),
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+
 		/**
 	 * Get the block, if the name is valid.
 	 *

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -134,13 +134,13 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 		$block_types                        = WP_Block_Type_Registry::get_instance()->get_all_registered();
 		$hooked_block_types                 = get_hooked_blocks();
 		$hooked_block_types_by_anchor_block = array();
-		foreach ( $block_types as $anchor_block_type ) {
+		foreach ( array_column( $block_types, 'name' ) as $anchor_block_type ) {
 			foreach ( $this->position_types as $position ) {
-				$hooked_block_types_by_anchor_block_position = isset( $hooked_block_types[ $anchor_block_type->name ][ $position ] )
-					? $hooked_block_types[ $anchor_block_type->name ][ $position ]
+				$hooked_block_types_by_anchor_block_position = isset( $hooked_block_types[ $anchor_block_type ][ $position ] )
+					? $hooked_block_types[ $anchor_block_type ][ $position ]
 					: array();
 
-				$hooked_block_types_by_anchor_block[ $anchor_block_type->name ][ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_by_anchor_block_position, $position, $block_type->name, $context );
+				$hooked_block_types_by_anchor_block[ $anchor_block_type ][ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_by_anchor_block_position, $position, $block_type->name, $context );
 			}
 		}
 

--- a/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
+++ b/lib/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php
@@ -23,6 +23,14 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 	 */
 	protected $valid_entity_types = array( 'wp_template', 'wp_template_part', 'wp_navigation' );
 
+	/*
+	 * Possible positions for hooked blocks.
+	 *
+	 * @since 6.5.0
+	 * @var string[]
+	 */
+	protected $position_types = array( 'first_child', 'last_child', 'before', 'after' );
+
 	/**
 	 * Constructs the controller.
 	 *
@@ -224,11 +232,19 @@ class Gutenberg_REST_Hooked_Blocks_Controller_6_5 extends WP_REST_Controller {
 			return $context;
 		}
 
-		foreach ( $hooked_block_types_for_anchor_block as $relative_position => $hooked_block_types ) {
-			$hooked_block_types_for_anchor_block[ $relative_position ] = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $block_name, $context );
+		foreach ( $this->position_types as $position ) {
+			$hooked_block_types_for_anchor_block[ $position ] = apply_filters( 'hooked_block_types', $hooked_block_types_for_anchor_block[ $position ], $position, $block_name, $context );
 		}
 
-		$data = $this->prepare_item_for_response( $hooked_block_types_for_anchor_block, $request );
+		// Filter non-empty arrays.
+		$filtered_hooked_block_types_for_anchor_block = array_filter(
+			$hooked_block_types_for_anchor_block,
+			function ( $hooked_block_types_for_position ) {
+				return ! empty( $hooked_block_types_for_position );
+			}
+		);
+
+		$data = $this->prepare_item_for_response( $filtered_hooked_block_types_for_anchor_block, $request );
 
 		return rest_ensure_response( $data );
 	}

--- a/lib/compat/wordpress-6.5/rest-api.php
+++ b/lib/compat/wordpress-6.5/rest-api.php
@@ -21,6 +21,16 @@ function gutenberg_register_global_styles_revisions_endpoints() {
 add_action( 'rest_api_init', 'gutenberg_register_global_styles_revisions_endpoints' );
 
 /**
+ * Registers the Hooked Blocks REST API routes.
+ */
+function gutenberg_register_hooked_blocks_endpoint() {
+	$hooked_blocks_controller = new Gutenberg_REST_Hooked_Blocks_Controller_6_5();
+	$hooked_blocks_controller->register_routes();
+}
+
+add_action( 'rest_api_init', 'gutenberg_register_hooked_blocks_endpoint' );
+
+/**
  * Registers additional fields for wp_template and wp_template_part rest api.
  *
  * @access private

--- a/lib/load.php
+++ b/lib/load.php
@@ -43,6 +43,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 6.5 compat.
 	require_once __DIR__ . '/compat/wordpress-6.5/class-gutenberg-rest-global-styles-revisions-controller-6-5.php';
+	require_once __DIR__ . '/compat/wordpress-6.5/class-gutenberg-rest-hooked-blocks-controller-6-5.php';
 	require_once __DIR__ . '/compat/wordpress-6.5/rest-api.php';
 
 	// Plugin specific code.

--- a/phpunit/class-gutenberg-rest-hooked-blocks-controller-gutenberg-test.php
+++ b/phpunit/class-gutenberg-rest-hooked-blocks-controller-gutenberg-test.php
@@ -31,12 +31,6 @@ class Gutenberg_REST_Hooked_Blocks_Controller_Test extends WP_Test_REST_Controll
 	 */
 	protected static $subscriber_id;
 
-	protected static $anchor_block_name = 'fake/anchor-block';
-	protected static $hooked_block_name = 'fake/hooked-block';
-
-	protected static $other_anchor_block_name = 'fake/other-anchor-block';
-	protected static $other_hooked_block_name = 'fake/other-hooked-block';
-
 	/**
 	 * Create fake data before our tests run.
 	 *
@@ -66,8 +60,8 @@ class Gutenberg_REST_Hooked_Blocks_Controller_Test extends WP_Test_REST_Controll
 			)
 		);
 
-		register_block_type( self::$anchor_block_name, $anchor_block_settings );
-		register_block_type( self::$hooked_block_name, $hooked_block_settings );
+		register_block_type( 'fake/anchor-block', $anchor_block_settings );
+		register_block_type( 'fake/hooked-block', $hooked_block_settings );
 
 		$other_hooked_block_settings = array(
 			'block_hooks' => array(
@@ -75,17 +69,17 @@ class Gutenberg_REST_Hooked_Blocks_Controller_Test extends WP_Test_REST_Controll
 			)
 		);
 
-		register_block_type( self::$other_anchor_block_name, array() );
-		register_block_type( self::$other_hooked_block_name, $other_hooked_block_settings );
+		register_block_type( 'fake/other-anchor-block', array() );
+		register_block_type( 'fake/other-hooked-block', $other_hooked_block_settings );
 	}
 
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$admin_id );
 		self::delete_user( self::$subscriber_id );
-		unregister_block_type( self::$anchor_block_name );
-		unregister_block_type( self::$hooked_block_name );
-		unregister_block_type( self::$other_anchor_block_name );
-		unregister_block_type( self::$other_hooked_block_name );
+		unregister_block_type( 'fake/anchor-block' );
+		unregister_block_type( 'fake/hooked-block' );
+		unregister_block_type( 'fake/other-anchor-block' );
+		unregister_block_type( 'fake/other-hooked-block' );
 	}
 
 	public function test_register_routes() {
@@ -121,28 +115,28 @@ class Gutenberg_REST_Hooked_Blocks_Controller_Test extends WP_Test_REST_Controll
 		$data     = $response->get_data();
 		$this->assertCount( 2, $data );
 		$this->assertSame( $data, array(
-			self::$anchor_block_name => array(
-				'after' => array( self::$hooked_block_name )
+			'fake/anchor-block' => array(
+				'after' => array( 'fake/hooked-block' )
 			),
-			self::$other_anchor_block_name => array(
-				'first_child' => array( self::$other_hooked_block_name )
+			'fake/other-anchor-block' => array(
+				'first_child' => array( 'fake/other-hooked-block' )
 			),
 		) );
 	}
 
 	public function test_get_item() {
 		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/' . self::$anchor_block_name );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/fake/anchor-block' );
 		$response = rest_get_server()->dispatch( $request );
 		$data	  = $response->get_data();
 		$this->assertSame( $data, array(
-			'after' => array( self::$hooked_block_name )
+			'after' => array( 'fake/hooked-block' )
 		) );
 	}
 
 	public function test_get_item_with_no_hooked_blocks() {
 		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/' . self::$hooked_block_name );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/fake/hooked-block' );
 		$response = rest_get_server()->dispatch( $request );
 		$data	  = $response->get_data();
 		$this->assertSame( $data, array() );
@@ -150,7 +144,7 @@ class Gutenberg_REST_Hooked_Blocks_Controller_Test extends WP_Test_REST_Controll
 
 	public function test_get_item_with_hooked_block_added_by_filter() {
 		$add_hooked_block = function( $hooked_block_types, $relative_position, $anchor_block_type ) {
-			if ( 'last_child' === $relative_position && self::$anchor_block_name === $anchor_block_type ) {
+			if ( 'last_child' === $relative_position && 'fake/anchor-block' === $anchor_block_type ) {
 				$hooked_block_types[] = 'fake/hooked-block-added-by-filter';
 			}
 			return $hooked_block_types;
@@ -158,13 +152,13 @@ class Gutenberg_REST_Hooked_Blocks_Controller_Test extends WP_Test_REST_Controll
 		add_filter( 'hooked_block_types', $add_hooked_block, 10, 3 );
 
 		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/' . self::$anchor_block_name );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/fake/anchor-block' );
 		$response = rest_get_server()->dispatch( $request );
 		$data	  = $response->get_data();
 
 		remove_filter( 'hooked_block_types', $add_hooked_block, 10 );
 		$this->assertSame( $data, array(
-			'after'      => array( self::$hooked_block_name ),
+			'after'      => array( 'fake/hooked-block' ),
 			'last_child' => array( 'fake/hooked-block-added-by-filter' )
 		) );
 	}

--- a/phpunit/class-gutenberg-rest-hooked-blocks-controller-gutenberg-test.php
+++ b/phpunit/class-gutenberg-rest-hooked-blocks-controller-gutenberg-test.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Unit tests covering Gutenberg_REST_Hooked_Blocks_Controller_6_5 functionality.
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 6.5.0
+ *
+ * @covers WP_REST_Block_Types_Controller
+ *
+ * @group restapi-blocks
+ * @group restapi
+ */
+class Gutenberg_REST_Hooked_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @var int $subscriber_id
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @var int $subscriber_id
+	 */
+	protected static $subscriber_id;
+
+	protected static $anchor_block_name = 'fake/anchor-block';
+	protected static $hooked_block_name = 'fake/hooked-block';
+
+	protected static $other_anchor_block_name = 'fake/other-anchor-block';
+	protected static $other_hooked_block_name = 'fake/other-hooked-block';
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		self::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+
+		$anchor_block_settings = array(
+			'icon' => 'text',
+		);
+
+		$hooked_block_settings = array(
+			'block_hooks' => array(
+				'fake/anchor-block' => 'after',
+			)
+		);
+
+		register_block_type( self::$anchor_block_name, $anchor_block_settings );
+		register_block_type( self::$hooked_block_name, $hooked_block_settings );
+
+		$other_hooked_block_settings = array(
+			'block_hooks' => array(
+				'fake/other-anchor-block' => 'first_child',
+			)
+		);
+
+		register_block_type( self::$other_anchor_block_name, array() );
+		register_block_type( self::$other_hooked_block_name, $other_hooked_block_settings );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+		self::delete_user( self::$subscriber_id );
+		unregister_block_type( self::$anchor_block_name );
+		unregister_block_type( self::$hooked_block_name );
+		unregister_block_type( self::$other_anchor_block_name );
+		unregister_block_type( self::$other_hooked_block_name );
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/wp/v2/hooked-blocks', $routes );
+		$this->assertCount( 1, $routes['/wp/v2/hooked-blocks'] );
+		$this->assertArrayHasKey( '/wp/v2/hooked-blocks/(?P<namespace>[a-zA-Z0-9_-]+)', $routes );
+		$this->assertCount( 1, $routes['/wp/v2/hooked-blocks/(?P<namespace>[a-zA-Z0-9_-]+)'] );
+		$this->assertArrayHasKey( '/wp/v2/hooked-blocks/(?P<namespace>[a-zA-Z0-9_-]+)/(?P<name>[a-zA-Z0-9_-]+)', $routes );
+		$this->assertCount( 1, $routes['/wp/v2/hooked-blocks/(?P<namespace>[a-zA-Z0-9_-]+)/(?P<name>[a-zA-Z0-9_-]+)'] );
+	}
+
+	public function test_context_param() {
+		// Collection.
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/hooked-blocks' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single.
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/hooked-blocks/fake/test' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
+	public function test_get_items() {
+		$block_name = 'fake/test';
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/fake' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 2, $data );
+		$this->assertSame( $data, array(
+			self::$anchor_block_name => array(
+				'after' => array( self::$hooked_block_name )
+			),
+			self::$other_anchor_block_name => array(
+				'first_child' => array( self::$other_hooked_block_name )
+			),
+		) );
+	}
+
+	public function test_get_item() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/' . self::$anchor_block_name );
+		$response = rest_get_server()->dispatch( $request );
+		$data	  = $response->get_data();
+		$this->assertSame( $data, array(
+			'after' => array( self::$hooked_block_name )
+		) );
+	}
+
+	public function test_get_item_with_no_hooked_blocks() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/' . self::$hooked_block_name );
+		$response = rest_get_server()->dispatch( $request );
+		$data	  = $response->get_data();
+		$this->assertSame( $data, array() );
+	}
+
+	public function test_get_item_with_hooked_block_added_by_filter() {
+		$add_hooked_block = function( $hooked_block_types, $relative_position, $anchor_block_type ) {
+			if ( 'last_child' === $relative_position && self::$anchor_block_name === $anchor_block_type ) {
+				$hooked_block_types[] = 'fake/hooked-block-added-by-filter';
+			}
+			return $hooked_block_types;
+		};
+		add_filter( 'hooked_block_types', $add_hooked_block, 10, 3 );
+
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/' . self::$anchor_block_name );
+		$response = rest_get_server()->dispatch( $request );
+		$data	  = $response->get_data();
+
+		remove_filter( 'hooked_block_types', $add_hooked_block, 10 );
+		$this->assertSame( $data, array(
+			'after'      => array( self::$hooked_block_name ),
+			'last_child' => array( 'fake/hooked-block-added-by-filter' )
+		) );
+	}
+
+	public function test_get_block_invalid_name() {
+		$block_type = 'fake/block';
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/' . $block_type );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_block_type_invalid', $response, 404 );
+	}
+
+	public function test_get_item_schema() {
+		wp_set_current_user( self::$admin_id );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/hooked-blocks' );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+		$this->assertCount( 1, $properties );
+		$this->assertArrayHasKey( 'block_name', $properties );
+	}
+
+	public function test_get_items_wrong_permission() {
+		wp_set_current_user( self::$subscriber_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_block_type_cannot_view', $response, 403 );
+	}
+
+	public function test_get_item_wrong_permission() {
+		wp_set_current_user( self::$subscriber_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/fake/test' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_block_type_cannot_view', $response, 403 );
+	}
+
+	public function test_get_items_no_permission() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_block_type_cannot_view', $response, 401 );
+	}
+
+	public function test_get_item_no_permission() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/hooked-blocks/fake/test' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_block_type_cannot_view', $response, 401 );
+	}
+
+	public function test_prepare_item() {
+		$registry = new WP_Block_Type_Registry();
+		$settings = array(
+			'icon'            => 'text',
+			'render_callback' => '__return_null',
+		);
+		$registry->register( 'fake/line', $settings );
+		$block_type = $registry->get_registered( 'fake/line' );
+		$endpoint   = new WP_REST_Block_Types_Controller();
+		$request    = new WP_REST_Request();
+		$request->set_param( 'context', 'edit' );
+		$response = $endpoint->prepare_item_for_response( $block_type, $request );
+		// $this->assertSame();
+	}
+
+	public function test_prepare_item_limit_fields() {
+		$registry = new WP_Block_Type_Registry();
+		$settings = array(
+			'icon'            => 'text',
+			'render_callback' => '__return_null',
+		);
+		$registry->register( 'fake/line', $settings );
+		$block_type = $registry->get_registered( 'fake/line' );
+		$request    = new WP_REST_Request();
+		$endpoint   = new WP_REST_Block_Types_Controller();
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( '_fields', 'name' );
+		$response = $endpoint->prepare_item_for_response( $block_type, $request );
+		$this->assertSame(
+			array(
+				'name',
+			),
+			array_keys( $response->get_data() )
+		);
+	}
+
+	/**
+	 * The create_item() method does not exist for hooked blocks.
+	 *
+	 * @doesNotPerformAssertions
+	 */
+	public function test_create_item() {
+		// Controller does not implement create_item().
+	}
+
+	/**
+	 * The update_item() method does not exist for hooked blocks.
+	 *
+	 * @doesNotPerformAssertions
+	 */
+	public function test_update_item() {
+		// Controller does not implement create_item().
+	}
+
+	/**
+	 * The delete_item() method does not exist for hooked blocks.
+	 *
+	 * @doesNotPerformAssertions
+	 */
+	public function test_delete_item() {
+		// Controller does not implement delete_item().
+	}
+}


### PR DESCRIPTION
_More details to come!_

## What?
Add a REST API controller for a new `/hooked-blocks` route that exposes hooked blocks for a given anchor block, when used in a certain context (e.g. within a template, a pattern, or a navigation menu).

This allows obtaining a list of blocks that are hooked to the given anchor within the current context. This takes blocks into account that are added (or removed) via the `hooked_block_types` filter -- unlike the `block-types` endpoint, which is only aware of the context-agnostic `blockHooks` field in `block.json`.

## Why?
See https://core.trac.wordpress.org/ticket/59574 and https://github.com/WordPress/gutenberg/pull/58553.

## How?
TBD

## Testing Instructions
TBD, but largely: Add a hooked block via the `hooked_block_types` filter, and verify that the endpoint includes it.
E.g. in the browser console:
```js
let result = await wp.apiFetch( { path: '/wp/v2/hooked-blocks/core/post-content?entity=template&id=twentytwentythree/single' } );
```


## Screenshots or screencast 

## TODO

_Work is largely inspired by the [`block-types` endpoint](https://developer.wordpress.org/rest-api/reference/block-types/)_

- [ ] Test with conditionally added blocks (i.e. via `hooked_block_types` filter) and verify that they're present in the endpoint's response; add unit test coverage for that.
- [ ] Build `$context` from query args, pass to `hooked_block_types` filter.
  - [x] Template
  - [x] Template Part
  - [ ] Pattern?
  - [x] Navigation 
- [ ] Add test coverage.
- [ ] Add schema
- [x] Get the `/hooked-blocks/` "root" to work.
- [ ] ~Filter fields (`after`, `before`, ... )~
- [ ] Re-write `getHookedBlocks` selector (introduced by #58553) to use endpoint as source of truth.