### PR TITLE
Editor: Don't hide authors' Combobox if the current author is missing

### DIFF
--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -18,9 +18,9 @@ import { AUTHORS_QUERY } from './constants';
 function PostAuthorCombobox() {
 	const [ fieldValue, setFieldValue ] = useState();
 
-	const { authorId, isLoading, authors, postAuthor } = useSelect(
+	const { authorId, authors, postAuthor } = useSelect(
 		( select ) => {
-			const { getUser, getUsers, isResolving } = select( coreStore );
+			const { getUser, getUsers } = select( coreStore );
 			const { getEditedPostAttribute } = select( editorStore );
 			const author = getUser( getEditedPostAttribute( 'author' ), {
 				context: 'view',
@@ -35,7 +35,6 @@ function PostAuthorCombobox() {
 				authorId: getEditedPostAttribute( 'author' ),
 				postAuthor: author,
 				authors: getUsers( query ),
-				isLoading: isResolving( 'core', 'getUsers', [ query ] ),
 			};
 		},
 		[ fieldValue ]
@@ -98,7 +97,6 @@ function PostAuthorCombobox() {
 			value={ authorId }
 			onFilterValueChange={ debounce( handleKeydown, 300 ) }
 			onChange={ handleSelect }
-			isLoading={ isLoading }
 			allowReset={ false }
 		/>
 	);

--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -89,10 +89,6 @@ function PostAuthorCombobox() {
 		setFieldValue( inputValue );
 	};
 
-	if ( ! postAuthor ) {
-		return null;
-	}
-
 	return (
 		<ComboboxControl
 			__nextHasNoMarginBottom


### PR DESCRIPTION
## What?
Fixes: #56164.

PR updates the `PostAuthorCombobox` component to always render the authors' Combobox.

## Why?
Allows manually reassigning post author if the current author is missing. This matches your behavior in Classic Editor.

## Testing Instructions
1. Create test users so that the authors' Combobox is visible - `wp user generate --role=editor --count=100`.
2. Create a post and assign it to a test user.
3. Delete this test user without reassigning posts - `wp user delete <test-user-id> --reassign=99999`
4. Reopen the same post, and confirm that the combobox is visible.

### Testing Instructions for Keyboard
Same.