### PR TITLE
Don't show Link preview when no selection

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -43,6 +43,14 @@ function Edit( {
 	const [ openedBy, setOpenedBy ] = useState( null );
 
 	useLayoutEffect( () => {
+		// close the Link popover if there is no active selection
+		// after the link was added - this can happen if the user
+		// adds a link without any text selected
+		if ( addingLink && ! value.activeFormats ) {
+			setAddingLink( false );
+			return;
+		}
+
 		const editableContentElement = contentRef.current;
 		if ( ! editableContentElement ) {
 			return;
@@ -67,7 +75,7 @@ function Edit( {
 		return () => {
 			editableContentElement.removeEventListener( 'click', handleClick );
 		};
-	}, [ contentRef, isActive ] );
+	}, [ contentRef, isActive, addingLink, value ] );
 
 	function addLink( target ) {
 		const text = getTextContent( slice( value ) );

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -43,16 +43,19 @@ function Edit( {
 	const [ openedBy, setOpenedBy ] = useState( null );
 
 	useLayoutEffect( () => {
-		// close the Link popover if there is no active selection
-		// after the link was added - this can happen if the user
-		// adds a link without any text selected
-		if ( addingLink && ! value.activeFormats ) {
-			setAddingLink( false );
+		const editableContentElement = contentRef.current;
+		if ( ! editableContentElement ) {
 			return;
 		}
 
-		const editableContentElement = contentRef.current;
-		if ( ! editableContentElement ) {
+		// Close the Link popover if there is no active selection
+		// after the link was added - this can happen if the user
+		// adds a link without any text selected.
+		// We assume that if there is no active selection after
+		// link insertion there are no active formats.
+		if ( ! value.activeFormats ) {
+			editableContentElement.focus();
+			setAddingLink( false );
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #58415

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Close the link ui preview if after the link is added there is no selection, hence no active format exists.
Alternatively another way would be to place the caret at the edge of the new link but inside the format. Although this seems like a better idea, I like the UX here better. I am also not sure there is a bug with caret placement, since there is no selection to count into.

My proposal is that if a link is added without any selection it should be an event that leaves the focus inline to allow for further text entry without the need to close distracting UI. So even if an alternate way is implemented I'd still favour the resulting UX of this PR.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a post
2. Add some text
3. Move the cursor between two words
4. Press Cmd/Ctrl + K
5. Pick a suggestion
6. **Notice the cursor is at the end of the new inserted link**
7. **Notice no Link UI is open**

## Screenshots or screencast <!-- if applicable -->


https://github.com/WordPress/gutenberg/assets/107534/bb421e70-9646-44e8-ac87-7d4a68e2eab1


