### PR TITLE
DEWP: Fix script module import field

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
--   Fix import type field in script module asset files ([#57199](https://github.com/WordPress/gutenberg/pull/57199)).
+-   Fix import type field in script module asset files ([#58770](https://github.com/WordPress/gutenberg/pull/58770)).
 
 ## 5.1.0 (2024-01-24)
 

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+-   Fix import type field in script module asset files ([#57199](https://github.com/WordPress/gutenberg/pull/57199)).
+
 ## 5.1.0 (2024-01-24)
 
 ## 5.0.0 (2024-01-10)

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -276,7 +276,7 @@ function requestToExternalModule( request ) {
 		return 'myModule';
 	}
 
-    // If the script module ID in source is the same as the external script module, `true` can be returned.
+	// If the script module ID in source is the same as the external script module, `true` can be returned.
 	return request === 'external-module-id-no-change-required';
 }
 

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -293,7 +293,7 @@ class DependencyExtractionWebpackPlugin {
 					...Array.from( chunkStaticDeps ).sort(),
 					...Array.from( chunkDynamicDeps )
 						.sort()
-						.map( ( id ) => ( { id, type: 'dynamic' } ) ),
+						.map( ( id ) => ( { id, import: 'dynamic' } ) ),
 				],
 				version: contentHash,
 			};

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -41,7 +41,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-g
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'type' => 'dynamic')), 'version' => '293aebad4ca761cf396f', 'type' => 'module');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '293aebad4ca761cf396f', 'type' => 'module');
 "
 `;
 
@@ -56,7 +56,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-depe
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'type' => 'dynamic')), 'version' => '4f59b7847b70a07b2710', 'type' => 'module');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'import' => 'dynamic')), 'version' => '4f59b7847b70a07b2710', 'type' => 'module');
 "
 `;
 
@@ -306,7 +306,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', array('id' => '@wordpress/interactivity', 'type' => 'dynamic')), 'version' => 'fcc07ce68574cdc2a6a5', 'type' => 'module');
+"<?php return array('dependencies' => array('lodash', array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => 'fcc07ce68574cdc2a6a5', 'type' => 'module');
 "
 `;
 


### PR DESCRIPTION

## What?

The script modules proposal shipped with import type field named `import` not `type`. Update accordingly.

## Testing Instructions

See the snapshot changes and see that they align with the script modules implementation in Gutenberg and [Core](https://github.com/WordPress/wordpress-develop/blob/5e345d4140b34ed62eec3b5a9e52cbbb08af4c18/src/wp-includes/class-wp-script-modules.php#L33-L94):

https://github.com/WordPress/gutenberg/blob/180b57ad4974c7ca11740a7eaac4e569dabbe630/lib/compat/wordpress-6.5/class-wp-script-modules.php#L34-L95


