### PR TITLE
Experiment: Allow editing of custom fields in block bindings

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -50,7 +50,7 @@ const createEditFunctionWithBindingsAttribute = () =>
 				);
 			}
 
-			const attributesWithSourcedAttributes = useMemo( () => {
+			const attributesWithBindings = useMemo( () => {
 				return {
 					...attributes,
 					...Object.fromEntries(
@@ -60,13 +60,13 @@ const createEditFunctionWithBindingsAttribute = () =>
 								if ( boundAttributes[ attributeName ] ) {
 									const {
 										placeholder,
-										useValue: [ metaValue = null ] = [],
+										useValue: [ sourceValue = null ] = [],
 									} = boundAttributes[ attributeName ];
 
 									const blockTypeAttribute =
 										blockType.attributes[ attributeName ];
 
-									if ( placeholder && ! metaValue ) {
+									if ( placeholder && ! sourceValue ) {
 										// If the attribute is `src` or `href`, a placeholder can't be used because it is not a valid url.
 										// Adding this workaround until attributes and metadata fields types are improved and include `url`.
 
@@ -81,9 +81,9 @@ const createEditFunctionWithBindingsAttribute = () =>
 										return [ attributeName, placeholder ];
 									}
 
-									if ( metaValue ) {
+									if ( sourceValue ) {
 										// TODO: If it is rich-text, I think we can't edit it this way.
-										return [ attributeName, metaValue ];
+										return [ attributeName, sourceValue ];
 									}
 								}
 								return [
@@ -104,26 +104,22 @@ const createEditFunctionWithBindingsAttribute = () =>
 						)
 						.forEach( ( [ attribute, value ] ) => {
 							const {
-								useValue: [ , updateMetaValue = null ] = [],
+								useValue: [ , setSourceValue = null ] = [],
 							} = boundAttributes[ attribute ];
-							if ( updateMetaValue ) {
-								updateMetaValue( value );
+							if ( setSourceValue ) {
+								setSourceValue( value );
 							}
 						} );
 					setAttributes( nextAttributes );
 				},
-				[
-					setAttributes,
-					attributesWithSourcedAttributes,
-					boundAttributes,
-				]
+				[ setAttributes, attributesWithBindings, boundAttributes ]
 			);
 
 			const registry = useRegistry();
 
 			return (
 				<BlockEdit
-					attributes={ attributesWithSourcedAttributes }
+					attributes={ attributesWithBindings }
 					setAttributes={ ( newAttributes ) => {
 						registry.batch( () =>
 							updatedSetAttributes( newAttributes )

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -38,5 +38,5 @@ export default {
 			useValue: [ metaValue, updateMetaValue ],
 		};
 	},
-	lockAttributesEditing: true,
+	lockAttributesEditing: false,
 };


### PR DESCRIPTION
# WIP
I'm creating this pull request to test different approaches to enable the editing of custom field. Bear in mind that this hasn't been even tested.

## What?
Experimental code to discuss different approach to be able to edit the value of the custom fields when using block bindings.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->