### PR TITLE
Interactivity API: Mark all core block stores as private

### DIFF
--- a/packages/block-library/src/file/view.js
+++ b/packages/block-library/src/file/view.js
@@ -7,10 +7,14 @@ import { store } from '@wordpress/interactivity';
  */
 import { browserSupportsPdfs } from './utils';
 
-store( 'core/file', {
-	state: {
-		get hasPdfPreview() {
-			return browserSupportsPdfs();
+store(
+	'core/file',
+	{
+		state: {
+			get hasPdfPreview() {
+				return browserSupportsPdfs();
+			},
 		},
 	},
-} );
+	{ lock: true }
+);

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -23,193 +23,206 @@ const focusableSelectors = [
 // capture the clicks, instead of relying on the focusout event.
 document.addEventListener( 'click', () => {} );
 
-const { state, actions } = store( 'core/navigation', {
-	state: {
-		get roleAttribute() {
-			const ctx = getContext();
-			return ctx.type === 'overlay' && state.isMenuOpen ? 'dialog' : null;
+const { state, actions } = store(
+	'core/navigation',
+	{
+		state: {
+			get roleAttribute() {
+				const ctx = getContext();
+				return ctx.type === 'overlay' && state.isMenuOpen
+					? 'dialog'
+					: null;
+			},
+			get ariaModal() {
+				const ctx = getContext();
+				return ctx.type === 'overlay' && state.isMenuOpen
+					? 'true'
+					: null;
+			},
+			get ariaLabel() {
+				const ctx = getContext();
+				return ctx.type === 'overlay' && state.isMenuOpen
+					? ctx.ariaLabel
+					: null;
+			},
+			get isMenuOpen() {
+				// The menu is opened if either `click`, `hover` or `focus` is true.
+				return (
+					Object.values( state.menuOpenedBy ).filter( Boolean )
+						.length > 0
+				);
+			},
+			get menuOpenedBy() {
+				const ctx = getContext();
+				return ctx.type === 'overlay'
+					? ctx.overlayOpenedBy
+					: ctx.submenuOpenedBy;
+			},
 		},
-		get ariaModal() {
-			const ctx = getContext();
-			return ctx.type === 'overlay' && state.isMenuOpen ? 'true' : null;
-		},
-		get ariaLabel() {
-			const ctx = getContext();
-			return ctx.type === 'overlay' && state.isMenuOpen
-				? ctx.ariaLabel
-				: null;
-		},
-		get isMenuOpen() {
-			// The menu is opened if either `click`, `hover` or `focus` is true.
-			return (
-				Object.values( state.menuOpenedBy ).filter( Boolean ).length > 0
-			);
-		},
-		get menuOpenedBy() {
-			const ctx = getContext();
-			return ctx.type === 'overlay'
-				? ctx.overlayOpenedBy
-				: ctx.submenuOpenedBy;
-		},
-	},
-	actions: {
-		openMenuOnHover() {
-			const { type, overlayOpenedBy } = getContext();
-			if (
-				type === 'submenu' &&
-				// Only open on hover if the overlay is closed.
-				Object.values( overlayOpenedBy || {} ).filter( Boolean )
-					.length === 0
-			)
-				actions.openMenu( 'hover' );
-		},
-		closeMenuOnHover() {
-			actions.closeMenu( 'hover' );
-		},
-		openMenuOnClick() {
-			const ctx = getContext();
-			const { ref } = getElement();
-			ctx.previousFocus = ref;
-			actions.openMenu( 'click' );
-		},
-		closeMenuOnClick() {
-			actions.closeMenu( 'click' );
-			actions.closeMenu( 'focus' );
-		},
-		openMenuOnFocus() {
-			actions.openMenu( 'focus' );
-		},
-		toggleMenuOnClick() {
-			const ctx = getContext();
-			const { ref } = getElement();
-			// Safari won't send focus to the clicked element, so we need to manually place it: https://bugs.webkit.org/show_bug.cgi?id=22261
-			if ( window.document.activeElement !== ref ) ref.focus();
-			const { menuOpenedBy } = state;
-			if ( menuOpenedBy.click || menuOpenedBy.focus ) {
-				actions.closeMenu( 'click' );
-				actions.closeMenu( 'focus' );
-			} else {
+		actions: {
+			openMenuOnHover() {
+				const { type, overlayOpenedBy } = getContext();
+				if (
+					type === 'submenu' &&
+					// Only open on hover if the overlay is closed.
+					Object.values( overlayOpenedBy || {} ).filter( Boolean )
+						.length === 0
+				)
+					actions.openMenu( 'hover' );
+			},
+			closeMenuOnHover() {
+				actions.closeMenu( 'hover' );
+			},
+			openMenuOnClick() {
+				const ctx = getContext();
+				const { ref } = getElement();
 				ctx.previousFocus = ref;
 				actions.openMenu( 'click' );
-			}
-		},
-		handleMenuKeydown( event ) {
-			const { type, firstFocusableElement, lastFocusableElement } =
-				getContext();
-			if ( state.menuOpenedBy.click ) {
-				// If Escape close the menu.
-				if ( event?.key === 'Escape' ) {
-					actions.closeMenu( 'click' );
-					actions.closeMenu( 'focus' );
-					return;
-				}
-
-				// Trap focus if it is an overlay (main menu).
-				if ( type === 'overlay' && event.key === 'Tab' ) {
-					// If shift + tab it change the direction.
-					if (
-						event.shiftKey &&
-						window.document.activeElement === firstFocusableElement
-					) {
-						event.preventDefault();
-						lastFocusableElement.focus();
-					} else if (
-						! event.shiftKey &&
-						window.document.activeElement === lastFocusableElement
-					) {
-						event.preventDefault();
-						firstFocusableElement.focus();
-					}
-				}
-			}
-		},
-		handleMenuFocusout( event ) {
-			const { modal } = getContext();
-			// If focus is outside modal, and in the document, close menu
-			// event.target === The element losing focus
-			// event.relatedTarget === The element receiving focus (if any)
-			// When focusout is outsite the document,
-			// `window.document.activeElement` doesn't change.
-
-			// The event.relatedTarget is null when something outside the navigation menu is clicked. This is only necessary for Safari.
-			if (
-				event.relatedTarget === null ||
-				( ! modal?.contains( event.relatedTarget ) &&
-					event.target !== window.document.activeElement )
-			) {
+			},
+			closeMenuOnClick() {
 				actions.closeMenu( 'click' );
 				actions.closeMenu( 'focus' );
-			}
-		},
-
-		openMenu( menuOpenedOn = 'click' ) {
-			const { type } = getContext();
-			state.menuOpenedBy[ menuOpenedOn ] = true;
-			if ( type === 'overlay' ) {
-				// Add a `has-modal-open` class to the <html> root.
-				document.documentElement.classList.add( 'has-modal-open' );
-			}
-		},
-
-		closeMenu( menuClosedOn = 'click' ) {
-			const ctx = getContext();
-			state.menuOpenedBy[ menuClosedOn ] = false;
-			// Check if the menu is still open or not.
-			if ( ! state.isMenuOpen ) {
-				if ( ctx.modal?.contains( window.document.activeElement ) ) {
-					ctx.previousFocus?.focus();
+			},
+			openMenuOnFocus() {
+				actions.openMenu( 'focus' );
+			},
+			toggleMenuOnClick() {
+				const ctx = getContext();
+				const { ref } = getElement();
+				// Safari won't send focus to the clicked element, so we need to manually place it: https://bugs.webkit.org/show_bug.cgi?id=22261
+				if ( window.document.activeElement !== ref ) ref.focus();
+				const { menuOpenedBy } = state;
+				if ( menuOpenedBy.click || menuOpenedBy.focus ) {
+					actions.closeMenu( 'click' );
+					actions.closeMenu( 'focus' );
+				} else {
+					ctx.previousFocus = ref;
+					actions.openMenu( 'click' );
 				}
-				ctx.modal = null;
-				ctx.previousFocus = null;
-				if ( ctx.type === 'overlay' ) {
-					document.documentElement.classList.remove(
-						'has-modal-open'
-					);
+			},
+			handleMenuKeydown( event ) {
+				const { type, firstFocusableElement, lastFocusableElement } =
+					getContext();
+				if ( state.menuOpenedBy.click ) {
+					// If Escape close the menu.
+					if ( event?.key === 'Escape' ) {
+						actions.closeMenu( 'click' );
+						actions.closeMenu( 'focus' );
+						return;
+					}
+
+					// Trap focus if it is an overlay (main menu).
+					if ( type === 'overlay' && event.key === 'Tab' ) {
+						// If shift + tab it change the direction.
+						if (
+							event.shiftKey &&
+							window.document.activeElement ===
+								firstFocusableElement
+						) {
+							event.preventDefault();
+							lastFocusableElement.focus();
+						} else if (
+							! event.shiftKey &&
+							window.document.activeElement ===
+								lastFocusableElement
+						) {
+							event.preventDefault();
+							firstFocusableElement.focus();
+						}
+					}
 				}
-			}
+			},
+			handleMenuFocusout( event ) {
+				const { modal } = getContext();
+				// If focus is outside modal, and in the document, close menu
+				// event.target === The element losing focus
+				// event.relatedTarget === The element receiving focus (if any)
+				// When focusout is outsite the document,
+				// `window.document.activeElement` doesn't change.
+
+				// The event.relatedTarget is null when something outside the navigation menu is clicked. This is only necessary for Safari.
+				if (
+					event.relatedTarget === null ||
+					( ! modal?.contains( event.relatedTarget ) &&
+						event.target !== window.document.activeElement )
+				) {
+					actions.closeMenu( 'click' );
+					actions.closeMenu( 'focus' );
+				}
+			},
+
+			openMenu( menuOpenedOn = 'click' ) {
+				const { type } = getContext();
+				state.menuOpenedBy[ menuOpenedOn ] = true;
+				if ( type === 'overlay' ) {
+					// Add a `has-modal-open` class to the <html> root.
+					document.documentElement.classList.add( 'has-modal-open' );
+				}
+			},
+
+			closeMenu( menuClosedOn = 'click' ) {
+				const ctx = getContext();
+				state.menuOpenedBy[ menuClosedOn ] = false;
+				// Check if the menu is still open or not.
+				if ( ! state.isMenuOpen ) {
+					if (
+						ctx.modal?.contains( window.document.activeElement )
+					) {
+						ctx.previousFocus?.focus();
+					}
+					ctx.modal = null;
+					ctx.previousFocus = null;
+					if ( ctx.type === 'overlay' ) {
+						document.documentElement.classList.remove(
+							'has-modal-open'
+						);
+					}
+				}
+			},
+		},
+		callbacks: {
+			initMenu() {
+				const ctx = getContext();
+				const { ref } = getElement();
+				if ( state.isMenuOpen ) {
+					const focusableElements =
+						ref.querySelectorAll( focusableSelectors );
+					ctx.modal = ref;
+					ctx.firstFocusableElement = focusableElements[ 0 ];
+					ctx.lastFocusableElement =
+						focusableElements[ focusableElements.length - 1 ];
+				}
+			},
+			focusFirstElement() {
+				const { ref } = getElement();
+				if ( state.isMenuOpen ) {
+					const focusableElements =
+						ref.querySelectorAll( focusableSelectors );
+					focusableElements?.[ 0 ]?.focus();
+				}
+			},
+			initNav() {
+				const context = getContext();
+				const mediaQuery = window.matchMedia(
+					`(max-width: ${ NAVIGATION_MOBILE_COLLAPSE })`
+				);
+
+				// Run once to set the initial state.
+				context.isCollapsed = mediaQuery.matches;
+
+				function handleCollapse( event ) {
+					context.isCollapsed = event.matches;
+				}
+
+				// Run on resize to update the state.
+				mediaQuery.addEventListener( 'change', handleCollapse );
+
+				// Remove the listener when the component is unmounted.
+				return () => {
+					mediaQuery.removeEventListener( 'change', handleCollapse );
+				};
+			},
 		},
 	},
-	callbacks: {
-		initMenu() {
-			const ctx = getContext();
-			const { ref } = getElement();
-			if ( state.isMenuOpen ) {
-				const focusableElements =
-					ref.querySelectorAll( focusableSelectors );
-				ctx.modal = ref;
-				ctx.firstFocusableElement = focusableElements[ 0 ];
-				ctx.lastFocusableElement =
-					focusableElements[ focusableElements.length - 1 ];
-			}
-		},
-		focusFirstElement() {
-			const { ref } = getElement();
-			if ( state.isMenuOpen ) {
-				const focusableElements =
-					ref.querySelectorAll( focusableSelectors );
-				focusableElements?.[ 0 ]?.focus();
-			}
-		},
-		initNav() {
-			const context = getContext();
-			const mediaQuery = window.matchMedia(
-				`(max-width: ${ NAVIGATION_MOBILE_COLLAPSE })`
-			);
-
-			// Run once to set the initial state.
-			context.isCollapsed = mediaQuery.matches;
-
-			function handleCollapse( event ) {
-				context.isCollapsed = event.matches;
-			}
-
-			// Run on resize to update the state.
-			mediaQuery.addEventListener( 'change', handleCollapse );
-
-			// Remove the listener when the component is unmounted.
-			return () => {
-				mediaQuery.removeEventListener( 'change', handleCollapse );
-			};
-		},
-	},
-} );
+	{ lock: true }
+);

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -18,54 +18,62 @@ const isValidEvent = ( event ) =>
 	! event.shiftKey &&
 	! event.defaultPrevented;
 
-store( 'core/query', {
-	actions: {
-		*navigate( event ) {
-			const ctx = getContext();
-			const { ref } = getElement();
-			const queryRef = ref.closest(
-				'.wp-block-query[data-wp-router-region]'
-			);
-			const isDisabled = queryRef?.dataset.wpNavigationDisabled;
-
-			if ( isValidLink( ref ) && isValidEvent( event ) && ! isDisabled ) {
-				event.preventDefault();
-
-				const { actions } = yield import(
-					'@wordpress/interactivity-router'
+store(
+	'core/query',
+	{
+		actions: {
+			*navigate( event ) {
+				const ctx = getContext();
+				const { ref } = getElement();
+				const queryRef = ref.closest(
+					'.wp-block-query[data-wp-router-region]'
 				);
-				yield actions.navigate( ref.href );
-				ctx.url = ref.href;
+				const isDisabled = queryRef?.dataset.wpNavigationDisabled;
 
-				// Focus the first anchor of the Query block.
-				const firstAnchor = `.wp-block-post-template a[href]`;
-				queryRef.querySelector( firstAnchor )?.focus();
-			}
+				if (
+					isValidLink( ref ) &&
+					isValidEvent( event ) &&
+					! isDisabled
+				) {
+					event.preventDefault();
+
+					const { actions } = yield import(
+						'@wordpress/interactivity-router'
+					);
+					yield actions.navigate( ref.href );
+					ctx.url = ref.href;
+
+					// Focus the first anchor of the Query block.
+					const firstAnchor = `.wp-block-post-template a[href]`;
+					queryRef.querySelector( firstAnchor )?.focus();
+				}
+			},
+			*prefetch() {
+				const { ref } = getElement();
+				const queryRef = ref.closest(
+					'.wp-block-query[data-wp-router-region]'
+				);
+				const isDisabled = queryRef?.dataset.wpNavigationDisabled;
+				if ( isValidLink( ref ) && ! isDisabled ) {
+					const { actions } = yield import(
+						'@wordpress/interactivity-router'
+					);
+					yield actions.prefetch( ref.href );
+				}
+			},
 		},
-		*prefetch() {
-			const { ref } = getElement();
-			const queryRef = ref.closest(
-				'.wp-block-query[data-wp-router-region]'
-			);
-			const isDisabled = queryRef?.dataset.wpNavigationDisabled;
-			if ( isValidLink( ref ) && ! isDisabled ) {
-				const { actions } = yield import(
-					'@wordpress/interactivity-router'
-				);
-				yield actions.prefetch( ref.href );
-			}
+		callbacks: {
+			*prefetch() {
+				const { url } = getContext();
+				const { ref } = getElement();
+				if ( url && isValidLink( ref ) ) {
+					const { actions } = yield import(
+						'@wordpress/interactivity-router'
+					);
+					yield actions.prefetch( ref.href );
+				}
+			},
 		},
 	},
-	callbacks: {
-		*prefetch() {
-			const { url } = getContext();
-			const { ref } = getElement();
-			if ( url && isValidLink( ref ) ) {
-				const { actions } = yield import(
-					'@wordpress/interactivity-router'
-				);
-				yield actions.prefetch( ref.href );
-			}
-		},
-	},
-} );
+	{ lock: true }
+);

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -3,66 +3,70 @@
  */
 import { store, getContext, getElement } from '@wordpress/interactivity';
 
-const { actions } = store( 'core/search', {
-	state: {
-		get ariaLabel() {
-			const {
-				isSearchInputVisible,
-				ariaLabelCollapsed,
-				ariaLabelExpanded,
-			} = getContext();
-			return isSearchInputVisible
-				? ariaLabelExpanded
-				: ariaLabelCollapsed;
+const { actions } = store(
+	'core/search',
+	{
+		state: {
+			get ariaLabel() {
+				const {
+					isSearchInputVisible,
+					ariaLabelCollapsed,
+					ariaLabelExpanded,
+				} = getContext();
+				return isSearchInputVisible
+					? ariaLabelExpanded
+					: ariaLabelCollapsed;
+			},
+			get ariaControls() {
+				const { isSearchInputVisible, inputId } = getContext();
+				return isSearchInputVisible ? null : inputId;
+			},
+			get type() {
+				const { isSearchInputVisible } = getContext();
+				return isSearchInputVisible ? 'submit' : 'button';
+			},
+			get tabindex() {
+				const { isSearchInputVisible } = getContext();
+				return isSearchInputVisible ? '0' : '-1';
+			},
 		},
-		get ariaControls() {
-			const { isSearchInputVisible, inputId } = getContext();
-			return isSearchInputVisible ? null : inputId;
-		},
-		get type() {
-			const { isSearchInputVisible } = getContext();
-			return isSearchInputVisible ? 'submit' : 'button';
-		},
-		get tabindex() {
-			const { isSearchInputVisible } = getContext();
-			return isSearchInputVisible ? '0' : '-1';
+		actions: {
+			openSearchInput( event ) {
+				const ctx = getContext();
+				const { ref } = getElement();
+				if ( ! ctx.isSearchInputVisible ) {
+					event.preventDefault();
+					ctx.isSearchInputVisible = true;
+					ref.parentElement.querySelector( 'input' ).focus();
+				}
+			},
+			closeSearchInput() {
+				const ctx = getContext();
+				ctx.isSearchInputVisible = false;
+			},
+			handleSearchKeydown( event ) {
+				const { ref } = getElement();
+				// If Escape close the menu.
+				if ( event?.key === 'Escape' ) {
+					actions.closeSearchInput();
+					ref.querySelector( 'button' ).focus();
+				}
+			},
+			handleSearchFocusout( event ) {
+				const { ref } = getElement();
+				// If focus is outside search form, and in the document, close menu
+				// event.target === The element losing focus
+				// event.relatedTarget === The element receiving focus (if any)
+				// When focusout is outside the document,
+				// `window.document.activeElement` doesn't change.
+				if (
+					! ref.contains( event.relatedTarget ) &&
+					event.target !== window.document.activeElement
+				) {
+					actions.closeSearchInput();
+				}
+			},
 		},
 	},
-	actions: {
-		openSearchInput( event ) {
-			const ctx = getContext();
-			const { ref } = getElement();
-			if ( ! ctx.isSearchInputVisible ) {
-				event.preventDefault();
-				ctx.isSearchInputVisible = true;
-				ref.parentElement.querySelector( 'input' ).focus();
-			}
-		},
-		closeSearchInput() {
-			const ctx = getContext();
-			ctx.isSearchInputVisible = false;
-		},
-		handleSearchKeydown( event ) {
-			const { ref } = getElement();
-			// If Escape close the menu.
-			if ( event?.key === 'Escape' ) {
-				actions.closeSearchInput();
-				ref.querySelector( 'button' ).focus();
-			}
-		},
-		handleSearchFocusout( event ) {
-			const { ref } = getElement();
-			// If focus is outside search form, and in the document, close menu
-			// event.target === The element losing focus
-			// event.relatedTarget === The element receiving focus (if any)
-			// When focusout is outside the document,
-			// `window.document.activeElement` doesn't change.
-			if (
-				! ref.contains( event.relatedTarget ) &&
-				event.target !== window.document.activeElement
-			) {
-				actions.closeSearchInput();
-			}
-		},
-	},
-} );
+	{ lock: true }
+);


### PR DESCRIPTION
## What?

Epic: https://github.com/WordPress/gutenberg/issues/56803

Mark the store of all core blocks as private, preventing access to their content from other plugins.

Also, fix private store initialization when populating the initial state.

## Why?

To avoid exposing internal data that shouldn't become a public API.

## How?

Simply adding a `{ lock: true }` option to each store definition. It's easier to see if the changes to whitespace characters are hidden.

## Testing Instructions
1. In the site editor, go to the home template (or whatever template you want).
2. Add a File block with the Show Inline Embed setting enabled.
3. Add an Image block with the Expand on Click setting enabled.
4. In the Navigation block, set the Overlay Menu to Always.
5. Ensure the Query block has Force Page Reload disabled.
6. There's another interactive block; reserve this one to load it asynchronously.
7. Visit the homepage.
8. Open the developer tools.
9. In the console, import `store()` from the Interactivity API module.
   ```js
   const { store } = await import( '@wordpress/interactivity' );
   ```
10. Try to access the `core/file` store. It should throw an error.
    ```js
    store( 'core/file' ); // Uncaught Error: Cannot unlock a private store with an invalid lock code
    ```
11. Repeat with `core/image`, `core/navigation` and `core/query`. The result must be the same.
12. Now load the Search block module asynchronously. Note that the URL can vary depending on your dev environment. Use the same path the other loaded modules have.
    ```js
    await import( 'http://localhost:8888/wp-content/plugins/gutenberg/build/interactivity/search.min.js?ver=6.5-alpha-57139' );
    ```
13. Try to access the `core/search` store. It should fail as expected.
    ```js
    store( 'core/search' ); // Uncaught Error: Cannot unlock a private store with an invalid lock code
    ```
14. Don't forget to test that the blocks keep working as expected.
