### PR TITLE
Add border back to LinkControl input

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -135,9 +135,10 @@ $block-editor-link-control-number-of-actions: 1;
 
 .block-editor-link-control__search-item {
 
-	&.components-button.components-menu-item__button {
+	&.components-button.components-menu-item__button.has-icon {
 		height: auto;
 		text-align: left;
+		padding-right: $grid-unit-15;
 	}
 
 	.components-menu-item__item {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -70,6 +70,10 @@ $block-editor-link-control-number-of-actions: 1;
 		position: relative;
 		width: 100%;
 
+		&:not(:focus) {
+			border-color: $gray-600;
+		}
+
 		.has-actions & {
 			padding-right: $grid-unit-20;
 		}


### PR DESCRIPTION
Quick fix to resolve the missing border in LinkControl, that I suspect was introduced by https://github.com/WordPress/gutenberg/pull/58750. Also adds a small optimization to ensure the left/right visual space on the menu items is the same on both sides. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a paragraph.
3. Add a link. 
4. See a border on the input. 

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-02-07 at 09 11 54](https://github.com/WordPress/gutenberg/assets/1813435/f1e0a477-2f16-4c7a-bf66-3f1da62eb86c)|![CleanShot 2024-02-07 at 09 03 12](https://github.com/WordPress/gutenberg/assets/1813435/fa444252-b0aa-46d1-a8a7-a42d9184abf2)|
