### PR TITLE
Interactivity API - Blocks: Move interactivity registration to render

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -38,13 +38,14 @@ function render_block_core_file( $attributes, $content ) {
 
 	// If it's interactive, enqueue the script module and add the directives.
 	if ( ! empty( $attributes['displayPreview'] ) ) {
+		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/interactivity/file.min.js' );
+			$module_url = gutenberg_url( "/build/interactivity/file{$suffix}.js" );
 		}
 
 		wp_register_script_module(
 			'@wordpress/block-library/file',
-			isset( $module_url ) ? $module_url : includes_url( 'blocks/file/view.min.js' ),
+			isset( $module_url ) ? $module_url : includes_url( "blocks/file/view{$suffix}.js" ),
 			array( '@wordpress/interactivity' ),
 			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 		);

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -38,6 +38,16 @@ function render_block_core_file( $attributes, $content ) {
 
 	// If it's interactive, enqueue the script module and add the directives.
 	if ( ! empty( $attributes['displayPreview'] ) ) {
+		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+			$module_url = gutenberg_url( '/build/interactivity/file.min.js' );
+		}
+
+		wp_register_script_module(
+			'@wordpress/block-library/file',
+			isset( $module_url ) ? $module_url : includes_url( 'blocks/file/view.min.js' ),
+			array( '@wordpress/interactivity' ),
+			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+		);
 		wp_enqueue_script_module( '@wordpress/block-library/file' );
 
 		$processor = new WP_HTML_Tag_Processor( $content );
@@ -61,17 +71,6 @@ function register_block_core_file() {
 		array(
 			'render_callback' => 'render_block_core_file',
 		)
-	);
-
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		$module_url = gutenberg_url( '/build/interactivity/file.min.js' );
-	}
-
-	wp_register_script_module(
-		'@wordpress/block-library/file',
-		isset( $module_url ) ? $module_url : includes_url( 'blocks/file/view.min.js' ),
-		array( '@wordpress/interactivity' ),
-		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);
 }
 add_action( 'init', 'register_block_core_file' );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -47,6 +47,17 @@ function render_block_core_image( $attributes, $content, $block ) {
 		isset( $lightbox_settings['enabled'] ) &&
 		true === $lightbox_settings['enabled']
 	) {
+		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+			$module_url = gutenberg_url( '/build/interactivity/image.min.js' );
+		}
+
+		wp_register_script_module(
+			'@wordpress/block-library/image',
+			isset( $module_url ) ? $module_url : includes_url( 'blocks/image/view.min.js' ),
+			array( '@wordpress/interactivity' ),
+			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+		);
+
 		wp_enqueue_script_module( '@wordpress/block-library/image' );
 
 		/*
@@ -321,17 +332,6 @@ function register_block_core_image() {
 		array(
 			'render_callback' => 'render_block_core_image',
 		)
-	);
-
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		$module_url = gutenberg_url( '/build/interactivity/image.min.js' );
-	}
-
-	wp_register_script_module(
-		'@wordpress/block-library/image',
-		isset( $module_url ) ? $module_url : includes_url( 'blocks/image/view.min.js' ),
-		array( '@wordpress/interactivity' ),
-		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);
 }
 add_action( 'init', 'register_block_core_image' );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -47,13 +47,14 @@ function render_block_core_image( $attributes, $content, $block ) {
 		isset( $lightbox_settings['enabled'] ) &&
 		true === $lightbox_settings['enabled']
 	) {
+		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/interactivity/image.min.js' );
+			$module_url = gutenberg_url( "/build/interactivity/image{$suffix}.js" );
 		}
 
 		wp_register_script_module(
 			'@wordpress/block-library/image',
-			isset( $module_url ) ? $module_url : includes_url( 'blocks/image/view.min.js' ),
+			isset( $module_url ) ? $module_url : includes_url( "blocks/image/view{$suffix}.js" ),
 			array( '@wordpress/interactivity' ),
 			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 		);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -588,6 +588,16 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function handle_view_script_module_loading( $attributes, $block, $inner_blocks ) {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
+			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+				$module_url = gutenberg_url( '/build/interactivity/navigation.min.js' );
+			}
+
+			wp_register_script_module(
+				'@wordpress/block-library/navigation',
+				isset( $module_url ) ? $module_url : includes_url( 'blocks/navigation/view.min.js' ),
+				array( '@wordpress/interactivity' ),
+				defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+			);
 			wp_enqueue_script_module( '@wordpress/block-library/navigation' );
 		}
 	}
@@ -1098,16 +1108,6 @@ function register_block_core_navigation() {
 		)
 	);
 
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		$module_url = gutenberg_url( '/build/interactivity/navigation.min.js' );
-	}
-
-	wp_register_script_module(
-		'@wordpress/block-library/navigation',
-		isset( $module_url ) ? $module_url : includes_url( 'blocks/navigation/view.min.js' ),
-		array( '@wordpress/interactivity' ),
-		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-	);
 }
 
 add_action( 'init', 'register_block_core_navigation' );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -588,13 +588,14 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function handle_view_script_module_loading( $attributes, $block, $inner_blocks ) {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
+			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build/interactivity/navigation.min.js' );
+				$module_url = gutenberg_url( "/build/interactivity/navigation{$suffix}.js" );
 			}
 
 			wp_register_script_module(
 				'@wordpress/block-library/navigation',
-				isset( $module_url ) ? $module_url : includes_url( 'blocks/navigation/view.min.js' ),
+				isset( $module_url ) ? $module_url : includes_url( "blocks/navigation/view{$suffix}.js" ),
 				array( '@wordpress/interactivity' ),
 				defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 			);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1107,7 +1107,6 @@ function register_block_core_navigation() {
 			'render_callback' => 'render_block_core_navigation',
 		)
 	);
-
 }
 
 add_action( 'init', 'register_block_core_navigation' );

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -24,13 +24,14 @@ function render_block_core_query( $attributes, $content, $block ) {
 	// Enqueue the script module and add the necessary directives if the block is
 	// interactive.
 	if ( $is_interactive ) {
+		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/interactivity/query.min.js' );
+			$module_url = gutenberg_url( "/build/interactivity/query{$suffix}.js" );
 		}
 
 		wp_register_script_module(
 			'@wordpress/block-library/query',
-			isset( $module_url ) ? $module_url : includes_url( 'blocks/query/view.min.js' ),
+			isset( $module_url ) ? $module_url : includes_url( "blocks/query/view{$suffix}.js" ),
 			array(
 				array(
 					'id'     => '@wordpress/interactivity',

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -24,6 +24,25 @@ function render_block_core_query( $attributes, $content, $block ) {
 	// Enqueue the script module and add the necessary directives if the block is
 	// interactive.
 	if ( $is_interactive ) {
+		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+			$module_url = gutenberg_url( '/build/interactivity/query.min.js' );
+		}
+
+		wp_register_script_module(
+			'@wordpress/block-library/query',
+			isset( $module_url ) ? $module_url : includes_url( 'blocks/query/view.min.js' ),
+			array(
+				array(
+					'id'     => '@wordpress/interactivity',
+					'import' => 'static',
+				),
+				array(
+					'id'     => '@wordpress/interactivity-router',
+					'import' => 'dynamic',
+				),
+			),
+			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+		);
 		wp_enqueue_script_module( '@wordpress/block-library/query' );
 
 		$p = new WP_HTML_Tag_Processor( $content );
@@ -64,26 +83,6 @@ function register_block_core_query() {
 		array(
 			'render_callback' => 'render_block_core_query',
 		)
-	);
-
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		$module_url = gutenberg_url( '/build/interactivity/query.min.js' );
-	}
-
-	wp_register_script_module(
-		'@wordpress/block-library/query',
-		isset( $module_url ) ? $module_url : includes_url( 'blocks/query/view.min.js' ),
-		array(
-			array(
-				'id'     => '@wordpress/interactivity',
-				'import' => 'static',
-			),
-			array(
-				'id'     => '@wordpress/interactivity-router',
-				'import' => 'dynamic',
-			),
-		),
-		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);
 }
 add_action( 'init', 'register_block_core_query' );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,6 +80,16 @@ function render_block_core_search( $attributes ) {
 		// If it's interactive, enqueue the script module and add the directives.
 		$is_expandable_searchfield = 'button-only' === $button_position;
 		if ( $is_expandable_searchfield ) {
+			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+				$module_url = gutenberg_url( '/build/interactivity/search.min.js' );
+			}
+
+			wp_register_script_module(
+				'@wordpress/block-library/search',
+				isset( $module_url ) ? $module_url : includes_url( 'blocks/search/view.min.js' ),
+				array( '@wordpress/interactivity' ),
+				defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
+			);
 			wp_enqueue_script_module( '@wordpress/block-library/search' );
 
 			$input->set_attribute( 'data-wp-bind--aria-hidden', '!context.isSearchInputVisible' );
@@ -195,17 +205,6 @@ function register_block_core_search() {
 		array(
 			'render_callback' => 'render_block_core_search',
 		)
-	);
-
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		$module_url = gutenberg_url( '/build/interactivity/search.min.js' );
-	}
-
-	wp_register_script_module(
-		'@wordpress/block-library/search',
-		isset( $module_url ) ? $module_url : includes_url( 'blocks/search/view.min.js' ),
-		array( '@wordpress/interactivity' ),
-		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 	);
 }
 add_action( 'init', 'register_block_core_search' );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,13 +80,14 @@ function render_block_core_search( $attributes ) {
 		// If it's interactive, enqueue the script module and add the directives.
 		$is_expandable_searchfield = 'button-only' === $button_position;
 		if ( $is_expandable_searchfield ) {
+			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build/interactivity/search.min.js' );
+				$module_url = gutenberg_url( "/build/interactivity/search{$suffix}.js" );
 			}
 
 			wp_register_script_module(
 				'@wordpress/block-library/search',
-				isset( $module_url ) ? $module_url : includes_url( 'blocks/search/view.min.js' ),
+				isset( $module_url ) ? $module_url : includes_url( "blocks/search/view{$suffix}.js" ),
 				array( '@wordpress/interactivity' ),
 				defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Move all modules registration to the render callback functions in interactive blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To be able to override the WP Core script modules in Gutenberg.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
All interactive blocks should work by default:
 - Navigation (mobile menu)
 - Search (search button only)
 - File (show inline embed disabled) 
 - Query (force reload disabled)

Edit .wp-env.json with:
```
	"config": {
		"SCRIPT_DEBUG": false
	}
```
All script modules files for those blocks should be `.min.js`
if the json is:
```
	"config": {
		"SCRIPT_DEBUG": false
	}
```
All script modules files for those blocks should be `.js`