### PR TITLE
Rich Text: Only apply focus to elements not selection

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -241,7 +241,7 @@ export function useInputAndSelection( props ) {
 					activeFormats: EMPTY_ACTIVE_FORMATS,
 				};
 			} else {
-				applyRecord( record.current );
+				applyRecord( record.current, { domOnly: true } );
 			}
 
 			onSelectionChange( record.current.start, record.current.end );

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -878,6 +878,48 @@ test.describe( 'Links', () => {
 		] );
 	} );
 
+	// Fix for https://github.com/WordPress/gutenberg/issues/58322
+	test( 'can click links within the same paragraph to open the correct link preview (@firefox)', async ( {
+		editor,
+		LinkUtils,
+	} ) => {
+		// Create a paragraph with two links
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: `<a href="https://wordpressfoundation.org/donate/">Donate to the Wordpress Foundation</a> to support <a href="https://wordpress.org/gutenberg">Gutenberg</a>`,
+			},
+		} );
+
+		// Click on "Gutenberg" link in the canvas
+		await editor.canvas
+			.getByRole( 'link', {
+				name: 'Gutenberg',
+			} )
+			.click();
+
+		const linkPopover = LinkUtils.getLinkPopover();
+		await expect( linkPopover ).toBeVisible();
+		await expect(
+			linkPopover.getByText( 'wordpress.org/gutenberg' )
+		).toBeVisible();
+
+		// Click the other link in the same paragraph. We need a short delay between mousdown and mouseup to get the popover to show
+		await editor.canvas
+			.getByRole( 'link', {
+				name: 'WordPress',
+			} )
+			.click( { delay: 10 } );
+
+		await expect( linkPopover ).toBeVisible();
+		await expect(
+			linkPopover.getByText( 'wordpress.org/gutenberg' )
+		).toBeHidden();
+		await expect(
+			linkPopover.getByText( 'wordpressfoundation.org/donate/' )
+		).toBeVisible();
+	} );
+
 	test.describe( 'Editing link text', () => {
 		test( 'should allow for modification of link text via the Link UI', async ( {
 			page,

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -909,7 +909,7 @@ test.describe( 'Links', () => {
 			.getByRole( 'link', {
 				name: 'WordPress',
 			} )
-			.click( { delay: 10 } );
+			.click( { delay: 100 } );
 
 		await expect( linkPopover ).toBeVisible();
 		await expect(

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -887,7 +887,7 @@ test.describe( 'Links', () => {
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: {
-				content: `<a href="https://wordpressfoundation.org/donate/">Donate to the Wordpress Foundation</a> to support <a href="https://wordpress.org/gutenberg">Gutenberg</a>`,
+				content: `<a href="https://wordpressfoundation.org/donate/">Donate to the WordPress Foundation</a> to support <a href="https://wordpress.org/gutenberg">Gutenberg</a>`,
 			},
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When handling focus events use the dom to handle.
This is an attempt to fix https://github.com/WordPress/gutenberg/issues/58322.

## Why?
I'm not totally sure what `__unstableDomOnly` does yet. More investigation needed.

## How?
Pass `{ domOnly: true }` to `applyRecord`.

We should add a test to verify the fix.

## Testing Instructions
1. Add a paragraph
2. Open the block options
3. Click back on the paragraph
4. Confirm that the caret moves to the new location.

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/275961/852d8e2d-718a-4d4e-bfeb-5c76dbdb28b4

