### PR TITLE
Escape as Select/Edit mode Toggle

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -131,6 +131,11 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 		const isEnter = keyCode === ENTER;
 		const isSpace = keyCode === SPACE;
 		const isShift = event.shiftKey;
+		if ( isEscape && editorMode === 'navigation' ) {
+			setNavigationMode( false );
+			event.preventDefault();
+			return;
+		}
 
 		if ( keyCode === BACKSPACE || keyCode === DELETE ) {
 			removeBlock( clientId );

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -99,7 +99,6 @@ export default function BlockTools( {
 		removeBlocks,
 		insertAfterBlock,
 		insertBeforeBlock,
-		clearSelectedBlock,
 		selectBlock,
 		moveBlocksUp,
 		moveBlocksDown,
@@ -157,21 +156,12 @@ export default function BlockTools( {
 			}
 
 			const clientIds = getSelectedBlockClientIds();
-			if ( clientIds.length ) {
+			if ( clientIds.length > 1 ) {
 				event.preventDefault();
-
 				// If there is more than one block selected, select the first
 				// block so that focus is directed back to the beginning of the selection.
 				// In effect, to the user this feels like deselecting the multi-selection.
-				if ( clientIds.length > 1 ) {
-					selectBlock( clientIds[ 0 ] );
-				} else {
-					clearSelectedBlock();
-				}
-				event.target.ownerDocument.defaultView
-					.getSelection()
-					.removeAllRanges();
-				__unstableContentRef?.current.focus();
+				selectBlock( clientIds[ 0 ] );
 			}
 		}
 	}

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -221,7 +221,7 @@ test.describe( 'Multi-block selection', () => {
 		pageUtils,
 		multiBlockSelectionUtils,
 	} ) => {
-		for ( let i = 1; i <= 2; i += 1 ) {
+		for ( let i = 1; i <= 3; i += 1 ) {
 			await editor.insertBlock( {
 				name: 'core/paragraph',
 				attributes: { content: `${ i }` },
@@ -232,14 +232,13 @@ test.describe( 'Multi-block selection', () => {
 
 		await expect
 			.poll( multiBlockSelectionUtils.getSelectedFlatIndices )
-			.toEqual( [ 1, 2 ] );
+			.toEqual( [ 1, 2, 3 ] );
 
 		await page.keyboard.press( 'Escape' );
 
-		// FIXME: This doesn't seem to work anymore.
-		// await expect
-		// 	.poll( multiBlockSelectionUtils.getSelectedFlatIndices )
-		// 	.toEqual( [] );
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedFlatIndices )
+			.toEqual( [ 1 ] );
 	} );
 
 	test( 'should select with shift + click', async ( {
@@ -875,35 +874,6 @@ test.describe( 'Multi-block selection', () => {
 				{ name: 'core/paragraph' },
 				{ name: 'core/list' },
 			] );
-	} );
-
-	test( 'should select all from empty selection', async ( {
-		page,
-		editor,
-		pageUtils,
-		multiBlockSelectionUtils,
-	} ) => {
-		for ( let i = 1; i <= 2; i += 1 ) {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: `${ i }` },
-			} );
-		}
-
-		// Clear the selected block.
-		await page.keyboard.press( 'Escape' );
-		await page.keyboard.press( 'Escape' );
-
-		await expect
-			.poll( multiBlockSelectionUtils.getSelectedBlocks )
-			.toEqual( [] );
-
-		await pageUtils.pressKeys( 'primary+a' );
-
-		await page.keyboard.press( 'Backspace' );
-
-		// Expect both paragraphs to be deleted.
-		await expect.poll( editor.getBlocks ).toEqual( [] );
 	} );
 
 	test( 'should select title if the cursor is on title', async ( {

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -927,28 +927,32 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 <!-- /wp:table -->` );
 	} );
 
-	test( 'should unselect all blocks when hitting double escape', async ( {
+	test( 'escape should toggle between edit and navigation modes', async ( {
 		page,
 		writingFlowUtils,
 	} ) => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Random Paragraph' );
 
+		// First escape enters navigation mode.
+		await page.keyboard.press( 'Escape' );
+		const navigationButton = page.getByLabel(
+			'Paragraph Block. Row 1. Random Paragraph'
+		);
+		await expect( navigationButton ).toBeVisible();
 		await expect
 			.poll( writingFlowUtils.getActiveBlockName )
 			.toBe( 'core/paragraph' );
 
-		// First escape enters navigaiton mode.
+		// Second escape Toggles back to Edit Mode
 		await page.keyboard.press( 'Escape' );
+		await expect( navigationButton ).toBeHidden();
+		const blockToolbar = page.getByLabel( 'Block tools' );
+
+		await expect( blockToolbar ).toBeVisible();
 		await expect
 			.poll( writingFlowUtils.getActiveBlockName )
 			.toBe( 'core/paragraph' );
-
-		// Second escape unselects the blocks.
-		await page.keyboard.press( 'Escape' );
-		await expect
-			.poll( writingFlowUtils.getActiveBlockName )
-			.toBe( undefined );
 	} );
 
 	// Checks for regressions of https://github.com/WordPress/gutenberg/issues/40091.


### PR DESCRIPTION
In the editor, escape is a shortcut to switch to Select/Navigation mode , and then another Escape keypress resets selection to the top of the DOM. This always surprises me, and feels like a focus loss as I can't see where the focus is anymore. I like @jasmussen's recommendation [to turn Escape into a toggle between Select/Edit modes](https://github.com/WordPress/gutenberg/issues/47172#issuecomment-1457707443)


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Use Escape as a toggle between Edit and Select modes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To have a more predictable experience. Escape doing two things (switching to select mode, then moving focus to the top of the DOM feels really off to me).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add an isEscape check to the top of the onKeydown for the breadcrumb. This makes it operate very similarly to the Enter keypress to switch to Edit mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. In the block editor, press Escape to enter select mode
2. Press Escape again to switch back to edit mode

## Screenshots or screencast <!-- if applicable -->
