### PR TITLE
Try: Make gallery randomization work when nested

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -117,6 +117,9 @@ function block_core_gallery_render( $attributes, $content ) {
 		)
 	);
 
+	// The WP_HTML_Tag_Processor class calls get_updated_html() internally
+	// when the instance is treated as a string, but here we explicitly
+	// convert it to a string.
 	$updated_content = $processed_content->get_updated_html();
 
 	/*

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -136,7 +136,8 @@ function block_core_gallery_render( $attributes, $content ) {
 		return $updated_content;
 	}
 
-	// Matches figure elements with class `wp-block-image`
+	// This pattern matches figure elements with the `wp-block-image` class to
+	// avoid the gallery's wrapping `figure` element and extract images only.
 	$pattern = '/<figure[^>]*\bwp-block-image\b[^>]*>.*?<\/figure>/';
 
 	// Find all Image blocks.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -149,10 +149,10 @@ function block_core_gallery_render( $attributes, $content ) {
 
 	// Randomize the order of Image blocks.
 	shuffle( $image_blocks );
-	$i = 0;
+	$i       = 0;
 	$content = preg_replace_callback(
 		$pattern,
-		static function( $matches ) use ( $image_blocks, &$i ) {
+		static function () use ( $image_blocks, &$i ) {
 			$new_image_block = $image_blocks[ $i ];
 			++$i;
 			return $new_image_block;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -33,32 +33,18 @@ function block_core_gallery_data_id_backcompatibility( $parsed_block ) {
 add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' );
 
 /**
- * Filter to randomize the order of image blocks.
- *
- * @param array $parsed_block The block being rendered.
- * @return array The block object with randomized order of image blocks.
- */
-function block_core_gallery_random_order( $parsed_block ) {
-	if ( 'core/gallery' === $parsed_block['blockName'] && ! empty( $parsed_block['attrs']['randomOrder'] ) ) {
-		shuffle( $parsed_block['innerBlocks'] );
-	}
-	return $parsed_block;
-}
-
-add_filter( 'render_block_data', 'block_core_gallery_random_order' );
-
-/**
- * Adds a style tag for the --wp--style--unstable-gallery-gap var.
- *
- * The Gallery block needs to recalculate Image block width based on
- * the current gap setting in order to maintain the number of flex columns
- * so a css var is added to allow this.
+ * Renders the `core/gallery` block on the server.
  *
  * @param array  $attributes Attributes of the block being rendered.
  * @param string $content Content of the block being rendered.
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content ) {
+	// Adds a style tag for the --wp--style--unstable-gallery-gap var.
+	// The Gallery block needs to recalculate Image block width based on
+	// the current gap setting in order to maintain the number of flex columns
+	// so a css var is added to allow this.
+
 	$gap = $attributes['style']['spacing']['blockGap'] ?? null;
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
@@ -130,7 +116,58 @@ function block_core_gallery_render( $attributes, $content ) {
 			'context' => 'block-supports',
 		)
 	);
-	return (string) $processed_content;
+
+	// Randomize the order of image blocks. Ideally we should shuffle
+	// the `$parsed_block['innerBlocks']` via the `render_block_data` hook.
+	// However, this hook doesn't apply inner block updates when blocks are
+	// nested.
+	// TODO: In the future, if this hook supports updating innerBlocks in
+	// nested blocks, it should be refactored.
+	// See: XXXXXXXXXXXXXXXXXXXXXXX
+	if ( empty( $attributes['randomOrder'] ) ) {
+		return $processed_content;
+	}
+
+	$processor = new WP_HTML_Tag_Processor( (string) $processed_content );
+
+	// Add an index to each figure tag to uniquely identify each Image block.
+	$i = 0;
+	while ( $processor->next_tag( array( 'class_name' => 'wp-block-image' ) ) ) {
+		$processor->set_attribute( 'data-image-index', $i );
+		++$i;
+	}
+	$content = $processor->get_updated_html();
+
+	$pattern = '/<figure[^>]*\bdata-image-index\b[^>]*>.*?<\/figure>/';
+
+	// Find all Image blocks.
+	preg_match_all( $pattern, $content, $matches );
+	if ( ! $matches ) {
+		return $content;
+	}
+	$image_blocks = $matches[0];
+
+	// Randomize the order of Image blocks.
+	shuffle( $image_blocks );
+	$i = 0;
+	$content = preg_replace_callback(
+		$pattern,
+		static function( $matches ) use ( $image_blocks, &$i ) {
+			$new_image_block = $image_blocks[ $i ];
+			++$i;
+			return $new_image_block;
+		},
+		$content
+	);
+
+	// Remove the index from each Image block.
+	$processor = new WP_HTML_Tag_Processor( $content );
+	while ( $processor->next_tag( array( 'class_name' => 'wp-block-image' ) ) ) {
+		$processor->remove_attribute( 'data-image-index' );
+	}
+	$content = $processor->get_updated_html();
+
+	return $content;
 }
 /**
  * Registers the `core/gallery` block on server.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -123,7 +123,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	// nested.
 	// TODO: In the future, if this hook supports updating innerBlocks in
 	// nested blocks, it should be refactored.
-	// See: XXXXXXXXXXXXXXXXXXXXXXX
+	// See: https://github.com/WordPress/gutenberg/pull/58733
 	if ( empty( $attributes['randomOrder'] ) ) {
 		return $processed_content;
 	}

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -117,13 +117,16 @@ function block_core_gallery_render( $attributes, $content ) {
 		)
 	);
 
-	// Randomize the order of image blocks. Ideally we should shuffle
-	// the `$parsed_block['innerBlocks']` via the `render_block_data` hook.
-	// However, this hook doesn't apply inner block updates when blocks are
-	// nested.
-	// TODO: In the future, if this hook supports updating innerBlocks in
-	// nested blocks, it should be refactored.
-	// See: https://github.com/WordPress/gutenberg/pull/58733
+	/*
+	 * Randomize the order of image blocks. Ideally we should shuffle
+	 * the `$parsed_block['innerBlocks']` via the `render_block_data` hook.
+	 * However, this hook doesn't apply inner block updates when blocks are
+	 * nested.
+	 * @todo: In the future, if this hook supports updating innerBlocks in
+	 * nested blocks, it should be refactored.
+	 *
+	 * @see: https://github.com/WordPress/gutenberg/pull/58733
+	 */
 	if ( empty( $attributes['randomOrder'] ) ) {
 		return $processed_content;
 	}


