### PR TITLE
Enter editing mode via Enter or Spacebar

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -273,13 +273,16 @@ function Iframe( {
 				src={ src }
 				title={ __( 'Editor canvas' ) }
 				onKeyDown={ ( event ) => {
+					if ( props.onKeyDown ) {
+						props.onKeyDown( event );
+					}
 					// If the event originates from inside the iframe, it means
 					// it bubbled through the portal, but only with React
 					// events. We need to to bubble native events as well,
 					// though by doing so we also trigger another React event,
 					// so we need to stop the propagation of this event to avoid
 					// duplication.
-					if (
+					else if (
 						event.currentTarget.ownerDocument !==
 						event.target.ownerDocument
 					) {

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -3,6 +3,12 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+test.use( {
+	editorNavigationUtils: async ( { page, pageUtils }, use ) => {
+		await use( new EditorNavigationUtils( { page, pageUtils } ) );
+	},
+} );
+
 test.describe( 'Site editor navigation', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
@@ -14,6 +20,7 @@ test.describe( 'Site editor navigation', () => {
 
 	test( 'Can use keyboard to navigate the site editor', async ( {
 		admin,
+		editorNavigationUtils,
 		page,
 		pageUtils,
 	} ) => {
@@ -22,18 +29,7 @@ test.describe( 'Site editor navigation', () => {
 		// Test: Can navigate to a sidebar item and into its subnavigation frame without losing focus
 		// Go to the Pages button
 
-		for ( let i = 0; i < 10; i++ ) {
-			await pageUtils.pressKeys( 'Tab' );
-			const activeLabel = await page.evaluate( () => {
-				return (
-					document.activeElement.getAttribute( 'aria-label' ) ||
-					document.activeElement.textContent
-				);
-			} );
-			if ( activeLabel === 'Pages' ) {
-				break;
-			}
-		}
+		await editorNavigationUtils.tabToLabel( 'Pages', { times: 10 } );
 
 		await expect(
 			page.getByRole( 'button', { name: 'Pages' } )
@@ -50,15 +46,7 @@ test.describe( 'Site editor navigation', () => {
 		).toBeFocused();
 
 		// Test: Can navigate into the iframe using the keyboard
-		for ( let i = 0; i < 10; i++ ) {
-			await pageUtils.pressKeys( 'Tab' );
-			const activeNode = await page.evaluate( () => {
-				return document.activeElement.nodeName;
-			} );
-			if ( activeNode === 'IFRAME' ) {
-				break;
-			}
-		}
+		await editorNavigationUtils.tabToNode( 'IFRAME', { times: 10 } );
 		// Getting the actual iframe as a cleaner locator was suprisingly tricky,
 		// so we're using a css selector with .is-focused which should be present when the iframe has focus.
 		await expect(
@@ -104,3 +92,39 @@ test.describe( 'Site editor navigation', () => {
 		).toBeFocused();
 	} );
 } );
+
+class EditorNavigationUtils {
+	constructor( { page, pageUtils } ) {
+		this.page = page;
+		this.pageUtils = pageUtils;
+	}
+
+	async tabToLabel( label, { times = 10 } ) {
+		for ( let i = 0; i < times; i++ ) {
+			await this.pageUtils.pressKeys( 'Tab' );
+			const activeLabel = await this.page.evaluate( () => {
+				return (
+					document.activeElement.getAttribute( 'aria-label' ) ||
+					document.activeElement.textContent
+				);
+			} );
+			if ( activeLabel === label ) {
+				return activeLabel;
+			}
+		}
+		return null;
+	}
+
+	async tabToNode( nodeName, { times = 10 } ) {
+		for ( let i = 0; i < times; i++ ) {
+			await this.pageUtils.pressKeys( 'Tab' );
+			const activeNode = await this.page.evaluate( () => {
+				return document.activeElement.nodeName;
+			} );
+			if ( activeNode === nodeName ) {
+				break;
+			}
+		}
+		return null;
+	}
+}

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -46,17 +46,22 @@ test.describe( 'Site editor navigation', () => {
 		).toBeFocused();
 
 		// Test: Can navigate into the iframe using the keyboard
-		await editorNavigationUtils.tabToNode( 'IFRAME', { times: 10 } );
-		await expect(
-			page.getByRole( 'button', { name: 'Editor Canvas' } )
-		).toBeFocused();
+		await editorNavigationUtils.tabToLabel( 'Editor Canvas', {
+			times: 10,
+		} );
+		const editorCanvasButton = page.getByRole( 'button', {
+			name: 'Editor Canvas',
+		} );
+		await expect( editorCanvasButton ).toBeFocused();
 		// Enter into the site editor frame
 		await pageUtils.pressKeys( 'Enter' );
-		// Focus should still be on the iframe.
+		// Focus should be on the iframe without the button role
 		await expect(
 			page.locator( 'iframe[name="editor-canvas"]' )
 		).toBeFocused();
-		// But did it do anything?
+		// The button role should have been removed from the iframe.
+		await expect( editorCanvasButton ).toBeHidden();
+
 		// Test to make sure a Tab keypress works as expected.
 		// As of this writing, we are in select mode and a tab
 		// keypress will reveal the header template select mode
@@ -88,6 +93,8 @@ test.describe( 'Site editor navigation', () => {
 		await expect(
 			page.getByLabel( 'Go to the Dashboard' ).first()
 		).toBeFocused();
+		// We should have our editor canvas button back
+		await expect( editorCanvasButton ).toBeVisible();
 	} );
 } );
 
@@ -107,18 +114,6 @@ class EditorNavigationUtils {
 				);
 			} );
 			if ( activeLabel === label ) {
-				return;
-			}
-		}
-	}
-
-	async tabToNode( nodeName, { times = 10 } ) {
-		for ( let i = 0; i < times; i++ ) {
-			await this.pageUtils.pressKeys( 'Tab' );
-			const activeNode = await this.page.evaluate( () => {
-				return document.activeElement.nodeName;
-			} );
-			if ( activeNode === nodeName ) {
 				return;
 			}
 		}

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -19,8 +19,11 @@ test.describe( 'Site editor navigation', () => {
 	} ) => {
 		await admin.visitSiteEditor();
 
+		// Test:
 		// Navigate to the iframe
 		await pageUtils.pressKeys( 'Tab', { times: 3 } );
+
+		// Test: Doesn't lose focus when using the command palette from the site editor navigation sidebar
 		// Open the command palette via button press
 		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
 		await pageUtils.pressKeys( 'Enter' );
@@ -30,6 +33,8 @@ test.describe( 'Site editor navigation', () => {
 		// Return focus to the button
 		await pageUtils.pressKeys( 'Escape' );
 		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
+
+		// Test: Doesn't lose focus when using the command palette from the command + k shortcut
 		// Open it again with Command + K
 		await pageUtils.pressKeys( 'primary+k' );
 		await expect(
@@ -37,6 +42,8 @@ test.describe( 'Site editor navigation', () => {
 		).toBeFocused();
 		await pageUtils.pressKeys( 'Escape' );
 		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
+
+		// Test: Can navigate to a sidebar item and into its subnavigation frame without losing focus
 		// Go to the Pages button
 		await pageUtils.pressKeys( 'Tab', { times: 4 } );
 		await expect(
@@ -52,18 +59,39 @@ test.describe( 'Site editor navigation', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Pages' } )
 		).toBeFocused();
+
+		// Test: Can navigate into the iframe using the keyboard
 		await pageUtils.pressKeys( 'Tab', { times: 6 } );
 		// Getting the actual iframe as a cleaner locator was suprisingly tricky,
 		// so we're using a css selector with .is-focused which should be present when the iframe has focus.
 		await expect(
 			page.locator( 'iframe[name="editor-canvas"].is-focused' )
 		).toBeFocused();
-
-		// Enter into editing mode
+		// Enter into the site editor frame
 		await pageUtils.pressKeys( 'Enter' );
+		// Focus should still be on the iframe.
+		await expect(
+			page.locator( 'iframe[name="editor-canvas"]' )
+		).toBeFocused();
+		// But did it do anything?
+		// Test to make sure a Tab keypress works as expected.
+		// As of this writing, we are in select mode and a tab
+		/// keypress will reveal the header template select mode
+		// button. This test is not documenting that we _want_
+		// that action, but checking that we are within the site
+		// editor and keypresses work as intened.
+		await pageUtils.pressKeys( 'Tab' );
+		await expect(
+			page.getByRole( 'button', {
+				name: 'Template Part Block. Row 1. header',
+			} )
+		).toBeFocused();
 
-		// We should now be in editing mode
-		await pageUtils.pressKeys( 'Shift+Tab', { times: 9 } );
+		// Test: We can go back to the main navigation from the editor frame
+		// Move to the document toolbar
+		await pageUtils.pressKeys( 'alt+F10' );
+		// Go to the open navigation button
+		await pageUtils.pressKeys( 'shift+Tab' );
 
 		// Open the sidebar again
 		await expect(
@@ -73,6 +101,7 @@ test.describe( 'Site editor navigation', () => {
 			} )
 		).toBeFocused();
 		await pageUtils.pressKeys( 'Enter' );
+
 		await expect(
 			page.getByLabel( 'Go to the Dashboard' ).first()
 		).toBeFocused();

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -19,33 +19,9 @@ test.describe( 'Site editor navigation', () => {
 	} ) => {
 		await admin.visitSiteEditor();
 
-		// Test:
-		// Navigate to the iframe
-		await pageUtils.pressKeys( 'Tab', { times: 3 } );
-
-		// Test: Doesn't lose focus when using the command palette from the site editor navigation sidebar
-		// Open the command palette via button press
-		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
-		await pageUtils.pressKeys( 'Enter' );
-		await expect(
-			page.getByPlaceholder( 'Search for commands' )
-		).toBeFocused();
-		// Return focus to the button
-		await pageUtils.pressKeys( 'Escape' );
-		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
-
-		// Test: Doesn't lose focus when using the command palette from the command + k shortcut
-		// Open it again with Command + K
-		await pageUtils.pressKeys( 'primary+k' );
-		await expect(
-			page.getByPlaceholder( 'Search for commands' )
-		).toBeFocused();
-		await pageUtils.pressKeys( 'Escape' );
-		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
-
 		// Test: Can navigate to a sidebar item and into its subnavigation frame without losing focus
 		// Go to the Pages button
-		await pageUtils.pressKeys( 'Tab', { times: 4 } );
+		await pageUtils.pressKeys( 'Tab', { times: 7 } );
 		await expect(
 			page.getByRole( 'button', { name: 'Pages' } )
 		).toBeFocused();

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -46,9 +46,7 @@ test.describe( 'Site editor navigation', () => {
 		).toBeFocused();
 
 		// Test: Can navigate into the iframe using the keyboard
-		await editorNavigationUtils.tabToLabel( 'Editor Canvas', {
-			times: 10,
-		} );
+		await editorNavigationUtils.tabToLabel( 'Editor Canvas' );
 		const editorCanvasButton = page.getByRole( 'button', {
 			name: 'Editor Canvas',
 		} );

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -104,7 +104,7 @@ class EditorNavigationUtils {
 		this.pageUtils = pageUtils;
 	}
 
-	async tabToLabel( label, { times = 10 } ) {
+	async tabToLabel( label, times = 10 ) {
 		for ( let i = 0; i < times; i++ ) {
 			await this.pageUtils.pressKeys( 'Tab' );
 			const activeLabel = await this.page.evaluate( () => {

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -61,7 +61,7 @@ test.describe( 'Site editor navigation', () => {
 		// But did it do anything?
 		// Test to make sure a Tab keypress works as expected.
 		// As of this writing, we are in select mode and a tab
-		/// keypress will reveal the header template select mode
+		// keypress will reveal the header template select mode
 		// button. This test is not documenting that we _want_
 		// that action, but checking that we are within the site
 		// editor and keypresses work as intened.

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Site editor navigation', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'Can use keyboard to navigate the site editor', async ( {
+		admin,
+		page,
+		pageUtils,
+	} ) => {
+		await admin.visitSiteEditor();
+
+		// Navigate to the iframe
+		await pageUtils.pressKeys( 'Tab', { times: 3 } );
+		// Open the command palette via button press
+		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
+		await pageUtils.pressKeys( 'Enter' );
+		await expect(
+			page.getByPlaceholder( 'Search for commands' )
+		).toBeFocused();
+		// Return focus to the button
+		await pageUtils.pressKeys( 'Escape' );
+		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
+		// Open it again with Command + K
+		await pageUtils.pressKeys( 'primary+k' );
+		await expect(
+			page.getByPlaceholder( 'Search for commands' )
+		).toBeFocused();
+		await pageUtils.pressKeys( 'Escape' );
+		await expect( page.getByLabel( 'Open command palette' ) ).toBeFocused();
+		// Go to the Pages button
+		await pageUtils.pressKeys( 'Tab', { times: 4 } );
+		await expect(
+			page.getByRole( 'button', { name: 'Pages' } )
+		).toBeFocused();
+		await pageUtils.pressKeys( 'Enter' );
+		// We should be in the Pages sidebar
+		await expect(
+			page.getByRole( 'button', { name: 'Back', exact: true } )
+		).toBeFocused();
+		await pageUtils.pressKeys( 'Enter' );
+		// Go back to the main navigation
+		await expect(
+			page.getByRole( 'button', { name: 'Pages' } )
+		).toBeFocused();
+		await pageUtils.pressKeys( 'Tab', { times: 6 } );
+		// Getting the actual iframe as a cleaner locator was suprisingly tricky,
+		// so we're using a css selector with .is-focused which should be present when the iframe has focus.
+		await expect(
+			page.locator( 'iframe[name="editor-canvas"].is-focused' )
+		).toBeFocused();
+
+		// Enter into editing mode
+		await pageUtils.pressKeys( 'Enter' );
+
+		// We should now be in editing mode
+		await pageUtils.pressKeys( 'Shift+Tab', { times: 9 } );
+
+		// Open the sidebar again
+		await expect(
+			page.getByRole( 'button', {
+				name: 'Open Navigation',
+				exact: true,
+			} )
+		).toBeFocused();
+		await pageUtils.pressKeys( 'Enter' );
+		await expect(
+			page.getByLabel( 'Go to the Dashboard' ).first()
+		).toBeFocused();
+	} );
+} );

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -47,10 +47,8 @@ test.describe( 'Site editor navigation', () => {
 
 		// Test: Can navigate into the iframe using the keyboard
 		await editorNavigationUtils.tabToNode( 'IFRAME', { times: 10 } );
-		// Getting the actual iframe as a cleaner locator was suprisingly tricky,
-		// so we're using a css selector with .is-focused which should be present when the iframe has focus.
 		await expect(
-			page.locator( 'iframe[name="editor-canvas"].is-focused' )
+			page.getByRole( 'button', { name: 'Editor Canvas' } )
 		).toBeFocused();
 		// Enter into the site editor frame
 		await pageUtils.pressKeys( 'Enter' );

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -29,7 +29,7 @@ test.describe( 'Site editor navigation', () => {
 		// Test: Can navigate to a sidebar item and into its subnavigation frame without losing focus
 		// Go to the Pages button
 
-		await editorNavigationUtils.tabToLabel( 'Pages', { times: 10 } );
+		await editorNavigationUtils.tabToLabel( 'Pages' );
 
 		await expect(
 			page.getByRole( 'button', { name: 'Pages' } )

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -21,7 +21,20 @@ test.describe( 'Site editor navigation', () => {
 
 		// Test: Can navigate to a sidebar item and into its subnavigation frame without losing focus
 		// Go to the Pages button
-		await pageUtils.pressKeys( 'Tab', { times: 7 } );
+
+		for ( let i = 0; i < 10; i++ ) {
+			await pageUtils.pressKeys( 'Tab' );
+			const activeLabel = await page.evaluate( () => {
+				return (
+					document.activeElement.getAttribute( 'aria-label' ) ||
+					document.activeElement.textContent
+				);
+			} );
+			if ( activeLabel === 'Pages' ) {
+				break;
+			}
+		}
+
 		await expect(
 			page.getByRole( 'button', { name: 'Pages' } )
 		).toBeFocused();
@@ -37,7 +50,15 @@ test.describe( 'Site editor navigation', () => {
 		).toBeFocused();
 
 		// Test: Can navigate into the iframe using the keyboard
-		await pageUtils.pressKeys( 'Tab', { times: 6 } );
+		for ( let i = 0; i < 10; i++ ) {
+			await pageUtils.pressKeys( 'Tab' );
+			const activeNode = await page.evaluate( () => {
+				return document.activeElement.nodeName;
+			} );
+			if ( activeNode === 'IFRAME' ) {
+				break;
+			}
+		}
 		// Getting the actual iframe as a cleaner locator was suprisingly tricky,
 		// so we're using a css selector with .is-focused which should be present when the iframe has focus.
 		await expect(

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -109,10 +109,9 @@ class EditorNavigationUtils {
 				);
 			} );
 			if ( activeLabel === label ) {
-				return activeLabel;
+				return;
 			}
 		}
-		return null;
 	}
 
 	async tabToNode( nodeName, { times = 10 } ) {
@@ -122,9 +121,8 @@ class EditorNavigationUtils {
 				return document.activeElement.nodeName;
 			} );
 			if ( activeNode === nodeName ) {
-				break;
+				return;
 			}
 		}
-		return null;
 	}
 }


### PR DESCRIPTION



<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allow entering into edit mode with keyboard enter/spacebar press on the site editor frame in view mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There was a regression in being able to enter editing mode via keydown on the site editor due to the onKeydown event being blocked. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This allows an onKeydown prop to be fired if passed to the iframe. I'm not positive this is the best way.

I also added a test to check for this as well as general keyboard navigation of the site editor in view mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the site editor
- Use the keyboard to move focus to the site editor 
- Focus ring should be present on iframe
- Press Enter/Spacebard
- Should be in editing mode

