### PR TITLE
Update workflows to use gradle/actions/setup-gradle (#58628)

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -47,7 +47,7 @@ jobs:
               run: npm run native test:e2e:setup
 
             - name: Gradle cache
-              uses: gradle/gradle-build-action@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # v3.0.0
+              uses: gradle/actions/setup-gradle@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # v3.0.0
 
             - name: AVD cache
               uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -47,7 +47,7 @@ jobs:
               run: npm run native test:e2e:setup
 
             - name: Gradle cache
-              uses: gradle/actions/setup-gradle@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # v3.0.0
+              uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
 
             - name: AVD cache
               uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates workflows to use gradle/actions/setup-gradle instead of gradle/gradle-build-action as the latter action has been superseded in version 3.0.0.

fixes #58628 

## Why?
The `gradle/gradle-build-action` has been updated to version 3.0.0, where it now acts as a pass-through to the preferred `gradle/actions/setup-gradle` action. This change ensures that our workflows stay up-to-date with the latest recommended practices and dependencies.

## How?
The PR modifies the relevant workflows (rnmobile-android-runner.yml) to replace the usage of `gradle/gradle-build-action` with `gradle/actions/setup-gradle`. 

## Testing Instructions

1. Run the modified workflows locally to ensure they execute without errors.
2. Test the workflows in different environments to ensure compatibility.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
