### PR TITLE
fix: innerBlocks schema description in block.json

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -739,7 +739,7 @@
 				},
 				"innerBlocks": {
 					"type": "array",
-					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this:\\n\\n[ { \"name\": \"core/heading\", \"innerBlocks\": [ { \"name\": \"core/heading\", \"attributes\": { \"content\": \"This is an Example\" } } ] } ]\\n\\nWhere each block itself is an object that contains the block name, the block attributes, and the blocks inner blocks."
+					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this:\n\n[ { \"name\": \"core/heading\", \"attributes\": { \"content\": \"This is an Example\" } } ]\n\nWhere each block itself is an object that contains the block name, the block attributes, and the blocks inner blocks."
 				}
 			}
 		},

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -739,7 +739,7 @@
 				},
 				"innerBlocks": {
 					"type": "array",
-					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this: \n\n [ [ 'core/heading', { content: 'This is an Example' }, [] ] ]\n\n Where each block itself is an array that contains the block name, the block attributes, and the blocks inner blocks."
+					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this:\\n\\n[{ name: 'core/heading', innerBlocks: [{ name: 'core/subheading', attributes: { content: 'This is an example.' }}, { }] }]\\n\\nWhere each block itself is an object that contains the block name, the block attributes, and the blocks inner blocks."
 				}
 			}
 		},

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -739,7 +739,7 @@
 				},
 				"innerBlocks": {
 					"type": "array",
-					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this:\\n\\n[{ name: 'core/heading', innerBlocks: [{ name: 'core/subheading', attributes: { content: 'This is an example.' }}, { }] }]\\n\\nWhere each block itself is an object that contains the block name, the block attributes, and the blocks inner blocks."
+					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this:\\n\\n[ { \"name\": \"core/heading\", \"innerBlocks\": [ { \"name\": \"core/heading\", \"attributes\": { \"content\": \"This is an Example\" } } ] } ]\\n\\nWhere each block itself is an object that contains the block name, the block attributes, and the blocks inner blocks."
 				}
 			}
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR corrects the schema description for example.innerBlocks in the block schema to accurately reflect the expected format.

Fixes #58381 

## Why?
The incorrect description was causing confusion for users and potentially leading to incorrect usage of the `innerBlocks` property. This PR is necessary to provide clear and accurate instructions for defining inner blocks within the block example.

## How?
This PR updates the description in the block schema file (`block.json`) to match the correct format for defining inner blocks. It removes syntax errors and provides clear instructions on how to use the `innerBlocks` property.

## Testing Instructions
1. Open block.json.
2. Look for innerBlocks Description

### Testing Instructions for Keyboard
1.Navigate to block.json using keyboard navigations.
2.Head down to around 700 lines and search for innerBlocks description.

## Screenshots or screencast <!-- if applicable -->
![Screenshot2](https://github.com/WordPress/gutenberg/assets/72603662/4ebbd541-e578-4130-9dec-d39940c778ec)

