### PR TITLE
Patterns: Add a confirmation dialog when a user tries to delete a synced pattern with overrides

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -17,10 +17,10 @@ import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 export function BlockRemovalWarningModal( { rules } ) {
-	const { clientIds, selectPrevious, blockNamesForPrompt } = useSelect(
-		( select ) =>
+	const { clientIds, selectPrevious, blockNamesForPrompt, messageType } =
+		useSelect( ( select ) =>
 			unlock( select( blockEditorStore ) ).getRemovalPromptData()
-	);
+		);
 
 	const {
 		clearBlockRemovalPrompt,
@@ -41,6 +41,18 @@ export function BlockRemovalWarningModal( { rules } ) {
 		return;
 	}
 
+	const messages = {
+		patternOverrides: _n(
+			'Deleting this block could break patterns on your site that have content linked to it. Are you sure you want to delete it?',
+			'Deleting these blocks could break patterns on your site that have content linked to them. Are you sure you want to delete them?',
+			blockNamesForPrompt.length
+		),
+		templates: _n(
+			'Deleting this block will stop your post or page content from displaying on this template. It is not recommended.',
+			'Deleting these blocks will stop your post or page content from displaying on this template. It is not recommended.',
+			blockNamesForPrompt.length
+		),
+	};
 	const onConfirmRemoval = () => {
 		privateRemoveBlocks( clientIds, selectPrevious, /* force */ true );
 		clearBlockRemovalPrompt();
@@ -52,13 +64,7 @@ export function BlockRemovalWarningModal( { rules } ) {
 			onRequestClose={ clearBlockRemovalPrompt }
 			size="medium"
 		>
-			<p>
-				{ _n(
-					'Deleting this block will stop your post or page content from displaying on this template. It is not recommended.',
-					'Deleting these blocks will stop your post or page content from displaying on this template. It is not recommended.',
-					blockNamesForPrompt.length
-				) }
-			</p>
+			<p>{ messages[ messageType ] }</p>
 			<HStack justify="right">
 				<Button variant="tertiary" onClick={ clearBlockRemovalPrompt }>
 					{ __( 'Cancel' ) }

--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -41,18 +41,19 @@ export function BlockRemovalWarningModal( { rules } ) {
 		return;
 	}
 
-	const messages = {
-		patternOverrides: _n(
-			'Deleting this block could break patterns on your site that have content linked to it. Are you sure you want to delete it?',
-			'Deleting these blocks could break patterns on your site that have content linked to them. Are you sure you want to delete them?',
-			blockNamesForPrompt.length
-		),
-		templates: _n(
-			'Deleting this block will stop your post or page content from displaying on this template. It is not recommended.',
-			'Deleting these blocks will stop your post or page content from displaying on this template. It is not recommended.',
-			blockNamesForPrompt.length
-		),
-	};
+	const message =
+		messageType === 'templates'
+			? _n(
+					'Deleting this block will stop your post or page content from displaying on this template. It is not recommended.',
+					'Deleting these blocks will stop your post or page content from displaying on this template. It is not recommended.',
+					blockNamesForPrompt.length
+			  )
+			: _n(
+					'Deleting this block could break patterns on your site that have content linked to it. Are you sure you want to delete it?',
+					'Deleting these blocks could break patterns on your site that have content linked to them. Are you sure you want to delete them?',
+					blockNamesForPrompt.length
+			  );
+
 	const onConfirmRemoval = () => {
 		privateRemoveBlocks( clientIds, selectPrevious, /* force */ true );
 		clearBlockRemovalPrompt();
@@ -64,7 +65,7 @@ export function BlockRemovalWarningModal( { rules } ) {
 			onRequestClose={ clearBlockRemovalPrompt }
 			size="medium"
 		>
-			<p>{ messages[ messageType ] }</p>
+			<p>{ message }</p>
 			<HStack justify="right">
 				<Button variant="tertiary" onClick={ clearBlockRemovalPrompt }>
 					{ __( 'Cancel' ) }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1521,11 +1521,17 @@ export function isSelectionEnabled( state = true, action ) {
 function removalPromptData( state = false, action ) {
 	switch ( action.type ) {
 		case 'DISPLAY_BLOCK_REMOVAL_PROMPT':
-			const { clientIds, selectPrevious, blockNamesForPrompt } = action;
+			const {
+				clientIds,
+				selectPrevious,
+				blockNamesForPrompt,
+				messageType,
+			} = action;
 			return {
 				clientIds,
 				selectPrevious,
 				blockNamesForPrompt,
+				messageType,
 			};
 		case 'CLEAR_BLOCK_REMOVAL_PROMPT':
 			return false;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -13,6 +13,8 @@ import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { CommandMenu } from '@wordpress/commands';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,6 +26,14 @@ import { unlock } from './lock-unlock';
 import useNavigateToEntityRecord from './hooks/use-navigate-to-entity-record';
 
 const { ExperimentalEditorProvider } = unlock( editorPrivateApis );
+const { BlockRemovalWarningModal } = unlock( blockEditorPrivateApis );
+// Prevent accidental removal of certain blocks, asking the user for
+// confirmation.
+const blockRemovalRules = {
+	'bindings/core/pattern-overrides': __(
+		'Blocks from synced patterns that can have overriden content.'
+	),
+};
 
 function Editor( {
 	postId: initialPostId,
@@ -123,6 +133,7 @@ function Editor( {
 					<CommandMenu />
 					<EditorInitialization postId={ currentPost.postId } />
 					<Layout initialPost={ initialPost } />
+					<BlockRemovalWarningModal rules={ blockRemovalRules } />
 				</ErrorBoundary>
 				<PostLockedModal />
 			</ExperimentalEditorProvider>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -84,6 +84,9 @@ const blockRemovalRules = {
 	'core/post-template': __(
 		'Post Template displays each post or page in a Query Loop.'
 	),
+	'bindings/core/pattern-overrides': __(
+		'Blocks from synced patterns that can have overriden content.'
+	),
 };
 
 export default function Editor( { isLoading } ) {


### PR DESCRIPTION

## What?
Adds a confirmation dialog when a user tries to delete a synced pattern with overrides.

## Why?
It is currently easy for a user to remove a block from a synced pattern without realising that it was break instances of the pattern that have overridden that content.

## How?
Extends the existing `BlockRemovalWarningModal` 

## Testing Instructions
 - Add a synced pattern with overridden blocks
 - In the pattern editor try and delete one of the blocks with overrides and make sure a confirmation dialog appears with message related to patterns appears
 - Click cancel and make sure block is not deleted
 - Try again and this time select `Delete` and make sure block is deleted
 - Try in both site and post editor
 - Try deleting a post content block from a template and make sure correct warning message still appears

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/7bb259d7-602c-4732-9be1-487865cdd345

