### PR TITLE
useOnBlockDrop: Fix TypeError via array coercion

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -252,6 +252,8 @@ export default function useOnBlockDrop(
 			initialPosition = 0,
 			clientIdsToReplace = []
 		) => {
+			if ( ! Array.isArray( blocks ) ) blocks = [ blocks ];
+
 			const clientIds = getBlockOrder( targetRootClientId );
 			const clientId = clientIds[ targetBlockIndex ];
 			const blocksClientIds = blocks.map( ( block ) => block.clientId );


### PR DESCRIPTION
Fixes #58653

## What?
Fix regression by which multiple image files could no longer be inserted in the editor by drag-and-drop action.

## How?
At the centre of the bug lies the fact that the Gallery's `files` transform [returns a single block](https://github.com/WordPress/gutenberg/blob/44950c832b7766c912d77514c04fc1ad9800d6f4/packages/block-library/src/gallery/transforms.js#L230) instead of an array of blocks. However, this is [allowed by the Block API](https://github.com/WordPress/gutenberg/blob/44950c832b7766c912d77514c04fc1ad9800d6f4/docs/reference-guides/block-api/block-transforms.md?plain=1#L44). The `blocks` value crosses several levels of the call stack until it causes the type error, but I decided that the `insertOrReplaceBlocks` callback of the `useOnBlockDrop` hook seems like a sensible catch-all place to coerce the `blocks` value.

## Testing Instructions
See parent issue.