### PR TITLE
Fix URLPopover preview overflow

### DIFF
--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -59,6 +59,9 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	margin-right: $grid-unit-10;
+	// Avoids the popover from growing too wide when the URL is long.
+	// See https: //github.com/WordPress/gutenberg/issues/58599.
+	max-width: $modal-min-width;
 
 	&.has-invalid-link {
 		color: $alert-red;

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -60,7 +60,7 @@
 	white-space: nowrap;
 	margin-right: $grid-unit-10;
 	// Avoids the popover from growing too wide when the URL is long.
-	// See https: //github.com/WordPress/gutenberg/issues/58599.
+	// See https://github.com/WordPress/gutenberg/issues/58599
 	max-width: $modal-min-width;
 
 	&.has-invalid-link {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Stops the preview for URL Popover growing wider than the max modal width constant.

Fixes https://github.com/WordPress/gutenberg/issues/58599

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We don't want hugely wide popovers when URLs are long.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use max-width.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Add image block
- Link the image block to a long url `https://make.wordpress.org/core/handbook/tutorials/linking-your-github-and-w-org-profiles/#4-add-your-wordpress-org-git-email-to-your-github-email-list`
- Submit link
- See that resulting link preview popover is not allowed to grow hugely wide (refer to Issue)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1942" alt="Screen Shot 2024-02-06 at 16 09 58" src="https://github.com/WordPress/gutenberg/assets/444434/ebf8254a-0263-4ab2-8c6d-d78f4e77b7a9">
