### PR TITLE
Disable overriding links of images inside pattern instances

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -405,6 +405,7 @@ export default function Image( {
 
 	const {
 		lockUrlControls = false,
+		lockHrefControls = false,
 		lockAltControls = false,
 		lockTitleControls = false,
 	} = useSelect(
@@ -417,6 +418,7 @@ export default function Image( {
 				unlock( select( blockEditorStore ) );
 			const {
 				url: urlBinding,
+				href: hrefBinding,
 				alt: altBinding,
 				title: titleBinding,
 			} = metadata?.bindings || {};
@@ -424,8 +426,12 @@ export default function Image( {
 				getBlockParentsByBlockName( clientId, 'core/block' ).length > 0;
 			return {
 				lockUrlControls:
-					( !! urlBinding &&
-						getBlockBindingsSource( urlBinding?.source )
+					!! urlBinding &&
+					getBlockBindingsSource( urlBinding?.source )
+						?.lockAttributesEditing === true,
+				lockHrefControls:
+					( !! hrefBinding &&
+						getBlockBindingsSource( hrefBinding?.source )
 							?.lockAttributesEditing === true ) ||
 					// Disable editing the link of the URL if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the link on the frontend.
@@ -446,21 +452,23 @@ export default function Image( {
 	const controls = (
 		<>
 			<BlockControls group="block">
-				{ isSingleSelected && ! isEditingImage && ! lockUrlControls && (
-					<ImageURLInputUI
-						url={ href || '' }
-						onChangeUrl={ onSetHref }
-						linkDestination={ linkDestination }
-						mediaUrl={ ( image && image.source_url ) || url }
-						mediaLink={ image && image.link }
-						linkTarget={ linkTarget }
-						linkClass={ linkClass }
-						rel={ rel }
-						showLightboxSetting={ showLightboxSetting }
-						lightboxEnabled={ lightboxChecked }
-						onSetLightbox={ onSetLightbox }
-					/>
-				) }
+				{ isSingleSelected &&
+					! isEditingImage &&
+					! lockHrefControls && (
+						<ImageURLInputUI
+							url={ href || '' }
+							onChangeUrl={ onSetHref }
+							linkDestination={ linkDestination }
+							mediaUrl={ ( image && image.source_url ) || url }
+							mediaLink={ image && image.link }
+							linkTarget={ linkTarget }
+							linkClass={ linkClass }
+							rel={ rel }
+							showLightboxSetting={ showLightboxSetting }
+							lightboxEnabled={ lightboxChecked }
+							onSetLightbox={ onSetLightbox }
+						/>
+					) }
 				{ allowCrop && (
 					<ToolbarButton
 						onClick={ () => setIsEditingImage( true ) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -439,24 +439,39 @@ export default function Image( {
 		[ isSingleSelected ]
 	);
 
+	const hasParentPattern = useSelect(
+		( select ) => {
+			const { getBlockParentsByBlockName } = select( blockEditorStore );
+			return (
+				getBlockParentsByBlockName( clientId, 'core/block' ).length > 0
+			);
+		},
+		[ clientId ]
+	);
+
 	const controls = (
 		<>
 			<BlockControls group="block">
-				{ isSingleSelected && ! isEditingImage && ! lockUrlControls && (
-					<ImageURLInputUI
-						url={ href || '' }
-						onChangeUrl={ onSetHref }
-						linkDestination={ linkDestination }
-						mediaUrl={ ( image && image.source_url ) || url }
-						mediaLink={ image && image.link }
-						linkTarget={ linkTarget }
-						linkClass={ linkClass }
-						rel={ rel }
-						showLightboxSetting={ showLightboxSetting }
-						lightboxEnabled={ lightboxChecked }
-						onSetLightbox={ onSetLightbox }
-					/>
-				) }
+				{ isSingleSelected &&
+					! isEditingImage &&
+					! lockUrlControls &&
+					// Disable editing the link of the URL if the image is inside a pattern instance.
+					// This is a temporary solution until we support overriding the link on the frontend.
+					! hasParentPattern && (
+						<ImageURLInputUI
+							url={ href || '' }
+							onChangeUrl={ onSetHref }
+							linkDestination={ linkDestination }
+							mediaUrl={ ( image && image.source_url ) || url }
+							mediaLink={ image && image.link }
+							linkTarget={ linkTarget }
+							linkClass={ linkClass }
+							rel={ rel }
+							showLightboxSetting={ showLightboxSetting }
+							lightboxEnabled={ lightboxChecked }
+							onSetLightbox={ onSetLightbox }
+						/>
+					) }
 				{ allowCrop && (
 					<ToolbarButton
 						onClick={ () => setIsEditingImage( true ) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -418,7 +418,6 @@ export default function Image( {
 				unlock( select( blockEditorStore ) );
 			const {
 				url: urlBinding,
-				href: hrefBinding,
 				alt: altBinding,
 				title: titleBinding,
 			} = metadata?.bindings || {};
@@ -430,9 +429,6 @@ export default function Image( {
 					getBlockBindingsSource( urlBinding?.source )
 						?.lockAttributesEditing === true,
 				lockHrefControls:
-					( !! hrefBinding &&
-						getBlockBindingsSource( hrefBinding?.source )
-							?.lockAttributesEditing === true ) ||
 					// Disable editing the link of the URL if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the link on the frontend.
 					hasParentPattern,
@@ -454,7 +450,8 @@ export default function Image( {
 			<BlockControls group="block">
 				{ isSingleSelected &&
 					! isEditingImage &&
-					! lockHrefControls && (
+					! lockHrefControls &&
+					! lockUrlControls && (
 						<ImageURLInputUI
 							url={ href || '' }
 							onChangeUrl={ onSetHref }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of #53705. Disable editing links of images inside pattern instances.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The link attributes of the image block mostly depend on the `figure > a` selector. The HTML Tag Processor API doesn't support the `>` syntax yet. (c.c. @artemiomorales, @SantosGuillamot)

The link can still be edited but won't be saved when inside a pattern instance. The easiest option for now is just to disable the editing control until we support it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Disable the edit control when the image is inside a parent pattern instance.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a pattern with an image and a link.
2. Enable "Allow instance overrides" in the "Advanced" block settings.
3. Insert the pattern in a post.
4. Expect that you can't edit the link of the image.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/WordPress/gutenberg/assets/7753001/9721e1ea-f715-4b0c-9516-411fa5718a82)
