### PR TITLE
DataViews: remove test artifact (status filter was set as primary)

### DIFF
--- a/packages/edit-site/src/components/page-pages/index.js
+++ b/packages/edit-site/src/components/page-pages/index.js
@@ -332,7 +332,6 @@ export default function PagePages() {
 				enableSorting: false,
 				filterBy: {
 					operators: [ OPERATOR_IN ],
-					isPrimary: true,
 				},
 			},
 			{


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083
Follow-up to https://github.com/WordPress/gutenberg/pull/58427

## What

When https://github.com/WordPress/gutenberg/pull/58427 landed, it included something that should have been removed: the status filter had been set as primary for demonstration purposes. This PR removes it.

| Before | After |
| --- | --- |
| <img width="1490" alt="Captura de ecrã 2024-02-05, às 17 19 34" src="https://github.com/WordPress/gutenberg/assets/583546/e6b6cab1-acf1-4683-8dc6-79d081134400"> | <img width="1490" alt="Captura de ecrã 2024-02-05, às 17 19 02" src="https://github.com/WordPress/gutenberg/assets/583546/da8e9c7e-bfa7-491f-bf8d-4867b43e0c0c"> | 

## Testing Instructions

Visit "Site Editor > Pages > Manage all pages". Verify no filter is visible on load, until the user adds one.

