### PR TITLE
Site editor: add pattern/template load performance test with TT4

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -10,7 +10,8 @@
 				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
 				"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",
 				"wp-content/themes/gutenberg-test-themes/twentytwentyone": "https://downloads.wordpress.org/theme/twentytwentyone.1.7.zip",
-				"wp-content/themes/gutenberg-test-themes/twentytwentythree": "https://downloads.wordpress.org/theme/twentytwentythree.1.0.zip"
+				"wp-content/themes/gutenberg-test-themes/twentytwentythree": "https://downloads.wordpress.org/theme/twentytwentythree.1.0.zip",
+				"wp-content/themes/gutenberg-test-themes/twentytwentyfour": "https://downloads.wordpress.org/theme/twentytwentyfour.1.0.zip"
 			}
 		}
 	}

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -219,11 +219,9 @@ test.describe( 'Site Editor Performance', () => {
 
 		test( 'Run the test', async ( { page, admin, perfUtils, editor } ) => {
 			const samples = 10;
-			const throwaway = 1;
-			const iterations = samples + throwaway;
-			for ( let i = 1; i <= iterations; i++ ) {
+			for ( let i = 1; i <= samples; i++ ) {
 				// We want to start from a fresh state each time, without
-				// queries or patterns already loaded.
+				// queries or patterns already cached.
 				await admin.visitSiteEditor( {
 					postId: 'twentytwentyfour//home',
 					postType: 'wp_template',
@@ -280,10 +278,7 @@ test.describe( 'Site Editor Performance', () => {
 
 				const endTime = performance.now();
 
-				// Save the results.
-				if ( i > throwaway ) {
-					results.loadPatterns.push( endTime - startTime );
-				}
+				results.loadPatterns.push( endTime - startTime );
 
 				await page.keyboard.press( 'Escape' );
 			}

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -250,9 +250,7 @@ test.describe( 'Site Editor Performance', () => {
 					'Blogging home template',
 					'Business home template',
 					'Portfolio home template with post featured images',
-					'Writer Home Template',
 					'Blogging index template',
-					'Writer Index Template',
 				];
 
 				await Promise.all(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds a test for pattern/template load in the site editor through the "replace template" flow.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These templates in particular are much slower to load because they contain patterns that are replaced on load. It is good to have some "real life" performance test for template/pattern previewing with TT4.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
