### PR TITLE
Font Library: sanitize font collection data

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 			}
 
 			// Validate required properties are not empty.
-			$data = $this->validate_data( $this->data );
+			$data = $this->validate_andd_sanitize( $this->data );
 			if ( is_wp_error( $data ) ) {
 				return $data;
 			}
@@ -229,7 +229,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 				}
 
 				// Make sure the data is valid before caching it.
-				$data = $this->validate_data( $data );
+				$data = $this->validate_andd_sanitize( $data );
 				if ( is_wp_error( $data ) ) {
 					return $data;
 				}
@@ -248,7 +248,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 * @param array $data Font collection configuration to validate.
 		 * @return array|WP_Error Array of data if valid, otherwise a WP_Error instance.
 		 */
-		private function validate_data( $data ) {
+		private function validate_andd_sanitize( $data ) {
 			$data                = WP_Font_Utils::sanitize_from_schema( $data, self::COLLECTION_SANITIZATION_SCHEMA );
 			$required_properties = array( 'name', 'font_families' );
 			foreach ( $required_properties as $property ) {

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 *
 		 * @var array
 		 */
-		private const COLLECTION_SANITIZATION_SCHEMA = array(
+		const COLLECTION_SANITIZATION_SCHEMA = array(
 			'name'          => 'sanitize_text_field',
 			'description'   => 'sanitize_text_field',
 			'font_families' => array(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -92,20 +92,16 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 				$this->data = $this->load_from_json( $this->src );
 			}
 
-			$data_or_error = $this->data;
-
-			if ( ! is_wp_error( $data_or_error ) ) {
-				// Set defaults for optional properties.
-				$data_or_error = wp_parse_args(
-					$this->data,
-					array(
-						'description' => '',
-						'categories'  => array(),
-					)
-				);
+			if ( is_wp_error( $this->data ) ) {
+				return $this->data;
 			}
 
-			return $data_or_error;
+			// Set defaults for optional properties.
+			$defaults = array(
+				'description' => '',
+				'categories'  => array(),
+			);
+			return wp_parse_args( $this->data, $defaults );
 		}
 
 		/**
@@ -192,8 +188,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param array $data Font collection data.
-		 *
+		 * @param array $data Font collection data to sanitize and validate.
 		 * @return array|WP_Error Sanitized data if valid, otherwise a WP_Error instance.
 		 */
 		private function sanitize_and_validate_data( $data ) {

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -269,20 +269,20 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 
 		/**
 		 * Sanitizes a src property.
-		 * 
+		 *
 		 * Font faces can have a src property consisting on a string or an array of strings.
 		 * This method sanitizes the src property value.
-		 * 
+		 *
 		 * @since 6.5.0
-		 * 
+		 *
 		 * @param string|array $value src property value to sanitize.
-		 * 
+		 *
 		 * @return string|array Sanitized URL value.
 		 */
 		public static function sanitize_src_property( $value ) {
-			if( is_array( $value ) ) {
-				foreach( $value as $key => $val ) {
-					$value[$key] = sanitize_url( $val );
+			if ( is_array( $value ) ) {
+				foreach ( $value as $key => $val ) {
+					$value[ $key ] = sanitize_url( $val );
 				}
 				return $value;
 			}

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 								'fontFamily'            => 'sanitize_text_field',
 								'fontStyle'             => 'sanitize_text_field',
 								'fontWeight'            => 'sanitize_text_field',
-								'src'                   => 'sanitize_url',
+								'src'                   => 'WP_Font_Collection::sanitize_src_property',
 								'preview'               => 'sanitize_url',
 								'fontDisplay'           => 'sanitize_text_field',
 								'fontStretch'           => 'sanitize_text_field',
@@ -265,6 +265,29 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 			}
 
 			return $data;
+		}
+
+		/**
+		 * Sanitizes a src property.
+		 * 
+		 * Font faces can have a src property consisting on a string or an array of strings.
+		 * This method sanitizes the src property value.
+		 * 
+		 * @since 6.5.0
+		 * 
+		 * @param string|array $value src property value to sanitize.
+		 * 
+		 * @return string|array Sanitized URL value.
+		 */
+		public static function sanitize_src_property( $value ) {
+			if( is_array( $value ) ) {
+				foreach( $value as $key => $val ) {
+					$value[$key] = sanitize_url( $val );
+				}
+				return $value;
+			}
+
+			return sanitize_url( $value );
 		}
 	}
 }

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -81,7 +81,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 							),
 						),
 					),
-					'categories' => array( 'sanitize_title' )
+					'categories'           => array( 'sanitize_title' ),
 				),
 			),
 			'categories'    => array(
@@ -249,7 +249,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 * @return array|WP_Error Array of data if valid, otherwise a WP_Error instance.
 		 */
 		private function validate_data( $data ) {
-			$data = WP_Font_Utils::sanitize_from_schema( $data, self::COLLECTION_SANITIZATION_SCHEMA );
+			$data                = WP_Font_Utils::sanitize_from_schema( $data, self::COLLECTION_SANITIZATION_SCHEMA );
 			$required_properties = array( 'name', 'font_families' );
 			foreach ( $required_properties as $property ) {
 				if ( empty( $data[ $property ] ) ) {

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -45,6 +45,54 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		private $src;
 
 		/**
+		 * Font collection sanitization schema.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @var array
+		 */
+		private const COLLECTION_SANITIZATION_SCHEMA = array(
+			'name'          => 'sanitize_text_field',
+			'description'   => 'sanitize_text_field',
+			'font_families' => array(
+				array(
+					'font_family_settings' => array(
+						'name'       => 'sanitize_text_field',
+						'slug'       => 'sanitize_title',
+						'fontFamily' => 'sanitize_text_field',
+						'preview'    => 'sanitize_url',
+						'fontFace'   => array(
+							array(
+								'fontFamily'            => 'sanitize_text_field',
+								'fontStyle'             => 'sanitize_text_field',
+								'fontWeight'            => 'sanitize_text_field',
+								'src'                   => 'sanitize_url',
+								'preview'               => 'sanitize_url',
+								'fontDisplay'           => 'sanitize_text_field',
+								'fontStretch'           => 'sanitize_text_field',
+								'ascentOverride'        => 'sanitize_text_field',
+								'descentOverride'       => 'sanitize_text_field',
+								'fontVariant'           => 'sanitize_text_field',
+								'fontFeatureSettings'   => 'sanitize_text_field',
+								'fontVariationSettings' => 'sanitize_text_field',
+								'lineGapOverride'       => 'sanitize_text_field',
+								'sizeAdjust'            => 'sanitize_text_field',
+								'unicodeRange'          => 'sanitize_text_field',
+							),
+						),
+					),
+					'categories' => array( 'sanitize_title' )
+				),
+			),
+			'categories'    => array(
+				array(
+					'name' => 'sanitize_text_field',
+					'slug' => 'sanitize_title',
+				),
+			),
+		);
+
+		/**
 		 * WP_Font_Collection constructor.
 		 *
 		 * @since 6.5.0
@@ -201,6 +249,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 * @return array|WP_Error Array of data if valid, otherwise a WP_Error instance.
 		 */
 		private function validate_data( $data ) {
+			$data = WP_Font_Utils::sanitize_from_schema( $data, self::COLLECTION_SANITIZATION_SCHEMA );
 			$required_properties = array( 'name', 'font_families' );
 			foreach ( $required_properties as $property ) {
 				if ( empty( $data[ $property ] ) ) {

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -158,7 +158,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 				}
 
 				$is_value_array  = is_array( $value );
-				$is_schema_array = is_array( $schema[ $key ] );
+				$is_schema_array = is_array( $schema[ $key ] ) && ! is_callable( $schema[ $key ] );
 
 				if ( $is_value_array && $is_schema_array ) {
 					if ( wp_is_numeric_array( $value ) ) {
@@ -193,6 +193,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		 * Apply the sanitizer to the value.
 		 *
 		 * @since 6.5.0
+		 *
 		 * @param mixed $value The value to sanitize.
 		 * @param mixed $sanitizer The sanitizer to apply.
 		 *

--- a/phpunit/tests/fonts/font-library/wpFontCollection/__construct.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/__construct.php
@@ -14,8 +14,12 @@ class Tests_Fonts_WpFontCollection_Construct extends WP_UnitTestCase {
 
 	public function test_should_do_it_wrong_with_invalid_slug() {
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::__construct' );
+		$mock_collection_data = array(
+			'name'          => 'Test Collection',
+			'font_families' => array( 'mock ' ),
+		);
 
-		$collection = new WP_Font_Collection( 'slug with spaces', array() );
+		$collection = new WP_Font_Collection( 'slug with spaces', $mock_collection_data );
 
 		$this->assertSame( 'slug-with-spaces', $collection->slug, 'Slug is not sanitized.' );
 	}

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -105,50 +105,50 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 				),
 			),
 
-			'font collection with risky data'      => array(
+			'font collection with risky data'    => array(
 				'slug'          => 'my-collection',
 				'config'        => array(
-					'name'          => 'My Collection<script>alert("xss")</script>',
-					'description'   => 'My collection description<script>alert("xss")</script>',
-					'font_families' => array( 
+					'name'              => 'My Collection<script>alert("xss")</script>',
+					'description'       => 'My collection description<script>alert("xss")</script>',
+					'font_families'     => array(
 						array(
 							'font_family_settings' => array(
-								'fontFamily' => 'Open Sans, sans-serif<script>alert("xss")</script>',
-								'slug' => 'open-sans',
-								'name' => 'Open Sans<script>alert("xss")</script>',
-								'unwanted_property'=> 'potentially evil value'
+								'fontFamily'        => 'Open Sans, sans-serif<script>alert("xss")</script>',
+								'slug'              => 'open-sans',
+								'name'              => 'Open Sans<script>alert("xss")</script>',
+								'unwanted_property' => 'potentially evil value',
 							),
-							'categories' => [ 'sans-serif<script>alert("xss")</script>' ]
-						)
-					 ),
-					'categories'    => array(
-						array (
-							'name' => 'Mock col<script>alert("xss")</script>',
-							'slug' => 'mock-col<script>alert("xss")</script>',
-							'unwanted_property'=> 'potentially evil value'
-						)
+							'categories'           => array( 'sans-serif<script>alert("xss")</script>' ),
+						),
 					),
-					'unwanted_property'=> 'potentially evil value'
+					'categories'        => array(
+						array(
+							'name'              => 'Mock col<script>alert("xss")</script>',
+							'slug'              => 'mock-col<script>alert("xss")</script>',
+							'unwanted_property' => 'potentially evil value',
+						),
+					),
+					'unwanted_property' => 'potentially evil value',
 				),
 				'expected_data' => array(
 					'description'   => 'My collection description',
 					'categories'    => array(
-						array (
+						array(
 							'name' => 'Mock col',
-							'slug' => 'mock-colalertxss'
-						)
+							'slug' => 'mock-colalertxss',
+						),
 					),
 					'name'          => 'My Collection',
-					'font_families' => array( 
+					'font_families' => array(
 						array(
 							'font_family_settings' => array(
 								'fontFamily' => 'Open Sans, sans-serif',
-								'slug' => 'open-sans',
-								'name' => 'Open Sans',
+								'slug'       => 'open-sans',
+								'name'       => 'Open Sans',
 							),
-							'categories' => [ 'sans-serifalertxss' ]
-						)
-					 ),
+							'categories'           => array( 'sans-serifalertxss' ),
+						),
+					),
 				),
 			),
 

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -195,7 +195,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 	 * @param array $config Font collection config.
 	 */
 	public function test_should_error_when_missing_properties( $config ) {
-		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::validate_data' );
+		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::validate_andd_sanitize' );
 
 		$collection = new WP_Font_Collection( 'my-collection', $config );
 		$data       = $collection->get_data();

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -116,6 +116,23 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 								'fontFamily'        => 'Open Sans, sans-serif<script>alert("xss")</script>',
 								'slug'              => 'open-sans',
 								'name'              => 'Open Sans<script>alert("xss")</script>',
+								'fontFace'			=> array(
+									array(
+										'fontFamily' => 'Open Sans',
+										'fontStyle'  => 'normal',
+										'fontWeight' => '400',
+										'src'        => 'https://example.com/src-as-string.ttf?a=<script>alert("xss")</script>',
+									),
+									array(
+										'fontFamily' => 'Open Sans',
+										'fontStyle'  => 'normal',
+										'fontWeight' => '400',
+										'src'        => array(
+											'https://example.com/src-as-array.woff2?a=<script>alert("xss")</script>',
+											'https://example.com/src-as-array.ttf',
+										)
+									),
+								),
 								'unwanted_property' => 'potentially evil value',
 							),
 							'categories'           => array( 'sans-serif<script>alert("xss")</script>' ),
@@ -145,6 +162,23 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 								'fontFamily' => 'Open Sans, sans-serif',
 								'slug'       => 'open-sans',
 								'name'       => 'Open Sans',
+								'fontFace'			=> array(
+									array(
+										'fontFamily' => 'Open Sans',
+										'fontStyle'  => 'normal',
+										'fontWeight' => '400',
+										'src'        => 'https://example.com/src-as-string.ttf?a=scriptalert(xss)/script',
+									),
+									array(
+										'fontFamily' => 'Open Sans',
+										'fontStyle'  => 'normal',
+										'fontWeight' => '400',
+										'src'        => array(
+											'https://example.com/src-as-array.woff2?a=scriptalert(xss)/script',
+											'https://example.com/src-as-array.ttf',
+										)
+									),
+								)
 							),
 							'categories'           => array( 'sans-serifalertxss' ),
 						),

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -167,14 +167,14 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 										'fontFamily' => 'Open Sans',
 										'fontStyle'  => 'normal',
 										'fontWeight' => '400',
-										'src'        => 'https://example.com/src-as-string.ttf?a=scriptalert(xss)/script',
+										'src'        => 'https://example.com/src-as-string.ttf?a=',
 									),
 									array(
 										'fontFamily' => 'Open Sans',
 										'fontStyle'  => 'normal',
 										'fontWeight' => '400',
 										'src'        => array(
-											'https://example.com/src-as-array.woff2?a=scriptalert(xss)/script',
+											'https://example.com/src-as-array.woff2?a=',
 											'https://example.com/src-as-array.ttf',
 										),
 									),
@@ -195,7 +195,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 	 * @param array $config Font collection config.
 	 */
 	public function test_should_error_when_missing_properties( $config ) {
-		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::validate_andd_sanitize' );
+		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::sanitize_and_validate_data' );
 
 		$collection = new WP_Font_Collection( 'my-collection', $config );
 		$data       = $collection->get_data();

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -79,13 +79,13 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 				'slug'          => 'my-collection',
 				'config'        => array(
 					'name'          => 'My Collection',
-					'font_families' => array( 'mock' ),
+					'font_families' => array( array() ),
 				),
 				'expected_data' => array(
 					'description'   => '',
 					'categories'    => array(),
 					'name'          => 'My Collection',
-					'font_families' => array( 'mock' ),
+					'font_families' => array( array() ),
 				),
 			),
 
@@ -94,14 +94,61 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 				'config'        => array(
 					'name'          => 'My Collection',
 					'description'   => 'My collection description',
-					'font_families' => array( 'mock' ),
-					'categories'    => array( 'mock' ),
+					'font_families' => array( array() ),
+					'categories'    => array(),
 				),
 				'expected_data' => array(
 					'description'   => 'My collection description',
-					'categories'    => array( 'mock' ),
+					'categories'    => array(),
 					'name'          => 'My Collection',
-					'font_families' => array( 'mock' ),
+					'font_families' => array( array() ),
+				),
+			),
+
+			'font collection with risky data'      => array(
+				'slug'          => 'my-collection',
+				'config'        => array(
+					'name'          => 'My Collection<script>alert("xss")</script>',
+					'description'   => 'My collection description<script>alert("xss")</script>',
+					'font_families' => array( 
+						array(
+							'font_family_settings' => array(
+								'fontFamily' => 'Open Sans, sans-serif<script>alert("xss")</script>',
+								'slug' => 'open-sans',
+								'name' => 'Open Sans<script>alert("xss")</script>',
+								'unwanted_property'=> 'potentially evil value'
+							),
+							'categories' => [ 'sans-serif<script>alert("xss")</script>' ]
+						)
+					 ),
+					'categories'    => array(
+						array (
+							'name' => 'Mock col<script>alert("xss")</script>',
+							'slug' => 'mock-col<script>alert("xss")</script>',
+							'unwanted_property'=> 'potentially evil value'
+						)
+					),
+					'unwanted_property'=> 'potentially evil value'
+				),
+				'expected_data' => array(
+					'description'   => 'My collection description',
+					'categories'    => array(
+						array (
+							'name' => 'Mock col',
+							'slug' => 'mock-colalertxss'
+						)
+					),
+					'name'          => 'My Collection',
+					'font_families' => array( 
+						array(
+							'font_family_settings' => array(
+								'fontFamily' => 'Open Sans, sans-serif',
+								'slug' => 'open-sans',
+								'name' => 'Open Sans',
+							),
+							'categories' => [ 'sans-serifalertxss' ]
+						)
+					 ),
 				),
 			),
 

--- a/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -116,7 +116,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 								'fontFamily'        => 'Open Sans, sans-serif<script>alert("xss")</script>',
 								'slug'              => 'open-sans',
 								'name'              => 'Open Sans<script>alert("xss")</script>',
-								'fontFace'			=> array(
+								'fontFace'          => array(
 									array(
 										'fontFamily' => 'Open Sans',
 										'fontStyle'  => 'normal',
@@ -130,7 +130,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 										'src'        => array(
 											'https://example.com/src-as-array.woff2?a=<script>alert("xss")</script>',
 											'https://example.com/src-as-array.ttf',
-										)
+										),
 									),
 								),
 								'unwanted_property' => 'potentially evil value',
@@ -162,7 +162,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 								'fontFamily' => 'Open Sans, sans-serif',
 								'slug'       => 'open-sans',
 								'name'       => 'Open Sans',
-								'fontFace'			=> array(
+								'fontFace'   => array(
 									array(
 										'fontFamily' => 'Open Sans',
 										'fontStyle'  => 'normal',
@@ -176,9 +176,9 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 										'src'        => array(
 											'https://example.com/src-as-array.woff2?a=scriptalert(xss)/script',
 											'https://example.com/src-as-array.ttf',
-										)
+										),
 									),
-								)
+								),
 							),
 							'categories'           => array( 'sans-serifalertxss' ),
 						),

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollection.php
@@ -13,7 +13,12 @@
 class Tests_Fonts_WpFontLibrary_GetFontCollection extends WP_Font_Library_UnitTestCase {
 
 	public function test_should_get_font_collection() {
-		wp_register_font_collection( 'my-font-collection', array( 'font_families' => array( 'mock' ) ) );
+		$mock_collection_data = array(
+			'name'          => 'Test Collection',
+			'font_families' => array( 'mock' ),
+		);
+
+		wp_register_font_collection( 'my-font-collection', $mock_collection_data );
 		$font_collection = WP_Font_Library::get_font_collection( 'my-font-collection' );
 		$this->assertInstanceOf( 'WP_Font_Collection', $font_collection );
 	}

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/registerFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/registerFontCollection.php
@@ -13,6 +13,7 @@
 class Tests_Fonts_WpFontLibrary_RegisterFontCollection extends WP_Font_Library_UnitTestCase {
 	public function test_should_register_font_collection() {
 		$config = array(
+			'name'          => 'My Collection',
 			'font_families' => array( 'mock' ),
 		);
 
@@ -21,14 +22,19 @@ class Tests_Fonts_WpFontLibrary_RegisterFontCollection extends WP_Font_Library_U
 	}
 
 	public function test_should_return_error_if_slug_is_repeated() {
+		$mock_collection_data = array(
+			'name'          => 'Test Collection',
+			'font_families' => array( 'mock' ),
+		);
+
 		// Register first collection.
-		$collection1 = WP_Font_Library::register_font_collection( 'my-collection-1', array( 'font_families' => array( 'mock' ) ) );
+		$collection1 = WP_Font_Library::register_font_collection( 'my-collection-1', $mock_collection_data );
 		$this->assertInstanceOf( 'WP_Font_Collection', $collection1, 'A collection should be registered.' );
 
 		// Expects a _doing_it_wrong notice.
 		$this->setExpectedIncorrectUsage( 'WP_Font_Library::register_font_collection' );
 
 		// Try to register a second collection with same slug.
-		WP_Font_Library::register_font_collection( 'my-collection-1', array( 'font_families' => array( 'mock' ) ) );
+		WP_Font_Library::register_font_collection( 'my-collection-1', $mock_collection_data );
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/unregisterFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/unregisterFontCollection.php
@@ -13,9 +13,14 @@
 class Tests_Fonts_WpFontLibrary_UnregisterFontCollection extends WP_Font_Library_UnitTestCase {
 
 	public function test_should_unregister_font_collection() {
+		$mock_collection_data = array(
+			'name'          => 'Test Collection',
+			'font_families' => array( 'mock' ),
+		);
+
 		// Registers two mock font collections.
-		WP_Font_Library::register_font_collection( 'mock-font-collection-1', array( 'font_families' => array( 'mock' ) ) );
-		WP_Font_Library::register_font_collection( 'mock-font-collection-2', array( 'font_families' => array( 'mock' ) ) );
+		WP_Font_Library::register_font_collection( 'mock-font-collection-1', $mock_collection_data );
+		WP_Font_Library::register_font_collection( 'mock-font-collection-2', $mock_collection_data );
 
 		// Unregister mock font collection.
 		WP_Font_Library::unregister_font_collection( 'mock-font-collection-1' );
@@ -36,6 +41,6 @@ class Tests_Fonts_WpFontLibrary_UnregisterFontCollection extends WP_Font_Library
 		// Unregisters non-existing font collection.
 		WP_Font_Library::unregister_font_collection( 'non-existing-collection' );
 		$collections = WP_Font_Library::get_font_collections();
-		$this->assertEmpty( $collections, 'Should not be registered collections.' );
+		$this->assertEmpty( $collections, 'No collections should be registered.' );
 	}
 }


### PR DESCRIPTION
## What?
Font Library: sanitize font collection data.
- Removes all the potential unwanted properties.
- Sanitizes all the values.
- Adds unit test case to ensure that data returned by  `get_data` is always sanitized.

## Why?
To return just the data that's safe to return.

## How?
- Adding a data schema in the WP_Font_Collection class.
- Sanitizing the data using the sanitizing util from WP_Font_Utils

## Testing Instructions
Run this PHP snippet featuring a font collection with risky data:

```php
function register_collections() {
    $ubuntu = array(
        'font_family_settings' => array (
            'name'       => 'Ubuntu<script>alert("xss")</script>',
            'fontFamily' => 'Ubuntu, sans-serif<script>alert("xss")</script>',
            'slug'       => 'ubuntu<script>alert("xss")</script>',
        ),
        'categories' => array(
            'sans-serif',
        ),
    );
    
    $verdana = array(
        'font_family_settings' => array (
            'name'       => 'Verdana<script>alert("xss")</script>',
            'fontFamily' => 'Verdana, sans-serif<script>alert("xss")</script>',
            'slug'       => 'verdana<script>alert("xss")</script>',
        ),
        'categories' => array(
            'sans-serif',
        ),
    );
    
    $font_families = array ( $ubuntu, $verdana );
    
    $categories = array(
        array (
            'name' => 'Sans Serif<script>alert("xss")</script>',
            'slug' => 'sans-serif<script>alert("xss")</script>',
        ),
    );
    
    $collection_with_xss = array(
        'name'          => 'PHP Custom Collection',
        'description'   => __( 'Custom fonts collection' ),
        'font_families' => $font_families,
        'categories'    => $categories
    );
    
    wp_register_font_collection( 'collection-with-xss', $collection_with_xss );
}

add_action( 'rest_api_init', 'register_collections' );
```
Request that font collection using the API:
```
/wp-json/wp/v2/font-collections/collection-with-xss
```

the response should be:

```json
{
    "slug": "collection-with-xss",
    "name": "PHP Custom Collection",
    "description": "Custom fonts collection",
    "font_families": [
        {
            "font_family_settings": {
                "name": "Ubuntu",
                "fontFamily": "Ubuntu, sans-serif",
                "slug": "ubuntualertxss"
            },
            "categories": [
                "sans-serif"
            ]
        },
        {
            "font_family_settings": {
                "name": "Verdana",
                "fontFamily": "Verdana, sans-serif",
                "slug": "verdanaalertxss"
            },
            "categories": [
                "sans-serif"
            ]
        }
    ],
    "categories": [
        {
            "name": "Sans Serif",
            "slug": "sans-serifalertxss"
        }
    ],
    "_links": {
        "self": [
            {
                "href": "http://localhost/wp1/wp-json/wp/v2/font-collections/collection-with-xss"
            }
        ],
        "collection": [
            {
                "href": "http://localhost/wp1/wp-json/wp/v2/font-collections"
            }
        ]
    }
}
```