### PR TITLE
Font Collections: standardizes docblock comments

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -15,13 +15,14 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 	 * Font Collection class.
 	 *
 	 * @since 6.5.0
+	 *
+	 * @see wp_register_font_collection()
 	 */
 	final class WP_Font_Collection {
 		/**
 		 * The unique slug for the font collection.
 		 *
 		 * @since 6.5.0
-		 *
 		 * @var string
 		 */
 		public $slug;
@@ -30,7 +31,6 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 * Font collection data.
 		 *
 		 * @since 6.5.0
-		 *
 		 * @var array|WP_Error|null
 		 */
 		private $data;
@@ -39,7 +39,6 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 * Font collection JSON file path or URL.
 		 *
 		 * @since 6.5.0
-		 *
 		 * @var string|null
 		 */
 		private $src;
@@ -49,15 +48,10 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param string        $slug Font collection slug.
-		 * @param array|string  $data_or_file {
-		 *     Font collection data array or a file path or URL to a JSON file containing the font collection.
-		 *
-		 *     @type string $name          Name of the font collection.
-		 *     @type string $description   Description of the font collection.
-		 *     @type array  $font_families Array of font family definitions included in the collection.
-		 *     @type array  $categories    Array of categories associated with the fonts in the collection.
-		 * }
+		 * @param string        $slug         Font collection slug.
+		 * @param array|string  $data_or_file Font collection data array or a path/URL to a JSON file
+		 *                                    containing the font collection.
+		 *                                    See {@see wp_register_font_collection()} for the supported fields.
 		 */
 		public function __construct( $slug, $data_or_file ) {
 			$this->slug = sanitize_title( $slug );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
@@ -56,10 +56,11 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 * @since 6.5.0
 		 *
 		 * @param string $slug         Font collection slug.
-		 * @param array  $data_or_file Font collection data array or a file path or url to a JSON file
+		 * @param array  $data_or_file Font collection data array or a path/URL to a JSON file
 		 *                             containing the font collection.
 		 *                             See {@see wp_register_font_collection()} for the supported fields.
-		 * @return WP_Font_Collection|WP_Error A font collection if registration was successful, else WP_Error.
+		 * @return WP_Font_Collection|WP_Error A font collection if it was registered successfully,
+		 *                                     or WP_Error object on failure.
 		 */
 		public static function register_font_collection( $slug, $data_or_file ) {
 			$new_collection = new WP_Font_Collection( $slug, $data_or_file );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -138,17 +138,19 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		}
 
 		/**
-		 * Sanitize a tree of data using a schema that defines the sanitization to apply to each key.
+		 * Sanitizes a tree of data using a schema.
 		 *
-		 * It removes the keys not in the schema and applies the sanitizer to the values.
+		 * The schema structure should mirror the data tree. Each value provided in the
+		 * schema should be a callable that will be applied to sanitize the corresponding
+		 * value in the data tree. Keys that are in the data tree, but not present in the
+		 * schema, will be removed in the santized data. Nested arrays are traversed recursively.
 		 *
 		 * @since 6.5.0
 		 *
 		 * @access private
 		 *
-		 * @param array $tree The data to sanitize.
+		 * @param array $tree   The data to sanitize.
 		 * @param array $schema The schema used for sanitization.
-		 *
 		 * @return array The sanitized data.
 		 */
 		public static function sanitize_from_schema( $tree, $schema ) {
@@ -175,7 +177,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 								: self::apply_sanitizer( $item_value, $schema[ $key ][0] );
 						}
 					} else {
-						// If it is an associative or indexed array., process as a single object.
+						// If it is an associative or indexed array, process as a single object.
 						$tree[ $key ] = self::sanitize_from_schema( $value, $schema[ $key ] );
 					}
 				} elseif ( ! $is_value_array && $is_schema_array ) {
@@ -196,13 +198,12 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		}
 
 		/**
-		 * Apply the sanitizer to the value.
+		 * Applies a sanitizer function to a value.
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param mixed $value The value to sanitize.
-		 * @param mixed $sanitizer The sanitizer to apply.
-		 *
+		 * @param mixed $value     The value to sanitize.
+		 * @param mixed $sanitizer The sanitizer function to apply.
 		 * @return mixed The sanitized value.
 		 */
 		private static function apply_sanitizer( $value, $sanitizer ) {

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -114,17 +114,20 @@ if ( ! function_exists( 'wp_register_font_collection' ) ) {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string          $slug Font collection slug or path/url to a JSON file defining the font collection.
+	 * @param string       $slug Font collection slug. May only contain alphanumeric characters, dashes,
+	 *                     and underscores. See sanitize_title().
 	 * @param array|string $data_or_file {
-	 *     Font collection associative array of data, or a file path or url to a JSON
-	 *     file containing the font collection.
+	 *     Font collection data array or a path/URL to a JSON file containing the font collection.
 	 *
-	 *     @type string $name           Name of the font collection.
-	 *     @type string $description    Description of the font collection.
-	 *     @type array  $font_families  Array of font family definitions that are in the collection.
-	 *     @type array  $categories     Array of categories for the fonts that are in the collection.
+	 *     @link https://schemas.wp.org/trunk/font-collection.json
+	 *
+	 *     @type string $name           Required. Name of the font collection shown in the Font Library.
+	 *     @type string $description    Optional. A short descriptive summary of the font collection. Default empty.
+	 *     @type array  $font_families  Required. Array of font family definitions that are in the collection.
+	 *     @type array  $categories     Optional. Array of categories, each with a name and slug, that are used by the
+	 *                                  fonts in the collection. Default empty.
 	 * }
-	 * @return WP_Font_Collection|WP_Error A font collection is it was registered
+	 * @return WP_Font_Collection|WP_Error A font collection if it was registered
 	 *                                     successfully, or WP_Error object on failure.
 	 */
 	function wp_register_font_collection( $slug, $data_or_file ) {
@@ -138,11 +141,11 @@ if ( ! function_exists( 'wp_unregister_font_collection' ) ) {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string $collection_id The font collection ID.
+	 * @param string $slug Font collection slug.
 	 * @return bool True if the font collection was unregistered successfully, else false.
 	 */
-	function wp_unregister_font_collection( $collection_id ) {
-		return WP_Font_Library::unregister_font_collection( $collection_id );
+	function wp_unregister_font_collection( $slug ) {
+		return WP_Font_Library::unregister_font_collection( $slug );
 	}
 }
 


### PR DESCRIPTION
## What?

Touches up the docblock comments related the font collections and font collection registration

## Why?

To align with [Core standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).

## How?

- Removes extra line in WP_Font_Collection property docblocks.
- Puts canonical font collection param descriptions in `wp_register_font_collection` and adds references to that function in related functions/methods.
- Fixes typo

## Testing Instructions

n/a
