### PR TITLE
Font Library: address feedback from wordpress-develop#6027

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -229,7 +229,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 									'fontFamily'          => 'sanitize_text_field',
 									'fontStyle'           => 'sanitize_text_field',
 									'fontWeight'          => 'sanitize_text_field',
-									'src'                 => function ( $value ) {
+									'src'                 => static function ( $value ) {
 										return is_array( $value )
 											? array_map( 'sanitize_text_field', $value )
 											: sanitize_text_field( $value );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -94,6 +94,7 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 				'description' => '',
 				'categories'  => array(),
 			);
+
 			return wp_parse_args( $this->data, $defaults );
 		}
 

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-collection.php
@@ -55,14 +55,6 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 		 */
 		public function __construct( $slug, $data_or_file ) {
 			$this->slug = sanitize_title( $slug );
-
-			if ( is_array( $data_or_file ) ) {
-				$this->data = $this->sanitize_and_validate_data( $data_or_file );
-			} else {
-				// JSON data is lazy loaded by ::get_data().
-				$this->src = $data_or_file;
-			}
-
 			if ( $this->slug !== $slug ) {
 				_doing_it_wrong(
 					__METHOD__,
@@ -70,6 +62,13 @@ if ( ! class_exists( 'WP_Font_Collection' ) ) {
 					sprintf( __( 'Font collection slug "%s" is not valid. Slugs must use only alphanumeric characters, dashes, and underscores.', 'gutenberg' ), $slug ),
 					'6.5.0'
 				);
+			}
+
+			if ( is_array( $data_or_file ) ) {
+				$this->data = $this->sanitize_and_validate_data( $data_or_file );
+			} else {
+				// JSON data is lazy loaded by ::get_data().
+				$this->src = $data_or_file;
 			}
 		}
 

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
@@ -122,7 +122,7 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 *                                     or WP_Error object if the font collection doesn't exist.
 		 */
 		public function get_font_collection( $slug ) {
-			if ( array_key_exists( $slug, $this->collections ) ) {
+			if ( $this->is_collection_registered( $slug ) ) {
 				return $this->collections[ $slug ];
 			}
 			return new WP_Error( 'font_collection_not_found', 'Font collection not found.' );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 			if ( $this->is_collection_registered( $new_collection->slug ) ) {
 				$error_message = sprintf(
 					/* translators: %s: Font collection slug. */
-					__( 'Font collection with slug: "%s" is already registered.', 'gutenberg' ),
+					__( 'Font collection with slug "%s" is already registered.', 'gutenberg' ),
 					$new_collection->slug
 				);
 				_doing_it_wrong(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 
 			if ( $this->is_collection_registered( $new_collection->slug ) ) {
 				$error_message = sprintf(
-				/* translators: %s: Font collection slug. */
+					/* translators: %s: Font collection slug. */
 					__( 'Font collection with slug: "%s" is already registered.', 'gutenberg' ),
 					$new_collection->slug
 				);

--- a/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-font-library.php
@@ -22,7 +22,6 @@ if ( ! class_exists( 'WP_Font_Library' ) ) {
 		 * Font collections.
 		 *
 		 * @since 6.5.0
-		 *
 		 * @var array
 		 */
 		private $collections = array();

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -257,9 +257,10 @@ if ( ! function_exists( '_wp_before_delete_font_face' ) ) {
 		}
 
 		$font_files = get_post_meta( $post_id, '_wp_font_face_file', false );
+		$font_dir   = wp_get_font_dir()['path'];
 
 		foreach ( $font_files as $font_file ) {
-			wp_delete_file( wp_get_font_dir()['path'] . '/' . $font_file );
+			wp_delete_file( $font_dir . '/' . $font_file );
 		}
 	}
 	add_action( 'before_delete_post', '_wp_before_delete_font_face', 10, 2 );

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -184,7 +184,6 @@ if ( ! function_exists( 'wp_get_font_dir' ) ) {
 	 * }
 	 */
 	function wp_get_font_dir( $defaults = array() ) {
-		// Multi site path
 		$site_path = '';
 		if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
 			$site_path = '/sites/' . get_current_blog_id();


### PR DESCRIPTION
## What?

Addresses initial feedback from https://github.com/WordPress/wordpress-develop/pull/6027

- [Removes unneeded comment in wp_get_font_dir](https://github.com/WordPress/wordpress-develop/pull/6027/files#r1478430824)
- [Move font collection slug check to immediately after slug is assigned](https://github.com/WordPress/wordpress-develop/pull/6027/files#r1478486442)
- [Removes extra line in WP_Font_Library::$collections docblock](https://github.com/WordPress/wordpress-develop/pull/6027/files#r1478395698)
- [Fix translators comment indentation](https://github.com/WordPress/wordpress-develop/pull/6027/files#r1478396460)
- [Remove unneeded colon from error message](https://github.com/WordPress/wordpress-develop/pull/6027/files#r1478474647)
- [Use is_collection_registered in get_font_collection](https://github.com/WordPress/wordpress-develop/pull/6027/files#r1478481880)
- [Use variable for font_dir so function isn't called repeatedly within loop](https://github.com/WordPress/wordpress-develop/pull/6027#discussion_r1478857460)
- [Adds empty line before the return of WP_Font_Collection::get_data](https://github.com/WordPress/wordpress-develop/pull/6027#discussion_r1478873639)
- [Uses static closure in font collection sanitization schema](https://github.com/WordPress/wordpress-develop/pull/6027/files#r1478876717)

## Why?

We're updating the code in Gutenberg first, and then updating the wordpress-develop PR to keep the Gutenberg and proposed Core code in sync.


## Testing Instructions

No functional changes. Check that phpunit tests pass and feature continues to work as expected.
