### PR TITLE
[RNMobile] Do not display progress bar when Image is uploading in the Editor

### DIFF
--- a/packages/block-editor/src/components/media-upload-progress/index.native.js
+++ b/packages/block-editor/src/components/media-upload-progress/index.native.js
@@ -188,15 +188,17 @@ export class MediaUploadProgress extends Component {
 				] }
 				pointerEvents="box-none"
 			>
-				<View style={ progressBarStyle }>
-					{ showSpinner && (
-						<Spinner
-							progress={ progress }
-							style={ this.props.spinnerStyle }
-							testID="spinner"
-						/>
-					) }
-				</View>
+				{ ! this.props.hideProgressBar && (
+					<View style={ progressBarStyle }>
+						{ showSpinner && (
+							<Spinner
+								progress={ progress }
+								style={ this.props.spinnerStyle }
+								testID="spinner"
+							/>
+						) }
+					</View>
+				) }
 				{ renderContent( {
 					isUploadPaused:
 						uploadState === MEDIA_UPLOAD_STATE_PAUSED &&

--- a/packages/block-editor/src/components/media-upload-progress/index.native.js
+++ b/packages/block-editor/src/components/media-upload-progress/index.native.js
@@ -187,6 +187,7 @@ export class MediaUploadProgress extends Component {
 					this.props.containerStyle,
 				] }
 				pointerEvents="box-none"
+				testID="progress-container"
 			>
 				{ ! this.props.hideProgressBar && (
 					<View style={ progressBarStyle }>

--- a/packages/block-editor/src/components/media-upload-progress/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload-progress/test/index.native.js
@@ -217,4 +217,32 @@ describe( 'MediaUploadProgress component', () => {
 		expect( onMediaUploadStateReset ).toHaveBeenCalledTimes( 1 );
 		expect( onMediaUploadStateReset ).toHaveBeenCalledWith( payloadReset );
 	} );
+
+	it( 'does not display the spinner when hideProgresBar is true', () => {
+		const renderContentMock = jest.fn();
+		const progress = 0.1;
+		const payload = {
+			state: MEDIA_UPLOAD_STATE_UPLOADING,
+			mediaId: MEDIA_ID,
+			progress,
+		};
+
+		const wrapper = render(
+			<MediaUploadProgress
+				hideProgressBar
+				mediaId={ MEDIA_ID }
+				renderContent={ renderContentMock }
+			/>
+		);
+
+		sendMediaUpload( payload );
+
+		expect( wrapper.queryByTestId( 'spinner' ) ).toBeNull();
+		expect( renderContentMock ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				isUploadInProgress: true,
+				isUploadFailed: false,
+			} )
+		);
+	} );
 } );

--- a/packages/block-editor/src/components/media-upload-progress/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload-progress/test/index.native.js
@@ -218,7 +218,7 @@ describe( 'MediaUploadProgress component', () => {
 		expect( onMediaUploadStateReset ).toHaveBeenCalledWith( payloadReset );
 	} );
 
