### PR TITLE
Global styles: update return values from getGlobalStylesChanges()

### DIFF
--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -50,13 +50,7 @@ function getTranslation( key ) {
 
 	if ( keyArray?.[ 0 ] === 'blocks' ) {
 		const blockName = getBlockNames()?.[ keyArray[ 1 ] ];
-		return blockName
-			? sprintf(
-					// translators: %s: block name.
-					__( '%s block' ),
-					blockName
-			  )
-			: keyArray[ 1 ];
+		return blockName || keyArray[ 1 ];
 	}
 
 	if ( keyArray?.[ 0 ] === 'elements' ) {
@@ -200,7 +194,7 @@ export default function getGlobalStylesChanges( next, previous, options = {} ) {
 		const deleteCount = changesLength - maxResults;
 		const andMoreText = sprintf(
 			// translators: %d: number of global styles changes that are not displayed in the UI.
-			_n( '…and %d more change.', '…and %d more changes.', deleteCount ),
+			_n( '…and %d more change', '…and %d more changes', deleteCount ),
 			deleteCount
 		);
 		changes.splice( maxResults, deleteCount, andMoreText );

--- a/packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/test/get-global-styles-changes.js
@@ -171,7 +171,7 @@ describe( 'getGlobalStylesChanges', () => {
 		expect( resultA ).toEqual( [
 			'Colors',
 			'Typography',
-			'Test pumpkin flowers block',
+			'Test pumpkin flowers',
 			'H3 element',
 			'Caption element',
 			'H6 element',
@@ -191,8 +191,8 @@ describe( 'getGlobalStylesChanges', () => {
 		expect( resultA ).toEqual( [
 			'Colors',
 			'Typography',
-			'Test pumpkin flowers block',
-			'…and 5 more changes.',
+			'Test pumpkin flowers',
+			'…and 5 more changes',
 		] );
 	} );
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -36,7 +36,7 @@ function ChangesSummary( { revision, previousRevision } ) {
 			data-testid="global-styles-revision-changes"
 			className="edit-site-global-styles-screen-revisions__changes"
 		>
-			{ changes.join( ', ' ) }
+			{ changes.join( ', ' ) }.
 		</span>
 	);
 }

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -59,7 +59,7 @@ function GlobalStylesDescription( { record } ) {
 			<h3 className="entities-saved-states__description-heading">
 				{ __( 'Changes made to:' ) }
 			</h3>
-			<PanelRow>{ globalStylesChanges.join( ', ' ) }</PanelRow>
+			<PanelRow>{ globalStylesChanges.join( ', ' ) }.</PanelRow>
 		</>
 	) : null;
 }

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -57,7 +57,7 @@ test.describe( 'Style Revisions', () => {
 		// Shows changes made in the revision.
 		await expect(
 			page.getByTestId( 'global-styles-revision-changes' )
-		).toHaveText( 'Colors' );
+		).toHaveText( 'Colors.' );
 
 		// There should be 2 revisions not including the reset to theme defaults button.
 		await expect( revisionButtons ).toHaveCount(


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Removes periods from return global style change items. 
- Remove "block" from the block labels, e.g., `"Audio"` vs `"Audio block"`

## Why?

Design feedback from:

- https://github.com/WordPress/gutenberg/pull/57470#issuecomment-1927066670

Also, let's leave it up to the consuming component as to how to present the changes. 



## Testing Instructions

1. In the site editor, make some global styles changes, making sure to update a block's global styles.
2. After clicking "Save", check that the global styles changes summary ends with a "period" and that "block" doesn't appear next to the block name.
3. Go ahead and save.
4. Check out the revision in the revisions panel.
5. Check that the revision's global styles changes summary ends with a "period" and that "block" doesn't appear next to the block name.


## Screenshots or screencast <!-- if applicable -->
<img width="270" alt="Screenshot 2024-02-06 at 1 33 38 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/d8c68964-ecb4-4289-bdd2-bedae4a5fc29">

<img width="259" alt="Screenshot 2024-02-06 at 1 33 49 pm" src="https://github.com/WordPress/gutenberg/assets/6458278/bd258e00-cc04-473f-a12d-c2e78118383f">


