### PR TITLE
Font Library: Refactor as a singleton

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
@@ -25,7 +25,15 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 *
 		 * @var array
 		 */
-		private static $collections = array();
+		private $collections = array();
+
+		/**
+		 * Container for the main instance of the class.
+		 *
+		 * @since 6.5.0
+		 * @var WP_Font_Library|null
+		 */
+		private static $instance = null;
 
 		/**
 		 * Register a new font collection.
@@ -39,10 +47,10 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 * @return WP_Font_Collection|WP_Error A font collection if it was registered successfully,
 		 *                                     or WP_Error object on failure.
 		 */
-		public static function register_font_collection( $slug, $data_or_file ) {
+		public function register_font_collection( $slug, $data_or_file ) {
 			$new_collection = new WP_Font_Collection( $slug, $data_or_file );
 
-			if ( self::is_collection_registered( $new_collection->slug ) ) {
+			if ( $this->is_collection_registered( $new_collection->slug ) ) {
 				$error_message = sprintf(
 				/* translators: %s: Font collection slug. */
 					__( 'Font collection with slug: "%s" is already registered.', 'gutenberg' ),
@@ -55,7 +63,7 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 				);
 				return new WP_Error( 'font_collection_registration_error', $error_message );
 			}
-			self::$collections[ $new_collection->slug ] = $new_collection;
+			$this->collections[ $new_collection->slug ] = $new_collection;
 			return $new_collection;
 		}
 
@@ -67,8 +75,8 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 * @param string $slug Font collection slug.
 		 * @return bool True if the font collection was unregistered successfully and false otherwise.
 		 */
-		public static function unregister_font_collection( $slug ) {
-			if ( ! self::is_collection_registered( $slug ) ) {
+		public function unregister_font_collection( $slug ) {
+			if ( ! $this->is_collection_registered( $slug ) ) {
 				_doing_it_wrong(
 					__METHOD__,
 					/* translators: %s: Font collection slug. */
@@ -77,7 +85,7 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 				);
 				return false;
 			}
-			unset( self::$collections[ $slug ] );
+			unset( $this->collections[ $slug ] );
 			return true;
 		}
 
@@ -89,8 +97,8 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 * @param string $slug Font collection slug.
 		 * @return bool True if the font collection is registered and false otherwise.
 		 */
-		private static function is_collection_registered( $slug ) {
-			return array_key_exists( $slug, self::$collections );
+		private function is_collection_registered( $slug ) {
+			return array_key_exists( $slug, $this->collections );
 		}
 
 		/**
@@ -100,8 +108,8 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 *
 		 * @return array List of font collections.
 		 */
-		public static function get_font_collections() {
-			return self::$collections;
+		public function get_font_collections() {
+			return $this->collections;
 		}
 
 		/**
@@ -113,11 +121,28 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 * @return WP_Font_Collection|WP_Error Font collection object,
 		 *                                     or WP_Error object if the font collection doesn't exist.
 		 */
-		public static function get_font_collection( $slug ) {
-			if ( array_key_exists( $slug, self::$collections ) ) {
-				return self::$collections[ $slug ];
+		public function get_font_collection( $slug ) {
+			if ( array_key_exists( $slug, $this->collections ) ) {
+				return $this->collections[ $slug ];
 			}
 			return new WP_Error( 'font_collection_not_found', 'Font collection not found.' );
+		}
+
+		/**
+		 * Utility method to retrieve the main instance of the class.
+		 *
+		 * The instance will be created if it does not exist yet.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @return WP_Font_Library The main instance.
+		 */
+		public static function get_instance() {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
 		}
 	}
 }

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 		 */
 		public function get_items( $request ) {
-			$collections_all = WP_Font_Library::get_font_collections();
+			$collections_all = WP_Font_Library::get_instance()->get_font_collections();
 
 			$page        = $request['page'];
 			$per_page    = $request['per_page'];
@@ -142,7 +142,7 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 		 */
 		public function get_item( $request ) {
 			$slug       = $request->get_param( 'slug' );
-			$collection = WP_Font_Library::get_font_collection( $slug );
+			$collection = WP_Font_Library::get_instance()->get_font_collection( $slug );
 
 			// If the collection doesn't exist returns a 404.
 			if ( is_wp_error( $collection ) ) {

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -131,7 +131,7 @@ if ( ! function_exists( 'wp_register_font_collection' ) ) {
 	 *                                     successfully, or WP_Error object on failure.
 	 */
 	function wp_register_font_collection( $slug, $data_or_file ) {
-		return WP_Font_Library::register_font_collection( $slug, $data_or_file );
+		return WP_Font_Library::get_instance()->register_font_collection( $slug, $data_or_file );
 	}
 }
 
@@ -145,7 +145,7 @@ if ( ! function_exists( 'wp_unregister_font_collection' ) ) {
 	 * @return bool True if the font collection was unregistered successfully, else false.
 	 */
 	function wp_unregister_font_collection( $slug ) {
-		return WP_Font_Library::unregister_font_collection( $slug );
+		return WP_Font_Library::get_instance()->unregister_font_collection( $slug );
 	}
 }
 

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/base.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/base.php
@@ -7,11 +7,10 @@
  */
 abstract class WP_Font_Library_UnitTestCase extends WP_UnitTestCase {
 	public function reset_font_collections() {
-		// Resets the private static property WP_Font_Library::$collections to empty array.
-		$reflection = new ReflectionClass( 'WP_Font_Library' );
-		$property   = $reflection->getProperty( 'collections' );
-		$property->setAccessible( true );
-		$property->setValue( array() );
+		$collections = WP_Font_Library::get_instance()->get_font_collections();
+		foreach ( $collections as $slug => $collection ) {
+			WP_Font_Library::get_instance()->unregister_font_collection( $slug );
+		}
 	}
 
 	public function set_up() {

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollection.php
@@ -19,12 +19,12 @@ class Tests_Fonts_WpFontLibrary_GetFontCollection extends WP_Font_Library_UnitTe
 		);
 
 		wp_register_font_collection( 'my-font-collection', $mock_collection_data );
-		$font_collection = WP_Font_Library::get_font_collection( 'my-font-collection' );
+		$font_collection = WP_Font_Library::get_instance()->get_font_collection( 'my-font-collection' );
 		$this->assertInstanceOf( 'WP_Font_Collection', $font_collection );
 	}
 
 	public function test_should_get_no_font_collection_if_the_slug_is_not_registered() {
-		$font_collection = WP_Font_Library::get_font_collection( 'not-registered-font-collection' );
+		$font_collection = WP_Font_Library::get_instance()->get_font_collection( 'not-registered-font-collection' );
 		$this->assertWPError( $font_collection );
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollections.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/getFontCollections.php
@@ -12,7 +12,7 @@
  */
 class Tests_Fonts_WpFontLibrary_GetFontCollections extends WP_Font_Library_UnitTestCase {
 	public function test_should_get_an_empty_list() {
-		$font_collections = WP_Font_Library::get_font_collections();
+		$font_collections = WP_Font_Library::get_instance()->get_font_collections();
 		$this->assertEmpty( $font_collections, 'Should return an empty array.' );
 	}
 
@@ -23,9 +23,9 @@ class Tests_Fonts_WpFontLibrary_GetFontCollections extends WP_Font_Library_UnitT
 			'font_families' => array( 'mock' ),
 		);
 
-		WP_Font_Library::register_font_collection( 'my-font-collection', $my_font_collection_config );
+		WP_Font_Library::get_instance()->register_font_collection( 'my-font-collection', $my_font_collection_config );
 
-		$font_collections = WP_Font_Library::get_font_collections();
+		$font_collections = WP_Font_Library::get_instance()->get_font_collections();
 		$this->assertNotEmpty( $font_collections, 'Should return an array of font collections.' );
 		$this->assertCount( 1, $font_collections, 'Should return an array with one font collection.' );
 		$this->assertArrayHasKey( 'my-font-collection', $font_collections, 'The array should have the key of the registered font collection id.' );

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/registerFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/registerFontCollection.php
@@ -17,7 +17,7 @@ class Tests_Fonts_WpFontLibrary_RegisterFontCollection extends WP_Font_Library_U
 			'font_families' => array( 'mock' ),
 		);
 
-		$collection = WP_Font_Library::register_font_collection( 'my-collection', $config );
+		$collection = WP_Font_Library::get_instance()->register_font_collection( 'my-collection', $config );
 		$this->assertInstanceOf( 'WP_Font_Collection', $collection );
 	}
 
@@ -28,13 +28,13 @@ class Tests_Fonts_WpFontLibrary_RegisterFontCollection extends WP_Font_Library_U
 		);
 
 		// Register first collection.
-		$collection1 = WP_Font_Library::register_font_collection( 'my-collection-1', $mock_collection_data );
+		$collection1 = WP_Font_Library::get_instance()->register_font_collection( 'my-collection-1', $mock_collection_data );
 		$this->assertInstanceOf( 'WP_Font_Collection', $collection1, 'A collection should be registered.' );
 
 		// Expects a _doing_it_wrong notice.
 		$this->setExpectedIncorrectUsage( 'WP_Font_Library::register_font_collection' );
 
 		// Try to register a second collection with same slug.
-		WP_Font_Library::register_font_collection( 'my-collection-1', $mock_collection_data );
+		WP_Font_Library::get_instance()->register_font_collection( 'my-collection-1', $mock_collection_data );
 	}
 }

--- a/phpunit/tests/fonts/font-library/wpFontLibrary/unregisterFontCollection.php
+++ b/phpunit/tests/fonts/font-library/wpFontLibrary/unregisterFontCollection.php
@@ -19,18 +19,18 @@ class Tests_Fonts_WpFontLibrary_UnregisterFontCollection extends WP_Font_Library
 		);
 
 		// Registers two mock font collections.
-		WP_Font_Library::register_font_collection( 'mock-font-collection-1', $mock_collection_data );
-		WP_Font_Library::register_font_collection( 'mock-font-collection-2', $mock_collection_data );
+		WP_Font_Library::get_instance()->register_font_collection( 'mock-font-collection-1', $mock_collection_data );
+		WP_Font_Library::get_instance()->register_font_collection( 'mock-font-collection-2', $mock_collection_data );
 
 		// Unregister mock font collection.
-		WP_Font_Library::unregister_font_collection( 'mock-font-collection-1' );
-		$collections = WP_Font_Library::get_font_collections();
+		WP_Font_Library::get_instance()->unregister_font_collection( 'mock-font-collection-1' );
+		$collections = WP_Font_Library::get_instance()->get_font_collections();
 		$this->assertArrayNotHasKey( 'mock-font-collection-1', $collections, 'Font collection was not unregistered.' );
 		$this->assertArrayHasKey( 'mock-font-collection-2', $collections, 'Font collection was unregistered by mistake.' );
 
 		// Unregisters remaining mock font collection.
-		WP_Font_Library::unregister_font_collection( 'mock-font-collection-2' );
-		$collections = WP_Font_Library::get_font_collections();
+		WP_Font_Library::get_instance()->unregister_font_collection( 'mock-font-collection-2' );
+		$collections = WP_Font_Library::get_instance()->get_font_collections();
 		$this->assertArrayNotHasKey( 'mock-font-collection-2', $collections, 'Mock font collection was not unregistered.' );
 
 		// Checks that all font collections were unregistered.
@@ -39,8 +39,8 @@ class Tests_Fonts_WpFontLibrary_UnregisterFontCollection extends WP_Font_Library
 
 	public function unregister_non_existing_collection() {
 		// Unregisters non-existing font collection.
-		WP_Font_Library::unregister_font_collection( 'non-existing-collection' );
-		$collections = WP_Font_Library::get_font_collections();
+		WP_Font_Library::get_instance()->unregister_font_collection( 'non-existing-collection' );
+		$collections = WP_Font_Library::get_instance()->get_font_collections();
 		$this->assertEmpty( $collections, 'No collections should be registered.' );
 	}
 }


### PR DESCRIPTION
## What?

The FontLibrary class is basically a registry of font collections. And to map existing code style used for "registries" (block types, block patterns...) in Core, we're updating the class to use the singleton pattern rather than static methods.

No functional change here.

This backports a change from Core implemented in https://github.com/WordPress/wordpress-develop/pull/6027 