### PR TITLE
Disable core shadow presets by default, let themes opt-in

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -72,7 +72,7 @@ Settings related to shadows.
 
 | Property  | Type   | Default | Props  |
 | ---       | ---    | ---    |---   |
-| defaultPresets | boolean | true |  |
+| defaultPresets | boolean | false |  |
 | presets | array |  | name, shadow, slug |
 
 ---

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -670,6 +670,7 @@ class WP_Theme_JSON_Gutenberg {
 		array( 'spacing', 'margin' ),
 		array( 'spacing', 'padding' ),
 		array( 'typography', 'lineHeight' ),
+		array( 'shadow', 'defaultPresets' ),
 	);
 
 	/**

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -191,7 +191,7 @@
 			"text": true
 		},
 		"shadow": {
-			"defaultPresets": true,
+			"defaultPresets": false,
 			"presets": [
 				{
 					"name": "Natural",

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -22,11 +22,7 @@ import { getValueFromVariable, TOOLSPANEL_DROPDOWNMENU_PROPS } from './utils';
 import { overrideOrigins } from '../../store/get-block-settings';
 import { setImmutably } from '../../utils/object';
 import { getBorderPanelLabel } from '../../hooks/border';
-import { ShadowPopover } from './shadow-panel-components';
-
-function useHasShadowControl( settings ) {
-	return !! settings?.shadow;
-}
+import { ShadowPopover, useShadowPresets } from './shadow-panel-components';
 
 export function useHasBorderPanel( settings ) {
 	const controls = [
@@ -54,6 +50,11 @@ function useHasBorderStyleControl( settings ) {
 
 function useHasBorderWidthControl( settings ) {
 	return settings?.border?.width;
+}
+
+function useHasShadowControl( settings ) {
+	const shadows = useShadowPresets( settings );
+	return !! settings?.shadow && shadows.length > 0;
 }
 
 function BorderToolsPanel( {

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -174,7 +174,7 @@ export function useShadowPresets( settings ) {
 
 		const defaultPresetsEnabled = settings?.shadow?.defaultPresets;
 		const { default: defaultShadows, theme: themeShadows } =
-			settings?.shadow?.presets;
+			settings?.shadow?.presets ?? {};
 		const unsetShadow = {
 			name: __( 'Unset' ),
 			slug: 'unset',

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -175,21 +175,20 @@ export function useShadowPresets( settings ) {
 		const defaultPresetsEnabled = settings?.shadow?.defaultPresets;
 		const { default: defaultShadows, theme: themeShadows } =
 			settings?.shadow?.presets;
-		const unsetShadow = [
-			{
-				name: __( 'Unset' ),
-				slug: 'unset',
-				shadow: 'none',
-			},
-		];
+		const unsetShadow = {
+			name: __( 'Unset' ),
+			slug: 'unset',
+			shadow: 'none',
+		};
 
-		// show unset option only in global styles
-		const isGlobalStyles = settings?.hasOwnProperty( 'appearanceTools' );
-
-		return [
-			...( isGlobalStyles ? unsetShadow : EMPTY_ARRAY ),
+		const shadowPresets = [
 			...( ( defaultPresetsEnabled && defaultShadows ) || EMPTY_ARRAY ),
 			...( themeShadows || EMPTY_ARRAY ),
 		];
+		if ( shadowPresets.length ) {
+			shadowPresets.unshift( unsetShadow );
+		}
+
+		return shadowPresets;
 	}, [ settings ] );
 }

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -12,6 +12,7 @@ import {
 	Dropdown,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
 import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
 
 /**
@@ -24,15 +25,16 @@ import classNames from 'classnames';
  */
 import { unlock } from '../../lock-unlock';
 
-export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
-	const defaultShadows = settings?.shadow?.presets?.default || [];
-	const themeShadows = settings?.shadow?.presets?.theme || [];
-	const defaultPresetsEnabled = settings?.shadow?.defaultPresets;
+/**
+ * Shared reference to an empty array for cases where it is important to avoid
+ * returning a new array reference on every invocation.
+ *
+ * @type {Array}
+ */
+const EMPTY_ARRAY = [];
 
