### PR TITLE
useOnBlockDrop: Fix the Gallery block check

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -234,7 +234,7 @@ export default function useOnBlockDrop(
 		getBlock,
 		isGroupable,
 	} = useSelect( blockEditorStore );
-	const { getBlockType, getGroupingBlockName } = useSelect( blocksStore );
+	const { getGroupingBlockName } = useSelect( blocksStore );
 	const {
 		insertBlocks,
 		moveBlocksToPosition,
@@ -283,7 +283,10 @@ export default function useOnBlockDrop(
 					return block.name === 'core/image';
 				} );
 
-				const galleryBlock = !! getBlockType( 'core/gallery' );
+				const galleryBlock = canInsertBlockType(
+					'core/gallery',
+					targetRootClientId
+				);
 
 				const wrappedBlocks = createBlock(
 					areAllImages && galleryBlock
@@ -292,7 +295,8 @@ export default function useOnBlockDrop(
 					{
 						layout: {
 							type: 'flex',
-							flexWrap: areAllImages ? null : 'nowrap',
+							flexWrap:
+								areAllImages && galleryBlock ? null : 'nowrap',
 						},
 					},
 					groupInnerBlocks
@@ -319,11 +323,12 @@ export default function useOnBlockDrop(
 			getBlockOrder,
 			targetRootClientId,
 			targetBlockIndex,
+			isGroupable,
 			operation,
 			replaceBlocks,
 			getBlock,
 			nearestSide,
-			getBlockType,
+			canInsertBlockType,
 			getGroupingBlockName,
 			insertBlocks,
 		]


### PR DESCRIPTION
## What?
This is a follow-up to #56186.

PR swaps block type existence check with `canInsertBlockType`.

## Why?
There are multiple ways to disable block type; the `canInsertBlockType` is the correct selector for this check.

## Testing Instructions
1. Open a post or page.
2. Insert multiple image blocks.
3. Disable the Gallery block via Preferences.
4. Drag an Image block beside another Image block.
5. Confirm it creates a Row block. On trunk action does nothing.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/240569/268b87ba-7ce8-4e47-86c6-6828064d83b3

