### PR TITLE
Add outline to template preview in table layout

### DIFF
--- a/packages/edit-site/src/components/page-templates-template-parts/style.scss
+++ b/packages/edit-site/src/components/page-templates-template-parts/style.scss
@@ -37,6 +37,22 @@
 			border-radius: 3px 3px 0 0;
 		}
 	}
+
+	&.is-viewtype-table {
+		border-radius: $radius-block-ui;
+		position: relative;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+			border-radius: $radius-block-ui;
+		}
+	}
 }
 
 .page-templates-description {


### PR DESCRIPTION
## What?
Apply an outline to the template preview in table layout.

## Why?
When templates have a white background it becomes tricky to differentiate the preview from the rest of the UI:

<img width="426" src="https://github.com/WordPress/gutenberg/assets/846565/62df7942-8dc7-4661-a038-42dddcf519e1">


## How?
Uses the same technique as the List layout, namely; a transparent inset shadow applied to the `after` pseudo element. This works a bit better for previews with dark backgrounds.

<img width="426" alt="Screenshot 2024-02-06 at 15 05 26" src="https://github.com/WordPress/gutenberg/assets/846565/682002cf-6d62-44e7-837c-7629094e784a">


## Testing Instructions
1. Navigate to Appearance > Editor > Templates > Manage all templates
2. Toggle the Preview field on in the view options
3. Observe the outline around the preview

