### PR TITLE
Data views: Update spacing around title in grid layout

### DIFF
--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -274,7 +274,7 @@
 		justify-content: flex-start;
 
 		.dataviews-view-grid__title-actions {
-			padding: $grid-unit-05 $grid-unit 0 $grid-unit-05;
+			padding: $grid-unit-05 $grid-unit $grid-unit-05 $grid-unit-05;
 		}
 
 		.dataviews-view-grid__primary-field {


### PR DESCRIPTION
## What?
Equalise space around title in data views grid layout.

## Why?
If you toggle all fields off, there's unequal space around the card contents making for an awkward appearance:

![grid](https://github.com/WordPress/gutenberg/assets/846565/4e603617-ef67-47cf-bf9a-320fe9b0664a)


## After
![grid2](https://github.com/WordPress/gutenberg/assets/846565/a5049f7e-44b1-424a-b950-cf06f450a059)


### Testing Instructions
* Navigate to any data view
* Switch to Grid layout
* Toggle _off_ all fields
* Observe updated spacing around title

