### PR TITLE
Remove open in new tab from link preview

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -427,25 +427,6 @@ function LinkControl( {
 					onEditClick={ () => setIsEditingLink( true ) }
 					hasRichPreviews={ hasRichPreviews }
 					hasUnlinkControl={ shownUnlinkControl }
-					additionalControls={ () => {
-						// Expose the "Opens in new tab" settings in the preview
-						// as it is the most common setting to change.
-						if (
-							settings?.find(
-								( setting ) => setting.id === 'opensInNewTab'
-							)
-						) {
-							return (
-								<LinkSettings
-									value={ internalControlValue }
-									settings={ settings?.filter(
-										( { id } ) => id === 'opensInNewTab'
-									) }
-									onChange={ onChange }
-								/>
-							);
-						}
-					} }
 					onRemove={ () => {
 						onRemove();
 						setIsEditingLink( true );

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -32,7 +32,6 @@ export default function LinkPreview( {
 	hasRichPreviews = false,
 	hasUnlinkControl = false,
 	onRemove,
-	additionalControls,
 } ) {
 	// Avoid fetching if rich previews are not desired.
 	const showRichPreviews = hasRichPreviews ? value?.url : null;
@@ -149,7 +148,6 @@ export default function LinkPreview( {
 				/>
 				<ViewerSlot fillProps={ value } />
 			</div>
-			{ additionalControls && additionalControls() }
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes open in new tab from link control preview as a follow-up to https://github.com/WordPress/gutenberg/pull/58183

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Adding the "Opens in new tab" checkbox to the preview was a temporary stop gap solution to allow content creators to more easily updated created links. This was because we previously remove the "Settings" controls from the initial link creation step and this caused some unexpected UX issues for certain users.

Recent advancements in the UX of the Link UI however, mean that the UI remains open after the initial link creation. This means users now need only click "Edit" to access the `Opens in new tab`. 

This workflow should be sufficient to avoid overburdening users who regularly create links that must open in a new tab.

In the future iterations on the Link UI, we may even [default to the "Edit" view upon initial link creation](https://github.com/WordPress/gutenberg/pull/57726) which would further streamline this flow.

For now however, it makes sense to remove the "hotfix" which gave special precedence to the `Opens in new tab`. This unifies the control and standardises the interface.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes `addionalControls` from `<LinkPreview />` component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a link
- Open in new tab should be gone from Link Preview

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
