### PR TITLE
Editor: Reuse data query in the post author components

### DIFF
--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -2,70 +2,22 @@
  * WordPress dependencies
  */
 import { debounce } from '@wordpress/compose';
-import { useState, useMemo } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { ComboboxControl } from '@wordpress/components';
-import { decodeEntities } from '@wordpress/html-entities';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { AUTHORS_QUERY } from './constants';
+import { useAuthorsQuery } from './hook';
 
-function PostAuthorCombobox() {
+export default function PostAuthorCombobox() {
 	const [ fieldValue, setFieldValue ] = useState();
 
-	const { authorId, authors, postAuthor } = useSelect(
-		( select ) => {
-			const { getUser, getUsers } = select( coreStore );
-			const { getEditedPostAttribute } = select( editorStore );
-			const author = getUser( getEditedPostAttribute( 'author' ), {
-				context: 'view',
-			} );
-			const query = { ...AUTHORS_QUERY };
-
-			if ( fieldValue ) {
-				query.search = fieldValue;
-			}
-
-			return {
-				authorId: getEditedPostAttribute( 'author' ),
-				postAuthor: author,
-				authors: getUsers( query ),
-			};
-		},
-		[ fieldValue ]
-	);
 	const { editPost } = useDispatch( editorStore );
-
-	const authorOptions = useMemo( () => {
-		const fetchedAuthors = ( authors ?? [] ).map( ( author ) => {
-			return {
-				value: author.id,
-				label: decodeEntities( author.name ),
-			};
-		} );
-
-		// Ensure the current author is included in the dropdown list.
-		const foundAuthor = fetchedAuthors.findIndex(
-			( { value } ) => postAuthor?.id === value
-		);
-
-		if ( foundAuthor < 0 && postAuthor ) {
-			return [
-				{
-					value: postAuthor.id,
-					label: decodeEntities( postAuthor.name ),
-				},
-				...fetchedAuthors,
-			];
-		}
-
-		return fetchedAuthors;
-	}, [ authors, postAuthor ] );
+	const { authorId, authorOptions } = useAuthorsQuery( fieldValue );
 
 	/**
 	 * Handle author selection.
@@ -101,5 +53,3 @@ function PostAuthorCombobox() {
 		/>
 	);
 }
-
-export default PostAuthorCombobox;

--- a/packages/editor/src/components/post-author/constants.js
+++ b/packages/editor/src/components/post-author/constants.js
@@ -1,6 +1,10 @@
+export const BASE_QUERY = {
+	_fields: 'id,name',
+	context: 'view', // Allows non-admins to perform requests.
+};
+
 export const AUTHORS_QUERY = {
 	who: 'authors',
 	per_page: 50,
-	_fields: 'id,name',
-	context: 'view', // Allows non-admins to perform requests.
+	...BASE_QUERY,
 };

--- a/packages/editor/src/components/post-author/hook.js
+++ b/packages/editor/src/components/post-author/hook.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { AUTHORS_QUERY, BASE_QUERY } from './constants';
+
+export function useAuthorsQuery( search ) {
+	const { authorId, authors, postAuthor } = useSelect(
+		( select ) => {
+			const { getUser, getUsers } = select( coreStore );
+			const { getEditedPostAttribute } = select( editorStore );
+			const _authorId = getEditedPostAttribute( 'author' );
+			const query = { ...AUTHORS_QUERY };
+
+			if ( search ) {
+				query.search = search;
+			}
+
+			return {
+				authorId: _authorId,
+				authors: getUsers( query ),
+				postAuthor: getUser( _authorId, BASE_QUERY ),
+			};
+		},
+		[ search ]
+	);
+
+	const authorOptions = useMemo( () => {
+		const fetchedAuthors = ( authors ?? [] ).map( ( author ) => {
+			return {
+				value: author.id,
+				label: decodeEntities( author.name ),
+			};
+		} );
+
+		// Ensure the current author is included in the dropdown list.
+		const foundAuthor = fetchedAuthors.findIndex(
+			( { value } ) => postAuthor?.id === value
+		);
+
+		if ( foundAuthor < 0 && postAuthor ) {
+			return [
+				{
+					value: postAuthor.id,
+					label: decodeEntities( postAuthor.name ),
+				},
+				...fetchedAuthors,
+			];
+		}
+
+		return fetchedAuthors;
+	}, [ authors, postAuthor ] );
+
+	return { authorId, authorOptions };
+}

--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -2,59 +2,18 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { decodeEntities } from '@wordpress/html-entities';
+import { useDispatch } from '@wordpress/data';
 import { SelectControl } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { AUTHORS_QUERY } from './constants';
+import { useAuthorsQuery } from './hook';
 
 export default function PostAuthorSelect() {
 	const { editPost } = useDispatch( editorStore );
-	const { authorId, postAuthor, authors } = useSelect( ( select ) => {
-		const { getUser, getUsers } = select( coreStore );
-		const { getEditedPostAttribute } = select( editorStore );
-		const _authorId = getEditedPostAttribute( 'author' );
-
-		return {
-			authorId: _authorId,
-			authors: getUsers( AUTHORS_QUERY ),
-			postAuthor: getUser( _authorId, {
-				context: 'view',
-			} ),
-		};
-	}, [] );
-
-	const authorOptions = useMemo( () => {
-		const fetchedAuthors = ( authors ?? [] ).map( ( author ) => {
-			return {
-				value: author.id,
-				label: decodeEntities( author.name ),
-			};
-		} );
-
-		// Ensure the current author is included in the dropdown list.
-		const foundAuthor = fetchedAuthors.findIndex(
-			( { value } ) => postAuthor?.id === value
-		);
-
-		if ( foundAuthor < 0 && postAuthor ) {
-			return [
-				{
-					value: postAuthor.id,
-					label: decodeEntities( postAuthor.name ),
-				},
-				...fetchedAuthors,
-			];
-		}
-
-		return fetchedAuthors;
-	}, [ authors, postAuthor ] );
+	const { authorId, authorOptions } = useAuthorsQuery();
 
 	const setAuthorId = ( value ) => {
 		const author = Number( value );


### PR DESCRIPTION
## What?
PRs introduces a new `useAuthorsQuery` hook and reuses it across the components.
 
## Why?
Maintenance.

## Testing Instructions
1. Open a post or page.
2. Confirm that the post-author setting works as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-02-07 at 08 14 35](https://github.com/WordPress/gutenberg/assets/240569/45750054-edc2-466b-83cb-8594c6092625)
