### PR TITLE
DocumentBar: Simplify component, use framer for animation

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -12,6 +12,8 @@ import {
 	Button,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
 import {
@@ -22,16 +24,16 @@ import {
 	symbol,
 } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
-import { useEntityRecord } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { store as commandsStore } from '@wordpress/commands';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-const typeLabels = {
+const TYPE_LABELS = {
 	// translators: 1: Pattern title.
 	wp_pattern: __( 'Editing pattern: %s' ),
 	// translators: 1: Navigation menu title.
@@ -42,127 +44,142 @@ const typeLabels = {
 	wp_template_part: __( 'Editing template part: %s' ),
 };
 
-const icons = {
+const ICONS = {
 	wp_block: symbol,
 	wp_navigation: navigationIcon,
 };
 
+const TEMPLATE_POST_TYPES = [ 'wp_template', 'wp_template_part' ];
+
+const GLOBAL_POST_TYPES = [
+	...TEMPLATE_POST_TYPES,
+	'wp_block',
+	'wp_navigation',
+];
+
+const MotionButton = motion( Button );
+
 export default function DocumentBar() {
-	const { postType, postId, onNavigateToPreviousEntityRecord } = useSelect(
-		( select ) => {
-			const {
-				getCurrentPostId,
-				getCurrentPostType,
-				getEditorSettings: getSettings,
-			} = select( editorStore );
-			return {
-				postType: getCurrentPostType(),
-				postId: getCurrentPostId(),
-				onNavigateToPreviousEntityRecord:
-					getSettings().onNavigateToPreviousEntityRecord,
-				getEditorSettings: getSettings,
-			};
-		},
-		[]
-	);
-
-	const handleOnBack = () => {
-		if ( onNavigateToPreviousEntityRecord ) {
-			onNavigateToPreviousEntityRecord();
-		}
-	};
-
-	return (
-		<BaseDocumentActions
-			postType={ postType }
-			postId={ postId }
-			onBack={
-				onNavigateToPreviousEntityRecord ? handleOnBack : undefined
-			}
-		/>
-	);
-}
-
-function BaseDocumentActions( { postType, postId, onBack } ) {
-	const { open: openCommandCenter } = useDispatch( commandsStore );
-	const { editedRecord: doc, isResolving } = useEntityRecord(
-		'postType',
+	const {
 		postType,
-		postId
-	);
-	const { templateIcon, templateTitle } = useSelect( ( select ) => {
-		const { __experimentalGetTemplateInfo: getTemplateInfo } =
-			select( editorStore );
-		const templateInfo = getTemplateInfo( doc );
+		document,
+		isResolving,
+		templateIcon,
+		templateTitle,
+		onNavigateToPreviousEntityRecord,
+	} = useSelect( ( select ) => {
+		const {
+			getCurrentPostType,
+			getCurrentPostId,
+			getEditorSettings,
+			__experimentalGetTemplateInfo: getTemplateInfo,
+		} = select( editorStore );
+		const { getEditedEntityRecord, getIsResolving } = select( coreStore );
+		const _postType = getCurrentPostType();
+		const _postId = getCurrentPostId();
+		const _document = getEditedEntityRecord(
+			'postType',
+			_postType,
+			_postId
+		);
+		const _templateInfo = getTemplateInfo( _document );
 		return {
-			templateIcon: templateInfo.icon,
-			templateTitle: templateInfo.title,
+			postType: _postType,
+			document: _document,
+			isResolving: getIsResolving(
+				'getEditedEntityRecord',
+				'postType',
+				_postType,
+				_postId
+			),
+			templateIcon: _templateInfo.icon,
+			templateTitle: _templateInfo.title,
+			onNavigateToPreviousEntityRecord:
+				getEditorSettings().onNavigateToPreviousEntityRecord,
 		};
-	} );
-	const isNotFound = ! doc && ! isResolving;
-	const icon = icons[ postType ] ?? pageIcon;
-	const [ isAnimated, setIsAnimated ] = useState( false );
-	const isMounting = useRef( true );
-	const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-		postType
-	);
-	const isGlobalEntity = [
-		'wp_template',
-		'wp_navigation',
-		'wp_template_part',
-		'wp_block',
-	].includes( postType );
+	}, [] );
 
+	const { open: openCommandCenter } = useDispatch( commandsStore );
+
+	const isNotFound = ! document && ! isResolving;
+	const icon = ICONS[ postType ] ?? pageIcon;
+	const isTemplate = TEMPLATE_POST_TYPES.includes( postType );
+	const isGlobalEntity = GLOBAL_POST_TYPES.includes( postType );
+	const hasBackButton = !! onNavigateToPreviousEntityRecord;
+	const title = isTemplate ? templateTitle : document.title;
+
+	const mounted = useRef( false );
 	useEffect( () => {
-		if ( ! isMounting.current ) {
-			setIsAnimated( true );
-		}
-		isMounting.current = false;
-	}, [ postType, postId ] );
-
-	const title = isTemplate ? templateTitle : doc.title;
+		mounted.current = true;
+	}, [] );
 
 	return (
 		<div
 			className={ classnames( 'editor-document-bar', {
-				'has-back-button': !! onBack,
-				'is-animated': isAnimated,
+				'has-back-button': hasBackButton,
 				'is-global': isGlobalEntity,
 			} ) }
 		>
-			{ onBack && (
-				<Button
-					className="editor-document-bar__back"
-					icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
-					onClick={ ( event ) => {
-						event.stopPropagation();
-						onBack();
-					} }
-					size="compact"
-				>
-					{ __( 'Back' ) }
-				</Button>
-			) }
-			{ isNotFound && <Text>{ __( 'Document not found' ) }</Text> }
-			{ ! isNotFound && (
+			<AnimatePresence>
+				{ hasBackButton && (
+					<MotionButton
+						className="editor-document-bar__back"
+						icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
+						onClick={ ( event ) => {
+							event.stopPropagation();
+							onNavigateToPreviousEntityRecord();
+						} }
+						size="compact"
+						initial={
+							mounted.current
+								? { opacity: 0, transform: 'translateX(15%)' }
+								: false // Don't show entry animation when DocumentBar mounts.
+						}
+						animate={ { opacity: 1, transform: 'translateX(0%)' } }
+						exit={ { opacity: 0, transform: 'translateX(15%)' } }
+					>
+						{ __( 'Back' ) }
+					</MotionButton>
+				) }
+			</AnimatePresence>
+			{ isNotFound ? (
+				<Text>{ __( 'Document not found' ) }</Text>
+			) : (
 				<Button
 					className="editor-document-bar__command"
 					onClick={ () => openCommandCenter() }
 					size="compact"
 				>
 					<HStack
+						as={ motion.div }
 						className="editor-document-bar__title"
 						spacing={ 1 }
 						justify="center"
+						// Force entry animation when the back button is added or removed.
+						key={ hasBackButton }
+						initial={
+							mounted.current
+								? {
+										opacity: 0,
+										transform: hasBackButton
+											? 'translateX(15%)'
+											: 'translateX(-15%)',
+								  }
+								: false // Don't show entry animation when DocumentBar mounts.
+						}
+						animate={ {
+							opacity: 1,
+							transform: 'translateX(0%)',
+						} }
 					>
 						<BlockIcon icon={ isTemplate ? templateIcon : icon } />
 						<Text
 							size="body"
 							as="h1"
 							aria-label={
-								typeLabels[ postType ]
+								TYPE_LABELS[ postType ]
 									? // eslint-disable-next-line @wordpress/valid-sprintf
-									  sprintf( typeLabels[ postType ], title )
+									  sprintf( TYPE_LABELS[ postType ], title )
 									: undefined
 							}
 						>

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -27,6 +27,7 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as commandsStore } from '@wordpress/commands';
 import { useRef, useEffect } from '@wordpress/element';
+import { useReducedMotion } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -100,6 +101,7 @@ export default function DocumentBar() {
 	}, [] );
 
 	const { open: openCommandCenter } = useDispatch( commandsStore );
+	const isReducedMotion = useReducedMotion();
 
 	const isNotFound = ! document && ! isResolving;
 	const icon = ICONS[ postType ] ?? pageIcon;
@@ -137,6 +139,9 @@ export default function DocumentBar() {
 						}
 						animate={ { opacity: 1, transform: 'translateX(0%)' } }
 						exit={ { opacity: 0, transform: 'translateX(15%)' } }
+						transition={
+							isReducedMotion ? { duration: 0 } : undefined
+						}
 					>
 						{ __( 'Back' ) }
 					</MotionButton>
@@ -171,6 +176,9 @@ export default function DocumentBar() {
 							opacity: 1,
 							transform: 'translateX(0%)',
 						} }
+						transition={
+							isReducedMotion ? { duration: 0 } : undefined
+						}
 					>
 						<BlockIcon icon={ isTemplate ? templateIcon : icon } />
 						<Text

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -66,16 +66,6 @@
 		max-width: 50%;
 		color: currentColor;
 	}
-
-	.editor-document-bar.is-animated.has-back-button & {
-		animation: editor-document-bar__slide-in-left 0.3s;
-		@include reduce-motion("animation");
-	}
-
-	.editor-document-bar.is-animated & {
-		animation: editor-document-bar__slide-in-right 0.3s;
-		@include reduce-motion("animation");
-	}
 }
 
 .editor-document-bar__shortcut {
@@ -99,32 +89,5 @@
 	&:hover {
 		color: var(--wp-block-synced-color);
 		background-color: transparent;
-	}
-
-	.editor-document-bar.is-animated & {
-		animation: editor-document-bar__slide-in-left 0.3s;
-		@include reduce-motion("animation");
-	}
-}
-
-@keyframes editor-document-bar__slide-in-right {
-	from {
-		transform: translateX(-15%);
-		opacity: 0;
-	}
-	to {
-		transform: translateX(0);
-		opacity: 1;
-	}
-}
-
-@keyframes editor-document-bar__slide-in-left {
-	from {
-		transform: translateX(15%);
-		opacity: 0;
-	}
-	to {
-		transform: translateX(0);
-		opacity: 1;
 	}
 }


### PR DESCRIPTION
## What and why

Simplifies the `DocumentBar` the component.

I split these changes out of https://github.com/WordPress/gutenberg/pull/58528.

- Combine `DocumentBar` and `BaseDocumentActions`. Having the component split up like this made sense [back when we would conditionally return a different "base" component depending on the rendering mode](https://github.com/WordPress/gutenberg/blob/1328f2db78cc5bc68f417d4f9c83329272c72474/packages/edit-site/src/components/header-edit-mode/document-actions/index.js#L76-L89). We don't do that now, though, so it just adds unnecessarily complexity.
- Combine the two `useSelect()` and `useEntityRecord` hooks into a single `useSelect`. This is simpler and ought to result in less updates.
- Use framer for the back button animation. This is simpler, more flexible, and lets us do away with the hacky `is-animated` CSS class which is added on mount. I originally used framer when implementing the animation in https://github.com/WordPress/gutenberg/pull/51224 but had to get rid of it because we were rendering different base components depending on the mode (see above). We no longer do that.


## Testing Instructions
1. Go to Appearance → Editor → Pages and select a page. The document actions at the top of screen should **not** animate.
2. Select _Edit template_ in the sidebar. The document actions at the top of screen should animate.
3. Click _Back_. The document actions at the top of screen should animate.