### PR DESCRIPTION
Fixes #58404

## What?

This PR resolves an issue where the randomization of the Gallery block added in #57477 does not work when nested.

## Why?

Randomization is achieved by shuffling the `$parsed_block['innerBlocks']` via the `render_block_data` hook. However, we found a problem with this hook: it cannot override `$parsed_block['innerBlocks']` when blocks are nested.

This issue is also reported in the core ticket: https://core.trac.wordpress.org/ticket/56417

Ideally, `render_block_data` should be improved, but the impact is probably large and there isn't much time left to fix it in WP6.5.

So in this PR, we will try similar randomization in the render callback function instead of `render_block_data`. If we can't find a good solution, we may need to consider reverting the randomization function.

## How?

Sort theIimage blocks within the content HTML based on the following logic:

- Use `WP_HTML_Tag_Processor` to add a sequential number (`data-image-index`) to elements with the `wp-block-image` class. This is to identify duplicate images when they are included in a gallery.
- Use the `preg_match_all()` function to extract elements with the `data-image-index` attribute, i.e. Image blocks.
- Randomize the extracted Image blocks.
- Use the `preg_replace_callback()` function to extract the Image blocks again and replace each Image block with the randomized Image in turn.
- Finally, use `WP_HTML_Tag_Processor` to remove unnecessary `data-image-index` attributes.

To be honest, this approach may not be perfect for the following reasons:

- What if the user has already given the data-image-index attribute?
- What if the user had rewritten the wp-block-image class?
- What if the user uses the new allowed_blocks to insert something other than an image block?

Let me discuss whether we should ship this approach or bring back the randomization feature. 🙇

## Testing Instructions

- Insert a Gallery block and add images.
- Enable "Randomize order".
- On the front end, check that the image order changes every time you reload the browser.