### PR TITLE
Try: Remove shadow preset overflow.

### DIFF
--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -23,8 +23,7 @@
 
 // wrapper to clip the shadow beyond 6px
 .block-editor-global-styles-effects-panel__shadow-indicator-wrapper {
-	padding: 6px;
-	overflow: hidden;
+	padding: $grid-unit-15 * 0.5;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -38,8 +37,8 @@
 	cursor: pointer;
 	padding: 0;
 
-	height: 24px;
-	width: 24px;
+	height: $button-size-small;
+	width: $button-size-small;
 }
 
 .block-editor-global-styles-advanced-panel__custom-css-input textarea {


### PR DESCRIPTION
## What?

The preset container for shadows looks awkwardly cropped:

![Screenshot 2024-02-05 at 11 50 50](https://github.com/WordPress/gutenberg/assets/1204802/801b5fe4-2a4b-4016-997e-e27af9966d3c)

While there's a question on how to best visualize shadows, as-is this preview is inaccurate. By removing overflow: hidden; the full shadow can be seen:

![Screenshot 2024-02-05 at 11 52 24](https://github.com/WordPress/gutenberg/assets/1204802/cec6486e-d548-4d9c-9e47-e750a2cf76e4)

While this does make shadows sequentially blend into each other, it seems a better solution for the interim, IMO.

## Testing Instructions

Insert a button, then look at the shadow preset style in the inspector. They should not be cropped.