### PR TITLE
Apply 40px across summary panel.

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -72,6 +72,7 @@ function PostVisibilityToggle( { isOpen, onClick } ) {
 	const label = usePostVisibilityLabel();
 	return (
 		<Button
+			__next40pxDefaultSize
 			className="edit-post-post-visibility__toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -1,6 +1,6 @@
 .editor-post-panel__row {
 	width: 100%;
-	min-height: $button-size;
+	min-height: $button-size-next-default-40px;
 	justify-content: flex-start !important;
 	align-items: flex-start !important;
 }
@@ -8,14 +8,14 @@
 .editor-post-panel__row-label {
 	width: 30%;
 	flex-shrink: 0;
-	min-height: $button-size;
+	min-height: $button-size-next-default-40px;
 	display: flex;
 	align-items: center;
 }
 
 .editor-post-panel__row-control {
 	flex-grow: 1;
-	min-height: $button-size;
+	min-height: $button-size-next-default-40px;
 	display: flex;
 	align-items: center;
 }

--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -40,6 +40,7 @@ export default function PostSchedulePanel() {
 					contentClassName="editor-post-schedule__dialog"
 					renderToggle={ ( { onToggle, isOpen } ) => (
 						<Button
+							__next40pxDefaultSize
 							className="editor-post-schedule__dialog-toggle"
 							variant="tertiary"
 							onClick={ onToggle }

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -46,6 +46,7 @@ export default function PostSwitchToDraftButton() {
 	return (
 		<>
 			<Button
+				__next40pxDefaultSize
 				className="editor-post-switch-to-draft"
 				onClick={ () => {
 					if ( ! isDisabled ) {

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -71,6 +71,7 @@ export default function BlockThemeControl( { id } ) {
 			popoverProps={ POPOVER_PROPS }
 			focusOnMount
 			toggleProps={ {
+				__next40pxDefaultSize: true,
 				variant: 'tertiary',
 			} }
 			label={ __( 'Template options' ) }

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -44,6 +44,7 @@ function PostTemplateToggle( { isOpen, onClick } ) {
 
 	return (
 		<Button
+			__next40pxDefaultSize
 			className="edit-post-post-template__toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -38,6 +38,7 @@ export default function PostTrash() {
 	return (
 		<>
 			<Button
+				__next40pxDefaultSize
 				className="editor-post-trash"
 				isDestructive
 				variant="secondary"

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -47,6 +47,7 @@ function PostURLToggle( { isOpen, onClick } ) {
 	const label = usePostURLLabel();
 	return (
 		<Button
+			__next40pxDefaultSize
 			className="editor-post-url__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }


### PR DESCRIPTION
## What?

Continues progress on #46734.

Currently there's a mix of previous 36px button sizes, and 40px button sizes in the Summary panel. This is a small PR to apply the new default 40px size across. Before:

![before](https://github.com/WordPress/gutenberg/assets/1204802/b4b8d8db-dfa6-42af-886b-3b4c583d52e7)

After:

![after](https://github.com/WordPress/gutenberg/assets/1204802/8cb6eda3-53f4-464c-a008-b9baefffb8b8)

![after 2](https://github.com/WordPress/gutenberg/assets/1204802/59c50ff1-f75f-4a26-ae50-12ea3d04fbf1)

![after 3](https://github.com/WordPress/gutenberg/assets/1204802/00ecd95a-93f6-4c2f-8128-fe4cad32958c)

The change makes the controls 280px tall, where before they were 252px. So it's 28px taller.