### PR TITLE
Docs: Update list formatting and descriptions in the Fundamentals of Block Development doc.

### DIFF
--- a/docs/getting-started/fundamentals/README.md
+++ b/docs/getting-started/fundamentals/README.md
@@ -1,14 +1,12 @@
 # Fundamentals of Block Development
 
-This section provides an introduction to the most relevant concepts in Block Development.
+This section provides an introduction to the most relevant concepts in block development. Use the following links to learn more:
 
-In this section, you will learn:
-
-1. [**File structure of a block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/file-structure-of-a-block) - The purpose of each one of the types of files available for a block, the relationships between them, and their role in the output of the block.
-1. [**`block.json`**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-json) - How a block is defined using its `block.json` metadata and some relevant properties of this file (such as `attributes` and `supports`).
-1. [**Registration of a block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/registration-of-a-block) - How a block is registered in both the server and the client.
-1. [**Block wrapper**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-wrapper) - How to set proper attributes to the block's markup wrapper.
-1. [**The block in the Editor**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-in-the-editor) - The block as a React component loaded in the Block Editor and its possibilities.
-1. [**Markup representation of a block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/markup-representation-block) - How blocks are represented in the database, theme templates, or patterns.
-1. [**Static or Dynamic rendering of a block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering) - How blocks can generate their output for the front end dynamically or statically.
-1. [**Javascript in the Block Editor**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/javascript-in-the-block-editor) - How to work with Javascript for the Block Editor.
+1. **[File structure of a block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/file-structure-of-a-block):** The purpose of each file that composes a block plugin, the relationships between them, and their role in the block output.
+1. **[`block.json`](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-json):** How a block is defined using its `block.json` metadata and some relevant properties of this file (such as `attributes` and `supports`).
+1. **[Registration of a block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/registration-of-a-block):** How a block is registered on both the server and in the client.
+1. **[Block wrapper](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-wrapper):** How to apply the proper attributes to the block's markup wrapper.
+1. **[The block in the Editor](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-in-the-editor):** How a block, as a React component, is loaded in the Block Editor and an overview of its structure.
+1. **[Markup representation of a block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/markup-representation-block):** How blocks are represented in the database, theme templates, and patterns.
+1. **[Static or Dynamic rendering of a block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering):** How blocks generate their front-end output either dynamically or statically.
+1. **[Javascript in the Block Editor](https://developer.wordpress.org/block-editor/getting-started/fundamentals/javascript-in-the-block-editor):** How to work with modern Javascript when developing for the Block Editor.


### PR DESCRIPTION
This is a minor PR that updates the list formatting and descriptions in the [Fundamentals of Block Development](https://developer.wordpress.org/block-editor/getting-started/fundamentals/) doc. The goal is to make the doc a bit easier to read and also standardize the list formatting with other areas of the Handbook (see https://github.com/WordPress/gutenberg/pull/58624)
