### PR TITLE
Rich Text: Add aria-readonly attribute to Rich Text component

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -46,6 +46,7 @@ import { getAllowedFormats } from './utils';
 import { Content } from './content';
 import { withDeprecations } from './with-deprecations';
 import { unlock } from '../../lock-unlock';
+import { BLOCK_BINDINGS_ALLOWED_BLOCKS } from '../../hooks/use-bindings-attributes';
 
 export const keyboardShortcutContext = createContext();
 export const inputEventContext = createContext();
@@ -147,7 +148,7 @@ export function RichTextWrapper(
 
 		// Disable Rich Text editing if block bindings specify that.
 		let shouldDisableEditing = false;
-		if ( blockBindings ) {
+		if ( blockBindings && blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS ) {
 			const blockTypeAttributes = getBlockType( blockName ).attributes;
 			const { getBlockBindingsSource } = unlock(
 				select( blockEditorStore )

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -355,6 +355,7 @@ export function RichTextWrapper(
 				role="textbox"
 				aria-multiline={ ! disableLineBreaks }
 				aria-label={ placeholder }
+				aria-readonly={ shouldDisableEditing }
 				{ ...props }
 				{ ...autocompleteProps }
 				ref={ useMergeRefs( [

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -22,7 +22,7 @@ import { unlock } from '../lock-unlock';
  * @return {WPHigherOrderComponent} Higher-order component.
  */
 
-const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
+export const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 	'core/paragraph': [ 'content' ],
 	'core/heading': [ 'content' ],
 	'core/image': [ 'url', 'title', 'alt' ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
To improve accessibility on Block Bindings elements that use Rich Text components with the `contenteditable` attribute, this PR adds the `aria-readonly` attribute to them.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This follows an accessibility recommendation mentioned [here](https://github.com/WordPress/gutenberg/issues/58595#issuecomment-1927195661) and can help ensure that elements with bound content attributes via the Block Bindings API, namely paragraphs, headings, and buttons, are marked up correctly as the ability to edit them toggles on and off.

*Please note that this PR is simply meant to address low-hanging fruit regarding the markup and does not address the screen reader behavior outlined in the issue above.*

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It adds the `aria-readonly` attribute to the `RichText` component.
In addition, it adds a check that was missing to ensure that we only add the attribute to blocks that support bindings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Blocks that Support Bindings
1. Register a new custom field using the following code in your theme's `functions.php`
```
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'This is the content of the text custom field',
	)
);
```
2. Add a new paragraph to a post with the following markup:
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<p>Paragraph content</p>
<!-- /wp:paragraph -->
```
3. View the post in the visual editor and see that the paragraph can no longer be edited
4. Inspect the paragraph using your browser's inspector tools and see that the `aria-readonly` attribute has been added with a value of `true`

Additionally, test steps 2-4 for the heading and button blocks using the following markup:

#### Heading
```
<!-- wp:heading {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<h2 class="wp-block-heading">Heading Content</h2>
<!-- /wp:heading -->
```

#### Button
```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"bindings":{"text":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button Text</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

### Blocks that Don't Support Bindings

I'll just illustrate one block that uses Rich Text and doesn't support bindings here, namely the list block, but you could test others:

1. Now add a new list to the post with the following markup:
```
<!-- wp:list -->
<ul><!-- wp:list-item {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<li>List item</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->
```
2. View the post in the visual editor and see that the list is still editable
3. Inspect the list with inspector tools and see that the `aria-readonly` attribute has a value of `false`