### PR TITLE
Tweak revisions panel for improved scanning

### DIFF
--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -37,7 +37,7 @@ function LastRevision() {
 					__( 'Revisions (%s)' ),
 					revisionsCount
 				) }
-			></Button>
+			/>
 		</PostLastRevisionCheck>
 	);
 }

--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -4,7 +4,7 @@
 import { sprintf, __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { external } from '@wordpress/icons';
+import { backup } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -30,7 +30,7 @@ function LastRevision() {
 					revision: lastRevisionId,
 				} ) }
 				className="editor-post-last-revision__title"
-				icon={ external }
+				icon={ backup }
 				iconPosition="right"
 				text={ sprintf(
 					/* translators: %s: number of revisions */

--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { sprintf, _n } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { backup } from '@wordpress/icons';
+import { external } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -30,14 +30,14 @@ function LastRevision() {
 					revision: lastRevisionId,
 				} ) }
 				className="editor-post-last-revision__title"
-				icon={ backup }
-			>
-				{ sprintf(
-					/* translators: %d: number of revisions */
-					_n( '%d Revision', '%d Revisions', revisionsCount ),
+				icon={ external }
+				iconPosition="right"
+				text={ sprintf(
+					/* translators: %s: number of revisions */
+					__( 'Revisions (%s)' ),
 					revisionsCount
 				) }
-			</Button>
+			></Button>
 		</PostLastRevisionCheck>
 	);
 }

--- a/packages/editor/src/components/post-last-revision/style.scss
+++ b/packages/editor/src/components/post-last-revision/style.scss
@@ -1,14 +1,14 @@
 .editor-post-last-revision__title {
 	width: 100%;
 	font-weight: 500;
-
-	.dashicon {
-		margin-right: 5px;
-	}
 }
 
-.components-button.editor-post-last-revision__title {
+.components-button.editor-post-last-revision__title.has-icon {
 	height: 100%;
+
+	&.has-icon {
+		justify-content: space-between;
+	}
 
 	&:hover,
 	&:active {

--- a/packages/editor/src/components/post-last-revision/style.scss
+++ b/packages/editor/src/components/post-last-revision/style.scss
@@ -1,6 +1,6 @@
 .editor-post-last-revision__title {
 	width: 100%;
-	font-weight: 600;
+	font-weight: 500;
 
 	.dashicon {
 		margin-right: 5px;

--- a/packages/editor/src/components/post-last-revision/style.scss
+++ b/packages/editor/src/components/post-last-revision/style.scss
@@ -3,12 +3,9 @@
 	font-weight: 500;
 }
 
-.components-button.editor-post-last-revision__title.has-icon {
+.editor-post-last-revision__title.components-button.has-icon {
 	height: 100%;
-
-	&.has-icon {
-		justify-content: space-between;
-	}
+	justify-content: space-between;
 
 	&:hover,
 	&:active {

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -364,7 +364,7 @@ test.describe( 'Footnotes', () => {
 			.getByRole( 'region', { name: 'Editor settings' } )
 			.getByRole( 'tab', { name: 'Post' } )
 			.click();
-		await page.locator( 'a:text("2 Revisions")' ).click();
+		await page.locator( 'a:text("Revisions (2)")' ).click();
 		await page.locator( '.revisions-controls .ui-slider-handle' ).focus();
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.locator( 'input:text("Restore This Revision")' ).click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Tweaks the Revisions PanelBody to be more aligned with the other items. All other PanelBody items have text aligned left and the relative icon on the right, and the site editor revisions also use this notion of "Revisions (X)". 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Save it.
3. Refresh, make a change, save.
4. Refresh, see changes.

## Screenshots or screencast <!-- if applicable -->


| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-02-06 at 14 28 53](https://github.com/WordPress/gutenberg/assets/1813435/93044b27-12e1-4c5d-8713-54b83b6615cc)|![CleanShot 2024-02-06 at 14 29 04](https://github.com/WordPress/gutenberg/assets/1813435/294452cd-e66f-4858-ab0a-9cc6b11a9c85)|



