### PR TITLE
Link UI: polish lightbox pieces.

### DIFF
--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -15,10 +15,12 @@ $input-size: 300px;
 			width: $input-size;
 		}
 		padding: $input-padding;
-		border: none;
-		border-radius: 0;
 		margin-left: 0;
 		margin-right: 0;
+
+		&:not(:focus) {
+			border-color: transparent;
+		}
 
 		/* Fonts smaller than 16px causes mobile safari to zoom. */
 		font-size: $mobile-text-min-font-size;

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -14,6 +14,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import {
+	Icon,
 	link as linkIcon,
 	image,
 	page,
@@ -342,9 +343,7 @@ const ImageURLInputUI = ( {
 					) }
 					{ ! url && ! isEditingLink && lightboxEnabled && (
 						<div className="block-editor-url-popover__expand-on-click">
-							<div className="fullscreen-icon">
-								{ fullscreen }
-							</div>
+							<Icon icon={ fullscreen } />
 							<div className="text">
 								<p>{ __( 'Expand on click' ) }</p>
 								<p className="description">
@@ -355,7 +354,6 @@ const ImageURLInputUI = ( {
 							</div>
 							<Button
 								icon={ linkOff }
-								className="remove-link"
 								label={ __( 'Disable expand on click' ) }
 								onClick={ () => {
 									onSetLightbox( false );

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -80,7 +80,6 @@
 			line-height: $grid-unit-20;
 
 			&.description {
-				margin-top: $grid-unit-05;
 				color: $gray-700;
 				font-size: $helptext-font-size;
 			}

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -5,7 +5,6 @@
 
 .block-editor-url-popover__input-container {
 	padding: $grid-unit-10;
-	padding-left: $grid-unit-20;
 }
 
 .block-editor-url-popover__row {
@@ -17,7 +16,7 @@
 // should take up as much space as possible.
 .block-editor-url-popover__row > :not(.block-editor-url-popover__settings-toggle) {
 	flex-grow: 1;
-	gap: $grid-unit-05;
+	gap: $grid-unit-10;
 }
 
 .block-editor-url-popover__additional-controls .components-button.has-icon {
@@ -69,11 +68,11 @@
 	display: flex;
 	align-items: center;
 	min-width: $modal-min-width;
-	overflow: hidden;
 	white-space: nowrap;
 
 	.fullscreen-icon {
-		padding-right: $grid-unit-05;
+		display: flex;
+		align-items: center;
 
 		> svg {
 			width: $icon-size;
@@ -86,15 +85,14 @@
 
 		p {
 			margin: 0;
+			// This ensures the text and help text is 32px, which with
+			// padding makes the popover same height as the block toolbar.
+			line-height: $grid-unit-20;
 		}
 	}
 
 	.description {
 		color: $gray-600;
+		font-size: $helptext-font-size;
 	}
-
-	.remove-link {
-		margin-right: $grid-unit-10;
-	}
-
 }

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -70,16 +70,6 @@
 	min-width: $modal-min-width;
 	white-space: nowrap;
 
-	.fullscreen-icon {
-		display: flex;
-		align-items: center;
-
-		> svg {
-			width: $icon-size;
-			height: $icon-size;
-		}
-	}
-
 	.text {
 		flex-grow: 1;
 
@@ -88,11 +78,12 @@
 			// This ensures the text and help text is 32px, which with
 			// padding makes the popover same height as the block toolbar.
 			line-height: $grid-unit-20;
-		}
-	}
 
-	.description {
-		color: $gray-600;
-		font-size: $helptext-font-size;
+			&.description {
+				margin-top: $grid-unit-05;
+				color: $gray-700;
+				font-size: $helptext-font-size;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## What?

This addresses as yet unfinished design work that went into #54916. Specifically the followup items mentioned here: https://github.com/WordPress/gutenberg/pull/57608#pullrequestreview-1835879214

The metrics in the link UI for lightbox can be improved:

![lighbox ui before](https://github.com/WordPress/gutenberg/assets/1204802/fec4b33b-b024-4f94-84d4-333c4c511935)

and the focus style is broken

![focus style broken](https://github.com/WordPress/gutenberg/assets/1204802/b5b84146-be4f-470a-887d-91743d8920aa)

This PR fixes both. First it addresses the metrics:

![new metrics](https://github.com/WordPress/gutenberg/assets/1204802/3a36e2b8-e432-456c-b025-df1d3b0b292a)

* 48px tall control, same as the block toolbar
* Harmonious padding and gap
* Tweaked vertical alignment
* Correct helper text font size

And the focus style is repaired too:

![fixed focus style](https://github.com/WordPress/gutenberg/assets/1204802/6b054afa-48a4-408c-9012-64a20c4f46ca)

## Testing Instructions

Insert an image, test the URL focus, test the lighbox option.