### PR TITLE
Try: text-wrap: pretty; across

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -355,6 +355,9 @@
 	*::after {
 		box-sizing: inherit;
 	}
+
+	// This default value avoids widows in multi-line paragraphs of text.
+	text-wrap: pretty;
 }
 
 // The editor input reset with increased specificity to avoid theme styles bleeding in.

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -31,6 +31,9 @@ html.interface-interface-skeleton__html-container {
 			top: 0;
 		}
 	}
+
+	// This default value avoids widows in multi-line paragraphs of text.
+	text-wrap: pretty;
 }
 
 .interface-interface-skeleton__editor {

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -31,9 +31,6 @@ html.interface-interface-skeleton__html-container {
 			top: 0;
 		}
 	}
-
-	// This default value avoids widows in multi-line paragraphs of text.
-	text-wrap: pretty;
 }
 
 .interface-interface-skeleton__editor {


### PR DESCRIPTION
## What?

There's a new CSS property, `text-wrap: balance;`, which when applied to paragraphs of text makes it avoid unfortunate wrapping, specifically avoiding typographic widows. This PR applies the property very broadly — perhaps too broadly — so as to enable us to always avoid widows. The best way to demonstrate the effect is to show what happens if you intentionally edit a paragraph of text to add a typographic widow, as shown in this GIF:

![text wrap before](https://github.com/WordPress/gutenberg/assets/1204802/2341bb85-28f2-489c-9ba2-56e20831d2fe)

Nothing happens, i.e. the typographic widow is permitted. The CSS property when applied, causes the wrapping to change, to avoid typographic widows, ensuring there are at least two words on the last line of text, as shown in this GIF:

![text wrap after](https://github.com/WordPress/gutenberg/assets/1204802/7fa2d78f-66b2-4ed9-a725-c1cf4e5fa798)

Avoiding typographic widows is important to do editorially, but even in the best cases, there will be cases where they can appear, such as responsive contexts, or in translations. This property would prevent that from happen.

An open question is how broadly we want to apply this, however. This PR intentionally makes it super broad; should it be scoped instead to `p` and `h[n]` tags?

## Testing Instructions

Browse the editor, perhaps using the inspector try and force a typographic widow to appear, see that text re-wraps.