### PR TITLE
Font Library: Remove slug from collection schema to accommodate the changes on the wp_register_font_collection function signature

### DIFF
--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -100,10 +100,6 @@
 			"description": "JSON schema URI for font-collection.json.",
 			"type": "string"
 		},
-		"slug": {
-			"type": "string",
-			"description": "Slug of the font collection. Must be unique and URL friendly."
-		},
 		"name": {
 			"type": "string",
 			"description": "Name of the font collection."


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Font Library: Remove slug from collection schema to accommodate the changes on the wp_register_font_collection function signature done in https://github.com/WordPress/gutenberg/pull/58530

## Why?
The slug is no longer part of the required collection JSON data. The slug is added in PHP when a font collection is registered. Example

```php
wp_register_font_collection( 'my-collection-slug', 'https://example.com/fonts/my-collection.json' );
```

## How?
Removing the slug from the schema