-	const shadows = [
-		...( defaultPresetsEnabled ? defaultShadows : [] ),
-		...themeShadows,
-	];
+export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
+	const shadows = useShadowPresets( settings );
 
 	return (
 		<div className="block-editor-global-styles__shadow-popover-container">
@@ -43,6 +45,14 @@ export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
 					activeShadow={ shadow }
 					onSelect={ onShadowChange }
 				/>
+				<div className="block-editor-global-styles__clear-shadow">
+					<Button
+						variant="tertiary"
+						onClick={ () => onShadowChange( undefined ) }
+					>
+						{ __( 'Clear' ) }
+					</Button>
+				</div>
 			</VStack>
 		</div>
 	);
@@ -64,6 +74,7 @@ export function ShadowPresets( { presets, activeShadow, onSelect } ) {
 					key={ slug }
 					label={ name }
 					isActive={ shadow === activeShadow }
+					type={ slug === 'unset' ? 'unset' : 'preset' }
 					onSelect={ () =>
 						onSelect( shadow === activeShadow ? undefined : shadow )
 					}
@@ -74,7 +85,7 @@ export function ShadowPresets( { presets, activeShadow, onSelect } ) {
 	);
 }
 
-export function ShadowIndicator( { label, isActive, onSelect, shadow } ) {
+export function ShadowIndicator( { type, label, isActive, onSelect, shadow } ) {
 	const { CompositeItemV2: CompositeItem } = unlock( componentsPrivateApis );
 	return (
 		<CompositeItem
@@ -89,7 +100,12 @@ export function ShadowIndicator( { label, isActive, onSelect, shadow } ) {
 			) }
 			render={
 				<Button
-					className="block-editor-global-styles__shadow-indicator"
+					className={ classNames(
+						'block-editor-global-styles__shadow-indicator',
+						{
+							unset: type === 'unset',
+						}
+					) }
 					onClick={ onSelect }
 					label={ label }
 					style={ { boxShadow: shadow } }
@@ -148,4 +164,32 @@ function renderShadowToggle() {
 			</Button>
 		);
 	};
+}
+
+export function useShadowPresets( settings ) {
+	return useMemo( () => {
+		if ( ! settings?.shadow ) {
+			return EMPTY_ARRAY;
+		}
+
+		const defaultPresetsEnabled = settings?.shadow?.defaultPresets;
+		const { default: defaultShadows, theme: themeShadows } =
+			settings?.shadow?.presets;
+		const unsetShadow = [
+			{
+				name: __( 'Unset' ),
+				slug: 'unset',
+				shadow: 'none',
+			},
+		];
+
+		// show unset option only in global styles
+		const isGlobalStyles = settings?.hasOwnProperty( 'appearanceTools' );
+
+		return [
+			...( isGlobalStyles ? unsetShadow : EMPTY_ARRAY ),
+			...( ( defaultPresetsEnabled && defaultShadows ) || EMPTY_ARRAY ),
+			...( themeShadows || EMPTY_ARRAY ),
+		];
+	}, [ settings ] );
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -16,6 +16,10 @@
 	padding-bottom: $grid-unit-10;
 }
 
+.block-editor-global-styles__clear-shadow {
+	text-align: right;
+}
+
 .block-editor-global-styles-filters-panel__dropdown,
 .block-editor-global-styles__shadow-dropdown {
 	display: block;
@@ -53,6 +57,10 @@
 
 	&:hover {
 		transform: scale(1.2);
+	}
+
+	&.unset {
+		background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 	}
 }
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -282,6 +282,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'typography' => array(
 				'lineHeight' => true,
 			),
+			'shadow'     => array(
+				'defaultPresets' => true,
+			),
 			'blocks'     => array(
 				'core/paragraph' => array(
 					'typography' => array(
@@ -320,6 +323,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 					'typography' => array(
 						'lineHeight' => false,
+					),
+					'shadow'     => array(
+						'defaultPresets' => true,
 					),
 				),
 			),

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -77,7 +77,7 @@
 						"defaultPresets": {
 							"description": "Allow users to choose shadows from the default shadow presets.",
 							"type": "boolean",
-							"default": true
+							"default": false
 						},
 						"presets": {
 							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR 
* disables the default core presets, and themes needs to opt-in (feedback from: #58298)
* introduces 'unset` option to unset an existing shadow.

<img width="571" alt="image" src="https://github.com/WordPress/gutenberg/assets/1935113/b891d677-9f48-4620-bd0f-6734fc8341b1">

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* By default, shadows dropdown should not show core preset shadows. It should only show `unset` option.
* Enable default shadows in the active theme via `theme.json` and verify core presets in the dropdown.

```
{
    "settings": {
        "shadow": {
			"defaultPresets": false,
        }
   }
}
```
