### PR TITLE
Site Editor: Break long URL in page sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -43,6 +43,8 @@
 
 .edit-site-sidebar-navigation-screen__page-link {
 	color: $gray-600;
+	display: inline-block;
+	word-break: break-word;
 
 	&:hover,
 	&:focus {
@@ -52,7 +54,6 @@
 	.components-external-link__icon {
 		margin-left: $grid-unit-05;
 	}
-	display: inline-block;
 }
 
 .edit-site-sidebar-navigation-screen__title-icon {


### PR DESCRIPTION
Fixes #58748

## What?

This PR will break the URL in the sidebar in the page menu of the site editor to prevent it from overflowing.

| Before | After |
|--------|--------|
| ![image](https://github.com/WordPress/gutenberg/assets/54422211/cc0177a5-122c-4e12-a37f-3c33dde92096) | ![image](https://github.com/WordPress/gutenberg/assets/54422211/7e330fd4-e901-41a7-b470-bcdd0fafc647) |

## How?

I applied `word-break: break-word;`. This also matches the post sidebar URL. I prefer displaying the full URL, but you may want to clip the URL.

![post-sidebar-link](https://github.com/WordPress/gutenberg/assets/54422211/5b489ce7-6412-43bc-878b-c0e3b05cd108)

## Testing Instructions

- Create a page with a long slug.
- Access Appearance > Editor > Pages > {page}.
- Check the URL in the sidebar.
