### PR TITLE
Docs: Copy and formatting edits for the "block.json" guide

### DIFF
--- a/docs/getting-started/fundamentals/block-json.md
+++ b/docs/getting-started/fundamentals/block-json.md
@@ -1,52 +1,56 @@
 # block.json
 
-The `block.json` file simplifies the process of defining and registering a block by using the same block's definition in JSON format to register the block in both the server and the client.
+The `block.json` file simplifies the process of defining and registering a block by using the same block's definition in JSON format to register the block on both the server and the client (Block Editor).
+
+The diagram below details the basic structure of the `block.json` file.
 
 [![Open block.json diagram image](https://developer.wordpress.org/files/2023/11/block-json.png)](https://developer.wordpress.org/files/2023/11/block-json.png "Open block.json diagram image")
 
 <div class="callout callout-info">
-Click <a href="https://github.com/WordPress/block-development-examples/tree/trunk/plugins/block-supports-6aa4dd">here</a> to see a full block example and check <a href="https://github.com/WordPress/block-development-examples/blob/trunk/plugins/block-supports-6aa4dd/src/block.json">its <code>block.json</code></a>
+	To view a complete block example and its associated <a href="https://github.com/WordPress/block-development-examples/blob/trunk/plugins/block-supports-6aa4dd/src/block.json"><code>block.json</code></a> file, visit the <a href="https://github.com/WordPress/block-development-examples/tree/trunk/plugins/block-supports-6aa4dd">Block Development Examples</a> GitHub repository.
 </div>
 
-Besides simplifying a block's registration, using a `block.json` has [several benefits](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#benefits-using-the-metadata-file), including improved performance and development.
+Besides simplifying a block's registration, using a `block.json` has [several benefits](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#benefits-using-the-metadata-file), including improved performance.
 
-At [**Metadata in block.json**](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) you can find a detailed explanation of all the properties you can set in a `block.json` for a block. With these properties, you can define things such as:
+The [Metadata in block.json](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) documentation has a comprehensive guide on all the properties you can use in a `block.json` file for a block. This article will cover the most common options, which allow you to specify:
 
-- Basic metadata of the block
-- Files for the block's behavior, style, or output
-- Data Storage in the Block
-- Setting UI panels for the block
+- The block's basic metadata.
+- The files that dictate the block's functionality, appearance, and output.
+- How data is stored within the block.
+- The block's setting panels within the user interface.
 
 ## Basic metadata of a block
 
-Using `block.json` properties, you can define how the block will be uniquely identified and the info displayed in the Block Editor. These properties include:
+Using `block.json` properties, you can define how the block will be uniquely identified and what information is displayed in the Block Editor. These properties include:
 
-- [`apiVersion`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#api-version): Specifies the [API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/) version the block uses.
-- [`name`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#name):  The unique name of the block, including namespace (e.g., `my-plugin/my-custom-block`).
-- [`title`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#title):  The display title for the block, shown in the Inserter.
-- [`category`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#category): The category under which the block appears in the Inserter. Common categories include `text`, `media`, `design`, `widgets`, and `theme`.
-- [`icon`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#icon):  An icon representing the block in the Inserter. This can be a [Dashicon](https://developer.wordpress.org/resource/dashicons) slug or a custom SVG icon.
-- [`description`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#description):  A short description of the block, providing more context than the title.
-- [`keywords`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#keywords): An array of keywords to help users find the block when searching.
-- [`textdomain`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#text-domain): The text domain for the block, used for internationalization.
+- **[`apiVersion`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#api-version):** Specifies the [API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/) version the block uses. Use the latest version unless you have specific requirements.
+- **[`name`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#name):**  The unique name of the block, including namespace (e.g., `my-plugin/my-custom-block`).
+- **[`title`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#title):** The display title for the block, shown in the Inserter.
+- **[`category`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#category):** The category under which the block appears in the Inserter. Common categories include `text`, `media`, `design`, `widgets`, and `theme`.
+- **[`icon`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#icon):**  An icon representing the block in the Inserter. This can be a [Dashicon](https://developer.wordpress.org/resource/dashicons) slug or a custom SVG icon.
+- **[`description`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#description):**  A short description of the block, providing more context than the title.
+- **[`keywords`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#keywords):** An array of keywords to help users find the block when searching.
+- **[`textdomain`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#text-domain):** The text domain for the block, used for internationalization.
 
 ## Files for the block's behavior, output, or style 
 
-The [`editorScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-script) and [`editorStyle`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style) properties allow defining Javascript and CSS files to be enqueued and loaded **only in the editor**.
+The `block.json` file also allows you to specify the essential files for a block's functionality:
 
-The [`script`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script) and [`style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style) properties allow the definition of Javascript and CSS files to be enqueued and loaded **in both the editor and the front end**.
+- **[`editorScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-script):** A JavaScript file or files for use only in the Block Editor.
+- **[`editorStyle`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style):** A CSS file or files for styling within the Block Editor.
+- **[`script`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script):** A JavaScript file or files loaded in both the Block Editor and the front end.
+- **[`style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style):** A CSS file or files applied in both the Block Editor and the front end.
+- **[`viewScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script):** A JavaScript file or files intended solely for the front end.
 
-The [`viewScript`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script) property allow us to define the Javascript file or files to be enqueued and loaded **only in the front end**.
+For all these properties, you can provide a [file path](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedpath) (starting with `file:`), a [handle](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset) that has been registered using `wp_register_script` or `wp_register_style`, or an array combining both options.
 
-All these properties (`editorScript`, `editorStyle`, `script` `style`,`viewScript`) accept as a value a [path for the file](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedpath) (prefixed with `file:`), a [handle registered with `wp_register_script` or `wp_register_style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset), or an array with a mix of both.
-
-The [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property ([introduced on WordPress 6.1](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/)) sets the path of a `.php` template file that will render the markup returned to the front end. This method will be used to return the markup for the block on request only if `$render_callback` function has not been passed to the `register_block_type` function.
+Additionally, the [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property, [introduced on WordPress 6.1](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/), specifies the path to a PHP template file responsible for generating a [dynamically rendered](/docs/getting-started/fundamentals/static-dynamic-rendering.md) block's front-end markup. This approach is used if a `$render_callback` function is not provided to the `register_block_type()` function.
 
 ## Using block `attributes` to store data
 
 Block [attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#attributes) are settings or data assigned to blocks. They can determine various aspects of a block, such as its content, layout, style, and any other specific information you need to store along with your block's structure. If the user changes a block, such as modifying the font size, you need a way to persist these changes. Attributes are the solution. 
 
-When registering a new block type, the `attributes` property of `block.json` describes the custom data the block requires and how they're stored in the database. This allows the Editor to parse these values correctly and pass the `attributes` to the block's `Edit` and `save` functions.
+When registering a new block type, the `attributes` property of `block.json` describes the custom data the block requires and how they're stored in the database. This allows the Block Editor to parse these values correctly and pass the `attributes` to the block's `Edit` component and `save` function.
 
 Here's an example of three attributes defined in `block.json`:
 
@@ -71,34 +75,34 @@ The code example below demonstrates the attributes defined in the block delimite
 ```html
 <!-- wp:block-development-examples/copyright-date-block-09aac3 {"fallbackCurrentYear":"2023","showStartingYear":true,"startingYear":"2020"} -->
 <p class="wp-block-block-development-examples-copyright-date-block-09aac3">© 2020–2023</p>
-<!-- /wp:block-development-examples/copyright-date-block-09aac3 -->x
+<!-- /wp:block-development-examples/copyright-date-block-09aac3 -->
 ```
  
 All attributes are serialized and stored in the block's delimiter by default, but this can be configured to suit your needs. Check out the [Understanding Block Attributes](https://developer.wordpress.org/news/2023/09/understanding-block-attributes/) article to learn more.
 
 ### Reading and updating attributes 
 
-These [attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#attributes) are passed to the React component `Edit` (to display in the Block Editor) and the `save` function (to return the markup saved to the database) of the block and to any server-side render definition for the block (see the `render` property above).
+These [attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#attributes) are passed to the block's `Edit` React component for display in the Block Editor, to the `save` function for generating the markup that gets stored in the database, and to any server-side rendering definition for the block.
 
-The `Edit` component receives exclusively the capability of updating the attributes via the [`setAttributes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#setattributes) function.
+The `Edit` component uniquely possesses the ability to modify these attributes through the [`setAttributes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#setattributes) function.
 
-_See how the attributes are passed to the [`Edit` component](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/edit.js), [the `save` function](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/save.js) and [the `render.php`](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/render.php) in this [full block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/copyright-date-block-09aac3) of the  code above_
-
-<div class="callout callout-info">
-Check the <a href="https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/"> <code>attributes</code> </a> reference page for full info about the Attributes API. 
-</div>
+The following diagram details how attributes are stored, read, and updated in a typical block.
 
 [![Open Attributes diagram image](https://developer.wordpress.org/files/2023/11/attributes.png)](https://developer.wordpress.org/files/2023/11/attributes.png "Open Attributes diagram image")
 
-## Using block `supports` to enable settings and styles
+_See how the attributes are passed to the [`Edit`](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/edit.js) component, the [`save`](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/save.js) function, and [`render.php`](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/copyright-date-block-09aac3/src/render.php) in this [complete block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/copyright-date-block-09aac3)._
 
-Many blocks, including Core blocks, offer similar customization options, whether changing the background color, text color, or adding padding customization options.
+For more information about attributes and how to use them in your custom blocks, visit the [Attributes API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/) reference page. 
 
-The [`supports`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#supports) property in `block.json` allows a block to declare support for certain features, enabling users to customize specific settings (like colors or margins) from the Settings Sidebar.
+## Using block supports to enable settings and styles
 
-Using the available block `supports` allows you to align your block's behavior with core blocks and avoid replicating the same functionality yourself.
+Many blocks, including Core blocks, offer similar customization options, such as background color, text color, and padding adjustments.
 
-_Example: Supports as defined in block.json_
+The [`supports`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#supports) property in `block.json` allows a block to declare support for a set of these common customization options. When enabled, users of the block can then adjust things like color or padding directly from the Settings Sidebar.
+
+Leveraging these predefined block supports helps ensure your block behaves consistently with Core blocks, eliminating the need to recreate similar functionalities from scratch.
+
+Here's an example of color supports defined in `block.json`:
 
 ```json
 "supports": {
@@ -110,9 +114,9 @@ _Example: Supports as defined in block.json_
 }
 ```
 
-The use of `supports` generates a set of properties that need to be manually added to the [wrapping element of the block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-wrapper/). This ensures they're properly stored as part of the block data and taken into account when generating the markup of the block that will be delivered to the front end.
+The use of block supports generates a set of properties that need to be manually added to the [wrapping element of the block](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-wrapper/). This ensures they're properly stored as part of the block data and taken into account when generating the markup of the block that will be delivered to the front end.
 
-_Example: Supports custom settings stored in the Markup representation of the block_
+The following code demonstrates how the attributes and CSS classes generated by enabling block supports are stored in the markup representation of the block.
 
 ```html
 <!-- wp:block-development-examples/block-supports-6aa4dd {"backgroundColor":"contrast","textColor":"accent-4"} -->
@@ -120,11 +124,9 @@ _Example: Supports custom settings stored in the Markup representation of the bl
 <!-- /wp:block-development-examples/block-supports-6aa4dd -->
 ```
 
-_See the [full block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/block-supports-6aa4dd) of the [code above](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/block-supports-6aa4dd/src/block.json)_
+_See the [complete block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/block-supports-6aa4dd) of the [code above](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/block-supports-6aa4dd/src/block.json)._
 
-<div class="callout callout-info">
-Check the <a href="https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/"> <code>supports</code> </a> reference page for full info about the Supports API. 
-</div>
+For more information about supports and how to use them in your custom blocks, visit the [Supports API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/) reference page. 
 
 
 ## Additional resources

--- a/docs/getting-started/fundamentals/block-json.md
+++ b/docs/getting-started/fundamentals/block-json.md
@@ -1,17 +1,16 @@
 # block.json
 
-The `block.json` file simplifies the processs of defining and registering a block by using the same block's definition in JSON format to register the block in both the server and the client.
+The `block.json` file simplifies the process of defining and registering a block by using the same block's definition in JSON format to register the block in both the server and the client.
 
 [![Open block.json diagram image](https://developer.wordpress.org/files/2023/11/block-json.png)](https://developer.wordpress.org/files/2023/11/block-json.png "Open block.json diagram image")
 
-
-<div class="callout callout-tip">
+<div class="callout callout-info">
 Click <a href="https://github.com/WordPress/block-development-examples/tree/trunk/plugins/block-supports-6aa4dd">here</a> to see a full block example and check <a href="https://github.com/WordPress/block-development-examples/blob/trunk/plugins/block-supports-6aa4dd/src/block.json">its <code>block.json</code></a>
 </div>
 
 Besides simplifying a block's registration, using a `block.json` has [several benefits](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#benefits-using-the-metadata-file), including improved performance and development.
 
-At [**Metadata in block.json**](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) you can find a detailed explanation of all the properties you can set in a `block.json` for a block. With these properties you can define things such as:
+At [**Metadata in block.json**](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) you can find a detailed explanation of all the properties you can set in a `block.json` for a block. With these properties, you can define things such as:
 
 - Basic metadata of the block
 - Files for the block's behavior, style, or output
@@ -20,16 +19,16 @@ At [**Metadata in block.json**](https://developer.wordpress.org/block-editor/ref
 
 ## Basic metadata of the block
 
-Through properties of the `block.json`, we can define how the block will be uniquely identified, how it can be found, and the info displayed for the block in the Block Editor. Some of these properties are:
+Using `block.json` properties, you can define how the block will be uniquely identified and the info displayed in the Block Editor. These properties include:
 
-- [`apiVersion`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#api-version): the version of [the API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/) used by the block (current version is 2).
-- [`name`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#name):  a unique identifier for a block, including a namespace.
-- [`title`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#title):  a display title for a block.
-- [`category`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#category):  a block category for the block in the Inserter panel.
-- [`icon`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#icon):  a [Dashicon](https://developer.wordpress.org/resource/dashicons) slug or a custom SVG icon.
-- [`description`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#description):  a short description visible in the block inspector.
-- [`keywords`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#keywords): to locate the block in the inserter.
-- [`textdomain`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#text-domain): the plugin text-domain (important for things such as translations).
+- [`apiVersion`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#api-version): Specifies the [API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/) version the block uses.
+- [`name`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#name):  The unique name of the block, including namespace (e.g., `my-plugin/my-custom-block`).
+- [`title`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#title):  The display title for the block, shown in the Inserter.
+- [`category`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#category): The category under which the block appears in the Inserter. Common categories include `text`, `media`, `design`, `widgets`, and `theme`.
+- [`icon`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#icon):  An icon representing the block in the Inserter. This can be a [Dashicon](https://developer.wordpress.org/resource/dashicons) slug or a custom SVG icon.
+- [`description`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#description):  A short description of the block, providing more context than the title.
+- [`keywords`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#keywords): An array of keywords to help users find the block when searching.
+- [`textdomain`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#text-domain): The text domain for the block, used for internationalization.
 
 ## Files for the block's behavior, output, or style 
 
@@ -41,7 +40,7 @@ The [`viewScript`](https://developer.wordpress.org/block-editor/reference-guides
 
 All these properties (`editorScript`, `editorStyle`, `script` `style`,`viewScript`) accept as a value a [path for the file](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedpath) (prefixed with `file:`), a [handle registered with `wp_register_script` or `wp_register_style`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset), or an array with a mix of both.
 
-The [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property ([introduced on WordPress 6.1](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/)) sets the path of a `.php` template file that will render the markup returned to the front end. This only method will be used to return the markup for the block on request only if `$render_callback` function has not been passed to the `register_block_type` function.
+The [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property ([introduced on WordPress 6.1](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/)) sets the path of a `.php` template file that will render the markup returned to the front end. This method will be used to return the markup for the block on request only if `$render_callback` function has not been passed to the `register_block_type` function.
 
 ## Using `attributes` to store block data
 
@@ -51,6 +50,7 @@ When registering a new block type, the `attributes` property of `block.json` des
 
 
 _Example: Attributes as defined in block.json_
+
 ```json
 "attributes": {
 	"fallbackCurrentYear": {
@@ -64,9 +64,10 @@ _Example: Attributes as defined in block.json_
 	}
 },
 ```
+
 By default, attributes are serialized and stored in the block's delimiter, but this [can be configured](https://developer.wordpress.org/news/2023/09/understanding-block-attributes/).
 
-_Example: Atributes stored in the Markup representation of the block_
+_Example: Attributes stored in the Markup representation of the block_
 ```html
 <!-- wp:block-development-examples/copyright-date-block-09aac3 {"fallbackCurrentYear":"2023","showStartingYear":true,"startingYear":"2020"} -->
 <p class="wp-block-block-development-examples-copyright-date-block-09aac3">© 2020–2023</p>
@@ -75,7 +76,7 @@ _Example: Atributes stored in the Markup representation of the block_
 
 ### Reading and updating attributes 
 
-These [attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#attributes) are passed to the React component `Edit`(to display in the Block Editor) and the `save` function (to return the markup saved to the database) of the block, and to any server-side render definition for the block (see the `render` property above).
+These [attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#attributes) are passed to the React component `Edit` (to display in the Block Editor) and the `save` function (to return the markup saved to the database) of the block and to any server-side render definition for the block (see the `render` property above).
 
 The `Edit` component receives exclusively the capability of updating the attributes via the [`setAttributes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#setattributes) function.
 
@@ -86,7 +87,6 @@ Check the <a href="https://developer.wordpress.org/block-editor/reference-guides
 </div>
 
 [![Open Attributes diagram image](https://developer.wordpress.org/files/2023/11/attributes.png)](https://developer.wordpress.org/files/2023/11/attributes.png "Open Attributes diagram image")
-
 
 ## Enable UI settings panels for the block with `supports`
 

--- a/docs/getting-started/fundamentals/block-json.md
+++ b/docs/getting-started/fundamentals/block-json.md
@@ -17,7 +17,7 @@ At [**Metadata in block.json**](https://developer.wordpress.org/block-editor/ref
 - Data Storage in the Block
 - Setting UI panels for the block
 
-## Basic metadata of the block
+## Basic metadata of a block
 
 Using `block.json` properties, you can define how the block will be uniquely identified and the info displayed in the Block Editor. These properties include:
 
@@ -42,14 +42,13 @@ All these properties (`editorScript`, `editorStyle`, `script` `style`,`viewScrip
 
 The [`render`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#render) property ([introduced on WordPress 6.1](https://make.wordpress.org/core/2022/10/12/block-api-changes-in-wordpress-6-1/)) sets the path of a `.php` template file that will render the markup returned to the front end. This method will be used to return the markup for the block on request only if `$render_callback` function has not been passed to the `register_block_type` function.
 
-## Using `attributes` to store block data
+## Using block `attributes` to store data
 
 Block [attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#attributes) are settings or data assigned to blocks. They can determine various aspects of a block, such as its content, layout, style, and any other specific information you need to store along with your block's structure. If the user changes a block, such as modifying the font size, you need a way to persist these changes. Attributes are the solution. 
 
 When registering a new block type, the `attributes` property of `block.json` describes the custom data the block requires and how they're stored in the database. This allows the Editor to parse these values correctly and pass the `attributes` to the block's `Edit` and `save` functions.
 
-
-_Example: Attributes as defined in block.json_
+Here's an example of three attributes defined in `block.json`:
 
 ```json
 "attributes": {
@@ -65,14 +64,17 @@ _Example: Attributes as defined in block.json_
 },
 ```
 
-By default, attributes are serialized and stored in the block's delimiter, but this [can be configured](https://developer.wordpress.org/news/2023/09/understanding-block-attributes/).
+Blocks are "delimited" using HTML-style comment tags that contain specific JSON-like attributes. These delimiters make it possible to recognize block boundaries and parse block attributes when rendering post content or editing a post in the Block Editor. 
 
-_Example: Attributes stored in the Markup representation of the block_
+The code example below demonstrates the attributes defined in the block delimiter. 
+
 ```html
 <!-- wp:block-development-examples/copyright-date-block-09aac3 {"fallbackCurrentYear":"2023","showStartingYear":true,"startingYear":"2020"} -->
 <p class="wp-block-block-development-examples-copyright-date-block-09aac3">© 2020–2023</p>
 <!-- /wp:block-development-examples/copyright-date-block-09aac3 -->x
 ```
+ 
+All attributes are serialized and stored in the block's delimiter by default, but this can be configured to suit your needs. Check out the [Understanding Block Attributes](https://developer.wordpress.org/news/2023/09/understanding-block-attributes/) article to learn more.
 
 ### Reading and updating attributes 
 
@@ -88,9 +90,9 @@ Check the <a href="https://developer.wordpress.org/block-editor/reference-guides
 
 [![Open Attributes diagram image](https://developer.wordpress.org/files/2023/11/attributes.png)](https://developer.wordpress.org/files/2023/11/attributes.png "Open Attributes diagram image")
 
-## Enable UI settings panels for the block with `supports`
+## Using block `supports` to enable settings and styles
 
-Many blocks, including core blocks, offer similar customization options, whether changing the background color, text color, or adding padding customization options.
+Many blocks, including Core blocks, offer similar customization options, whether changing the background color, text color, or adding padding customization options.
 
 The [`supports`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#supports) property in `block.json` allows a block to declare support for certain features, enabling users to customize specific settings (like colors or margins) from the Settings Sidebar.
 


### PR DESCRIPTION
This PR focused on formatting and copy edits for the [block.json](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-json/) guide. The goal is to fix a few formatting issues and improve readability.