### PR TITLE
Add contributing guidelines around Component versioning

### DIFF
--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -645,7 +645,7 @@ function NewComponentImplementation( props ) {
 
 In case that is not possible (eg. too difficult to reconciliate new and legacy implementations, or impossible to preserve backward compatibility), then the legacy implementation can stay as-is.
 
-In any case, extra attention should be payed to legacy component families made of two or more subcomponents. It is possible, in fact, that the a legacy subcomponent is used as a parent / child of a subcomponent from the new version (this can happen, for example, when Gutenberg allows third party developers to inject React components via Slot/Fill). To avoid incompatibility issues and unexpected behavior, there should be some code in the components warning warning when the above scenario happens — or even better, aliasing to the correct version of the component.
+In any case, extra attention should be payed to legacy component families made of two or more subcomponents. It is possible, in fact, that the a legacy subcomponent is used as a parent / child of a subcomponent from the new version (this can happen, for example, when Gutenberg allows third party developers to inject React components via Slot/Fill). To avoid incompatibility issues and unexpected behavior, there should be some code in the components warning when the above scenario happens — or even better, aliasing to the correct version of the component.
 
 ##### Naming
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related to https://github.com/WordPress/gutenberg/issues/58324

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR introduces a section in the Contributing Guidelines of the `@wordpress/components` package to standardize the procedure of introducing a new version of an existing component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We've been recently working on introducing new version of existing components (`Tooltip`, `TabPanel`, `CustomSelectControl`, `DropdownMenu`, `Composite`). While working on it, we gathered experience on what worked well, and we thing it's a good idea to standardize the process for future work.
