### PR TITLE
Interactivity API: Remove non default suffix data wp context processing.

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -134,3 +134,10 @@ wp_enqueue_script_module( 'directive-context-view' );
 	<button data-testid="navigate" data-wp-on--click="actions.navigate">Navigate</button>
 	<button data-testid="async navigate" data-wp-on--click="actions.asyncNavigate">Async Navigate</button>
 </div>
+
+<div
+	data-wp-interactive='{"namespace": "directive-context-non-default"}'
+	data-wp-context--non-default='{ "text": "non default" }'
+>
+	<span data-testid="non-default suffix context" data-wp-text="context.text"></span>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -138,6 +138,8 @@ wp_enqueue_script_module( 'directive-context-view' );
 <div
 	data-wp-interactive='{"namespace": "directive-context-non-default"}'
 	data-wp-context--non-default='{ "text": "non default" }'
+	data-wp-context='{ "defaultText": "default" }'
 >
 	<span data-testid="non-default suffix context" data-wp-text="context.text"></span>
+	<span data-testid="default suffix context" data-wp-text="context.defaultText"></span>
 </div>

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Break up init with yielding to main to prevent long task from hydration. ([#58227](https://github.com/WordPress/gutenberg/pull/58227))
 
+### Bug fixes
+
+-   Interactivity API: Remove non default suffix data wp context processing. ([#58664](https://github.com/WordPress/gutenberg/pull/58664))
+
 ## 4.0.1 (2024-01-31)
 
 ### Bug Fixes

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -102,24 +102,17 @@ export default () => {
 			const inheritedValue = useContext( inheritedContext );
 			const currentValue = useRef( deepSignal( {} ) );
 			const passedValues = context.map( ( { value } ) => value );
-			try {
+			currentValue.current = useMemo( () => {
 				const { namespace, value } = context.find(
 					( { suffix } ) => suffix === 'default'
 				);
-				currentValue.current = useMemo( () => {
-					const newValue = deepSignal( {
-						[ namespace ]: value,
-					} );
-					mergeDeepSignals( newValue, inheritedValue );
-					mergeDeepSignals( currentValue.current, newValue, true );
-					return currentValue.current;
-				}, [ inheritedValue, ...passedValues ] );
-			} catch ( e ) {
-				// If there's an error, we'll just return the inherited context.
-				return (
-					<Provider value={ inheritedValue }>{ children }</Provider>
-				);
-			}
+				const newValue = deepSignal( {
+					[ namespace ]: value,
+				} );
+				mergeDeepSignals( newValue, inheritedValue );
+				mergeDeepSignals( currentValue.current, newValue, true );
+				return currentValue.current;
+			}, [ inheritedValue, ...passedValues ] );
 			return (
 				<Provider value={ currentValue.current }>{ children }</Provider>
 			);

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -101,21 +101,26 @@ export default () => {
 			const { Provider } = inheritedContext;
 			const inheritedValue = useContext( inheritedContext );
 			const currentValue = useRef( deepSignal( {} ) );
-			const passedValues = context.map( ( { value } ) => value );
+			const defaultEntry = context.find(
+				( { suffix } ) => suffix === 'default'
+			);
+
 			currentValue.current = useMemo( () => {
-				const { namespace, value } = context.find(
-					( { suffix } ) => suffix === 'default'
-				);
-				const newValue = deepSignal( {
-					[ namespace ]: value,
-				} );
+				if ( ! defaultEntry ) return null;
+				const { namespace, value } = defaultEntry;
+				const newValue = deepSignal( { [ namespace ]: value } );
 				mergeDeepSignals( newValue, inheritedValue );
 				mergeDeepSignals( currentValue.current, newValue, true );
 				return currentValue.current;
-			}, [ inheritedValue, ...passedValues ] );
-			return (
-				<Provider value={ currentValue.current }>{ children }</Provider>
-			);
+			}, [ inheritedValue, defaultEntry ] );
+
+			if ( currentValue.current ) {
+				return (
+					<Provider value={ currentValue.current }>
+						{ children }
+					</Provider>
+				);
+			}
 		},
 		{ priority: 5 }
 	);

--- a/packages/interactivity/src/directives.js
+++ b/packages/interactivity/src/directives.js
@@ -102,17 +102,24 @@ export default () => {
 			const inheritedValue = useContext( inheritedContext );
 			const currentValue = useRef( deepSignal( {} ) );
 			const passedValues = context.map( ( { value } ) => value );
-
-			currentValue.current = useMemo( () => {
-				const newValue = context
-					.map( ( c ) => deepSignal( { [ c.namespace ]: c.value } ) )
-					.reduceRight( mergeDeepSignals );
-
-				mergeDeepSignals( newValue, inheritedValue );
-				mergeDeepSignals( currentValue.current, newValue, true );
-				return currentValue.current;
-			}, [ inheritedValue, ...passedValues ] );
-
+			try {
+				const { namespace, value } = context.find(
+					( { suffix } ) => suffix === 'default'
+				);
+				currentValue.current = useMemo( () => {
+					const newValue = deepSignal( {
+						[ namespace ]: value,
+					} );
+					mergeDeepSignals( newValue, inheritedValue );
+					mergeDeepSignals( currentValue.current, newValue, true );
+					return currentValue.current;
+				}, [ inheritedValue, ...passedValues ] );
+			} catch ( e ) {
+				// If there's an error, we'll just return the inherited context.
+				return (
+					<Provider value={ inheritedValue }>{ children }</Provider>
+				);
+			}
 			return (
 				<Provider value={ currentValue.current }>{ children }</Provider>
 			);

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -42,7 +42,6 @@ test.describe( 'data-wp-context', () => {
 		const childContext = await parseContent(
 			page.getByTestId( 'child context' )
 		);
-
 		expect( childContext ).toMatchObject( {
 			prop1: 'parent',
 			prop2: 'child',
@@ -188,5 +187,13 @@ test.describe( 'data-wp-context', () => {
 		await expect( element ).toHaveText( '' );
 		await page.getByTestId( 'async navigate' ).click();
 		await expect( element ).toHaveText( 'changed from async action' );
+	} );
+	test( 'should bail out if the context is not a default directive', async ( {
+		page,
+	} ) => {
+		// This test is to ensure that the context directive is only applied to the default directive
+		// and not to any other directive.
+		const element = page.getByTestId( 'non-default suffix context' );
+		await expect( element ).toHaveText( '' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -194,6 +194,8 @@ test.describe( 'data-wp-context', () => {
 	} ) => {
 		// This test is to ensure that the context directive is only applied to the default directive
 		// and not to any other directive.
+		const defaultElement = page.getByTestId( 'default suffix context' );
+		await expect( defaultElement ).toHaveText( 'default' );
 		const element = page.getByTestId( 'non-default suffix context' );
 		await expect( element ).toHaveText( '' );
 	} );

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -42,6 +42,7 @@ test.describe( 'data-wp-context', () => {
 		const childContext = await parseContent(
 			page.getByTestId( 'child context' )
 		);
+
 		expect( childContext ).toMatchObject( {
 			prop1: 'parent',
 			prop2: 'child',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent from processing directives of `data-wp-context` with other suffixes. In other directives, you may have different suffixes like:
`data-wp-on-document-ready` or `data-wp-on-document-scroll`

But, in `data-wp-context`, we only want developers to use `data-wp-context`, not `data-wp-context--a` or `data-wp-context--b`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because there is no need to overcomplicate things. Contexts are unique per element, and you can always add more elements to the already existing context rather than creting new ones.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add an interactive block with a `data-wp-context-whatever`.
- Add a `wp-text` directive reading that context.
- It should not appear.
