### PR TITLE
Interactivity API: Support setting a namespace using a string in `data-wp-interactive`

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/render.php
@@ -17,7 +17,15 @@ wp_enqueue_script_module( 'tovdom-islands-view' );
 
 	<div data-wp-interactive='{ "namespace": "tovdom-islands" }'>
 		<div data-wp-show-mock="state.falseValue">
-			<span data-testid="inside an island">
+			<span data-testid="inside an island with json object">
+				This should not be shown because it is inside an island.
+			</span>
+		</div>
+	</div>
+
+	<div data-wp-interactive="tovdom-islands">
+		<div data-wp-show-mock="state.falseValue">
+			<span data-testid="inside an island with string">
 				This should not be shown because it is inside an island.
 			</span>
 		</div>
@@ -68,8 +76,6 @@ wp_enqueue_script_module( 'tovdom-islands-view' );
 			</div>
 		</div>
 	</div>
-
-
 
 	<div data-wp-interactive='{ "namespace": "tovdom-islands" }'>
 		<div data-wp-interactive='{ "namespace": "something-new" }'></div>

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Break up init with yielding to main to prevent long task from hydration. ([#58227](https://github.com/WordPress/gutenberg/pull/58227))
+-   Support setting the namespace using a string in `data-wp-interactive`, like `data-wp-interactive="myPlugin"`. ([#](https://github.com/WordPress/gutenberg/pull/))
 
 ## 4.0.1 (2024-01-31)
 

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   Break up init with yielding to main to prevent long task from hydration. ([#58227](https://github.com/WordPress/gutenberg/pull/58227))
--   Support setting the namespace using a string in `data-wp-interactive`, like `data-wp-interactive="myPlugin"`. ([#](https://github.com/WordPress/gutenberg/pull/))
+-   Support setting the namespace using a string in `data-wp-interactive`, like `data-wp-interactive="myPlugin"`. ([#58743](https://github.com/WordPress/gutenberg/pull/58743))
 
 ## 4.0.1 (2024-01-31)
 

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -29,8 +29,6 @@ const directiveParser = new RegExp(
 
 // Regular expression for reference parsing. It can contain a namespace before
 // the reference, separated by `::`, like `some-namespace::state.somePath`.
-// Namespaces can contain any alphanumeric characters, hyphens, underscores or
-// forward slashes. References don't have any restrictions.
 const nsPathRegExp = /^(.+)::(.+)$/;
 
 export const hydratedIslands = new WeakSet();

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -29,7 +29,9 @@ const directiveParser = new RegExp(
 
 // Regular expression for reference parsing. It can contain a namespace before
 // the reference, separated by `::`, like `some-namespace::state.somePath`.
-const nsPathRegExp = /^(.+)::(.+)$/;
+// Namespaces can contain any alphanumeric characters, hyphens, underscores or
+// forward slashes. References don't have any restrictions.
+const nsPathRegExp = /^([\w-_\/]+)::(.+)$/;
 
 export const hydratedIslands = new WeakSet();
 

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -31,7 +31,7 @@ const directiveParser = new RegExp(
 // the reference, separated by `::`, like `some-namespace::state.somePath`.
 // Namespaces can contain any alphanumeric characters, hyphens, underscores or
 // forward slashes. References don't have any restrictions.
-const nsPathRegExp = /^([\w-_\/]+)::(.+)$/;
+const nsPathRegExp = /^(.+)::(.+)$/;
 
 export const hydratedIslands = new WeakSet();
 
@@ -85,7 +85,11 @@ export function toVdom( root ) {
 					} catch ( e ) {}
 					if ( n === islandAttr ) {
 						island = true;
-						namespaces.push( value?.namespace ?? null );
+						namespaces.push(
+							typeof value === 'string'
+								? value
+								: value?.namespace ?? null
+						);
 					} else {
 						directives.push( [ n, ns, value ] );
 					}

--- a/test/e2e/specs/interactivity/tovdom-islands.spec.ts
+++ b/test/e2e/specs/interactivity/tovdom-islands.spec.ts
@@ -23,10 +23,17 @@ test.describe( 'toVdom - islands', () => {
 		await expect( el ).toBeVisible();
 	} );
 
-	test( 'directives that are inside islands should be hydrated', async ( {
+	test( 'directives that are inside islands with json objects should be hydrated', async ( {
 		page,
 	} ) => {
-		const el = page.getByTestId( 'inside an island' );
+		const el = page.getByTestId( 'inside an island with json object' );
+		await expect( el ).toBeHidden();
+	} );
+
+	test( 'directives that are inside islands with strings should be hydrated', async ( {
+		page,
+	} ) => {
+		const el = page.getByTestId( 'inside an island with string' );
 		await expect( el ).toBeHidden();
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Support setting a namespace using a string in `data-wp-interactive`, like `data-wp-intearctive="myPlugin"`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the namespace is the main and only property supported now, so it makes sense to allow it, instead of the longer `data-wp-interactive='{ "namespace": "myPlugin" }'` form.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By checking if the attribute value of `data-wp-intearctive` is a string, and if it is, using it as the namespace.

---

In the server, string namespaces are supported in this WP Core PR:

- https://github.com/WordPress/wordpress-develop/pull/5953
- https://github.com/WordPress/wordpress-develop/pull/5953/commits/6345e2494793cad4294b792fc6ddc54a2bdeb94d

Be aware that here in Gutenberg this will be supported once the PR is committed to WP Core and the code is synced back to Gutenberg.

---

Co-authored with @sirreal.