### PR TITLE
Template Part: Reflect name updates without saving changes

### DIFF
--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -32,8 +32,9 @@ export const settings = {
 			return;
 		}
 
-		const { getCurrentTheme, getEntityRecord } = select( coreDataStore );
-		const entity = getEntityRecord(
+		const { getCurrentTheme, getEditedEntityRecord } =
+			select( coreDataStore );
+		const entity = getEditedEntityRecord(
 			'postType',
 			'wp_template_part',
 			( theme || getCurrentTheme()?.stylesheet ) + '//' + slug
@@ -42,10 +43,7 @@ export const settings = {
 			return;
 		}
 
-		return (
-			decodeEntities( entity.title?.rendered ) ||
-			capitalCase( entity.slug )
-		);
+		return decodeEntities( entity.title ) || capitalCase( entity.slug );
 	},
 	edit,
 };


### PR DESCRIPTION
## What?
Fixes #29844.

PR updates the `__experimentalLabel` method for the Template Part block to reflect name updates without saving changes.

## Why?
See #29844.

## How?
Swap the `getEntityRecord` selector with `getEditedEntityRecord`.

## Testing Instructions
1. Open or create a template in the Site Editor.
2. Add a template part block.
3. Use the settings options to rename the template part.
4. Confirm that the title change is immediately reflected.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/7c3cf221-9dec-4e1f-b82c-4baa6d6664ea