### PR TITLE
Footnotes: fix anchor order replacing

### DIFF
--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -64,7 +64,7 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 			const richTextValue =
 				typeof value === 'string'
 					? RichTextData.fromHTMLString( value )
-					: value;
+					: new RichTextData( value );
 
 			richTextValue.replacements.forEach( ( replacement ) => {
 				if ( replacement.type === 'core/footnote' ) {

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -60,6 +60,13 @@ test.describe( 'Footnotes', () => {
 			},
 		] );
 
+		// Check if the numbers in the editor content update.
+		const anchorNumber = await editor.canvas
+			.locator( ':root' )
+			.evaluate( () => document.querySelector( '.fn' ).textContent );
+
+		expect( anchorNumber ).toBe( '1' );
+
 		await editor.canvas.locator( 'p:text("first paragraph")' ).click();
 
 		await editor.showBlockToolbar();

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -60,7 +60,7 @@ test.describe( 'Footnotes', () => {
 			},
 		] );
 
-		// Check if the numbers in the editor content update.
+		// Check if the numbers in the editor content updated.
 		const anchorNumber = await editor.canvas
 			.locator( ':root' )
 			.evaluate( () => document.querySelector( '.fn' ).textContent );

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -61,11 +61,7 @@ test.describe( 'Footnotes', () => {
 		] );
 
 		// Check if the numbers in the editor content updated.
-		const anchorNumber = await editor.canvas
-			.locator( ':root' )
-			.evaluate( () => document.querySelector( '.fn' ).textContent );
-
-		expect( anchorNumber ).toBe( '1' );
+		await expect( editor.canvas.locator( '.fn' ) ).toHaveText( '1' );
 
 		await editor.canvas.locator( 'p:text("first paragraph")' ).click();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #57598 + adds an e2e test.

The problem is that a RichTextData instance shouldn't be changed once initialised, it will have no effect.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Create a new instance before modifying it.

I briefly considered throwing an error when trying to modify the properties, but `String` actually behaves the same. You can try to set the `length` or indices on a string, and it will throw no error, but it will actually have no effect.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
