### PR TITLE
Interactivity API: Fix state intialization for asynchronous private stores

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Break up init with yielding to main to prevent long task from hydration. ([#58227](https://github.com/WordPress/gutenberg/pull/58227))
 
+### Bug Fixes
+
+-   Avoid initializing private stores as public when they have initial state. ([#58754](https://github.com/WordPress/gutenberg/pull/58754))
+
 ## 4.0.1 (2024-01-31)
 
 ### Bug Fixes

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -302,5 +302,5 @@ export function store(
 
 // Parse and populate the initial state.
 Object.entries( parseInitialState() ).forEach( ( [ namespace, state ] ) => {
-	store( namespace, { state } );
+	store( namespace, { state }, { lock: universalUnlock } );
 } );


### PR DESCRIPTION
## What?

Fixes a bug that appears when a private store is loaded asynchronously, and the page contains the initial state for that store.

## Why?

The current implementation makes those stores become public, thus making private stores throw an error when they try to lock their namespace.

## How?

Using the `universalUnlock` variable defined in `store.ts`. That prevents the store from being marked as "public" and can be set as "private" later on.
