### PR TITLE
Font Library: code style and code quality feedback from core 6.5 review

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -158,22 +158,22 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 		*
 		* @since 6.5.0
 		*
-		* @param WP_Font_Collection $collection Collection object.
-		* @param WP_REST_Request    $request    Request object.
+		* @param WP_Font_Collection $item    Font collection object.
+		* @param WP_REST_Request    $request Request object.
 		* @return WP_REST_Response Response object.
 		*/
-		public function prepare_item_for_response( $collection, $request ) {
+		public function prepare_item_for_response( $item, $request ) {
 			$fields = $this->get_fields_for_response( $request );
-			$item   = array();
+			$data   = array();
 
 			if ( rest_is_field_included( 'slug', $fields ) ) {
-				$item['slug'] = $collection->slug;
+				$data['slug'] = $item->slug;
 			}
 
 			// If any data fields are requested, get the collection data.
 			$data_fields = array( 'name', 'description', 'font_families', 'categories' );
 			if ( ! empty( array_intersect( $fields, $data_fields ) ) ) {
-				$collection_data = $collection->get_data();
+				$collection_data = $item->get_data();
 				if ( is_wp_error( $collection_data ) ) {
 					$collection_data->add_data( array( 'status' => 500 ) );
 					return $collection_data;
@@ -181,15 +181,15 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 
 				foreach ( $data_fields as $field ) {
 					if ( rest_is_field_included( $field, $fields ) ) {
-						$item[ $field ] = $collection_data[ $field ];
+						$data[ $field ] = $collection_data[ $field ];
 					}
 				}
 			}
 
-			$response = rest_ensure_response( $item );
+			$response = rest_ensure_response( $data );
 
 			if ( rest_is_field_included( '_links', $fields ) ) {
-				$links = $this->prepare_links( $collection );
+				$links = $this->prepare_links( $item );
 				$response->add_links( $links );
 			}
 
@@ -198,17 +198,15 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 			$response->data = $this->filter_response_by_context( $response->data, $context );
 
 			/**
-			 * Filters a font collection returned from the REST API.
-			 *
-			 * Allows modification of the font collection right before it is returned.
+			 * Filters the font collection data for a REST API response.
 			 *
 			 * @since 6.5.0
 			 *
 			 * @param WP_REST_Response   $response    The response object.
-			 * @param WP_Font_Collection $collection  The Font Collection object.
+			 * @param WP_Font_Collection $item        The font collection object.
 			 * @param WP_REST_Request    $request     Request used to generate the response.
 			 */
-			return apply_filters( 'rest_prepare_font_collection', $response, $collection, $request );
+			return apply_filters( 'rest_prepare_font_collection', $response, $item, $request );
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -202,9 +202,9 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 			 *
 			 * @since 6.5.0
 			 *
-			 * @param WP_REST_Response   $response    The response object.
-			 * @param WP_Font_Collection $item        The font collection object.
-			 * @param WP_REST_Request    $request     Request used to generate the response.
+			 * @param WP_REST_Response   $response The response object.
+			 * @param WP_Font_Collection $item     The font collection object.
+			 * @param WP_REST_Request    $request  Request used to generate the response.
 			 */
 			return apply_filters( 'rest_prepare_font_collection', $response, $item, $request );
 		}

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-collections-controller.php
@@ -160,7 +160,7 @@ if ( ! class_exists( 'WP_REST_Font_Collections_Controller' ) ) {
 		*
 		* @param WP_Font_Collection $item    Font collection object.
 		* @param WP_REST_Request    $request Request object.
-		* @return WP_REST_Response Response object.
+		* @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 		*/
 		public function prepare_item_for_response( $item, $request ) {
 			$fields = $this->get_fields_for_response( $request );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -17,9 +17,6 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		/**
 		 * The latest version of theme.json schema supported by the controller.
 		 *
-		 * If WP_Theme_JSON::LATEST_SCHEMA is changed, this controller should be updated to handle any differences
-		 * in `fontFace` structure to ensure support for the latest theme.json schema.
-		 *
 		 * @since 6.5.0
 		 * @var int
 		 */

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -443,7 +443,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				$data['id'] = $item->ID;
 			}
 			if ( rest_is_field_included( 'theme_json_version', $fields ) ) {
-				$data['theme_json_version'] = 2;
+				$data['theme_json_version'] = WP_Theme_JSON::LATEST_SCHEMA;
 			}
 
 			if ( rest_is_field_included( 'parent', $fields ) ) {
@@ -504,9 +504,9 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 					'theme_json_version' => array(
 						'description' => __( 'Version of the theme.json schema used for the typography settings.', 'gutenberg' ),
 						'type'        => 'integer',
-						'default'     => 2,
+						'default'     => WP_Theme_JSON::LATEST_SCHEMA,
 						'minimum'     => 2,
-						'maximum'     => 2,
+						'maximum'     => WP_Theme_JSON::LATEST_SCHEMA,
 						'context'     => array( 'view', 'edit', 'embed' ),
 					),
 					'parent'             => array(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -699,14 +699,16 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 			$query_params = parent::get_collection_params();
 
 			// Remove unneeded params.
-			unset( $query_params['after'] );
-			unset( $query_params['modified_after'] );
-			unset( $query_params['before'] );
-			unset( $query_params['modified_before'] );
-			unset( $query_params['search'] );
-			unset( $query_params['search_columns'] );
-			unset( $query_params['slug'] );
-			unset( $query_params['status'] );
+			unset(
+				$query_params['after'],
+				$query_params['modified_after'],
+				$query_params['before'],
+				$query_params['modified_before'],
+				$query_params['search'],
+				$query_params['search_columns'],
+				$query_params['slug'],
+				$query_params['status']
+			);
 
 			$query_params['orderby']['default'] = 'id';
 			$query_params['orderby']['enum']    = array( 'id', 'include' );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -418,7 +418,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				return new WP_Error(
 					'rest_trash_not_supported',
 					/* translators: %s: force=true */
-					sprintf( __( "Font faces do not support trashing. Set '%s' to delete.", 'gutenberg' ), 'force=true' ),
+					sprintf( __( 'Font faces do not support trashing. Set "%s" to delete.', 'gutenberg' ), 'force=true' ),
 					array( 'status' => 501 )
 				);
 			}

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -328,7 +328,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 					'update_post_term_cache' => false,
 				)
 			);
-			if ( ! empty( $query->get_posts() ) ) {
+			if ( ! empty( $query->posts ) ) {
 				return new WP_Error(
 					'rest_duplicate_font_face',
 					__( 'A font face matching those settings already exists.', 'gutenberg' ),

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -13,6 +13,18 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 	 * Class to access font faces through the REST API.
 	 */
 	class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
+
+		/**
+		 * The latest version of theme.json schema supported by the controller.
+		 *
+		 * If WP_Theme_JSON::LATEST_SCHEMA is changed, this controller should be updated to handle any differences
+		 * in `fontFace` structure to ensure support for the latest theme.json schema.
+		 *
+		 * @since 6.5.0
+		 * @var int
+		 */
+		const LATEST_THEME_JSON_VERSION_SUPPORTED = 2;
+
 		/**
 		 * Whether the controller supports batching.
 		 *
@@ -443,7 +455,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 				$data['id'] = $item->ID;
 			}
 			if ( rest_is_field_included( 'theme_json_version', $fields ) ) {
-				$data['theme_json_version'] = WP_Theme_JSON::LATEST_SCHEMA;
+				$data['theme_json_version'] = static::LATEST_THEME_JSON_VERSION_SUPPORTED;
 			}
 
 			if ( rest_is_field_included( 'parent', $fields ) ) {
@@ -504,9 +516,9 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 					'theme_json_version' => array(
 						'description' => __( 'Version of the theme.json schema used for the typography settings.', 'gutenberg' ),
 						'type'        => 'integer',
-						'default'     => WP_Theme_JSON::LATEST_SCHEMA,
+						'default'     => static::LATEST_THEME_JSON_VERSION_SUPPORTED,
 						'minimum'     => 2,
-						'maximum'     => WP_Theme_JSON::LATEST_SCHEMA,
+						'maximum'     => static::LATEST_THEME_JSON_VERSION_SUPPORTED,
 						'context'     => array( 'view', 'edit', 'embed' ),
 					),
 					'parent'             => array(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -245,9 +245,8 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param string          $value   Encoded JSON string of font face settings.
-		 * @param WP_REST_Request $request Request object.
-		 * @return array                   Decoded array of font face settings.
+		 * @param string $value Encoded JSON string of font face settings.
+		 * @return array Decoded array of font face settings.
 		 */
 		public function sanitize_font_face_settings( $value ) {
 			// Settings arrive as stringified JSON, since this is a multipart/form-data request.
@@ -817,7 +816,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 * @since 6.5.0
 		 *
 		 * @param WP_REST_Request $request Request object.
-		 * @return stdClass|WP_Error Post object or WP_Error.
+		 * @return stdClass Post object.
 		 */
 		protected function prepare_item_for_database( $request ) {
 			$prepared_post = new stdClass();
@@ -859,7 +858,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 * @since 6.5.0
 		 *
 		 * @param array $file Single file item from $_FILES.
-		 * @return array Array containing uploaded file attributes on success, or error on failure.
+		 * @return array|WP_Error Array containing uploaded file attributes on success, or error on failure.
 		 */
 		protected function handle_font_file_upload( $file ) {
 			add_filter( 'upload_mimes', array( 'WP_Font_Utils', 'get_allowed_font_mime_types' ) );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-faces-controller.php
@@ -243,7 +243,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 * @since 6.5.0
 		 *
 		 * @param string $value Encoded JSON string of font face settings.
-		 * @return array Decoded array of font face settings.
+		 * @return array Decoded and sanitized array of font face settings.
 		 */
 		public function sanitize_font_face_settings( $value ) {
 			// Settings arrive as stringified JSON, since this is a multipart/form-data request.
@@ -841,7 +841,6 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 * @since 6.5.0
 		 *
 		 * @param string $value Font face src that is a URL or the key for a $_FILES array item.
-		 *
 		 * @return string Sanitized value.
 		 */
 		protected function sanitize_src( $value ) {
@@ -855,7 +854,7 @@ if ( ! class_exists( 'WP_REST_Font_Faces_Controller' ) ) {
 		 * @since 6.5.0
 		 *
 		 * @param array $file Single file item from $_FILES.
-		 * @return array|WP_Error Array containing uploaded file attributes on success, or error on failure.
+		 * @return array|WP_Error Array containing uploaded file attributes on success, or WP_Error object on failure.
 		 */
 		protected function handle_font_file_upload( $file ) {
 			add_filter( 'upload_mimes', array( 'WP_Font_Utils', 'get_allowed_font_mime_types' ) );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -231,7 +231,7 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 			}
 
 			if ( rest_is_field_included( 'theme_json_version', $fields ) ) {
-				$data['theme_json_version'] = 2;
+				$data['theme_json_version'] = WP_Theme_JSON::LATEST_SCHEMA;
 			}
 
 			if ( rest_is_field_included( 'font_faces', $fields ) ) {
@@ -292,9 +292,9 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 					'theme_json_version'   => array(
 						'description' => __( 'Version of the theme.json schema used for the typography settings.', 'gutenberg' ),
 						'type'        => 'integer',
-						'default'     => 2,
+						'default'     => WP_Theme_JSON::LATEST_SCHEMA,
 						'minimum'     => 2,
-						'maximum'     => 2,
+						'maximum'     => WP_Theme_JSON::LATEST_SCHEMA,
 						'context'     => array( 'view', 'edit', 'embed' ),
 					),
 					'font_faces'           => array(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -491,7 +491,7 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 			foreach ( $font_face_ids as $font_face_id ) {
 				$links[] = array(
 					'embeddable' => true,
-					'href'       => rest_url( $this->namespace . '/' . $this->rest_base . '/' . $font_family_id . '/font-faces/' . $font_face_id ),
+					'href'       => rest_url( sprintf( '%s/%s/%s/font-faces/%s', $this->namespace, $this->rest_base, $font_family_id, $font_face_id ) ),
 				);
 			}
 			return $links;

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -385,13 +385,15 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 			$query_params = parent::get_collection_params();
 
 			// Remove unneeded params.
-			unset( $query_params['after'] );
-			unset( $query_params['modified_after'] );
-			unset( $query_params['before'] );
-			unset( $query_params['modified_before'] );
-			unset( $query_params['search'] );
-			unset( $query_params['search_columns'] );
-			unset( $query_params['status'] );
+			unset(
+				$query_params['after'],
+				$query_params['modified_after'],
+				$query_params['before'],
+				$query_params['modified_before'],
+				$query_params['search'],
+				$query_params['search_columns'],
+				$query_params['status']
+			);
 
 			$query_params['orderby']['default'] = 'id';
 			$query_params['orderby']['enum']    = array( 'id', 'include' );

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -15,6 +15,18 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 	 * @since 6.5.0
 	 */
 	class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
+
+		/**
+		 * The latest version of theme.json schema supported by the controller.
+		 *
+		 * If WP_Theme_JSON::LATEST_SCHEMA is changed, this controller should be updated to handle any differences
+		 * in `fontFamilies` structure to ensure support for the latest theme.json schema.
+		 *
+		 * @since 6.5.0
+		 * @var int
+		 */
+		const LATEST_THEME_JSON_VERSION_SUPPORTED = 2;
+
 		/**
 		 * Whether the controller supports batching.
 		 *
@@ -231,7 +243,7 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 			}
 
 			if ( rest_is_field_included( 'theme_json_version', $fields ) ) {
-				$data['theme_json_version'] = WP_Theme_JSON::LATEST_SCHEMA;
+				$data['theme_json_version'] = static::LATEST_THEME_JSON_VERSION_SUPPORTED;
 			}
 
 			if ( rest_is_field_included( 'font_faces', $fields ) ) {
@@ -292,9 +304,9 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 					'theme_json_version'   => array(
 						'description' => __( 'Version of the theme.json schema used for the typography settings.', 'gutenberg' ),
 						'type'        => 'integer',
-						'default'     => WP_Theme_JSON::LATEST_SCHEMA,
+						'default'     => static::LATEST_THEME_JSON_VERSION_SUPPORTED,
 						'minimum'     => 2,
-						'maximum'     => WP_Theme_JSON::LATEST_SCHEMA,
+						'maximum'     => static::LATEST_THEME_JSON_VERSION_SUPPORTED,
 						'context'     => array( 'view', 'edit', 'embed' ),
 					),
 					'font_faces'           => array(

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -177,7 +177,7 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 					'update_post_term_cache' => false,
 				)
 			);
-			if ( ! empty( $query->get_posts() ) ) {
+			if ( ! empty( $query->posts ) ) {
 				return new WP_Error(
 					'rest_duplicate_font_family',
 					/* translators: %s: Font family slug. */
@@ -457,7 +457,7 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 				)
 			);
 
-			return $query->get_posts();
+			return $query->posts;
 		}
 
 		/**

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -150,9 +150,8 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param string          $value   Encoded JSON string of font family settings.
-		 * @param WP_REST_Request $request Request object.
-		 * @return array                   Decoded array font family settings.
+		 * @param string $value Encoded JSON string of font family settings.
+		 * @return array Decoded array of font family settings.
 		 */
 		public function sanitize_font_family_settings( $value ) {
 			// Settings arrive as stringified JSON, since this is a multipart/form-data request.

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -19,9 +19,6 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 		/**
 		 * The latest version of theme.json schema supported by the controller.
 		 *
-		 * If WP_Theme_JSON::LATEST_SCHEMA is changed, this controller should be updated to handle any differences
-		 * in `fontFamilies` structure to ensure support for the latest theme.json schema.
-		 *
 		 * @since 6.5.0
 		 * @var int
 		 */

--- a/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
+++ b/lib/compat/wordpress-6.5/fonts/class-wp-rest-font-families-controller.php
@@ -205,7 +205,7 @@ if ( ! class_exists( 'WP_REST_Font_Families_Controller' ) ) {
 				return new WP_Error(
 					'rest_trash_not_supported',
 					/* translators: %s: force=true */
-					sprintf( __( "Font faces do not support trashing. Set '%s' to delete.", 'gutenberg' ), 'force=true' ),
+					sprintf( __( 'Font faces do not support trashing. Set "%s" to delete.', 'gutenberg' ), 'force=true' ),
 					array( 'status' => 501 )
 				);
 			}

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -1013,6 +1013,12 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		}
 	}
 
+
+	/**
+	 * If WP_Theme_JSON::LATEST_SCHEMA is changed, the controller should be updated to handle any differences
+	 * in `fontFace` structure to ensure support for the latest theme.json schema, and backwards compatibility
+	 * for existing wp_font_face posts.
+	 */
 	public function test_controller_supports_latest_theme_json_version() {
 		$this->assertSame( WP_Theme_JSON::LATEST_SCHEMA, WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 	}

--- a/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -362,7 +362,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$files = $this->setup_font_file_upload( array( 'woff2' ) );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param(
 			'font_face_settings',
 			wp_json_encode(
@@ -406,7 +406,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$files = $this->setup_font_file_upload( array( 'ttf', 'otf', 'woff', 'woff2' ) );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param(
 			'font_face_settings',
 			wp_json_encode(
@@ -452,7 +452,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param(
 			'font_face_settings',
 			wp_json_encode(
@@ -478,7 +478,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 	public function test_create_item_with_url_src() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param(
 			'font_face_settings',
 			wp_json_encode(
@@ -523,7 +523,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param( 'font_face_settings', wp_json_encode( $properties ) );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -597,7 +597,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		$this->assertSame( 201, $response->get_status(), 'The response status should be 201.' );
 		$this->assertArrayHasKey( 'theme_json_version', $data, 'The theme_json_version property should exist in the response data.' );
-		$this->assertSame( 2, $data['theme_json_version'], 'The default theme.json version should be 2.' );
+		$this->assertSame( WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED, $data['theme_json_version'], 'The default theme.json version should match the latest version supported by the controller.' );
 	}
 
 	/**
@@ -639,7 +639,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 	public function test_create_item_invalid_settings( $settings ) {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param( 'font_face_settings', wp_json_encode( $settings ) );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -693,7 +693,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 	public function test_create_item_invalid_settings_json() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param( 'font_face_settings', 'invalid' );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -713,7 +713,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( self::$admin_id );
 		$src     = 'invalid';
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param(
 			'font_face_settings',
 			wp_json_encode(
@@ -738,7 +738,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param(
 			'font_face_settings',
 			wp_json_encode(
@@ -974,9 +974,9 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$properties = $data['schema']['properties'];
 		$this->assertCount( 4, $properties, 'There should be 4 properties in the schema::properties data.' );
 		$this->assertArrayHasKey( 'id', $properties, 'The id property should exist in the schema::properties data.' );
-		$this->assertArrayHasKey( 'theme_json_version', $properties, 'The id property should exist in the schema::properties data.' );
-		$this->assertArrayHasKey( 'parent', $properties, 'The id property should exist in the schema::properties data.' );
-		$this->assertArrayHasKey( 'font_face_settings', $properties, 'The id property should exist in the schema::properties data.' );
+		$this->assertArrayHasKey( 'theme_json_version', $properties, 'The theme_json_version property should exist in the schema::properties data.' );
+		$this->assertArrayHasKey( 'parent', $properties, 'The parent property should exist in the schema::properties data.' );
+		$this->assertArrayHasKey( 'font_face_settings', $properties, 'The font_face_settings property should exist in the schema::properties data.' );
 	}
 
 	/**
@@ -1013,6 +1013,10 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		}
 	}
 
+	public function test_controller_supports_latest_theme_json_version() {
+		$this->assertSame( WP_Theme_JSON::LATEST_SCHEMA, WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
+	}
+
 	protected function check_font_face_data( $data, $post_id, $links ) {
 		self::$post_ids_for_cleanup[] = $post_id;
 		$post                         = get_post( $post_id );
@@ -1024,7 +1028,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$this->assertSame( $post->post_parent, $data['parent'], 'The "parent" from the response data should match the post parent.' );
 
 		$this->assertArrayHasKey( 'theme_json_version', $data, 'The theme_json_version property should exist in response data.' );
-		$this->assertSame( WP_Theme_JSON::LATEST_SCHEMA, $data['theme_json_version'], 'The "theme_json_version" from the response data should match WP_Theme_JSON::LATEST_SCHEMA.' );
+		$this->assertSame( WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED, $data['theme_json_version'], 'The "theme_json_version" from the response data should match the latest version supported by the controller.' );
 
 		$this->assertArrayHasKey( 'font_face_settings', $data, 'The font_face_settings property should exist in response data.' );
 		$this->assertSame( $post->post_content, wp_json_encode( $data['font_face_settings'] ), 'The encoded "font_face_settings" from the response data should match the post content.' );

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -376,7 +376,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param( 'font_family_settings', wp_json_encode( $settings ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -405,7 +405,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 
 		$this->assertSame( 201, $response->get_status(), 'The response status should be 201.' );
 		$this->assertArrayHasKey( 'theme_json_version', $data, 'The theme_json_version property should exist in the response data.' );
-		$this->assertSame( 2, $data['theme_json_version'], 'The default theme.json version should be 2.' );
+		$this->assertSame( WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED, $data['theme_json_version'], 'The default theme.json version should match the latest version supported by the controller.' );
 	}
 
 	/**
@@ -447,7 +447,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	public function test_create_item_with_default_preview( $settings ) {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param( 'font_family_settings', wp_json_encode( $settings ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -569,7 +569,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	public function test_create_item_invalid_settings( $settings ) {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param( 'font_family_settings', wp_json_encode( $settings ) );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -619,7 +619,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	public function test_create_item_invalid_settings_json() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param( 'font_family_settings', 'invalid' );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -636,7 +636,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	public function test_create_item_with_duplicate_slug() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
-		$request->set_param( 'theme_json_version', 2 );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 		$request->set_param( 'font_family_settings', wp_json_encode( array_merge( self::$default_settings, array( 'slug' => 'helvetica' ) ) ) );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -990,6 +990,10 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		}
 	}
 
+	public function test_controller_supports_latest_theme_json_version() {
+		$this->assertSame( WP_Theme_JSON::LATEST_SCHEMA, WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
+	}
+
 	protected function check_font_family_data( $data, $post_id, $links ) {
 		static::$post_ids_to_cleanup[] = $post_id;
 		$post                          = get_post( $post_id );
@@ -998,7 +1002,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		$this->assertSame( $post->ID, $data['id'], 'The "id" from the response data should match the post ID.' );
 
 		$this->assertArrayHasKey( 'theme_json_version', $data, 'The theme_json_version property should exist in response data.' );
-		$this->assertSame( WP_Theme_JSON::LATEST_SCHEMA, $data['theme_json_version'], 'The "theme_json_version" from the response data should match WP_Theme_JSON::LATEST_SCHEMA.' );
+		$this->assertSame( WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED, $data['theme_json_version'], 'The "theme_json_version" from the response data should match the latest version supported by the controller.' );
 
 		$font_face_ids = get_children(
 			array(

--- a/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -990,6 +990,11 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		}
 	}
 
+	/**
+	 * If WP_Theme_JSON::LATEST_SCHEMA is changed, the controller should be updated to handle any differences
+	 * in `fontFamilies` structure to ensure support for the latest theme.json schema, and backwards compatibility
+	 * for existing wp_font_family posts.
+	 */
 	public function test_controller_supports_latest_theme_json_version() {
 		$this->assertSame( WP_Theme_JSON::LATEST_SCHEMA, WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
 	}


### PR DESCRIPTION
## What?
Address the code formatting or code style feedback from https://github.com/WordPress/wordpress-develop/pull/6034

- [Replace double quotes with single quotes.](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1479446556): https://github.com/WordPress/gutenberg/pull/58736/commits/715efe6a865e484ccd6db19db3aadae3a88a699d
- [Avoid multiple unset calls](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1479448203): https://github.com/WordPress/gutenberg/pull/58736/commits/c054a28c0f6751d7e8d765d565658492d92e253f
- [Avoid multiple unset calls](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1479460643): https://github.com/WordPress/gutenberg/pull/58736/commits/1c581f9da95adefb48f8855ac991d8b708c5d292
- [Use sprintf for assembling REST URLs](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1479455867): https://github.com/WordPress/gutenberg/pull/58736/commits/90281956a81e30bd41f72233eb6344df5f767263
- [Avoid extra get_posts() call](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1479454003): https://github.com/WordPress/gutenberg/pull/58736/commits/91911e850a228ea7cabd28e1aec22186e1542dff
- [Adds constant to font controllers for tracking latest theme.json version supported](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1480276134): https://github.com/WordPress/gutenberg/pull/58736/commits/738ca82dc85913186553b61314f57ed5c6d4256e
- [Corrects docblocks in WP_REST_Font_Faces_Controller](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1480554641): https://github.com/WordPress/gutenberg/pull/58736/commits/dbbab15518d33a5b817018dc15aab6dd6634c613
- [Updates WP_REST_Font_Collections_Controller::prepare_item_for_response](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1480559228): https://github.com/WordPress/gutenberg/pull/58736/commits/78817e664783bd9d1c317882b40659ae78244ee5
- [Corrects docblock in WP_REST_Font_Collections_Controller](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1480560090): https://github.com/WordPress/gutenberg/pull/58736/commits/2becf2ff15db4251e5cc3495a3d8a1fde27d2bf2
- [Fix docblock in WP_REST_Font_Families_Controller](https://github.com/WordPress/wordpress-develop/pull/6034#discussion_r1480561750): https://github.com/WordPress/gutenberg/pull/58736/commits/f721ffdbd3526ae03c44d50a00a8da00ceba6283

## Why?

To be consistent with WordPress core code style and address Core PR feedback so far.

## How?
Implementing the changes requested.

## Testing Instructions
Run unit tests