### PR TITLE
ImageURLInputUI: fix focus loss when settings are changed

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useRef, useState } from '@wordpress/element';
+import { useRef, useEffect, useState } from '@wordpress/element';
+import { focus } from '@wordpress/dom';
 import {
 	ToolbarButton,
 	Button,
@@ -57,6 +58,17 @@ const ImageURLInputUI = ( {
 	const [ urlInput, setUrlInput ] = useState( null );
 
 	const autocompleteRef = useRef( null );
+	const wrapperRef = useRef();
+
+	useEffect( () => {
+		if ( ! wrapperRef.current ) {
+			return;
+		}
+		const nextFocusTarget =
+			focus.focusable.find( wrapperRef.current )[ 0 ] ||
+			wrapperRef.current;
+		nextFocusTarget.focus();
+	}, [ isEditingLink, url, lightboxEnabled ] );
 
 	const startEditLink = () => {
 		if (
@@ -249,6 +261,7 @@ const ImageURLInputUI = ( {
 			/>
 			{ isOpen && (
 				<URLPopover
+					ref={ wrapperRef }
 					anchor={ popoverAnchor }
 					onFocusOutside={ onFocusOutside() }
 					onClose={ closeLinkUI }

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { forwardRef, useState } from '@wordpress/element';
 import {
 	Button,
 	Popover,
@@ -24,83 +24,89 @@ const { __experimentalPopoverLegacyPositionToPlacement } = unlock(
 
 const DEFAULT_PLACEMENT = 'bottom';
 
-function URLPopover( {
-	additionalControls,
-	children,
-	renderSettings,
-	// The DEFAULT_PLACEMENT value is assigned inside the function's body
-	placement,
-	focusOnMount = 'firstElement',
-	// Deprecated
-	position,
-	// Rest
-	...popoverProps
-} ) {
-	if ( position !== undefined ) {
-		deprecated( '`position` prop in wp.blockEditor.URLPopover', {
-			since: '6.2',
-			alternative: '`placement` prop',
-		} );
-	}
+const URLPopover = forwardRef(
+	(
+		{
+			additionalControls,
+			children,
+			renderSettings,
+			// The DEFAULT_PLACEMENT value is assigned inside the function's body
+			placement,
+			focusOnMount = 'firstElement',
+			// Deprecated
+			position,
+			// Rest
+			...popoverProps
+		},
+		ref
+	) => {
+		if ( position !== undefined ) {
+			deprecated( '`position` prop in wp.blockEditor.URLPopover', {
+				since: '6.2',
+				alternative: '`placement` prop',
+			} );
+		}
 
-	// Compute popover's placement:
-	// - give priority to `placement` prop, if defined
-	// - otherwise, compute it from the legacy `position` prop (if defined)
-	// - finally, fallback to the DEFAULT_PLACEMENT.
-	let computedPlacement;
-	if ( placement !== undefined ) {
-		computedPlacement = placement;
-	} else if ( position !== undefined ) {
-		computedPlacement =
-			__experimentalPopoverLegacyPositionToPlacement( position );
-	}
-	computedPlacement = computedPlacement || DEFAULT_PLACEMENT;
+		// Compute popover's placement:
+		// - give priority to `placement` prop, if defined
+		// - otherwise, compute it from the legacy `position` prop (if defined)
+		// - finally, fallback to the DEFAULT_PLACEMENT.
+		let computedPlacement;
+		if ( placement !== undefined ) {
+			computedPlacement = placement;
+		} else if ( position !== undefined ) {
+			computedPlacement =
+				__experimentalPopoverLegacyPositionToPlacement( position );
+		}
+		computedPlacement = computedPlacement || DEFAULT_PLACEMENT;
 
-	const [ isSettingsExpanded, setIsSettingsExpanded ] = useState( false );
+		const [ isSettingsExpanded, setIsSettingsExpanded ] = useState( false );
 
-	const showSettings = !! renderSettings && isSettingsExpanded;
+		const showSettings = !! renderSettings && isSettingsExpanded;
 
-	const toggleSettingsVisibility = () => {
-		setIsSettingsExpanded( ! isSettingsExpanded );
-	};
+		const toggleSettingsVisibility = () => {
+			setIsSettingsExpanded( ! isSettingsExpanded );
+		};
 
-	return (
-		<Popover
-			className="block-editor-url-popover"
-			focusOnMount={ focusOnMount }
-			placement={ computedPlacement }
-			shift
-			variant="toolbar"
-			{ ...popoverProps }
-		>
-			<div className="block-editor-url-popover__input-container">
-				<div className="block-editor-url-popover__row">
-					{ children }
-					{ !! renderSettings && (
-						<Button
-							className="block-editor-url-popover__settings-toggle"
-							icon={ chevronDown }
-							label={ __( 'Link settings' ) }
-							onClick={ toggleSettingsVisibility }
-							aria-expanded={ isSettingsExpanded }
-							size="compact"
-						/>
+		return (
+			<Popover
+				ref={ ref }
+				className="block-editor-url-popover"
+				focusOnMount={ focusOnMount }
+				placement={ computedPlacement }
+				shift
+				variant="toolbar"
+				{ ...popoverProps }
+			>
+				<div className="block-editor-url-popover__input-container">
+					<div className="block-editor-url-popover__row">
+						{ children }
+						{ !! renderSettings && (
+							<Button
+								className="block-editor-url-popover__settings-toggle"
+								icon={ chevronDown }
+								label={ __( 'Link settings' ) }
+								onClick={ toggleSettingsVisibility }
+								aria-expanded={ isSettingsExpanded }
+								size="compact"
+							/>
+						) }
+					</div>
+					{ showSettings && (
+						<div className="block-editor-url-popover__row block-editor-url-popover__settings">
+							{ renderSettings() }
+						</div>
 					) }
 				</div>
-				{ showSettings && (
-					<div className="block-editor-url-popover__row block-editor-url-popover__settings">
-						{ renderSettings() }
+				{ additionalControls && ! showSettings && (
+					<div className="block-editor-url-popover__additional-controls">
+						{ additionalControls }
 					</div>
 				) }
-			</div>
-			{ additionalControls && ! showSettings && (
-				<div className="block-editor-url-popover__additional-controls">
-					{ additionalControls }
-				</div>
-			) }
-		</Popover>
-	);
-}
+			</Popover>
+		);
+	}
+);
 
 URLPopover.LinkEditor = LinkEditor;
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -823,7 +823,7 @@ test.describe( 'Image', () => {
 			} )
 		).toBeFocused();
 
-		// Select "Expand on click".
+		// Select "Expand on click", then remove it.
 		await pageUtils.pressKeys( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 		await pageUtils.pressKeys( 'Tab', { times: 5 } );
@@ -836,6 +836,9 @@ test.describe( 'Image', () => {
 				name: 'Disable expand on click',
 			} )
 		).toBeFocused();
+		await page.keyboard.press( 'Enter' );
+		await expect( uriInput ).toBeFocused();
+		await expect( uriInput ).toBeEmpty();
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -742,6 +742,101 @@ test.describe( 'Image', () => {
 
 		expect( src ).toMatch( /\/wp-content\/uploads\// );
 	} );
+
+	test( 'should have keyboard navigable link UI popover', async ( {
+		editor,
+		page,
+		pageUtils,
+		imageBlockUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		await expect( imageBlock ).toBeVisible();
+
+		await imageBlockUtils.upload(
+			imageBlock.locator( 'data-testid=form-file-upload-input' )
+		);
+
+		await page.getByLabel( 'Block tools' ).getByLabel( 'Link' ).click();
+
+		const uriInput = page.getByRole( 'combobox', {
+			name: 'URL',
+		} );
+
+		await expect( uriInput ).toBeFocused();
+
+		// Enter a link.
+		await uriInput.fill( 'https://example.com' );
+		await page.keyboard.press( 'Enter' );
+		await expect(
+			page.getByRole( 'link', {
+				name: 'example.com',
+			} )
+		).toBeFocused();
+
+		// Edit a link.
+		await pageUtils.pressKeys( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+		await expect( uriInput ).toBeFocused();
+		await uriInput.fill( 'https://example.com/updated/' );
+		await page.keyboard.press( 'Enter' );
+		await expect(
+			page.getByRole( 'link', {
+				name: 'example.com/updated/',
+			} )
+		).toBeFocused();
+
+		// Remove a link.
+		await pageUtils.pressKeys( 'Tab', { times: 2 } );
+		await expect(
+			page.getByRole( 'button', { name: 'Remove link' } )
+		).toBeFocused();
+		await page.keyboard.press( 'Enter' );
+		await expect( uriInput ).toBeFocused();
+		await expect( uriInput ).toBeEmpty();
+
+		// Select "Link to image file".
+		await pageUtils.pressKeys( 'Tab', { times: 3 } );
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Link to image file' } )
+		).toBeFocused();
+		await page.keyboard.press( 'Enter' );
+		await expect(
+			page.getByRole( 'link', {
+				name: 'Link to image file',
+			} )
+		).toBeFocused();
+
+		// Select "Link to attachment page".
+		await pageUtils.pressKeys( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+		await pageUtils.pressKeys( 'Tab', { times: 4 } );
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Link to attachment page' } )
+		).toBeFocused();
+		await page.keyboard.press( 'Enter' );
+		await expect(
+			page.getByRole( 'link', {
+				name: 'Link to attachment page',
+			} )
+		).toBeFocused();
+
+		// Select "Expand on click".
+		await pageUtils.pressKeys( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+		await pageUtils.pressKeys( 'Tab', { times: 5 } );
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Expand on click' } )
+		).toBeFocused();
+		await page.keyboard.press( 'Enter' );
+		await expect(
+			page.getByRole( 'button', {
+				name: 'Disable expand on click',
+			} )
+		).toBeFocused();
+	} );
 } );
 
 // Skipping these tests for now as we plan


### PR DESCRIPTION
Fixes #58509

## What?
This PR prevents focus loss from occurring in the `ImageURLInputUI` component used in the Image block and the Media & Text block.

## Why?

My guess is that the components inside the popover will appear and disappear as the URL settings change, causing the focus to be lost unless you explicitly control the focus.

## How?

To control focus, this PR uses the following approaches:

- Allows the `URLPopover` component that the `ImageURLInputUI` component is internally rendering to receive the forwarded ref.
- Use the forwarded ref to refer to the `Popover` component that the `URLPopover` component is internally rendering.
- The `ImageURLInputUI` component focuses on the "first focusable element" each time its state changes based on the `URLPopover` ref.

This approach is also [used](https://github.com/WordPress/gutenberg/blob/408c1186af35e19ed040b8fa56765b1ac731969d/packages/block-editor/src/components/link-control/index.js#L218-L239) in the `LinkControl` component.

This PR allows URLPopover components to accept the ref, but does not necessarily require them to opt in, so there should be no impact to consumers.

Additionally, I added E2E tests to prevent regressions. I've tried to test as much as possible to make sure that the focus is as expected, but it might be a bit redundant.

### Testing Instructions for Keyboard

- Insert an Image block.
- Click the "Link" on the block toolbar.
- You can control everything using just the keyboard and never lose focus.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/54422211/ef5e86f8-b18e-473c-80b7-f62d7c1baf45


