### PR TITLE
Font Library Address Outstanding Feedback from WP 6.4 review

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -162,7 +162,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 
 				$data = json_decode( wp_remote_retrieve_body( $response ), true );
 				if ( empty( $data ) ) {
-					return new WP_Error( 'font_collection_decode_error', __( 'Error decoding the font collection data from the http response JSON.', 'gutenberg' ) );
+					return new WP_Error( 'font_collection_decode_error', __( 'Error decoding the font collection data from the HTTP response JSON.', 'gutenberg' ) );
 				}
 
 				// Make sure the data is valid before storing it in a transient.

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -48,10 +48,10 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param string        $slug         Font collection slug.
-		 * @param array|string  $data_or_file Font collection data array or a path/URL to a JSON file
-		 *                                    containing the font collection.
-		 *                                    See {@see wp_register_font_collection()} for the supported fields.
+		 * @param string       $slug         Font collection slug.
+		 * @param array|string $data_or_file Font collection data array or a path/URL to a JSON file
+		 *                                   containing the font collection.
+		 *                                   See {@see wp_register_font_collection()} for the supported fields.
 		 */
 		public function __construct( $slug, $data_or_file ) {
 			$this->slug = sanitize_title( $slug );
@@ -194,7 +194,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 				if ( empty( $data[ $property ] ) ) {
 					$message = sprintf(
 					// translators: 1: Font collection slug, 2: Missing property name.
-						__( 'Font collection "%1$s" has missing or empty property: "%2$s."', 'gutenberg' ),
+						__( 'Font collection "%1$s" has missing or empty property: "%2$s".', 'gutenberg' ),
 						$this->slug,
 						$property
 					);

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -193,7 +193,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 			foreach ( $required_properties as $property ) {
 				if ( empty( $data[ $property ] ) ) {
 					$message = sprintf(
-					// translators: 1: Font collection slug, 2: Missing property name.
+					// translators: 1: Font collection slug, 2: Missing property name, e.g. "font_families".
 						__( 'Font collection "%1$s" has missing or empty property: "%2$s".', 'gutenberg' ),
 						$this->slug,
 						$property

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -162,7 +162,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 
 				$data = json_decode( wp_remote_retrieve_body( $response ), true );
 				if ( empty( $data ) ) {
-					return new WP_Error( 'font_collection_decode_error', __( 'Error decoding the font collection data from the REST response JSON.', 'gutenberg' ) );
+					return new WP_Error( 'font_collection_decode_error', __( 'Error decoding the font collection data from the http response JSON.', 'gutenberg' ) );
 				}
 
 				// Make sure the data is valid before storing it in a transient.

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
@@ -125,7 +125,7 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 			if ( array_key_exists( $slug, $this->collections ) ) {
 				return $this->collections[ $slug ];
 			}
-			return new WP_Error( 'font_collection_not_found', 'Font collection not found.' );
+			return new WP_Error( 'font_collection_not_found', __( 'Font collection not found.', 'gutenberg' ) );
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 			$wrapped_font_families = array_map(
 				function ( $family ) {
 					$trimmed = trim( $family );
-					if ( ! empty( $trimmed ) && false !== strpos( $trimmed, ' ' ) && false === strpos( $trimmed, "'" ) && false === strpos( $trimmed, '"' ) ) {
+					if ( ! empty( $trimmed ) && str_contains( $trimmed, ' ' ) && ! str_contains( $trimmed, "'" ) && ! str_contains( $trimmed, '"' ) ) {
 							return '"' . $trimmed . '"';
 					}
 					return $trimmed;

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-utils.php
@@ -215,13 +215,17 @@ if ( ! class_exists( 'WP_Font_Utils' ) ) {
 		}
 
 		/**
-		 * Provide the expected mime-type value for font files per-PHP release. Due to differences in the values returned these values differ between PHP versions.
+		 * Returns the expected mime-type values for font files, depending on PHP version.
 		 *
-		 * This is necessary until a collection of valid mime-types per-file extension can be provided to 'upload_mimes' filter.
+		 * This is needed because font mime types vary by PHP version, so checking the PHP version
+		 * is necessary until a list of valid mime-types for each file extension can be provided to
+		 * the 'upload_mimes' filter.
 		 *
 		 * @since 6.5.0
 		 *
-		 * @return Array A collection of mime types keyed by file extension.
+		 * @access private
+		 *
+		 * @return array A collection of mime types keyed by file extension.
 		 */
 		public static function get_allowed_font_mime_types() {
 			$php_7_ttf_mime_type = PHP_VERSION_ID >= 70300 ? 'application/font-sfnt' : 'application/x-font-ttf';

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -319,7 +319,7 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 
 			return new WP_Error(
 				'rest_cannot_read',
-				__( 'Sorry, you are not allowed to use the Font Library on this site.', 'gutenberg' ),
+				__( 'Sorry, you are not allowed to access font collections.', 'gutenberg' ),
 				array(
 					'status' => rest_authorization_required_code(),
 				)

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -180,7 +180,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				if ( isset( $settings[ $key ] ) && ! $settings[ $key ] ) {
 					return new WP_Error(
 						'rest_invalid_param',
-						/* translators: %s: Name of the missing font face setting parameter, e.g. "font_face_settings[src]". */
+						/* translators: %s: Name of the missing font face settings parameter, e.g. "font_face_settings[src]". */
 						sprintf( __( '%s cannot be empty.', 'gutenberg' ), "font_face_setting[ $key ]" ),
 						array( 'status' => 400 )
 					);

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -180,8 +180,8 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				if ( isset( $settings[ $key ] ) && ! $settings[ $key ] ) {
 					return new WP_Error(
 						'rest_invalid_param',
-						/* translators: %s: Font family setting key. */
-						sprintf( __( 'font_face_setting[%s] cannot be empty.', 'gutenberg' ), $key ),
+						/* translators: %s: Name of the missing font face setting parameter, e.g. "font_face_settings[src]". */
+						sprintf( __( '%s cannot be empty.', 'gutenberg' ), "font_face_setting[ $key ]" ),
 						array( 'status' => 400 )
 					);
 				}
@@ -196,7 +196,8 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				if ( empty( $src ) ) {
 					return new WP_Error(
 						'rest_invalid_param',
-						__( 'font_face_settings[src] values must be non-empty strings.', 'gutenberg' ),
+						/* translators: %s: Font face source parameter name: "font_face_settings[src]". */
+						sprintf( __( '%s values must be non-empty strings.', 'gutenberg' ), 'font_face_settings[src]' ),
 						array( 'status' => 400 )
 					);
 				}
@@ -205,8 +206,8 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				if ( false === wp_http_validate_url( $src ) && ! isset( $files[ $src ] ) ) {
 					return new WP_Error(
 						'rest_invalid_param',
-						/* translators: %s: src value in the font face settings. */
-						sprintf( __( 'font_face_settings[src] value "%s" must be a valid URL or file reference.', 'gutenberg' ), $src ),
+						/* translators: 1: Font face source parameter name: "font_face_settings[src]", 2: The invalid src value. */
+						sprintf( __( '%1$s value "%2$s" must be a valid URL or file reference.', 'gutenberg' ), 'font_face_settings[src]', $src ),
 						array( 'status' => 400 )
 					);
 				}
@@ -217,8 +218,8 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				if ( ! in_array( $file, $srcs, true ) ) {
 					return new WP_Error(
 						'rest_invalid_param',
-						// translators: %s: File key (e.g. `file-0`) in the request data.
-						sprintf( __( 'File %1$s must be used in font_face_settings[src].', 'gutenberg' ), $file ),
+						/* translators: 1: File key (e.g. "file-0") in the request data, 2: Font face source parameter name: "font_face_settings[src]". */
+						sprintf( __( 'File %1$s must be used in %2$s.', 'gutenberg' ), $file, 'font_face_settings[src]' ),
 						array( 'status' => 400 )
 					);
 				}
@@ -291,7 +292,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				return new WP_Error(
 					'rest_font_face_parent_id_mismatch',
 					/* translators: %d: A post id. */
-					sprintf( __( 'The font face does not belong to the specified font family with id of "%d"', 'gutenberg' ), $font_family->ID ),
+					sprintf( __( 'The font face does not belong to the specified font family with id of "%d".', 'gutenberg' ), $font_family->ID ),
 					array( 'status' => 404 )
 				);
 			}
@@ -405,7 +406,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				return new WP_Error(
 					'rest_font_face_parent_id_mismatch',
 					/* translators: %d: A post id. */
-					sprintf( __( 'The font face does not belong to the specified font family with id of "%d"', 'gutenberg' ), $font_family->ID ),
+					sprintf( __( 'The font face does not belong to the specified font family with id of "%d".', 'gutenberg' ), $font_family->ID ),
 					array( 'status' => 404 )
 				);
 			}

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -86,7 +86,8 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 			if ( null === $settings ) {
 				return new WP_Error(
 					'rest_invalid_param',
-					__( 'font_family_settings parameter must be a valid JSON string.', 'gutenberg' ),
+					/* translators: %s: Parameter name: "font_family_settings". */
+					sprintf( __( '%s parameter must be a valid JSON string.', 'gutenberg' ), 'font_family_settings' ),
 					array( 'status' => 400 )
 				);
 			}
@@ -102,7 +103,8 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 				if ( isset( $settings['slug'] ) ) {
 					return new WP_Error(
 						'rest_invalid_param',
-						__( 'font_family_settings[slug] cannot be updated.', 'gutenberg' ),
+						/* translators: %s: Name of parameter being updated: font_family_settings[slug]". */
+						sprintf( __( '%s cannot be updated.', 'gutenberg' ), 'font_family_settings[slug]' ),
 						array( 'status' => 400 )
 					);
 				}
@@ -121,8 +123,8 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 				if ( isset( $settings[ $key ] ) && ! $settings[ $key ] ) {
 					return new WP_Error(
 						'rest_invalid_param',
-						/* translators: %s: Font family setting key. */
-						sprintf( __( 'font_family_settings[%s] cannot be empty.', 'gutenberg' ), $key ),
+						/* translators: %s: Name of the empty font family setting parameter, e.g. "font_family_settings[slug]". */
+						sprintf( __( '%s cannot be empty.', 'gutenberg' ), "font_family_settings[ $key ]" ),
 						array( 'status' => 400 )
 					);
 				}

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -350,7 +350,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_font_face_parent_id_mismatch', $response, 404 );
 
-		$expected_message = 'The font face does not belong to the specified font family with id of "' . self::$other_font_family_id . '"';
+		$expected_message = 'The font face does not belong to the specified font family with id of "' . self::$other_font_family_id . '".';
 		$this->assertSame( $expected_message, $response->as_error()->get_error_messages()[0], 'The message must contain the correct parent ID.' );
 	}
 
@@ -928,7 +928,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_font_face_parent_id_mismatch', $response, 404, 'The response should return an error for "rest_font_face_parent_id_mismatch" with 404 status.' );
 
-		$expected_message = 'The font face does not belong to the specified font family with id of "' . self::$other_font_family_id . '"';
+		$expected_message = 'The font face does not belong to the specified font family with id of "' . self::$other_font_family_id . '".';
 		$this->assertSame( $expected_message, $response->as_error()->get_error_messages()[0], 'The message must contain the correct parent ID.' );
 	}
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR applies any feedback that may have been missed from a review on the original Fonts proposal for WP 6.4 which happened on https://github.com/WordPress/wordpress-develop/pull/5285/.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Much of the review is now outdated and is largely stale. Nonetheless, this is a good opportunity to pick up on any queries that have previously been raised as it is easy to miss things from months ago.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Applies any outstanding feedback where it could be identified and applied directly without further discussion.

Any further feedback should now happen on the new Core PR(s) for the Font Library.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
