### PR TITLE
Tabs: Fix flaky unit tests

### DIFF
--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render, screen, waitFor } from '@testing-library/react';
-import { press, click } from '@ariakit/test';
+import { press, click, sleep } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -1185,6 +1185,12 @@ describe( 'Tabs', () => {
 							/>
 						);
 
+						// Due to the timing of the component re-rendering, we
+						// need to force a delay to ensure the test doesn't run
+						// the upcoming assertions too early.
+						// see https://github.com/WordPress/gutenberg/pull/58629#issuecomment-1924875249
+						await sleep();
+
 						// Tab key should focus the currently selected tab, which is Beta.
 						await press.Tab();
 						await waitFor( async () =>
@@ -1204,11 +1210,10 @@ describe( 'Tabs', () => {
 
 						// When the selected tab is changed, it should not automatically receive focus.
 
-						await waitFor( async () =>
-							expect( await getSelectedTab() ).toHaveTextContent(
-								'Gamma'
-							)
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Gamma'
 						);
+
 						expect(
 							screen.getByRole( 'tab', { name: 'Beta' } )
 						).toHaveFocus();
@@ -1252,11 +1257,11 @@ describe( 'Tabs', () => {
 						);
 
 						// When the selected tab is changed, it should not automatically receive focus.
-						await waitFor( async () =>
-							expect( await getSelectedTab() ).toHaveTextContent(
-								'Gamma'
-							)
+
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Gamma'
 						);
+
 						expect(
 							screen.getByRole( 'tab', { name: 'Beta' } )
 						).toHaveFocus();

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1203,8 +1203,11 @@ describe( 'Tabs', () => {
 						);
 
 						// When the selected tab is changed, it should not automatically receive focus.
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Gamma'
+
+						await waitFor( async () =>
+							expect( await getSelectedTab() ).toHaveTextContent(
+								'Gamma'
+							)
 						);
 						expect(
 							screen.getByRole( 'tab', { name: 'Beta' } )

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1187,8 +1187,10 @@ describe( 'Tabs', () => {
 
 						// Tab key should focus the currently selected tab, which is Beta.
 						await press.Tab();
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Beta'
+						await waitFor( async () =>
+							expect( await getSelectedTab() ).toHaveTextContent(
+								'Beta'
+							)
 						);
 						expect( await getSelectedTab() ).toHaveFocus();
 
@@ -1247,8 +1249,10 @@ describe( 'Tabs', () => {
 						);
 
 						// When the selected tab is changed, it should not automatically receive focus.
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Gamma'
+						await waitFor( async () =>
+							expect( await getSelectedTab() ).toHaveTextContent(
+								'Gamma'
+							)
 						);
 						expect(
 							screen.getByRole( 'tab', { name: 'Beta' } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes flaky tests!

## Why?
Because tests, unlike pastry, should not be flaky!

## How?
The Ariakit internals go through a few different renders on selection changes. This can cause the test to run an assertion before the component is actually ready, especially in Controlled Mode.

this PR adds `waitFor` falls to our first assertions after Controlled mode selection changes in the newest unit tests. That ensures the component is done rendering before moving forward.

## Testing Instructions
Just wait for that beautiful green checkmark.
