### PR TITLE
Font Library: Do not register the google fonts collection if already registered

### DIFF
--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -155,7 +155,7 @@ function gutenberg_register_font_collections() {
 	}
 	wp_register_font_collection( 'google-fonts', 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json' );
 }
-add_action( 'init', 'gutenberg_register_font_collections' );
+add_action( 'init', 'gutenberg_register_font_collections', 11 );
 
 // @core-merge: This code should probably go into Core's src/wp-includes/functions.php.
 if ( ! function_exists( 'wp_get_font_dir' ) ) {

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -150,6 +150,9 @@ if ( ! function_exists( 'wp_unregister_font_collection' ) ) {
 }
 
 function gutenberg_register_font_collections() {
+	if ( null !== WP_Font_Library::get_instance()->get_font_collection( 'google-fonts') ) {
+		return;
+	}
 	wp_register_font_collection( 'google-fonts', 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json' );
 }
 add_action( 'init', 'gutenberg_register_font_collections' );

--- a/lib/compat/wordpress-6.5/fonts/fonts.php
+++ b/lib/compat/wordpress-6.5/fonts/fonts.php
@@ -150,7 +150,7 @@ if ( ! function_exists( 'wp_unregister_font_collection' ) ) {
 }
 
 function gutenberg_register_font_collections() {
-	if ( null !== WP_Font_Library::get_instance()->get_font_collection( 'google-fonts') ) {
+	if ( null !== WP_Font_Library::get_instance()->get_font_collection( 'google-fonts' ) ) {
 		return;
 	}
 	wp_register_font_collection( 'google-fonts', 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json' );

--- a/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
@@ -52,8 +52,9 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertCount( 1, $routes['/wp/v2/font-collections'], 'Rest server has not the collections path initialized.' );
-		$this->assertCount( 1, $routes['/wp/v2/font-collections/(?P<slug>[\/\w-]+)'], 'Rest server has not the collection path initialized.' );
+		// Double becaue the route is registered by both core and gutenberg.
+		$this->assertCount( 2, $routes['/wp/v2/font-collections'], 'Rest server has not the collections path initialized.' );
+		$this->assertCount( 2, $routes['/wp/v2/font-collections/(?P<slug>[\/\w-]+)'], 'Rest server has not the collection path initialized.' );
 
 		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections'][0]['methods'], 'Rest server has not the GET method for collections initialized.' );
 		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections/(?P<slug>[\/\w-]+)'][0]['methods'], 'Rest server has not the GET method for collection initialized.' );

--- a/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
+++ b/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
@@ -52,9 +52,6 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		// Double becaue the route is registered by both core and gutenberg.
-		$this->assertCount( 2, $routes['/wp/v2/font-collections'], 'Rest server has not the collections path initialized.' );
-		$this->assertCount( 2, $routes['/wp/v2/font-collections/(?P<slug>[\/\w-]+)'], 'Rest server has not the collection path initialized.' );
 
 		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections'][0]['methods'], 'Rest server has not the GET method for collections initialized.' );
 		$this->assertArrayHasKey( 'GET', $routes['/wp/v2/font-collections/(?P<slug>[\/\w-]+)'][0]['methods'], 'Rest server has not the GET method for collection initialized.' );


### PR DESCRIPTION
## What?

In order to test this properly, you'll have to run this PR on top of the following Core patch https://github.com/WordPress/wordpress-develop/pull/6056

You shouldn't see any error due to "double registration of google-fonts" collection.

This PR is blocking the introduction of the google fonts collection into Core.