### PR TITLE
Update dataviews search input placeholder

### DIFF
--- a/packages/dataviews/src/search.js
+++ b/packages/dataviews/src/search.js
@@ -24,7 +24,7 @@ const Search = memo( function Search( { label, view, onChangeView } ) {
 			search: debouncedSearch,
 		} );
 	}, [ debouncedSearch ] );
-	const searchLabel = label || __( 'Filter list' );
+	const searchLabel = label || __( 'Search' );
 	return (
 		<SearchControl
 			__nextHasNoMarginBottom

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -50,7 +50,7 @@ test.describe( 'Templates', () => {
 		} );
 		await admin.visitSiteEditor( { path: '/wp_template/all' } );
 		// Global search.
-		await page.getByRole( 'searchbox', { name: 'Filter list' } ).click();
+		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 		await page.keyboard.type( 'tag' );
 		const titles = page
 			.getByRole( 'region', { name: 'Template' } )
@@ -72,7 +72,7 @@ test.describe( 'Templates', () => {
 
 		// Filter by author and text.
 		await page.getByRole( 'button', { name: 'Reset filters' } ).click();
-		await page.getByRole( 'searchbox', { name: 'Filter list' } ).click();
+		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 		await page.keyboard.type( 'archives' );
 		await expect( titles ).toHaveCount( 3 );
 		await page

--- a/test/e2e/specs/site-editor/new-templates-list.spec.js
+++ b/test/e2e/specs/site-editor/new-templates-list.spec.js
@@ -50,8 +50,7 @@ test.describe( 'Templates', () => {
 		} );
 		await admin.visitSiteEditor( { path: '/wp_template/all' } );
 		// Global search.
-		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
-		await page.keyboard.type( 'tag' );
+		await page.getByRole( 'searchbox', { name: 'Search' } ).fill( 'tag' );
 		const titles = page
 			.getByRole( 'region', { name: 'Template' } )
 			.getByRole( 'link', { includeHidden: true } );
@@ -72,8 +71,9 @@ test.describe( 'Templates', () => {
 
 		// Filter by author and text.
 		await page.getByRole( 'button', { name: 'Reset filters' } ).click();
-		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
-		await page.keyboard.type( 'archives' );
+		await page
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'archives' );
 		await expect( titles ).toHaveCount( 3 );
 		await page
 			.getByRole( 'button', { name: 'Filters', exact: true } )


### PR DESCRIPTION
## What?
Update the search input placeholder in data views to read "Search" rather than "Filter list"

## Why?
* "Search" seems a little friendlier and more familiar
* "List" isn't always accurate – sometimes you're viewing a grid

<img width="1070" alt="Screenshot 2024-02-06 at 16 29 21" src="https://github.com/WordPress/gutenberg/assets/846565/152648f9-9097-432b-aff4-902622548126">
