### PR TITLE
Fix flaky test of data-wp-on-window directive

### DIFF
--- a/test/e2e/specs/interactivity/directive-on-window.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-window.spec.ts
@@ -28,7 +28,10 @@ test.describe( 'data-wp-on-window', () => {
 		await expect( counter ).toHaveText( '0' );
 
 		// Make sure the event listener is attached.
-		await page.getByTestId( 'isEventAttached' ).filter( { hasText: 'yes' } ).waitFor();
+		await page
+			.getByTestId( 'isEventAttached' )
+			.filter( { hasText: 'yes' } )
+			.waitFor();
 
 		// Change the viewport size.
 		await page.setViewportSize( { width: 600, height: 600 } );
@@ -38,7 +41,10 @@ test.describe( 'data-wp-on-window', () => {
 		await visibilityButton.click();
 
 		// Make sure the event listener is not attached.
-		await page.getByTestId( 'isEventAttached' ).filter( { hasText: 'no' } ).waitFor();
+		await page
+			.getByTestId( 'isEventAttached' )
+			.filter( { hasText: 'no' } )
+			.waitFor();
 
 		// This resize should not increase the counter.
 		await page.setViewportSize( { width: 300, height: 600 } );
@@ -50,7 +56,10 @@ test.describe( 'data-wp-on-window', () => {
 		await expect( counter ).toHaveText( '1' );
 
 		// Make sure the event listener is re-attached.
-		await page.getByTestId( 'isEventAttached' ).filter( { hasText: 'yes' } ).waitFor();
+		await page
+			.getByTestId( 'isEventAttached' )
+			.filter( { hasText: 'yes' } )
+			.waitFor();
 
 		// This resize should increase the counter.
 		await page.setViewportSize( { width: 200, height: 600 } );

--- a/test/e2e/specs/interactivity/directive-on-window.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-window.spec.ts
@@ -28,9 +28,7 @@ test.describe( 'data-wp-on-window', () => {
 		await expect( counter ).toHaveText( '0' );
 
 		// Make sure the event listener is attached.
-		await page.waitForSelector(
-			'[data-testid="isEventAttached"]:has-text("yes")'
-		);
+		await page.getByTestId( 'isEventAttached' ).filter( { hasText: 'yes' } ).waitFor();
 
 		// Change the viewport size.
 		await page.setViewportSize( { width: 600, height: 600 } );
@@ -40,9 +38,7 @@ test.describe( 'data-wp-on-window', () => {
 		await visibilityButton.click();
 
 		// Make sure the event listener is not attached.
-		await page.waitForSelector(
-			'[data-testid="isEventAttached"]:has-text("no")'
-		);
+		await page.getByTestId( 'isEventAttached' ).filter( { hasText: 'no' } ).waitFor();
 
 		// This resize should not increase the counter.
 		await page.setViewportSize( { width: 300, height: 600 } );
@@ -54,9 +50,7 @@ test.describe( 'data-wp-on-window', () => {
 		await expect( counter ).toHaveText( '1' );
 
 		// Make sure the event listener is re-attached.
-		await page.waitForSelector(
-			'[data-testid="isEventAttached"]:has-text("yes")'
-		);
+		await page.getByTestId( 'isEventAttached' ).filter( { hasText: 'yes' } ).waitFor();
 
 		// This resize should increase the counter.
 		await page.setViewportSize( { width: 200, height: 600 } );

--- a/test/e2e/specs/interactivity/directive-on-window.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-window.spec.ts
@@ -18,38 +18,47 @@ test.describe( 'data-wp-on-window', () => {
 		await utils.deleteAllPosts();
 	} );
 
-	test( 'callbacks should run whenever the specified event is dispatched', async ( {
-		page,
-	} ) => {
-		await page.setViewportSize( { width: 600, height: 600 } );
-		const counter = page.getByTestId( 'counter' );
-		await expect( counter ).toHaveText( '1' );
-	} );
-	test( 'the event listener is removed when the element is removed', async ( {
+	test( 'the event listener is attached when the element is added', async ( {
 		page,
 	} ) => {
 		const counter = page.getByTestId( 'counter' );
-		const isEventAttached = page.getByTestId( 'isEventAttached' );
 		const visibilityButton = page.getByTestId( 'visibility' );
 
+		// Initial value.
 		await expect( counter ).toHaveText( '0' );
-		await expect( isEventAttached ).toHaveText( 'yes' );
+
+		// Make sure the event listener is attached.
+		await page.waitForSelector(
+			'[data-testid="isEventAttached"]:has-text("yes")'
+		);
+
+		// Change the viewport size.
 		await page.setViewportSize( { width: 600, height: 600 } );
 		await expect( counter ).toHaveText( '1' );
 
 		// Remove the element.
 		await visibilityButton.click();
 
+		// Make sure the event listener is not attached.
+		await page.waitForSelector(
+			'[data-testid="isEventAttached"]:has-text("no")'
+		);
+
 		// This resize should not increase the counter.
 		await page.setViewportSize( { width: 300, height: 600 } );
 
 		// Add the element back.
 		await visibilityButton.click();
+
+		// The counter should have the same value as before.
 		await expect( counter ).toHaveText( '1' );
 
-		// Wait until the effects run again.
-		await expect( isEventAttached ).toHaveText( 'yes' );
+		// Make sure the event listener is re-attached.
+		await page.waitForSelector(
+			'[data-testid="isEventAttached"]:has-text("yes")'
+		);
 
+		// This resize should increase the counter.
 		await page.setViewportSize( { width: 200, height: 600 } );
 		await expect( counter ).toHaveText( '2' );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Another attempt to fix https://github.com/WordPress/gutenberg/issues/58398.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It keeps failing sometimes.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I added this line to expect that the event listener is attached, but didn't use `expect` to make sure Playwright waits until this happens. Instead, I used `waitForSelector`:

```js
// Make sure the event listener is attached.
await page.waitForSelector('[data-testid="isEventAttached"]:has-text("yes")');
```

I also removed the other test because it was unnecessary. The longer test was covering the same again.
