### PR TITLE
Tabs: delay `activeId` updates until focus can be properly detected

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,7 @@
 -   `Guide`, `Modal`: Restore accent color themability ([#58098](https://github.com/WordPress/gutenberg/pull/58098)).
 -   `DropdownMenuV2`: Restore accent color themability ([#58130](https://github.com/WordPress/gutenberg/pull/58130)).
 -   `Tabs`: improve controlled mode focus handling and keyboard navigation ([#57696](https://github.com/WordPress/gutenberg/pull/57696)).
+-   `Tabs`: prevent internal focus from updating too early ([#58625](https://github.com/WordPress/gutenberg/pull/58625)).
 -   Expand theming support in the `COLORS` variable object ([#58097](https://github.com/WordPress/gutenberg/pull/58097)).
 
 ### Enhancements

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -164,23 +164,25 @@ function Tabs( {
 			return;
 		}
 
-		const focusedElement =
-			items?.[ 0 ]?.element?.ownerDocument.activeElement;
+		requestAnimationFrame( () => {
+			const focusedElement =
+				items?.[ 0 ]?.element?.ownerDocument.activeElement;
 
-		if (
-			! focusedElement ||
-			! items.some( ( item ) => focusedElement === item.element )
-		) {
-			return; // Return early if no tabs are focused.
-		}
+			if (
+				! focusedElement ||
+				! items.some( ( item ) => focusedElement === item.element )
+			) {
+				return; // Return early if no tabs are focused.
+			}
 
-		// If, after ariakit re-computes the active tab, that tab doesn't match
-		// the currently focused tab, then we force an update to ariakit to avoid
-		// any mismatches, especially when navigating to previous/next tab with
-		// arrow keys.
-		if ( activeId !== focusedElement.id ) {
-			setActiveId( focusedElement.id );
-		}
+			// If, after ariakit re-computes the active tab, that tab doesn't match
+			// the currently focused tab, then we force an update to ariakit to avoid
+			// any mismatches, especially when navigating to previous/next tab with
+			// arrow keys.
+			if ( activeId !== focusedElement.id ) {
+				setActiveId( focusedElement.id );
+			}
+		} );
 	}, [ activeId, isControlled, items, setActiveId ] );
 
 	const contextValue = useMemo(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make sure the `Tabs` component doesn't update its internal `activeId` too early.

## Why?
Tabs uses Ariakit internally, which uses an `activeId` property to track focus internally. In certain situations, it's possible for that internal focus to become out of sync with actual browser focus, [so we update it accordingly to ensure arrow key behavior works as expected](https://github.com/WordPress/gutenberg/pull/57696).

In some cases, such as #56959, the browser focus value doesn't update quickly enough, and our internal syncing efforts lead to arrow keys not working at all, which is obviously not the desired outcome. This PR addresses such cases by delaying the update.

## How?
Wrapping our existing logic in `requestAnimationFrame()` allows enough time to make sure the currently focused ID has finished updating before we check for a mismatch and update our internal focus value.

## Testing Instructions
1. First check out #56959, as that PR demonstrates the issue we're solving the most clearly.
2. Open a template in the Site Editor
3. Click on the **Template** tab in the editor setting sidebar
4. Press <kbd>RightArrow</kbd> several times. Notice that focus does not move over to the **Block** tab as it should.
5. Check out this PR, and rebase it off of the branch from the site-editor PR you checked out in a previous step.
6. Refresh the site editor and repeat the test above.
7. Confirm that focus now follows arrow key presses as expected.

