### PR TITLE
Reduce label and fix capitalization for image block upload label

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -490,7 +490,7 @@ export default function Image( {
 						<ToolbarButton
 							onClick={ uploadExternal }
 							icon={ upload }
-							label={ __( 'Upload image to media library' ) }
+							label={ __( 'Upload to Media Library' ) }
 						/>
 					</ToolbarGroup>
 				</BlockControls>

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -703,7 +703,7 @@ test.describe( 'Image', () => {
 			},
 		} );
 
-		await editor.clickBlockToolbarButton( 'Upload image to media library' );
+		await editor.clickBlockToolbarButton( 'Upload to Media Library' );
 
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow-up to https://github.com/WordPress/gutenberg/pull/57704, resolving the label to use proper "Media Library" capitalization, and reduce it slightly. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Insert a Image Block.
2. Insert an image from URL.
3. Focus the upload icon on the block toolbar.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-02-05 at 09 49 40](https://github.com/WordPress/gutenberg/assets/1813435/8ef0d1cd-99e0-405f-8a51-4184083eb35d)|![CleanShot 2024-02-05 at 09 50 00](https://github.com/WordPress/gutenberg/assets/1813435/efceaea8-422d-429d-9d03-894049a3d183)|