### PR TITLE
Pattern: Use the '__experimentalLabel' method to get a title

### DIFF
--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -27,6 +27,7 @@ const blockLabelMap = {
 	'Block With Long Label':
 		'This is a longer label than typical for blocks to have.',
 	'Block With Custom Label': 'A Custom Label like a Block Variation Label',
+	'Reusable Block': 'Reuse me!',
 };
 
 jest.mock( '@wordpress/blocks', () => {
@@ -102,7 +103,6 @@ describe( 'BlockTitle', () => {
 				getBlockName: () => 'reusable-block',
 				getBlockType: ( name ) => blockTypeMap[ name ],
 				getBlockAttributes: () => ( { ref: 1 } ),
-				__experimentalGetReusableBlockTitle: () => 'Reuse me!',
 			} ) )
 		);
 

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -3,7 +3,6 @@
  */
 import { useSelect } from '@wordpress/data';
 import {
-	isReusableBlock,
 	__experimentalGetBlockLabel as getBlockLabel,
 	store as blocksStore,
 } from '@wordpress/blocks';
@@ -40,11 +39,8 @@ export default function useBlockDisplayTitle( {
 				return null;
 			}
 
-			const {
-				getBlockName,
-				getBlockAttributes,
-				__experimentalGetReusableBlockTitle,
-			} = select( blockEditorStore );
+			const { getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 
@@ -55,15 +51,6 @@ export default function useBlockDisplayTitle( {
 			}
 
 			const attributes = getBlockAttributes( clientId );
-			const isReusable = isReusableBlock( blockType );
-			const reusableBlockTitle = isReusable
-				? __experimentalGetReusableBlockTitle( attributes.ref )
-				: null;
-
-			if ( reusableBlockTitle ) {
-				return reusableBlockTitle;
-			}
-
 			const label = getBlockLabel( blockType, attributes, context );
 			// If the label is defined we prioritize it over a possible block variation title match.
 			if ( label !== blockType.title ) {

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -2,6 +2,9 @@
  * WordPress dependencies
  */
 import { symbol as icon } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
+import { select } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -17,6 +20,22 @@ export { metadata, name };
 export const settings = {
 	edit,
 	icon,
+	__experimentalLabel: ( { ref } ) => {
+		if ( ! ref ) {
+			return;
+		}
+
+		const entity = select( coreStore ).getEditedEntityRecord(
+			'postType',
+			'wp_block',
+			ref
+		);
+		if ( ! entity?.title ) {
+			return;
+		}
+
+		return decodeEntities( entity.title );
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
## What?
PR updates the Pattern block to use the `__experimentalLabel` method to get a title. It also removes special handling in the `useBlockDisplayTitle` hook.

## Why?
Standardizes method of getting a title for controlled blocks.

## Testing Instructions
1. Open a post or page.
2. Instert synced Pattern.
3. Confirm that the correct title is displayed in the block toolbar.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-02-04 at 18 44 01](https://github.com/WordPress/gutenberg/assets/240569/d9ff4979-5b4c-43c1-9830-e8610b8bb650)
