### PR TITLE
Button: Add focusable disabled variant to vizreg Storybook

### DIFF
--- a/packages/components/src/button/stories/e2e/index.story.tsx
+++ b/packages/components/src/button/stories/e2e/index.story.tsx
@@ -40,6 +40,12 @@ export const VariantStates: StoryFn< typeof Button > = (
 				>
 					<Button { ...props } variant={ variant } />
 					<Button { ...props } variant={ variant } disabled />
+					<Button
+						{ ...props }
+						variant={ variant }
+						disabled
+						__experimentalIsFocusable
+					/>
 					<Button { ...props } variant={ variant } isBusy />
 					<Button { ...props } variant={ variant } isDestructive />
 					<Button { ...props } variant={ variant } isPressed />


### PR DESCRIPTION
## What?

Adds a focusable disabled (`disabled` + `__experimentalIsFocusable`) column to the Button variant matrix we have in the dev Storybook we have for local visual regression testing.

## Why?

We don't have automated vizreg tests for focus states yet, but this is still useful for manual testing. It was helpful when testing #58606, and also helped catch a bug (#58632).

## Testing Instructions

Run `npm run storybook:e2e:dev` and see the story for Button ▸ Variant States.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2024-02-03 at 03 24 00](https://github.com/WordPress/gutenberg/assets/555336/91fa5569-d162-4600-a156-3c70ec95ea18)
