### PR TITLE
Try/unlock Block Binding API actions and selectors

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1924,3 +1924,13 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
+
+export function registerBlockBindingsSource( source ) {
+	return {
+		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
+		sourceName: source.name,
+		sourceLabel: source.label,
+		useSource: source.useSource,
+		lockAttributesEditing: source.lockAttributesEditing,
+	};
+}

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -361,15 +361,15 @@ export function stopEditingAsBlocks( clientId ) {
 	};
 }
 
-export function registerBlockBindingsSource( source ) {
-	return {
-		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
-		sourceName: source.name,
-		sourceLabel: source.label,
-		useSource: source.useSource,
-		lockAttributesEditing: source.lockAttributesEditing,
-	};
-}
+// export function registerBlockBindingsSource( source ) {
+// 	return {
+// 		type: 'REGISTER_BLOCK_BINDINGS_SOURCE',
+// 		sourceName: source.name,
+// 		sourceLabel: source.label,
+// 		useSource: source.useSource,
+// 		lockAttributesEditing: source.lockAttributesEditing,
+// 	};
+// }
 
 /**
  * Returns an action object used in signalling that the user has begun to drag.
@@ -392,3 +392,4 @@ export function stopDragging() {
 		type: 'STOP_DRAGGING',
 	};
 }
+

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -348,9 +348,9 @@ export function getAllBlockBindingsSources( state ) {
 	return state.blockBindingsSources;
 }
 
-export function getBlockBindingsSource( state, sourceName ) {
-	return state.blockBindingsSources[ sourceName ];
-}
+// export function getBlockBindingsSource( state, sourceName ) {
+// 	return state.blockBindingsSources[ sourceName ];
+// }
 
 /**
  * Returns true if the user is dragging anything, or false otherwise. It is possible for a

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2972,3 +2972,7 @@ export const isGroupable = createRegistrySelector(
 			);
 		}
 );
+
+export function getBlockBindingsSource( state, sourceName ) {
+	return state.blockBindingsSources[ sourceName ];
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Unlock the action that allows the registration of a block-binding source handler. Also, unlock the selector.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because I want to use the Block Binding API for the Woocommerce Product editor app.
PR: https://github.com/woocommerce/woocommerce/pull/44366

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
