### PR TITLE
Font Library: update fonts collection data url for Gutenberg 17.7

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -150,8 +150,7 @@ if ( ! function_exists( 'wp_unregister_font_collection' ) ) {
 }
 
 function gutenberg_register_font_collections() {
-	// TODO: update to production font collection URL.
-	wp_register_font_collection( 'google-fonts', 'https://raw.githubusercontent.com/WordPress/google-fonts-to-wordpress-collection/01aa57731575bd13f9db8d86ab80a2d74e28a1ac/releases/gutenberg-17.6/collections/google-fonts-with-preview.json' );
+	wp_register_font_collection( 'google-fonts', 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json' );
 }
 add_action( 'init', 'gutenberg_register_font_collections' );
 


### PR DESCRIPTION
## What?
Font Library: update fonts collection data url for Gutenberg 17.7

## Why?
To use the updated data structure for Gutenberg 17.7 hosted on the wordpress.org CDN.
https://meta.trac.wordpress.org/ticket/7441#ticket

## How?
Removing the provisional URL coming from a GitHub repo and using the wordpress.org CDN for this version.

## Testing Instructions
- Open the Google Fonts collection
- Install some fonts from there.
- Check that the fonts were installed correctly.


