### PR TITLE
Add the block name to the pattern content data

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -146,7 +146,9 @@ function getContentValuesFromInnerBlocks( blocks, defaultValues ) {
 				block.attributes[ attributeKey ] !==
 				defaultValues[ blockId ][ attributeKey ]
 			) {
-				content[ blockId ] ??= { values: {} };
+				content[ blockId ] ??= { values: {}, blockName: block.name };
+				// TODO: We need a way to represent `undefined` in the serialized overrides.
+				// Also see: https://github.com/WordPress/gutenberg/pull/57249#discussion_r1452987871
 				content[ blockId ].values[ attributeKey ] =
 					block.attributes[ attributeKey ] === undefined
 						? // TODO: We use an empty string to represent undefined for now until


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of https://github.com/WordPress/gutenberg/issues/53705.

Proposes adding the block name to the pattern content data.

Currently in `trunk` the data is just in this form:
```json
"content":{"gOKbjJ":{"values":{"text":"1"}}
```
There's no way to decipher which block the `text` value might be for.

This PR updates it to look like this:
```json
"content":{"gOKbjJ":{"values":{"text":"1"},"blockName":"core/button"}}
```

## Why?
As discussed in the tracking issue (https://github.com/WordPress/gutenberg/issues/53705#issuecomment-1916025011), I believe this could be useful and could support features like:
- A rudimentary form of shuffling to other patterns that are within the same category
- Recovery of pattern content when the source pattern has been deleted (either restoring just the blocks that are listed in the content, or giving the user an option to choose another compatible pattern)

Because this data is stored, I think it's better to add this new property earlier so that it's in widespread usage before the feature is launched.

## How?
Add the `block.name` as a property

## Testing Instructions
1. Insert a pattern that supports overrides into a post
2. Update the override value
3. Switch to the code editor

Expected, you should see a content value that looks like this: 
```json
"content":{"gOKbjJ":{"values":{"text":"1"},"blockName":"core/button"}}
```