-	it( 'does not display the spinner when hideProgresBar is true', () => {
+	it( 'does not display the spinner when hideProgressBar is true', () => {
 		const renderContentMock = jest.fn();
 		const progress = 0.1;
 		const payload = {

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -202,13 +202,17 @@ describe( 'Gallery block', () => {
 		await notifyUploadingState( media[ 0 ] );
 		await notifyUploadingState( media[ 1 ] );
 
-		// Check that images are showing a loading state
+		// Check that images do not display the progress bar
 		expect(
-			within( getGalleryItem( galleryBlock, 1 ) ).getByTestId( 'spinner' )
-		).toBeVisible();
+			within( getGalleryItem( galleryBlock, 1 ) ).queryByTestId(
+				'spinner'
+			)
+		).toBeNull();
 		expect(
-			within( getGalleryItem( galleryBlock, 2 ) ).getByTestId( 'spinner' )
-		).toBeVisible();
+			within( getGalleryItem( galleryBlock, 2 ) ).queryByTestId(
+				'spinner'
+			)
+		).toBeNull();
 
 		// Notify that the media items upload succeeded
 		await notifySucceedState( media[ 0 ] );
@@ -295,11 +299,11 @@ describe( 'Gallery block', () => {
 		expect( galleryItem1 ).toBeVisible();
 		expect( galleryItem2 ).toBeVisible();
 
-		// Check that images are showing a loading state
+		// Check that images do not display the progress bar
 		await notifyUploadingState( media[ 0 ] );
 		await notifyUploadingState( media[ 1 ] );
-		expect( within( galleryItem1 ).getByTestId( 'spinner' ) ).toBeVisible();
-		expect( within( galleryItem2 ).getByTestId( 'spinner' ) ).toBeVisible();
+		expect( within( galleryItem1 ).queryByTestId( 'spinner' ) ).toBeNull();
+		expect( within( galleryItem2 ).queryByTestId( 'spinner' ) ).toBeNull();
 
 		// Notify that the media items upload succeeded
 		await notifySucceedState( media[ 0 ] );
@@ -333,11 +337,11 @@ describe( 'Gallery block', () => {
 		expect( galleryItem1 ).toBeVisible();
 		expect( galleryItem2 ).toBeVisible();
 
-		// Check that images are showing a loading state
+		// Check that images do not display the progress bar
 		await notifyUploadingState( media[ 0 ] );
 		await notifyUploadingState( media[ 1 ] );
-		expect( within( galleryItem1 ).getByTestId( 'spinner' ) ).toBeVisible();
-		expect( within( galleryItem2 ).getByTestId( 'spinner' ) ).toBeVisible();
+		expect( within( galleryItem1 ).queryByTestId( 'spinner' ) ).toBeNull();
+		expect( within( galleryItem2 ).queryByTestId( 'spinner' ) ).toBeNull();
 
 		// Notify that the media items uploads failed
 		await notifyFailedState( media[ 0 ] );
@@ -385,9 +389,9 @@ describe( 'Gallery block', () => {
 		const galleryItem = getGalleryItem( galleryBlock, 1 );
 		expect( galleryItem ).toBeVisible();
 
-		// Check image is showing a loading state
+		// Check that the image does not display the progress bar
 		await notifyUploadingState( media[ 0 ] );
-		expect( within( galleryItem ).getByTestId( 'spinner' ) ).toBeVisible();
+		expect( within( galleryItem ).queryByTestId( 'spinner' ) ).toBeNull();
 
 		// Notify that the media item upload succeeded
 		await notifySucceedState( media[ 0 ] );
@@ -443,11 +447,11 @@ describe( 'Gallery block', () => {
 		expect( galleryItem1 ).toBeVisible();
 		expect( galleryItem2 ).toBeVisible();
 
-		// Check that images are showing a loading state
+		// Check that images do not display the progress bar
 		await notifyUploadingState( freePhotoMedia[ 0 ] );
 		await notifyUploadingState( freePhotoMedia[ 1 ] );
-		expect( within( galleryItem1 ).getByTestId( 'spinner' ) ).toBeVisible();
-		expect( within( galleryItem2 ).getByTestId( 'spinner' ) ).toBeVisible();
+		expect( within( galleryItem1 ).queryByTestId( 'spinner' ) ).toBeNull();
+		expect( within( galleryItem2 ).queryByTestId( 'spinner' ) ).toBeNull();
 
 		// Notify that the media items upload succeeded
 		await notifySucceedState( freePhotoMedia[ 0 ] );
@@ -481,22 +485,26 @@ describe( 'Gallery block', () => {
 		expect( galleryItem1 ).toBeVisible();
 		expect( galleryItem2 ).toBeVisible();
 
-		// Check that images are showing a loading state
+		// Check that images do not display the progress bar
 		await notifyUploadingState( media[ 0 ] );
 		await notifyUploadingState( media[ 1 ] );
-		expect( within( galleryItem1 ).getByTestId( 'spinner' ) ).toBeVisible();
-		expect( within( galleryItem2 ).getByTestId( 'spinner' ) ).toBeVisible();
+		expect( within( galleryItem1 ).queryByTestId( 'spinner' ) ).toBeNull();
+		expect( within( galleryItem2 ).queryByTestId( 'spinner' ) ).toBeNull();
 
 		// Cancel uploads
 		fireEvent.press( galleryItem1 );
-		fireEvent.press( within( galleryItem1 ).getByTestId( 'spinner' ) );
+		fireEvent.press(
+			within( galleryItem1 ).getByTestId( 'progress-container' )
+		);
 		expect( requestImageUploadCancelDialog ).toHaveBeenCalledWith(
 			media[ 0 ].localId
 		);
 		await notifyResetState( media[ 0 ] );
 
 		fireEvent.press( galleryItem2 );
-		fireEvent.press( within( galleryItem2 ).getByTestId( 'spinner' ) );
+		fireEvent.press(
+			within( galleryItem2 ).getByTestId( 'progress-container' )
+		);
 		expect( requestImageUploadCancelDialog ).toHaveBeenCalledWith(
 			media[ 1 ].localId
 		);
@@ -581,11 +589,11 @@ describe( 'Gallery block', () => {
 		expect( galleryItem1 ).toBeVisible();
 		expect( galleryItem2 ).toBeVisible();
 
-		// Check that images are showing a loading state
+		// Check that images do not diplay the progress bar
 		await notifyUploadingState( otherAppsMedia[ 0 ] );
 		await notifyUploadingState( otherAppsMedia[ 1 ] );
-		expect( within( galleryItem1 ).getByTestId( 'spinner' ) ).toBeVisible();
-		expect( within( galleryItem2 ).getByTestId( 'spinner' ) ).toBeVisible();
+		expect( within( galleryItem1 ).queryByTestId( 'spinner' ) ).toBeNull();
+		expect( within( galleryItem2 ).queryByTestId( 'spinner' ) ).toBeNull();
 
 		// Notify that the media items upload succeeded
 		await notifySucceedState( otherAppsMedia[ 0 ] );

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -815,6 +815,7 @@ export class ImageEdit extends Component {
 							enablePausedUploads
 							coverUrl={ url }
 							mediaId={ id }
+							hideProgressBar={ true }
 							onUpdateMediaProgress={ this.updateMediaProgress }
 							onFinishMediaUploadWithSuccess={
 								this.finishMediaUploadWithSuccess

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Animated, Image as RNImage, Text, View } from 'react-native';
+import { Image as RNImage, Text, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 
 /**
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
 import { image, offline } from '@wordpress/icons';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
-import { useEffect, useState, useRef, Platform } from '@wordpress/element';
+import { useEffect, useState, Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -218,19 +218,8 @@ const ImageComponent = ( {
 		focalPoint && styles.focalPointContainer,
 	];
 
-	const opacityValue = useRef( new Animated.Value( 1 ) ).current;
-
-	useEffect( () => {
-		Animated.timing( opacityValue, {
-			toValue: isUploadInProgress ? 0.3 : 1,
-			duration: 100,
-			useNativeDriver: true,
-		} ).start();
-	}, [ isUploadInProgress, opacityValue ] );
-
 	const imageStyles = [
 		{
-			opacity: opacityValue,
 			height: containerSize?.height,
 		},
 		! resizeMode && {
@@ -319,7 +308,7 @@ const ImageComponent = ( {
 						{ Platform.isAndroid && (
 							<>
 								{ networkImageLoaded && networkURL && (
-									<Animated.Image
+									<Image
 										style={ imageStyles }
 										fadeDuration={ 0 }
 										source={ { uri: networkURL } }
@@ -331,7 +320,7 @@ const ImageComponent = ( {
 									/>
 								) }
 								{ ! networkImageLoaded && ! networkURL && (
-									<Animated.Image
+									<Image
 										style={ imageStyles }
 										fadeDuration={ 0 }
 										source={ { uri: localURL } }
@@ -345,7 +334,7 @@ const ImageComponent = ( {
 						) }
 						{ Platform.isIOS && (
 							<>
-								<Animated.Image
+								<Image
 									style={ imageStyles }
 									source={ {
 										uri:

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -310,7 +310,6 @@ const ImageComponent = ( {
 								{ networkImageLoaded && networkURL && (
 									<Image
 										style={ imageStyles }
-										fadeDuration={ 0 }
 										source={ { uri: networkURL } }
 										{ ...( ! focalPoint && {
 											resizeMethod: 'scale',
@@ -322,7 +321,6 @@ const ImageComponent = ( {
 								{ ! networkImageLoaded && ! networkURL && (
 									<Image
 										style={ imageStyles }
-										fadeDuration={ 0 }
 										source={ { uri: localURL } }
 										{ ...( ! focalPoint && {
 											resizeMethod: 'scale',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes:

* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6603

## What?
This PR mobile editor media uploads to not display a spinner or opacity change when the media type is an Image.

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6604


## Why?
As part of ongoing efforts to improve the media upload experience, we have received feedback that Image upload process could be improved by not displaying an "in progress" state when uploading Images.

This PR focuses on UI display only, and intentionally does not update any of the media progress upload logic in order to reduce regressions.


## How?
- Remove opacity changes when the Image is being uploaded
- Add a new prop to MediaUploadProgress component called `hideProgressBar`
- Add `hideProgressBar={ true }` to the Image block to ensure the progress bar can be displayed for other components.

## Testing Instructions
Scenario 1: Testing Images
1. Create a post or page and insert an **Image** or **Gallery** block
2. Add an image from the device
3. Observe that the progress bar is not displayed, and the image opacity does not change

Scenario 1: Testing other media
1. Create a post or page and insert a **Video** block
2. Add a video from the device
3. Observe that the progress bar is displayed

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/643285/c101c563-29ae-4eaa-86dc-c463651f3bb2




## Todo

- [ ] Update test snapshots and resolve test failures
- [x] Add screenshots
